### PR TITLE
Improve CLI error message for unknown test id

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -339,7 +339,8 @@ def run(test_id: str, dry_run: bool) -> None:
 
     item = find_test_item(test_id)
     if item is None:
-        raise click.ClickException(f"Unknown test id: {test_id}")
+        raise click.ClickException(
+    f"Unknown test id: {test_id}. Run 'opensre tests list' to see available test ids.")
 
     capture_test_run_started(test_id, dry_run=dry_run)
     raise SystemExit(run_catalog_item(item, dry_run=dry_run))


### PR DESCRIPTION
## Fixes #182

## Description

Improves the CLI error message for unknown test ids by adding a helpful hint.
Users are now guided to run `opensre tests list` to discover valid test ids.

---

## Type of Change

- [x] 🐛 **Bug fix** (fixes #182, non-breaking)

---

## Testing

**How was this tested?**
- [x] Manual testing: Verified the error message when an invalid test id is passed to `opensre tests run`

**Test coverage:**
- [ ] New code has tests
- [x] Edge cases covered (invalid test id)
- [ ] All checks pass locally