### PR TITLE
add CLI test inventory commands

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -24,6 +24,7 @@ def cli() -> None:
     Quick start:
       opensre onboard                        Configure LLM provider and integrations
       opensre investigate -i alert.json      Run RCA against an alert payload
+      opensre tests                          Browse and run inventoried tests
       opensre integrations list              Show configured integrations
 
     \b
@@ -163,6 +164,61 @@ def verify(service: str | None, send_slack_test: bool) -> None:
     from app.integrations.cli import cmd_verify
 
     cmd_verify(service, send_slack_test=send_slack_test)
+
+
+@cli.group(invoke_without_command=True)
+@click.pass_context
+def tests(ctx: click.Context) -> None:
+    """Browse and run inventoried tests from the terminal."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    from app.cli.tests.discover import load_test_catalog
+    from app.cli.tests.interactive import run_interactive_picker
+
+    raise SystemExit(run_interactive_picker(load_test_catalog()))
+
+
+@tests.command(name="list")
+@click.option(
+    "--category",
+    type=click.Choice(["all", "rca", "demo", "infra-heavy", "ci-safe"]),
+    default="all",
+    show_default=True,
+    help="Filter the inventory by category tag.",
+)
+@click.option("--search", default="", help="Case-insensitive text filter.")
+def list_tests(category: str, search: str) -> None:
+    """List available tests and suites."""
+    from app.cli.tests.discover import load_test_catalog
+
+    def _echo_item(item, *, indent: int = 0) -> None:
+        prefix = "  " * indent
+        tag_text = f" [{', '.join(item.tags)}]" if item.tags else ""
+        click.echo(f"{prefix}{item.id} - {item.display_name}{tag_text}")
+        if item.description:
+            click.echo(f"{prefix}  {item.description}")
+        if item.children:
+            for child in item.children:
+                _echo_item(child, indent=indent + 1)
+
+    catalog = load_test_catalog()
+    for item in catalog.filter(category=category, search=search):
+        _echo_item(item)
+
+
+@tests.command()
+@click.argument("test_id")
+@click.option("--dry-run", is_flag=True, help="Print the selected command without running it.")
+def run(test_id: str, dry_run: bool) -> None:
+    """Run a test or suite by stable inventory id."""
+    from app.cli.tests.runner import find_test_item, run_catalog_item
+
+    item = find_test_item(test_id)
+    if item is None:
+        raise click.ClickException(f"Unknown test id: {test_id}")
+
+    raise SystemExit(run_catalog_item(item, dry_run=dry_run))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/app/cli/tests/__init__.py
+++ b/app/cli/tests/__init__.py
@@ -1,0 +1,15 @@
+"""OpenSRE test inventory and interactive selection helpers."""
+
+from app.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement
+from app.cli.tests.discover import load_test_catalog
+from app.cli.tests.runner import find_test_item, format_command, run_catalog_item
+
+__all__ = [
+    "TestCatalog",
+    "TestCatalogItem",
+    "TestRequirement",
+    "find_test_item",
+    "format_command",
+    "load_test_catalog",
+    "run_catalog_item",
+]

--- a/app/cli/tests/catalog.py
+++ b/app/cli/tests/catalog.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TestRequirement:
+    env_vars: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def summary(self) -> str:
+        parts: list[str] = []
+        if self.env_vars:
+            parts.append("env:" + ",".join(self.env_vars))
+        parts.extend(self.notes)
+        return " | ".join(parts)
+
+
+@dataclass(frozen=True)
+class TestCatalogItem:
+    id: str
+    kind: str
+    display_name: str
+    description: str
+    command: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    source_path: str = ""
+    requirements: TestRequirement = field(default_factory=TestRequirement)
+    children: tuple[TestCatalogItem, ...] = ()
+
+    @property
+    def command_display(self) -> str:
+        return shlex.join(self.command) if self.command else ""
+
+    @property
+    def is_runnable(self) -> bool:
+        return bool(self.command)
+
+    def matches(self, *, category: str = "all", search: str = "") -> bool:
+        if category != "all" and category not in self.tags:
+            return False
+        if not search:
+            return True
+
+        query = search.lower()
+        searchable = " ".join(
+            [
+                self.id,
+                self.display_name,
+                self.description,
+                " ".join(self.tags),
+                self.source_path,
+            ]
+        ).lower()
+        return query in searchable
+
+
+def iter_items(items: tuple[TestCatalogItem, ...]) -> list[TestCatalogItem]:
+    flattened: list[TestCatalogItem] = []
+    for item in items:
+        flattened.append(item)
+        if item.children:
+            flattened.extend(iter_items(item.children))
+    return flattened
+
+
+@dataclass(frozen=True)
+class TestCatalog:
+    items: tuple[TestCatalogItem, ...]
+
+    def all_items(self) -> list[TestCatalogItem]:
+        return iter_items(self.items)
+
+    def find(self, item_id: str) -> TestCatalogItem | None:
+        for item in self.all_items():
+            if item.id == item_id:
+                return item
+        return None
+
+    def filter(self, *, category: str = "all", search: str = "") -> list[TestCatalogItem]:
+        matched: list[TestCatalogItem] = []
+        for item in self.items:
+            if item.matches(category=category, search=search):
+                matched.append(item)
+                continue
+            if any(child.matches(category=category, search=search) for child in item.children):
+                matched.append(item)
+        return matched

--- a/app/cli/tests/cli_inventory_test.py
+++ b/app/cli/tests/cli_inventory_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from app.cli.__main__ import cli
+
+
+def test_tests_list_filters_ci_safe_inventory() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["tests", "list", "--category", "ci-safe"])
+
+    assert result.exit_code == 0
+    assert "make:test-cov" in result.output
+    assert "make:test-full" in result.output
+    assert "rca:pipeline_error_in_logs" not in result.output
+
+
+def test_tests_run_dry_run_prints_command() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["tests", "run", "make:test-cov", "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "make test-cov" in result.output

--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TypedDict, cast
+
+from app.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MAKEFILE_PATH = REPO_ROOT / "Makefile"
+RCA_DIR = REPO_ROOT / "tests" / "rca"
+
+_TARGETS_TO_INDEX = (
+    "test",
+    "test-full",
+    "test-cov",
+    "test-grafana",
+    "demo",
+    "local-rca-demo",
+    "cloudwatch-demo",
+    "datadog-demo",
+    "crashloop-demo",
+    "prefect-demo",
+    "simulate-k8s-alert",
+    "test-k8s-local",
+    "test-k8s",
+    "test-k8s-datadog",
+    "test-k8s-eks",
+    "trigger-alert",
+    "trigger-alert-verify",
+    "prefect-local-test",
+    "upstream-downstream",
+    "flink-demo",
+    "grafana-demo",
+    "deploy",
+    "destroy",
+    "deploy-lambda",
+    "deploy-prefect",
+    "deploy-flink",
+    "destroy-lambda",
+    "destroy-prefect",
+    "destroy-flink",
+    "deploy-dd-monitors",
+    "cleanup-dd-monitors",
+    "deploy-eks",
+    "destroy-eks",
+)
+
+
+class _TargetMetadata(TypedDict, total=False):
+    display_name: str
+    tags: tuple[str, ...]
+    requirements: TestRequirement
+
+
+_TARGET_METADATA: dict[str, _TargetMetadata] = {
+    "test": {
+        "display_name": "Fast Unit + Prefect E2E",
+        "tags": ("ci-safe", "test", "pytest"),
+        "requirements": TestRequirement(),
+    },
+    "test-full": {
+        "display_name": "Full Pytest Suite",
+        "tags": ("ci-safe", "test", "pytest"),
+        "requirements": TestRequirement(),
+    },
+    "test-cov": {
+        "display_name": "Coverage Suite",
+        "tags": ("ci-safe", "test", "coverage"),
+        "requirements": TestRequirement(),
+    },
+    "test-grafana": {
+        "display_name": "Grafana Integration Tests",
+        "tags": ("test", "grafana"),
+        "requirements": TestRequirement(env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY")),
+    },
+    "demo": {
+        "display_name": "Prefect ECS Demo",
+        "tags": ("demo", "aws"),
+        "requirements": TestRequirement(notes=("AWS infra",)),
+    },
+    "local-rca-demo": {
+        "display_name": "Bundled Local RCA Demo",
+        "tags": ("demo", "local"),
+        "requirements": TestRequirement(env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY")),
+    },
+    "cloudwatch-demo": {
+        "display_name": "CloudWatch Demo",
+        "tags": ("demo", "aws", "cloudwatch"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "datadog-demo": {
+        "display_name": "Datadog Demo",
+        "tags": ("demo", "datadog", "k8s", "infra-heavy"),
+        "requirements": TestRequirement(env_vars=("DD_API_KEY", "DD_APP_KEY"), notes=("Docker/Kubernetes",)),
+    },
+    "crashloop-demo": {
+        "display_name": "CrashLoopBackOff Demo",
+        "tags": ("demo", "datadog", "k8s"),
+        "requirements": TestRequirement(env_vars=("DD_API_KEY", "DD_APP_KEY")),
+    },
+    "prefect-demo": {
+        "display_name": "Prefect Demo Alias",
+        "tags": ("demo", "aws"),
+        "requirements": TestRequirement(notes=("AWS infra",)),
+    },
+    "simulate-k8s-alert": {
+        "display_name": "Simulate Kubernetes Alert",
+        "tags": ("k8s", "datadog", "infra-heavy"),
+        "requirements": TestRequirement(notes=("LangGraph dev server", "Kubernetes context")),
+    },
+    "test-k8s-local": {
+        "display_name": "Kubernetes Local Test",
+        "tags": ("k8s", "ci-safe"),
+        "requirements": TestRequirement(notes=("Local cluster",)),
+    },
+    "test-k8s": {
+        "display_name": "Kubernetes Test",
+        "tags": ("k8s", "infra-heavy"),
+        "requirements": TestRequirement(notes=("Kubernetes test env",)),
+    },
+    "test-k8s-datadog": {
+        "display_name": "Kubernetes + Datadog Test",
+        "tags": ("k8s", "datadog", "infra-heavy"),
+        "requirements": TestRequirement(env_vars=("DD_API_KEY", "DD_APP_KEY")),
+    },
+    "test-k8s-eks": {
+        "display_name": "Kubernetes + Datadog On EKS",
+        "tags": ("k8s", "aws", "datadog", "infra-heavy"),
+        "requirements": TestRequirement(env_vars=("DD_API_KEY", "DD_APP_KEY"), notes=("EKS cluster",)),
+    },
+    "trigger-alert": {
+        "display_name": "Trigger K8s Alert",
+        "tags": ("k8s", "datadog"),
+        "requirements": TestRequirement(notes=("Kubernetes alert env",)),
+    },
+    "trigger-alert-verify": {
+        "display_name": "Trigger K8s Alert + Verify",
+        "tags": ("k8s", "datadog", "infra-heavy"),
+        "requirements": TestRequirement(notes=("Slack + Datadog configured",)),
+    },
+    "prefect-local-test": {
+        "display_name": "Prefect Local Test",
+        "tags": ("aws", "local"),
+        "requirements": TestRequirement(notes=("Optional CLOUD=1",)),
+    },
+    "upstream-downstream": {
+        "display_name": "Upstream/Downstream Lambda E2E",
+        "tags": ("aws", "demo"),
+        "requirements": TestRequirement(notes=("AWS infra",)),
+    },
+    "flink-demo": {
+        "display_name": "Apache Flink ECS Demo",
+        "tags": ("aws", "demo"),
+        "requirements": TestRequirement(notes=("AWS infra",)),
+    },
+    "grafana-demo": {
+        "display_name": "Grafana Demo",
+        "tags": ("demo", "grafana"),
+        "requirements": TestRequirement(),
+    },
+    "deploy": {
+        "display_name": "Deploy All Test Stacks",
+        "tags": ("aws", "infra-heavy", "deploy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "destroy": {
+        "display_name": "Destroy All Test Stacks",
+        "tags": ("aws", "infra-heavy", "destroy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "deploy-lambda": {
+        "display_name": "Deploy Lambda Stack",
+        "tags": ("aws", "deploy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "deploy-prefect": {
+        "display_name": "Deploy Prefect Stack",
+        "tags": ("aws", "deploy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "deploy-flink": {
+        "display_name": "Deploy Flink Stack",
+        "tags": ("aws", "deploy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "destroy-lambda": {
+        "display_name": "Destroy Lambda Stack",
+        "tags": ("aws", "destroy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "destroy-prefect": {
+        "display_name": "Destroy Prefect Stack",
+        "tags": ("aws", "destroy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "destroy-flink": {
+        "display_name": "Destroy Flink Stack",
+        "tags": ("aws", "destroy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "deploy-dd-monitors": {
+        "display_name": "Deploy Datadog Monitors",
+        "tags": ("datadog", "deploy"),
+        "requirements": TestRequirement(env_vars=("DD_API_KEY", "DD_APP_KEY")),
+    },
+    "cleanup-dd-monitors": {
+        "display_name": "Cleanup Datadog Monitors",
+        "tags": ("datadog", "destroy"),
+        "requirements": TestRequirement(env_vars=("DD_API_KEY", "DD_APP_KEY")),
+    },
+    "deploy-eks": {
+        "display_name": "Deploy EKS Test Cluster",
+        "tags": ("aws", "k8s", "deploy", "infra-heavy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+    "destroy-eks": {
+        "display_name": "Destroy EKS Test Cluster",
+        "tags": ("aws", "k8s", "destroy", "infra-heavy"),
+        "requirements": TestRequirement(notes=("AWS credentials",)),
+    },
+}
+
+
+def _comment_map_for_makefile(path: Path) -> dict[str, str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    target_comments: dict[str, str] = {}
+    comment_buffer: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            comment_buffer.append(stripped.lstrip("# ").strip())
+            continue
+        if not stripped:
+            comment_buffer = []
+            continue
+
+        match = re.match(r"^([A-Za-z0-9_-]+):", stripped)
+        if match:
+            target_comments[match.group(1)] = " ".join(part for part in comment_buffer if part)
+            comment_buffer = []
+            continue
+
+        comment_buffer = []
+
+    return target_comments
+
+
+def discover_make_targets() -> list[TestCatalogItem]:
+    comment_map = _comment_map_for_makefile(MAKEFILE_PATH)
+    makefile_text = MAKEFILE_PATH.read_text(encoding="utf-8")
+    items: list[TestCatalogItem] = []
+
+    for target in _TARGETS_TO_INDEX:
+        if f"\n{target}:" not in makefile_text:
+            continue
+        metadata = _TARGET_METADATA.get(target, {})
+        tags = cast(tuple[str, ...], metadata.get("tags") or ("make",))
+        requirements = cast(TestRequirement, metadata.get("requirements") or TestRequirement())
+        items.append(
+            TestCatalogItem(
+                id=f"make:{target}",
+                kind="make_target",
+                display_name=str(metadata.get("display_name") or target),
+                description=comment_map.get(target) or f"Run `{target}` from the Makefile.",
+                command=("make", target),
+                tags=tags,
+                source_path=str(MAKEFILE_PATH),
+                requirements=requirements,
+            )
+        )
+
+    return items
+
+
+def discover_rca_files() -> list[TestCatalogItem]:
+    items: list[TestCatalogItem] = []
+    for path in sorted(RCA_DIR.glob("*.md")):
+        title = path.stem.replace("_", " ").title()
+        first_line = path.read_text(encoding="utf-8").splitlines()[0].strip()
+        if first_line.startswith("# "):
+            title = first_line[2:].strip()
+        items.append(
+            TestCatalogItem(
+                id=f"rca:{path.stem}",
+                kind="rca_file",
+                display_name=title,
+                description="Run a bundled markdown RCA alert fixture.",
+                command=("make", "test-rca", f"FILE={path.stem}"),
+                tags=("rca", "fixture"),
+                source_path=str(path),
+                requirements=TestRequirement(env_vars=("ANTHROPIC_API_KEY", "OPENAI_API_KEY")),
+            )
+        )
+    return items
+
+
+def load_test_catalog() -> TestCatalog:
+    items: list[TestCatalogItem] = []
+    items.extend(discover_make_targets())
+    items.extend(discover_rca_files())
+    items.sort(key=lambda item: item.display_name.lower())
+    return TestCatalog(items=tuple(items))

--- a/app/cli/tests/discover_test.py
+++ b/app/cli/tests/discover_test.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from app.cli.tests.discover import load_test_catalog
+
+
+def test_load_test_catalog_includes_make_targets_and_rca_fixtures() -> None:
+    catalog = load_test_catalog()
+
+    assert catalog.find("make:test-cov") is not None
+    assert catalog.find("make:demo") is not None
+    assert catalog.find("rca:pipeline_error_in_logs") is not None
+
+
+def test_load_test_catalog_excludes_synthetic_suite_for_now() -> None:
+    catalog = load_test_catalog()
+
+    assert catalog.find("suite:rds_postgres") is None

--- a/app/cli/tests/interactive.py
+++ b/app/cli/tests/interactive.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from rich.console import Console
+
+from app.cli.tests.catalog import TestCatalog, TestCatalogItem
+from app.cli.tests.runner import format_command, run_catalog_item
+
+_questionary: Any
+_QuestionaryChoice: Any
+_QuestionaryStyle: Any
+_select_prompt: Any
+
+try:
+    import questionary as _questionary
+    from questionary import Choice as _QuestionaryChoice
+    from questionary import Style as _QuestionaryStyle
+
+    from app.cli.wizard.prompts import select as _select_prompt
+except ModuleNotFoundError:  # pragma: no cover - depends on optional interactive deps
+    _questionary = None
+    _QuestionaryChoice = None
+    _QuestionaryStyle = None
+    _select_prompt = None
+
+_console = Console()
+
+_STYLE = (
+    _QuestionaryStyle(
+        [
+            ("qmark", "fg:cyan bold"),
+            ("question", "bold"),
+            ("answer", "fg:cyan bold"),
+            ("pointer", "fg:cyan bold"),
+            ("highlighted", "fg:cyan bold"),
+            ("selected", "fg:green"),
+            ("separator", "fg:cyan"),
+            ("instruction", "fg:#858585 italic"),
+        ]
+    )
+    if _QuestionaryStyle is not None
+    else None
+)
+
+_CATEGORY_OPTIONS: list[tuple[str, str]] = [
+    ("all", "All"),
+    ("rca", "RCA"),
+    ("demo", "Demos"),
+    ("infra-heavy", "Infra-heavy"),
+    ("ci-safe", "CI-safe"),
+]
+
+
+def _require_interactive_dependencies() -> None:
+    if _questionary is None or _QuestionaryChoice is None or _select_prompt is None or _STYLE is None:
+        raise RuntimeError(
+            "Interactive test browsing requires optional terminal dependencies. "
+            "Use `opensre tests list` or `opensre tests run <id>` in this environment."
+        )
+
+
+def _questionary_api() -> Any:
+    _require_interactive_dependencies()
+    return _questionary
+
+
+def _choose_category() -> str:
+    _require_interactive_dependencies()
+    choices = [_QuestionaryChoice(title=label, value=value) for value, label in _CATEGORY_OPTIONS]
+    result = _select_prompt(
+        "Choose a test category:",
+        choices=choices,
+        default="all",
+        style=_STYLE,
+        instruction="(Tab, arrows, Enter)",
+    ).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    return str(result)
+
+
+def _prompt_search_term() -> str:
+    result = _questionary_api().text(
+        "Optional search filter:",
+        default="",
+        style=_STYLE,
+        instruction="(Press Enter to show all matches)",
+    ).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    return str(result).strip()
+
+
+def _item_title(item: TestCatalogItem) -> str:
+    requirement_summary = item.requirements.summary()
+    suffix = f" [{requirement_summary}]" if requirement_summary else ""
+    return f"{item.display_name}{suffix}"
+
+
+def _select_item(items: list[TestCatalogItem], *, prompt: str) -> TestCatalogItem:
+    _require_interactive_dependencies()
+    choices = [_QuestionaryChoice(title=_item_title(item), value=item.id) for item in items]
+    result = _select_prompt(
+        prompt,
+        choices=choices,
+        style=_STYLE,
+        instruction="(Tab, arrows, Enter)",
+    ).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    selected_id = str(result)
+    for item in items:
+        if item.id == selected_id:
+            return item
+    raise ValueError(f"Unknown selected item: {selected_id}")
+
+
+def _select_child(item: TestCatalogItem) -> TestCatalogItem:
+    if not item.children:
+        return item
+    child_items = list(item.children)
+    return _select_item(child_items, prompt=f"Select a scenario from {item.display_name}:")
+
+
+def _matching_children(item: TestCatalogItem, *, category: str, search: str) -> list[TestCatalogItem]:
+    return [child for child in item.children if child.matches(category=category, search=search)]
+
+
+def _resolve_suite_selection(
+    item: TestCatalogItem,
+    *,
+    category: str,
+    search: str,
+) -> TestCatalogItem:
+    if not item.children:
+        return item
+
+    matching_children = _matching_children(item, category=category, search=search) or list(item.children)
+    if len(matching_children) == 1:
+        return matching_children[0]
+    return _select_item(matching_children, prompt=f"Select a scenario from {item.display_name}:")
+
+
+def _confirm_run(item: TestCatalogItem) -> bool:
+    _console.print(f"\n[bold]{item.display_name}[/]")
+    _console.print(item.description)
+    if item.source_path:
+        _console.print(f"[dim]Source: {item.source_path}[/]")
+    if item.tags:
+        _console.print(f"[dim]Tags: {', '.join(item.tags)}[/]")
+    if item.requirements.env_vars:
+        _console.print(f"[dim]Env vars: {', '.join(item.requirements.env_vars)}[/]")
+    if item.requirements.notes:
+        _console.print(f"[dim]Notes: {', '.join(item.requirements.notes)}[/]")
+    if item.command:
+        _console.print(f"[cyan]Command:[/] {format_command(item)}")
+
+    result = _questionary_api().confirm("Run this test?", default=True, style=_STYLE).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    return bool(result)
+
+
+def choose_interactive_item(catalog: TestCatalog) -> TestCatalogItem:
+    category = _choose_category()
+    search = _prompt_search_term()
+    filtered = catalog.filter(category=category, search=search)
+    if not filtered:
+        raise ValueError("No tests matched the selected filters.")
+
+    if len(filtered) == 1:
+        return _resolve_suite_selection(filtered[0], category=category, search=search)
+
+    selected = _select_item(filtered, prompt="Choose a test or suite:")
+    return _resolve_suite_selection(selected, category=category, search=search)
+
+
+def run_interactive_picker(catalog: TestCatalog) -> int:
+    _require_interactive_dependencies()
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        raise RuntimeError("Interactive terminal required. Use `opensre tests list` or `opensre tests run <id>`.")
+
+    item = choose_interactive_item(catalog)
+    if not _confirm_run(item):
+        return 0
+    return run_catalog_item(item)

--- a/app/cli/tests/interactive_test.py
+++ b/app/cli/tests/interactive_test.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from app.cli.tests import interactive
+from app.cli.tests.discover import load_test_catalog
+
+
+def test_choose_interactive_item_returns_single_filtered_match(monkeypatch) -> None:
+    catalog = load_test_catalog()
+    selected_prompts: list[str] = []
+
+    monkeypatch.setattr(interactive, "_choose_category", lambda: "ci-safe")
+    monkeypatch.setattr(interactive, "_prompt_search_term", lambda: "coverage")
+
+    def _mock_select_item(items, *, prompt: str):
+        selected_prompts.append(prompt)
+        return items[0]
+
+    monkeypatch.setattr(interactive, "_select_item", _mock_select_item)
+
+    item = interactive.choose_interactive_item(catalog)
+
+    assert item.id == "make:test-cov"
+    assert selected_prompts == []
+
+
+def test_choose_interactive_item_prompts_when_multiple_matches_exist(monkeypatch) -> None:
+    catalog = load_test_catalog()
+    selected_prompts: list[str] = []
+    selected_item_ids: list[list[str]] = []
+
+    monkeypatch.setattr(interactive, "_choose_category", lambda: "ci-safe")
+    monkeypatch.setattr(interactive, "_prompt_search_term", lambda: "")
+
+    def _mock_select_item(items, *, prompt: str):
+        selected_prompts.append(prompt)
+        selected_item_ids.append([item.id for item in items])
+        return items[0]
+
+    monkeypatch.setattr(interactive, "_select_item", _mock_select_item)
+
+    item = interactive.choose_interactive_item(catalog)
+
+    assert item.id == selected_item_ids[0][0]
+    assert selected_prompts == ["Choose a test or suite:"]
+    assert "make:test-cov" in selected_item_ids[0]
+
+
+def test_choose_interactive_item_raises_on_empty_filter(monkeypatch) -> None:
+    catalog = load_test_catalog()
+
+    monkeypatch.setattr(interactive, "_choose_category", lambda: "rca")
+    monkeypatch.setattr(interactive, "_prompt_search_term", lambda: "definitely-no-match")
+
+    try:
+        interactive.choose_interactive_item(catalog)
+    except ValueError as exc:
+        assert "No tests matched" in str(exc)
+    else:
+        raise AssertionError("Expected choose_interactive_item to reject empty filter results")

--- a/app/cli/tests/runner.py
+++ b/app/cli/tests/runner.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from app.cli.tests.catalog import TestCatalogItem
+from app.cli.tests.discover import REPO_ROOT, load_test_catalog
+
+
+def format_command(item: TestCatalogItem) -> str:
+    return item.command_display
+
+
+def find_test_item(item_id: str) -> TestCatalogItem | None:
+    return load_test_catalog().find(item_id)
+
+
+def run_catalog_item(
+    item: TestCatalogItem,
+    *,
+    dry_run: bool = False,
+    working_directory: Path | None = None,
+) -> int:
+    if not item.command:
+        raise ValueError(f"Test item '{item.id}' does not define a runnable command")
+
+    if dry_run:
+        print(format_command(item))
+        return 0
+
+    result = subprocess.run(
+        list(item.command),
+        cwd=working_directory or REPO_ROOT,
+        check=False,
+    )
+    return int(result.returncode)

--- a/app/cli/wizard/__init__.py
+++ b/app/cli/wizard/__init__.py
@@ -9,5 +9,4 @@ def run_wizard(*args, **kwargs):
 
     return _run_wizard(*args, **kwargs)
 
-
 __all__ = ["run_wizard"]

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -73,16 +73,16 @@ def validate_sentry_integration(**kwargs):
     return _validate(**kwargs)
 
 
-class IntegrationHealthResult:
-    def __init__(self, ok: bool, detail: str) -> None:
-        self.ok = ok
-        self.detail = detail
-
-
 def get_sentry_auth_recommendations():
     from app.integrations.sentry import get_sentry_auth_recommendations as _get
 
     return _get()
+
+
+@dataclass(frozen=True)
+class IntegrationHealthResult:
+    ok: bool
+    detail: str
 
 _STYLE = Style(
     [


### PR DESCRIPTION
## Summary
- add an `opensre tests` command group for listing, browsing, and running inventoried test targets from the terminal
- build a reusable test catalog/runner layer for Makefile targets and bundled RCA fixtures
- keep the wizard import path lightweight so the CLI test inventory flow avoids optional dependency churn at import time

## Test plan
- [x] `pytest app/cli/tests -q`
- [x] `make lint`
- [x] `make typecheck`

Made with [Cursor](https://cursor.com)