### PR TITLE
fix: stabilize k8s alert trigger without EKS redeploy

### DIFF
--- a/tests/shared/infrastructure_sdk/trigger_config.py
+++ b/tests/shared/infrastructure_sdk/trigger_config.py
@@ -1,0 +1,178 @@
+"""Centralized config manager for Kubernetes trigger API URL."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from tests.shared.infrastructure_sdk.config import OUTPUTS_DIR, load_outputs
+from tests.shared.infrastructure_sdk.deployer import get_boto3_client
+from tests.test_case_kubernetes.infrastructure_sdk.eks import (
+    ECR_REPO_NAME,
+    REGION,
+    STACK_NAME,
+    TRIGGER_LAMBDA_NAME,
+)
+
+TRIGGER_CONFIG_NAME = "tracer-k8s-trigger"
+TRIGGER_CONFIG_PATH = OUTPUTS_DIR / f"{TRIGGER_CONFIG_NAME}.json"
+
+
+def load_trigger_config() -> dict[str, Any]:
+    if not TRIGGER_CONFIG_PATH.exists():
+        raise FileNotFoundError(
+            f"Missing trigger config: {TRIGGER_CONFIG_PATH}. Run: make regen-trigger-config"
+        )
+
+    with open(TRIGGER_CONFIG_PATH) as f:
+        payload = json.load(f)
+
+    trigger_api_url = (payload.get("trigger_api_url") or "").strip()
+    if not trigger_api_url:
+        raise ValueError(
+            f"Invalid trigger config (missing trigger_api_url): {TRIGGER_CONFIG_PATH}. "
+            "Run: make regen-trigger-config"
+        )
+    return payload
+
+
+def save_trigger_config(trigger_api_url: str) -> Path:
+    OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "stack_name": STACK_NAME,
+        "region": REGION,
+        "trigger_api_url": trigger_api_url.rstrip("/"),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    with open(TRIGGER_CONFIG_PATH, "w") as f:
+        json.dump(payload, f, indent=2)
+    return TRIGGER_CONFIG_PATH
+
+
+def _discover_trigger_api_url() -> str | None:
+    # First: check SDK outputs file if it has trigger API URL
+    try:
+        outputs = load_outputs(STACK_NAME)
+        from_outputs = (outputs.get("trigger_api_url") or "").strip().rstrip("/")
+        if from_outputs:
+            return from_outputs
+    except FileNotFoundError:
+        pass
+
+    # Fallback: discover API Gateway via AWS tags
+    tagger = get_boto3_client("resourcegroupstaggingapi", REGION)
+    rest_api_id = None
+    paginator = tagger.get_paginator("get_resources")
+    for page in paginator.paginate(
+        TagFilters=[
+            {"Key": "tracer:stack", "Values": [STACK_NAME]},
+            {"Key": "tracer:managed", "Values": ["sdk"]},
+        ],
+        ResourceTypeFilters=["apigateway:restapis"],
+    ):
+        for resource in page.get("ResourceTagMappingList", []):
+            arn = resource.get("ResourceARN", "")
+            marker = "/restapis/"
+            if marker in arn:
+                rest_api_id = arn.split(marker, 1)[1].split("/", 1)[0]
+                break
+        if rest_api_id:
+            break
+
+    if not rest_api_id:
+        return None
+
+    api_client = get_boto3_client("apigateway", REGION)
+    stages = api_client.get_stages(restApiId=rest_api_id).get("item", [])
+    stage_name = "prod"
+    if not any(stage.get("stageName") == "prod" for stage in stages):
+        stage_name = stages[0]["stageName"] if stages else "prod"
+
+    return f"https://{rest_api_id}.execute-api.{REGION}.amazonaws.com/{stage_name}"
+
+
+def discover_runtime_outputs() -> dict[str, str] | None:
+    """Discover runtime outputs without mutating infrastructure."""
+    try:
+        outputs = load_outputs(STACK_NAME)
+        if outputs.get("landing_bucket") and outputs.get("processed_bucket") and outputs.get("ecr_image_uri"):
+            return {
+                "landing_bucket": outputs["landing_bucket"],
+                "processed_bucket": outputs["processed_bucket"],
+                "ecr_image_uri": outputs["ecr_image_uri"],
+            }
+    except FileNotFoundError:
+        pass
+
+    lambda_client = get_boto3_client("lambda", REGION)
+    try:
+        env = lambda_client.get_function_configuration(
+            FunctionName=TRIGGER_LAMBDA_NAME
+        ).get("Environment", {}).get("Variables", {})
+    except Exception:
+        env = {}
+
+    landing = (env.get("LANDING_BUCKET") or "").strip()
+    processed = (env.get("PROCESSED_BUCKET") or "").strip()
+    image_uri = (env.get("IMAGE_URI") or "").strip()
+    if landing and processed and image_uri:
+        return {
+            "landing_bucket": landing,
+            "processed_bucket": processed,
+            "ecr_image_uri": image_uri,
+        }
+
+    tagger = get_boto3_client("resourcegroupstaggingapi", REGION)
+    s3_client = get_boto3_client("s3", REGION)
+    ecr_client = get_boto3_client("ecr", REGION)
+    created_at = {
+        bucket["Name"]: bucket["CreationDate"]
+        for bucket in s3_client.list_buckets().get("Buckets", [])
+    }
+
+    bucket_names: list[str] = []
+    paginator = tagger.get_paginator("get_resources")
+    for page in paginator.paginate(
+        TagFilters=[
+            {"Key": "tracer:stack", "Values": [STACK_NAME]},
+            {"Key": "tracer:managed", "Values": ["sdk"]},
+        ],
+        ResourceTypeFilters=["s3"],
+    ):
+        for resource in page.get("ResourceTagMappingList", []):
+            arn = resource.get("ResourceARN", "")
+            if arn.startswith("arn:aws:s3:::"):
+                bucket_names.append(arn.split(":::")[1])
+
+    landing_buckets = [b for b in bucket_names if b.startswith("tracer-k8s-landing-")]
+    processed_buckets = [b for b in bucket_names if b.startswith("tracer-k8s-processed-")]
+    if not landing_buckets or not processed_buckets:
+        return None
+
+    def _latest_bucket(names: list[str]) -> str:
+        return max(names, key=lambda n: created_at.get(n))
+
+    try:
+        repo = ecr_client.describe_repositories(repositoryNames=[ECR_REPO_NAME])
+        repo_uri = repo["repositories"][0]["repositoryUri"]
+        image_uri = f"{repo_uri}:latest"
+    except Exception:
+        return None
+
+    return {
+        "landing_bucket": _latest_bucket(landing_buckets),
+        "processed_bucket": _latest_bucket(processed_buckets),
+        "ecr_image_uri": image_uri,
+    }
+
+
+def regenerate_trigger_config() -> Path:
+    trigger_api_url = _discover_trigger_api_url()
+    if not trigger_api_url:
+        raise RuntimeError(
+            "Could not discover trigger API URL from AWS tags. "
+            "Ensure trigger API exists and is tagged with tracer:stack=tracer-eks-k8s-test."
+        )
+    return save_trigger_config(trigger_api_url)

--- a/tests/test_case_kubernetes/infrastructure_sdk/eks.py
+++ b/tests/test_case_kubernetes/infrastructure_sdk/eks.py
@@ -339,6 +339,38 @@ def update_kubeconfig() -> None:
     )
 
 
+def cluster_exists() -> bool:
+    """Return True if the EKS cluster exists."""
+    eks_client = get_boto3_client("eks", REGION)
+    try:
+        eks_client.describe_cluster(name=CLUSTER_NAME)
+        return True
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ResourceNotFoundException":
+            return False
+        raise
+
+
+def ensure_nodegroup_capacity() -> None:
+    """Ensure the EKS cluster has an ACTIVE managed node group without redeploying cluster."""
+    status = _cluster_exists()
+    if status != "ACTIVE":
+        raise RuntimeError(
+            f"EKS cluster {CLUSTER_NAME} is not ACTIVE (status={status}). "
+            "Create or recover the cluster before running tests."
+        )
+
+    node_status = _node_group_exists()
+    if node_status == "ACTIVE":
+        return
+
+    node_role = _create_node_role()
+    vpc_info = vpc.get_default_vpc(REGION)
+    subnet_ids = vpc.get_public_subnets(vpc_info["vpc_id"], REGION)
+    subnet_ids = _filter_eks_subnets(subnet_ids)
+    _create_node_group(node_role["arn"], subnet_ids)
+
+
 # ---------------------------------------------------------------------------
 # Subnet filtering
 # ---------------------------------------------------------------------------
@@ -383,9 +415,29 @@ def _enable_api_auth_mode() -> None:
         pass
 
 
+def _wait_for_auth_mode(expected: str, timeout: int = 180) -> bool:
+    """Wait until cluster accessConfig.authenticationMode reaches expected value."""
+    eks_client = get_boto3_client("eks", REGION)
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        try:
+            resp = eks_client.describe_cluster(name=CLUSTER_NAME)
+            mode = resp["cluster"]["accessConfig"]["authenticationMode"]
+            if mode == expected:
+                return True
+        except ClientError:
+            pass
+        time.sleep(5)
+    return False
+
+
 def _grant_ci_access() -> None:
     """Grant the CI IAM principal cluster admin access."""
     eks_client = get_boto3_client("eks", REGION)
+    if not _wait_for_auth_mode("API_AND_CONFIG_MAP", timeout=240):
+        raise RuntimeError(
+            "EKS auth mode did not become API_AND_CONFIG_MAP in time; cannot create access entry yet."
+        )
     try:
         eks_client.create_access_entry(
             clusterName=CLUSTER_NAME,
@@ -559,16 +611,25 @@ def deploy_trigger_lambda(outputs: dict[str, Any]) -> str:
     time.sleep(5)  # IAM propagation
 
     # 2. Grant Lambda role access to EKS cluster
+    _enable_api_auth_mode()
     eks_client = get_boto3_client("eks", REGION)
-    try:
-        eks_client.create_access_entry(
-            clusterName=CLUSTER_NAME,
-            principalArn=role["arn"],
-            type="STANDARD",
-        )
-        print("  Created EKS access entry for Lambda role")
-    except ClientError as e:
-        if e.response["Error"]["Code"] != "ResourceInUseException":
+    for attempt in range(10):
+        try:
+            eks_client.create_access_entry(
+                clusterName=CLUSTER_NAME,
+                principalArn=role["arn"],
+                type="STANDARD",
+            )
+            print("  Created EKS access entry for Lambda role")
+            break
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code == "ResourceInUseException":
+                break
+            if code == "InvalidRequestException" and "authentication mode" in str(e):
+                if attempt < 9:
+                    time.sleep(10)
+                    continue
             raise
 
     with contextlib.suppress(ClientError):

--- a/tests/test_case_kubernetes/infrastructure_sdk/local.py
+++ b/tests/test_case_kubernetes/infrastructure_sdk/local.py
@@ -140,7 +140,14 @@ def deploy_datadog_helm(values_file: str, namespace: str) -> None:
         cmd.extend(["--set", f"datadog.site={site}"])
 
     print("Installing Datadog Helm chart...")
-    _run(cmd, capture=False)
+    try:
+        _run(cmd, capture=False)
+    except subprocess.CalledProcessError:
+        # Datadog operator/cluster-agent can exceed helm --wait timeout on fresh installs.
+        # Retry without blocking wait and let wait_for_datadog_agent handle readiness.
+        cmd_no_wait = [arg for arg in cmd if arg not in {"--wait", "--timeout", "3m"}]
+        print("Helm wait timed out, retrying install without --wait...")
+        _run(cmd_no_wait, capture=False)
     print("Datadog Helm chart installed")
 
 

--- a/tests/test_case_kubernetes/test_eks.py
+++ b/tests/test_case_kubernetes/test_eks.py
@@ -28,9 +28,11 @@ import sys
 import uuid
 
 from tests.shared.infrastructure_sdk.config import load_outputs
+from tests.shared.infrastructure_sdk.trigger_config import discover_runtime_outputs
 from tests.test_case_kubernetes.infrastructure_sdk.eks import (
     deploy_eks_stack,
     destroy_eks_stack,
+    ensure_nodegroup_capacity,
     get_ecr_image_uri,
     update_kubeconfig,
 )
@@ -99,8 +101,16 @@ def main() -> int:
             deploy_eks_stack()
         else:
             update_kubeconfig()
+            ensure_nodegroup_capacity()
 
-        config = load_outputs("tracer-eks-k8s-test")
+        try:
+            config = load_outputs("tracer-eks-k8s-test")
+        except FileNotFoundError:
+            fallback = discover_runtime_outputs()
+            if not fallback:
+                print("FAIL: Could not resolve EKS runtime outputs from local file or AWS tags")
+                return 1
+            config = fallback
         image_uri = config["ecr_image_uri"]
         print(f"Using ECR image: {image_uri}")
 

--- a/tests/test_case_kubernetes/trigger_alert.py
+++ b/tests/test_case_kubernetes/trigger_alert.py
@@ -1,21 +1,14 @@
 #!/usr/bin/env python3
 """
-Fast alert trigger: run the 3-stage ETL pipeline on EKS with bad data.
+Fast alert trigger and verification for Kubernetes test case.
 
-Flow:
-  1. Upload bad data to S3 (missing customer_id)
-  2. Submit extract job -> wait for completion
-  3. Submit transform job -> wait for failure (schema validation error)
-  4. Poll Datadog Logs API until PIPELINE_ERROR appears
-  5. Optionally verify Slack alert
+Default mode triggers the failure via trigger API URL from centralized JSON config.
+Config file: tests/shared/infrastructure_sdk/outputs/tracer-k8s-trigger.json
 
 Usage:
     python -m tests.test_case_kubernetes.trigger_alert
     python -m tests.test_case_kubernetes.trigger_alert --verify
-    python -m tests.test_case_kubernetes.trigger_alert --configure-kubectl --verify
-
-    # Verify only (after a trigger already happened via API or other means):
-    python -m tests.test_case_kubernetes.trigger_alert --verify-only
+    python -m tests.test_case_kubernetes.trigger_alert --regen-config
     python -m tests.test_case_kubernetes.trigger_alert --verify-only --since-epoch 1771466422
 """
 
@@ -28,33 +21,39 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
 import urllib.request
-import uuid
 
-from tests.shared.infrastructure_sdk.config import load_outputs
+import boto3
 from tests.shared.slack_polling import get_channel_id, poll_for_message
-from tests.test_case_kubernetes.infrastructure_sdk.eks import (
-    get_ecr_image_uri,
-    update_kubeconfig,
+from tests.shared.infrastructure_sdk.trigger_config import (
+    load_trigger_config,
+    regenerate_trigger_config,
 )
-from tests.utils.s3_upload_validate import INVALID_PAYLOAD, upload_test_data
+from tests.test_case_kubernetes.infrastructure_sdk.eks import cluster_exists
 
-NAMESPACE = "tracer-test"
-BASE_DIR = os.path.dirname(__file__)
-MANIFESTS_DIR = os.path.join(BASE_DIR, "k8s_manifests")
+
+def _trigger_via_api(trigger_api_url: str) -> dict:
+    url = trigger_api_url.rstrip("/") + "/trigger?inject_error=true"
+    req = urllib.request.Request(url, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        if exc.code == 504:
+            # API Gateway timed out waiting, but Lambda may still be executing.
+            return {
+                "status": "accepted_timeout",
+                "http_status": 504,
+                "raw_body": body,
+            }
+        raise RuntimeError(f"HTTP {exc.code} from trigger API: {body}") from exc
+    return payload if isinstance(payload, dict) else {}
 
 
 def _run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, check=check, capture_output=True, text=True)
-
-
-def _load_config() -> dict:
-    outputs = load_outputs("tracer-eks-k8s-test")
-    return {
-        "landing_bucket": outputs["landing_bucket"],
-        "processed_bucket": outputs["processed_bucket"],
-        "ecr_image_uri": outputs["ecr_image_uri"],
-    }
 
 
 def _render_eks_manifest(
@@ -66,11 +65,11 @@ def _render_eks_manifest(
     pipeline_run_id: str,
     image_uri: str,
 ) -> str:
-    """Render manifest for EKS: replace templates, set ECR image, Always pull."""
+    """Compatibility helper used by test_eks flow."""
     with open(manifest_path) as f:
         content = f.read()
 
-    return (
+    rendered = (
         content.replace("{{LANDING_BUCKET}}", landing_bucket)
         .replace("{{PROCESSED_BUCKET}}", processed_bucket)
         .replace("{{S3_KEY}}", s3_key)
@@ -79,42 +78,55 @@ def _render_eks_manifest(
         .replace("imagePullPolicy: Never", "imagePullPolicy: Always")
     )
 
+    creds = boto3.Session().get_credentials()
+    frozen = creds.get_frozen_credentials() if creds else None
+    if frozen:
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        credentials_env = (
+            f'            - name: AWS_ACCESS_KEY_ID\n'
+            f'              value: "{frozen.access_key}"\n'
+            f'            - name: AWS_SECRET_ACCESS_KEY\n'
+            f'              value: "{frozen.secret_key}"\n'
+            f'            - name: AWS_SESSION_TOKEN\n'
+            f'              value: "{frozen.token or ""}"\n'
+            f'            - name: AWS_REGION\n'
+            f'              value: "{region}"\n'
+            f'            - name: AWS_DEFAULT_REGION\n'
+            f'              value: "{region}"\n'
+        )
+        rendered = rendered.replace(
+            f'            - name: PIPELINE_RUN_ID\n'
+            f'              value: "{pipeline_run_id}"\n',
+            f'            - name: PIPELINE_RUN_ID\n'
+            f'              value: "{pipeline_run_id}"\n'
+            + credentials_env,
+        )
+
+    return rendered
+
 
 def _apply_manifest(content: str) -> None:
+    """Compatibility helper used by test_eks flow."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         f.write(content)
         path = f.name
-    _run(["kubectl", "apply", "-f", path])
-    os.unlink(path)
+    try:
+        _run(["kubectl", "apply", "-f", path])
+    finally:
+        os.unlink(path)
 
 
 def _delete_job(job_name: str) -> None:
-    _run(["kubectl", "delete", "job", job_name, "-n", NAMESPACE, "--ignore-not-found"], check=False)
+    """Compatibility helper used by test_eks flow."""
+    _run(["kubectl", "delete", "job", job_name, "-n", "tracer-test", "--ignore-not-found"], check=False)
 
 
-def _wait_for_job(job_name: str, timeout: int = 120) -> str:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        result = _run(
-            ["kubectl", "get", "job", job_name, "-n", NAMESPACE,
-             "-o", "jsonpath={.status.conditions[*].type}"],
-            check=False,
-        )
-        conditions = result.stdout.strip()
-        if "Failed" in conditions:
-            return "failed"
-        if "Complete" in conditions:
-            return "complete"
-        time.sleep(1)
-    return "timeout"
-
-
-def _get_logs(label: str) -> str:
-    result = _run(
-        ["kubectl", "logs", "-l", label, "-n", NAMESPACE, "--all-containers=true"],
-        check=False,
-    )
-    return (result.stdout + result.stderr).strip()
+def _load_or_regen_trigger_config() -> dict:
+    try:
+        return load_trigger_config()
+    except Exception:
+        regenerate_trigger_config()
+        return load_trigger_config()
 
 
 # ---------------------------------------------------------------------------
@@ -221,87 +233,52 @@ def verify(since_epoch: float, *, dd_max_wait: int = 120, slack_max_wait: int = 
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="K8s ETL pipeline alert trigger and verifier")
-    parser.add_argument("--configure-kubectl", action="store_true", help="Run aws eks update-kubeconfig first")
+    parser = argparse.ArgumentParser(description="K8s trigger alert and verifier")
+    parser.add_argument("--regen-config", action="store_true", help="Regenerate centralized trigger config JSON")
     parser.add_argument("--verify", action="store_true", help="Verify logs in DD + wait for DD alert in Slack")
     parser.add_argument("--verify-only", action="store_true", help="Skip trigger, only run DD + Slack verification")
     parser.add_argument("--since-epoch", type=float, default=None, help="Unix timestamp to search Slack from (for --verify-only)")
     args = parser.parse_args()
+
+    if args.regen_config:
+        try:
+            path = regenerate_trigger_config()
+            print(f"Trigger config regenerated: {path}")
+            return 0
+        except Exception as exc:
+            print(f"ERROR: {exc}")
+            return 1
 
     since_epoch = args.since_epoch or time.time()
 
     if args.verify_only:
         return verify(since_epoch)
 
-    start = time.monotonic()
     start_epoch = time.time()
-
-    if args.configure_kubectl:
-        update_kubeconfig()
-
-    config = _load_config()
-    image_uri = config["ecr_image_uri"]
-    run_id = f"alert-{uuid.uuid4().hex[:8]}"
-
-    common = {
-        "landing_bucket": config["landing_bucket"],
-        "processed_bucket": config["processed_bucket"],
-        "pipeline_run_id": run_id,
-        "image_uri": image_uri,
-    }
-
-    print("Uploading bad test data to S3...")
-    test_data = upload_test_data(config["landing_bucket"], INVALID_PAYLOAD)
-
-    print("\nCleaning up old jobs...")
-    for job in ("etl-extract", "etl-transform", "etl-transform-error"):
-        _delete_job(job)
-
-    print("Submitting extract job to EKS...")
-    extract_content = _render_eks_manifest(
-        os.path.join(MANIFESTS_DIR, "job-extract.yaml"),
-        s3_key=test_data.key,
-        **common,
-    )
-    _apply_manifest(extract_content)
-
-    print("Waiting for extract to complete...")
-    status = _wait_for_job("etl-extract")
-    if status != "complete":
-        logs = _get_logs("stage=extract")
-        print(f"FAIL: extract {status}\n{logs}")
-        return 1
-    print("  Extract completed")
-
-    print("Submitting transform job to EKS...")
-    transform_content = _render_eks_manifest(
-        os.path.join(MANIFESTS_DIR, "job-transform-error.yaml"),
-        s3_key=test_data.key,
-        **common,
-    )
-    _apply_manifest(transform_content)
-
-    print("Waiting for transform to fail...")
-    status = _wait_for_job("etl-transform-error")
-    logs = _get_logs("stage=transform-error")
-
-    trigger_elapsed = time.monotonic() - start
-    print(f"\nTransform status: {status} ({trigger_elapsed:.1f}s)")
-    print(f"Pod logs: {logs}")
-
-    if status != "failed" or "Schema validation failed" not in logs:
-        print("FAIL: transform did not fail as expected")
+    try:
+        cfg = _load_or_regen_trigger_config()
+    except Exception as exc:
+        print(f"ERROR: {exc}")
+        print("Run: make regen-trigger-config")
         return 1
 
-    print(f"\nAlert triggered in {trigger_elapsed:.1f}s")
+    trigger_api_url = cfg["trigger_api_url"]
+    if not cluster_exists():
+        print("ERROR: EKS cluster 'tracer-eks-test' is not available.")
+        print("Trigger API exists but cannot run pipeline jobs without the cluster.")
+        return 1
+    print(f"Triggering pipeline via API: {trigger_api_url}")
+    try:
+        response = _trigger_via_api(trigger_api_url)
+    except Exception as exc:
+        print(f"ERROR: API trigger failed: {exc}")
+        return 1
+
+    print(f"Trigger response: {json.dumps(response)}")
 
     if not args.verify:
         print("Done. DD monitor will fire in ~1-2 min -> Slack alert follows.")
         return 0
-
-    # Cleanup jobs before verifying
-    for job in ("etl-extract", "etl-transform-error"):
-        _delete_job(job)
 
     return verify(start_epoch)
 

--- a/tests/test_case_kubernetes/trigger_lambda/handler.py
+++ b/tests/test_case_kubernetes/trigger_lambda/handler.py
@@ -112,10 +112,50 @@ def _delete_job(job_name: str) -> None:
         )
 
 
+def _ensure_namespace_and_service_account() -> None:
+    """Ensure namespace and service account exist for job submissions."""
+    ns_path = f"/api/v1/namespaces/{NAMESPACE}"
+    sa_path = f"/api/v1/namespaces/{NAMESPACE}/serviceaccounts/{SERVICE_ACCOUNT}"
+
+    try:
+        _k8s_request("GET", ns_path)
+    except RuntimeError as err:
+        if '"code":404' in str(err):
+            _k8s_request(
+                "POST",
+                "/api/v1/namespaces",
+                {"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": NAMESPACE}},
+            )
+        else:
+            raise
+
+    try:
+        _k8s_request("GET", sa_path)
+    except RuntimeError as err:
+        if '"code":404' in str(err):
+            _k8s_request(
+                "POST",
+                f"/api/v1/namespaces/{NAMESPACE}/serviceaccounts",
+                {"apiVersion": "v1", "kind": "ServiceAccount", "metadata": {"name": SERVICE_ACCOUNT}},
+            )
+        else:
+            raise
+
+
 def _create_job(job_name: str, stage: str, env_vars: dict[str, str]) -> None:
     """Submit a K8s Job for the given pipeline stage."""
     env = [{"name": k, "value": v} for k, v in env_vars.items()]
     env.append({"name": "PIPELINE_STAGE", "value": stage})
+    creds = boto3.Session().get_credentials().get_frozen_credentials()
+    env.extend(
+        [
+            {"name": "AWS_ACCESS_KEY_ID", "value": creds.access_key},
+            {"name": "AWS_SECRET_ACCESS_KEY", "value": creds.secret_key},
+            {"name": "AWS_SESSION_TOKEN", "value": creds.token or ""},
+            {"name": "AWS_REGION", "value": REGION},
+            {"name": "AWS_DEFAULT_REGION", "value": REGION},
+        ]
+    )
 
     manifest = {
         "apiVersion": "batch/v1",
@@ -196,6 +236,9 @@ def lambda_handler(event: dict, context) -> dict:
     try:
         # Upload data to S3
         s3_key, correlation_id = _upload_data(payload)
+
+        # Ensure base namespace primitives exist
+        _ensure_namespace_and_service_account()
 
         # Clean up stale jobs
         for job in ("etl-extract", "etl-transform", "etl-transform-error"):


### PR DESCRIPTION
Restore trigger/test compatibility helpers and add AWS-backed config/runtime discovery so alert verification works on existing EKS resources. Also harden Datadog/job execution paths by ensuring node capacity and propagating credentials to in-cluster jobs.

Made-with: Cursor