### PR TITLE
refactor: split investigation helpers from main entrypoint

### DIFF
--- a/app/cli/investigate.py
+++ b/app/cli/investigate.py
@@ -1,0 +1,72 @@
+"""Shared investigation helpers for CLI entrypoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langsmith import traceable
+
+if TYPE_CHECKING:
+    from app.agent.state import AgentState
+
+
+def _call_run_investigation(
+    alert_name: str,
+    pipeline_name: str,
+    severity: str,
+    *,
+    raw_alert: dict[str, Any],
+) -> AgentState:
+    """Import the heavy investigation runner only when execution starts."""
+    from app.agent.runners import run_investigation
+
+    return run_investigation(
+        alert_name,
+        pipeline_name,
+        severity,
+        raw_alert=raw_alert,
+    )
+
+
+def resolve_investigation_context(
+    *,
+    raw_alert: dict[str, Any],
+    alert_name: str | None,
+    pipeline_name: str | None,
+    severity: str | None,
+) -> tuple[str, str, str]:
+    """Resolve investigation metadata from CLI overrides and payload defaults."""
+    return (
+        alert_name or raw_alert.get("alert_name") or "Incident",
+        pipeline_name or raw_alert.get("pipeline_name") or "events_fact",
+        severity or raw_alert.get("severity") or "warning",
+    )
+
+
+@traceable(name="investigation")
+def run_investigation_cli(
+    *,
+    raw_alert: dict[str, Any],
+    alert_name: str | None = None,
+    pipeline_name: str | None = None,
+    severity: str | None = None,
+) -> dict[str, Any]:
+    """Run the investigation and return the CLI-facing JSON payload."""
+    resolved_alert_name, resolved_pipeline_name, resolved_severity = resolve_investigation_context(
+        raw_alert=raw_alert,
+        alert_name=alert_name,
+        pipeline_name=pipeline_name,
+        severity=severity,
+    )
+    state = _call_run_investigation(
+        resolved_alert_name,
+        resolved_pipeline_name,
+        resolved_severity,
+        raw_alert=raw_alert,
+    )
+    return {
+        "slack_message": state["slack_message"],
+        "report": state["slack_message"],
+        "problem_md": state["problem_md"],
+        "root_cause": state["root_cause"],
+    }

--- a/app/cli/investigate_test.py
+++ b/app/cli/investigate_test.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from app.cli.investigate import resolve_investigation_context, run_investigation_cli
+
+
+def test_resolve_investigation_context_prefers_cli_overrides() -> None:
+    alert_name, pipeline_name, severity = resolve_investigation_context(
+        raw_alert={
+            "alert_name": "PayloadAlert",
+            "pipeline_name": "payload_pipeline",
+            "severity": "warning",
+        },
+        alert_name="CliAlert",
+        pipeline_name="cli_pipeline",
+        severity="critical",
+    )
+
+    assert alert_name == "CliAlert"
+    assert pipeline_name == "cli_pipeline"
+    assert severity == "critical"
+
+
+def test_run_investigation_cli_shapes_agent_state(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_investigation(
+        alert_name: str,
+        pipeline_name: str,
+        severity: str,
+        *,
+        raw_alert: dict[str, object],
+    ) -> dict[str, object]:
+        captured["alert_name"] = alert_name
+        captured["pipeline_name"] = pipeline_name
+        captured["severity"] = severity
+        captured["raw_alert"] = raw_alert
+        return {
+            "slack_message": "report body",
+            "problem_md": "# problem",
+            "root_cause": "bad deploy",
+        }
+
+    monkeypatch.setattr("app.cli.investigate._call_run_investigation", fake_run_investigation)
+
+    result = run_investigation_cli(
+        raw_alert={"alert_name": "PayloadAlert"},
+        alert_name=None,
+        pipeline_name=None,
+        severity=None,
+    )
+
+    assert captured == {
+        "alert_name": "PayloadAlert",
+        "pipeline_name": "events_fact",
+        "severity": "warning",
+        "raw_alert": {"alert_name": "PayloadAlert"},
+    }
+    assert result == {
+        "slack_message": "report body",
+        "report": "report body",
+        "problem_md": "# problem",
+        "root_cause": "bad deploy",
+    }

--- a/app/cli/payload.py
+++ b/app/cli/payload.py
@@ -1,0 +1,79 @@
+"""Alert payload loading helpers for CLI investigations."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def parse_payload_text(raw_text: str, source_label: str) -> dict[str, Any]:
+    """Parse and validate a JSON object payload."""
+    try:
+        data: Any = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"Invalid alert JSON from {source_label}: {exc.msg} at line {exc.lineno}, column {exc.colno}."
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise SystemExit(f"Alert payload from {source_label} must be a JSON object.")
+
+    return data
+
+
+def load_stdin_payload() -> dict[str, Any]:
+    """Read a JSON payload from stdin."""
+    if sys.stdin.isatty():
+        raise SystemExit(
+            "No alert input provided on stdin. Use --interactive, --input <file>, or --input-json."
+        )
+    return parse_payload_text(sys.stdin.read(), "stdin")
+
+
+def load_interactive_payload() -> dict[str, Any]:
+    """Prompt the user to paste an alert payload."""
+    print(
+        "Paste the alert JSON payload, then press Ctrl-D when finished.",
+        file=sys.stderr,
+    )
+    raw_text = sys.stdin.read()
+    if not raw_text.strip():
+        raise SystemExit("No alert JSON was provided in interactive mode.")
+    return parse_payload_text(raw_text, "interactive input")
+
+
+def load_file_payload(path_str: str) -> dict[str, Any]:
+    """Read and parse an alert payload from a local file."""
+    try:
+        raw_text = Path(path_str).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Alert JSON file not found: {path_str}") from exc
+    except UnicodeDecodeError as exc:
+        raise SystemExit(f"Alert JSON file must be UTF-8 text: {path_str}") from exc
+    except OSError as exc:
+        raise SystemExit(f"Could not read alert JSON file {path_str}: {exc}") from exc
+
+    return parse_payload_text(raw_text, path_str)
+
+
+def load_payload(
+    input_path: str | None,
+    input_json: str | None,
+    interactive: bool,
+) -> dict[str, Any]:
+    """Load raw alert payload from file, stdin, inline JSON, or interactive paste."""
+    if input_json:
+        return parse_payload_text(input_json, "--input-json")
+    if interactive:
+        return load_interactive_payload()
+    if input_path == "-":
+        return load_stdin_payload()
+    if input_path:
+        return load_file_payload(input_path)
+    if sys.stdin.isatty():
+        raise SystemExit(
+            "No alert input provided. Use --interactive, --input <file>, --input-json, or pipe JSON to stdin."
+        )
+    return load_stdin_payload()

--- a/app/main.py
+++ b/app/main.py
@@ -1,110 +1,13 @@
-"""
-CLI entry point for the incident resolution agent.
-"""
-
-import json
-import sys
-from argparse import Namespace
-from pathlib import Path
-from typing import Any
+"""CLI entry point for the incident resolution agent."""
 
 from dotenv import load_dotenv
 
 load_dotenv(override=False)
 
-from langsmith import traceable  # noqa: E402
-
-from app.agent.runners import run_investigation  # noqa: E402
 from app.alert_templates import build_alert_template  # noqa: E402
 from app.cli import parse_args, write_json  # noqa: E402
-
-
-def _parse_payload_text(raw_text: str, source_label: str) -> dict[str, Any]:
-    """Parse and validate a JSON object payload."""
-    try:
-        data: Any = json.loads(raw_text)
-    except json.JSONDecodeError as exc:
-        raise SystemExit(
-            f"Invalid alert JSON from {source_label}: {exc.msg} at line {exc.lineno}, column {exc.colno}."
-        ) from exc
-
-    if not isinstance(data, dict):
-        raise SystemExit(f"Alert payload from {source_label} must be a JSON object.")
-
-    return data
-
-
-def _read_stdin_payload() -> dict[str, Any]:
-    """Read a JSON payload from stdin."""
-    if sys.stdin.isatty():
-        raise SystemExit(
-            "No alert input provided on stdin. Use --interactive, --input <file>, or --input-json."
-        )
-    return _parse_payload_text(sys.stdin.read(), "stdin")
-
-
-def _read_interactive_payload() -> dict[str, Any]:
-    """Prompt the user to paste an alert payload."""
-    print(
-        "Paste the alert JSON payload, then press Ctrl-D when finished.",
-        file=sys.stderr,
-    )
-    raw_text = sys.stdin.read()
-    if not raw_text.strip():
-        raise SystemExit("No alert JSON was provided in interactive mode.")
-    return _parse_payload_text(raw_text, "interactive input")
-
-
-def _read_file_payload(path_str: str) -> dict[str, Any]:
-    """Read and parse an alert payload from a local file."""
-    try:
-        raw_text = Path(path_str).read_text(encoding="utf-8")
-    except FileNotFoundError as exc:
-        raise SystemExit(f"Alert JSON file not found: {path_str}") from exc
-    except UnicodeDecodeError as exc:
-        raise SystemExit(f"Alert JSON file must be UTF-8 text: {path_str}") from exc
-    except OSError as exc:
-        raise SystemExit(f"Could not read alert JSON file {path_str}: {exc}") from exc
-
-    return _parse_payload_text(raw_text, path_str)
-
-
-def _load_payload(args: Namespace) -> dict[str, Any]:
-    """Load raw alert payload from file, stdin, inline JSON, or interactive paste."""
-    if args.input_json:
-        return _parse_payload_text(args.input_json, "--input-json")
-    if args.interactive:
-        return _read_interactive_payload()
-    if args.input == "-":
-        return _read_stdin_payload()
-    if args.input:
-        return _read_file_payload(args.input)
-    if sys.stdin.isatty():
-        raise SystemExit(
-            "No alert input provided. Use --interactive, --input <file>, --input-json, or pipe JSON to stdin."
-        )
-    return _read_stdin_payload()
-
-
-@traceable(name="investigation")
-def _run(
-    alert_name: str,
-    pipeline_name: str,
-    severity: str,
-    raw_alert: dict[str, Any],
-) -> dict:
-    state = run_investigation(
-        alert_name,
-        pipeline_name,
-        severity,
-        raw_alert=raw_alert,
-    )
-    return {
-        "slack_message": state["slack_message"],
-        "report": state["slack_message"],
-        "problem_md": state["problem_md"],
-        "root_cause": state["root_cause"],
-    }
+from app.cli.investigate import run_investigation_cli  # noqa: E402
+from app.cli.payload import load_payload  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -114,17 +17,16 @@ def main(argv: list[str] | None = None) -> int:
         write_json(build_alert_template(args.print_template), args.output)
         return 0
 
-    payload = _load_payload(args)
-
-    alert_name = args.alert_name or payload.get("alert_name") or "Incident"
-    pipeline_name = args.pipeline_name or payload.get("pipeline_name") or "events_fact"
-    severity = args.severity or payload.get("severity") or "warning"
-
-    result = _run(
-        alert_name=alert_name,
-        pipeline_name=pipeline_name,
-        severity=severity,
+    payload = load_payload(
+        input_path=args.input,
+        input_json=args.input_json,
+        interactive=args.interactive,
+    )
+    result = run_investigation_cli(
         raw_alert=payload,
+        alert_name=args.alert_name,
+        pipeline_name=args.pipeline_name,
+        severity=args.severity,
     )
     write_json(result, args.output)
     return 0

--- a/app/main_test.py
+++ b/app/main_test.py
@@ -1,31 +1,28 @@
 from __future__ import annotations
 
-from argparse import Namespace
 from io import StringIO
 
 import pytest
 
 from app.alert_templates import build_alert_template
-from app.main import _load_payload, _parse_payload_text
+from app.cli.payload import load_payload, parse_payload_text
 
 
 def test_parse_payload_text_rejects_invalid_json() -> None:
     with pytest.raises(SystemExit, match="Invalid alert JSON"):
-        _parse_payload_text("{bad json", "test")
+        parse_payload_text("{bad json", "test")
 
 
 def test_parse_payload_text_rejects_non_object_json() -> None:
     with pytest.raises(SystemExit, match="must be a JSON object"):
-        _parse_payload_text('["not", "an", "object"]', "test")
+        parse_payload_text('["not", "an", "object"]', "test")
 
 
 def test_load_payload_accepts_inline_json() -> None:
-    payload = _load_payload(
-        Namespace(
-            input=None,
-            input_json='{"alert_name":"HighErrorRate","severity":"critical"}',
-            interactive=False,
-        )
+    payload = load_payload(
+        input_path=None,
+        input_json='{"alert_name":"HighErrorRate","severity":"critical"}',
+        interactive=False,
     )
 
     assert payload["alert_name"] == "HighErrorRate"
@@ -36,38 +33,24 @@ def test_load_payload_reads_file(tmp_path) -> None:
     path = tmp_path / "alert.json"
     path.write_text('{"pipeline_name":"payments_etl"}', encoding="utf-8")
 
-    payload = _load_payload(
-        Namespace(
-            input=str(path),
-            input_json=None,
-            interactive=False,
-        )
-    )
+    payload = load_payload(input_path=str(path), input_json=None, interactive=False)
 
     assert payload["pipeline_name"] == "payments_etl"
 
 
 def test_load_payload_missing_file_exits_cleanly() -> None:
     with pytest.raises(SystemExit, match="Alert JSON file not found"):
-        _load_payload(
-            Namespace(
-                input="/tmp/does-not-exist-alert.json",
-                input_json=None,
-                interactive=False,
-            )
+        load_payload(
+            input_path="/tmp/does-not-exist-alert.json",
+            input_json=None,
+            interactive=False,
         )
 
 
 def test_load_payload_reads_interactive_input(monkeypatch) -> None:
     monkeypatch.setattr("sys.stdin", StringIO('{"alert_name":"PastedAlert"}'))
 
-    payload = _load_payload(
-        Namespace(
-            input=None,
-            input_json=None,
-            interactive=True,
-        )
-    )
+    payload = load_payload(input_path=None, input_json=None, interactive=True)
 
     assert payload["alert_name"] == "PastedAlert"
 

--- a/tests/test_case_cloudwatch_demo/test_orchestrator.py
+++ b/tests/test_case_cloudwatch_demo/test_orchestrator.py
@@ -57,7 +57,7 @@ def main(test_name: str = "demo-pipeline-empty-file-error") -> int:
 
         from langsmith import traceable
 
-        from app.main import _run
+        from app.cli.investigate import run_investigation_cli
 
         print("Running investigation...")
 
@@ -73,7 +73,7 @@ def main(test_name: str = "demo-pipeline-empty-file-error") -> int:
             },
         )
         def run_with_alert_id():
-            return _run(
+            return run_investigation_cli(
                 alert_name=f"Pipeline failure: {pipeline_name}",
                 pipeline_name=pipeline_name,
                 severity="critical",

--- a/tests/test_case_s3_failed_python_on_linux/test_orchestrator.py
+++ b/tests/test_case_s3_failed_python_on_linux/test_orchestrator.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 
 from langsmith import traceable
 
-from app.main import _run
+from app.cli.investigate import run_investigation_cli
 from tests.shared.tracer_ingest import StepTimer, emit_tool_event
 from tests.test_case_s3_failed_python_on_linux import use_case
 from tests.utils.alert_factory import create_alert
@@ -159,7 +159,7 @@ def main() -> int:
         },
     )
     def run_with_alert_id():
-        return _run(
+        return run_investigation_cli(
             alert_name=f"Pipeline failure: {pipeline_name}",
             pipeline_name=pipeline_name,
             severity="critical",

--- a/tests/test_case_upstream_apache_flink_ecs/test_agent_e2e.py
+++ b/tests/test_case_upstream_apache_flink_ecs/test_agent_e2e.py
@@ -18,7 +18,7 @@ import boto3
 import requests
 from langsmith import traceable
 
-from app.main import _run
+from app.cli.investigate import run_investigation_cli
 from tests.shared.stack_config import get_flink_config
 from tests.utils.alert_factory import create_alert
 
@@ -162,7 +162,7 @@ def test_agent_investigation(failure_data: dict):
         },
     )
     def run_investigation():
-        return _run(
+        return run_investigation_cli(
             alert_name=alert.get("labels", {}).get("alertname", "FlinkTaskFailure"),
             pipeline_name="tracer_flink_batch_pipeline",
             severity="critical",

--- a/tests/test_case_upstream_lambda/test_agent_e2e.py
+++ b/tests/test_case_upstream_lambda/test_agent_e2e.py
@@ -13,7 +13,7 @@ import boto3
 import requests
 from langsmith import traceable
 
-from app.main import _run
+from app.cli.investigate import run_investigation_cli
 from tests.utils.alert_factory import create_alert
 from tests.utils.conftest import UPSTREAM_DOWNSTREAM_CONFIG
 
@@ -166,7 +166,7 @@ def test_agent_investigation(failure_data: dict) -> bool:
         },
     )
     def run_investigation():
-        return _run(
+        return run_investigation_cli(
             alert_name=f"Pipeline failure: {pipeline_name}",
             pipeline_name=pipeline_name,
             severity="critical",

--- a/tests/test_case_upstream_prefect_ecs_fargate/test_agent_e2e.py
+++ b/tests/test_case_upstream_prefect_ecs_fargate/test_agent_e2e.py
@@ -20,7 +20,7 @@ import requests
 from langsmith import traceable
 
 from app.agent.tools.clients.grafana import get_grafana_client
-from app.main import _run
+from app.cli.investigate import run_investigation_cli
 from tests.shared.stack_config import get_prefect_config
 from tests.shared.tracer_ingest import StepTimer, emit_tool_event
 from tests.utils.alert_factory import create_alert
@@ -240,7 +240,7 @@ def _run_agent_investigation(failure_data: dict, run_id: str, trace_id: str) -> 
         },
     )
     def run_investigation():
-        return _run(
+        return run_investigation_cli(
             alert_name=alert.get("labels", {}).get("alertname", "PrefectFlowFailure"),
             pipeline_name="upstream_downstream_pipeline_prefect",
             severity="critical",


### PR DESCRIPTION
Move payload loading and traced investigation orchestration out of app/main.py so the entrypoint stays focused on CLI flow while preserving existing behavior.

Made-with: Cursor