### PR TITLE
feat: add routing metadata and explainable tool selection

### DIFF
--- a/app/nodes/plan_actions/build_prompt.py
+++ b/app/nodes/plan_actions/build_prompt.py
@@ -97,7 +97,9 @@ def _build_available_sources_hint(available_sources: dict[str, dict]) -> str:
         grafana = available_sources["grafana"]
         loki_only = grafana.get("loki_only", False)
         grafana_label = "Grafana Local (Loki only)" if loki_only else "Grafana Cloud"
-        traces_hint = "" if loki_only else "\n- Use query_grafana_traces to find distributed traces in Tempo"
+        traces_hint = (
+            "" if loki_only else "\n- Use query_grafana_traces to find distributed traces in Tempo"
+        )
         hints.append(
             f"""{grafana_label} Available:
 - Service Name: {grafana.get("service_name")}
@@ -302,11 +304,7 @@ def select_actions(
     Returns:
         Tuple of (available_actions, available_action_names)
     """
-    available_actions = [
-        action
-        for action in actions
-        if action.is_available(available_sources)
-    ]
+    available_actions = [action for action in actions if action.is_available(available_sources)]
 
     executed_actions_flat = set()
     for hyp in executed_hypotheses:
@@ -370,9 +368,18 @@ def _format_action_metadata(action) -> str:
     outputs_desc = "\n    ".join(f"- {field}: {desc}" for field, desc in action.outputs.items())
     use_cases_desc = "\n    ".join(f"- {uc}" for uc in action.use_cases)
 
+    # Include routing metadata if available (for explainable tool selection)
+    routing_info = ""
+    if getattr(action, "toolset", None) and action.toolset != "default":
+        routing_info += f"\n  Toolset: {action.toolset}"
+    if getattr(action, "tags", None):
+        routing_info += f"\n  Tags: {', '.join(action.tags)}"
+    if getattr(action, "cost_hint", None) and action.cost_hint != "low":
+        routing_info += f"\n  Cost Hint: {action.cost_hint}"
+
     return f"""Action: {action.name}
   Description: {action.description}
-  Source: {action.source}
+  Source: {action.source}{routing_info}
   Required Inputs:
     {inputs_desc}
   Returns:

--- a/app/nodes/route_tools/__init__.py
+++ b/app/nodes/route_tools/__init__.py
@@ -1,0 +1,31 @@
+"""Tool routing node with explainable selection and safe fallback paths.
+
+This module provides deterministic tool selection with human-readable inclusion
+reasons and bounded fallback for low-confidence routing scenarios.
+"""
+
+from __future__ import annotations
+
+from app.nodes.route_tools.route_tools import (
+    DEFAULT_FALLBACK_TOOLSETS,
+    MAX_FALLBACK_TOOLS,
+    MIN_CONFIDENCE_THRESHOLD,
+    RoutingResult,
+    ToolSelectionResult,
+    filter_available_tools,
+    route_tools_by_tags,
+    route_tools_by_toolset,
+    select_fallback_tools,
+)
+
+__all__ = [
+    "DEFAULT_FALLBACK_TOOLSETS",
+    "MAX_FALLBACK_TOOLS",
+    "MIN_CONFIDENCE_THRESHOLD",
+    "RoutingResult",
+    "ToolSelectionResult",
+    "filter_available_tools",
+    "route_tools_by_tags",
+    "route_tools_by_toolset",
+    "select_fallback_tools",
+]

--- a/app/nodes/route_tools/route_tools.py
+++ b/app/nodes/route_tools/route_tools.py
@@ -167,11 +167,21 @@ def route_tools_by_tags(
     cost_priority = {"low": 0, "medium": 1, "high": 2}
     matching_tools.sort(key=lambda x: (-x[2], cost_priority.get(x[0].cost_hint, 0), x[0].name))
 
+    best_confidence = matching_tools[0][2]
+    # If overall confidence is too low, use fallback instead
+    if best_confidence < min_confidence:
+        fallback_results = select_fallback_tools(available_tools)
+        return RoutingResult(
+            selected_tools=fallback_results,
+            fallback_used=True,
+            routing_reason=f"Low confidence ({best_confidence:.0%}) below threshold - using fallback",
+            confidence=best_confidence,
+        )
+
     # Select tools with confidence above threshold
     selected: list[ToolSelectionResult] = []
-    overall_confidence = 0.0
     for tool, matching_tags, confidence in matching_tools:
-        if confidence >= min_confidence or not selected:
+        if confidence >= min_confidence:
             reason = f"Tag match: {', '.join(sorted(matching_tags))} (confidence: {confidence:.0%})"
             selected.append(
                 ToolSelectionResult(
@@ -181,23 +191,12 @@ def route_tools_by_tags(
                     is_fallback=False,
                 )
             )
-            overall_confidence = max(overall_confidence, confidence)
-
-    # If overall confidence is too low, use fallback instead
-    if overall_confidence < min_confidence:
-        fallback_results = select_fallback_tools(available_tools)
-        return RoutingResult(
-            selected_tools=fallback_results,
-            fallback_used=True,
-            routing_reason=f"Low confidence ({overall_confidence:.0%}) below threshold - using fallback",
-            confidence=overall_confidence,
-        )
 
     return RoutingResult(
         selected_tools=selected,
         fallback_used=False,
         routing_reason=f"Tag-based routing matched {len(selected)} tools for tags: {required_tags}",
-        confidence=overall_confidence,
+        confidence=best_confidence,
     )
 
 

--- a/app/nodes/route_tools/route_tools.py
+++ b/app/nodes/route_tools/route_tools.py
@@ -1,0 +1,284 @@
+"""Tool routing with explainable selection and safe fallback paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.tools.registered_tool import RegisteredTool
+
+# Default fallback toolsets for low-confidence routing scenarios
+# Tools selected deterministically when confidence is below threshold
+DEFAULT_FALLBACK_TOOLSETS: frozenset[str] = frozenset({"core", "discovery", "logs"})
+
+# Minimum confidence threshold for normal routing
+# Below this, use deterministic fallback selection
+MIN_CONFIDENCE_THRESHOLD: float = 0.5
+
+# Maximum number of tools in fallback selection
+MAX_FALLBACK_TOOLS: int = 3
+
+
+@dataclass
+class ToolSelectionResult:
+    """Result of tool selection with human-readable inclusion reasons."""
+
+    tool: RegisteredTool
+    inclusion_reason: str = ""  # Human-readable explanation for why this tool was selected
+    confidence: float = 1.0  # Confidence score for this selection (0.0-1.0)
+    is_fallback: bool = False  # Whether this was selected as part of fallback
+
+
+@dataclass
+class RoutingResult:
+    """Complete routing result with selected tools and metadata."""
+
+    selected_tools: list[ToolSelectionResult] = field(default_factory=list)
+    fallback_used: bool = False  # Whether fallback selection was used
+    routing_reason: str = ""  # Overall explanation for routing decisions
+    confidence: float = 1.0  # Overall confidence score
+
+    def to_tool_names(self) -> list[str]:
+        """Return list of selected tool names."""
+        return [result.tool.name for result in self.selected_tools]
+
+    def to_detailed_dict(self) -> dict[str, Any]:
+        """Return detailed routing result as dictionary for logging/debugging."""
+        return {
+            "tools": [
+                {
+                    "name": result.tool.name,
+                    "reason": result.inclusion_reason,
+                    "confidence": result.confidence,
+                    "is_fallback": result.is_fallback,
+                    "toolset": result.tool.toolset,
+                    "cost_hint": result.tool.cost_hint,
+                    "tags": result.tool.tags,
+                }
+                for result in self.selected_tools
+            ],
+            "fallback_used": self.fallback_used,
+            "routing_reason": self.routing_reason,
+            "overall_confidence": self.confidence,
+        }
+
+
+def select_fallback_tools(
+    available_tools: list[RegisteredTool],
+    max_tools: int = MAX_FALLBACK_TOOLS,
+) -> list[ToolSelectionResult]:
+    """Deterministically select fallback tools when confidence is low.
+
+    Fallback selection prioritizes:
+    1. Tools from core toolsets (discovery, logs, core)
+    2. Low cost_hint tools first
+    3. Alphabetical by toolset, then by name for determinism
+
+    Args:
+        available_tools: All available tools to choose from
+        max_tools: Maximum number of tools to select
+
+    Returns:
+        List of ToolSelectionResult with fallback selections and reasons
+    """
+    # Filter to fallback-eligible tools
+    eligible = [tool for tool in available_tools if tool.toolset in DEFAULT_FALLBACK_TOOLSETS]
+
+    if not eligible:
+        # If no eligible tools in default toolsets, use any available
+        eligible = available_tools[: max_tools * 2]
+
+    # Sort by: cost_hint priority (low < medium < high), then toolset, then name
+    cost_priority = {"low": 0, "medium": 1, "high": 2}
+    sorted_tools = sorted(
+        eligible,
+        key=lambda t: (
+            cost_priority.get(t.cost_hint, 0),
+            t.toolset,
+            t.name,
+        ),
+    )
+
+    selected = sorted_tools[:max_tools]
+
+    results = []
+    for tool in selected:
+        reason = (
+            f"Fallback selection: {tool.toolset} tool with {tool.cost_hint} cost "
+            f"(deterministic fallback for low-confidence routing)"
+        )
+        results.append(
+            ToolSelectionResult(
+                tool=tool,
+                inclusion_reason=reason,
+                confidence=0.5,  # Fixed confidence for fallback
+                is_fallback=True,
+            )
+        )
+
+    return results
+
+
+def route_tools_by_tags(
+    available_tools: list[RegisteredTool],
+    required_tags: list[str],
+    min_confidence: float = MIN_CONFIDENCE_THRESHOLD,
+) -> RoutingResult:
+    """Route tools by matching tags with explainable selection.
+
+    Args:
+        available_tools: All available tools
+        required_tags: Tags that must be present for tool selection
+        min_confidence: Minimum confidence threshold
+
+    Returns:
+        RoutingResult with selected tools and reasons
+    """
+    if not required_tags:
+        # No tags specified - use fallback
+        fallback_results = select_fallback_tools(available_tools)
+        return RoutingResult(
+            selected_tools=fallback_results,
+            fallback_used=True,
+            routing_reason="No routing tags specified - using deterministic fallback selection",
+            confidence=0.5,
+        )
+
+    matching_tools = []
+    for tool in available_tools:
+        # Calculate match score (number of matching tags)
+        matching_tags = set(tool.tags) & set(required_tags)
+        if matching_tags:
+            # Confidence based on proportion of required tags matched
+            confidence = len(matching_tags) / len(required_tags)
+            matching_tools.append((tool, matching_tags, confidence))
+
+    if not matching_tools:
+        # No matching tools - use fallback
+        fallback_results = select_fallback_tools(available_tools)
+        return RoutingResult(
+            selected_tools=fallback_results,
+            fallback_used=True,
+            routing_reason=f"No tools match required tags {required_tags} - using fallback",
+            confidence=0.3,
+        )
+
+    # Sort by confidence (highest first), then by cost_hint
+    cost_priority = {"low": 0, "medium": 1, "high": 2}
+    matching_tools.sort(key=lambda x: (-x[2], cost_priority.get(x[0].cost_hint, 0), x[0].name))
+
+    # Select tools with confidence above threshold
+    selected: list[ToolSelectionResult] = []
+    overall_confidence = 0.0
+    for tool, matching_tags, confidence in matching_tools:
+        if confidence >= min_confidence or not selected:
+            reason = f"Tag match: {', '.join(sorted(matching_tags))} (confidence: {confidence:.0%})"
+            selected.append(
+                ToolSelectionResult(
+                    tool=tool,
+                    inclusion_reason=reason,
+                    confidence=confidence,
+                    is_fallback=False,
+                )
+            )
+            overall_confidence = max(overall_confidence, confidence)
+
+    # If overall confidence is too low, use fallback instead
+    if overall_confidence < min_confidence:
+        fallback_results = select_fallback_tools(available_tools)
+        return RoutingResult(
+            selected_tools=fallback_results,
+            fallback_used=True,
+            routing_reason=f"Low confidence ({overall_confidence:.0%}) below threshold - using fallback",
+            confidence=overall_confidence,
+        )
+
+    return RoutingResult(
+        selected_tools=selected,
+        fallback_used=False,
+        routing_reason=f"Tag-based routing matched {len(selected)} tools for tags: {required_tags}",
+        confidence=overall_confidence,
+    )
+
+
+def route_tools_by_toolset(
+    available_tools: list[RegisteredTool],
+    target_toolsets: list[str],
+) -> RoutingResult:
+    """Route tools by toolset with explainable selection.
+
+    Args:
+        available_tools: All available tools
+        target_toolsets: Toolsets to prioritize
+
+    Returns:
+        RoutingResult with selected tools and reasons
+    """
+    if not target_toolsets:
+        # No toolsets specified - use fallback
+        fallback_results = select_fallback_tools(available_tools)
+        return RoutingResult(
+            selected_tools=fallback_results,
+            fallback_used=True,
+            routing_reason="No target toolsets specified - using deterministic fallback selection",
+            confidence=0.5,
+        )
+
+    # Normalize target toolsets
+    target_set = {ts.lower() for ts in target_toolsets}
+
+    matching_tools = []
+    for tool in available_tools:
+        if tool.toolset.lower() in target_set:
+            confidence = 1.0  # Full confidence for exact toolset match
+            matching_tools.append((tool, confidence))
+
+    if not matching_tools:
+        # No matching toolsets - use fallback
+        fallback_results = select_fallback_tools(available_tools)
+        return RoutingResult(
+            selected_tools=fallback_results,
+            fallback_used=True,
+            routing_reason=f"No tools in target toolsets {target_toolsets} - using fallback",
+            confidence=0.3,
+        )
+
+    # Sort by cost_hint, then name for determinism
+    cost_priority = {"low": 0, "medium": 1, "high": 2}
+    matching_tools.sort(key=lambda x: (cost_priority.get(x[0].cost_hint, 0), x[0].name))
+
+    selected = []
+    overall_confidence = 1.0
+    for tool, confidence in matching_tools:
+        reason = f"Toolset match: {tool.toolset} (exact match, {tool.cost_hint} cost)"
+        selected.append(
+            ToolSelectionResult(
+                tool=tool,
+                inclusion_reason=reason,
+                confidence=confidence,
+                is_fallback=False,
+            )
+        )
+
+    return RoutingResult(
+        selected_tools=selected,
+        fallback_used=False,
+        routing_reason=f"Toolset-based routing matched {len(selected)} tools for toolsets: {target_toolsets}",
+        confidence=overall_confidence,
+    )
+
+
+def filter_available_tools(
+    tools: list[RegisteredTool],
+    available_sources: dict[str, dict],
+) -> list[RegisteredTool]:
+    """Filter tools based on available data sources.
+
+    Args:
+        tools: All registered tools
+        available_sources: Available data sources
+
+    Returns:
+        List of tools that can be executed with available sources
+    """
+    return [tool for tool in tools if tool.is_available(available_sources)]

--- a/app/tools/base.py
+++ b/app/tools/base.py
@@ -50,7 +50,9 @@ class ToolMetadata(StrictConfigModel):
         valid_hints = {"low", "medium", "high"}
         normalized = value.strip().lower()
         if normalized not in valid_hints:
-            return "low"  # Default to low for safety
+            raise ValueError(
+                f"cost_hint must be one of {sorted(valid_hints)}, got {value!r}"
+            )
         return normalized
 
 

--- a/app/tools/base.py
+++ b/app/tools/base.py
@@ -12,7 +12,10 @@ from app.types.evidence import EvidenceSource
 
 
 class ToolMetadata(StrictConfigModel):
-    """Strict schema for tool metadata declared on BaseTool subclasses."""
+    """Strict schema for tool metadata declared on BaseTool subclasses.
+
+    Includes routing-friendly fields for strong tool selection and explainability.
+    """
 
     name: str
     description: str
@@ -21,6 +24,17 @@ class ToolMetadata(StrictConfigModel):
     use_cases: list[str] = Field(default_factory=list)
     requires: list[str] = Field(default_factory=list)
     outputs: dict[str, str] = Field(default_factory=dict)
+    # Routing metadata for explainable and safe tool selection
+    toolset: str = Field(
+        default="default", description="Logical grouping for routing (e.g., 'aws', 'k8s', 'logs')"
+    )
+    tags: list[str] = Field(
+        default_factory=list, description="Tags for filtering and categorization"
+    )
+    cost_hint: str = Field(
+        default="low",
+        description="Cost/impact hint: 'low', 'medium', 'high' for resource estimation",
+    )
 
     @field_validator("name", "description")
     @classmethod
@@ -28,6 +42,15 @@ class ToolMetadata(StrictConfigModel):
         normalized = value.strip()
         if not normalized:
             raise ValueError("must be a non-empty string")
+        return normalized
+
+    @field_validator("cost_hint")
+    @classmethod
+    def _validate_cost_hint(cls, value: str) -> str:
+        valid_hints = {"low", "medium", "high"}
+        normalized = value.strip().lower()
+        if normalized not in valid_hints:
+            return "low"  # Default to low for safety
         return normalized
 
 
@@ -54,6 +77,10 @@ class BaseTool(ABC):
     use_cases: ClassVar[list[str]] = []
     requires: ClassVar[list[str]] = []
     outputs: ClassVar[dict[str, str]] = {}  # Output field -> description (optional, for prompting)
+    # Routing metadata for explainable and safe tool selection
+    toolset: ClassVar[str] = "default"  # Logical grouping for routing (e.g., 'aws', 'k8s', 'logs')
+    tags: ClassVar[list[str]] = []  # Tags for filtering and categorization
+    cost_hint: ClassVar[str] = "low"  # Cost/impact hint: 'low', 'medium', 'high'
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -65,19 +92,27 @@ class BaseTool(ABC):
         cls.use_cases = metadata.use_cases
         cls.requires = metadata.requires
         cls.outputs = metadata.outputs
+        cls.toolset = metadata.toolset
+        cls.tags = metadata.tags
+        cls.cost_hint = metadata.cost_hint
 
     @classmethod
     def metadata(cls) -> ToolMetadata:
         """Return validated tool metadata for this subclass."""
-        return ToolMetadata.model_validate({
-            "name": getattr(cls, "name", ""),
-            "description": getattr(cls, "description", ""),
-            "input_schema": getattr(cls, "input_schema", {}),
-            "source": getattr(cls, "source", ""),
-            "use_cases": list(getattr(cls, "use_cases", [])),
-            "requires": list(getattr(cls, "requires", [])),
-            "outputs": dict(getattr(cls, "outputs", {})),
-        })
+        return ToolMetadata.model_validate(
+            {
+                "name": getattr(cls, "name", ""),
+                "description": getattr(cls, "description", ""),
+                "input_schema": getattr(cls, "input_schema", {}),
+                "source": getattr(cls, "source", ""),
+                "use_cases": list(getattr(cls, "use_cases", [])),
+                "requires": list(getattr(cls, "requires", [])),
+                "outputs": dict(getattr(cls, "outputs", {})),
+                "toolset": getattr(cls, "toolset", "default"),
+                "tags": list(getattr(cls, "tags", [])),
+                "cost_hint": getattr(cls, "cost_hint", "low"),
+            }
+        )
 
     @property
     def inputs(self) -> dict[str, str]:

--- a/app/tools/registered_tool.py
+++ b/app/tools/registered_tool.py
@@ -128,6 +128,10 @@ class RegisteredTool:
     use_cases: list[str] = field(default_factory=list)
     requires: list[str] = field(default_factory=list)
     outputs: dict[str, str] = field(default_factory=dict)
+    # Routing metadata for explainable and safe tool selection
+    toolset: str = field(default="default")
+    tags: list[str] = field(default_factory=list)
+    cost_hint: str = field(default="low")
     is_available: Callable[[dict[str, dict]], bool] = field(
         default=_always_available,
         repr=False,
@@ -140,15 +144,20 @@ class RegisteredTool:
     origin_name: str = ""
 
     def __post_init__(self) -> None:
-        metadata = ToolMetadata.model_validate({
-            "name": self.name,
-            "description": self.description,
-            "input_schema": self.input_schema,
-            "source": self.source,
-            "use_cases": self.use_cases,
-            "requires": self.requires,
-            "outputs": self.outputs,
-        })
+        metadata = ToolMetadata.model_validate(
+            {
+                "name": self.name,
+                "description": self.description,
+                "input_schema": self.input_schema,
+                "source": self.source,
+                "use_cases": self.use_cases,
+                "requires": self.requires,
+                "outputs": self.outputs,
+                "toolset": self.toolset,
+                "tags": self.tags,
+                "cost_hint": self.cost_hint,
+            }
+        )
         self.name = metadata.name
         self.description = metadata.description
         self.input_schema = metadata.input_schema
@@ -156,6 +165,9 @@ class RegisteredTool:
         self.use_cases = metadata.use_cases
         self.requires = metadata.requires
         self.outputs = metadata.outputs
+        self.toolset = metadata.toolset
+        self.tags = metadata.tags
+        self.cost_hint = metadata.cost_hint
         self.surfaces = _normalize_surfaces(self.surfaces)
 
         if not callable(self.run):
@@ -184,8 +196,26 @@ class RegisteredTool:
         surfaces: Iterable[str] | None = None,
     ) -> RegisteredTool:
         metadata = tool.metadata()
-        resolved_surfaces = surfaces or getattr(tool, "surfaces", None) or getattr(
-            tool.__class__, "surfaces", None
+        resolved_surfaces = (
+            surfaces or getattr(tool, "surfaces", None) or getattr(tool.__class__, "surfaces", None)
+        )
+        return cls(
+            name=metadata.name,
+            description=metadata.description,
+            input_schema=metadata.input_schema,
+            source=metadata.source,
+            use_cases=metadata.use_cases,
+            requires=metadata.requires,
+            outputs=metadata.outputs,
+            toolset=metadata.toolset,
+            tags=metadata.tags,
+            cost_hint=metadata.cost_hint,
+            surfaces=_normalize_surfaces(resolved_surfaces),
+            run=tool.run,  # type: ignore[attr-defined]
+            is_available=tool.is_available,
+            extract_params=tool.extract_params,
+            origin_module=tool.__class__.__module__,
+            origin_name=tool.__class__.__name__,
         )
         return cls(
             name=metadata.name,
@@ -216,6 +246,9 @@ class RegisteredTool:
         use_cases: list[str] | None = None,
         requires: list[str] | None = None,
         outputs: dict[str, str] | None = None,
+        toolset: str | None = None,
+        tags: list[str] | None = None,
+        cost_hint: str | None = None,
         is_available: Callable[[dict[str, dict]], bool] | None = None,
         extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
     ) -> RegisteredTool:
@@ -232,10 +265,12 @@ class RegisteredTool:
             use_cases=list(use_cases or []),
             requires=list(requires or []),
             outputs=dict(outputs or {}),
+            toolset=toolset or "default",
+            tags=list(tags or []),
+            cost_hint=cost_hint or "low",
             run=func,
             is_available=is_available or _always_available,
             extract_params=extract_params or _extract_no_params,
             origin_module=func.__module__,
             origin_name=func.__name__,
         )
-

--- a/app/tools/registered_tool.py
+++ b/app/tools/registered_tool.py
@@ -217,21 +217,6 @@ class RegisteredTool:
             origin_module=tool.__class__.__module__,
             origin_name=tool.__class__.__name__,
         )
-        return cls(
-            name=metadata.name,
-            description=metadata.description,
-            input_schema=metadata.input_schema,
-            source=metadata.source,
-            use_cases=metadata.use_cases,
-            requires=metadata.requires,
-            outputs=metadata.outputs,
-            surfaces=_normalize_surfaces(resolved_surfaces),
-            run=tool.run,  # type: ignore[attr-defined]
-            is_available=tool.is_available,
-            extract_params=tool.extract_params,
-            origin_module=tool.__class__.__module__,
-            origin_name=tool.__class__.__name__,
-        )
 
     @classmethod
     def from_function(

--- a/app/tools/tool_decorator.py
+++ b/app/tools/tool_decorator.py
@@ -24,6 +24,9 @@ def tool(
     use_cases: list[str] | None = None,
     requires: list[str] | None = None,
     outputs: dict[str, str] | None = None,
+    toolset: str | None = None,
+    tags: list[str] | None = None,
+    cost_hint: str | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
 ) -> BaseTool:
@@ -42,6 +45,9 @@ def tool(  # noqa: UP047
     use_cases: list[str] | None = None,
     requires: list[str] | None = None,
     outputs: dict[str, str] | None = None,
+    toolset: str | None = None,
+    tags: list[str] | None = None,
+    cost_hint: str | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
 ) -> F:
@@ -60,6 +66,9 @@ def tool(  # noqa: UP047
     use_cases: list[str] | None = None,
     requires: list[str] | None = None,
     outputs: dict[str, str] | None = None,
+    toolset: str | None = None,
+    tags: list[str] | None = None,
+    cost_hint: str | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
 ) -> Callable[[F], F]:
@@ -77,6 +86,9 @@ def tool(  # noqa: UP047
     use_cases: list[str] | None = None,
     requires: list[str] | None = None,
     outputs: dict[str, str] | None = None,
+    toolset: str | None = None,
+    tags: list[str] | None = None,
+    cost_hint: str | None = None,
     is_available: Callable[[dict[str, dict]], bool] | None = None,
     extract_params: Callable[[dict[str, dict]], dict[str, Any]] | None = None,
 ) -> Any:
@@ -88,18 +100,23 @@ def tool(  # noqa: UP047
     """
 
     def should_register_function() -> bool:
-        return any([
-            name is not None,
-            description is not None,
-            input_schema is not None,
-            source is not None,
-            surfaces is not None,
-            bool(use_cases),
-            bool(requires),
-            bool(outputs),
-            is_available is not None,
-            extract_params is not None,
-        ])
+        return any(
+            [
+                name is not None,
+                description is not None,
+                input_schema is not None,
+                source is not None,
+                surfaces is not None,
+                bool(use_cases),
+                bool(requires),
+                bool(outputs),
+                bool(tags),
+                toolset is not None,
+                cost_hint is not None,
+                is_available is not None,
+                extract_params is not None,
+            ]
+        )
 
     def attach(target: F | BaseTool) -> F | BaseTool:
         if isinstance(target, BaseTool):
@@ -125,6 +142,9 @@ def tool(  # noqa: UP047
                     use_cases=use_cases,
                     requires=requires,
                     outputs=outputs,
+                    toolset=toolset,
+                    tags=tags,
+                    cost_hint=cost_hint,
                     is_available=is_available,
                     extract_params=extract_params,
                 ),
@@ -132,6 +152,7 @@ def tool(  # noqa: UP047
         return target
 
     if func is None:
+
         def wrapper(inner: F) -> F:
             return cast(F, attach(inner))
 

--- a/tests/nodes/route_tools/test_route_tools.py
+++ b/tests/nodes/route_tools/test_route_tools.py
@@ -1,0 +1,370 @@
+"""Tests for tool routing metadata and fallback selection."""
+
+from __future__ import annotations
+
+from app.nodes.route_tools.route_tools import (
+    DEFAULT_FALLBACK_TOOLSETS,
+    MAX_FALLBACK_TOOLS,
+    MIN_CONFIDENCE_THRESHOLD,
+    RoutingResult,
+    ToolSelectionResult,
+    filter_available_tools,
+    route_tools_by_tags,
+    route_tools_by_toolset,
+    select_fallback_tools,
+)
+from app.tools.base import BaseTool, ToolMetadata
+from app.tools.registered_tool import RegisteredTool
+
+
+class MockTool:
+    """Mock tool for testing routing logic."""
+
+    def __init__(
+        self,
+        name: str,
+        toolset: str = "default",
+        tags: list[str] | None = None,
+        cost_hint: str = "low",
+        source: str = "storage",
+    ):
+        self.name = name
+        self.description = f"Mock {name}"
+        self.toolset = toolset
+        self.tags = tags or []
+        self.cost_hint = cost_hint
+        self.source = source
+        self.input_schema: dict = {"type": "object", "properties": {}}
+        self.use_cases: list = []
+        self.requires: list = []
+        self.outputs: dict = {}
+
+    def is_available(self, _sources: dict) -> bool:
+        return True
+
+
+class TestToolMetadata:
+    """Tests for ToolMetadata routing fields."""
+
+    def test_default_routing_values(self) -> None:
+        metadata = ToolMetadata.model_validate(
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "input_schema": {},
+                "source": "storage",
+            }
+        )
+        assert metadata.toolset == "default"
+        assert metadata.tags == []
+        assert metadata.cost_hint == "low"
+
+    def test_custom_routing_values(self) -> None:
+        metadata = ToolMetadata.model_validate(
+            {
+                "name": "aws_tool",
+                "description": "AWS tool",
+                "input_schema": {},
+                "source": "aws_sdk",
+                "toolset": "aws",
+                "tags": ["infrastructure", "compute"],
+                "cost_hint": "medium",
+            }
+        )
+        assert metadata.toolset == "aws"
+        assert metadata.tags == ["infrastructure", "compute"]
+        assert metadata.cost_hint == "medium"
+
+    def test_cost_hint_validation_normalizes_case(self) -> None:
+        metadata = ToolMetadata.model_validate(
+            {
+                "name": "test",
+                "description": "Test",
+                "input_schema": {},
+                "source": "storage",
+                "cost_hint": "HIGH",
+            }
+        )
+        assert metadata.cost_hint == "high"
+
+    def test_cost_hint_validation_defaults_invalid(self) -> None:
+        metadata = ToolMetadata.model_validate(
+            {
+                "name": "test",
+                "description": "Test",
+                "input_schema": {},
+                "source": "storage",
+                "cost_hint": "invalid",
+            }
+        )
+        assert metadata.cost_hint == "low"
+
+
+class TestBaseToolRoutingMetadata:
+    """Tests for BaseTool routing metadata inheritance."""
+
+    def test_base_tool_with_routing_metadata(self) -> None:
+        class K8sTool(BaseTool):
+            name = "k8s_discovery"
+            description = "Discover K8s resources"
+            input_schema = {"type": "object", "properties": {}}
+            source = "eks"
+            toolset = "k8s"
+            tags = ["discovery", "infrastructure"]
+            cost_hint = "low"
+            use_cases = ["Find pods", "List deployments"]
+
+            def run(self, **_kwargs) -> dict:
+                return {}
+
+        tool = K8sTool()
+        metadata = tool.metadata()
+
+        assert metadata.toolset == "k8s"
+        assert metadata.tags == ["discovery", "infrastructure"]
+        assert metadata.cost_hint == "low"
+
+
+class TestRegisteredToolRouting:
+    """Tests for RegisteredTool routing metadata."""
+
+    def test_registered_tool_with_routing(self) -> None:
+        tool = RegisteredTool(
+            name="test",
+            description="Test tool",
+            input_schema={},
+            source="storage",
+            run=lambda: {},
+            toolset="logs",
+            tags=["query", "filter"],
+            cost_hint="high",
+        )
+
+        assert tool.toolset == "logs"
+        assert tool.tags == ["query", "filter"]
+        assert tool.cost_hint == "high"
+
+    def test_registered_tool_defaults(self) -> None:
+        tool = RegisteredTool(
+            name="test",
+            description="Test tool",
+            input_schema={},
+            source="storage",
+            run=lambda: {},
+        )
+
+        assert tool.toolset == "default"
+        assert tool.tags == []
+        assert tool.cost_hint == "low"
+
+
+class TestFallbackSelection:
+    """Tests for deterministic fallback selection."""
+
+    def test_fallback_selects_from_default_toolsets(self) -> None:
+        tools = [
+            MockTool("tool1", toolset="core"),
+            MockTool("tool2", toolset="discovery"),
+            MockTool("tool3", toolset="logs"),
+            MockTool("tool4", toolset="custom"),  # Should be excluded
+        ]
+
+        result = select_fallback_tools(tools)
+
+        selected_toolsets = {r.tool.toolset for r in result}
+        assert selected_toolsets.issubset(DEFAULT_FALLBACK_TOOLSETS)
+        assert "custom" not in selected_toolsets
+
+    def test_fallback_prioritizes_low_cost_first(self) -> None:
+        tools = [
+            MockTool("expensive", toolset="core", cost_hint="high"),
+            MockTool("cheap", toolset="core", cost_hint="low"),
+            MockTool("medium", toolset="core", cost_hint="medium"),
+        ]
+
+        result = select_fallback_tools(tools)
+
+        # Low cost should be first
+        assert result[0].tool.name == "cheap"
+        assert result[0].tool.cost_hint == "low"
+
+    def test_fallback_limited_to_max_tools(self) -> None:
+        tools = [MockTool(f"tool{i}", toolset="core") for i in range(10)]
+
+        result = select_fallback_tools(tools)
+
+        assert len(result) <= MAX_FALLBACK_TOOLS
+
+    def test_fallback_provides_inclusion_reasons(self) -> None:
+        tools = [MockTool("test", toolset="core", cost_hint="low")]
+
+        result = select_fallback_tools(tools)
+
+        assert len(result) == 1
+        assert "Fallback selection" in result[0].inclusion_reason
+        assert "core" in result[0].inclusion_reason
+        assert "low" in result[0].inclusion_reason
+
+    def test_fallback_uses_any_when_no_eligible(self) -> None:
+        tools = [
+            MockTool("custom1", toolset="custom1"),
+            MockTool("custom2", toolset="custom2"),
+        ]
+
+        result = select_fallback_tools(tools)
+
+        # Should use some tools since no default toolset matches
+        assert len(result) > 0
+
+
+class TestRoutingByTags:
+    """Tests for tag-based tool routing."""
+
+    def test_route_by_tags_finds_matches(self) -> None:
+        tools = [
+            MockTool("logs", tags=["logs", "query"]),
+            MockTool("metrics", tags=["metrics", "query"]),
+            MockTool("traces", tags=["traces"]),
+        ]
+
+        result = route_tools_by_tags(tools, ["query"])
+
+        assert not result.fallback_used
+        assert len(result.selected_tools) == 2
+        selected_names = {t.tool.name for t in result.selected_tools}
+        assert selected_names == {"logs", "metrics"}
+
+    def test_route_by_tags_uses_fallback_when_no_match(self) -> None:
+        tools = [
+            MockTool("logs", toolset="logs", tags=["logs"]),
+            MockTool("metrics", toolset="core", tags=["metrics"]),
+        ]
+
+        result = route_tools_by_tags(tools, ["nonexistent"])
+
+        assert result.fallback_used
+        assert result.confidence < MIN_CONFIDENCE_THRESHOLD
+
+    def test_route_by_tags_uses_fallback_when_no_tags_specified(self) -> None:
+        tools = [MockTool("tool1", toolset="core")]
+
+        result = route_tools_by_tags(tools, [])
+
+        assert result.fallback_used
+
+    def test_route_by_tags_includes_reasons(self) -> None:
+        tools = [MockTool("logs", tags=["logs", "error"])]
+
+        result = route_tools_by_tags(tools, ["logs", "error"])
+
+        assert len(result.selected_tools) == 1
+        reason = result.selected_tools[0].inclusion_reason
+        assert "Tag match" in reason
+        assert "logs" in reason
+        assert "error" in reason
+
+
+class TestRoutingByToolset:
+    """Tests for toolset-based routing."""
+
+    def test_route_by_toolset_finds_matches(self) -> None:
+        tools = [
+            MockTool("aws1", toolset="aws"),
+            MockTool("aws2", toolset="aws"),
+            MockTool("k8s1", toolset="k8s"),
+        ]
+
+        result = route_tools_by_toolset(tools, ["aws"])
+
+        assert not result.fallback_used
+        assert len(result.selected_tools) == 2
+        for r in result.selected_tools:
+            assert r.tool.toolset == "aws"
+
+    def test_route_by_toolset_uses_fallback_when_no_match(self) -> None:
+        tools = [
+            MockTool("aws", toolset="aws"),
+            MockTool("k8s", toolset="k8s"),
+        ]
+
+        result = route_tools_by_toolset(tools, ["nonexistent"])
+
+        assert result.fallback_used
+
+    def test_route_by_toolset_case_insensitive(self) -> None:
+        tools = [MockTool("test", toolset="AWS")]
+
+        result = route_tools_by_toolset(tools, ["aws"])
+
+        assert not result.fallback_used
+        assert len(result.selected_tools) == 1
+
+
+class TestFilterAvailableTools:
+    """Tests for filtering available tools."""
+
+    def test_filters_by_is_available(self) -> None:
+        class UnavailableTool(MockTool):
+            def is_available(self, _sources: dict) -> bool:
+                return False
+
+        available = MockTool("available")
+        unavailable = UnavailableTool("unavailable")
+
+        result = filter_available_tools([available, unavailable], {})
+
+        assert len(result) == 1
+        assert result[0].name == "available"
+
+
+class TestRoutingResult:
+    """Tests for RoutingResult data structure."""
+
+    def test_to_tool_names(self) -> None:
+        tool = MockTool("test")
+        result = RoutingResult(
+            selected_tools=[ToolSelectionResult(tool=tool, inclusion_reason="test", confidence=1.0)]
+        )
+
+        assert result.to_tool_names() == ["test"]
+
+    def test_to_detailed_dict(self) -> None:
+        tool = MockTool("test", toolset="logs", tags=["query"], cost_hint="medium")
+        result = RoutingResult(
+            selected_tools=[
+                ToolSelectionResult(
+                    tool=tool,
+                    inclusion_reason="test reason",
+                    confidence=0.9,
+                    is_fallback=False,
+                )
+            ],
+            fallback_used=False,
+            routing_reason="test",
+            confidence=0.9,
+        )
+
+        detailed = result.to_detailed_dict()
+
+        assert detailed["fallback_used"] is False
+        assert detailed["overall_confidence"] == 0.9
+        assert len(detailed["tools"]) == 1
+        assert detailed["tools"][0]["name"] == "test"
+        assert detailed["tools"][0]["reason"] == "test reason"
+        assert detailed["tools"][0]["toolset"] == "logs"
+        assert detailed["tools"][0]["cost_hint"] == "medium"
+
+
+class TestConstants:
+    """Tests for routing constants."""
+
+    def test_default_fallback_toolsets(self) -> None:
+        assert "core" in DEFAULT_FALLBACK_TOOLSETS
+        assert "discovery" in DEFAULT_FALLBACK_TOOLSETS
+        assert "logs" in DEFAULT_FALLBACK_TOOLSETS
+
+    def test_min_confidence_threshold(self) -> None:
+        assert MIN_CONFIDENCE_THRESHOLD == 0.5
+
+    def test_max_fallback_tools(self) -> None:
+        assert MAX_FALLBACK_TOOLS == 3

--- a/tests/nodes/route_tools/test_route_tools.py
+++ b/tests/nodes/route_tools/test_route_tools.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from app.nodes.route_tools.route_tools import (
     DEFAULT_FALLBACK_TOOLSETS,
     MAX_FALLBACK_TOOLS,
@@ -87,17 +90,17 @@ class TestToolMetadata:
         )
         assert metadata.cost_hint == "high"
 
-    def test_cost_hint_validation_defaults_invalid(self) -> None:
-        metadata = ToolMetadata.model_validate(
-            {
-                "name": "test",
-                "description": "Test",
-                "input_schema": {},
-                "source": "storage",
-                "cost_hint": "invalid",
-            }
-        )
-        assert metadata.cost_hint == "low"
+    def test_cost_hint_validation_rejects_invalid(self) -> None:
+        with pytest.raises(ValidationError, match="cost_hint"):
+            ToolMetadata.model_validate(
+                {
+                    "name": "test",
+                    "description": "Test",
+                    "input_schema": {},
+                    "source": "storage",
+                    "cost_hint": "invalid",
+                }
+            )
 
 
 class TestBaseToolRoutingMetadata:
@@ -262,6 +265,18 @@ class TestRoutingByTags:
         assert "Tag match" in reason
         assert "logs" in reason
         assert "error" in reason
+
+    def test_route_by_tags_uses_fallback_when_best_match_below_threshold(self) -> None:
+        tools = [
+            MockTool("logs", toolset="logs", tags=["logs"]),
+            MockTool("metrics", toolset="core", tags=["metrics"]),
+        ]
+
+        result = route_tools_by_tags(tools, ["logs", "query"], min_confidence=0.75)
+
+        assert result.fallback_used is True
+        assert all(selection.is_fallback for selection in result.selected_tools)
+        assert result.confidence == 0.5
 
 
 class TestRoutingByToolset:

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -115,3 +115,19 @@ def test_base_tool_cost_hint_validation() -> None:
     tool = HighCostTool()
     metadata = tool.metadata()
     assert metadata.cost_hint == "high"  # Normalized to lowercase
+
+
+def test_base_tool_rejects_invalid_cost_hint() -> None:
+    with pytest.raises(ValidationError, match="cost_hint"):
+        type(
+            "InvalidCostTool",
+            (BaseTool,),
+            {
+                "name": "invalid_cost",
+                "description": "Invalid cost hint tool",
+                "input_schema": {"type": "object", "properties": {}},
+                "source": "batch",
+                "cost_hint": "critical",
+                "run": lambda _self, **_kwargs: {},
+            },
+        )

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -34,3 +34,84 @@ def test_base_tool_rejects_blank_description() -> None:
                 "run": lambda _self, **_kwargs: {},
             },
         )
+
+
+def test_base_tool_default_routing_metadata() -> None:
+    class SimpleTool(BaseTool):
+        name = "simple_tool"
+        description = "A simple test tool"
+        input_schema = {"type": "object", "properties": {}}
+        source = "storage"
+
+        def run(self, **_kwargs) -> dict:
+            return {}
+
+    tool = SimpleTool()
+    metadata = tool.metadata()
+
+    assert metadata.toolset == "default"
+    assert metadata.tags == []
+    assert metadata.cost_hint == "low"
+
+
+def test_base_tool_custom_routing_metadata() -> None:
+    class RoutingTool(BaseTool):
+        name = "aws_discovery"
+        description = "AWS discovery tool"
+        input_schema = {"type": "object", "properties": {}}
+        source = "aws_sdk"
+        toolset = "aws"
+        tags = ["infrastructure", "discovery", "ec2"]
+        cost_hint = "medium"
+
+        def run(self, **_kwargs) -> dict:
+            return {}
+
+    tool = RoutingTool()
+    metadata = tool.metadata()
+
+    assert metadata.toolset == "aws"
+    assert metadata.tags == ["infrastructure", "discovery", "ec2"]
+    assert metadata.cost_hint == "medium"
+
+
+def test_base_tool_classvars_inherited_correctly() -> None:
+    class K8sTool(BaseTool):
+        name = "k8s_pods"
+        description = "List Kubernetes pods"
+        input_schema = {"type": "object", "properties": {}}
+        source = "eks"
+        toolset = "k8s"
+        tags = ["discovery", "pods"]
+        cost_hint = "low"
+
+        def run(self, **_kwargs) -> dict:
+            return {}
+
+    # Check class-level attributes
+    assert K8sTool.toolset == "k8s"
+    assert K8sTool.tags == ["discovery", "pods"]
+    assert K8sTool.cost_hint == "low"
+
+    # Check instance-level metadata
+    tool = K8sTool()
+    metadata = tool.metadata()
+    assert metadata.toolset == "k8s"
+    assert metadata.tags == ["discovery", "pods"]
+    assert metadata.cost_hint == "low"
+
+
+def test_base_tool_cost_hint_validation() -> None:
+    class HighCostTool(BaseTool):
+        name = "expensive_tool"
+        description = "Expensive operation"
+        input_schema = {"type": "object", "properties": {}}
+        source = "batch"
+        cost_hint = "HIGH"  # Uppercase - should be normalized
+
+        def run(self, **_kwargs) -> dict:
+            return {}
+
+    tool = HighCostTool()
+    metadata = tool.metadata()
+    assert metadata.cost_hint == "high"  # Normalized to lowercase


### PR DESCRIPTION
## Summary
Implements P0 requirements from #473 to make tool selection explainable and safe by default.

## Changes
- Extended \`ToolMetadata\` with routing-friendly fields: \`toolset\`, \`tags\`, \`cost_hint\`
- Added deterministic fallback selection for low-confidence routing scenarios
- Added human-readable inclusion reasons to all routing results
- Created \`route_tools\` module with \`RoutingResult\` and \`ToolSelectionResult\` types

## Safety
- All new fields have safe defaults to preserve backward compatibility
- Existing tool registration continues to work unchanged
- Fallback selection prioritizes low-cost tools from core toolsets

## Testing
- 31 new tests covering routing metadata and selection logic
- All tests pass, no breaking changes to existing functionality

## Risk/Rollback
- Low risk: additive changes only, existing behavior preserved via defaults
- Rollback: revert commit, no migration required

Closes #473