### PR TITLE
fix: duplicate trello field in EffectiveIntegrations (fixes #562)

### DIFF
--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -443,4 +443,3 @@ class EffectiveIntegrations(StrictConfigModel):
     trello: EffectiveIntegrationEntry | None = None
     discord: EffectiveIntegrationEntry | None = None
     mysql: EffectiveIntegrationEntry | None = None
-    trello: EffectiveIntegrationEntry | None = None


### PR DESCRIPTION
Fixes #562

---

### Describe the changes you have made in this PR

Removed duplicate `trello` field definition in `EffectiveIntegrations` (`app/integrations/models.py`), which was causing a mypy `no-redef` typecheck failure.

This change ensures that `make typecheck` passes successfully on a fresh setup.

---

### Screenshots of the UI changes (If any)

**Before:**
<img width="845" height="130" alt="Screenshot from 2026-04-14 18-58-34" src="https://github.com/user-attachments/assets/1ae3d593-4f49-4dae-bfa2-2b247d052b26" />


**After:**
<img width="1557" height="266" alt="Screenshot from 2026-04-14 18-59-39" src="https://github.com/user-attachments/assets/58997668-7b99-4bf3-99df-0618a615c9d7" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [x] No, I wrote all the code myself
* [ ] Yes, I used AI assistance (continue below)

---

## Explain your implementation approach

* The issue was caused by a duplicate field (`trello`) in the `EffectiveIntegrations` class.
* This resulted in a mypy `no-redef` error during type checking.
* The fix was to remove the duplicate field definition while keeping the original intact.
* This approach was chosen because it is the minimal and correct fix that resolves the type error without affecting functionality.

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] I can explain the purpose of every function, class, and logic block I added
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [ ] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions

---
