### PR TITLE
fix: disable analytics in CI pipelines

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -25,6 +25,16 @@ _FIRST_RUN_PATH = _CONFIG_DIR / "installed"
 
 _POSTHOG_API_KEY = "phc_zutpVhmQw7oUmMkbawKNdYCKQWjpfASATtf5ywB75W2"
 _POSTHOG_HOST = "https://us.i.posthog.com"
+_CI_ENV_VARS: Final[tuple[str, ...]] = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "GITLAB_CI",
+    "BUILDKITE",
+    "CIRCLECI",
+    "TRAVIS",
+    "JENKINS_URL",
+    "TEAMCITY_VERSION",
+)
 
 _QUEUE_SIZE = 128
 _SEND_TIMEOUT = 2.0
@@ -40,10 +50,15 @@ class _Envelope:
     properties: Properties
 
 
+def _is_ci_environment() -> bool:
+    return any(os.getenv(name, "") not in ("", "0", "false", "False") for name in _CI_ENV_VARS)
+
+
 def _is_opted_out() -> bool:
     return (
         os.getenv("OPENSRE_ANALYTICS_DISABLED", "0") == "1"
         or os.getenv("DO_NOT_TRACK", "0") == "1"
+        or _is_ci_environment()
     )
 
 
@@ -88,7 +103,7 @@ _BASE_PROPERTIES: Final[Properties] = {
 class Analytics:
     def __init__(self) -> None:
         self._disabled = _is_opted_out()
-        self._anonymous_id = _get_or_create_anonymous_id()
+        self._anonymous_id = "disabled" if self._disabled else _get_or_create_anonymous_id()
         self._queue: queue.Queue[_Envelope | None] = queue.Queue(maxsize=_QUEUE_SIZE)
         self._pending_lock = threading.Lock()
         self._pending = 0
@@ -195,11 +210,15 @@ def shutdown_analytics(*, flush: bool = True) -> None:
 
 
 def mark_install_detected() -> None:
+    if _is_opted_out():
+        return
     with contextlib.suppress(OSError):
         _FIRST_RUN_PATH.parent.mkdir(parents=True, exist_ok=True)
         _FIRST_RUN_PATH.touch(exist_ok=True)
 
 
 def capture_first_run_if_needed() -> None:
+    if _is_opted_out():
+        return
     if _touch_once(_FIRST_RUN_PATH):
         get_analytics().capture(Event.INSTALL_DETECTED)

--- a/app/analytics/provider_test.py
+++ b/app/analytics/provider_test.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.analytics import provider
+
+
+def test_is_opted_out_in_ci_environment(monkeypatch) -> None:
+    monkeypatch.setenv("CI", "true")
+
+    assert provider._is_ci_environment() is True
+    assert provider._is_opted_out() is True
+
+
+def test_capture_first_run_if_needed_skips_files_in_ci(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    anonymous_id_path = tmp_path / "anonymous_id"
+    first_run_path = tmp_path / "installed"
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", anonymous_id_path)
+    monkeypatch.setattr(provider, "_FIRST_RUN_PATH", first_run_path)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_instance", None)
+
+    analytics = provider.Analytics()
+    provider.capture_first_run_if_needed()
+
+    assert analytics._disabled is True
+    assert anonymous_id_path.exists() is False
+    assert first_run_path.exists() is False


### PR DESCRIPTION
## Summary
- treat common CI environments as analytics opt-out conditions so CLI PostHog events do not fire in automated pipelines
- skip creating analytics state files like the anonymous id and install marker when CI disables analytics
- add focused tests covering CI detection and the no-file-side-effects behavior

## Test plan
- [x] `pytest app/analytics/provider_test.py -q`
- [x] `make lint`
- [x] `make typecheck`

Made with [Cursor](https://cursor.com)