### PR TITLE
fix: align wizard test with questionary prompts

### DIFF
--- a/app/cli/wizard/flow_test.py
+++ b/app/cli/wizard/flow_test.py
@@ -225,19 +225,20 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
 
 
 def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, capsys) -> None:
-    responses = iter([
-        "",  # quickstart
-        "",  # provider
-        "",  # model
-        "5,6",  # github + sentry
-        "",  # github mode -> default
-        "",  # github url -> default
-        "",  # github toolsets -> default
-        "",  # sentry base url -> default
+    select_responses = iter([
+        "quickstart",
+        "anthropic",
+        "claude-opus-4-20250514",
+        flow.DEFAULT_GITHUB_MCP_MODE,
+    ])
+    text_responses = iter([
+        flow.DEFAULT_GITHUB_MCP_URL,
+        "repos,issues,pull_requests,actions",
+        flow.DEFAULT_SENTRY_URL,
         "demo-org",
         "payments",
     ])
-    secrets = iter([
+    password_responses = iter([
         "llm-secret",
         "ghp_test",
         "sntrys_test",
@@ -245,8 +246,30 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
     saved_integrations: list[tuple[str, dict]] = []
     synced_env_values: list[dict[str, str]] = []
 
-    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
-    monkeypatch.setattr(flow.getpass, "getpass", lambda _prompt="": next(secrets))
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_checkbox(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = ["github", "sentry"]
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(password_responses)
+        return m
+
+    def _mock_text(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(text_responses)
+        return m
+
+    monkeypatch.setattr(flow.questionary, "select", _mock_select)
+    monkeypatch.setattr(flow.questionary, "checkbox", _mock_checkbox)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow.questionary, "text", _mock_text)
     monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(


### PR DESCRIPTION
The onboarding flow now uses questionary instead of input/getpass, so the GitHub MCP and Sentry regression test needs to mock the current prompt APIs to keep main green.

Made-with: Cursor