### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/util/url.py
+++ b/tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/util/url.py
@@ -291,7 +291,8 @@ def _remove_path_dot_segments(path: str) -> str:
 
 
 @typing.overload
-def _normalize_host(host: None, scheme: str | None) -> None: ...
+def _normalize_host(host: None, scheme: str | None) -> None: 
+    pass
 
 
 @typing.overload


### PR DESCRIPTION
In general, to fix a “statement has no effect” issue where `...` is used as a placeholder expression, replace the bare `...` expression with an explicit no‑op statement like `pass`, or with something that makes the intent explicit (e.g., `raise NotImplementedError`). For `@typing.overload` stubs that should never run at runtime, `pass` is the least intrusive choice and preserves existing behavior.

Specifically for this file, change the body of the `_normalize_host` overload taking `(host: None, scheme: str | None) -> None` so that it contains `pass` instead of `...`. This is at line 294 in `tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/util/url.py`. No imports or additional definitions are needed. The other overload and the concrete implementation of `_normalize_host` already have real bodies and remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._