### PR TITLE
Add .editorconfig and clean up tooling config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+max_line_length = 100
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ coverage.xml
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,12 +15,6 @@ ignore_missing_imports = True
 [mypy-kubernetes]
 ignore_missing_imports = True
 
-[mypy-kubernetes.*]
-ignore_missing_imports = True
-
-[mypy-kubernetes.client.exceptions]
-ignore_missing_imports = True
-
 [mypy-requests]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Fixes #186

#### Describe the changes you have made in this PR -

Adds a project-level `.editorconfig` so editors automatically pick up the conventions already defined in `ruff.toml`, and tidies two small gaps in the existing tooling config.

1. **`.editorconfig` (new)** — 4-space Python indent, 100-char line length, UTF-8/LF, 2-space YAML/JSON/TOML, tab-indented Makefiles. All values match the existing `ruff.toml` and `pyproject.toml`.
2. **`.gitignore`** — added `.ruff_cache/` entry. Every other tool cache (`.mypy_cache/`, `.pytest_cache/`, `.pyre/`) was already listed; ruff was the only one missing.
3. **`mypy.ini`** — removed unused `[mypy-kubernetes.*]` and `[mypy-kubernetes.client.exceptions]` sections. The codebase only uses `from kubernetes import client`, which is covered by the existing `[mypy-kubernetes]` section. mypy's `warn_unused_configs` flagged both sections.

### Screenshots of the UI changes (If any) -

N/A — config-only changes, no UI impact.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

- `.editorconfig` values were derived directly from the existing `ruff.toml` (line-length = 100, target-version = "py312") and `pyproject.toml`. YAML/JSON use 2-space indent to match the existing files in the repo. Makefile uses tabs as required by make.
- `.ruff_cache/` was the only tool cache directory missing from `.gitignore` — I noticed it was generated locally after running `ruff check` and confirmed it was untracked.
- The mypy sections were identified by running `mypy app/` which emitted `unused section(s)` notes due to `warn_unused_configs = True` in `mypy.ini`. I verified with `grep -r "from kubernetes" app/` that only top-level imports exist, confirming the wildcard and submodule sections are unnecessary.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Verification:
```
ruff check app/ tests/     # All checks passed
mypy app/                   # Success: no issues found in 207 source files (0 warnings)
```