### PR TITLE
fix: add .vale.ini to activate vocabulary for Mintlify spellcheck

### DIFF
--- a/docs-mintlify/.vale.ini
+++ b/docs-mintlify/.vale.ini
@@ -1,0 +1,21 @@
+StylesPath = styles
+MinAlertLevel = suggestion
+Vocab = Mintlify
+
+[formats]
+mdx = md
+
+[*.mdx]
+BasedOnStyles = Vale
+Vale.Terms = NO
+
+TokenIgnores = (?m)((?:import|export) .+?$), \
+(?<!`)(<\w+ ?.+ ?\/>)(?!`), \
+(<[A-Z]\w+>.+?<\/[A-Z]\w+>), \
+(<[^>]*>), \
+\{[^}]*\}, \
+(`[^`]*`)
+
+BlockIgnores = (?sm)^(<\w+\n .*\s\/>)$, \
+(?sm)^({.+.*})$, \
+(?sm)^```[\s\S]*?```$


### PR DESCRIPTION
## Summary

- Add a `.vale.ini` to the `docs-mintlify/` directory that points `StylesPath` to the local `styles/` directory and activates the `Mintlify` vocabulary

## Context

PR #335 added the vocabulary files at `styles/config/vocabularies/Mintlify/accept.txt` but without a `.vale.ini`, Mintlify's default config uses its built-in paths and ignores the local vocabulary — resulting in 320 spellcheck false positives on every PR.

This `.vale.ini` matches [Mintlify's documented default config](https://mintlify.com/docs/settings/ci) with `StylesPath = styles` so the accepted domain-specific terms (Datadog, Nextflow, Grafana, bioinformatics, etc.) are loaded.

## Test plan

- [ ] Verify Mintlify `vale-spellcheck` CI check passes (was failing with 320 findings)

Made with [Cursor](https://cursor.com)