### PR TITLE
docs: add Windows setup instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,26 @@ This document describes how to propose changes, report bugs, and submit pull req
    All three must pass. CI runs the same checks and a PR cannot be merged if they fail.
 5. Open a pull request
 
+## Windows Setup
+
+Windows does not include `make` by default. You need to install it first.
+
+**Step 1 — Open PowerShell as Administrator** (search "PowerShell" in Start Menu → right-click → "Run as administrator")
+
+**Step 2 — Install Chocolatey** (paste this and press Enter):
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+```
+
+**Step 3 — Install make:**
+
+```powershell
+choco install make
+```
+
+**Step 4 — Restart your terminal**, then continue with the standard setup steps above (`make lint`, `make typecheck`, `make test-cov` will all work).
+
 ### Pull request guidelines
 
 To keep PRs easy to review:


### PR DESCRIPTION
## What changed
Added a new `## Windows Setup` section to `CONTRIBUTING.md` with step-by-step instructions for Windows users to install `make` via Chocolatey, since `make` is not available on Windows by default.

## Why
The existing setup steps (`make lint`, `make typecheck`, `make test-cov`) don't work on Windows out of the box. This caused confusion for me as a Windows contributor. These instructions fix that.

## Testing
- Chocolatey install command verified from https://chocolatey.org/install
- `choco install make` package verified from the Chocolatey community registry (3.4M+ downloads, approved package)