### PR TITLE
added the health check fastapi endpoint for hosted deployments

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib
+
+from fastapi import FastAPI, Response, status
+from pydantic import BaseModel
+
+from app.config import LLMSettings, get_environment
+from app.version import get_version
+
+
+class HealthResponse(BaseModel):
+    ok: bool
+    version: str
+    graph_loaded: bool
+    llm_configured: bool
+    env: str
+
+
+app = FastAPI()
+
+
+def _graph_loaded() -> bool:
+    try:
+        importlib.import_module("app.graph_pipeline")
+    except Exception:
+        return False
+    return True
+
+
+def _llm_configured() -> bool:
+    try:
+        LLMSettings.from_env()
+    except Exception:
+        return False
+    return True
+
+
+def get_health_response() -> HealthResponse:
+    is_graph_loaded = _graph_loaded()
+    is_llm_configured = _llm_configured()
+    env = get_environment().value
+
+    return HealthResponse(
+        ok=is_graph_loaded and is_llm_configured,
+        version=get_version(),
+        graph_loaded=is_graph_loaded,
+        llm_configured=is_llm_configured,
+        env=env,
+    )
+
+@app.get("/health", response_model=HealthResponse)
+def health(response: Response) -> HealthResponse:
+    health_response = get_health_response()
+    response.status_code = status.HTTP_200_OK if health_response.ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    return health_response

--- a/langgraph.json
+++ b/langgraph.json
@@ -7,6 +7,9 @@
   "auth": {
     "path": "./app/auth/auth.py:auth"
   },
+  "http": {
+    "app": "./app/webapp.py:app"
+  },
   "env": ".env",
   "image_distro": "wolfi"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     # HTTP and async
     "httpx>=0.27.0",
     "aiohttp>=3.9.0",
+    "fastapi>=0.135.3",
     # Authentication
     "PyJWT>=2.8.0",
     "cryptography>=42.0.0",

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import Environment
+from app.webapp import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+class TestWebApp:
+    def test_health_ok(self, client: TestClient, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("app.webapp._graph_loaded", lambda: True)
+        monkeypatch.setattr("app.webapp._llm_configured", lambda: True)
+        monkeypatch.setattr("app.webapp.get_version", lambda: "0.1.0")
+        monkeypatch.setattr("app.webapp.get_environment", lambda: Environment.PRODUCTION)
+        expected_response = {
+            "ok": True,
+            "version": "0.1.0",
+            "graph_loaded": True,
+            "llm_configured": True,
+            "env": "production",
+        }
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+    def test_health_failed(self, client: TestClient, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("app.webapp._graph_loaded", lambda: False)
+        monkeypatch.setattr("app.webapp._llm_configured", lambda: True)
+        monkeypatch.setattr("app.webapp.get_version", lambda: "0.1.0")
+        monkeypatch.setattr("app.webapp.get_environment", lambda: Environment.PRODUCTION)
+        expected_response = {
+            "ok": False,
+            "version": "0.1.0",
+            "graph_loaded": False,
+            "llm_configured": True,
+            "env": "production",
+        }
+        response = client.get("/health")
+        assert response.status_code == 503
+        assert response.json() == expected_response


### PR DESCRIPTION
Fixes #268 

#### Describe the changes you have made in this PR -
Added lightweight health endpoint that checks that is graph_pipeline, llm env is loaded and configured or not and returns HealthResponse as suggested in issue.
```python
class HealthResponse(BaseModel):
    ok: bool
    version: str
    graph_loaded: bool
    llm_configured: bool
    env: Environment
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I added as suggested webapp.py in app and wrote a minimal endpoint health that checks if llm env is configured and graph pipeline loaded and if so returns structured json as expected.
I also added tests for this (mocking http client). 

**Files modified/added**
```bash
app/webapp.py
tests/test_webapp.py
langgraph.json
pyproject.toml (added fastapi as deps)
```
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



If there are any additional requirements or modifications required pls let me know.