### PR TITLE
refactor: fix auth hooks , thread safety

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -54,36 +54,28 @@ async def authenticate(authorization: str | None) -> Auth.types.MinimalUserDict:
     )
 
 
-# Threads - no filtering to allow stateless runs
+# Threads - filter by org
 @auth.on.threads.create  # type: ignore[arg-type]
-async def on_thread_create(ctx: Auth.types.AuthContext, value: dict[str, Any]) -> None:
-    """Tag thread with org_id but don't filter."""
+async def on_thread_create(ctx: Auth.types.AuthContext, value: dict[str, Any]) -> dict[str, str]:
+    """Tag thread with org_id and enforce org-scoped access."""
     md = value.setdefault("metadata", {})
     md["org_id"] = _get_org_id(ctx)
+    return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.threads.read
-async def on_thread_read(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
-) -> None:
-    return None
+async def on_thread_read(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+    return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.threads.update
-async def on_thread_update(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
-) -> None:
-    return None
+async def on_thread_update(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+    return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.threads.delete
-async def on_thread_delete(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
-) -> None:
-    return None
+async def on_thread_delete(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+    return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.threads.search
@@ -92,11 +84,8 @@ async def on_thread_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str,
 
 
 @auth.on.threads.create_run
-async def on_thread_create_run(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
-) -> None:
-    return None
+async def on_thread_create_run(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+    return {"org_id": _get_org_id(ctx)}
 
 
 # Assistants - filter by org

--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -58,9 +58,10 @@ async def authenticate(authorization: str | None) -> Auth.types.MinimalUserDict:
 @auth.on.threads.create  # type: ignore[arg-type]
 async def on_thread_create(ctx: Auth.types.AuthContext, value: dict[str, Any]) -> dict[str, str]:
     """Tag thread with org_id and enforce org-scoped access."""
+    org_id = _get_org_id(ctx)
     md = value.setdefault("metadata", {})
-    md["org_id"] = _get_org_id(ctx)
-    return {"org_id": _get_org_id(ctx)}
+    md["org_id"] = org_id
+    return {"org_id": org_id}
 
 
 @auth.on.threads.read

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -443,4 +443,3 @@ class EffectiveIntegrations(StrictConfigModel):
     trello: EffectiveIntegrationEntry | None = None
     discord: EffectiveIntegrationEntry | None = None
     mysql: EffectiveIntegrationEntry | None = None
-    trello: EffectiveIntegrationEntry | None = None


### PR DESCRIPTION


Fixes #561

#### Describe the changes you have made in this PR -

Added `org_id` filtering to all LangGraph thread auth hooks that were previously returning `None`, closing a cross-tenant authorization gap.

**Changed in `app/auth/auth.py`:**
- `on_thread_create` — now returns `{"org_id": ...}` in addition to tagging metadata
- `on_thread_read` — was returning `None` (no filter), now returns `{"org_id": ...}`
- `on_thread_update` — same fix
- `on_thread_delete` — same fix
- `on_thread_create_run` — same fix
- `on_thread_search` — already correct, no change

This aligns all 6 thread hooks with the identical pattern already used for assistants (5 hooks) and crons (5 hooks) in the same file.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions



## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions