### PR TITLE
fix: add health command to CLI help and landing page

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -74,6 +74,7 @@ def _render_help() -> None:
         ("investigate",   "Run an RCA investigation against an alert payload."),
         ("tests",         "Browse and run inventoried tests from the terminal."),
         ("integrations",  "Manage local integration credentials."),
+        ("health",        "Check integration and agent setup status."),
         ("update",        "Check for a newer version and update if one is available."),
     ]:
         console.print(Text.assemble(("    ", ""), (f"{name:<16}", "bold cyan"), desc))
@@ -106,6 +107,7 @@ def _render_landing() -> None:
         ("opensre investigate -i alert.json", "Run RCA against an alert payload"),
         ("opensre tests",                     "Browse and run inventoried tests"),
         ("opensre integrations list",         "Show configured integrations"),
+        ("opensre health",                    "Check integration and agent setup status"),
         ("opensre update",                    "Update to the latest version"),
     ]:
         console.print(Text.assemble(("    ", ""), (f"{cmd:<42}", "bold cyan"), desc))


### PR DESCRIPTION
## Summary
- The `opensre health` command was registered in Click but missing from the hardcoded command lists in `_render_help()` and `_render_landing()`, making it invisible when running `opensre` or `opensre -h`.
- Added `health` to both display lists so it shows alongside the other commands.

## Test plan
- [x] Ran `opensre` and verified `health` appears in the Quick start section
- [x] Ran `opensre -h` and verified `health` appears in the Commands section

Made with [Cursor](https://cursor.com)