### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/util/ssltransport.py
+++ b/tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/util/ssltransport.py
@@ -217,11 +217,13 @@ class SSLTransport:
 
     # func is sslobj.do_handshake or sslobj.unwrap
     @typing.overload
-    def _ssl_io_loop(self, func: typing.Callable[[], None]) -> None: ...
+    def _ssl_io_loop(self, func: typing.Callable[[], None]) -> None:
+        pass
 
     # func is sslobj.write, arg1 is data
     @typing.overload
-    def _ssl_io_loop(self, func: typing.Callable[[bytes], int], arg1: bytes) -> int: ...
+    def _ssl_io_loop(self, func: typing.Callable[[bytes], int], arg1: bytes) -> int:
+        pass
 
     # func is sslobj.read, arg1 is len, arg2 is buffer
     @typing.overload
@@ -230,7 +232,8 @@ class SSLTransport:
         func: typing.Callable[[int, bytearray | None], bytes],
         arg1: int,
         arg2: bytearray | None,
-    ) -> bytes: ...
+    ) -> bytes:
+        pass
 
     def _ssl_io_loop(
         self,


### PR DESCRIPTION
Generally, to fix "statement has no effect" for overload bodies, we should replace bare `...` expression statements with `pass` so the body is an explicit no-op rather than evaluating an unused expression. This keeps the function intentionally empty while avoiding confusing or misleading code.

In this file, there are three overloaded definitions of `_ssl_io_loop` (lines 219–233). Each currently uses `...` as the entire body. The best fix that does not alter functionality is to change the body of each of these overloads to `pass`. This keeps them valid empty definitions for type checkers, preserves the actual implementation in the non-overloaded `_ssl_io_loop` at lines 235–271, and removes the "no effect" expression statements that CodeQL flags.

Concretely:
- In `tests/test_case_upstream_lambda/pipeline_code/api_ingester/urllib3/util/ssltransport.py`, locate the three `@typing.overload` definitions of `_ssl_io_loop` (returning `None`, `int`, and `bytes`).
- Replace the `...` on the same line as the function signature with an indented `pass` on the next line, matching the file’s indentation (4 spaces inside the class).
- No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._