### PR TITLE
Add MCP CLI entrypoint for opensre_mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ Changelog = "https://github.com/Tracer-Cloud/opensre/releases"
 [project.scripts]
 opensre = "app.cli.__main__:main"
 opensre-mcp = "app.integrations.opensre_mcp:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",


### PR DESCRIPTION
Fixes #303

Add MCP CLI entrypoint (`opensre-mcp`) to expose the MCP server for integration.
