### PR TITLE
fix: clean up chat model caches

### DIFF
--- a/app/nodes/chat.py
+++ b/app/nodes/chat.py
@@ -101,10 +101,8 @@ def _normalize_messages(msgs: list[Any]) -> list[ChatMessage]:
 
 type ToolEnabledChatModel = Runnable[object, object]
 
-_chat_llm: BaseChatModel | None = None
-_chat_llm_with_tools: ToolEnabledChatModel | None = None
-_chat_llm_provider: str | None = None
-_chat_llm_with_tools_provider: str | None = None
+_chat_llm_cache: dict[str, BaseChatModel] = {}
+_chat_llm_with_tools_cache: dict[str, ToolEnabledChatModel] = {}
 
 
 def _resolve_models(provider: str) -> tuple[str, str]:
@@ -171,23 +169,24 @@ def _build_chat_model(*, provider: str, model_name: str) -> BaseChatModel:
 
 def _get_chat_llm(*, with_tools: bool = False) -> BaseChatModel | ToolEnabledChatModel:
     """Get the provider-aware chat model used by chat nodes."""
-    global _chat_llm, _chat_llm_with_tools, _chat_llm_provider, _chat_llm_with_tools_provider
-
     provider = CfgHelpers.resolve_llm_provider()
     tool_model, reasoning_model = _resolve_models(provider)
 
     if with_tools:
-        # Rebuild the cache when switching providers between requests.
-        if _chat_llm_with_tools is None or _chat_llm_with_tools_provider != provider:
+        cached_tool_model = _chat_llm_with_tools_cache.get(provider)
+        if cached_tool_model is None:
             base = _build_chat_model(provider=provider, model_name=tool_model)
-            _chat_llm_with_tools = base.bind_tools(CHAT_TOOLS)  # type: ignore[assignment]
-            _chat_llm_with_tools_provider = provider
-        return _chat_llm_with_tools  # type: ignore[return-value]
+            cached_tool_model = cast(ToolEnabledChatModel, base.bind_tools(CHAT_TOOLS))
+            _chat_llm_with_tools_cache[provider] = cached_tool_model
+        return cached_tool_model
 
-    if _chat_llm is None or _chat_llm_provider != provider:
-        _chat_llm = _build_chat_model(provider=provider, model_name=reasoning_model)
-        _chat_llm_provider = provider
-    return _chat_llm
+    cached_reasoning_model = _chat_llm_cache.get(provider)
+    if cached_reasoning_model is None:
+        cached_reasoning_model = _build_chat_model(
+            provider=provider, model_name=reasoning_model
+        )
+        _chat_llm_cache[provider] = cached_reasoning_model
+    return cached_reasoning_model
 
 
 # ── Node functions ───────────────────────────────────────────────────────

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -28,7 +28,7 @@ def init_sentry() -> None:
         _initialised = True
         return
 
-    import sentry_sdk
+    import sentry_sdk  # type: ignore[import-not-found]
 
     from app.config import get_environment
     from app.version import get_version

--- a/tests/nodes/test_chat.py
+++ b/tests/nodes/test_chat.py
@@ -11,10 +11,8 @@ from app.nodes import chat as chat_mod
 
 def _clear_chat_llm_singletons() -> None:
     """Reset module-level chat model cache (isolated test runs)."""
-    chat_mod._chat_llm = None
-    chat_mod._chat_llm_with_tools = None
-    chat_mod._chat_llm_provider = None
-    chat_mod._chat_llm_with_tools_provider = None
+    chat_mod._chat_llm_cache.clear()
+    chat_mod._chat_llm_with_tools_cache.clear()
 
 
 class _OpenAIModule:

--- a/tests/nodes/test_chat_provider_awareness.py
+++ b/tests/nodes/test_chat_provider_awareness.py
@@ -144,10 +144,8 @@ def _reset_chat_cache(monkeypatch) -> None:
     Returns:
         None.
     """
-    monkeypatch.setattr(chat, "_chat_llm", None)
-    monkeypatch.setattr(chat, "_chat_llm_with_tools", None)
-    monkeypatch.setattr(chat, "_chat_llm_provider", None)
-    monkeypatch.setattr(chat, "_chat_llm_with_tools_provider", None)
+    monkeypatch.setattr(chat, "_chat_llm_cache", {})
+    monkeypatch.setattr(chat, "_chat_llm_with_tools_cache", {})
 
 
 def test_get_chat_llm_uses_openai_toolcall_model_when_provider_openai(


### PR DESCRIPTION
## Summary
- replace the chat module's provider sentinel globals with provider-keyed caches so CodeQL no longer reports unused global variables
- update the chat cache reset helpers in the existing node tests to match the new cache structure
- make the optional `sentry_sdk` import explicit for mypy so the branch passes the repo typecheck hook cleanly

## Test plan
- [x] `pytest tests/nodes/test_chat.py tests/nodes/test_chat_provider_awareness.py -q`
- [x] `make lint`
- [x] `make typecheck`

Made with [Cursor](https://cursor.com)