### PR TITLE
Update installation process for virtual environment and pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ endif
 # PIP_INSTALL_FLAGS = --user --break-system-packages
 USER_BASE := $(shell $(PYTHON) -m site --user-base)
 USER_BIN := $(USER_BASE)/bin
-export PATH := $(USER_BIN):$(PATH)
+export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,)$(USER_BIN):$(PATH)
 
 # Create venv and install dependencies
 install:
 	python3 -m venv .venv
-	.venv/bin/python -m pip install --upgrade pip
-	.venv/bin/python -m pip install $(PIP_INSTALL_FLAGS) -e ".[dev]"
-	.venv/bin/python -m app.analytics.install
+	$(PIP) install --upgrade pip
+	$(PIP) install $(PIP_INSTALL_FLAGS) -e ".[dev]"
+	$(PYTHON) -m app.analytics.install
 
 build:
 	$(PYTHON) -m build


### PR DESCRIPTION
This pull request updates the `install` target in the `Makefile` to ensure a Python virtual environment is created and used for dependency installation, rather than relying on the user's global Python environment.

Dependency installation improvements:

* The `install` target now explicitly creates a `.venv` virtual environment, upgrades `pip` within it, and installs dependencies using the virtual environment's Python interpreter, improving isolation and reproducibility.

/fix #357 