### PR TITLE
fix: harden release versioning and installer fallback behavior

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Mark vendored third-party code so GitHub's analysis tools skip it.
 # This suppresses false-positive code scanning alerts in code we don't own.
+*.sh                                                        text eol=lf
 tests/test_case_upstream_lambda/pipeline_code/**          linguist-vendored=true
 tests/test_case_upstream_apache_flink_ecs/pipeline_code/** linguist-vendored=true
 tests/test_case_upstream_prefect_ecs_fargate/pipeline_code/** linguist-vendored=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,9 @@ jobs:
 
   build-python-dist:
     runs-on: ubuntu-latest
-    needs: verify
+    needs: [verify, prepare]
+    env:
+      TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
 
     steps:
       - uses: actions/checkout@v5
@@ -85,6 +87,10 @@ jobs:
           python-version: "3.13"
           cache: "pip"
 
+      - name: Sync release version
+        shell: bash
+        run: python packaging/sync_release_version.py --tag "$TAG_NAME"
+
       - name: Build Python distributions
         run: |
           python -m pip install --upgrade pip
@@ -92,6 +98,14 @@ jobs:
           pip install build twine
           python -m build
           twine check dist/*
+
+      - name: Verify Python distribution version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${TAG_NAME#v}"
+          test -f "dist/opensre-${VERSION}.tar.gz"
+          test -f "dist/opensre-${VERSION}-py3-none-any.whl"
 
       - name: Upload Python distributions
         uses: actions/upload-artifact@v4
@@ -143,6 +157,10 @@ jobs:
           python-version: "3.13"
           cache: "pip"
 
+      - name: Sync release version
+        shell: bash
+        run: python packaging/sync_release_version.py --tag "$TAG_NAME"
+
       - name: Install binary build dependencies
         run: |
           python -m pip install --upgrade pip
@@ -156,14 +174,29 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          ./dist/${{ matrix.binary_name }} --version
+          VERSION="${TAG_NAME#v}"
+          VERSION_OUTPUT="$(./dist/${{ matrix.binary_name }} --version 2>&1)"
+          printf '%s\n' "$VERSION_OUTPUT"
+          case "$VERSION_OUTPUT" in
+            *"$VERSION"*) ;;
+            *)
+              printf 'Binary version mismatch: expected %s but saw %s\n' "$VERSION" "$VERSION_OUTPUT" >&2
+              exit 1
+              ;;
+          esac
           ./dist/${{ matrix.binary_name }} -h >/dev/null
 
       - name: Smoke test binary
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          & ".\dist\${{ matrix.binary_name }}" --version
+          $expectedVersion = $env:TAG_NAME.TrimStart("v")
+          $versionOutput = & ".\dist\${{ matrix.binary_name }}" --version 2>&1 | Out-String
+          $versionText = $versionOutput.Trim()
+          Write-Host $versionText
+          if ($versionText -notmatch [regex]::Escape($expectedVersion)) {
+            throw "Binary version mismatch. Expected '$expectedVersion' but saw '$versionText'."
+          }
           & ".\dist\${{ matrix.binary_name }}" -h | Out-Null
 
       - name: Package binary archive

--- a/app/remote/system_metrics.py
+++ b/app/remote/system_metrics.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import platform
-import resource
 import shutil
 import socket
 import subprocess
@@ -17,6 +16,13 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
+
+_resource: Any | None
+
+try:
+    import resource as _resource
+except ModuleNotFoundError:
+    _resource = None
 
 
 def collect_system_metrics() -> dict[str, Any]:
@@ -58,8 +64,12 @@ def collect_system_metrics() -> dict[str, Any]:
 
 
 def _collect_cpu() -> dict[str, Any] | None:
+    getloadavg = getattr(os, "getloadavg", None)
+    if getloadavg is None:
+        return None
+
     try:
-        load1, load5, load15 = os.getloadavg()
+        load1, load5, load15 = getloadavg()
         return {
             "load_avg_1m": round(load1, 2),
             "load_avg_5m": round(load5, 2),
@@ -226,8 +236,16 @@ def _collect_platform() -> dict[str, Any]:
 
 
 def _collect_process() -> dict[str, Any] | None:
+    if _resource is None:
+        return None
+
+    getrusage = getattr(_resource, "getrusage", None)
+    rusage_self = getattr(_resource, "RUSAGE_SELF", None)
+    if getrusage is None or rusage_self is None:
+        return None
+
     try:
-        usage = resource.getrusage(resource.RUSAGE_SELF)
+        usage = getrusage(rusage_self)
         # maxrss is in kB on Linux, bytes on macOS
         rss_kb = usage.ru_maxrss if sys.platform == "linux" else usage.ru_maxrss // 1024
         result: dict[str, Any] = {"rss_mb": round(rss_kb / 1024, 1)}

--- a/install.ps1
+++ b/install.ps1
@@ -426,12 +426,10 @@ function Get-OpenSreBinaryPathFromArchive {
     throw "Archive did not contain '$BinaryName'."
 }
 
-function Assert-OpenSreBinaryVersion {
+function Get-OpenSreBinaryVersionInfo {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$BinaryPath,
-        [Parameter(Mandatory = $true)]
-        [string]$ExpectedVersion
+        [string]$BinaryPath
     )
 
     try {
@@ -442,8 +440,15 @@ function Assert-OpenSreBinaryVersion {
     }
 
     $versionText = ($versionOutput | Out-String).Trim()
-    if ($versionText -notmatch [Regex]::Escape($ExpectedVersion)) {
-        throw "Downloaded binary version mismatch. Expected '$ExpectedVersion' but got '$versionText'."
+    $detectedVersion = ""
+    $match = [System.Text.RegularExpressions.Regex]::Match($versionText, '\d{4}\.\d{1,2}\.\d{1,2}')
+    if ($match.Success) {
+        $detectedVersion = $match.Value
+    }
+
+    return [pscustomobject]@{
+        Text = $versionText
+        Version = $detectedVersion
     }
 }
 
@@ -451,6 +456,7 @@ function Install-OpenSre {
     $repo = if ($env:OPENSRE_INSTALL_REPO) { $env:OPENSRE_INSTALL_REPO } else { "Tracer-Cloud/opensre" }
     $installDir = if ($env:OPENSRE_INSTALL_DIR) { $env:OPENSRE_INSTALL_DIR } else { Get-OpenSreDefaultInstallDir }
     $binaryName = "opensre.exe"
+    $requestedVersion = if ($env:OPENSRE_VERSION) { $env:OPENSRE_VERSION.Trim().TrimStart("v") } else { "" }
 
     Enable-OpenSreTls
 
@@ -496,7 +502,23 @@ function Install-OpenSre {
         Expand-Archive -LiteralPath $archivePath -DestinationPath $tmpDir -Force
 
         $binaryPath = Get-OpenSreBinaryPathFromArchive -ExtractionRoot $tmpDir -BinaryName $binaryName
-        Assert-OpenSreBinaryVersion -BinaryPath $binaryPath -ExpectedVersion $version
+        $binaryVersionInfo = Get-OpenSreBinaryVersionInfo -BinaryPath $binaryPath
+        $binaryVersionText = [string]$binaryVersionInfo.Text
+        $binaryVersion = [string]$binaryVersionInfo.Version
+
+        if ($binaryVersionText -notmatch [Regex]::Escape($version)) {
+            if ($requestedVersion) {
+                throw "Downloaded binary version mismatch. Expected '$version' but got '$binaryVersionText'."
+            }
+
+            if (-not $binaryVersion) {
+                throw "Downloaded binary version mismatch. Expected '$version' but got '$binaryVersionText'."
+            }
+
+            Write-Warning "Latest release metadata reports v$version, but the downloaded binary reports v$binaryVersion. Installing the verified binary anyway."
+            $version = $binaryVersion
+        }
+
         Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $installDir $binaryName) -Force
     }
     finally {

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+[ -n "${BASH_VERSION:-}" ] || {
+  printf '%s\n' "Error: install.sh requires bash. Run 'bash install.sh' or pipe it into bash." >&2
+  exit 1
+}
+
 set -euo pipefail
 
 REPO="${OPENSRE_INSTALL_REPO:-Tracer-Cloud/opensre}"
@@ -246,16 +251,25 @@ verify_binary_version() {
   local binary_path="$1"
   local expected_version="$2"
   local version_output
+  local actual_version
 
   if ! version_output="$("$binary_path" --version 2>&1)"; then
     die "Failed to execute '${binary_path##*/} --version': ${version_output}"
   fi
 
+  actual_version="$(printf '%s\n' "$version_output" | sed -n 's/.*\([0-9][0-9][0-9][0-9]\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' | head -n 1)"
+
   case "$version_output" in
     *"$expected_version"*)
+      printf '%s\n' "$expected_version"
       ;;
     *)
-      die "Downloaded binary version mismatch. Expected '${expected_version}' but got: ${version_output}"
+      if [ -n "${OPENSRE_VERSION:-}" ] || [ -z "$actual_version" ]; then
+        die "Downloaded binary version mismatch. Expected '${expected_version}' but got: ${version_output}"
+      fi
+
+      warn "Latest release metadata reports v${expected_version}, but the downloaded binary reports v${actual_version}. Installing the verified binary anyway."
+      printf '%s\n' "$actual_version"
       ;;
   esac
 }
@@ -358,10 +372,10 @@ mkdir -p "$INSTALL_DIR"
 extract_archive "$archive_path" "$tmp_dir"
 
 binary_path="$(get_binary_path_from_archive "$tmp_dir" "$BIN_NAME")"
-verify_binary_version "$binary_path" "$version"
+installed_version="$(verify_binary_version "$binary_path" "$version")"
 install_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
 
-log "Installed ${BIN_NAME} v${version} to ${INSTALL_DIR}/${BIN_NAME}"
+log "Installed ${BIN_NAME} v${installed_version} to ${INSTALL_DIR}/${BIN_NAME}"
 
 case ":$PATH:" in
   *":${INSTALL_DIR}:"*)

--- a/packaging/sync_release_version.py
+++ b/packaging/sync_release_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 APP_VERSION_PATH = ROOT / "app" / "version.py"
-VERSION_PATTERN = re.compile(r"^v?(?P<version>\d{4}\.\d{1,2}\.\d{1,2})$")
+VERSION_PATTERN = re.compile(r"v?(?P<version>\d{4}\.\d{1,2}\.\d{1,2})")
 
 
 def _normalize_release_version(raw_value: str) -> str:
@@ -37,9 +37,12 @@ def _replace_project_version(version: str, text: str) -> str:
             continue
 
         if in_project_section and line.lstrip().startswith("version = "):
-            prefix, _, _ = line.partition("=")
-            line_ending = _line_ending_for(line)
-            lines[index] = f'{prefix}= "{version}"{line_ending}'
+            lines[index] = re.sub(
+                r'(?P<prefix>\bversion\s*=\s*")[^"]+(?P<suffix>")',
+                rf"\g<prefix>{version}\g<suffix>",
+                line,
+                count=1,
+            )
             return "".join(lines)
 
     msg = f"Could not find [project].version in {PYPROJECT_PATH}."

--- a/packaging/sync_release_version.py
+++ b/packaging/sync_release_version.py
@@ -1,0 +1,93 @@
+"""Sync release-facing version strings to a Git tag-derived version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = ROOT / "pyproject.toml"
+APP_VERSION_PATH = ROOT / "app" / "version.py"
+VERSION_PATTERN = re.compile(r"^v?(?P<version>\d{4}\.\d{1,2}\.\d{1,2})$")
+
+
+def _normalize_release_version(raw_value: str) -> str:
+    match = VERSION_PATTERN.fullmatch(raw_value.strip())
+    if match is None:
+        msg = (
+            "Release tag must look like 'vYYYY.M.D' or 'YYYY.M.D'; "
+            f"got {raw_value!r}."
+        )
+        raise ValueError(msg)
+
+    return match.group("version")
+
+
+def _replace_project_version(version: str, text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    in_project_section = False
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project_section = stripped == "[project]"
+            continue
+
+        if in_project_section and line.lstrip().startswith("version = "):
+            prefix, _, _ = line.partition("=")
+            line_ending = _line_ending_for(line)
+            lines[index] = f'{prefix}= "{version}"{line_ending}'
+            return "".join(lines)
+
+    msg = f"Could not find [project].version in {PYPROJECT_PATH}."
+    raise RuntimeError(msg)
+
+
+def _replace_default_version(version: str, text: str) -> str:
+    lines = text.splitlines(keepends=True)
+
+    for index, line in enumerate(lines):
+        stripped = line.rstrip("\r\n")
+        if stripped.startswith('DEFAULT_VERSION = "'):
+            line_ending = _line_ending_for(line)
+            lines[index] = f'DEFAULT_VERSION = "{version}"{line_ending}'
+            return "".join(lines)
+
+    msg = f"Could not find DEFAULT_VERSION in {APP_VERSION_PATH}."
+    raise RuntimeError(msg)
+
+
+def _line_ending_for(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def _sync_file(path: Path, updater: Callable[[str, str], str], version: str) -> None:
+    original_text = path.read_text(encoding="utf-8")
+    updated_text = updater(version, original_text)
+    path.write_text(updated_text, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="Release tag to sync from, e.g. v2026.4.13.",
+    )
+    args = parser.parse_args()
+
+    version = _normalize_release_version(args.tag)
+    _sync_file(PYPROJECT_PATH, _replace_project_version, version)
+    _sync_file(APP_VERSION_PATH, _replace_default_version, version)
+    print(f"Synchronized release version to {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #555

#### Describe the changes you have made in this PR -

- Synced release builds to the Git tag version before building wheels, sdists, and frozen binaries.
- Added release workflow checks to verify artifact filenames and binary `--version` output match the tagged release version.
- Hardened `install.ps1` and `install.sh` so `latest` installs can recover when GitHub release metadata and the checksum-verified binary version drift, while keeping pinned `OPENSRE_VERSION` installs strict.
- Added a Bash guard to `install.sh` and enforced LF line endings for `*.sh`.
- Updated `app/remote/system_metrics.py` to handle Unix-only metrics APIs safely on Windows, which fixes the Windows mypy failures.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This PR fixes a release drift problem where the release tag could advance independently of the package/binary version, which caused the installers to fail on version verification. I considered simply relaxing installer validation, but that would have hidden real release problems and weakened pinned installs. Instead, I made the release workflow use the tag as the source of truth before building artifacts, and I kept installers strict for pinned versions while allowing `latest` installs to warn and continue when the downloaded binary is checksum-verified but the GitHub release metadata is inconsistent.

The key pieces are:
- `packaging/sync_release_version.py`, which updates `pyproject.toml` and `app/version.py` from the release tag.
- `.github/workflows/release.yml`, which runs that sync step before building Python distributions and binaries, and verifies the resulting artifacts report the expected version.
- `install.ps1` and `install.sh`, which now recover gracefully from the currently broken `latest` release metadata case without masking real pinned-version mismatches.
- `app/remote/system_metrics.py`, which now guards Unix-only APIs so Windows environments degrade gracefully and type-check cleanly.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

