### PR TITLE
docs: add MariaDB integration page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,6 +54,7 @@
             "defaultOpen": true,
             "pages": [
               "mongodb",
+              "mariadb",
               "honeycomb",
               "coralogix",
               "sentry",

--- a/docs/intergrations-overview.mdx
+++ b/docs/intergrations-overview.mdx
@@ -51,7 +51,7 @@ Or set environment variables and OpenSRE picks them up automatically.
 | Category | Integrations |
 | --- | --- |
 | **Observability** | [Honeycomb](/honeycomb), [Coralogix](/coralogix), [Sentry](/sentry) |
-| **Databases** | [MongoDB](/mongodb), [ClickHouse](/clickhouse), [Kafka](/kafka) |
+| **Databases** | [MongoDB](/mongodb), [MariaDB](/mariadb), [ClickHouse](/clickhouse), [Kafka](/kafka) |
 | **Source control** | [GitHub](/github), [GitLab](/gitlab), [Bitbucket](/bitbucket) |
 | **Deployments** | [Vercel](/vercel) |
 | **Orchestration** | [Prefect](/prefect) |

--- a/docs/mariadb.mdx
+++ b/docs/mariadb.mdx
@@ -99,7 +99,7 @@ Returns a curated set of key metrics from `SHOW GLOBAL STATUS` — thread counts
 
 ### InnoDB status
 
-Runs `SHOW ENGINE INNODB STATUS` and returns the full engine status text (truncated to 4 KB). Useful for investigating deadlocks, buffer pool pressure, and I/O patterns.
+Runs `SHOW ENGINE INNODB STATUS` and returns the engine status text, truncated to 4000 characters with a truncation marker appended when shortening occurs. Useful for investigating deadlocks, buffer pool pressure, and I/O patterns.
 
 ### Slow queries
 

--- a/docs/mariadb.mdx
+++ b/docs/mariadb.mdx
@@ -1,0 +1,145 @@
+---
+title: "MariaDB"
+description: "Connect MariaDB so OpenSRE can diagnose database issues during investigations"
+---
+
+OpenSRE uses MariaDB diagnostics to investigate database-related alerts — checking server health, finding slow queries, monitoring replication, and analyzing active threads and InnoDB engine state.
+
+## Prerequisites
+
+- MariaDB 10.5+ (10.11 LTS or 11.x recommended)
+- Network access from the OpenSRE environment to your MariaDB instance
+- A database user with at least `SELECT` + `PROCESS` privileges (and `SELECT` on `performance_schema` for slow-query insights)
+
+## Setup
+
+### Option 1: Interactive CLI
+
+```bash
+opensre integrations setup mariadb
+```
+
+You will be prompted for host, port, database, username, password, and whether to enable SSL.
+
+### Option 2: Environment variables
+
+Add to your `.env`:
+
+```bash
+MARIADB_HOST=db.example.com
+MARIADB_PORT=3306
+MARIADB_DATABASE=production
+MARIADB_USERNAME=opensre_ro
+MARIADB_PASSWORD=...
+MARIADB_SSL=true
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MARIADB_HOST` | — | **Required.** MariaDB server hostname or IP |
+| `MARIADB_PORT` | `3306` | MariaDB server port |
+| `MARIADB_DATABASE` | — | **Required.** Target database for slow-query analysis |
+| `MARIADB_USERNAME` | _(empty)_ | Database user |
+| `MARIADB_PASSWORD` | _(empty)_ | Database password |
+| `MARIADB_SSL` | `true` | Use TLS with certificate verification |
+
+### Option 3: Persistent store
+
+Credentials are automatically persisted to `~/.tracer/integrations.json` with `0o600` permissions:
+
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "mariadb-prod",
+      "service": "mariadb",
+      "status": "active",
+      "credentials": {
+        "host": "db.example.com",
+        "port": 3306,
+        "database": "production",
+        "username": "opensre_ro",
+        "password": "...",
+        "ssl": true
+      }
+    }
+  ]
+}
+```
+
+## Recommended user setup
+
+Create a dedicated read-only user for OpenSRE so it cannot modify data:
+
+```sql
+CREATE USER 'opensre_ro'@'%' IDENTIFIED BY 'strong-password';
+GRANT SELECT, PROCESS, REPLICATION CLIENT ON *.* TO 'opensre_ro'@'%';
+GRANT SELECT ON performance_schema.* TO 'opensre_ro'@'%';
+FLUSH PRIVILEGES;
+```
+
+The `PROCESS` privilege lets OpenSRE read `information_schema.PROCESSLIST`. `REPLICATION CLIENT` enables `SHOW ALL SLAVES STATUS` / `SHOW SLAVE STATUS`. `SELECT` on `performance_schema` is only needed if you want slow-query insights.
+
+## TLS configuration
+
+SSL is enabled by default and uses the system CA bundle to verify the server certificate. Set `MARIADB_SSL=false` only in trusted local networks (development).
+
+## Investigation tools
+
+When OpenSRE investigates a MariaDB-related alert, five diagnostic tools are available:
+
+### Process list
+
+Retrieves active threads from `information_schema.PROCESSLIST`, excluding sleeping connections. Results are sorted by duration so long-running queries appear first.
+
+### Global status
+
+Returns a curated set of key metrics from `SHOW GLOBAL STATUS` — thread counts, connection totals, slow query count, InnoDB buffer pool statistics, row lock waits, and uptime.
+
+### InnoDB status
+
+Runs `SHOW ENGINE INNODB STATUS` and returns the full engine status text (truncated to 4 KB). Useful for investigating deadlocks, buffer pool pressure, and I/O patterns.
+
+### Slow queries
+
+Reads `performance_schema.events_statements_summary_by_digest` to list statements by average execution time. Requires `performance_schema` to be enabled.
+
+<Info>
+If `performance_schema` is disabled, the tool returns an informative note instead of failing. Enable it in `my.cnf` with `performance_schema=ON`.
+</Info>
+
+### Replication status
+
+Runs `SHOW ALL SLAVES STATUS` (MariaDB multi-source replication) with a fallback to `SHOW SLAVE STATUS` for older versions. Returns all configured replication channels, each with I/O thread state, SQL thread state, seconds behind master, last error, and log positions.
+
+## Verify
+
+```bash
+opensre integrations verify mariadb
+```
+
+Expected output:
+
+```
+SERVICE   SOURCE       STATUS    DETAIL
+mariadb   local env    passed    Connected to MariaDB 11.8.6-MariaDB; target database: production.
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **Connection refused** | Verify host/port, check firewall rules, and confirm MariaDB is listening on the network interface (`bind-address` in `my.cnf`). |
+| **Access denied for user** | Confirm the username/password and that the user is granted access from the OpenSRE host (`'opensre_ro'@'%'` or a specific IP). |
+| **SSL: CERTIFICATE_VERIFY_FAILED** | The server certificate is not trusted by the system CA bundle. Install the correct CA or set `MARIADB_SSL=false` in trusted networks. |
+| **performance_schema is disabled** | Slow-query tool returns an empty list with a note. Enable in `my.cnf`: `performance_schema=ON`. |
+| **SELECT command denied on performance_schema** | Grant `SELECT` on `performance_schema.*` to the user. |
+| **This server is not configured as a replica** | Expected on standalone instances — replication tool returns an empty channel list, other tools still work. |
+
+## Security best practices
+
+- Use a **dedicated read-only** user — never `root` or an admin account.
+- Always enable **TLS** in production (`MARIADB_SSL=true`, which is the default).
+- Keep passwords out of source control — use `.env` or the persistent store.
+- Rotate credentials periodically and scope them to specific hosts where possible.

--- a/docs/mariadb.mdx
+++ b/docs/mariadb.mdx
@@ -111,7 +111,7 @@ If `performance_schema` is disabled, the tool returns an informative note instea
 
 ### Replication status
 
-Runs `SHOW ALL SLAVES STATUS` (MariaDB multi-source replication) with a fallback to `SHOW SLAVE STATUS` for older versions. Returns all configured replication channels, each with I/O thread state, SQL thread state, seconds behind master, last error, and log positions.
+Runs `SHOW ALL REPLICAS STATUS` (MariaDB multi-source replication; alias: `SHOW ALL SLAVES STATUS` on older builds) with a fallback to `SHOW REPLICA STATUS`. Returns all configured replication channels, each with I/O thread state, SQL thread state, seconds behind primary, last error, and log positions.
 
 ## Verify
 

--- a/docs/mariadb.mdx
+++ b/docs/mariadb.mdx
@@ -39,8 +39,8 @@ MARIADB_SSL=true
 | `MARIADB_HOST` | — | **Required.** MariaDB server hostname or IP |
 | `MARIADB_PORT` | `3306` | MariaDB server port |
 | `MARIADB_DATABASE` | — | **Required.** Target database for slow-query analysis |
-| `MARIADB_USERNAME` | _(empty)_ | Database user |
-| `MARIADB_PASSWORD` | _(empty)_ | Database password |
+| `MARIADB_USERNAME` | — | **Required.** Database user |
+| `MARIADB_PASSWORD` | _(empty)_ | Database password; required unless the user is configured for passwordless authentication |
 | `MARIADB_SSL` | `true` | Use TLS with certificate verification |
 
 ### Option 3: Persistent store


### PR DESCRIPTION
## What this does

Adds user-facing documentation for the MariaDB integration that shipped in #492. The docs site at opensre.com/docs currently has pages for every other integration but none for MariaDB, so users discovering OpenSRE through the docs have no clear path to configure it.

## Why

The MariaDB integration is fully shipped and working, but it's effectively hidden without documentation. A dedicated page makes setup, configuration, and troubleshooting discoverable in the same place as the other database integrations.

## What's included

- A new MariaDB page covering prerequisites, three setup options (interactive CLI, environment variables, persistent store), a recommended read-only user SQL snippet, the five investigation tools with what each one does, the verify command, a troubleshooting table, and security best practices.
- A navigation entry added to the Integrations > Local group so the page shows up in the sidebar alongside MongoDB and other databases.
- An update to the integrations overview page so MariaDB appears in the Databases row.

## How to verify locally

From the docs directory run the mintlify dev server and open the MariaDB page to confirm it renders, the sidebar entry is visible, and the integrations overview lists MariaDB.

Closes #545