### PR TITLE
Refactor repeated string-list validation in synthetic schemas

### DIFF
--- a/tests/synthetic/schemas.py
+++ b/tests/synthetic/schemas.py
@@ -346,7 +346,6 @@ def validate_answer_key(data: dict[str, Any]) -> AnswerKeySchema:
         raise ValueError("answer.yml: 'max_investigation_loops' must be a positive integer when present")
     for axis2_list_field in ("ruling_out_keywords", "required_queries"):
         _require_non_empty_str_list(data, axis2_list_field, "answer.yml")
-        
     return data  # type: ignore[return-value]
 
 


### PR DESCRIPTION
Fixes #177

Refactored duplicated validation logic in validate_answer_key by extracting a helper function _require_non_empty_str_list.

Improves readability and reduces code duplication without changing behavior.