### PR TITLE
feat: implement Claud Code like terminal application

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -19,6 +19,7 @@ from app.analytics.provider import capture_first_run_if_needed, shutdown_analyti
 from app.cli.commands import register_commands
 from app.cli.layout import RichGroup, render_landing
 from app.cli.prompt_support import install_questionary_escape_cancel
+from app.cli.session import run_repl_session
 from app.version import get_version
 
 
@@ -28,7 +29,9 @@ from app.version import get_version
     invoke_without_command=True,
 )
 @click.version_option(version=get_version(), prog_name="opensre")
-@click.option("--json", "-j", "json_output", is_flag=True, help="Emit machine-readable JSON output.")
+@click.option(
+    "--json", "-j", "json_output", is_flag=True, help="Emit machine-readable JSON output."
+)
 @click.option("--verbose", is_flag=True, help="Print extra diagnostic information.")
 @click.option("--debug", is_flag=True, help="Print debug-level logs and traces.")
 @click.option("--yes", "-y", is_flag=True, help="Auto-confirm all interactive prompts.")
@@ -52,6 +55,8 @@ def cli(
 
     if ctx.invoked_subcommand is None:
         capture_cli_invoked()
+        if not os.getenv("OPENSRE_LEGACY_LANDING") and not json_output:
+            raise SystemExit(run_repl_session())
         render_landing()
         raise SystemExit(0)
 

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -154,6 +154,7 @@ def investigate_command(
         input_json=input_json,
         interactive=interactive,
     )
+    exit_code = ERROR
     try:
         if print_template:
             _write_result(build_alert_template(print_template), output)
@@ -174,6 +175,4 @@ def investigate_command(
 
     if exit_code == SUCCESS:
         capture_investigation_completed()
-    else:
-        capture_investigation_failed()
     raise SystemExit(exit_code)

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import platform
 import time
+from pathlib import Path
+from typing import Any
 
 import click
 
@@ -20,26 +22,12 @@ from app.cli.exit_codes import ERROR, SUCCESS
 from app.version import get_version
 
 
-def _build_investigate_argv(
-    *,
-    input_path: str | None,
-    input_json: str | None,
-    interactive: bool,
-    print_template: str | None,
-    output: str | None,
-) -> list[str]:
-    argv: list[str] = []
-    if input_path is not None:
-        argv.extend(["--input", input_path])
-    if input_json is not None:
-        argv.extend(["--input-json", input_json])
-    if interactive:
-        argv.append("--interactive")
-    if print_template is not None:
-        argv.extend(["--print-template", print_template])
-    if output is not None:
-        argv.extend(["--output", output])
-    return argv
+def _write_result(payload: dict[str, Any], output: str | None) -> None:
+    encoded = json.dumps(payload, indent=2)
+    if output:
+        Path(output).write_text(encoded + "\n", encoding="utf-8")
+        return
+    click.echo(encoded)
 
 
 @click.command(name="update")
@@ -63,12 +51,16 @@ def version_command() -> None:
     """Print detailed version, Python and OS info."""
     capture_cli_invoked()
     if is_json_output():
-        click.echo(json.dumps({
-            "opensre": get_version(),
-            "python": platform.python_version(),
-            "os": platform.system().lower(),
-            "arch": platform.machine(),
-        }))
+        click.echo(
+            json.dumps(
+                {
+                    "opensre": get_version(),
+                    "python": platform.python_version(),
+                    "os": platform.system().lower(),
+                    "arch": platform.machine(),
+                }
+            )
+        )
         return
     click.echo(f"opensre {get_version()}")
     click.echo(f"Python  {platform.python_version()}")
@@ -77,7 +69,9 @@ def version_command() -> None:
 
 @click.command(name="health")
 @click.option("--watch", is_flag=True, help="Continuously refresh the health report.")
-@click.option("--rate", default=5, show_default=True, help="Refresh interval in seconds (with --watch).")
+@click.option(
+    "--rate", default=5, show_default=True, help="Refresh interval in seconds (with --watch)."
+)
 def health_command(watch: bool, rate: int) -> None:
     """Show a quick health summary of the local agent setup."""
     from app.cli.health_view import render_health_json, render_health_report
@@ -151,7 +145,9 @@ def investigate_command(
     output: str | None,
 ) -> None:
     """Run an RCA investigation against an alert payload."""
-    from app.main import main as investigate_main
+    from app.cli.alert_templates import build_alert_template
+    from app.cli.investigate import run_investigation_cli_streaming
+    from app.cli.payload import load_payload
 
     capture_investigation_started(
         input_path=input_path,
@@ -159,15 +155,19 @@ def investigate_command(
         interactive=interactive,
     )
     try:
-        exit_code = investigate_main(
-            _build_investigate_argv(
-                input_path=input_path,
-                input_json=input_json,
-                interactive=interactive,
-                print_template=print_template,
-                output=output,
-            )
+        if print_template:
+            _write_result(build_alert_template(print_template), output)
+            capture_investigation_completed()
+            raise SystemExit(SUCCESS)
+
+        payload = load_payload(
+            input_path=input_path,
+            input_json=input_json,
+            interactive=interactive,
         )
+        result = run_investigation_cli_streaming(raw_alert=payload)
+        _write_result(result, output)
+        exit_code = SUCCESS
     except Exception:
         capture_investigation_failed()
         raise

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -154,7 +154,6 @@ def investigate_command(
         input_json=input_json,
         interactive=interactive,
     )
-    exit_code = ERROR
     try:
         if print_template:
             _write_result(build_alert_template(print_template), output)
@@ -168,11 +167,8 @@ def investigate_command(
         )
         result = run_investigation_cli_streaming(raw_alert=payload)
         _write_result(result, output)
-        exit_code = SUCCESS
+        capture_investigation_completed()
+        raise SystemExit(SUCCESS)
     except Exception:
         capture_investigation_failed()
         raise
-
-    if exit_code == SUCCESS:
-        capture_investigation_completed()
-    raise SystemExit(exit_code)

--- a/app/cli/investigate.py
+++ b/app/cli/investigate.py
@@ -154,6 +154,9 @@ def run_investigation_cli_streaming(
 
     Uses ``astream_events`` + ``StreamRenderer`` so the local CLI shows
     the same live tool-call and reasoning updates as a remote investigation.
+
+    Important: callers should not wrap this function in ``Console.status()``.
+    ``StreamRenderer`` already owns live terminal output and spinner updates.
     """
     from app.remote.renderer import StreamRenderer
 

--- a/app/cli/session/__init__.py
+++ b/app/cli/session/__init__.py
@@ -1,0 +1,5 @@
+"""Interactive OpenSRE session runtime."""
+
+from app.cli.session.repl import run_repl_session
+
+__all__ = ["run_repl_session"]

--- a/app/cli/session/banner.py
+++ b/app/cli/session/banner.py
@@ -11,9 +11,10 @@ from rich.text import Text
 from app.cli.session.state import SessionState
 from app.version import get_version
 
+_console = Console(highlight=False)
+
 
 def render_banner(state: SessionState) -> None:
-    console = Console(highlight=False)
     trust = "on" if state.trust_mode else "off"
     status = "idle" if not state.active_run else "running"
     subtitle = f"v{get_version()}   model: {state.model_label}"
@@ -31,8 +32,8 @@ def render_banner(state: SessionState) -> None:
         (status, "bold white"),
     )
 
-    console.print()
-    console.print(
+    _console.print()
+    _console.print(
         Panel(
             body,
             title=title,
@@ -43,11 +44,10 @@ def render_banner(state: SessionState) -> None:
             padding=(1, 2),
         )
     )
-    console.print()
+    _console.print()
 
 
 def render_status(state: SessionState) -> None:
-    console = Console(highlight=False)
     trust = "on" if state.trust_mode else "off"
     status = "running" if state.active_run else "idle"
     last_alert = "none"
@@ -65,14 +65,13 @@ def render_status(state: SessionState) -> None:
     table.add_row("turns", str(turns))
     if state.last_duration_s is not None:
         table.add_row("last run", f"{state.last_duration_s:.1f}s")
-    console.print(table)
+    _console.print(table)
 
 
 def render_run_summary(state: SessionState) -> None:
     if not state.last_result:
         return
 
-    console = Console(highlight=False)
     last_alert = "none"
     if state.last_alert:
         last_alert = str(state.last_alert.get("alert_name", "alert"))
@@ -93,7 +92,7 @@ def render_run_summary(state: SessionState) -> None:
     summary_table.add_row("root cause", root_cause or "n/a")
     summary_table.add_row("report", report or "n/a")
 
-    console.print(
+    _console.print(
         Panel(
             summary_table,
             title=Text.assemble(("Last Investigation", "bold green")),

--- a/app/cli/session/banner.py
+++ b/app/cli/session/banner.py
@@ -1,0 +1,104 @@
+"""Session banner and status rendering."""
+
+from __future__ import annotations
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from app.cli.session.state import SessionState
+from app.version import get_version
+
+
+def render_banner(state: SessionState) -> None:
+    console = Console(highlight=False)
+    trust = "on" if state.trust_mode else "off"
+    status = "idle" if not state.active_run else "running"
+    subtitle = f"v{get_version()}   model: {state.model_label}"
+
+    title = Text.assemble(("OpenSRE Session", "bold cyan"))
+    body = Text.assemble(
+        ("Investigation terminal for alert triage and RCA\n", "white"),
+        ("/help", "bold cyan"),
+        (" commands   ", "dim"),
+        ("/quit", "bold cyan"),
+        (" exit   ", "dim"),
+        ("trust:", "dim"),
+        (trust, "bold green" if trust == "on" else "bold yellow"),
+        ("   status:", "dim"),
+        (status, "bold white"),
+    )
+
+    console.print()
+    console.print(
+        Panel(
+            body,
+            title=title,
+            subtitle=subtitle,
+            subtitle_align="right",
+            border_style="cyan",
+            box=box.ROUNDED,
+            padding=(1, 2),
+        )
+    )
+    console.print()
+
+
+def render_status(state: SessionState) -> None:
+    console = Console(highlight=False)
+    trust = "on" if state.trust_mode else "off"
+    status = "running" if state.active_run else "idle"
+    last_alert = "none"
+    if state.last_alert:
+        last_alert = str(state.last_alert.get("alert_name", "alert"))
+    turns = len(state.conversation)
+
+    table = Table(box=box.SIMPLE_HEAD, show_header=False, pad_edge=False)
+    table.add_column("k", style="dim", no_wrap=True)
+    table.add_column("v", style="white")
+    table.add_row("status", status)
+    table.add_row("trust", trust)
+    table.add_row("model", state.model_label)
+    table.add_row("last alert", last_alert)
+    table.add_row("turns", str(turns))
+    if state.last_duration_s is not None:
+        table.add_row("last run", f"{state.last_duration_s:.1f}s")
+    console.print(table)
+
+
+def render_run_summary(state: SessionState) -> None:
+    if not state.last_result:
+        return
+
+    console = Console(highlight=False)
+    last_alert = "none"
+    if state.last_alert:
+        last_alert = str(state.last_alert.get("alert_name", "alert"))
+
+    root_cause = str(state.last_result.get("root_cause", "")).strip()
+    report = str(state.last_result.get("report", "")).strip()
+    if len(report) > 240:
+        report = report[:237] + "..."
+
+    summary_table = Table(box=box.SIMPLE, show_header=False, pad_edge=False)
+    summary_table.add_column("k", style="dim", no_wrap=True)
+    summary_table.add_column("v", style="white")
+    summary_table.add_row("alert", last_alert)
+    summary_table.add_row(
+        "duration", f"{state.last_duration_s:.1f}s" if state.last_duration_s else "n/a"
+    )
+    summary_table.add_row("noise", str(bool(state.last_result.get("is_noise", False))).lower())
+    summary_table.add_row("root cause", root_cause or "n/a")
+    summary_table.add_row("report", report or "n/a")
+
+    console.print(
+        Panel(
+            summary_table,
+            title=Text.assemble(("Last Investigation", "bold green")),
+            border_style="green",
+            box=box.ROUNDED,
+            padding=(0, 1),
+        )
+    )

--- a/app/cli/session/commands.py
+++ b/app/cli/session/commands.py
@@ -26,6 +26,7 @@ def handle_slash_command(text: str, state: SessionState) -> bool:
     if command in {"/clear", "/reset"}:
         state.last_alert = None
         state.last_result = None
+        state.interruption_requested = False
         state.conversation.clear()
         _console.print("[green]Session context cleared.[/green]")
         return False

--- a/app/cli/session/commands.py
+++ b/app/cli/session/commands.py
@@ -1,0 +1,45 @@
+"""Slash commands for interactive session mode."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from app.cli.session.banner import render_status
+from app.cli.session.state import SessionState
+
+_console = Console(highlight=False)
+
+
+def handle_slash_command(text: str, state: SessionState) -> bool:
+    command = text.strip()
+    if command == "/help":
+        _console.print("[bold cyan]Session commands[/bold cyan]")
+        _console.print("  [cyan]/help[/cyan]         Show command reference")
+        _console.print("  [cyan]/status[/cyan]       Show current session status")
+        _console.print("  [cyan]/trust on|off[/cyan] Toggle trust mode")
+        _console.print("  [cyan]/clear[/cyan]        Reset in-memory context")
+        _console.print("  [cyan]/quit[/cyan]         Exit session")
+        return False
+    if command == "/status":
+        render_status(state)
+        return False
+    if command in {"/clear", "/reset"}:
+        state.last_alert = None
+        state.last_result = None
+        state.conversation.clear()
+        _console.print("[green]Session context cleared.[/green]")
+        return False
+    if command.startswith("/trust"):
+        parts = command.split()
+        if len(parts) != 2 or parts[1] not in {"on", "off"}:
+            _console.print("[yellow]Usage:[/yellow] /trust on|off")
+            return False
+        state.trust_mode = parts[1] == "on"
+        _console.print(
+            f"[green]Trust mode {'enabled' if state.trust_mode else 'disabled'}.[/green]"
+        )
+        return False
+    if command in {"/quit", "/exit"}:
+        return True
+    _console.print("[red]Unknown command.[/red] Use [cyan]/help[/cyan].")
+    return False

--- a/app/cli/session/repl.py
+++ b/app/cli/session/repl.py
@@ -53,6 +53,8 @@ def run_repl_session() -> int:
             if state.active_run:
                 state.interruption_requested = True
                 state.active_run = False
+            else:
+                state.interruption_requested = False
             _console.print("\n[dim]Interrupted. Session still running.[/dim]")
             continue
 

--- a/app/cli/session/repl.py
+++ b/app/cli/session/repl.py
@@ -1,0 +1,85 @@
+"""Persistent REPL runtime for OpenSRE terminal mode."""
+
+from __future__ import annotations
+
+import json
+
+from rich.console import Console
+
+from app.cli.errors import OpenSREError
+from app.cli.session.banner import render_banner, render_run_summary
+from app.cli.session.commands import handle_slash_command
+from app.cli.session.router import route_input
+from app.cli.session.run_manager import run_alert_investigation, run_followup
+from app.cli.session.state import SessionState
+
+_console = Console(highlight=False)
+
+
+def _read_user_input(*, base_prompt: str) -> str:
+    """Read one command from stdin, supporting multiline JSON paste."""
+    first = input(base_prompt)
+    stripped = first.lstrip()
+    if not stripped.startswith("{"):
+        return first
+
+    buffer = first
+    for _ in range(64):
+        try:
+            parsed = json.loads(buffer)
+        except json.JSONDecodeError:
+            next_line = input("... ")
+            if next_line == "":
+                return buffer
+            buffer = f"{buffer}\n{next_line}"
+            continue
+        if isinstance(parsed, dict):
+            return buffer
+        return first
+    return buffer
+
+
+def run_repl_session() -> int:
+    state = SessionState()
+    render_banner(state)
+
+    while True:
+        try:
+            trust = "trust:on" if state.trust_mode else "trust:off"
+            raw = _read_user_input(base_prompt=f"opensre[{trust}]> ")
+        except EOFError:
+            return 0
+        except KeyboardInterrupt:
+            if state.active_run:
+                state.interruption_requested = True
+                state.active_run = False
+            _console.print("\n[dim]Interrupted. Session still running.[/dim]")
+            continue
+
+        routed = route_input(raw)
+        if routed.kind == "empty":
+            continue
+        if routed.kind == "slash":
+            if handle_slash_command(routed.text, state):
+                return 0
+            continue
+
+        try:
+            if routed.kind == "alert" and routed.payload is not None:
+                with _console.status("[cyan]Investigating alert...[/cyan]", spinner="dots"):
+                    run_alert_investigation(state, routed.payload)
+                render_run_summary(state)
+            else:
+                with _console.status("[cyan]Refining investigation...[/cyan]", spinner="dots"):
+                    run_followup(state, routed.text)
+                render_run_summary(state)
+        except KeyboardInterrupt:
+            state.interruption_requested = True
+            state.active_run = False
+            _console.print(
+                "\n[yellow]Interrupted.[/yellow] Investigation canceled; session preserved."
+            )
+        except OpenSREError as exc:
+            exc.show()
+        except Exception as exc:  # noqa: BLE001
+            _console.print(f"[red]Error:[/red] {type(exc).__name__}: {exc}")

--- a/app/cli/session/repl.py
+++ b/app/cli/session/repl.py
@@ -52,10 +52,14 @@ def run_repl_session() -> int:
         except KeyboardInterrupt:
             if state.active_run:
                 state.interruption_requested = True
+        except KeyboardInterrupt:
+            if state.active_run:
+                state.interruption_requested = True
                 state.active_run = False
             else:
                 state.interruption_requested = False
             _console.print("\n[dim]Interrupted. Session still running.[/dim]")
+            continue
             continue
 
         routed = route_input(raw)

--- a/app/cli/session/repl.py
+++ b/app/cli/session/repl.py
@@ -52,14 +52,10 @@ def run_repl_session() -> int:
         except KeyboardInterrupt:
             if state.active_run:
                 state.interruption_requested = True
-        except KeyboardInterrupt:
-            if state.active_run:
-                state.interruption_requested = True
                 state.active_run = False
             else:
                 state.interruption_requested = False
             _console.print("\n[dim]Interrupted. Session still running.[/dim]")
-            continue
             continue
 
         routed = route_input(raw)

--- a/app/cli/session/repl.py
+++ b/app/cli/session/repl.py
@@ -68,12 +68,10 @@ def run_repl_session() -> int:
 
         try:
             if routed.kind == "alert" and routed.payload is not None:
-                with _console.status("[cyan]Investigating alert...[/cyan]", spinner="dots"):
-                    run_alert_investigation(state, routed.payload)
+                run_alert_investigation(state, routed.payload)
                 render_run_summary(state)
             else:
-                with _console.status("[cyan]Refining investigation...[/cyan]", spinner="dots"):
-                    run_followup(state, routed.text)
+                run_followup(state, routed.text)
                 render_run_summary(state)
         except KeyboardInterrupt:
             state.interruption_requested = True

--- a/app/cli/session/router.py
+++ b/app/cli/session/router.py
@@ -6,7 +6,6 @@ import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
-
 RouteKind = Literal["slash", "alert", "followup", "empty"]
 
 

--- a/app/cli/session/router.py
+++ b/app/cli/session/router.py
@@ -1,0 +1,33 @@
+"""Input router for session mode."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+RouteKind = Literal["slash", "alert", "followup", "empty"]
+
+
+@dataclass(frozen=True)
+class RouteResult:
+    kind: RouteKind
+    text: str
+    payload: dict[str, Any] | None = None
+
+
+def route_input(text: str) -> RouteResult:
+    stripped = text.strip()
+    if not stripped:
+        return RouteResult(kind="empty", text=text)
+    if stripped.startswith("/"):
+        return RouteResult(kind="slash", text=stripped)
+    if stripped.startswith("{"):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return RouteResult(kind="followup", text=text)
+        if isinstance(parsed, dict):
+            return RouteResult(kind="alert", text=text, payload=parsed)
+    return RouteResult(kind="followup", text=text)

--- a/app/cli/session/run_manager.py
+++ b/app/cli/session/run_manager.py
@@ -15,6 +15,8 @@ _console = Console(highlight=False)
 
 
 def run_alert_investigation(state: SessionState, payload: dict[str, Any]) -> None:
+    if state.interruption_requested:
+        state.interruption_requested = False
     state.active_run = True
     started = time.perf_counter()
     try:
@@ -47,6 +49,8 @@ def run_followup(state: SessionState, text: str) -> None:
     merged_alert["session_history"] = history_items
     merged_alert["session_followup"] = prompt
 
+    if state.interruption_requested:
+        state.interruption_requested = False
     state.active_run = True
     started = time.perf_counter()
     try:

--- a/app/cli/session/run_manager.py
+++ b/app/cli/session/run_manager.py
@@ -1,0 +1,61 @@
+"""Execution helpers for interactive session investigations."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from rich.console import Console
+
+from app.cli.investigate import run_investigation_cli_streaming
+from app.cli.session.state import SessionState
+
+_console = Console(highlight=False)
+
+
+def run_alert_investigation(state: SessionState, payload: dict[str, Any]) -> None:
+    state.active_run = True
+    started = time.perf_counter()
+    try:
+        state.last_alert = payload
+        result = run_investigation_cli_streaming(raw_alert=payload)
+        state.last_result = result
+        state.append_turn(json.dumps(payload, sort_keys=True))
+        root_cause = str(result.get("root_cause", "")).strip()
+        if root_cause:
+            _console.print(f"\nRoot cause: {root_cause}")
+    finally:
+        state.last_duration_s = time.perf_counter() - started
+        state.active_run = False
+
+
+def run_followup(state: SessionState, text: str) -> None:
+    prompt = text.strip()
+    if not prompt:
+        return
+    state.append_turn(prompt)
+
+    if not state.last_alert:
+        _console.print("No active alert context. Paste alert JSON to start an investigation.")
+        return
+
+    merged_alert = dict(state.last_alert)
+    history = merged_alert.get("session_history")
+    history_items = list(history) if isinstance(history, list) else []
+    history_items.append(prompt)
+    merged_alert["session_history"] = history_items
+    merged_alert["session_followup"] = prompt
+
+    state.active_run = True
+    started = time.perf_counter()
+    try:
+        result = run_investigation_cli_streaming(raw_alert=merged_alert)
+        state.last_alert = merged_alert
+        state.last_result = result
+        root_cause = str(result.get("root_cause", "")).strip()
+        if root_cause:
+            _console.print(f"\nUpdated root cause: {root_cause}")
+    finally:
+        state.last_duration_s = time.perf_counter() - started
+        state.active_run = False

--- a/app/cli/session/state.py
+++ b/app/cli/session/state.py
@@ -1,0 +1,48 @@
+"""Session state for persistent interactive CLI mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.config import LLMSettings
+
+
+@dataclass
+class SessionState:
+    """In-memory state that survives across REPL commands."""
+
+    trust_mode: bool = False
+    active_run: bool = False
+    interruption_requested: bool = False
+    last_alert: dict[str, Any] | None = None
+    last_result: dict[str, Any] | None = None
+    conversation: list[str] = field(default_factory=list)
+    last_duration_s: float | None = None
+
+    def append_turn(self, text: str) -> None:
+        if text.strip():
+            self.conversation.append(text.strip())
+
+    @property
+    def model_label(self) -> str:
+        try:
+            settings = LLMSettings.from_env()
+        except Exception:
+            return "unknown"
+        provider = settings.provider
+        if provider == "anthropic":
+            return settings.anthropic_reasoning_model
+        if provider == "openai":
+            return settings.openai_reasoning_model
+        if provider == "openrouter":
+            return settings.openrouter_reasoning_model
+        if provider == "gemini":
+            return settings.gemini_reasoning_model
+        if provider == "nvidia":
+            return settings.nvidia_reasoning_model
+        if provider == "bedrock":
+            return settings.bedrock_reasoning_model
+        if provider == "ollama":
+            return settings.ollama_model
+        return "unknown"

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -27,7 +27,6 @@ def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
     return updated
 
 
-
 def sync_env_values(
     values: dict[str, str],
     *,
@@ -35,7 +34,11 @@ def sync_env_values(
 ) -> Path:
     """Write multiple environment values into the target .env file."""
     target_path = env_path or PROJECT_ENV_PATH
-    existing = target_path.read_text(encoding="utf-8").splitlines(keepends=True) if target_path.exists() else []
+    existing = (
+        target_path.read_text(encoding="utf-8").splitlines(keepends=True)
+        if target_path.exists()
+        else []
+    )
 
     lines = existing
     for key, value in values.items():
@@ -78,13 +81,17 @@ def sync_provider_env(
     from app.cli.wizard.config import SUPPORTED_PROVIDERS
 
     target_path = env_path or PROJECT_ENV_PATH
-    existing = target_path.read_text(encoding="utf-8").splitlines(keepends=True) if target_path.exists() else []
+    existing = (
+        target_path.read_text(encoding="utf-8").splitlines(keepends=True)
+        if target_path.exists()
+        else []
+    )
 
     stale_keys: set[str] = set()
     for p in SUPPORTED_PROVIDERS:
         stale_keys |= _provider_specific_keys(p)
 
-    active_keys = {provider.model_env, provider.api_key_env}
+    active_keys = {provider.model_env}
     if provider.legacy_model_env:
         active_keys.add(provider.legacy_model_env)
     stale_keys -= active_keys

--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -86,17 +86,23 @@ def postgresql_config_from_env() -> PostgreSQLConfig | None:
     database = os.getenv("POSTGRESQL_DATABASE", "").strip()
     if not host or not database:
         return None
-    return build_postgresql_config({
-        "host": host,
-        "port": int(_pg_port) if (_pg_port := os.getenv("POSTGRESQL_PORT", "").strip()).isdigit() else DEFAULT_POSTGRESQL_PORT,
-        "database": database,
-        "username": os.getenv("POSTGRESQL_USERNAME", DEFAULT_POSTGRESQL_USER).strip(),
-        "password": os.getenv("POSTGRESQL_PASSWORD", "").strip(),
-        "ssl_mode": os.getenv("POSTGRESQL_SSL_MODE", DEFAULT_POSTGRESQL_SSL_MODE).strip(),
-    })
+    return build_postgresql_config(
+        {
+            "host": host,
+            "port": int(_pg_port)
+            if (_pg_port := os.getenv("POSTGRESQL_PORT", "").strip()).isdigit()
+            else DEFAULT_POSTGRESQL_PORT,
+            "database": database,
+            "username": os.getenv("POSTGRESQL_USERNAME", DEFAULT_POSTGRESQL_USER).strip(),
+            "password": os.getenv("POSTGRESQL_PASSWORD", "").strip(),
+            "ssl_mode": os.getenv("POSTGRESQL_SSL_MODE", DEFAULT_POSTGRESQL_SSL_MODE).strip(),
+        }
+    )
 
 
-def resolve_postgresql_config(host: str, database: str, port: int = DEFAULT_POSTGRESQL_PORT) -> PostgreSQLConfig:
+def resolve_postgresql_config(
+    host: str, database: str, port: int = DEFAULT_POSTGRESQL_PORT
+) -> PostgreSQLConfig:
     """Build a config for the given host/database, resolving credentials from store or env.
 
     The LLM supplies only identifying params (host, database, port).
@@ -108,32 +114,36 @@ def resolve_postgresql_config(host: str, database: str, port: int = DEFAULT_POST
     stored = get_integration("postgresql")
     if stored:
         creds = stored.get("credentials", {})
-        return build_postgresql_config({
-            "host": host,
-            "port": creds.get("port", port),
-            "database": database,
-            "username": creds.get("username", DEFAULT_POSTGRESQL_USER),
-            "password": creds.get("password", ""),
-            "ssl_mode": creds.get("ssl_mode", DEFAULT_POSTGRESQL_SSL_MODE),
-        })
+        return build_postgresql_config(
+            {
+                "host": host,
+                "port": creds.get("port", port),
+                "database": database,
+                "username": creds.get("username", DEFAULT_POSTGRESQL_USER),
+                "password": creds.get("password", ""),
+                "ssl_mode": creds.get("ssl_mode", DEFAULT_POSTGRESQL_SSL_MODE),
+            }
+        )
 
     env_cfg = postgresql_config_from_env()
     if env_cfg:
-        return build_postgresql_config({
-            "host": host,
-            "port": port,
-            "database": database,
-            "username": env_cfg.username,
-            "password": env_cfg.password,
-            "ssl_mode": env_cfg.ssl_mode,
-        })
+        return build_postgresql_config(
+            {
+                "host": host,
+                "port": port,
+                "database": database,
+                "username": env_cfg.username,
+                "password": env_cfg.password,
+                "ssl_mode": env_cfg.ssl_mode,
+            }
+        )
 
     return build_postgresql_config({"host": host, "port": port, "database": database})
 
 
 def _get_connection(config: PostgreSQLConfig) -> Any:
     """Create a psycopg2 connection from config. Caller must close."""
-    import psycopg2
+    import psycopg2  # type: ignore[import-untyped]
 
     return psycopg2.connect(
         host=config.host,
@@ -168,10 +178,7 @@ def validate_postgresql_config(config: PostgreSQLConfig) -> PostgreSQLValidation
 
             return PostgreSQLValidationResult(
                 ok=True,
-                detail=(
-                    f"Connected to PostgreSQL {version}; "
-                    f"target database: {config.database}."
-                ),
+                detail=(f"Connected to PostgreSQL {version}; target database: {config.database}."),
             )
         finally:
             conn.close()
@@ -193,7 +200,9 @@ def get_server_status(config: PostgreSQLConfig) -> dict[str, Any]:
             cursor = conn.cursor()
 
             # Get server version and uptime
-            cursor.execute("SELECT version(), date_trunc('second', current_timestamp - pg_postmaster_start_time()) as uptime")
+            cursor.execute(
+                "SELECT version(), date_trunc('second', current_timestamp - pg_postmaster_start_time()) as uptime"
+            )
             version_info, uptime = cursor.fetchone()
             version = version_info.split()[1] if version_info else "unknown"
 
@@ -282,7 +291,8 @@ def get_current_queries(
         try:
             cursor = conn.cursor()
 
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT
                     pid,
                     usename,
@@ -301,22 +311,26 @@ def get_current_queries(
                     AND pid != pg_backend_pid()
                 ORDER BY query_start ASC
                 LIMIT %s
-            """, (threshold_seconds, config.max_results))
+            """,
+                (threshold_seconds, config.max_results),
+            )
 
             queries = []
             for row in cursor.fetchall():
-                queries.append({
-                    "pid": row[0],
-                    "username": row[1],
-                    "application_name": row[2] or "",
-                    "client_addr": row[3] or "local",
-                    "state": row[4],
-                    "query_start": str(row[5]),
-                    "duration_seconds": row[6],
-                    "wait_event_type": row[7] or "",
-                    "wait_event": row[8] or "",
-                    "query_truncated": row[9] or "",
-                })
+                queries.append(
+                    {
+                        "pid": row[0],
+                        "username": row[1],
+                        "application_name": row[2] or "",
+                        "client_addr": row[3] or "local",
+                        "state": row[4],
+                        "query_start": str(row[5]),
+                        "duration_seconds": row[6],
+                        "wait_event_type": row[7] or "",
+                        "wait_event": row[8] or "",
+                        "query_truncated": row[9] or "",
+                    }
+                )
 
             cursor.close()
             return {
@@ -382,22 +396,24 @@ def get_replication_status(config: PostgreSQLConfig) -> dict[str, Any]:
 
             replicas = []
             for row in cursor.fetchall():
-                replicas.append({
-                    "pid": row[0],
-                    "username": row[1],
-                    "application_name": row[2] or "",
-                    "client_addr": row[3] or "local",
-                    "client_hostname": row[4] or "",
-                    "state": row[5],
-                    "sent_lsn": row[6] or "",
-                    "write_lsn": row[7] or "",
-                    "flush_lsn": row[8] or "",
-                    "replay_lsn": row[9] or "",
-                    "write_lag": str(row[10]) if row[10] else "",
-                    "flush_lag": str(row[11]) if row[11] else "",
-                    "replay_lag": str(row[12]) if row[12] else "",
-                    "sync_state": row[13] or "",
-                })
+                replicas.append(
+                    {
+                        "pid": row[0],
+                        "username": row[1],
+                        "application_name": row[2] or "",
+                        "client_addr": row[3] or "local",
+                        "client_hostname": row[4] or "",
+                        "state": row[5],
+                        "sent_lsn": row[6] or "",
+                        "write_lsn": row[7] or "",
+                        "flush_lsn": row[8] or "",
+                        "replay_lsn": row[9] or "",
+                        "write_lag": str(row[10]) if row[10] else "",
+                        "flush_lag": str(row[11]) if row[11] else "",
+                        "replay_lag": str(row[12]) if row[12] else "",
+                        "sync_state": row[13] or "",
+                    }
+                )
 
             # Get current WAL position on primary
             cursor.execute("SELECT pg_current_wal_lsn()")
@@ -479,7 +495,8 @@ def get_slow_queries(
                 }
 
             # Get slow queries by mean execution time
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT
                     queryid,
                     left(query, 500) as query_truncated,
@@ -495,22 +512,26 @@ def get_slow_queries(
                 WHERE mean_exec_time >= %s
                 ORDER BY mean_exec_time DESC
                 LIMIT %s
-            """, (threshold_ms, effective_limit))
+            """,
+                (threshold_ms, effective_limit),
+            )
 
             queries = []
             for row in cursor.fetchall():
-                queries.append({
-                    "queryid": str(row[0]) if row[0] else "",
-                    "query_truncated": row[1] or "",
-                    "calls": row[2],
-                    "total_time_ms": row[3],
-                    "mean_time_ms": row[4],
-                    "min_time_ms": row[5],
-                    "max_time_ms": row[6],
-                    "stddev_time_ms": row[7],
-                    "total_rows": row[8],
-                    "cache_hit_percent": round(row[9] or 0, 2),
-                })
+                queries.append(
+                    {
+                        "queryid": str(row[0]) if row[0] else "",
+                        "query_truncated": row[1] or "",
+                        "calls": row[2],
+                        "total_time_ms": row[3],
+                        "mean_time_ms": row[4],
+                        "min_time_ms": row[5],
+                        "max_time_ms": row[6],
+                        "stddev_time_ms": row[7],
+                        "total_rows": row[8],
+                        "cache_hit_percent": round(row[9] or 0, 2),
+                    }
+                )
 
             cursor.close()
             return {
@@ -544,7 +565,8 @@ def get_table_stats(
         try:
             cursor = conn.cursor()
 
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT
                     schemaname,
                     relname,
@@ -568,7 +590,9 @@ def get_table_stats(
                 WHERE schemaname = %s
                 ORDER BY pg_total_relation_size(t.relid) DESC
                 LIMIT %s
-            """, (schema_name, config.max_results))
+            """,
+                (schema_name, config.max_results),
+            )
 
             tables = []
             for row in cursor.fetchall():
@@ -578,36 +602,38 @@ def get_table_stats(
                 if total_scans > 0:
                     index_usage = round(((row[9] or 0) / total_scans) * 100, 2)
 
-                tables.append({
-                    "schema": row[0],
-                    "table_name": row[1],
-                    "tuples": {
-                        "inserted": row[2] or 0,
-                        "updated": row[3] or 0,
-                        "deleted": row[4] or 0,
-                        "live": row[5] or 0,
-                        "dead": row[6] or 0,
-                    },
-                    "scans": {
-                        "sequential": row[7] or 0,
-                        "sequential_tuples": row[8] or 0,
-                        "index": row[9] or 0,
-                        "index_tuples": row[10] or 0,
-                        "index_usage_percent": index_usage,
-                    },
-                    "maintenance": {
-                        "last_vacuum": str(row[11]) if row[11] else None,
-                        "last_autovacuum": str(row[12]) if row[12] else None,
-                        "last_analyze": str(row[13]) if row[13] else None,
-                        "last_autoanalyze": str(row[14]) if row[14] else None,
-                    },
-                    "size": {
-                        "total_bytes": row[15] or 0,
-                        "table_bytes": row[16] or 0,
-                        "indexes_bytes": row[17] or 0,
-                        "total_mb": round((row[15] or 0) / 1024 / 1024, 2),
-                    },
-                })
+                tables.append(
+                    {
+                        "schema": row[0],
+                        "table_name": row[1],
+                        "tuples": {
+                            "inserted": row[2] or 0,
+                            "updated": row[3] or 0,
+                            "deleted": row[4] or 0,
+                            "live": row[5] or 0,
+                            "dead": row[6] or 0,
+                        },
+                        "scans": {
+                            "sequential": row[7] or 0,
+                            "sequential_tuples": row[8] or 0,
+                            "index": row[9] or 0,
+                            "index_tuples": row[10] or 0,
+                            "index_usage_percent": index_usage,
+                        },
+                        "maintenance": {
+                            "last_vacuum": str(row[11]) if row[11] else None,
+                            "last_autovacuum": str(row[12]) if row[12] else None,
+                            "last_analyze": str(row[13]) if row[13] else None,
+                            "last_autoanalyze": str(row[14]) if row[14] else None,
+                        },
+                        "size": {
+                            "total_bytes": row[15] or 0,
+                            "table_bytes": row[16] or 0,
+                            "indexes_bytes": row[17] or 0,
+                            "total_mb": round((row[15] or 0) / 1024 / 1024, 2),
+                        },
+                    }
+                )
 
             cursor.close()
             return {

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from app.cli.investigate import (
     resolve_investigation_context,
     run_investigation_cli,
+    run_investigation_cli_streaming,
     stream_investigation_cli,
 )
 from app.remote.stream import StreamEvent
@@ -103,3 +104,32 @@ def test_stream_investigation_cli_raises_queued_exception_immediately(
     assert first.event_type == "metadata"
     with pytest.raises(RuntimeError, match="stream failed"):
         next(events)
+
+
+def test_run_investigation_cli_streaming_does_not_use_rich_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_status(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("Console.status() must not be used for streaming investigations")
+
+    class FakeRenderer:
+        def render_stream(self, _events: object) -> dict[str, object]:
+            return {
+                "slack_message": "report body",
+                "problem_md": "# problem",
+                "root_cause": "bad deploy",
+                "is_noise": False,
+            }
+
+    monkeypatch.setattr("rich.console.Console.status", fail_status)
+    monkeypatch.setattr("app.cli.investigate.stream_investigation_cli", lambda **_kwargs: iter(()))
+    monkeypatch.setattr("app.remote.renderer.StreamRenderer", FakeRenderer)
+
+    result = run_investigation_cli_streaming(raw_alert={"alert_name": "PayloadAlert"})
+
+    assert result == {
+        "report": "report body",
+        "problem_md": "# problem",
+        "root_cause": "bad deploy",
+        "is_noise": False,
+    }

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -365,6 +365,7 @@ def test_opensre_session_multiline_json_routes_as_alert(cli_sandbox: CliSandbox)
 
     assert result.exit_code == 0
     assert "No active alert context" not in result.stdout
+    assert result.stdout.count("opensre[trust:off]>") >= 2
 
 
 def test_opensre_help_smoke(cli_sandbox: CliSandbox) -> None:

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -351,22 +351,10 @@ def test_opensre_session_starts_and_quits(cli_sandbox: CliSandbox) -> None:
 
 
 @pytest.mark.skipif(os.name == "nt", reason="interactive smoke uses POSIX PTYs")
-def test_opensre_session_multiline_json_routes_as_alert(cli_sandbox: CliSandbox) -> None:
-    result = _run_cli_pty(
-        cli_sandbox,
-        actions=[
-            PtyAction(
-                expect="opensre[trust:off]>",
-                send=(b'{\r  "alert_name": "example-alert",\r  "message": "synthetic test"\r}\r'),
-            ),
-            PtyAction(expect="opensre[trust:off]>", send=b"/quit\r"),
-        ],
-    )
-
     assert result.exit_code == 0
     assert "No active alert context" not in result.stdout
+    # Confirm the REPL returned to the prompt after processing the alert input
     assert result.stdout.count("opensre[trust:off]>") >= 2
-
 
 def test_opensre_help_smoke(cli_sandbox: CliSandbox) -> None:
     result = _run_cli(cli_sandbox, "-h")

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -351,10 +351,23 @@ def test_opensre_session_starts_and_quits(cli_sandbox: CliSandbox) -> None:
 
 
 @pytest.mark.skipif(os.name == "nt", reason="interactive smoke uses POSIX PTYs")
+def test_opensre_session_multiline_json_routes_as_alert(cli_sandbox: CliSandbox) -> None:
+    result = _run_cli_pty(
+        cli_sandbox,
+        actions=[
+            PtyAction(
+                expect="opensre[trust:off]>",
+                send=(b'{\r  "alert_name": "example-alert",\r  "message": "synthetic test"\r}\r'),
+            ),
+            PtyAction(expect="opensre[trust:off]>", send=b"/quit\r"),
+        ],
+    )
+
     assert result.exit_code == 0
     assert "No active alert context" not in result.stdout
     # Confirm the REPL returned to the prompt after processing the alert input
     assert result.stdout.count("opensre[trust:off]>") >= 2
+
 
 def test_opensre_help_smoke(cli_sandbox: CliSandbox) -> None:
     result = _run_cli(cli_sandbox, "-h")

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -331,11 +331,40 @@ def release_api_url() -> str:
 
 
 def test_opensre_landing_page_smoke(cli_sandbox: CliSandbox) -> None:
-    result = _run_cli(cli_sandbox)
+    result = _run_cli(cli_sandbox, extra_env={"OPENSRE_LEGACY_LANDING": "1"})
 
     assert result.exit_code == 0
     assert "Quick start:" in result.stdout
     assert "opensre investigate -i alert.json" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="interactive smoke uses POSIX PTYs")
+def test_opensre_session_starts_and_quits(cli_sandbox: CliSandbox) -> None:
+    result = _run_cli_pty(
+        cli_sandbox,
+        actions=[PtyAction(expect="OpenSRE Session", send=b"/quit\r")],
+    )
+
+    assert result.exit_code == 0
+    assert "OpenSRE Session" in result.stdout
+    assert "Investigation terminal for alert triage and RCA" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="interactive smoke uses POSIX PTYs")
+def test_opensre_session_multiline_json_routes_as_alert(cli_sandbox: CliSandbox) -> None:
+    result = _run_cli_pty(
+        cli_sandbox,
+        actions=[
+            PtyAction(
+                expect="opensre[trust:off]>",
+                send=(b'{\r  "alert_name": "example-alert",\r  "message": "synthetic test"\r}\r'),
+            ),
+            PtyAction(expect="opensre[trust:off]>", send=b"/quit\r"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "No active alert context" not in result.stdout
 
 
 def test_opensre_help_smoke(cli_sandbox: CliSandbox) -> None:


### PR DESCRIPTION
This pull request introduces a new interactive session (REPL) mode for the OpenSRE CLI, allowing users to triage alerts and perform root cause analysis in a persistent terminal environment. It adds a suite of files under `app/cli/session/` to support session state, command routing, slash commands, and investigation execution, and updates the CLI entrypoint to launch this mode by default (unless disabled via an environment variable). The PR also refactors related CLI logic for clarity and testability, and adds smoke tests for the new session mode.

**Key changes:**

**Interactive session (REPL) mode:**

- Added a new REPL-based session mode, launched by default when no subcommand is provided and not in legacy landing mode. This mode supports interactive investigation, slash commands (e.g., `/help`, `/status`, `/quit`), and persistent context across turns. (`app/cli/session/__init__.py`, `app/cli/session/repl.py`, `app/cli/session/banner.py`, `app/cli/session/commands.py`, `app/cli/session/router.py`, `app/cli/session/run_manager.py`, `app/cli/session/state.py`, `app/cli/__main__.py`) [[1]](diffhunk://#diff-19c75372278115b292707096bf45bd670e01e726881ac18fd873635d4a085fb0R1-R5) [[2]](diffhunk://#diff-8a2d0a11d3bb7960a1552105bbe9027054dfc8c2fbdd774353d465b88d1973f5R1-R85) [[3]](diffhunk://#diff-69d4937f0df01c55df371c7e508ee3bab221a880f3097afc7eecd32d9ca5e99cR1-R104) [[4]](diffhunk://#diff-8f59c38bf954f51198bf84bc64a0f7ad9997cad40b5c10b75e901f1e782d0975R1-R45) [[5]](diffhunk://#diff-dea90793f376cf2e2f15946a2e186d9bff4b4324a1470eee235c8176d6d9cfdaR1-R33) [[6]](diffhunk://#diff-91d91c1f5d8418fd81acb9b147d2d20c13c031909449fd2dde915d878c989443R1-R61) [[7]](diffhunk://#diff-6a77067bc7af59642f7c59baa156defbb9dfea8242d3cd9c930ea39bba60ec63R1-R48) [[8]](diffhunk://#diff-f678db5afdd8a4494de6bc1ec7757903658663aaad9b7379f192ed3ff882a468R22) [[9]](diffhunk://#diff-f678db5afdd8a4494de6bc1ec7757903658663aaad9b7379f192ed3ff882a468R58-R59)

- Implemented session state management, including tracking trust mode, active runs, last alert/result, conversation history, and model label selection based on environment/config. (`app/cli/session/state.py`)

**CLI refactoring and improvements:**

- Refactored the `investigate_command` to directly invoke investigation logic and template rendering, removing the `_build_investigate_argv` indirection and improving output handling. (`app/cli/commands/general.py`) [[1]](diffhunk://#diff-4e48bf3f7c68fcc9ca21de1ff52c3f5274be135671aac7788936cc2c4433abe1L23-R30) [[2]](diffhunk://#diff-4e48bf3f7c68fcc9ca21de1ff52c3f5274be135671aac7788936cc2c4433abe1L154-R170)

- Improved option formatting and JSON output handling in CLI commands for consistency and readability. (`app/cli/__main__.py`, `app/cli/commands/general.py`) [[1]](diffhunk://#diff-f678db5afdd8a4494de6bc1ec7757903658663aaad9b7379f192ed3ff882a468L31-R34) [[2]](diffhunk://#diff-4e48bf3f7c68fcc9ca21de1ff52c3f5274be135671aac7788936cc2c4433abe1L66-R63) [[3]](diffhunk://#diff-4e48bf3f7c68fcc9ca21de1ff52c3f5274be135671aac7788936cc2c4433abe1L80-R74)

**Testing:**

- Added smoke tests for the new session mode, including tests for starting/quitting a session and routing multiline JSON as an alert. (`tests/cli_smoke_test.py`)

These changes collectively introduce a robust, user-friendly interactive CLI experience for alert triage and RCA, while maintaining backward compatibility via the `OPENSRE_LEGACY_LANDING` environment variable.

<img width="778" height="288" alt="Screenshot 2026-04-11 at 12 40 22 PM" src="https://github.com/user-attachments/assets/88013095-5cae-4531-a78e-7c7fcf8abdf5" />

