### PR TITLE
fix: remove unused EvidenceSource re-export from app.state

### DIFF
--- a/app/state/__init__.py
+++ b/app/state/__init__.py
@@ -2,7 +2,7 @@
 
 from app.state.agent_state import AgentState, AgentStateModel, InvestigationState
 from app.state.factory import STATE_DEFAULTS, make_chat_state, make_initial_state
-from app.state.types import AgentMode, ChatMessage, ChatMessageModel, EvidenceSource
+from app.state.types import AgentMode, ChatMessage, ChatMessageModel
 
 __all__ = [
     "AgentMode",
@@ -10,7 +10,6 @@ __all__ = [
     "AgentStateModel",
     "ChatMessage",
     "ChatMessageModel",
-    "EvidenceSource",
     "InvestigationState",
     "STATE_DEFAULTS",
     "make_chat_state",

--- a/app/state/types.py
+++ b/app/state/types.py
@@ -7,7 +7,6 @@ from typing import Any, Literal, TypedDict
 from pydantic import Field
 
 from app.strict_config import StrictConfigModel
-from app.types.evidence import EvidenceSource as EvidenceSource  # re-export
 
 AgentMode = Literal["chat", "investigation"]
 


### PR DESCRIPTION
## Summary

- Removes the unused `EvidenceSource` re-export from `app/state/types.py` and `app/state/__init__.py`
- Resolves [CodeQL alert #257](https://github.com/Tracer-Cloud/opensre/security/code-scanning/257) (unused import)
- All callers already import `EvidenceSource` directly from `app.types.evidence`

## Test plan

- [x] `make lint` — passes
- [x] `make typecheck` — passes
- [x] `make test-cov` — 465 passed, 1 skipped

Made with [Cursor](https://cursor.com)