### PR TITLE
fix: resolve all 6 open CodeQL security/quality alerts

### DIFF
--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -27,7 +27,6 @@ from app.pipeline.routing import (
     route_investigation_loop,
     should_call_tools,
 )
-from app.pipeline.runners import SimpleAgent
 from app.state import AgentState
 
 
@@ -79,5 +78,4 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     return graph.compile()
 
 
-agent = SimpleAgent()
 graph = build_graph()

--- a/tests/app/test_agent_state_sync.py
+++ b/tests/app/test_agent_state_sync.py
@@ -4,8 +4,6 @@ If this test fails, a field was added/removed in one definition but not the othe
 Fix the drift by updating both classes in app/state/agent_state.py.
 """
 
-import pytest
-
 from app.state.agent_state import AgentState, AgentStateModel
 
 

--- a/tests/tools/test_datadog_context_tool.py
+++ b/tests/tools/test_datadog_context_tool.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from app.tools.DataDogContextTool import fetch_datadog_context
 from tests.tools.conftest import BaseToolContract, mock_agent_state

--- a/tests/tools/test_tracer_failed_run_tool.py
+++ b/tests/tools/test_tracer_failed_run_tool.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from app.services.tracer_client import PipelineRunSummary
 from app.tools.TracerFailedRunTool import fetch_failed_run
-from tests.tools.conftest import BaseToolContract, mock_agent_state
+from tests.tools.conftest import BaseToolContract
 
 
 class TestTracerFailedRunToolContract(BaseToolContract):


### PR DESCRIPTION
## Summary

- **Cyclic import** (#262, #263, #264): `app/pipeline/graph.py` imported `SimpleAgent` from `runners.py` solely for a module-level `agent = SimpleAgent()` that was never referenced anywhere in the codebase. Removing the import and the dead assignment breaks the `graph → runners → (package __init__) → graph` cycle.
- **Unused imports** (#265, #271, #272): Removed `pytest` from `test_agent_state_sync.py`, `AsyncMock` from `test_datadog_context_tool.py`, and `mock_agent_state` from `test_tracer_failed_run_tool.py`.

Resolves https://github.com/Tracer-Cloud/opensre/security/code-scanning alerts #262, #263, #264, #265, #271, #272.

## Test plan

- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues in 248 source files
- [x] `make test-cov` — 1205 passed, 1 skipped

Made with [Cursor](https://cursor.com)