### PR TITLE
feat: add trello integration with e2e tests

### DIFF
--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -1,11 +1,11 @@
-
 import os
+
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import BaseModel, Field, field_validator
 
+from pydantic import BaseModel, Field, field_validator
 
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
 

--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -136,8 +136,10 @@ def create_trello_card(
         "/cards",
         params=[
             ("idList", target_list_id),
-            ("name", name),
-            ("desc", desc),
         ],
+        json={
+            "name": name,
+            "desc": desc,
+        },
     )
     return payload if isinstance(payload, dict) else {}

--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -4,14 +4,13 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import BaseModel, Field, field_validator
 
-from app.strict_config import StrictConfigModel
 
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
 
 
-class TrelloConfig(StrictConfigModel):
+class TrelloConfig(BaseModel):
     """Normalized Trello connection settings."""
 
     base_url: str = DEFAULT_TRELLO_BASE_URL
@@ -129,7 +128,7 @@ def create_trello_card(
     """Create a Trello card."""
     target_list_id = (list_id or config.list_id).strip()
     if not target_list_id:
-        return {}
+        raise ValueError("A list_id must be provided either via argument or config.")
 
     payload = _request_json(
         config,

--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -1,10 +1,8 @@
 import os
-
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
-
 from pydantic import BaseModel, Field, field_validator
 
 DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"

--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -1,0 +1,144 @@
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from pydantic import Field, field_validator
+
+from app.strict_config import StrictConfigModel
+
+DEFAULT_TRELLO_BASE_URL = "https://api.trello.com/1"
+
+
+class TrelloConfig(StrictConfigModel):
+    """Normalized Trello connection settings."""
+
+    base_url: str = DEFAULT_TRELLO_BASE_URL
+    api_key: str = ""
+    token: str = ""
+    board_id: str = ""
+    list_id: str = ""
+    timeout_seconds: float = Field(default=15.0, gt=0)
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _normalize_base_url(cls, value: Any) -> str:
+        normalized = str(value or DEFAULT_TRELLO_BASE_URL).strip()
+        return normalized or DEFAULT_TRELLO_BASE_URL
+
+    @property
+    def api_base_url(self) -> str:
+        return self.base_url.rstrip("/")
+
+
+@dataclass(frozen=True)
+class TrelloValidationResult:
+    """Result of validating a Trello integration."""
+
+    ok: bool
+    detail: str
+
+
+def build_trello_config(raw: dict[str, Any] | None) -> TrelloConfig:
+    """Build a normalized Trello config object from env/store data."""
+    return TrelloConfig.model_validate(raw or {})
+
+
+def trello_config_from_env() -> TrelloConfig | None:
+    """Load a Trello config from env vars."""
+    api_key = os.getenv("TRELLO_API_KEY", "").strip()
+    token = os.getenv("TRELLO_TOKEN", "").strip()
+    if not api_key or not token:
+        return None
+
+    return build_trello_config({
+        "base_url": os.getenv("TRELLO_BASE_URL", DEFAULT_TRELLO_BASE_URL).strip()
+        or DEFAULT_TRELLO_BASE_URL,
+        "api_key": api_key,
+        "token": token,
+        "board_id": os.getenv("TRELLO_BOARD_ID", "").strip(),
+        "list_id": os.getenv("TRELLO_LIST_ID", "").strip(),
+    })
+
+
+def _request_json(
+    config: TrelloConfig,
+    method: str,
+    path: str,
+    *,
+    params: list[tuple[str, str | int | float | bool | None]] | None = None,
+    json: dict[str, Any] | None = None,
+) -> Any:
+    request_params: list[tuple[str, str | int | float | bool | None]] = [
+        ("key", config.api_key),
+        ("token", config.token),
+    ]
+    if params:
+        request_params.extend(params)
+
+    url = f"{config.api_base_url}{path}"
+    response = httpx.request(
+        method,
+        url,
+        params=request_params,
+        json=json,
+        timeout=config.timeout_seconds,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def validate_trello_connection(
+    *,
+    config: TrelloConfig,
+) -> dict[str, Any]:
+    """Validate Trello connection with a lightweight member query."""
+    payload = _request_json(config, "GET", "/members/me")
+    return payload if isinstance(payload, dict) else {}
+
+
+def validate_trello_config(config: TrelloConfig) -> TrelloValidationResult:
+    """Validate Trello connectivity."""
+    if not config.api_key:
+        return TrelloValidationResult(ok=False, detail="Trello API key is required.")
+    if not config.token:
+        return TrelloValidationResult(ok=False, detail="Trello token is required.")
+
+    try:
+        member = validate_trello_connection(config=config)
+        username = member.get("username", "unknown")
+        return TrelloValidationResult(
+            ok=True,
+            detail=f"Trello connectivity successful. Authenticated as @{username}",
+        )
+    except httpx.HTTPStatusError as err:
+        detail = err.response.text.strip() or str(err)
+        return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {detail}")
+    except Exception as err:  # noqa: BLE001
+        return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {err}")
+
+
+def create_trello_card(
+    *,
+    config: TrelloConfig,
+    name: str,
+    desc: str,
+    list_id: str | None = None,
+) -> dict[str, Any]:
+    """Create a Trello card."""
+    target_list_id = (list_id or config.list_id).strip()
+    if not target_list_id:
+        return {}
+
+    payload = _request_json(
+        config,
+        "POST",
+        "/cards",
+        params=[
+            ("idList", target_list_id),
+            ("name", name),
+            ("desc", desc),
+        ],
+    )
+    return payload if isinstance(payload, dict) else {}

--- a/tests/e2e/trello/test_orchestrator.py
+++ b/tests/e2e/trello/test_orchestrator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.integrations.trello import TrelloConfig, create_trello_card, validate_trello_config
+
+
+def test_trello_validation_and_card_creation_e2e(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="trello_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_request_json(config, method, path, *, params=None, json=None):
+        calls.append((method, path))
+
+        if method == "GET" and path == "/members/me":
+            return {"id": "member123", "username": "test_user"}
+
+        if method == "POST" and path == "/cards":
+            return {
+                "id": "card123",
+                "name": "Critical incident",
+                "desc": "Root cause details",
+                "idList": "list123",
+            }
+
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("app.integrations.trello._request_json", fake_request_json)
+
+    validation = validate_trello_config(config)
+    assert validation.ok is True
+    assert "@test_user" in validation.detail
+
+    result = create_trello_card(
+        config=config,
+        name="Critical incident",
+        desc="Root cause details",
+    )
+
+    assert result["id"] == "card123"
+    assert result["name"] == "Critical incident"
+    assert result["idList"] == "list123"
+    assert calls == [("GET", "/members/me"), ("POST", "/cards")]
+
+
+def test_trello_validation_failure_e2e(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="bad_key",
+        token="bad_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    request = httpx.Request("GET", "https://api.trello.com/1/members/me")
+    response = httpx.Response(401, request=request, text="unauthorized")
+
+    def fake_request_json(config, method, path, *, params=None, json=None):
+        if method == "GET" and path == "/members/me":
+            raise httpx.HTTPStatusError(
+                "Client error '401 Unauthorized' for url 'https://api.trello.com/1/members/me'",
+                request=request,
+                response=response,
+            )
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("app.integrations.trello._request_json", fake_request_json)
+
+    validation = validate_trello_config(config)
+    assert validation.ok is False
+    assert "401" in validation.detail or "unauthorized" in validation.detail.lower()

--- a/tests/integrations/test_trello.py
+++ b/tests/integrations/test_trello.py
@@ -1,0 +1,221 @@
+import httpx
+import pytest
+
+from app.integrations.trello import (
+    DEFAULT_TRELLO_BASE_URL,
+    TrelloConfig,
+    build_trello_config,
+    create_trello_card,
+    trello_config_from_env,
+    validate_trello_config,
+    validate_trello_connection,
+)
+
+
+def test_build_trello_config_defaults() -> None:
+    config = build_trello_config({})
+
+    assert config.base_url == DEFAULT_TRELLO_BASE_URL
+    assert config.api_key == ""
+    assert config.token == ""
+    assert config.board_id == ""
+    assert config.list_id == ""
+    assert config.timeout_seconds == 15.0
+
+
+def test_trello_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRELLO_API_KEY", "trello_key")
+    monkeypatch.setenv("TRELLO_TOKEN", "trello_token")
+    monkeypatch.setenv("TRELLO_BASE_URL", "https://api.trello.com/1")
+    monkeypatch.setenv("TRELLO_BOARD_ID", "board123")
+    monkeypatch.setenv("TRELLO_LIST_ID", "list123")
+
+    config = trello_config_from_env()
+
+    assert config is not None
+    assert config.api_key == "trello_key"
+    assert config.token == "trello_token"
+    assert config.board_id == "board123"
+    assert config.list_id == "list123"
+    assert config.base_url == "https://api.trello.com/1"
+
+
+def test_trello_config_from_env_returns_none_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TRELLO_API_KEY", raising=False)
+    monkeypatch.delenv("TRELLO_TOKEN", raising=False)
+
+    config = trello_config_from_env()
+
+    assert config is None
+
+
+def test_validate_trello_connection_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="trello_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    def fake_request_json(*args, **kwargs):
+        return {"id": "member123", "username": "test_user"}
+
+    monkeypatch.setattr("app.integrations.trello._request_json", fake_request_json)
+
+    result = validate_trello_connection(config=config)
+
+    assert result["username"] == "test_user"
+
+
+def test_validate_trello_config_missing_api_key() -> None:
+    config = TrelloConfig(
+        api_key="",
+        token="trello_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    result = validate_trello_config(config)
+
+    assert result.ok is False
+    assert "api key" in result.detail.lower()
+
+
+def test_validate_trello_config_missing_token() -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    result = validate_trello_config(config)
+
+    assert result.ok is False
+    assert "token" in result.detail.lower()
+
+
+def test_validate_trello_config_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="trello_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    def fake_validate_connection(*, config: TrelloConfig):
+        return {"id": "member123", "username": "test_user"}
+
+    monkeypatch.setattr(
+        "app.integrations.trello.validate_trello_connection",
+        fake_validate_connection,
+    )
+
+    result = validate_trello_config(config)
+
+    assert result.ok is True
+    assert "@test_user" in result.detail
+
+
+def test_validate_trello_config_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="bad_key",
+        token="bad_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    request = httpx.Request("GET", "https://api.trello.com/1/members/me")
+    response = httpx.Response(401, request=request, text="unauthorized")
+
+    def fake_validate_connection(*, config: TrelloConfig):
+        raise httpx.HTTPStatusError(
+            "Client error '401 Unauthorized' for url 'https://api.trello.com/1/members/me'",
+            request=request,
+            response=response,
+        )
+
+    monkeypatch.setattr(
+        "app.integrations.trello.validate_trello_connection",
+        fake_validate_connection,
+    )
+
+    result = validate_trello_config(config)
+
+    assert result.ok is False
+    assert "401" in result.detail or "unauthorized" in result.detail.lower()
+
+
+def test_create_trello_card_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="trello_token",
+        board_id="board123",
+        list_id="list123",
+    )
+
+    def fake_request_json(*args, **kwargs):
+        return {
+            "id": "card123",
+            "name": "Critical incident",
+            "desc": "Root cause details",
+            "idList": "list123",
+        }
+
+    monkeypatch.setattr("app.integrations.trello._request_json", fake_request_json)
+
+    result = create_trello_card(
+        config=config,
+        name="Critical incident",
+        desc="Root cause details",
+    )
+
+    assert result["id"] == "card123"
+    assert result["name"] == "Critical incident"
+
+
+def test_create_trello_card_uses_override_list_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="trello_token",
+        board_id="board123",
+        list_id="default_list",
+    )
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_request_json(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return {"id": "card123", "idList": "override_list"}
+
+    monkeypatch.setattr("app.integrations.trello._request_json", fake_request_json)
+
+    result = create_trello_card(
+        config=config,
+        name="Incident",
+        desc="Details",
+        list_id="override_list",
+    )
+
+    assert result["id"] == "card123"
+    params = captured_kwargs["params"]
+    assert ("idList", "override_list") in params
+
+
+def test_create_trello_card_returns_empty_dict_without_list_id() -> None:
+    config = TrelloConfig(
+        api_key="trello_key",
+        token="trello_token",
+        board_id="board123",
+        list_id="",
+    )
+
+    result = create_trello_card(
+        config=config,
+        name="Incident",
+        desc="Details",
+    )
+
+    assert result == {}

--- a/tests/integrations/test_trello.py
+++ b/tests/integrations/test_trello.py
@@ -204,7 +204,7 @@ def test_create_trello_card_uses_override_list_id(monkeypatch: pytest.MonkeyPatc
     assert ("idList", "override_list") in params
 
 
-def test_create_trello_card_returns_empty_dict_without_list_id() -> None:
+def test_create_trello_card_raises_without_list_id() -> None:
     config = TrelloConfig(
         api_key="trello_key",
         token="trello_token",
@@ -212,10 +212,9 @@ def test_create_trello_card_returns_empty_dict_without_list_id() -> None:
         list_id="",
     )
 
-    result = create_trello_card(
-        config=config,
-        name="Incident",
-        desc="Details",
-    )
-
-    assert result == {}
+    with pytest.raises(ValueError, match="list_id"):
+        create_trello_card(
+            config=config,
+            name="Incident",
+            desc="Details",
+        )


### PR DESCRIPTION
Fixes #361

Adds a first-class Trello integration for incident task tracking.

Includes:
- Trello authentication and connectivity validation
- creating cards from investigation findings
- integration with existing workflow structure
- unit tests for core functionality
- end-to-end tests covering validation and card creation

All tests passing (unit + e2e).

This implements an MVP and can be extended with update/query support if needed.