### PR TITLE
feat: add "Run All" option to interactive test picker

### DIFF
--- a/app/cli/tests/__init__.py
+++ b/app/cli/tests/__init__.py
@@ -2,7 +2,7 @@
 
 from app.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement
 from app.cli.tests.discover import load_test_catalog
-from app.cli.tests.runner import find_test_item, format_command, run_catalog_item
+from app.cli.tests.runner import find_test_item, format_command, run_catalog_item, run_catalog_items
 
 __all__ = [
     "TestCatalog",
@@ -12,4 +12,5 @@ __all__ = [
     "format_command",
     "load_test_catalog",
     "run_catalog_item",
+    "run_catalog_items",
 ]

--- a/app/cli/tests/interactive.py
+++ b/app/cli/tests/interactive.py
@@ -7,7 +7,7 @@ from typing import Any
 from rich.console import Console
 
 from app.cli.tests.catalog import TestCatalog, TestCatalogItem
-from app.cli.tests.runner import format_command, run_catalog_item
+from app.cli.tests.runner import format_command, run_catalog_item, run_catalog_items
 
 _questionary_module: Any
 _questionary_choice: Any
@@ -33,6 +33,7 @@ _select_prompt: Any = _select_prompt_impl
 _console = Console()
 _BACK = object()
 _EXIT = object()
+_RUN_ALL = "__run_all__"
 
 
 class _GoBack(Exception):
@@ -172,8 +173,40 @@ def _confirm_run(item: TestCatalogItem) -> bool:
     return bool(result)
 
 
-def choose_interactive_item(catalog: TestCatalog) -> tuple[TestCatalogItem, bool]:
-    """Return (item, auto_selected) where auto_selected=True means only one item matched."""
+def _select_item_or_all(
+    items: list[TestCatalogItem],
+    *,
+    prompt: str,
+    allow_back: bool = False,
+) -> TestCatalogItem | list[TestCatalogItem]:
+    """Like ``_select_item`` but prepends a *Run All* choice."""
+    _require_interactive_dependencies()
+    run_all_choice = _QuestionaryChoice(title="Run All", value=_RUN_ALL)
+    item_choices = [_QuestionaryChoice(title=_item_title(item), value=item.id) for item in items]
+    result = _select_prompt(
+        prompt,
+        choices=[run_all_choice, *item_choices],
+        style=_STYLE,
+        instruction="(Tab, arrows, Enter, Esc back)" if allow_back else "(Tab, arrows, Enter)",
+        escape_result=_BACK if allow_back else None,
+    ).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    if result is _BACK:
+        raise _GoBack
+    if result == _RUN_ALL:
+        return items
+    selected_id = str(result)
+    for item in items:
+        if item.id == selected_id:
+            return item
+    raise ValueError(f"Unknown selected item: {selected_id}")
+
+
+def choose_interactive_item(
+    catalog: TestCatalog,
+) -> tuple[TestCatalogItem | list[TestCatalogItem], bool]:
+    """Return (item_or_items, auto_selected) where auto_selected=True means only one item matched."""
     while True:
         category = _choose_category()
         search = ""
@@ -184,30 +217,75 @@ def choose_interactive_item(catalog: TestCatalog) -> tuple[TestCatalogItem, bool
         while True:
             try:
                 if len(filtered) == 1:
-                    return _resolve_suite_selection(filtered[0], category=category, search=search), True
+                    return (
+                        _resolve_suite_selection(filtered[0], category=category, search=search),
+                        True,
+                    )
 
-                selected = _select_item(filtered, prompt="Choose a test or suite:", allow_back=True)
-                return _resolve_suite_selection(selected, category=category, search=search), False
+                selection = _select_item_or_all(
+                    filtered, prompt="Choose a test or suite:", allow_back=True,
+                )
+                if isinstance(selection, list):
+                    return selection, False
+                return (
+                    _resolve_suite_selection(selection, category=category, search=search),
+                    False,
+                )
             except _GoBack:
                 break
+
+
+def _confirm_run_all(items: list[TestCatalogItem]) -> bool:
+    runnable = [i for i in items if i.is_runnable]
+    _console.print(f"\n[bold]Run All — {len(runnable)} test(s)[/]")
+    for item in runnable:
+        _console.print(f"  • {item.display_name}")
+
+    result = _select_prompt(
+        "Run all tests?",
+        choices=[
+            _QuestionaryChoice(title="Yes", value=True),
+            _QuestionaryChoice(title="No", value=False),
+        ],
+        default=True,
+        style=_STYLE,
+        instruction="(Tab, arrows, Enter, Esc back)",
+        escape_result=_BACK,
+    ).ask()
+    if result is None:
+        raise KeyboardInterrupt
+    if result is _BACK:
+        raise _GoBack
+    return bool(result)
 
 
 def run_interactive_picker(catalog: TestCatalog) -> int:
     _require_interactive_dependencies()
     if not sys.stdin.isatty() or not sys.stdout.isatty():
-        raise RuntimeError("Interactive terminal required. Use `opensre tests list` or `opensre tests run <id>`.")
+        raise RuntimeError(
+            "Interactive terminal required. Use `opensre tests list` or `opensre tests run <id>`."
+        )
 
     try:
         while True:
-            item, auto_selected = choose_interactive_item(catalog)
+            selection, auto_selected = choose_interactive_item(catalog)
+
+            if isinstance(selection, list):
+                try:
+                    if not _confirm_run_all(selection):
+                        return 0
+                except _GoBack:
+                    continue
+                runnable = [i for i in selection if i.is_runnable]
+                return run_catalog_items(runnable)
+
             if auto_selected:
-                # Single item in category — skip confirmation and run immediately.
-                return run_catalog_item(item)
+                return run_catalog_item(selection)
             try:
-                if not _confirm_run(item):
+                if not _confirm_run(selection):
                     return 0
             except _GoBack:
                 continue
-            return run_catalog_item(item)
+            return run_catalog_item(selection)
     except KeyboardInterrupt:
         return 0

--- a/app/cli/tests/interactive.py
+++ b/app/cli/tests/interactive.py
@@ -33,7 +33,7 @@ _select_prompt: Any = _select_prompt_impl
 _console = Console()
 _BACK = object()
 _EXIT = object()
-_RUN_ALL = "__run_all__"
+_RUN_ALL = object()
 
 
 class _GoBack(Exception):
@@ -141,6 +141,29 @@ def _resolve_suite_selection(
     )
 
 
+def _expand_runnable_items(
+    items: list[TestCatalogItem],
+    *,
+    category: str,
+    search: str,
+) -> list[TestCatalogItem]:
+    runnable: list[TestCatalogItem] = []
+    for item in items:
+        if item.children:
+            matching_children = _matching_children(item, category=category, search=search)
+            runnable.extend(
+                _expand_runnable_items(
+                    matching_children or list(item.children),
+                    category=category,
+                    search=search,
+                )
+            )
+            continue
+        if item.is_runnable:
+            runnable.append(item)
+    return runnable
+
+
 def _confirm_run(item: TestCatalogItem) -> bool:
     _console.print(f"\n[bold]{item.display_name}[/]")
     _console.print(item.description)
@@ -194,7 +217,7 @@ def _select_item_or_all(
         raise KeyboardInterrupt
     if result is _BACK:
         raise _GoBack
-    if result == _RUN_ALL:
+    if result is _RUN_ALL:
         return items
     selected_id = str(result)
     for item in items:
@@ -226,7 +249,11 @@ def choose_interactive_item(
                     filtered, prompt="Choose a test or suite:", allow_back=True,
                 )
                 if isinstance(selection, list):
-                    return selection, False
+                    return _expand_runnable_items(
+                        selection,
+                        category=category,
+                        search=search,
+                    ), False
                 return (
                     _resolve_suite_selection(selection, category=category, search=search),
                     False,
@@ -236,9 +263,8 @@ def choose_interactive_item(
 
 
 def _confirm_run_all(items: list[TestCatalogItem]) -> bool:
-    runnable = [i for i in items if i.is_runnable]
-    _console.print(f"\n[bold]Run All — {len(runnable)} test(s)[/]")
-    for item in runnable:
+    _console.print(f"\n[bold]Run All — {len(items)} test(s)[/]")
+    for item in items:
         _console.print(f"  • {item.display_name}")
 
     result = _select_prompt(
@@ -271,13 +297,15 @@ def run_interactive_picker(catalog: TestCatalog) -> int:
             selection, auto_selected = choose_interactive_item(catalog)
 
             if isinstance(selection, list):
+                if not selection:
+                    _console.print("[yellow]No runnable tests in this selection.[/]")
+                    continue
                 try:
                     if not _confirm_run_all(selection):
                         return 0
                 except _GoBack:
                     continue
-                runnable = [i for i in selection if i.is_runnable]
-                return run_catalog_items(runnable)
+                return run_catalog_items(selection)
 
             if auto_selected:
                 return run_catalog_item(selection)

--- a/app/cli/tests/runner.py
+++ b/app/cli/tests/runner.py
@@ -34,3 +34,17 @@ def run_catalog_item(
         check=False,
     )
     return int(result.returncode)
+
+
+def run_catalog_items(
+    items: list[TestCatalogItem],
+    *,
+    dry_run: bool = False,
+    working_directory: Path | None = None,
+) -> int:
+    """Run multiple catalog items sequentially. Returns worst (max) exit code."""
+    worst = 0
+    for item in items:
+        code = run_catalog_item(item, dry_run=dry_run, working_directory=working_directory)
+        worst = max(worst, code)
+    return worst

--- a/app/cli/tests/runner.py
+++ b/app/cli/tests/runner.py
@@ -42,9 +42,14 @@ def run_catalog_items(
     dry_run: bool = False,
     working_directory: Path | None = None,
 ) -> int:
-    """Run multiple catalog items sequentially. Returns worst (max) exit code."""
+    """Run multiple catalog items sequentially. Returns worst (max) exit code.
+
+    Non-runnable items are skipped so callers can safely pass mixed selections.
+    """
     worst = 0
     for item in items:
+        if not item.is_runnable:
+            continue
         code = run_catalog_item(item, dry_run=dry_run, working_directory=working_directory)
         worst = max(worst, code)
     return worst

--- a/tests/cli/test_interactive.py
+++ b/tests/cli/test_interactive.py
@@ -46,13 +46,13 @@ def test_choose_interactive_item_prompts_when_multiple_matches_exist(monkeypatch
 
     monkeypatch.setattr(interactive, "_choose_category", lambda: "ci-safe")
 
-    def _mock_select_item(items, *, prompt: str, allow_back: bool = False):
+    def _mock_select_item_or_all(items, *, prompt: str, allow_back: bool = False):
         _ = allow_back
         selected_prompts.append(prompt)
         selected_item_ids.append([item.id for item in items])
         return items[0]
 
-    monkeypatch.setattr(interactive, "_select_item", _mock_select_item)
+    monkeypatch.setattr(interactive, "_select_item_or_all", _mock_select_item_or_all)
 
     item, auto_selected = interactive.choose_interactive_item(catalog)
 
@@ -109,14 +109,14 @@ def test_choose_interactive_item_reselects_category_after_escape(monkeypatch) ->
 
     monkeypatch.setattr(interactive, "_choose_category", lambda: next(category_choices))
 
-    def _mock_select_item(items, *, prompt: str, allow_back: bool = False):
+    def _mock_select_item_or_all(items, *, prompt: str, allow_back: bool = False):
         _ = allow_back
         selected_prompts.append(prompt)
         if len(selected_prompts) == 1:
             raise interactive._GoBack
         return items[0]
 
-    monkeypatch.setattr(interactive, "_select_item", _mock_select_item)
+    monkeypatch.setattr(interactive, "_select_item_or_all", _mock_select_item_or_all)
 
     item, _ = interactive.choose_interactive_item(catalog)
 
@@ -172,7 +172,11 @@ def test_choose_interactive_item_returns_to_parent_list_after_escape(monkeypatch
             raise interactive._GoBack
         return leaf
 
+    def _mock_select_item_or_all(items, *, prompt: str, allow_back: bool = False):
+        return _mock_select_item(items, prompt=prompt, allow_back=allow_back)
+
     monkeypatch.setattr(interactive, "_select_item", _mock_select_item)
+    monkeypatch.setattr(interactive, "_select_item_or_all", _mock_select_item_or_all)
 
     item, _ = interactive.choose_interactive_item(catalog)
 
@@ -181,6 +185,87 @@ def test_choose_interactive_item_returns_to_parent_list_after_escape(monkeypatch
         "Choose a test or suite:",
         "Select a scenario from Demo Suite:",
         "Choose a test or suite:",
+    ]
+
+
+def test_select_item_or_all_allows_literal_run_all_item_id(monkeypatch) -> None:
+    item = CatalogItem(
+        id="__run_all__",
+        kind="make_target",
+        display_name="Literal Run All Test",
+        description="A test whose id matches the old sentinel string.",
+        command=("make", "test-cov"),
+        tags=("ci-safe",),
+    )
+
+    def _mock_select_prompt(*_args, **_kwargs):
+        return SimpleNamespace(ask=lambda: "__run_all__")
+
+    monkeypatch.setattr(interactive, "_require_interactive_dependencies", lambda: None)
+    monkeypatch.setattr(
+        interactive,
+        "_QuestionaryChoice",
+        lambda *, title, value: {"title": title, "value": value},
+    )
+    monkeypatch.setattr(interactive, "_select_prompt", _mock_select_prompt)
+
+    selection = interactive._select_item_or_all([item], prompt="Choose a test or suite:")
+
+    assert selection is item
+
+
+def test_choose_interactive_item_expands_run_all_suites(monkeypatch) -> None:
+    suite = CatalogItem(
+        id="suite:demo",
+        kind="suite",
+        display_name="Demo Suite",
+        description="A grouped demo suite.",
+        tags=("demo",),
+        children=(
+            CatalogItem(
+                id="scenario:demo:first",
+                kind="scenario",
+                display_name="First scenario",
+                description="First child.",
+                command=("make", "demo-first"),
+                tags=("demo",),
+            ),
+            CatalogItem(
+                id="scenario:demo:second",
+                kind="scenario",
+                display_name="Second scenario",
+                description="Second child.",
+                command=("make", "demo-second"),
+                tags=("demo",),
+            ),
+        ),
+    )
+    leaf = CatalogItem(
+        id="make:demo",
+        kind="make_target",
+        display_name="Standalone Demo",
+        description="Run the demo.",
+        command=("make", "demo"),
+        tags=("demo",),
+    )
+    catalog = Catalog(items=(suite, leaf))
+
+    def _mock_select_item_or_all(
+        items, *, prompt: str, allow_back: bool = False
+    ):
+        _ = (prompt, allow_back)
+        return items
+
+    monkeypatch.setattr(interactive, "_choose_category", lambda: "demo")
+    monkeypatch.setattr(interactive, "_select_item_or_all", _mock_select_item_or_all)
+
+    selection, auto_selected = interactive.choose_interactive_item(catalog)
+
+    assert auto_selected is False
+    assert [item.id for item in selection] == [
+        "scenario:demo:first",
+        "scenario:demo:second",
+        "make:demo",
     ]
 
 
@@ -233,3 +318,24 @@ def test_run_interactive_picker_returns_to_selection_after_escape_from_confirm(m
     monkeypatch.setattr(interactive, "run_catalog_item", lambda item: 7 if item.id == "make:test-full" else 1)
 
     assert interactive.run_interactive_picker(Catalog(items=(first, second))) == 7
+
+
+def test_run_catalog_items_skips_non_runnable_items() -> None:
+    runnable = CatalogItem(
+        id="make:test-cov",
+        kind="make_target",
+        display_name="Coverage Suite",
+        description="Run coverage.",
+        command=("make", "test-cov"),
+        tags=("ci-safe",),
+    )
+    suite = CatalogItem(
+        id="suite:ci-safe",
+        kind="suite",
+        display_name="Grouped CI Tests",
+        description="A suite without a direct command.",
+        tags=("ci-safe",),
+        children=(runnable,),
+    )
+
+    assert interactive.run_catalog_items([suite, runnable], dry_run=True) == 0


### PR DESCRIPTION
## Summary

- Adds a **"Run All"** choice at the top of the test/suite selection list in `opensre test` interactive picker
- When selected, shows a confirmation prompt listing all tests, then runs every runnable test in the category sequentially
- Adds `run_catalog_items()` helper in `runner.py` for batch execution (returns worst exit code)

## Test plan

- [ ] Run `opensre test`, pick a category (e.g. Synthetics), verify "Run All" appears as the first option
- [ ] Select "Run All", confirm the list is shown, select "Yes" and verify all tests execute sequentially
- [ ] Verify Esc goes back from the "Run All" confirmation prompt
- [ ] Verify selecting a single test still works as before
- [ ] Verify categories with a single test auto-run without showing "Run All"


Made with [Cursor](https://cursor.com)