### PR TITLE
fix(#419): validate GitHub MCP config before saving in legacy CLI

### DIFF
--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -19,6 +19,11 @@ from typing import Any, NoReturn
 
 import questionary
 
+from app.integrations.github_mcp import (
+    GitHubMCPValidationResult,
+    build_github_mcp_config,
+    validate_github_mcp_config,
+)
 from app.integrations.store import (
     STORE_PATH,
     get_integration,
@@ -217,6 +222,19 @@ def _setup_vercel() -> None:
     upsert_integration("vercel", {"credentials": {"api_token": api_token, "team_id": team_id}})
 
 
+def _validate_github(credentials: dict[str, Any]) -> GitHubMCPValidationResult:
+    """Build a GitHubMCPConfig from collected credentials and validate it."""
+    config = build_github_mcp_config({
+        "url": credentials.get("url", ""),
+        "mode": credentials.get("mode", "streamable-http"),
+        "auth_token": credentials.get("auth_token", ""),
+        "command": credentials.get("command", ""),
+        "args": credentials.get("args", []),
+        "toolsets": credentials.get("toolsets", []),
+    })
+    return validate_github_mcp_config(config)
+
+
 def _setup_github() -> None:
     print("  1) SSE  2) Streamable HTTP  3) stdio")
     choice = _p("Choice", default="2")
@@ -240,6 +258,13 @@ def _setup_github() -> None:
     )
     toolsets = _p("Toolsets", default="repos,issues,pull_requests,actions")
     credentials["toolsets"] = [part.strip() for part in toolsets.split(",") if part.strip()]
+
+    print("  Validating GitHub MCP integration...")
+    result = _validate_github(credentials)
+    if not result.ok:
+        _die(f"GitHub validation failed: {result.detail}")
+
+    print(f"  ✓ {result.detail}")
     upsert_integration("github", {"credentials": credentials})
 
 

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import contextlib
+import types
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from app.cli.__main__ import cli
+from app.integrations.cli import _setup_github, _validate_github
 
 
 def test_integrations_show_redacts_api_token() -> None:
@@ -81,6 +84,52 @@ def test_integrations_setup_skips_auto_verify_for_unverifiable_service() -> None
     assert result.exit_code == 0
     mock_setup.assert_called_once_with("opensearch")
     mock_verify.assert_not_called()
+
+
+def test_setup_github_validates_before_saving() -> None:
+    """_setup_github must validate credentials before persisting them (issue #419)."""
+    ok_result = types.SimpleNamespace(ok=True, detail="Validated for testuser; 12 tools")
+    with (
+        patch("app.integrations.cli._p", side_effect=["2", "https://api.githubcopilot.com/mcp/", "tok", "repos"]),
+        patch("app.integrations.cli._validate_github", return_value=ok_result) as mock_val,
+        patch("app.integrations.cli.upsert_integration") as mock_save,
+    ):
+        _setup_github()
+
+    mock_val.assert_called_once()
+    mock_save.assert_called_once()
+
+
+def test_setup_github_aborts_on_validation_failure() -> None:
+    """_setup_github must NOT save credentials when validation fails (issue #419)."""
+    bad_result = types.SimpleNamespace(ok=False, detail="auth failed")
+    with (
+        patch("app.integrations.cli._p", side_effect=["2", "https://api.githubcopilot.com/mcp/", "bad-tok", "repos"]),
+        patch("app.integrations.cli._validate_github", return_value=bad_result),
+        patch("app.integrations.cli.upsert_integration") as mock_save,
+        contextlib.suppress(SystemExit),
+    ):
+        _setup_github()
+
+    mock_save.assert_not_called()
+
+
+def test_validate_github_calls_mcp_validation() -> None:
+    """_validate_github builds config and delegates to validate_github_mcp_config."""
+    ok_result = types.SimpleNamespace(ok=True, detail="ok", tool_names=(), authenticated_user="me")
+    with patch(
+        "app.integrations.cli.validate_github_mcp_config",
+        return_value=ok_result,
+    ) as mock_val:
+        result = _validate_github({
+            "url": "https://example.com/mcp/",
+            "mode": "streamable-http",
+            "auth_token": "ghp_test",
+            "toolsets": ["repos"],
+        })
+
+    assert result.ok is True
+    mock_val.assert_called_once()
 
 
 def test_integrations_verify_accepts_github() -> None:


### PR DESCRIPTION
## Summary

- The legacy `opensre integrations setup github` path saved credentials without any validation — the user had no idea if auth worked or if the MCP server was reachable
- The wizard flow (`app/cli/wizard/flow.py`) already validates via `validate_github_mcp_config` before saving — this was a parity gap
- Now the legacy path also validates connectivity, tool discovery, and authentication before persisting, and aborts with a clear error on failure

Closes #419

## Test plan

- [x] `test_setup_github_validates_before_saving` — validates is called before upsert
- [x] `test_setup_github_aborts_on_validation_failure` — credentials NOT saved when validation fails
- [x] `test_validate_github_calls_mcp_validation` — helper delegates to `validate_github_mcp_config`
- [x] All 8 integration CLI tests pass
- [x] Full suite: 1578 passed, `make lint` clean, `make typecheck` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)