### PR TITLE
fix: remove unused Prefect client global

### DIFF
--- a/app/integrations/clients/prefect/client.py
+++ b/app/integrations/clients/prefect/client.py
@@ -21,9 +21,6 @@ logger = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT = 30
 _PREFECT_CLOUD_BASE = "https://api.prefect.cloud/api"
 
-# Flow run states considered unhealthy
-_FAILED_STATES = {"FAILED", "CRASHED", "CANCELLED", "CANCELLING"}
-
 
 class PrefectConfig(StrictConfigModel):
     """Normalized Prefect credentials.


### PR DESCRIPTION
## Summary
- remove the unused `_FAILED_STATES` constant from the Prefect client module
- keep failed-state filtering in `PrefectFlowRunsTool`, where the logic is actively used
- clear CodeQL alert #253 without changing Prefect runtime behavior

## Test plan
- [x] `pytest app/tools/PrefectFlowRunsTool/tool_test.py app/tools/PrefectWorkerHealthTool/tool_test.py`
- [x] `make lint`
- [x] `"/Users/janvincentfranciszek/tracer-agent-2026/.venv/bin/python" -m mypy app/`


Made with [Cursor](https://cursor.com)