### PR TITLE
refactor: remove dead code and reduce duplication across codebase

### DIFF
--- a/app/agent/nodes/frame_problem/frame_problem.py
+++ b/app/agent/nodes/frame_problem/frame_problem.py
@@ -9,7 +9,7 @@ from typing import cast
 
 from langsmith import traceable
 
-from app.agent.memory import get_memory_context, is_memory_enabled
+from app.agent.memory import get_memory_context
 from app.agent.nodes.frame_problem.models import (
     ProblemStatement,
     ProblemStatementInput,
@@ -92,6 +92,15 @@ def _fallback_problem_statement(state: InvestigationState) -> ProblemStatement:
     )
 
 
+def _load_memory_context(state: InvestigationState) -> str:
+    """Load memory context if enabled."""
+    pipeline_name = state.get("pipeline_name", "")
+    memory_context = get_memory_context(pipeline_name=pipeline_name)
+    if memory_context:
+        debug_print("[MEMORY] Loaded context for problem framing")
+    return memory_context
+
+
 @traceable(name="node_frame_problem")
 def node_frame_problem(state: InvestigationState) -> dict:
     """
@@ -107,21 +116,7 @@ def node_frame_problem(state: InvestigationState) -> dict:
     tracker = get_tracker()
     tracker.start("frame_problem", "Generating problem statement")
 
-    # Load memory context if enabled
-    memory_context = ""
-    if is_memory_enabled():
-        from app.agent.memory.architecture_discovery import find_architecture_doc_for_pipeline
-
-        pipeline_name = state.get("pipeline_name", "")
-        seed_paths = find_architecture_doc_for_pipeline(pipeline_name)
-
-        memory_context = get_memory_context(
-            pipeline_name=pipeline_name,
-            alert_id=state.get("alert_json", {}).get("alert_id"),
-            seed_paths=seed_paths,
-        )
-        if memory_context:
-            debug_print("[MEMORY] Loaded context for problem framing")
+    memory_context = _load_memory_context(state)
 
     problem = _generate_output_problem_statement(state, memory_context)
     problem_md = render_problem_statement_md(problem, state)

--- a/app/agent/nodes/root_cause_diagnosis/node.py
+++ b/app/agent/nodes/root_cause_diagnosis/node.py
@@ -180,15 +180,10 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
 
 def _load_memory_context(state: InvestigationState) -> str:
     """Load memory context if enabled."""
-    from app.agent.memory import get_memory_context, is_memory_enabled
-    from app.agent.memory.architecture_discovery import find_architecture_doc_for_pipeline
-
-    if not is_memory_enabled():
-        return ""
+    from app.agent.memory import get_memory_context
 
     pipeline_name = state.get("pipeline_name", "")
-    seed_paths = find_architecture_doc_for_pipeline(pipeline_name)
-    memory_context = get_memory_context(pipeline_name=pipeline_name, seed_paths=seed_paths)
+    memory_context = get_memory_context(pipeline_name=pipeline_name)
 
     if memory_context:
         debug_print("[MEMORY] Loaded context for diagnosis")

--- a/app/agent/routing.py
+++ b/app/agent/routing.py
@@ -40,31 +40,15 @@ def should_continue_investigation(state: InvestigationState) -> str:
     """
     Decide whether to continue investigation or publish findings.
 
-    This function implements the conditional routing logic after validation:
-    - If confidence/validity is too low AND there are recommendations, loop back
-    - If max loops reached, proceed to publish findings
-    - If no actions can be planned, stop looping (safety check)
-    - Otherwise, proceed to publish findings
-
-    Args:
-        state: Current investigation state
-
-    Returns:
-        Next node name: "investigate" or "publish"
+    Loops back to investigate while recommendations exist and loop limit is not reached.
+    Publishes findings when recommendations are exhausted, max loops exceeded, or no
+    actions are available.
     """
     try:
-        confidence = state.get("confidence", 0.0)
-        validity_score = state.get("validity_score", 0.0)
         investigation_recommendations = state.get("investigation_recommendations", [])
         loop_count = state.get("investigation_loop_count", 0)
         available_action_names = state.get("available_action_names", [])
         max_loops = 4  # Maximum 4 additional loops (5 total loops max)
-
-        print(
-            f"[DEBUG] Routing: confidence={confidence:.0%}, validity={validity_score:.0%}, "
-            f"loop={loop_count}/{max_loops}, recommendations={len(investigation_recommendations)}, "
-            f"available_actions={len(available_action_names)}"
-        )
 
         # Safety check: if no actions are available, we can't gather more evidence
         if not available_action_names:
@@ -76,37 +60,12 @@ def should_continue_investigation(state: InvestigationState) -> str:
             debug_print(f"Max loops ({max_loops}) exceeded -> publish")
             return "publish"
 
-        # Continue investigation if:
-        # 1. confidence or validity is low AND we have recommendations, OR
-        # 2. we have recommendations (regardless of confidence) for critical missing evidence
-        confidence_threshold = 0.6
-        validity_threshold = 0.5
-
-        low_confidence_or_validity = (
-            confidence < confidence_threshold or validity_score < validity_threshold
-        )
-        has_recommendations = bool(investigation_recommendations)
-
-        # Loop back if low confidence/validity OR if recommendations exist (critical evidence missing)
-        should_loop = (low_confidence_or_validity and has_recommendations) or (
-            has_recommendations and loop_count <= max_loops
-        )
-
-        print(
-            f"[DEBUG] Routing decision: should_loop={should_loop}, "
-            f"low_conf_or_val={low_confidence_or_validity}, has_recs={has_recommendations}, "
-            f"loop={loop_count}/{max_loops}"
-        )
-
-        if should_loop:
-            print("[DEBUG] Routing -> investigate (looping back)")
+        # Loop while there are recommendations for additional evidence to gather
+        if investigation_recommendations:
+            debug_print(f"Has recommendations -> investigate (loop {loop_count}/{max_loops})")
             return "investigate"
 
-        print("[DEBUG] Routing -> publish")
         return "publish"
     except Exception as e:
-        # If there's any error, log it and default to publishing findings
-        import sys
-
-        print(f"[ERROR] Routing function failed: {e}", file=sys.stderr)
+        debug_print(f"Routing function failed: {e} -> publish")
         return "publish"

--- a/app/agent/tools/clients/cloudwatch_client.py
+++ b/app/agent/tools/clients/cloudwatch_client.py
@@ -1,32 +1,22 @@
 """CloudWatch client for metrics and logs - LangChain tool implementation."""
 
-import os
 from typing import Any
 
-from app.agent.tools.clients.env import require_aws_credentials
+from app.agent.tools.clients.env import make_boto3_client, require_aws_credentials
+from app.agent.tools.tool_decorator import tool
 
 try:
-    import boto3
     from botocore.exceptions import ClientError
 except ImportError:
-    boto3 = None  # type: ignore[assignment]
     ClientError = Exception  # type: ignore[assignment, misc]
-
-from app.agent.tools.tool_decorator import tool
 
 
 def _get_cloudwatch_client():
-    """Get or create CloudWatch client."""
-    if boto3 is None:
-        return None
-    return boto3.client("cloudwatch", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    return make_boto3_client("cloudwatch")
 
 
 def _get_cloudwatch_logs_client():
-    """Get or create CloudWatch Logs client."""
-    if boto3 is None:
-        return None
-    return boto3.client("logs", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    return make_boto3_client("logs")
 
 
 def get_metric_statistics(

--- a/app/agent/tools/clients/env.py
+++ b/app/agent/tools/clients/env.py
@@ -26,6 +26,15 @@ def require_env(keys: list[str], *, context: str, hint: str | None = None) -> di
     return _missing_env_error(missing, context=context, hint=hint)
 
 
+def make_boto3_client(service: str):
+    """Return a boto3 client for the given service using the configured AWS region."""
+    try:
+        import boto3 as _boto3
+    except ImportError:
+        return None
+    return _boto3.client(service, region_name=os.getenv("AWS_REGION", "us-east-1"))
+
+
 def require_aws_credentials(*, context: str) -> dict[str, Any] | None:
     try:
         import boto3

--- a/app/agent/tools/clients/lambda_client.py
+++ b/app/agent/tools/clients/lambda_client.py
@@ -1,33 +1,24 @@
 """Lambda client for function inspection and log retrieval."""
 
 import base64
-import os
 from io import BytesIO
 from typing import Any
 from zipfile import ZipFile
 
-from app.agent.tools.clients.env import require_aws_credentials
+from app.agent.tools.clients.env import make_boto3_client, require_aws_credentials
 
 try:
-    import boto3
     from botocore.exceptions import ClientError
 except ImportError:
-    boto3 = None  # type: ignore[assignment]
     ClientError = Exception  # type: ignore[assignment, misc]
 
 
 def _get_lambda_client():
-    """Get or create Lambda client."""
-    if boto3 is None:
-        return None
-    return boto3.client("lambda", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    return make_boto3_client("lambda")
 
 
 def _get_cloudwatch_logs_client():
-    """Get or create CloudWatch Logs client."""
-    if boto3 is None:
-        return None
-    return boto3.client("logs", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    return make_boto3_client("logs")
 
 
 def get_function_configuration(function_name: str) -> dict[str, Any]:

--- a/app/agent/tools/clients/s3_client.py
+++ b/app/agent/tools/clients/s3_client.py
@@ -1,17 +1,14 @@
 """S3 client for data inspection and version tracking."""
 
-import os
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from app.agent.tools.clients.env import require_aws_credentials
+from app.agent.tools.clients.env import make_boto3_client, require_aws_credentials
 
 try:
-    import boto3
     from botocore.exceptions import ClientError
 except ImportError:
-    boto3 = None  # type: ignore[assignment]
     ClientError = Exception  # type: ignore[assignment, misc]
 
 
@@ -53,10 +50,7 @@ class S3ObjectVersion:
 
 
 def _get_s3_client():
-    """Get or create S3 client."""
-    if boto3 is None:
-        return None
-    return boto3.client("s3", region_name=os.getenv("AWS_REGION", "us-east-1"))
+    return make_boto3_client("s3")
 
 
 def head_object(bucket: str, key: str) -> dict[str, Any]:

--- a/app/memories/2026-02-19-test_pipeline-prior000.md
+++ b/app/memories/2026-02-19-test_pipeline-prior000.md
@@ -1,4 +1,4 @@
-# Session: 2026-02-19 09:05:12 UTC
+# Session: 2026-02-19 11:20:05 UTC
 
 - **Pipeline**: test_pipeline
 - **Alert ID**: prior000

--- a/app/memories/2026-02-19-test_pipeline-prior001.md
+++ b/app/memories/2026-02-19-test_pipeline-prior001.md
@@ -1,4 +1,4 @@
-# Session: 2026-02-19 09:05:12 UTC
+# Session: 2026-02-19 11:20:05 UTC
 
 - **Pipeline**: test_pipeline
 - **Alert ID**: prior001

--- a/app/memories/2026-02-19-test_pipeline-prior002.md
+++ b/app/memories/2026-02-19-test_pipeline-prior002.md
@@ -1,4 +1,4 @@
-# Session: 2026-02-19 09:05:12 UTC
+# Session: 2026-02-19 11:20:05 UTC
 
 - **Pipeline**: test_pipeline
 - **Alert ID**: prior002

--- a/app/outbound_telemetry/__init__.py
+++ b/app/outbound_telemetry/__init__.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import os
-import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -29,7 +27,6 @@ from config.grafana_config import (
     build_resource,
     get_aws_lambda_function_name,
     get_otel_exporter_otlp_endpoint,
-    get_otel_exporter_otlp_headers,
     get_otel_exporter_otlp_protocol,
     validate_grafana_cloud_config,
 )
@@ -47,26 +44,6 @@ __all__ = [
 
 _telemetry: PipelineTelemetry | None = None
 _std_logging = importlib.import_module("logging")
-_DEBUG_LOG_PATH = "/Users/janvincentfranciszek/tracer-agent-2026/.cursor/debug.log"
-_DEBUG_SESSION_ID = "debug-session"
-_DEBUG_RUN_ID = "pre-fix"
-
-
-def _debug_log(hypothesis_id: str, location: str, message: str, data: dict) -> None:
-    payload = {
-        "sessionId": _DEBUG_SESSION_ID,
-        "runId": _DEBUG_RUN_ID,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": int(time.time() * 1000),
-    }
-    try:
-        with open(_DEBUG_LOG_PATH, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload) + "\n")
-    except Exception:
-        return
 
 
 @dataclass(frozen=True)
@@ -134,39 +111,6 @@ def init_telemetry(
         return _telemetry
 
     try:
-        # region agent log
-        _debug_log(
-            "H1",
-            "app/outbound_telemetry/__init__.py:init_telemetry",
-            "init_start",
-            {
-                "service_name": service_name,
-                "resource_attr_keys": sorted((resource_attributes or {}).keys()),
-                "env_present": {
-                    "OTEL_EXPORTER_OTLP_ENDPOINT": bool(
-                        os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-                    ),
-                    "OTEL_EXPORTER_OTLP_HEADERS": bool(
-                        os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
-                    ),
-                    "OTEL_EXPORTER_OTLP_PROTOCOL": bool(
-                        os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
-                    ),
-                    "GCLOUD_OTLP_ENDPOINT": bool(os.getenv("GCLOUD_OTLP_ENDPOINT")),
-                    "GCLOUD_OTLP_AUTH_HEADER": bool(
-                        os.getenv("GCLOUD_OTLP_AUTH_HEADER")
-                    ),
-                    "GCLOUD_HOSTED_LOGS_ID": bool(
-                        os.getenv("GCLOUD_HOSTED_LOGS_ID")
-                    ),
-                    "GCLOUD_HOSTED_LOGS_URL": bool(
-                        os.getenv("GCLOUD_HOSTED_LOGS_URL")
-                    ),
-                },
-            },
-        )
-        # endregion agent log
-
         apply_otel_env_defaults()
         config_ok = validate_grafana_cloud_config()
         resource = build_resource(service_name, resource_attributes)
@@ -183,19 +127,6 @@ def init_telemetry(
                 }
             )
         )
-        # region agent log
-        _debug_log(
-            "H2",
-            "app/outbound_telemetry/__init__.py:init_telemetry",
-            "otel_env_resolved",
-            {
-                "config_ok": config_ok,
-                "endpoint": get_otel_exporter_otlp_endpoint(),
-                "protocol": get_otel_exporter_otlp_protocol(default=""),
-                "headers_present": bool(get_otel_exporter_otlp_headers()),
-            },
-        )
-        # endregion agent log
         tracer = setup_tracing(resource)
         metrics = setup_metrics(resource)
 
@@ -212,14 +143,6 @@ def init_telemetry(
 
         _telemetry = PipelineTelemetry(tracer=tracer, metrics=metrics)
     except Exception as exc:  # noqa: BLE001 - avoid breaking pipelines on telemetry failures
-        # region agent log
-        _debug_log(
-            "H5",
-            "app/outbound_telemetry/__init__.py:init_telemetry",
-            "init_failed",
-            {"error_type": type(exc).__name__, "error_message": str(exc)},
-        )
-        # endregion agent log
         _std_logging.getLogger(__name__).warning("Telemetry init failed: %s", exc)
         _telemetry = PipelineTelemetry(
             tracer=trace.get_tracer(__name__), metrics=PipelineMetrics.noop()

--- a/app/outbound_telemetry/logging.py
+++ b/app/outbound_telemetry/logging.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import sys
-import time
 
 from opentelemetry import trace
 
@@ -12,27 +11,6 @@ from config.grafana_config import (
     get_otel_exporter_otlp_protocol,
     parse_otel_headers,
 )
-
-_DEBUG_LOG_PATH = "/Users/janvincentfranciszek/tracer-agent-2026/.cursor/debug.log"
-_DEBUG_SESSION_ID = "debug-session"
-_DEBUG_RUN_ID = "pre-fix"
-
-
-def _debug_log(hypothesis_id: str, location: str, message: str, data: dict) -> None:
-    payload = {
-        "sessionId": _DEBUG_SESSION_ID,
-        "runId": _DEBUG_RUN_ID,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": int(time.time() * 1000),
-    }
-    try:
-        with open(_DEBUG_LOG_PATH, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload) + "\n")
-    except Exception:
-        return
 
 
 def _get_log_exporter():
@@ -106,19 +84,6 @@ def setup_logging(resource) -> None:
     logs_endpoint = endpoint
     if protocol in ("http/protobuf", "http") and endpoint and not endpoint.endswith("/v1/logs"):
         logs_endpoint = endpoint.rstrip("/") + "/v1/logs"
-    # region agent log
-    _debug_log(
-        "H3",
-        "app/outbound_telemetry/logging.py:setup_logging",
-        "log_exporter_status",
-        {
-            "exporter": exporter.__class__.__name__ if exporter else None,
-            "protocol": protocol,
-            "endpoint": endpoint,
-            "logs_endpoint": logs_endpoint if exporter else None,
-        },
-    )
-    # endregion agent log
     if exporter is None:
         logging.getLogger(__name__).warning("OTLP log exporter is unavailable")
         return

--- a/tests/benchmark_service_map_performance.py
+++ b/tests/benchmark_service_map_performance.py
@@ -236,6 +236,3 @@ This needs investigation:
 
     results_file.write_text(content)
     print(f"\n✓ Results written to: {results_file.name}")
-
-
-import json

--- a/tests/outbound_telemetry/conftest.py
+++ b/tests/outbound_telemetry/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def temp_env(values: dict[str, str]):
+    original = os.environ.copy()
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original)

--- a/tests/outbound_telemetry/grafana_client_test.py
+++ b/tests/outbound_telemetry/grafana_client_test.py
@@ -1,18 +1,5 @@
-import os
-from contextlib import contextmanager
-
 from app.outbound_telemetry.grafana_client import GrafanaCloudClient
-
-
-@contextmanager
-def temp_env(values: dict[str, str]):
-    original = os.environ.copy()
-    os.environ.update(values)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(original)
+from tests.outbound_telemetry.conftest import temp_env
 
 
 def test_grafana_client_builders():

--- a/tests/outbound_telemetry/logging_test.py
+++ b/tests/outbound_telemetry/logging_test.py
@@ -1,6 +1,4 @@
 import logging
-import os
-from contextlib import contextmanager
 
 from opentelemetry.sdk.resources import Resource
 
@@ -9,17 +7,7 @@ from app.outbound_telemetry.logging import (
     ensure_otel_logging,
     setup_logging,
 )
-
-
-@contextmanager
-def temp_env(values: dict[str, str]):
-    original = os.environ.copy()
-    os.environ.update(values)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(original)
+from tests.outbound_telemetry.conftest import temp_env
 
 
 def test_setup_logging_and_ensure_handler():

--- a/tests/outbound_telemetry/metrics_test.py
+++ b/tests/outbound_telemetry/metrics_test.py
@@ -1,20 +1,7 @@
-import os
-from contextlib import contextmanager
-
 from opentelemetry.sdk.resources import Resource
 
 from app.outbound_telemetry.metrics import PipelineMetrics, setup_metrics
-
-
-@contextmanager
-def temp_env(values: dict[str, str]):
-    original = os.environ.copy()
-    os.environ.update(values)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(original)
+from tests.outbound_telemetry.conftest import temp_env
 
 
 def test_setup_metrics_returns_pipeline_metrics():

--- a/tests/outbound_telemetry/tracing_test.py
+++ b/tests/outbound_telemetry/tracing_test.py
@@ -1,20 +1,7 @@
-import os
-from contextlib import contextmanager
-
 from opentelemetry.sdk.resources import Resource
 
 from app.outbound_telemetry.tracing import setup_tracing, traced_operation
-
-
-@contextmanager
-def temp_env(values: dict[str, str]):
-    original = os.environ.copy()
-    os.environ.update(values)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(original)
+from tests.outbound_telemetry.conftest import temp_env
 
 
 def test_setup_tracing_and_traced_operation():

--- a/tests/shared/infra.py
+++ b/tests/shared/infra.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import os
+
+
+def infrastructure_available() -> bool:
+    """Return True when AWS infrastructure is available (not CI and not explicitly skipped)."""
+    return not (os.getenv("CI") or os.getenv("SKIP_INFRA_TESTS"))

--- a/tests/test_case_upstream_apache_flink_ecs/conftest.py
+++ b/tests/test_case_upstream_apache_flink_ecs/conftest.py
@@ -4,21 +4,15 @@ These tests require deployed AWS infrastructure and should be skipped in CI.
 Run manually with: pytest tests/test_case_upstream_apache_flink_ecs/ -v
 """
 
-import os
-
 import pytest
 
-
-def _infrastructure_available() -> bool:
-    """Check if AWS infrastructure is available for testing."""
-    # Skip if running in CI or if explicitly disabled
-    return not (os.getenv("CI") or os.getenv("SKIP_INFRA_TESTS"))
+from tests.shared.infra import infrastructure_available
 
 
 @pytest.fixture(scope="session")
 def failure_data() -> dict:
     """Fixture for Flink pipeline failure data - skip if infrastructure unavailable."""
-    if not _infrastructure_available():
+    if not infrastructure_available():
         pytest.skip("Infrastructure tests skipped in CI - run manually")
 
     from tests.test_case_upstream_apache_flink_ecs.test_agent_e2e import (

--- a/tests/test_case_upstream_lambda/conftest.py
+++ b/tests/test_case_upstream_lambda/conftest.py
@@ -4,21 +4,15 @@ These tests require deployed AWS infrastructure and should be skipped in CI.
 Run manually with: pytest tests/test_case_upstream_lambda/ -v
 """
 
-import os
-
 import pytest
 
-
-def _infrastructure_available() -> bool:
-    """Check if AWS infrastructure is available for testing."""
-    # Skip if running in CI or if explicitly disabled
-    return not (os.getenv("CI") or os.getenv("SKIP_INFRA_TESTS"))
+from tests.shared.infra import infrastructure_available
 
 
 @pytest.fixture
 def stack_outputs() -> dict:
     """Fixture for CDK stack outputs - skip if infrastructure unavailable."""
-    if not _infrastructure_available():
+    if not infrastructure_available():
         pytest.skip("Infrastructure tests skipped in CI - run manually")
     # Return placeholder - actual values come from CDK deployment
     return {}
@@ -27,7 +21,7 @@ def stack_outputs() -> dict:
 @pytest.fixture(scope="session")
 def failure_data() -> dict:
     """Fixture for pipeline failure data - skip if infrastructure unavailable."""
-    if not _infrastructure_available():
+    if not infrastructure_available():
         pytest.skip("Infrastructure tests skipped in CI - run manually")
     from tests.test_case_upstream_lambda.test_agent_e2e import trigger_pipeline_failure
 

--- a/tests/test_case_upstream_prefect_ecs_fargate/conftest.py
+++ b/tests/test_case_upstream_prefect_ecs_fargate/conftest.py
@@ -4,20 +4,15 @@ These tests require deployed AWS infrastructure and should be skipped in CI.
 Run manually with: pytest tests/test_case_upstream_prefect_ecs_fargate/ -v
 """
 
-import os
-
 import pytest
 
-
-def _infrastructure_available() -> bool:
-    """Check if AWS infrastructure is available for testing."""
-    return not (os.getenv("CI") or os.getenv("SKIP_INFRA_TESTS"))
+from tests.shared.infra import infrastructure_available
 
 
 @pytest.fixture(scope="session")
 def failure_data() -> dict:
     """Fixture for Prefect pipeline failure data - skip if infrastructure unavailable."""
-    if not _infrastructure_available():
+    if not infrastructure_available():
         pytest.skip("Infrastructure tests skipped in CI - run manually")
 
     from tests.test_case_upstream_prefect_ecs_fargate.test_agent_e2e import (


### PR DESCRIPTION
- Remove temporary _debug_log instrumentation with hardcoded local paths from outbound_telemetry/__init__.py and logging.py
- Simplify should_continue_investigation() routing logic: remove redundant boolean expression and replace print() calls with debug_print
- Extract shared make_boto3_client() factory to env.py; use in s3, cloudwatch, lambda clients (removes repeated boto3.client + region pattern)
- Extract temp_env context manager from 5 test files into shared conftest.py
- Extract infrastructure_available() from 3 test conftest files into shared infra.py
- Unify memory context loading in frame_problem.py to match root_cause_diagnosis pattern
- Remove duplicate import json in benchmark, unused tool import in cloudwatch client