### PR TITLE
Fix: resolve all GitHub code scanning security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tracer-demo-prefect-ecs.yml
+++ b/.github/workflows/tracer-demo-prefect-ecs.yml
@@ -3,6 +3,9 @@ name: Tracer Demo – Prefect ECS
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tracer-demo-prefect-ecs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tracer-demo-tools-ingest.yml
+++ b/.github/workflows/tracer-demo-tools-ingest.yml
@@ -3,6 +3,9 @@ name: Tracer Demo Ingest Tools
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tracer-demo:
     runs-on: ubuntu-latest

--- a/.github/workflows/tracer-demo.yml
+++ b/.github/workflows/tracer-demo.yml
@@ -3,6 +3,9 @@ name: Tracer Demo
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tracer-demo:
     runs-on: ubuntu-latest

--- a/.github/workflows/tracer-grafana.yml
+++ b/.github/workflows/tracer-grafana.yml
@@ -3,6 +3,9 @@ name: Tracer Grafana
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tracer-grafana:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-k8s-alert.yml
+++ b/.github/workflows/trigger-k8s-alert.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 9 * * 1"  # every Monday 9am UTC
 
+permissions:
+  contents: read
+
 jobs:
   trigger-alert:
     runs-on: ubuntu-latest

--- a/tests/grafana_config.py
+++ b/tests/grafana_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from opentelemetry.sdk.resources import Resource
 
@@ -180,9 +181,14 @@ def get_rw_api_key() -> str:
     return get_env("GCLOUD_RW_API_KEY", "")
 
 
+def _is_grafana_hostname(endpoint: str) -> bool:
+    hostname = urlparse(endpoint).hostname or ""
+    return hostname == "grafana.net" or hostname.endswith(".grafana.net") or hostname == "grafana.com" or hostname.endswith(".grafana.com")
+
+
 def is_grafana_otlp_endpoint(value: str | None = None) -> bool:
     endpoint = value if value is not None else get_effective_otlp_endpoint()
-    return "grafana.net" in endpoint or "grafana.com" in endpoint
+    return _is_grafana_hostname(endpoint)
 
 
 def configure_grafana_cloud(env_file: Path | str | None = None) -> None:
@@ -234,7 +240,7 @@ def apply_otel_env_defaults() -> None:
 def validate_grafana_cloud_config() -> bool:
     """Validate that Grafana Cloud configuration is present when using cloud endpoints."""
     endpoint = get_effective_otlp_endpoint()
-    if "grafana.net" in endpoint or "grafana.com" in endpoint:
+    if _is_grafana_hostname(endpoint):
         required_values = {
             "GCLOUD_HOSTED_METRICS_ID": get_hosted_metrics_id(),
             "GCLOUD_HOSTED_METRICS_URL": get_hosted_metrics_url(),


### PR DESCRIPTION
- Add `permissions: contents: read` at workflow level to all GitHub Actions workflows (ci.yml, tracer-demo.yml, tracer-grafana.yml, tracer-demo-tools-ingest.yml, tracer-demo-prefect-ecs.yml, trigger-k8s-alert.yml) to prevent GITHUB_TOKEN over-permissioning
- Fix incomplete URL substring sanitization in grafana_config.py by using urlparse to check hostname properly instead of `in` string matching, preventing bypass via URLs like `evil-grafana.net.attacker.com`
- Dismissed vendored-code alerts (alerts 15-19) for urllib3/requests in test fixtures as "used in tests" — these are third-party libraries not owned by this codebase

Made-with: Cursor