### PR TITLE
ci: add Windows ARM64 binary to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,10 @@ jobs:
             target: windows-x64
             binary_name: opensre.exe
             archive_ext: zip
+          - runner: windows-11-arm
+            target: windows-arm64
+            binary_name: opensre.exe
+            archive_ext: zip
     runs-on: ${{ matrix.runner }}
     env:
       TAG_NAME: ${{ needs.prepare.outputs.tag_name }}


### PR DESCRIPTION
Fixes #553

#### Describe the changes you have made in this PR -
- Added a `windows-arm64` target to the `build-binaries` matrix in `.github/workflows/release.yml`.
- Configured the new target to run on the `windows-11-arm` GitHub Actions runner.
- Reused the existing Windows release flow so the job builds `opensre.exe` and publishes it as a `.zip` release artifact.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I added a `windows-arm64` matrix entry that uses the `windows-11-arm` runner and keeps the same binary name and archive format as the current Windows release path. This keeps the workflow DRY, preserves the existing smoke test and packaging behavior for Windows builds, and ensures ARM64 Windows users receive a native release asset without changing the rest of the release process.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
