### PR TITLE
fix: wire grafana_backend into GrafanaTracesTool for synthetic tests

### DIFF
--- a/app/tools/GrafanaTracesTool/__init__.py
+++ b/app/tools/GrafanaTracesTool/__init__.py
@@ -13,6 +13,21 @@ from app.tools.tool_decorator import tool
 from app.tools.utils.compaction import DEFAULT_TRACE_LIMIT, compact_traces, summarize_counts
 
 
+def _extract_pipeline_spans(traces: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    pipeline_spans: list[dict[str, Any]] = []
+    for trace in traces:
+        for span in trace.get("spans", []):
+            if span.get("name") in ["extract_data", "validate_data", "transform_data", "load_data"]:
+                pipeline_spans.append(
+                    {
+                        "span_name": span.get("name"),
+                        "execution_run_id": span.get("attributes", {}).get("execution.run_id"),
+                        "record_count": span.get("attributes", {}).get("record_count"),
+                    }
+                )
+    return pipeline_spans
+
+
 def _query_grafana_traces_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     grafana = sources["grafana"]
     return {
@@ -81,7 +96,7 @@ def query_grafana_traces(
             "source": "grafana_tempo",
             "available": True,
             "traces": compacted_traces,
-            "pipeline_spans": [],
+            "pipeline_spans": _extract_pipeline_spans(compacted_traces),
             "total_traces": len(traces),
             "service_name": service_name,
             "execution_run_id": execution_run_id,
@@ -131,23 +146,11 @@ def query_grafana_traces(
     compacted_traces = compact_traces(traces, limit=limit)
     summary = summarize_counts(len(traces), len(compacted_traces), "traces")
 
-    pipeline_spans = []
-    for trace in compacted_traces:
-        for span in trace.get("spans", []):
-            if span.get("name") in ["extract_data", "validate_data", "transform_data", "load_data"]:
-                pipeline_spans.append(
-                    {
-                        "span_name": span.get("name"),
-                        "execution_run_id": span.get("attributes", {}).get("execution.run_id"),
-                        "record_count": span.get("attributes", {}).get("record_count"),
-                    }
-                )
-
     result_data = {
         "source": "grafana_tempo",
         "available": True,
         "traces": compacted_traces,
-        "pipeline_spans": pipeline_spans,
+        "pipeline_spans": _extract_pipeline_spans(compacted_traces),
         "total_traces": result.get("total_traces", 0),
         "service_name": service_name,
         "execution_run_id": execution_run_id,

--- a/app/tools/GrafanaTracesTool/__init__.py
+++ b/app/tools/GrafanaTracesTool/__init__.py
@@ -19,6 +19,7 @@ def _query_grafana_traces_extract_params(sources: dict[str, dict]) -> dict[str, 
         "service_name": grafana.get("service_name", ""),
         "execution_run_id": grafana.get("execution_run_id"),
         "limit": grafana.get("limit", DEFAULT_TRACE_LIMIT),
+        "grafana_backend": grafana.get("_backend"),
         **_grafana_creds(grafana),
     }
 
@@ -57,9 +58,38 @@ def query_grafana_traces(
     limit: int = 20,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
     """Query Grafana Cloud Tempo for pipeline traces."""
+    if grafana_backend is not None:
+        raw = grafana_backend.query_traces(service_name=service_name)
+        traces = raw.get("traces", [])
+        if execution_run_id and traces:
+            filtered = [
+                t
+                for t in traces
+                if any(
+                    s.get("attributes", {}).get("execution.run_id") == execution_run_id
+                    for s in t.get("spans", [])
+                )
+            ]
+            traces = filtered if filtered else traces
+        compacted_traces = compact_traces(traces, limit=limit)
+        summary = summarize_counts(len(traces), len(compacted_traces), "traces")
+        result_data: dict[str, Any] = {
+            "source": "grafana_tempo",
+            "available": True,
+            "traces": compacted_traces,
+            "pipeline_spans": [],
+            "total_traces": len(traces),
+            "service_name": service_name,
+            "execution_run_id": execution_run_id,
+        }
+        if summary:
+            result_data["truncation_note"] = summary
+        return result_data
+
     client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
     if not client or not client.is_configured:
         return {

--- a/tests/synthetic/mock_grafana_backend/backend.py
+++ b/tests/synthetic/mock_grafana_backend/backend.py
@@ -58,7 +58,7 @@ class GrafanaBackend(Protocol):
 class FixtureGrafanaBackend:
     """GrafanaBackend implementation backed by a ScenarioFixture.
 
-    All three methods delegate to the pure formatter functions, converting
+    All four methods delegate to the pure formatter functions, converting
     AWS-faithful fixture data into the Grafana wire format the agent expects.
     No HTTP calls, no external dependencies.
     """

--- a/tests/synthetic/mock_grafana_backend/backend.py
+++ b/tests/synthetic/mock_grafana_backend/backend.py
@@ -20,6 +20,7 @@ from tests.synthetic.mock_grafana_backend.formatters import (
     format_loki_query_range,
     format_mimir_query_range,
     format_ruler_rules,
+    format_tempo_search,
 )
 
 if TYPE_CHECKING:
@@ -30,10 +31,11 @@ if TYPE_CHECKING:
 class GrafanaBackend(Protocol):
     """Minimal observability interface used by the RDS investigation agent.
 
-    Three methods — one per evidence pillar:
+    Four methods — one per evidence pillar:
         query_timeseries  → Mimir/Prometheus matrix response
         query_logs        → Loki streams response
         query_alert_rules → Grafana Ruler rules response
+        query_traces      → Tempo search response
     """
 
     def query_timeseries(self, query: str = "", **kwargs: Any) -> dict[str, Any]:
@@ -46,6 +48,10 @@ class GrafanaBackend(Protocol):
 
     def query_alert_rules(self, **kwargs: Any) -> dict[str, Any]:
         """Return a Grafana Ruler /api/v1/rules response."""
+        pass
+
+    def query_traces(self, **kwargs: Any) -> dict[str, Any]:
+        """Return a Tempo-compatible search response."""
         pass
 
 
@@ -79,3 +85,6 @@ class FixtureGrafanaBackend:
 
     def query_alert_rules(self, **_: Any) -> dict[str, Any]:
         return format_ruler_rules(self._fixture.alert)
+
+    def query_traces(self, **_: Any) -> dict[str, Any]:
+        return format_tempo_search()

--- a/tests/synthetic/mock_grafana_backend/formatters.py
+++ b/tests/synthetic/mock_grafana_backend/formatters.py
@@ -9,6 +9,7 @@ Endpoints modelled:
     Mimir  /api/v1/query_range          ← aws_cloudwatch_metrics.json
     Loki   /loki/api/v1/query_range     ← aws_rds_events.json
     Ruler  /api/v1/rules                ← alert.json
+    Tempo  /api/search                  ← (empty — RDS scenarios have no traces)
 """
 
 from __future__ import annotations
@@ -152,6 +153,20 @@ def format_loki_query_range(rds_events_fixture: dict[str, Any]) -> dict[str, Any
 # ---------------------------------------------------------------------------
 # Ruler / Alertmanager
 # ---------------------------------------------------------------------------
+
+
+def format_tempo_search() -> dict[str, Any]:
+    """Return an empty Tempo /api/search response.
+
+    RDS synthetic scenarios do not include trace fixture data, so the mock
+    returns a structurally valid but empty response.  This allows the traces
+    tool to report ``available=True`` with zero traces instead of failing
+    with "Grafana integration not configured".
+    """
+    return {
+        "traces": [],
+        "metrics": {},
+    }
 
 
 def format_ruler_rules(alert_fixture: dict[str, Any]) -> dict[str, Any]:

--- a/tests/synthetic/mock_grafana_backend/selective_backend.py
+++ b/tests/synthetic/mock_grafana_backend/selective_backend.py
@@ -36,6 +36,7 @@ from tests.synthetic.mock_grafana_backend.formatters import (
     format_loki_query_range,
     format_mimir_query_range,
     format_ruler_rules,
+    format_tempo_search,
 )
 
 if TYPE_CHECKING:
@@ -87,6 +88,9 @@ class SelectiveGrafanaBackend:
 
     def query_alert_rules(self, **_: Any) -> dict[str, Any]:
         return format_ruler_rules(self._fixture.alert)
+
+    def query_traces(self, **_: Any) -> dict[str, Any]:
+        return format_tempo_search()
 
     def reset(self) -> None:
         """Clear the queried_metrics audit log (useful for re-running a scenario)."""

--- a/tests/tools/test_grafana_traces_tool.py
+++ b/tests/tools/test_grafana_traces_tool.py
@@ -77,6 +77,7 @@ def test_run_with_injected_backend() -> None:
     assert result["available"] is True
     assert result["source"] == "grafana_tempo"
     assert result["total_traces"] == 1
+    assert len(result["pipeline_spans"]) == 1
     backend.query_traces.assert_called_once_with(service_name="svc")
 
 

--- a/tests/tools/test_grafana_traces_tool.py
+++ b/tests/tools/test_grafana_traces_tool.py
@@ -16,6 +16,7 @@ class TestGrafanaTracesToolContract(BaseToolContract):
 def test_is_available_requires_grafana_creds() -> None:
     rt = query_grafana_traces.__opensre_registered_tool__
     assert rt.is_available({"grafana": {"connection_verified": True}}) is True
+    assert rt.is_available({"grafana": {"_backend": MagicMock()}}) is True
     assert rt.is_available({"grafana": {}}) is False
     assert rt.is_available({}) is False
 
@@ -63,6 +64,29 @@ def test_run_happy_path() -> None:
     assert result["available"] is True
     assert result["total_traces"] == 1
     assert len(result["pipeline_spans"]) == 1
+
+
+def test_run_with_injected_backend() -> None:
+    backend = MagicMock()
+    backend.query_traces.return_value = {
+        "traces": [
+            {"traceId": "t1", "spans": [{"name": "extract_data", "attributes": {}}]},
+        ],
+    }
+    result = query_grafana_traces(service_name="svc", grafana_backend=backend)
+    assert result["available"] is True
+    assert result["source"] == "grafana_tempo"
+    assert result["total_traces"] == 1
+    backend.query_traces.assert_called_once_with(service_name="svc")
+
+
+def test_run_with_injected_backend_empty_traces() -> None:
+    backend = MagicMock()
+    backend.query_traces.return_value = {"traces": [], "metrics": {}}
+    result = query_grafana_traces(service_name="svc", grafana_backend=backend)
+    assert result["available"] is True
+    assert result["traces"] == []
+    assert result["total_traces"] == 0
 
 
 def test_run_filters_by_execution_run_id() -> None:


### PR DESCRIPTION
The traces tool was the only Grafana tool that didn't support the injected _backend path, causing synthetic investigations to fail with "Grafana integration not configured". Thread grafana_backend through extract_params and the function body (matching the logs/metrics pattern), and add query_traces to the GrafanaBackend protocol + both mock implementations.

Made-with: Cursor

Fixes #

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
