### PR TITLE
fix: inline actual log messages in RCA report instead of [evidence: source] tags

### DIFF
--- a/app/agent/nodes/publish_findings/formatters/report.py
+++ b/app/agent/nodes/publish_findings/formatters/report.py
@@ -57,11 +57,12 @@ def _render_claim_lines(ctx: ReportContext) -> tuple[list[str], list[str]]:
     the catalog-lookup and link-formatting logic.
     """
     catalog = ctx.get("evidence_catalog") or {}
+    evidence = ctx.get("evidence") or {}
 
     validated_lines: list[str] = []
     for claim_data in ctx.get("validated_claims", []):
         claim = claim_data.get("claim", "")
-        claim = re.sub(r"\s*\[(?i:evidence):[^\]]*\]", "", claim).strip()
+        claim = _resolve_evidence_tags(claim, evidence)
         claim = _sanitize_for_slack(claim)
         evidence_ids = claim_data.get("evidence_ids", [])
         evidence_labels = claim_data.get("evidence_labels", [])
@@ -115,6 +116,40 @@ def _mrkdwn_section(text: str) -> "dict | None":
 
 
 # ---------------------------------------------------------------------------
+# Evidence tag resolution helpers
+# ---------------------------------------------------------------------------
+
+# Maps LLM source name → ordered list of evidence dict keys to try for a log message
+_EVIDENCE_LOG_KEYS: dict[str, list[str]] = {
+    "datadog_logs":    ["datadog_error_logs", "datadog_logs"],
+    "datadog":         ["datadog_error_logs", "datadog_logs"],
+    "grafana_logs":    ["grafana_error_logs", "grafana_logs"],
+    "grafana":         ["grafana_error_logs", "grafana_logs"],
+    "cloudwatch_logs": ["cloudwatch_logs"],
+    "cloudwatch":      ["cloudwatch_logs"],
+}
+
+
+def _resolve_evidence_tags(text: str, evidence: dict) -> str:
+    """Replace [evidence: source] tags with the actual quoted log message.
+
+    Tries error logs first, then all logs for the named source. If no message
+    is found the tag is removed silently to avoid leaking raw LLM annotations.
+    """
+    def _replace(m: re.Match) -> str:
+        source = m.group(1).strip().lower()
+        for key in _EVIDENCE_LOG_KEYS.get(source, [source]):
+            logs = evidence.get(key) or []
+            if logs:
+                msg = (logs[0].get("message") or "").strip()
+                if msg:
+                    return f': "{msg}"'
+        return ""
+
+    return re.sub(r"\s*\[(?i:evidence):\s*([^\]]+)\]", _replace, text).strip()
+
+
+# ---------------------------------------------------------------------------
 # Root cause derivation helpers
 # ---------------------------------------------------------------------------
 
@@ -152,7 +187,9 @@ def _remove_speculative_words(text: str) -> str:
 
 def _derive_root_cause_sentence(ctx: ReportContext) -> str:
     """Derive a concise, single-sentence root cause with causal preference."""
+    evidence = ctx.get("evidence") or {}
     root_cause_text = ctx.get("root_cause", "") or ""
+    root_cause_text = _resolve_evidence_tags(root_cause_text, evidence)
     validated_claims = ctx.get("validated_claims", [])
 
     if root_cause_text:

--- a/app/agent/nodes/publish_findings/report_context.py
+++ b/app/agent/nodes/publish_findings/report_context.py
@@ -328,12 +328,16 @@ def _add_datadog_logs(
         f"{len(datadog_logs)} logs" if datadog_logs else None,
         f"{len(datadog_error_logs)} errors" if datadog_error_logs else None,
     ] if p]
+    top_msg = next(
+        (e.get("message", "").strip() for e in (datadog_error_logs or datadog_logs) if e.get("message")),
+        None,
+    )
     eid = "evidence/datadog/logs"
     catalog[eid] = {
         "label": "Datadog Logs",
         "url": build_datadog_logs_url(datadog_query, datadog_site) if datadog_query else None,
         "summary": ", ".join(summary_parts) or None,
-        "snippet": _as_snippet(datadog_query) if datadog_query else None,
+        "snippet": _as_snippet(top_msg) if top_msg else (_as_snippet(datadog_query) if datadog_query else None),
     }
     source_to_id["datadog_logs"] = eid
 


### PR DESCRIPTION
## Summary

- Replace `[evidence: datadog_logs]`-style LLM annotations in the root cause sentence and individual finding/claim lines with the actual quoted log message (e.g. `"ValidationError: missing required field 'customer_id' was missing from record 0"`)
- Error logs are preferred over all logs when resolving the message; tag is silently removed if no message is found
- Update the Datadog Logs evidence catalog entry (`E1`) to use the first error log message as the snippet instead of the raw query filter string

## Test plan

- [ ] Run a full investigation against the Kubernetes test case and verify the root cause sentence shows the quoted log message inline
- [ ] Verify finding/claim lines show the quoted log message inline alongside the `[E1]` citation
- [ ] Verify the cited evidence section (`E1`) shows the actual error message as the snippet
- [ ] Run `make lint` and `make typecheck` — both pass

Made with [Cursor](https://cursor.com)