### PR TITLE
chore: pin mcp to >=1.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     # Core AI/Agent
     "anthropic>=0.77.1",
-     "mcp",
+    "mcp>=1.20.0",
     "openai>=2.0.0",
     "langsmith>=0.6.8",
     "langgraph>=0.4.0",


### PR DESCRIPTION
Pins the mcp dependency in pyproject.toml so installs don’t pick an old release that doesn’t expose streamable_http_client, which caused an ImportError when loading the GitHub MCP integration. No application code changes.

Closes #173