### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/_collections.py
+++ b/tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/_collections.py
@@ -13,9 +13,11 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Self
 
     class HasGettableStringKeys(Protocol):
-        def keys(self) -> typing.Iterator[str]: ...
+        def keys(self) -> typing.Iterator[str]:
+            pass
 
-        def __getitem__(self, key: str) -> str: ...
+        def __getitem__(self, key: str) -> str:
+            pass
 
 
 __all__ = ["RecentlyUsedContainer", "HTTPHeaderDict"]


### PR DESCRIPTION
In general, to fix “statement has no effect” issues where `...` is used as a function body in real source files (not `.pyi`), replace the bare ellipsis with `pass` (or a proper implementation) so the body is an explicit no-op rather than a meaningless expression statement.

For this file, the best minimal fix is to change the `...` bodies of the two `HasGettableStringKeys` methods to `pass`. These methods are only defined when `typing.TYPE_CHECKING` is true, so this change does not affect runtime behavior; it just makes the bodies syntactically conventional and eliminates the CodeQL warning. Concretely:

- In `tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/_collections.py`, within the `if typing.TYPE_CHECKING:` block, update:
  - `def keys(self) -> typing.Iterator[str]: ...`
  - `def __getitem__(self, key: str) -> str: ...`
- Replace the `...` in each method with `pass` on the same line, preserving signatures and indentation.
- No imports, extra methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._