### PR TITLE
fix: collapse dual orchestrator into single LangGraph execution path

### DIFF
--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -487,6 +487,9 @@ def node_resolve_integrations(state: InvestigationState) -> dict:
       2. JWT_TOKEN env var — remote API, with local store/env filling missing services
       3. Local sources: ~/.tracer/integrations.json, plus env-based integrations for standalone use
     """
+    if state.get("resolved_integrations"):
+        return {}
+
     tracker = get_tracker()
     tracker.start("resolve_integrations", "Fetching org integrations")
     org_id = state.get("org_id", "")

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -7,16 +7,7 @@ from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
 
-from app.nodes import (
-    node_diagnose_root_cause,
-    node_extract_alert,
-    node_plan_actions,
-    node_publish_findings,
-    node_resolve_integrations,
-)
 from app.nodes.chat import chat_agent_node, general_node, router_node
-from app.nodes.investigate.node import node_investigate
-from app.pipeline.routing import should_continue_investigation
 from app.state import AgentState, make_initial_state
 
 
@@ -44,27 +35,6 @@ def run_chat(state: AgentState, config: RunnableConfig | None = None) -> AgentSt
     return state
 
 
-def _run_investigation_pipeline(state: AgentState) -> AgentState:
-    """Run investigation pipeline sequentially without LangGraph."""
-    _merge_state(state, node_extract_alert(state))
-
-    if state.get("is_noise"):
-        return state
-
-    if not state.get("resolved_integrations"):
-        _merge_state(state, node_resolve_integrations(state))
-
-    while True:
-        _merge_state(state, node_plan_actions(state))
-        _merge_state(state, node_investigate(state))
-        _merge_state(state, node_diagnose_root_cause(state))
-        if should_continue_investigation(state) != "investigate":
-            break
-
-    _merge_state(state, node_publish_findings(state))
-    return state
-
-
 def run_investigation(
     alert_name: str,
     pipeline_name: str,
@@ -72,17 +42,19 @@ def run_investigation(
     raw_alert: str | dict[str, Any] | None = None,
     resolved_integrations: dict[str, Any] | None = None,
 ) -> AgentState:
-    """Run investigation pipeline. Pure function: inputs in, state out.
+    """Run investigation pipeline via LangGraph. Pure function: inputs in, state out.
 
     Args:
         resolved_integrations: Optional pre-resolved integrations dict. When provided,
             node_resolve_integrations is skipped — useful for synthetic testing where a
             FixtureGrafanaBackend should be injected without real credential resolution.
     """
+    from app.pipeline.graph import graph as compiled_graph  # lazy to avoid circular import
+
     initial = make_initial_state(alert_name, pipeline_name, severity, raw_alert=raw_alert)
     if resolved_integrations is not None:
         cast(dict[str, Any], initial)["resolved_integrations"] = resolved_integrations
-    return cast(AgentState, _run_investigation_pipeline(initial))
+    return cast(AgentState, compiled_graph.invoke(initial))
 
 
 @dataclass
@@ -90,6 +62,7 @@ class SimpleAgent:
     def invoke(
         self, state: AgentState, config: RunnableConfig | None = None
     ) -> AgentState:
-        if state.get("mode") == "chat":
-            return run_chat(state, config)
-        return _run_investigation_pipeline(state)
+        from app.pipeline.graph import graph as compiled_graph  # lazy to avoid circular import
+
+        cfg = config or {"configurable": {}}
+        return cast(AgentState, compiled_graph.invoke(state, cfg))

--- a/tests/e2e/rca/run_rca_test.py
+++ b/tests/e2e/rca/run_rca_test.py
@@ -9,15 +9,12 @@ Usage:
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from typing import Any
 
-import app.pipeline.runners as runners
-from app.auth.jwt_auth import extract_org_id_from_jwt
-from app.state import make_initial_state
+from app.pipeline.runners import run_investigation
 
 RCA_DIR = Path(__file__).parent
 
@@ -39,31 +36,17 @@ def _parse_alert_md(path: Path) -> dict[str, Any]:
     return {"title": title, "severity": severity, "pipeline_name": pipeline_name, "raw_alert": meta}
 
 
-def _get_local_auth() -> tuple[str, str]:
-    """Extract org_id and JWT token from the local JWT_TOKEN env var."""
-    jwt_token = os.getenv("JWT_TOKEN", "").strip()
-    if not jwt_token:
-        return "", ""
-    org_id = extract_org_id_from_jwt(jwt_token) or ""
-    return org_id, jwt_token
-
-
 def run_file(path: Path) -> bool:
     print(f"\n  RCA TEST  {path.stem}")
 
     alert = _parse_alert_md(path)
-    org_id, jwt_token = _get_local_auth()
 
-    state = make_initial_state(
+    state = run_investigation(
         alert_name=alert["title"],
         pipeline_name=alert["pipeline_name"],
         severity=alert["severity"],
         raw_alert=alert["raw_alert"],
     )
-    # Inject auth so node_resolve_integrations fetches real integrations
-    runners._merge_state(state, {"org_id": org_id, "auth_token": jwt_token})
-
-    runners._run_investigation_pipeline(state)
 
     passed = bool(state.get("root_cause"))
     category = state.get("root_cause_category") or "—"


### PR DESCRIPTION
## Summary

- Removes `_run_investigation_pipeline` — a manual sequential node runner that duplicated the LangGraph execution path, creating a dual-orchestrator problem where investigations could run outside the graph's control flow
- `run_investigation()` now invokes the compiled LangGraph graph directly (lazy import to avoid circular dependency with `graph.py`)
- `SimpleAgent.invoke()` delegates to the graph for both chat and investigation modes instead of branching between `run_chat` and `_run_investigation_pipeline`
- Adds an early-return idempotency guard to `node_resolve_integrations`: if `resolved_integrations` is already set in state, the node is a no-op — prevents double-resolution when integrations are pre-injected (e.g. fixture backends in tests)
- Updates `tests/e2e/rca/run_rca_test.py` to call `run_investigation(...)` instead of the removed internal helper

## Test plan

- [ ] `make typecheck` — passes (252 source files, no issues)
- [ ] `ruff check` on changed files — passes
- [ ] E2E: `make test-rca` against real alerts (requires infra credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)