### PR TITLE
test: full unit test coverage for all investigation tools

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-
 # ---------------------------------------------------------------------------
 # Shared fixture factories (plain functions, called directly from tests)
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_aws_operation_tool.py
+++ b/tests/tools/test_aws_operation_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.AWSOperationTool import execute_aws_operation
+from tests.tools.conftest import BaseToolContract
 
 
 class TestAWSOperationToolContract(BaseToolContract):

--- a/tests/tools/test_cloudwatch_batch_metrics_tool.py
+++ b/tests/tools/test_cloudwatch_batch_metrics_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.CloudWatchBatchMetricsTool import get_cloudwatch_batch_metrics
+from tests.tools.conftest import BaseToolContract
 
 
 class TestCloudWatchBatchMetricsToolContract(BaseToolContract):

--- a/tests/tools/test_cloudwatch_logs_tool.py
+++ b/tests/tools/test_cloudwatch_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.CloudWatchLogsTool import get_cloudwatch_logs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestCloudWatchLogsToolContract(BaseToolContract):

--- a/tests/tools/test_coralogix_logs_tool.py
+++ b/tests/tools/test_coralogix_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.CoralogixLogsTool import CoralogixLogsTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestCoralogixLogsToolContract(BaseToolContract):
@@ -51,12 +50,12 @@ def test_run_happy_path() -> None:
         "total": 2,
         "warnings": [],
     }
-    with patch("app.tools.CoralogixLogsTool.CoralogixClient", return_value=mock_client):
-        with patch("app.tools.CoralogixLogsTool.build_coralogix_logs_query", return_value="source logs"):
-            result = tool.run(
-                query="source logs | limit 50",
-                coralogix_api_key="cx_key",
-            )
+    with patch("app.tools.CoralogixLogsTool.CoralogixClient", return_value=mock_client), \
+         patch("app.tools.CoralogixLogsTool.build_coralogix_logs_query", return_value="source logs"):
+        result = tool.run(
+            query="source logs | limit 50",
+            coralogix_api_key="cx_key",
+        )
     assert result["available"] is True
     assert len(result["logs"]) == 2
     assert len(result["error_logs"]) == 1
@@ -67,7 +66,7 @@ def test_run_api_error() -> None:
     mock_client = MagicMock()
     mock_client.is_configured = True
     mock_client.query_logs.return_value = {"success": False, "error": "Rate limited"}
-    with patch("app.tools.CoralogixLogsTool.CoralogixClient", return_value=mock_client):
-        with patch("app.tools.CoralogixLogsTool.build_coralogix_logs_query", return_value="source logs"):
-            result = tool.run(query="source logs", coralogix_api_key="cx_key")
+    with patch("app.tools.CoralogixLogsTool.CoralogixClient", return_value=mock_client), \
+         patch("app.tools.CoralogixLogsTool.build_coralogix_logs_query", return_value="source logs"):
+        result = tool.run(query="source logs", coralogix_api_key="cx_key")
     assert result["available"] is False

--- a/tests/tools/test_datadog_context_tool.py
+++ b/tests/tools/test_datadog_context_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.DataDogContextTool import fetch_datadog_context
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestDataDogContextToolContract(BaseToolContract):

--- a/tests/tools/test_datadog_events_tool.py
+++ b/tests/tools/test_datadog_events_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.DataDogEventsTool import query_datadog_events
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestDataDogEventsToolContract(BaseToolContract):

--- a/tests/tools/test_datadog_logs_tool.py
+++ b/tests/tools/test_datadog_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.DataDogLogsTool import query_datadog_logs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestDataDogLogsToolContract(BaseToolContract):

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.DataDogMetricsTool import query_datadog_metrics
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestDataDogMetricsToolContract(BaseToolContract):

--- a/tests/tools/test_datadog_monitors_tool.py
+++ b/tests/tools/test_datadog_monitors_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.DataDogMonitorsTool import query_datadog_monitors
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestDataDogMonitorsToolContract(BaseToolContract):

--- a/tests/tools/test_datadog_node_pods_tool.py
+++ b/tests/tools/test_datadog_node_pods_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.DataDogNodePodsTool import get_pods_on_node
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestDataDogNodePodsToolContract(BaseToolContract):

--- a/tests/tools/test_eks_deployment_status_tool.py
+++ b/tests/tools/test_eks_deployment_status_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSDeploymentStatusTool import get_eks_deployment_status
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSDeploymentStatusToolContract(BaseToolContract):

--- a/tests/tools/test_eks_describe_addon_tool.py
+++ b/tests/tools/test_eks_describe_addon_tool.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+
 from botocore.exceptions import ClientError
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSDescribeAddonTool import describe_eks_addon
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSDescribeAddonToolContract(BaseToolContract):

--- a/tests/tools/test_eks_describe_cluster_tool.py
+++ b/tests/tools/test_eks_describe_cluster_tool.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+
 from botocore.exceptions import ClientError
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSDescribeClusterTool import describe_eks_cluster
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSDescribeClusterToolContract(BaseToolContract):

--- a/tests/tools/test_eks_events_tool.py
+++ b/tests/tools/test_eks_events_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSEventsTool import get_eks_events
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSEventsToolContract(BaseToolContract):

--- a/tests/tools/test_eks_list_clusters_tool.py
+++ b/tests/tools/test_eks_list_clusters_tool.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+
 from botocore.exceptions import ClientError
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSListClustersTool import list_eks_clusters
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSListClustersToolContract(BaseToolContract):

--- a/tests/tools/test_eks_list_deployments_tool.py
+++ b/tests/tools/test_eks_list_deployments_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSListDeploymentsTool import list_eks_deployments
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSListDeploymentsToolContract(BaseToolContract):

--- a/tests/tools/test_eks_list_namespaces_tool.py
+++ b/tests/tools/test_eks_list_namespaces_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSListNamespacesTool import list_eks_namespaces
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSListNamespacesToolContract(BaseToolContract):

--- a/tests/tools/test_eks_list_pods_tool.py
+++ b/tests/tools/test_eks_list_pods_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSListPodsTool import list_eks_pods
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSListPodsToolContract(BaseToolContract):

--- a/tests/tools/test_eks_node_health_tool.py
+++ b/tests/tools/test_eks_node_health_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSNodeHealthTool import get_eks_node_health
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSNodeHealthToolContract(BaseToolContract):

--- a/tests/tools/test_eks_nodegroup_health_tool.py
+++ b/tests/tools/test_eks_nodegroup_health_tool.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+
 from botocore.exceptions import ClientError
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSNodegroupHealthTool import get_eks_nodegroup_health
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSNodegroupHealthToolContract(BaseToolContract):

--- a/tests/tools/test_eks_pod_logs_tool.py
+++ b/tests/tools/test_eks_pod_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.EKSPodLogsTool import get_eks_pod_logs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestEKSPodLogsToolContract(BaseToolContract):

--- a/tests/tools/test_elasticsearch_logs_tool.py
+++ b/tests/tools/test_elasticsearch_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.ElasticsearchLogsTool import ElasticsearchLogsTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestElasticsearchLogsToolContract(BaseToolContract):

--- a/tests/tools/test_github_commits_tool.py
+++ b/tests/tools/test_github_commits_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GitHubCommitsTool import list_github_commits
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGitHubCommitsToolContract(BaseToolContract):
@@ -47,12 +46,12 @@ def test_run_happy_path() -> None:
         "content": [],
     }
     mock_config = MagicMock()
-    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
-        with patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config):
-            with patch("app.tools.GitHubCommitsTool.call_github_mcp_tool", return_value=fake_result):
-                result = list_github_commits(
-                    owner="org", repo="repo",
-                    github_url="http://mcp", github_mode="streamable-http", github_token="tok",
-                )
+    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None), \
+         patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config), \
+         patch("app.tools.GitHubCommitsTool.call_github_mcp_tool", return_value=fake_result):
+        result = list_github_commits(
+            owner="org", repo="repo",
+            github_url="http://mcp", github_mode="streamable-http", github_token="tok",
+        )
     assert result["available"] is True
     assert len(result["commits"]) == 2

--- a/tests/tools/test_github_file_contents_tool.py
+++ b/tests/tools/test_github_file_contents_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GitHubFileContentsTool import get_github_file_contents
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGitHubFileContentsToolContract(BaseToolContract):
@@ -48,12 +47,12 @@ def test_run_happy_path() -> None:
         "content": [],
     }
     mock_config = MagicMock()
-    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
-        with patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config):
-            with patch("app.tools.GitHubFileContentsTool.call_github_mcp_tool", return_value=fake_result):
-                result = get_github_file_contents(
-                    owner="org", repo="repo", path="main.py",
-                    github_url="http://mcp", github_mode="streamable-http", github_token="tok",
-                )
+    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None), \
+         patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config), \
+         patch("app.tools.GitHubFileContentsTool.call_github_mcp_tool", return_value=fake_result):
+        result = get_github_file_contents(
+            owner="org", repo="repo", path="main.py",
+            github_url="http://mcp", github_mode="streamable-http", github_token="tok",
+        )
     assert result["available"] is True
     assert result["file"]["name"] == "main.py"

--- a/tests/tools/test_github_repository_tree_tool.py
+++ b/tests/tools/test_github_repository_tree_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GitHubRepositoryTreeTool import get_github_repository_tree
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGitHubRepositoryTreeToolContract(BaseToolContract):
@@ -47,12 +46,12 @@ def test_run_happy_path() -> None:
         "content": [],
     }
     mock_config = MagicMock()
-    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
-        with patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config):
-            with patch("app.tools.GitHubRepositoryTreeTool.call_github_mcp_tool", return_value=fake_result):
-                result = get_github_repository_tree(
-                    owner="org", repo="repo",
-                    github_url="http://mcp", github_mode="streamable-http", github_token="tok",
-                )
+    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None), \
+         patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config), \
+         patch("app.tools.GitHubRepositoryTreeTool.call_github_mcp_tool", return_value=fake_result):
+        result = get_github_repository_tree(
+            owner="org", repo="repo",
+            github_url="http://mcp", github_mode="streamable-http", github_token="tok",
+        )
     assert result["available"] is True
     assert result["tree"] is not None

--- a/tests/tools/test_github_search_code_tool.py
+++ b/tests/tools/test_github_search_code_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GitHubSearchCodeTool import search_github_code
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGitHubSearchCodeToolContract(BaseToolContract):
@@ -49,13 +48,13 @@ def test_run_happy_path() -> None:
     }
     from unittest.mock import MagicMock
     mock_config = MagicMock()
-    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
-        with patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config):
-            with patch("app.tools.GitHubSearchCodeTool.call_github_mcp_tool", return_value=fake_result):
-                result = search_github_code(
-                    owner="org", repo="repo", query="error",
-                    github_url="http://mcp", github_mode="streamable-http", github_token="tok",
-                )
+    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None), \
+         patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config), \
+         patch("app.tools.GitHubSearchCodeTool.call_github_mcp_tool", return_value=fake_result):
+        result = search_github_code(
+            owner="org", repo="repo", query="error",
+            github_url="http://mcp", github_mode="streamable-http", github_token="tok",
+        )
     assert result["available"] is True
     assert result["matches"] == fake_result["structured_content"]
 
@@ -69,12 +68,12 @@ def test_run_tool_error() -> None:
     }
     from unittest.mock import MagicMock
     mock_config = MagicMock()
-    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
-        with patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config):
-            with patch("app.tools.GitHubSearchCodeTool.call_github_mcp_tool", return_value=fake_result):
-                result = search_github_code(
-                    owner="org", repo="repo", query="error",
-                    github_url="http://mcp", github_mode="streamable-http", github_token="tok",
-                )
+    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None), \
+         patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config), \
+         patch("app.tools.GitHubSearchCodeTool.call_github_mcp_tool", return_value=fake_result):
+        result = search_github_code(
+            owner="org", repo="repo", query="error",
+            github_url="http://mcp", github_mode="streamable-http", github_token="tok",
+        )
     assert result["available"] is False
     assert "rate limited" in result["error"]

--- a/tests/tools/test_google_docs_create_report_tool.py
+++ b/tests/tools/test_google_docs_create_report_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GoogleDocsCreateReportTool import create_google_docs_incident_report
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGoogleDocsCreateReportToolContract(BaseToolContract):

--- a/tests/tools/test_grafana_alert_rules_tool.py
+++ b/tests/tools/test_grafana_alert_rules_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GrafanaAlertRulesTool import query_grafana_alert_rules
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGrafanaAlertRulesToolContract(BaseToolContract):

--- a/tests/tools/test_grafana_logs_tool.py
+++ b/tests/tools/test_grafana_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GrafanaLogsTool import query_grafana_logs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGrafanaLogsToolContract(BaseToolContract):

--- a/tests/tools/test_grafana_metrics_tool.py
+++ b/tests/tools/test_grafana_metrics_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GrafanaMetricsTool import query_grafana_metrics
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGrafanaMetricsToolContract(BaseToolContract):

--- a/tests/tools/test_grafana_service_names_tool.py
+++ b/tests/tools/test_grafana_service_names_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GrafanaServiceNamesTool import query_grafana_service_names
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGrafanaServiceNamesToolContract(BaseToolContract):

--- a/tests/tools/test_grafana_traces_tool.py
+++ b/tests/tools/test_grafana_traces_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.GrafanaTracesTool import query_grafana_traces
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestGrafanaTracesToolContract(BaseToolContract):

--- a/tests/tools/test_honeycomb_traces_tool.py
+++ b/tests/tools/test_honeycomb_traces_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.HoneycombTracesTool import HoneycombTracesTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestHoneycombTracesToolContract(BaseToolContract):

--- a/tests/tools/test_lambda_config_tool.py
+++ b/tests/tools/test_lambda_config_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.LambdaConfigTool import get_lambda_configuration
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestLambdaConfigToolContract(BaseToolContract):

--- a/tests/tools/test_lambda_errors_tool.py
+++ b/tests/tools/test_lambda_errors_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.LambdaErrorsTool import get_lambda_errors
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestLambdaErrorsToolContract(BaseToolContract):

--- a/tests/tools/test_lambda_inspect_tool.py
+++ b/tests/tools/test_lambda_inspect_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.LambdaInspectTool import inspect_lambda_function
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestLambdaInspectToolContract(BaseToolContract):

--- a/tests/tools/test_lambda_invocation_logs_tool.py
+++ b/tests/tools/test_lambda_invocation_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.LambdaInvocationLogsTool import get_lambda_invocation_logs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestLambdaInvocationLogsToolContract(BaseToolContract):

--- a/tests/tools/test_mongodb_collection_stats_tool.py
+++ b/tests/tools/test_mongodb_collection_stats_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.MongoDBCollectionStatsTool import get_mongodb_collection_stats
+from tests.tools.conftest import BaseToolContract
 
 
 class TestMongoDBCollectionStatsToolContract(BaseToolContract):

--- a/tests/tools/test_mongodb_current_ops_tool.py
+++ b/tests/tools/test_mongodb_current_ops_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.MongoDBCurrentOpsTool import get_mongodb_current_ops
+from tests.tools.conftest import BaseToolContract
 
 
 class TestMongoDBCurrentOpsToolContract(BaseToolContract):

--- a/tests/tools/test_mongodb_profiler_tool.py
+++ b/tests/tools/test_mongodb_profiler_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.MongoDBProfilerTool import get_mongodb_profiler_data
+from tests.tools.conftest import BaseToolContract
 
 
 class TestMongoDBProfilerToolContract(BaseToolContract):

--- a/tests/tools/test_mongodb_replica_status_tool.py
+++ b/tests/tools/test_mongodb_replica_status_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.MongoDBReplicaStatusTool import get_mongodb_replica_status
+from tests.tools.conftest import BaseToolContract
 
 
 class TestMongoDBReplicaStatusToolContract(BaseToolContract):

--- a/tests/tools/test_mongodb_server_status_tool.py
+++ b/tests/tools/test_mongodb_server_status_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.MongoDBServerStatusTool import get_mongodb_server_status
+from tests.tools.conftest import BaseToolContract
 
 
 class TestMongoDBServerStatusToolContract(BaseToolContract):

--- a/tests/tools/test_prefect_flow_runs_tool.py
+++ b/tests/tools/test_prefect_flow_runs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.PrefectFlowRunsTool import PrefectFlowRunsTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestPrefectFlowRunsToolContract(BaseToolContract):

--- a/tests/tools/test_prefect_worker_health_tool.py
+++ b/tests/tools/test_prefect_worker_health_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.PrefectWorkerHealthTool import PrefectWorkerHealthTool
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestPrefectWorkerHealthToolContract(BaseToolContract):

--- a/tests/tools/test_s3_get_object_tool.py
+++ b/tests/tools/test_s3_get_object_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.S3GetObjectTool import get_s3_object
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestS3GetObjectToolContract(BaseToolContract):

--- a/tests/tools/test_s3_inspect_tool.py
+++ b/tests/tools/test_s3_inspect_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.S3InspectTool import inspect_s3_object
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestS3InspectToolContract(BaseToolContract):
@@ -50,9 +49,9 @@ def test_run_happy_path() -> None:
         "metadata": {},
     }
     fake_sample = {"is_text": True, "sample": "hello world", "sample_bytes": 11}
-    with patch("app.tools.S3InspectTool.get_object_metadata", return_value={"success": True, "exists": True, "data": fake_meta}):
-        with patch("app.tools.S3InspectTool.get_object_sample", return_value={"success": True, "data": fake_sample}):
-            result = inspect_s3_object(bucket="b", key="k")
+    with patch("app.tools.S3InspectTool.get_object_metadata", return_value={"success": True, "exists": True, "data": fake_meta}), \
+         patch("app.tools.S3InspectTool.get_object_sample", return_value={"success": True, "data": fake_sample}):
+        result = inspect_s3_object(bucket="b", key="k")
     assert result["found"] is True
     assert result["size"] == 2048
     assert result["is_text"] is True

--- a/tests/tools/test_s3_list_tool.py
+++ b/tests/tools/test_s3_list_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.S3ListTool import list_s3_objects
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestS3ListToolContract(BaseToolContract):

--- a/tests/tools/test_s3_marker_tool.py
+++ b/tests/tools/test_s3_marker_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.S3MarkerTool import check_s3_marker
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestS3MarkerToolContract(BaseToolContract):

--- a/tests/tools/test_sentry_issue_details_tool.py
+++ b/tests/tools/test_sentry_issue_details_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.SentryIssueDetailsTool import get_sentry_issue_details
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestSentryIssueDetailsToolContract(BaseToolContract):
@@ -40,10 +39,10 @@ def test_run_returns_unavailable_when_no_config() -> None:
 
 def test_run_happy_path() -> None:
     fake_issue = {"id": "123", "title": "TypeError", "culprit": "app/views.py"}
-    with patch("app.tools.SentryIssueDetailsTool.get_sentry_issue", return_value=fake_issue):
-        with patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
-            result = get_sentry_issue_details(
-                organization_slug="my-org", sentry_token="tok_test", issue_id="123"
-            )
+    with patch("app.tools.SentryIssueDetailsTool.get_sentry_issue", return_value=fake_issue), \
+         patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
+        result = get_sentry_issue_details(
+            organization_slug="my-org", sentry_token="tok_test", issue_id="123"
+        )
     assert result["available"] is True
     assert result["issue"]["id"] == "123"

--- a/tests/tools/test_sentry_issue_events_tool.py
+++ b/tests/tools/test_sentry_issue_events_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.SentryIssueEventsTool import list_sentry_issue_events
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestSentryIssueEventsToolContract(BaseToolContract):
@@ -41,10 +40,10 @@ def test_run_returns_unavailable_when_no_config() -> None:
 
 def test_run_happy_path() -> None:
     fake_events = [{"eventID": "e1", "dateCreated": "2024-01-01"}]
-    with patch("app.tools.SentryIssueEventsTool.sentry_list_issue_events", return_value=fake_events):
-        with patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
-            result = list_sentry_issue_events(
-                organization_slug="my-org", sentry_token="tok_test", issue_id="123"
-            )
+    with patch("app.tools.SentryIssueEventsTool.sentry_list_issue_events", return_value=fake_events), \
+         patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
+        result = list_sentry_issue_events(
+            organization_slug="my-org", sentry_token="tok_test", issue_id="123"
+        )
     assert result["available"] is True
     assert len(result["events"]) == 1

--- a/tests/tools/test_sentry_search_issues_tool.py
+++ b/tests/tools/test_sentry_search_issues_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.SentrySearchIssuesTool import search_sentry_issues
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestSentrySearchIssuesToolContract(BaseToolContract):
@@ -39,23 +38,23 @@ def test_run_returns_unavailable_when_no_config() -> None:
 
 def test_run_happy_path() -> None:
     fake_issues = [{"id": "1", "title": "TypeError", "status": "unresolved"}]
-    with patch("app.tools.SentrySearchIssuesTool.list_sentry_issues", return_value=fake_issues):
-        with patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
-            result = search_sentry_issues(
-                organization_slug="my-org",
-                sentry_token="tok_test",
-                query="TypeError",
-            )
+    with patch("app.tools.SentrySearchIssuesTool.list_sentry_issues", return_value=fake_issues), \
+         patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
+        result = search_sentry_issues(
+            organization_slug="my-org",
+            sentry_token="tok_test",
+            query="TypeError",
+        )
     assert result["available"] is True
     assert len(result["issues"]) == 1
     assert result["query"] == "TypeError"
 
 
 def test_run_empty_issues() -> None:
-    with patch("app.tools.SentrySearchIssuesTool.list_sentry_issues", return_value=[]):
-        with patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
-            result = search_sentry_issues(
-                organization_slug="my-org", sentry_token="tok_test"
-            )
+    with patch("app.tools.SentrySearchIssuesTool.list_sentry_issues", return_value=[]), \
+         patch("app.tools.SentrySearchIssuesTool.sentry_config_from_env", return_value=None):
+        result = search_sentry_issues(
+            organization_slug="my-org", sentry_token="tok_test"
+        )
     assert result["available"] is True
     assert result["issues"] == []

--- a/tests/tools/test_sre_guidance_tool.py
+++ b/tests/tools/test_sre_guidance_tool.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.SREGuidanceTool import get_sre_guidance
+from tests.tools.conftest import BaseToolContract
 
 
 class TestSREGuidanceToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_airflow_metrics_tool.py
+++ b/tests/tools/test_tracer_airflow_metrics_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.TracerAirflowMetricsTool import get_airflow_metrics
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerAirflowMetricsToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_batch_statistics_tool.py
+++ b/tests/tools/test_tracer_batch_statistics_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.TracerBatchStatisticsTool import get_batch_statistics
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerBatchStatisticsToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_error_logs_tool.py
+++ b/tests/tools/test_tracer_error_logs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.TracerErrorLogsTool import get_error_logs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerErrorLogsToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_failed_jobs_tool.py
+++ b/tests/tools/test_tracer_failed_jobs_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.TracerFailedJobsTool import get_failed_jobs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerFailedJobsToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_failed_run_tool.py
+++ b/tests/tools/test_tracer_failed_run_tool.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
-from app.tools.TracerFailedRunTool import fetch_failed_run
 from app.services.tracer_client import PipelineRunSummary
+from app.tools.TracerFailedRunTool import fetch_failed_run
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerFailedRunToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_failed_tools_tool.py
+++ b/tests/tools/test_tracer_failed_tools_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.TracerFailedToolsTool import get_failed_tools
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerFailedToolsToolContract(BaseToolContract):

--- a/tests/tools/test_tracer_host_metrics_tool.py
+++ b/tests/tools/test_tracer_host_metrics_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract, mock_agent_state
-
 from app.tools.TracerHostMetricsTool import get_host_metrics
+from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
 class TestTracerHostMetricsToolContract(BaseToolContract):
@@ -37,8 +36,8 @@ def test_run_happy_path() -> None:
     mock_client = MagicMock()
     raw_metrics = {"cpu": [{"timestamp": "2024-01-01", "value": 85.0}]}
     mock_client.get_host_metrics.return_value = raw_metrics
-    with patch("app.tools.TracerHostMetricsTool.get_tracer_web_client", return_value=mock_client):
-        with patch("app.tools.TracerHostMetricsTool.validate_host_metrics", return_value=raw_metrics):
-            result = get_host_metrics(trace_id="trace-123")
+    with patch("app.tools.TracerHostMetricsTool.get_tracer_web_client", return_value=mock_client), \
+         patch("app.tools.TracerHostMetricsTool.validate_host_metrics", return_value=raw_metrics):
+        result = get_host_metrics(trace_id="trace-123")
     assert "metrics" in result
     assert result["validation_performed"] is True

--- a/tests/tools/test_tracer_run_tool.py
+++ b/tests/tools/test_tracer_run_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.TracerRunTool import get_tracer_run
+from tests.tools.conftest import BaseToolContract
 
 
 class TestTracerRunToolContract(BaseToolContract):
@@ -40,5 +39,5 @@ def test_run_with_pipeline_name() -> None:
     mock_result = MagicMock()
     mock_client.get_latest_run.return_value = mock_result
     with patch("app.tools.TracerRunTool.get_tracer_client", return_value=mock_client):
-        result = get_tracer_run(pipeline_name="my-pipeline")
+        get_tracer_run(pipeline_name="my-pipeline")
     mock_client.get_latest_run.assert_called_once_with("my-pipeline")

--- a/tests/tools/test_tracer_tasks_tool.py
+++ b/tests/tools/test_tracer_tasks_tool.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from tests.tools.conftest import BaseToolContract
-
 from app.tools.TracerTasksTool import get_tracer_tasks
+from tests.tools.conftest import BaseToolContract
 
 
 class TestTracerTasksToolContract(BaseToolContract):


### PR DESCRIPTION
## Summary
- Added `BaseToolContract` mixin in `tests/tools/conftest.py` with 6 shared contract tests (name, description, input_schema, source, is_available, extract_params) that apply to all tools automatically
- Added shared factory functions: `mock_agent_state()`, `mock_boto3_client()`, `mock_http_response()` for use in tests
- Added 63 new test files covering all investigation tools across: CloudWatch, DataDog, Grafana, EKS, Lambda, Sentry, GitHub, S3, MongoDB, Tracer, Prefect, Elasticsearch, Honeycomb, Coralogix, GoogleDocs, and AWSOperation
- All tests mock at the client/HTTP boundary — no real network calls
- Each tool test covers: metadata validation (via BaseToolContract), is_available(), extract_params(), happy path, empty/error responses, and edge cases

## Test plan
- [x] All 727 tests pass: `pytest tests/tools/ -q`
- [x] No real network calls in any test
- [x] `BaseToolContract` mixin covers both class-based tools (BaseTool subclasses) and function-based tools (@tool decorated)
- [x] Tests mock at the import boundary (e.g. `patch("app.tools.ToolName.make_client")`) not internal methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)