### PR TITLE
fix: resolve investigation failures for audit trail and external API detection

### DIFF
--- a/app/agent/nodes/investigate/processing/post_process.py
+++ b/app/agent/nodes/investigate/processing/post_process.py
@@ -120,6 +120,16 @@ def _map_lambda_configuration(data: dict) -> dict:
     }
 
 
+def _map_check_s3_marker(data: dict) -> dict:
+    return {
+        "s3_marker": {
+            "marker_exists": data.get("marker_exists", False),
+            "file_count": data.get("file_count", 0),
+            "files": data.get("files", []),
+        }
+    }
+
+
 def _map_s3_object(data: dict) -> dict:
     return {
         "s3_audit_payload": {
@@ -199,6 +209,7 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "get_host_metrics": _map_host_metrics,
     "get_cloudwatch_logs": _map_cloudwatch_logs,
     "inspect_s3_object": _map_inspect_s3_object,
+    "check_s3_marker": _map_check_s3_marker,
     "list_s3_objects": _map_list_s3_objects,
     "get_lambda_invocation_logs": _map_lambda_invocation_logs,
     "get_lambda_errors": _map_lambda_errors,

--- a/app/agent/nodes/plan_actions/plan_actions.py
+++ b/app/agent/nodes/plan_actions/plan_actions.py
@@ -90,6 +90,15 @@ def plan_actions(
         available_sources=available_sources,
         memory_context=memory_context,
     )
+
+    # Ensure audit trail is fetched when s3_audit source is available
+    if (
+        "s3_audit" in available_sources
+        and "get_s3_object" not in plan.actions
+        and "get_s3_object" in available_action_names
+    ):
+        plan.actions.append("get_s3_object")
+
     print(f"[DEBUG] LLM Plan: {plan.actions}")
     print(f"[DEBUG] Rationale: {plan.rationale[:200]}")
     debug_print(f"Plan: {plan.actions} | {plan.rationale[:100]}...")

--- a/app/agent/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/agent/nodes/root_cause_diagnosis/evidence_checker.py
@@ -29,6 +29,11 @@ def check_evidence_availability(
         or evidence.get("datadog_logs")
         or evidence.get("datadog_monitors")
         or evidence.get("datadog_events")
+        or evidence.get("s3_object", {}).get("found")
+        or evidence.get("s3_audit_payload", {}).get("found")
+        or evidence.get("s3_marker")
+        or evidence.get("lambda_function")
+        or evidence.get("lambda_logs")
     )
 
     # Check for evidence in alert annotations
@@ -40,6 +45,7 @@ def check_evidence_availability(
                 annotations.get("log_excerpt")
                 or annotations.get("failed_steps")
                 or annotations.get("error")
+                or annotations.get("error_message")
                 or annotations.get("cloudwatch_logs_url")
             )
 

--- a/app/agent/nodes/root_cause_diagnosis/node.py
+++ b/app/agent/nodes/root_cause_diagnosis/node.py
@@ -7,7 +7,7 @@ from app.agent.state import InvestigationState
 from app.agent.tools.clients import get_llm, parse_root_cause
 
 from .claim_validator import calculate_validity_score, validate_and_categorize_claims
-from .evidence_checker import check_evidence_availability
+from .evidence_checker import check_evidence_availability, check_vendor_evidence_missing
 from .prompt_builder import build_diagnosis_prompt
 
 
@@ -77,6 +77,11 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
 
     loop_count = state.get("investigation_loop_count", 0)
 
+    # Generate recommendations when vendor/audit evidence is missing
+    recommendations: list[str] = []
+    if check_vendor_evidence_missing(evidence) and loop_count < 3:
+        recommendations.append("Fetch audit payload from S3 to trace external vendor interactions")
+
     tracker.complete(
         "diagnose_root_cause",
         fields_updated=["root_cause", "confidence", "validated_claims", "validity_score"],
@@ -89,7 +94,7 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
         "validated_claims": validated_claims_list,
         "non_validated_claims": non_validated_claims_list,
         "validity_score": validity_score,
-        "investigation_recommendations": [],
+        "investigation_recommendations": recommendations,
         "remediation_steps": [],
         "investigation_loop_count": loop_count,
     }

--- a/app/agent/tools/tool_actions/aws/s3_actions.py
+++ b/app/agent/tools/tool_actions/aws/s3_actions.py
@@ -5,7 +5,6 @@ No printing, no LLM calls. Just fetch data and return typed results.
 """
 
 from app.agent.tools.clients.s3_client import (
-    S3CheckResult,
     compare_versions,
     get_full_object,
     get_object_metadata,
@@ -17,7 +16,7 @@ from app.agent.tools.clients.s3_client import (
 )
 
 
-def check_s3_marker(bucket: str, prefix: str) -> S3CheckResult:
+def check_s3_marker(bucket: str, prefix: str) -> dict:
     """
     Check if _SUCCESS marker exists in S3 storage.
 
@@ -29,10 +28,15 @@ def check_s3_marker(bucket: str, prefix: str) -> S3CheckResult:
         prefix: S3 key prefix (path) where the marker should be located
 
     Returns:
-        S3CheckResult with marker existence status and file count
+        Dictionary with marker existence status and file count
     """
     client = get_s3_client()
-    return client.check_marker(bucket, prefix)
+    result = client.check_marker(bucket, prefix)
+    return {
+        "marker_exists": result.marker_exists,
+        "file_count": result.file_count,
+        "files": result.files,
+    }
 
 
 def inspect_s3_object(bucket: str, key: str) -> dict:


### PR DESCRIPTION
## Summary

Fixes the two failing CI test cases (`test-thorough (flink-ecs)` and `test-thorough (prefect-ecs-fargate)`) by addressing five interconnected bugs in the investigation pipeline:

- **`check_s3_marker` type mismatch**: Returned `S3CheckResult` dataclass instead of `dict`, causing `execute_actions.py` to reject it with "Invalid response"
- **Missing evidence mapper**: `check_s3_marker` had no entry in `EVIDENCE_MAPPERS`, so marker data was never added to evidence state
- **Evidence checker too restrictive**: Only recognized CloudWatch/Grafana/Datadog evidence, ignoring S3/Lambda evidence and `error_message` annotations — causing the prefect test to hit the "insufficient evidence" path (0.2% confidence)
- **Audit payload not fetched**: LLM planner didn't reliably select `get_s3_object` even when `s3_audit` source was available. Now auto-included when audit source is detected
- **Investigation never looped**: `diagnose_root_cause` always returned empty `investigation_recommendations`, so the investigation loop never triggered for additional evidence gathering. Now generates recommendations when vendor/audit evidence is missing

## Test plan

- [x] `make test` passes locally (prefect E2E test now passes all 5/5 checks)
- [x] All 15 unit tests pass
- [x] `ruff check` clean
- [ ] CI should pass both `test-thorough (flink-ecs)` and `test-thorough (prefect-ecs-fargate)`

Made with [Cursor](https://cursor.com)