### PR TITLE
feat: add Kubernetes synthetic RCA test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ test-synthetic:
 test-rds-synthetic:
 	$(PYTHON) -m tests.synthetic.rds_postgres.run_suite $(if $(SCENARIO),--scenario $(SCENARIO),)
 
+# Run synthetic Kubernetes RCA benchmark suite via the CLI runner (supports --json, --scenario, --mock-backends)
+test-k8s-synthetic:
+	$(PYTHON) -m tests.synthetic.eks.run_suite $(if $(SCENARIO),--scenario $(SCENARIO),)
+
 # Boot local Grafana+Loki, seed deterministic test logs, then run the RCA pipeline
 # Requires GRAFANA_INSTANCE_URL + GRAFANA_READ_TOKEN in .env (see .env.example for local defaults)
 test-rca-grafana: grafana-local-up grafana-local-seed

--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -580,6 +580,16 @@ def detect_sources(
     _has_injected_eks_backend = bool(_eks_int and "_backend" in _eks_int)
     if _eks_int and (_eks_int.get("role_arn") or _has_injected_eks_backend):
         eks_cluster = annotations.get("eks_cluster") or annotations.get("cluster_name")
+        # When a backend is injected but the alert omits cluster_name from its
+        # annotations, fall back to the first cluster_names entry on the
+        # integration dict.  Without this fallback, backend-only investigations
+        # silently produce zero EKS tool activity — future synthetic scenarios
+        # that forget to put cluster_name in commonAnnotations would otherwise
+        # fail with no diagnostic.
+        if not eks_cluster and _has_injected_eks_backend:
+            cluster_names = _eks_int.get("cluster_names") or []
+            if cluster_names:
+                eks_cluster = cluster_names[0]
         kube_namespace = (
             annotations.get("kube_namespace")
             or annotations.get("kubernetes_namespace")

--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -418,17 +418,21 @@ def detect_sources(
                 grafana_params["_backend"] = grafana_int["_backend"]
             sources["grafana"] = grafana_params
 
-    # Only include Datadog when alert came from Datadog, or when source is truly unknown
-    if (
-        resolved_integrations
-        and resolved_integrations.get("datadog")
-        and alert_source in ("datadog", "")
-    ):
+    # Only include Datadog when alert came from Datadog, or when source is truly unknown,
+    # or when a pre-injected backend is present (e.g. FixtureDatadogBackend for synthetic tests).
+    dd_int = None
+    if resolved_integrations and resolved_integrations.get("datadog"):
         dd_int = resolved_integrations["datadog"]
+
+    _has_injected_dd_backend = bool(dd_int and "_backend" in dd_int)
+    if dd_int and not (_has_injected_dd_backend or alert_source in ("datadog", "")):
+        dd_int = None  # suppress real Datadog for non-Datadog alerts
+
+    if dd_int:
         dd_api_key = dd_int.get("api_key", "")
         dd_app_key = dd_int.get("app_key", "")
 
-        if dd_api_key and dd_app_key:
+        if _has_injected_dd_backend or (dd_api_key and dd_app_key):
             # kube_namespace: prefer LLM-injected top-level field, fall back to annotations
             kube_namespace = raw_alert.get("kube_namespace", "") or annotations.get(
                 "kube_namespace", ""
@@ -462,12 +466,17 @@ def detect_sources(
                 "api_key": dd_api_key,
                 "app_key": dd_app_key,
                 "site": dd_int.get("site", "datadoghq.com"),
-                "connection_verified": True,
                 "pipeline_name": pipeline_name,
                 "default_query": default_query,
                 "monitor_query": f"tag:pipeline:{pipeline_name}" if pipeline_name else None,
                 "time_range_minutes": alert_time_range_minutes,
             }
+            if _has_injected_dd_backend:
+                # Backend-only path: only fixture-aware Datadog tools should activate,
+                # so connection_verified stays unset to keep the real-Datadog tools quiet.
+                dd_params["_backend"] = dd_int["_backend"]
+            else:
+                dd_params["connection_verified"] = True
 
             kube_job = annotations.get("kube_job", "") or annotations.get("kube_job_name", "")
             kube_deployment = annotations.get("kube_deployment", "")
@@ -564,9 +573,12 @@ def detect_sources(
                 "connection_verified": True,
             }
 
-    # Detect EKS: uses the AWS integration (EKS maps to aws in resolve_integrations)
+    # Detect EKS: uses the AWS integration (EKS maps to aws in resolve_integrations).
+    # A pre-injected _backend (e.g. FixtureEKSBackend for synthetic tests) bypasses
+    # the role_arn credential gate the same way the Grafana path does.
     _eks_int = (resolved_integrations or {}).get("aws")
-    if _eks_int and _eks_int.get("role_arn"):
+    _has_injected_eks_backend = bool(_eks_int and "_backend" in _eks_int)
+    if _eks_int and (_eks_int.get("role_arn") or _has_injected_eks_backend):
         eks_cluster = annotations.get("eks_cluster") or annotations.get("cluster_name")
         kube_namespace = (
             annotations.get("kube_namespace")
@@ -576,7 +588,7 @@ def detect_sources(
         )
 
         if eks_cluster:
-            sources["eks"] = {
+            eks_params: dict[str, Any] = {
                 "cluster_name": eks_cluster,
                 "namespace": kube_namespace,
                 "pod_name": annotations.get("pod_name", ""),
@@ -589,11 +601,17 @@ def detect_sources(
                     or annotations.get("region")
                     or _eks_int.get("region", "us-east-1")
                 ),
-                "role_arn": _eks_int["role_arn"],
+                "role_arn": _eks_int.get("role_arn", ""),
                 "external_id": _eks_int.get("external_id", ""),
                 "cluster_names": _eks_int.get("cluster_names", []),
-                "connection_verified": True,
             }
+            if _has_injected_eks_backend:
+                # Backend-only path: only fixture-aware EKS tools should activate,
+                # so connection_verified stays unset to keep the real-AWS tools quiet.
+                eks_params["_backend"] = _eks_int["_backend"]
+            else:
+                eks_params["connection_verified"] = True
+            sources["eks"] = eks_params
 
     github_int = (resolved_integrations or {}).get("github")
     if github_int:

--- a/app/tools/DataDogLogsTool/__init__.py
+++ b/app/tools/DataDogLogsTool/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from app.tools.DataDogLogsTool._client import make_client, unavailable
 from app.tools.tool_decorator import tool
@@ -31,8 +31,19 @@ def _dd_creds(dd: dict) -> dict:
     }
 
 
+def _dd_available_or_backend(sources: dict[str, dict]) -> bool:
+    """Available when real Datadog credentials are present OR a fixture backend is injected.
+
+    Used by tools whose extract_params can delegate to a mock ``datadog_backend``
+    (synthetic harness under ``tests/synthetic/eks/``).  Tools without backend
+    support continue to use ``_logs_is_available`` / their own check.
+    """
+    dd = sources.get("datadog", {})
+    return bool(dd.get("connection_verified") or dd.get("_backend"))
+
+
 def _logs_is_available(sources: dict[str, dict]) -> bool:
-    return bool(sources.get("datadog", {}).get("connection_verified"))
+    return _dd_available_or_backend(sources)
 
 
 def _logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -41,6 +52,7 @@ def _logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         "query": dd.get("default_query", ""),
         "time_range_minutes": dd.get("time_range_minutes", 60),
         "limit": 50,
+        "datadog_backend": dd.get("_backend"),
         **_dd_creds(dd),
     }
 
@@ -78,9 +90,17 @@ def query_datadog_logs(
     api_key: str | None = None,
     app_key: str | None = None,
     site: str = "datadoghq.com",
+    datadog_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """Search Datadog logs for pipeline errors, exceptions, and application events."""
+    """Search Datadog logs for pipeline errors, exceptions, and application events.
+
+    When ``datadog_backend`` is provided (e.g. a FixtureDatadogBackend from the
+    synthetic harness) the call short-circuits and returns the backend's response
+    directly.
+    """
+    if datadog_backend is not None:
+        return cast("dict[str, Any]", datadog_backend.query_logs(query=query))
     client = make_client(api_key, app_key, site)
     if not client:
         return unavailable("datadog_logs", "logs", "Datadog integration not configured")

--- a/app/tools/DataDogLogsTool/__init__.py
+++ b/app/tools/DataDogLogsTool/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from app.tools.DataDogLogsTool._client import make_client, unavailable
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import datadog_available_or_backend
 from app.tools.utils.compaction import compact_logs, summarize_counts
 
 _ERROR_KEYWORDS = (
@@ -31,19 +32,8 @@ def _dd_creds(dd: dict) -> dict:
     }
 
 
-def _dd_available_or_backend(sources: dict[str, dict]) -> bool:
-    """Available when real Datadog credentials are present OR a fixture backend is injected.
-
-    Used by tools whose extract_params can delegate to a mock ``datadog_backend``
-    (synthetic harness under ``tests/synthetic/eks/``).  Tools without backend
-    support continue to use ``_logs_is_available`` / their own check.
-    """
-    dd = sources.get("datadog", {})
-    return bool(dd.get("connection_verified") or dd.get("_backend"))
-
-
 def _logs_is_available(sources: dict[str, dict]) -> bool:
-    return _dd_available_or_backend(sources)
+    return datadog_available_or_backend(sources)
 
 
 def _logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/app/tools/DataDogMonitorsTool/__init__.py
+++ b/app/tools/DataDogMonitorsTool/__init__.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from app.tools.DataDogLogsTool import _dd_available_or_backend, _dd_creds
+from app.tools.DataDogLogsTool import _dd_creds
 from app.tools.DataDogLogsTool._client import make_client, unavailable
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import datadog_available_or_backend
 
 
 def _monitors_is_available(sources: dict[str, dict]) -> bool:
-    return _dd_available_or_backend(sources)
+    return datadog_available_or_backend(sources)
 
 
 def _monitors_extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/app/tools/DataDogMonitorsTool/__init__.py
+++ b/app/tools/DataDogMonitorsTool/__init__.py
@@ -2,21 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
-from app.tools.DataDogLogsTool import _dd_creds
+from app.tools.DataDogLogsTool import _dd_available_or_backend, _dd_creds
 from app.tools.DataDogLogsTool._client import make_client, unavailable
 from app.tools.tool_decorator import tool
 
 
 def _monitors_is_available(sources: dict[str, dict]) -> bool:
-    return bool(sources.get("datadog", {}).get("connection_verified"))
+    return _dd_available_or_backend(sources)
 
 
 def _monitors_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     dd = sources["datadog"]
     return {
         "query": dd.get("monitor_query"),
+        "datadog_backend": dd.get("_backend"),
         **_dd_creds(dd),
     }
 
@@ -50,9 +51,17 @@ def query_datadog_monitors(
     api_key: str | None = None,
     app_key: str | None = None,
     site: str = "datadoghq.com",
+    datadog_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """List Datadog monitors to understand alerting configuration and current states."""
+    """List Datadog monitors to understand alerting configuration and current states.
+
+    When ``datadog_backend`` is provided (e.g. a FixtureDatadogBackend from the
+    synthetic harness) the call short-circuits and returns the backend's response
+    directly.
+    """
+    if datadog_backend is not None:
+        return cast("dict[str, Any]", datadog_backend.query_monitors(query=query))
     client = make_client(api_key, app_key, site)
     if not client:
         return unavailable("datadog_monitors", "monitors", "Datadog integration not configured")

--- a/app/tools/EKSEventsTool/__init__.py
+++ b/app/tools/EKSEventsTool/__init__.py
@@ -3,24 +3,25 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available, _eks_creds
+from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
 from app.tools.tool_decorator import tool
 
 logger = logging.getLogger(__name__)
 
 
 def _events_is_available(sources: dict[str, dict]) -> bool:
-    return bool(_eks_available(sources) and sources.get("eks", {}).get("cluster_name"))
+    return bool(_eks_available_or_backend(sources) and sources.get("eks", {}).get("cluster_name"))
 
 
 def _events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     eks = sources["eks"]
     return {
-        "cluster_name": eks["cluster_name"],
+        "cluster_name": eks.get("cluster_name", ""),
         "namespace": eks.get("namespace", "default"),
+        "eks_backend": eks.get("_backend"),
         **_eks_creds(eks),
     }
 
@@ -51,13 +52,23 @@ def _events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
 def get_eks_events(
     cluster_name: str,
     namespace: str,
-    role_arn: str,
+    role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """Get Kubernetes Warning events in a namespace."""
+    """Get Kubernetes Warning events in a namespace.
+
+    When ``eks_backend`` is provided (e.g. a FixtureEKSBackend from the synthetic
+    harness) the call short-circuits and returns the backend's response directly.
+    """
     logger.info("[eks] get_eks_events cluster=%s ns=%s", cluster_name, namespace)
+    if eks_backend is not None:
+        return cast(
+            "dict[str, Any]",
+            eks_backend.get_events(cluster_name=cluster_name, namespace=namespace),
+        )
     try:
         core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
         event_list = core_v1.list_event_for_all_namespaces() if namespace == "all" else core_v1.list_namespaced_event(namespace=namespace)

--- a/app/tools/EKSEventsTool/__init__.py
+++ b/app/tools/EKSEventsTool/__init__.py
@@ -6,14 +6,15 @@ import logging
 from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
+from app.tools.EKSListClustersTool import _eks_creds
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import eks_available_or_backend
 
 logger = logging.getLogger(__name__)
 
 
 def _events_is_available(sources: dict[str, dict]) -> bool:
-    return bool(_eks_available_or_backend(sources) and sources.get("eks", {}).get("cluster_name"))
+    return bool(eks_available_or_backend(sources) and sources.get("eks", {}).get("cluster_name"))
 
 
 def _events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -17,17 +17,6 @@ def _eks_available(sources: dict[str, dict]) -> bool:
     return bool(sources.get("eks", {}).get("connection_verified"))
 
 
-def _eks_available_or_backend(sources: dict[str, dict]) -> bool:
-    """Available when real EKS credentials are present OR a fixture backend is injected.
-
-    Used by tools whose extract_params can delegate to a mock ``eks_backend``
-    (synthetic harness under ``tests/synthetic/eks/``).  Tools without backend
-    support continue to use :func:`_eks_available`.
-    """
-    eks = sources.get("eks", {})
-    return bool(eks.get("connection_verified") or eks.get("_backend"))
-
-
 def _eks_creds(eks: dict) -> dict:
     return {
         "role_arn": eks.get("role_arn", ""),

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -17,9 +17,20 @@ def _eks_available(sources: dict[str, dict]) -> bool:
     return bool(sources.get("eks", {}).get("connection_verified"))
 
 
+def _eks_available_or_backend(sources: dict[str, dict]) -> bool:
+    """Available when real EKS credentials are present OR a fixture backend is injected.
+
+    Used by tools whose extract_params can delegate to a mock ``eks_backend``
+    (synthetic harness under ``tests/synthetic/eks/``).  Tools without backend
+    support continue to use :func:`_eks_available`.
+    """
+    eks = sources.get("eks", {})
+    return bool(eks.get("connection_verified") or eks.get("_backend"))
+
+
 def _eks_creds(eks: dict) -> dict:
     return {
-        "role_arn": eks["role_arn"],
+        "role_arn": eks.get("role_arn", ""),
         "external_id": eks.get("external_id", ""),
         "region": eks.get("region", "us-east-1"),
     }

--- a/app/tools/EKSListDeploymentsTool/__init__.py
+++ b/app/tools/EKSListDeploymentsTool/__init__.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available, _eks_creds
+from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
 from app.tools.tool_decorator import tool
 
 logger = logging.getLogger(__name__)
@@ -15,8 +15,9 @@ logger = logging.getLogger(__name__)
 def _list_deployments_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     eks = sources["eks"]
     return {
-        "cluster_name": eks["cluster_name"],
+        "cluster_name": eks.get("cluster_name", ""),
         "namespace": eks.get("namespace") or "all",
+        "eks_backend": eks.get("_backend"),
         **_eks_creds(eks),
     }
 
@@ -41,19 +42,29 @@ def _list_deployments_extract_params(sources: dict[str, dict]) -> dict[str, Any]
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
-    is_available=_eks_available,
+    is_available=_eks_available_or_backend,
     extract_params=_list_deployments_extract_params,
 )
 def list_eks_deployments(
     cluster_name: str,
     namespace: str,
-    role_arn: str,
+    role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """List all deployments in a namespace with replica counts and availability status."""
+    """List all deployments in a namespace with replica counts and availability status.
+
+    When ``eks_backend`` is provided (e.g. a FixtureEKSBackend from the synthetic
+    harness) the call short-circuits and returns the backend's response directly.
+    """
     logger.info("[eks] list_eks_deployments cluster=%s ns=%s", cluster_name, namespace)
+    if eks_backend is not None:
+        return cast(
+            "dict[str, Any]",
+            eks_backend.list_deployments(cluster_name=cluster_name, namespace=namespace),
+        )
     try:
         _, apps_v1 = build_k8s_clients(cluster_name, role_arn, external_id, region)
         dep_list = apps_v1.list_deployment_for_all_namespaces() if namespace == "all" else apps_v1.list_namespaced_deployment(namespace=namespace)

--- a/app/tools/EKSListDeploymentsTool/__init__.py
+++ b/app/tools/EKSListDeploymentsTool/__init__.py
@@ -6,8 +6,9 @@ import logging
 from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
+from app.tools.EKSListClustersTool import _eks_creds
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import eks_available_or_backend
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ def _list_deployments_extract_params(sources: dict[str, dict]) -> dict[str, Any]
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
-    is_available=_eks_available_or_backend,
+    is_available=eks_available_or_backend,
     extract_params=_list_deployments_extract_params,
 )
 def list_eks_deployments(

--- a/app/tools/EKSListPodsTool/__init__.py
+++ b/app/tools/EKSListPodsTool/__init__.py
@@ -6,8 +6,9 @@ import logging
 from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
+from app.tools.EKSListClustersTool import _eks_creds
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import eks_available_or_backend
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def _list_pods_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
-    is_available=_eks_available_or_backend,
+    is_available=eks_available_or_backend,
     extract_params=_list_pods_extract_params,
 )
 def list_eks_pods(

--- a/app/tools/EKSListPodsTool/__init__.py
+++ b/app/tools/EKSListPodsTool/__init__.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available, _eks_creds
+from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
 from app.tools.tool_decorator import tool
 
 logger = logging.getLogger(__name__)
@@ -15,8 +15,9 @@ logger = logging.getLogger(__name__)
 def _list_pods_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     eks = sources["eks"]
     return {
-        "cluster_name": eks["cluster_name"],
+        "cluster_name": eks.get("cluster_name", ""),
         "namespace": eks.get("namespace") or "all",
+        "eks_backend": eks.get("_backend"),
         **_eks_creds(eks),
     }
 
@@ -42,19 +43,29 @@ def _list_pods_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
-    is_available=_eks_available,
+    is_available=_eks_available_or_backend,
     extract_params=_list_pods_extract_params,
 )
 def list_eks_pods(
     cluster_name: str,
     namespace: str,
-    role_arn: str,
+    role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """List all pods in a namespace with their status, phase, restart counts, and conditions."""
+    """List all pods in a namespace with their status, phase, restart counts, and conditions.
+
+    When ``eks_backend`` is provided (e.g. a FixtureEKSBackend from the synthetic
+    harness) the call short-circuits and returns the backend's response directly.
+    """
     logger.info("[eks] list_eks_pods cluster=%s ns=%s", cluster_name, namespace)
+    if eks_backend is not None:
+        return cast(
+            "dict[str, Any]",
+            eks_backend.list_pods(cluster_name=cluster_name, namespace=namespace),
+        )
     try:
         core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
         pod_list = core_v1.list_pod_for_all_namespaces() if namespace == "all" else core_v1.list_namespaced_pod(namespace=namespace)

--- a/app/tools/EKSNodeHealthTool/__init__.py
+++ b/app/tools/EKSNodeHealthTool/__init__.py
@@ -6,14 +6,15 @@ import logging
 from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
+from app.tools.EKSListClustersTool import _eks_creds
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import eks_available_or_backend
 
 logger = logging.getLogger(__name__)
 
 
 def _node_health_is_available(sources: dict[str, dict]) -> bool:
-    return bool(_eks_available_or_backend(sources) and sources.get("eks", {}).get("cluster_name"))
+    return bool(eks_available_or_backend(sources) and sources.get("eks", {}).get("cluster_name"))
 
 
 def _node_health_extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/app/tools/EKSNodeHealthTool/__init__.py
+++ b/app/tools/EKSNodeHealthTool/__init__.py
@@ -3,22 +3,26 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available, _eks_creds
+from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
 from app.tools.tool_decorator import tool
 
 logger = logging.getLogger(__name__)
 
 
 def _node_health_is_available(sources: dict[str, dict]) -> bool:
-    return bool(_eks_available(sources) and sources.get("eks", {}).get("cluster_name"))
+    return bool(_eks_available_or_backend(sources) and sources.get("eks", {}).get("cluster_name"))
 
 
 def _node_health_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     eks = sources["eks"]
-    return {"cluster_name": eks["cluster_name"], **_eks_creds(eks)}
+    return {
+        "cluster_name": eks.get("cluster_name", ""),
+        "eks_backend": eks.get("_backend"),
+        **_eks_creds(eks),
+    }
 
 
 @tool(
@@ -45,13 +49,23 @@ def _node_health_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
 )
 def get_eks_node_health(
     cluster_name: str,
-    role_arn: str,
+    role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """Get health status of all EKS nodes — conditions, capacity, allocatable, pod counts."""
+    """Get health status of all EKS nodes — conditions, capacity, allocatable, pod counts.
+
+    When ``eks_backend`` is provided (e.g. a FixtureEKSBackend from the synthetic
+    harness) the call short-circuits and returns the backend's response directly.
+    """
     logger.info("[eks] get_eks_node_health cluster=%s", cluster_name)
+    if eks_backend is not None:
+        return cast(
+            "dict[str, Any]",
+            eks_backend.get_node_health(cluster_name=cluster_name),
+        )
     try:
         core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
         nodes = core_v1.list_node()

--- a/app/tools/EKSPodLogsTool/__init__.py
+++ b/app/tools/EKSPodLogsTool/__init__.py
@@ -6,14 +6,15 @@ import logging
 from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
+from app.tools.EKSListClustersTool import _eks_creds
 from app.tools.tool_decorator import tool
+from app.tools.utils.availability import eks_available_or_backend
 
 logger = logging.getLogger(__name__)
 
 
 def _pod_logs_is_available(sources: dict[str, dict]) -> bool:
-    return bool(_eks_available_or_backend(sources) and sources.get("eks", {}).get("pod_name"))
+    return bool(eks_available_or_backend(sources) and sources.get("eks", {}).get("pod_name"))
 
 
 def _pod_logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/app/tools/EKSPodLogsTool/__init__.py
+++ b/app/tools/EKSPodLogsTool/__init__.py
@@ -3,25 +3,26 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from app.services.eks.eks_k8s_client import build_k8s_clients
-from app.tools.EKSListClustersTool import _eks_available, _eks_creds
+from app.tools.EKSListClustersTool import _eks_available_or_backend, _eks_creds
 from app.tools.tool_decorator import tool
 
 logger = logging.getLogger(__name__)
 
 
 def _pod_logs_is_available(sources: dict[str, dict]) -> bool:
-    return bool(_eks_available(sources) and sources.get("eks", {}).get("pod_name"))
+    return bool(_eks_available_or_backend(sources) and sources.get("eks", {}).get("pod_name"))
 
 
 def _pod_logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     eks = sources["eks"]
     return {
-        "cluster_name": eks["cluster_name"],
+        "cluster_name": eks.get("cluster_name", ""),
         "namespace": eks.get("namespace", "default"),
-        "pod_name": eks["pod_name"],
+        "pod_name": eks.get("pod_name", ""),
+        "eks_backend": eks.get("_backend"),
         **_eks_creds(eks),
     }
 
@@ -55,14 +56,26 @@ def get_eks_pod_logs(
     cluster_name: str,
     namespace: str,
     pod_name: str,
-    role_arn: str,
+    role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
     tail_lines: int = 100,
+    eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """Fetch logs from a specific EKS pod."""
+    """Fetch logs from a specific EKS pod.
+
+    When ``eks_backend`` is provided (e.g. a FixtureEKSBackend from the synthetic
+    harness) the call short-circuits and returns the backend's response directly.
+    """
     logger.info("[eks] get_eks_pod_logs cluster=%s ns=%s pod=%s", cluster_name, namespace, pod_name)
+    if eks_backend is not None:
+        return cast(
+            "dict[str, Any]",
+            eks_backend.get_pod_logs(
+                cluster_name=cluster_name, namespace=namespace, pod_name=pod_name
+            ),
+        )
     try:
         core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
         logs = core_v1.read_namespaced_pod_log(name=pod_name, namespace=namespace, tail_lines=tail_lines)

--- a/app/tools/utils/availability.py
+++ b/app/tools/utils/availability.py
@@ -1,0 +1,34 @@
+"""Shared tool-availability helpers for backend-aware integration sources.
+
+Tools that can delegate to a pre-injected fixture backend — as the
+synthetic harnesses under ``tests/synthetic/`` do — need an availability
+check that accepts either real connection-verified credentials or an
+injected ``_backend`` object.  Centralising those helpers here avoids
+cross-tool imports (e.g. ``DataDogMonitorsTool`` reaching into
+``DataDogLogsTool`` to borrow a helper) and keeps the pattern consistent
+across integrations.
+"""
+
+from __future__ import annotations
+
+
+def eks_available_or_backend(sources: dict[str, dict]) -> bool:
+    """Available when real EKS credentials are present OR a fixture backend is injected.
+
+    Used by EKS tool wrappers whose ``extract_params`` can delegate to a
+    mock ``eks_backend`` for synthetic tests.  Tools without backend
+    support continue to use the narrower check in
+    ``app.tools.EKSListClustersTool._eks_available``.
+    """
+    eks = sources.get("eks", {})
+    return bool(eks.get("connection_verified") or eks.get("_backend"))
+
+
+def datadog_available_or_backend(sources: dict[str, dict]) -> bool:
+    """Available when real Datadog credentials are present OR a fixture backend is injected.
+
+    Used by Datadog tool wrappers whose ``extract_params`` can delegate
+    to a mock ``datadog_backend`` for synthetic tests.
+    """
+    dd = sources.get("datadog", {})
+    return bool(dd.get("connection_verified") or dd.get("_backend"))

--- a/tests/synthetic/eks/000-healthy/alert.json
+++ b/tests/synthetic/eks/000-healthy/alert.json
@@ -1,0 +1,26 @@
+{
+  "title": "[synthetic-k8s] Scheduled Health Check — payments-api",
+  "state": "normal",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesScheduledHealthCheck",
+    "severity": "info",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Periodic health check passed. All Kubernetes signals within normal operating bounds.",
+    "description": "Routine verification of pods, deployments, nodes, and application monitors for payments-api.",
+    "error": "",
+    "suspected_symptom": "None — workload is operating normally.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "k8s_failure_mode": "healthy",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/000-healthy/answer.yml
+++ b/tests/synthetic/eks/000-healthy/answer.yml
@@ -1,0 +1,21 @@
+root_cause_category: healthy
+required_keywords:
+  - normal
+  - no failure
+model_response: |
+  ROOT_CAUSE: The Kubernetes workload payments-api is operating within normal parameters. All three replicas of the deployment are Running and Ready with zero container restarts. No Warning events exist in the payments namespace, all nodes report Ready, and every Datadog monitor associated with the workload is in the OK state. Application logs show only routine informational messages with no errors. No anomaly detected.
+  ROOT_CAUSE_CATEGORY: healthy
+
+  VALIDATED_CLAIMS:
+  - All 3 pods of deployment payments-api are in Running phase with 0 restarts. [evidence: eks_pods]
+  - Deployment payments-api reports 3/3 replicas_ready and observed_generation matches generation. [evidence: eks_deployments]
+  - Both cluster nodes report Ready=true with no pressure conditions. [evidence: eks_node_health]
+  - No Warning events have been emitted in the payments namespace. [evidence: eks_events]
+  - Datadog monitors for payments-api latency and error rate are all in OK state. [evidence: datadog_monitors]
+  - Application logs contain only info-level messages, no errors, timeouts, or exceptions. [evidence: datadog_logs]
+
+  NON_VALIDATED_CLAIMS:
+  - The routine health check alert is scheduled and does not indicate any failure.
+
+  CAUSAL_CHAIN:
+  - Scheduled health check fired as a periodic verification. All telemetry signals are stable and within expected operating ranges. No root cause exists.

--- a/tests/synthetic/eks/000-healthy/datadog_logs.json
+++ b/tests/synthetic/eks/000-healthy/datadog_logs.json
@@ -1,0 +1,46 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-14T10:15:03Z",
+      "message": "[payments-api] Started HTTP server on :8080",
+      "status": "info",
+      "service": "payments-api",
+      "host": "ip-10-0-1-42.us-east-1.compute.internal",
+      "tags": [
+        "kube_namespace:payments",
+        "kube_deployment:payments-api",
+        "pod_name:payments-api-7f9dd8b6c4-x7gr9",
+        "env:prod",
+        "service:payments-api"
+      ]
+    },
+    {
+      "timestamp": "2026-04-14T10:16:12Z",
+      "message": "[payments-api] Processed 142 requests in the last minute, p95 latency 34ms",
+      "status": "info",
+      "service": "payments-api",
+      "host": "ip-10-0-1-42.us-east-1.compute.internal",
+      "tags": [
+        "kube_namespace:payments",
+        "kube_deployment:payments-api",
+        "pod_name:payments-api-7f9dd8b6c4-x7gr9",
+        "env:prod",
+        "service:payments-api"
+      ]
+    },
+    {
+      "timestamp": "2026-04-14T10:17:45Z",
+      "message": "[payments-api] Heartbeat OK, connection pool at 12/100",
+      "status": "info",
+      "service": "payments-api",
+      "host": "ip-10-0-1-73.us-east-1.compute.internal",
+      "tags": [
+        "kube_namespace:payments",
+        "kube_deployment:payments-api",
+        "pod_name:payments-api-7f9dd8b6c4-k2m4p",
+        "env:prod",
+        "service:payments-api"
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/000-healthy/datadog_monitors.json
+++ b/tests/synthetic/eks/000-healthy/datadog_monitors.json
@@ -1,0 +1,28 @@
+{
+  "monitors": [
+    {
+      "name": "[payments] API Latency p95",
+      "type": "metric alert",
+      "query": "avg(last_5m):p95:trace.http.request.duration{service:payments-api} > 0.5",
+      "message": "payments-api p95 latency is elevated. Investigate downstream database and cache.",
+      "overall_state": "OK",
+      "tags": [
+        "env:prod",
+        "service:payments-api",
+        "managed_by:platform"
+      ]
+    },
+    {
+      "name": "[payments] API Error Rate",
+      "type": "metric alert",
+      "query": "sum(last_5m):sum:trace.http.request.errors{service:payments-api}.as_count() / sum:trace.http.request.hits{service:payments-api}.as_count() > 0.02",
+      "message": "payments-api error rate exceeded 2%. Check recent deploys and error logs.",
+      "overall_state": "OK",
+      "tags": [
+        "env:prod",
+        "service:payments-api",
+        "managed_by:platform"
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/000-healthy/eks_deployments.json
+++ b/tests/synthetic/eks/000-healthy/eks_deployments.json
@@ -1,0 +1,12 @@
+{
+  "deployments": [
+    {
+      "name": "payments-api",
+      "namespace": "payments",
+      "desired": 3,
+      "ready": 3,
+      "available": 3,
+      "unavailable": 0
+    }
+  ]
+}

--- a/tests/synthetic/eks/000-healthy/eks_events.json
+++ b/tests/synthetic/eks/000-healthy/eks_events.json
@@ -1,0 +1,3 @@
+{
+  "warning_events": []
+}

--- a/tests/synthetic/eks/000-healthy/eks_node_health.json
+++ b/tests/synthetic/eks/000-healthy/eks_node_health.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.42",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16276604Ki",
+      "allocatable_cpu": "3920m",
+      "allocatable_memory": "15321276Ki",
+      "instance_type": "m6i.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.73",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16276604Ki",
+      "allocatable_cpu": "3920m",
+      "allocatable_memory": "15321276Ki",
+      "instance_type": "m6i.xlarge"
+    }
+  ]
+}

--- a/tests/synthetic/eks/000-healthy/eks_pods.json
+++ b/tests/synthetic/eks/000-healthy/eks_pods.json
@@ -1,0 +1,76 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": true,
+          "restart_count": 0,
+          "state": {
+            "running": true,
+            "started_at": "2026-04-13T14:02:19Z"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:14Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": true,
+          "restart_count": 0,
+          "state": {
+            "running": true,
+            "started_at": "2026-04-13T14:02:22Z"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-9bvlq",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:17Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": true,
+          "restart_count": 0,
+          "state": {
+            "running": true,
+            "started_at": "2026-04-13T14:02:25Z"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/000-healthy/scenario.yml
+++ b/tests/synthetic/eks/000-healthy/scenario.yml
@@ -1,0 +1,18 @@
+schema_version: "1.0"
+scenario_id: 000-healthy
+engine: eks
+cluster_name: payments-prod-eks
+namespace: payments
+workload_type: deployment
+workload_name: payments-api
+region: us-east-1
+failure_mode: healthy
+severity: info
+scenario_difficulty: 0
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/__init__.py
+++ b/tests/synthetic/eks/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic Kubernetes RCA benchmark suite."""

--- a/tests/synthetic/eks/run_suite.py
+++ b/tests/synthetic/eks/run_suite.py
@@ -30,13 +30,16 @@ _EVIDENCE_KEY_MAP: dict[str, str] = {
 
 @dataclass(frozen=True)
 class TrajectoryScore:
-    actual_sequence: list[str]
-    expected_sequence: list[str]
+    actual_sequence: list[str]    # flattened actions from executed_hypotheses
+    expected_sequence: list[str]  # from answer_key.optimal_trajectory
     loops_used: int
     max_loops: int
+    # Set-membership check: every expected action appears somewhere in actual.
+    # Ordering is intentionally not enforced — actions execute in parallel and
+    # completion order is non-deterministic.
     sequencing_ok: bool
-    calibration_ok: bool
-    efficiency_score: float
+    calibration_ok: bool           # loops_used <= max_loops
+    efficiency_score: float        # mean(sequencing_ok, calibration_ok)
 
 
 @dataclass(frozen=True)
@@ -179,6 +182,10 @@ def score_trajectory(
         final_state.get("investigation_loop_count") or len(executed_hypotheses)
     )
 
+    # Every expected action must appear somewhere in actual_sequence.  The check
+    # is set-membership, not positional: when a real LLM skips a required action
+    # entirely, this flips to False.  See the TrajectoryScore docstring above for
+    # the rationale for ignoring order.
     sequencing_ok = set(expected) <= set(actual_sequence)
     calibration_ok = loops_used <= max_loops
     efficiency_score = (int(sequencing_ok) + int(calibration_ok)) / 2.0

--- a/tests/synthetic/eks/run_suite.py
+++ b/tests/synthetic/eks/run_suite.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from app.pipeline.runners import run_investigation
+from tests.synthetic.eks.scenario_loader import (
+    SUITE_DIR,
+    K8sScenarioFixture,
+    load_all_scenarios,
+)
+from tests.synthetic.mock_datadog_backend.backend import FixtureDatadogBackend
+from tests.synthetic.mock_eks_backend.backend import FixtureEKSBackend
+
+# Maps fixture schema evidence keys to the agent's internal state keys.
+# Kept identity for the initial harness drop; refine as scenarios #261+ land
+# and we learn which state keys the K8s pipeline actually populates.
+_EVIDENCE_KEY_MAP: dict[str, str] = {
+    "eks_pods": "eks_pods",
+    "eks_events": "eks_events",
+    "eks_deployments": "eks_deployments",
+    "eks_node_health": "eks_node_health",
+    "eks_pod_logs": "eks_pod_logs",
+    "datadog_logs": "datadog_logs",
+    "datadog_monitors": "datadog_monitors",
+}
+
+
+@dataclass(frozen=True)
+class TrajectoryScore:
+    actual_sequence: list[str]
+    expected_sequence: list[str]
+    loops_used: int
+    max_loops: int
+    sequencing_ok: bool
+    calibration_ok: bool
+    efficiency_score: float
+
+
+@dataclass(frozen=True)
+class ReasoningScore:
+    """Axis 2 adversarial reasoning quality score.
+
+    ruling_out_ok: every ruling_out_keywords token was found in agent output.
+    queries_ok: every required_queries token was requested via a tool call.
+    reasoning_score: mean(ruling_out_ok, queries_ok); 1.0 = full pass.
+    """
+
+    ruling_out_ok: bool
+    queries_ok: bool
+    missing_ruling_out: list[str]
+    missing_queries: list[str]
+    reasoning_score: float
+
+
+@dataclass(frozen=True)
+class ScenarioScore:
+    scenario_id: str
+    passed: bool
+    root_cause_present: bool
+    expected_category: str
+    actual_category: str
+    missing_keywords: list[str]
+    matched_keywords: list[str]
+    root_cause: str
+    failure_reason: str = ""
+    trajectory: TrajectoryScore | None = None
+    reasoning: ReasoningScore | None = None
+
+
+@dataclass(frozen=True)
+class ResolvedBackends:
+    """Container for pre-built backends passed into ``run_scenario``."""
+
+    eks: Any = None
+    datadog: Any = None
+    queried_tools: list[str] = field(default_factory=list)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the synthetic Kubernetes RCA suite.")
+    parser.add_argument(
+        "--scenario",
+        default="",
+        help="Run a single scenario directory name, e.g. 000-healthy.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON results.",
+    )
+    parser.add_argument(
+        "--mock-backends",
+        action="store_true",
+        dest="mock_backends",
+        help="Serve fixture data via FixtureEKSBackend + FixtureDatadogBackend "
+        "instead of real EKS/Datadog calls.",
+    )
+    return parser.parse_args(argv)
+
+
+def _build_resolved_integrations(
+    fixture: K8sScenarioFixture,
+    use_mock_backends: bool,
+    eks_backend: Any = None,
+    datadog_backend: Any = None,
+) -> dict[str, Any] | None:
+    """Build pre-resolved integrations to inject into run_investigation.
+
+    Accepts optional pre-built backends so callers can instrument them
+    (e.g. SelectiveEKSBackend for Axis 2) before injection.  Falls back to
+    fresh fixture-backed backends when use_mock_backends=True and no backend
+    is provided.
+
+    EKS integrations live under the ``aws`` key (not ``eks``) because
+    ``detect_sources`` reads the raw integration dict from
+    ``resolved_integrations["aws"]`` and then emits a derived
+    ``sources["eks"]`` that the EKS tools consume.  The injected ``_backend``
+    propagates through that transform.
+    """
+    if not use_mock_backends and eks_backend is None and datadog_backend is None:
+        return None
+
+    resolved_eks = eks_backend
+    if resolved_eks is None and use_mock_backends:
+        resolved_eks = FixtureEKSBackend(fixture)
+
+    resolved_datadog = datadog_backend
+    if resolved_datadog is None and use_mock_backends:
+        resolved_datadog = FixtureDatadogBackend(fixture)
+
+    integrations: dict[str, Any] = {}
+    if resolved_eks is not None:
+        integrations["aws"] = {
+            "role_arn": "",
+            "external_id": "",
+            "region": fixture.metadata.region,
+            "cluster_names": [fixture.metadata.cluster_name],
+            "_backend": resolved_eks,
+        }
+    if resolved_datadog is not None:
+        integrations["datadog"] = {
+            "api_key": "",
+            "app_key": "",
+            "site": "datadoghq.com",
+            "_backend": resolved_datadog,
+        }
+
+    return integrations or None
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.lower().split())
+
+
+def score_trajectory(
+    fixture: K8sScenarioFixture,
+    final_state: dict[str, Any],
+) -> TrajectoryScore | None:
+    """Score the agent's investigation trajectory against the expected sequence.
+
+    Returns None when no optimal_trajectory is declared for the scenario.
+    """
+    expected = list(fixture.answer_key.optimal_trajectory)
+    if not expected:
+        return None
+
+    max_loops = fixture.answer_key.max_investigation_loops
+
+    executed_hypotheses: list[dict[str, Any]] = final_state.get("executed_hypotheses") or []
+    actual_sequence: list[str] = []
+    for hyp in executed_hypotheses:
+        for action in hyp.get("actions", []):
+            actual_sequence.append(action)
+
+    loops_used: int = int(
+        final_state.get("investigation_loop_count") or len(executed_hypotheses)
+    )
+
+    sequencing_ok = set(expected) <= set(actual_sequence)
+    calibration_ok = loops_used <= max_loops
+    efficiency_score = (int(sequencing_ok) + int(calibration_ok)) / 2.0
+
+    return TrajectoryScore(
+        actual_sequence=actual_sequence,
+        expected_sequence=expected,
+        loops_used=loops_used,
+        max_loops=max_loops,
+        sequencing_ok=sequencing_ok,
+        calibration_ok=calibration_ok,
+        efficiency_score=efficiency_score,
+    )
+
+
+def score_reasoning(
+    fixture: K8sScenarioFixture,
+    final_state: dict[str, Any],
+    queried_tools: list[str] | None = None,
+) -> ReasoningScore | None:
+    """Score Axis 2 adversarial reasoning quality.
+
+    Returns None when neither ruling_out_keywords nor required_queries are
+    declared for the scenario.
+
+    Args:
+        fixture: The scenario fixture containing the answer key.
+        final_state: The agent's final investigation state dict.
+        queried_tools: List of tool identifiers the agent invoked (from
+            SelectiveEKSBackend.queried_tools and
+            SelectiveDatadogBackend.queried_tools).  Pass None or [] when the
+            backends do not record queries (Axis 1).
+    """
+    has_ruling_out = bool(fixture.answer_key.ruling_out_keywords)
+    has_required_queries = bool(fixture.answer_key.required_queries)
+    if not has_ruling_out and not has_required_queries:
+        return None
+
+    evidence_text = " ".join(
+        [
+            str(final_state.get("root_cause") or ""),
+            " ".join(
+                claim.get("claim", "") for claim in final_state.get("validated_claims", [])
+            ),
+            " ".join(
+                claim.get("claim", "") for claim in final_state.get("non_validated_claims", [])
+            ),
+            " ".join(final_state.get("causal_chain", [])),
+        ]
+    )
+    normalized_output = _normalize_text(evidence_text)
+
+    missing_ruling_out: list[str] = []
+    if has_ruling_out:
+        for token in fixture.answer_key.ruling_out_keywords:
+            if token.lower() not in normalized_output:
+                missing_ruling_out.append(token)
+
+    missing_queries: list[str] = []
+    if has_required_queries:
+        audited = queried_tools or []
+        for required in fixture.answer_key.required_queries:
+            token = required.lower()
+            if not any(token in q.lower() for q in audited):
+                missing_queries.append(required)
+
+    ruling_out_ok = not missing_ruling_out
+    queries_ok = not missing_queries
+    reasoning_score = (int(ruling_out_ok) + int(queries_ok)) / 2.0
+
+    return ReasoningScore(
+        ruling_out_ok=ruling_out_ok,
+        queries_ok=queries_ok,
+        missing_ruling_out=missing_ruling_out,
+        missing_queries=missing_queries,
+        reasoning_score=reasoning_score,
+    )
+
+
+def score_result(
+    fixture: K8sScenarioFixture,
+    final_state: dict[str, Any],
+    queried_tools: list[str] | None = None,
+) -> ScenarioScore:
+    root_cause = str(final_state.get("root_cause") or "").strip()
+    actual_category = str(final_state.get("root_cause_category") or "unknown").strip()
+    root_cause_present = bool(
+        root_cause and root_cause.lower() != "unable to determine root cause"
+    )
+
+    evidence_text = " ".join(
+        [
+            root_cause,
+            " ".join(
+                claim.get("claim", "") for claim in final_state.get("validated_claims", [])
+            ),
+            " ".join(
+                claim.get("claim", "") for claim in final_state.get("non_validated_claims", [])
+            ),
+            " ".join(final_state.get("causal_chain", [])),
+        ]
+    )
+    normalized_output = _normalize_text(evidence_text)
+
+    matched_keywords = [
+        keyword
+        for keyword in fixture.answer_key.required_keywords
+        if _normalize_text(keyword) in normalized_output
+    ]
+    missing_keywords = [
+        keyword
+        for keyword in fixture.answer_key.required_keywords
+        if keyword not in matched_keywords
+    ]
+
+    answer_key = fixture.answer_key
+    failure_reason = ""
+
+    if not root_cause_present:
+        failure_reason = "no root cause in output"
+    elif actual_category != answer_key.root_cause_category:
+        failure_reason = (
+            f"wrong category: got {actual_category!r}, "
+            f"expected {answer_key.root_cause_category!r}"
+        )
+    elif missing_keywords:
+        failure_reason = f"missing required keywords: {missing_keywords}"
+    elif answer_key.forbidden_categories and actual_category in answer_key.forbidden_categories:
+        failure_reason = f"forbidden category in output: {actual_category!r}"
+    elif answer_key.forbidden_keywords:
+        forbidden_hits = [
+            kw
+            for kw in answer_key.forbidden_keywords
+            if _normalize_text(kw) in normalized_output
+        ]
+        if forbidden_hits:
+            failure_reason = f"forbidden keywords in output: {forbidden_hits}"
+
+    if not failure_reason and answer_key.required_evidence_sources:
+        evidence = final_state.get("evidence") or {}
+        for source_key in answer_key.required_evidence_sources:
+            state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
+            if not evidence.get(state_key):
+                failure_reason = f"required evidence not gathered: {source_key!r}"
+                break
+
+    passed = not failure_reason
+    trajectory = score_trajectory(fixture, final_state)
+    reasoning = score_reasoning(fixture, final_state, queried_tools)
+    return ScenarioScore(
+        scenario_id=fixture.scenario_id,
+        passed=passed,
+        root_cause_present=root_cause_present,
+        expected_category=fixture.answer_key.root_cause_category,
+        actual_category=actual_category,
+        missing_keywords=missing_keywords,
+        matched_keywords=matched_keywords,
+        root_cause=root_cause,
+        failure_reason=failure_reason,
+        trajectory=trajectory,
+        reasoning=reasoning,
+    )
+
+
+def _collect_queried_tools(eks_backend: Any, datadog_backend: Any) -> list[str]:
+    """Collect audit-log entries from any Selective* backends that were injected."""
+    tools: list[str] = []
+    if eks_backend is not None and hasattr(eks_backend, "queried_tools"):
+        tools.extend(list(eks_backend.queried_tools))
+    if datadog_backend is not None and hasattr(datadog_backend, "queried_tools"):
+        tools.extend(list(datadog_backend.queried_tools))
+    return tools
+
+
+def run_scenario(
+    fixture: K8sScenarioFixture,
+    use_mock_backends: bool = False,
+    eks_backend: Any = None,
+    datadog_backend: Any = None,
+) -> tuple[dict[str, Any], ScenarioScore]:
+    alert = fixture.alert
+    labels = alert.get("commonLabels", {}) or {}
+
+    alert_name = str(alert.get("title") or labels.get("alertname") or fixture.scenario_id)
+    pipeline_name = str(labels.get("pipeline_name") or "k8s-eks-synthetic")
+    severity = str(labels.get("severity") or "critical")
+
+    resolved_integrations = _build_resolved_integrations(
+        fixture,
+        use_mock_backends,
+        eks_backend=eks_backend,
+        datadog_backend=datadog_backend,
+    )
+
+    final_state = run_investigation(
+        alert_name=alert_name,
+        pipeline_name=pipeline_name,
+        severity=severity,
+        raw_alert=alert,
+        resolved_integrations=resolved_integrations,
+    )
+    state_dict = dict(final_state)
+
+    queried_tools = _collect_queried_tools(eks_backend, datadog_backend)
+    return state_dict, score_result(fixture, state_dict, queried_tools=queried_tools)
+
+
+def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
+    args = parse_args(argv)
+    fixtures = load_all_scenarios(SUITE_DIR)
+    if args.scenario:
+        fixtures = [fixture for fixture in fixtures if fixture.scenario_id == args.scenario]
+        if not fixtures:
+            raise SystemExit(f"Unknown scenario: {args.scenario}")
+
+    results: list[ScenarioScore] = []
+    for fixture in fixtures:
+        _, score = run_scenario(fixture, use_mock_backends=args.mock_backends)
+        results.append(score)
+
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], indent=2))
+    else:
+        for result in results:
+            status = "PASS" if result.passed else "FAIL"
+            detail = (
+                f"reason={result.failure_reason!r}"
+                if result.failure_reason
+                else f"category={result.actual_category}"
+            )
+            print(f"{status} {result.scenario_id} {detail}")
+
+        passed_count = sum(1 for result in results if result.passed)
+        print(f"\nResults: {passed_count}/{len(results)} passed")
+
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    results = run_suite(argv)
+    return 0 if all(result.passed for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/synthetic/eks/scenario_loader.py
+++ b/tests/synthetic/eks/scenario_loader.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from tests.synthetic.k8s_schemas import (
+    K8sScenarioEvidence,
+    K8sScenarioMetadataSchema,
+    validate_datadog_logs,
+    validate_datadog_monitors,
+    validate_eks_deployments,
+    validate_eks_events,
+    validate_eks_node_health,
+    validate_eks_pod_logs,
+    validate_eks_pods,
+    validate_k8s_alert,
+    validate_k8s_answer_key,
+    validate_k8s_scenario_metadata,
+)
+
+SUITE_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class K8sScenarioMetadata:
+    schema_version: str
+    scenario_id: str
+    engine: str
+    cluster_name: str
+    namespace: str
+    workload_type: str
+    workload_name: str
+    region: str
+    failure_mode: str
+    severity: str
+    available_evidence: list[str]
+    scenario_difficulty: int = 1
+    adversarial_signals: list[str] = field(default_factory=list)
+    depends_on: str = ""
+
+
+@dataclass(frozen=True)
+class K8sScenarioAnswerKey:
+    root_cause_category: str
+    required_keywords: list[str]
+    model_response: str
+    forbidden_categories: list[str] = field(default_factory=list)
+    forbidden_keywords: list[str] = field(default_factory=list)
+    required_evidence_sources: list[str] = field(default_factory=list)
+    optimal_trajectory: list[str] = field(default_factory=list)
+    max_investigation_loops: int = 1
+    ruling_out_keywords: list[str] = field(default_factory=list)
+    required_queries: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class K8sScenarioFixture:
+    scenario_id: str
+    scenario_dir: Path
+    alert: dict[str, Any]
+    evidence: K8sScenarioEvidence
+    metadata: K8sScenarioMetadata
+    answer_key: K8sScenarioAnswerKey
+    problem_md: str
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected YAML object in {path}")
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Base-inheritance helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_base_dir(suite_dir: Path, base_id: str) -> Path:
+    """Find the base scenario directory by its directory name (e.g. '000-healthy')."""
+    base_dir = suite_dir / base_id
+    if not base_dir.is_dir():
+        raise ValueError(f"Base scenario '{base_id}' not found at {base_dir}")
+    base_raw = _read_yaml(base_dir / "scenario.yml")
+    if "base" in base_raw:
+        raise ValueError(
+            f"Chained inheritance is not supported: base scenario '{base_id}' "
+            f"itself declares base '{base_raw['base']}'"
+        )
+    return base_dir
+
+
+def _merge_scenario_yaml(
+    base_raw: dict[str, Any], scenario_raw: dict[str, Any]
+) -> dict[str, Any]:
+    """Shallow-merge scenario overrides on top of base metadata.
+
+    scenario_raw values win. The ``base`` directive is consumed and removed.
+    """
+    merged = {**base_raw, **{k: v for k, v in scenario_raw.items() if k != "base"}}
+    merged.pop("base", None)
+    return merged
+
+
+def _resolve_evidence_path(
+    scenario_dir: Path, base_dir: Path | None, filename: str
+) -> Path:
+    """Return the scenario's own evidence file if it exists, otherwise the base's."""
+    for search_dir in (scenario_dir, base_dir):
+        if search_dir is None:
+            continue
+        candidate = search_dir / filename
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"Evidence '{filename}' not found in {scenario_dir}"
+        + (f" or base {base_dir}" if base_dir else "")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _validated_metadata(raw: dict[str, Any]) -> K8sScenarioMetadata:
+    """Validate a (possibly merged) raw dict and return a K8sScenarioMetadata."""
+    validated: K8sScenarioMetadataSchema = validate_k8s_scenario_metadata(raw)
+    return K8sScenarioMetadata(
+        schema_version=validated["schema_version"],
+        scenario_id=validated["scenario_id"],
+        engine=validated["engine"],
+        cluster_name=validated["cluster_name"],
+        namespace=validated["namespace"],
+        workload_type=validated["workload_type"],
+        workload_name=validated["workload_name"],
+        region=validated["region"],
+        failure_mode=validated["failure_mode"],
+        severity=validated["severity"],
+        available_evidence=list(validated["available_evidence"]),
+        scenario_difficulty=validated.get("scenario_difficulty", 1),  # type: ignore[arg-type]
+        adversarial_signals=list(validated.get("adversarial_signals") or []),
+        depends_on=validated.get("depends_on", ""),  # type: ignore[arg-type]
+    )
+
+
+def _parse_scenario_yaml(path: Path) -> tuple[K8sScenarioMetadata, Path | None]:
+    """Parse scenario.yml, resolving base inheritance if declared.
+
+    Returns (metadata, base_dir) where base_dir is the resolved base scenario
+    directory, or None if no ``base`` field was declared.
+    """
+    raw = _read_yaml(path)
+    base_id = raw.get("base")
+    base_dir: Path | None = None
+
+    if base_id:
+        suite_dir = path.parent.parent
+        base_dir = _resolve_base_dir(suite_dir, base_id)
+        base_raw = _read_yaml(base_dir / "scenario.yml")
+        raw = _merge_scenario_yaml(base_raw, raw)
+
+    return _validated_metadata(raw), base_dir
+
+
+def _parse_answer_yaml(path: Path) -> K8sScenarioAnswerKey:
+    payload = _read_yaml(path)
+    validated = validate_k8s_answer_key(payload)
+    return K8sScenarioAnswerKey(
+        root_cause_category=validated["root_cause_category"].strip(),
+        required_keywords=[k.strip() for k in validated["required_keywords"]],
+        model_response=validated["model_response"].strip(),
+        forbidden_categories=list(validated.get("forbidden_categories") or []),
+        forbidden_keywords=list(validated.get("forbidden_keywords") or []),
+        required_evidence_sources=list(validated.get("required_evidence_sources") or []),
+        optimal_trajectory=list(validated.get("optimal_trajectory") or []),
+        max_investigation_loops=int(validated.get("max_investigation_loops") or 1),
+        ruling_out_keywords=list(validated.get("ruling_out_keywords") or []),
+        required_queries=list(validated.get("required_queries") or []),
+    )
+
+
+def _build_problem_md(alert: dict[str, Any], metadata: K8sScenarioMetadata) -> str:
+    title = str(alert.get("title") or metadata.scenario_id)
+    annotations = alert.get("commonAnnotations", {}) or {}
+
+    parts = [
+        f"# {title}",
+        (
+            f"Platform: {metadata.engine.upper()}"
+            f" | Severity: {metadata.severity}"
+            f" | Scenario: {metadata.failure_mode}"
+        ),
+        f"Scenario ID: {metadata.scenario_id}",
+        f"Cluster: {metadata.cluster_name}",
+        f"Namespace: {metadata.namespace}",
+        f"Workload: {metadata.workload_type}/{metadata.workload_name}",
+    ]
+
+    summary = annotations.get("summary")
+    if summary:
+        parts.append(f"\nSummary: {summary}")
+
+    description = annotations.get("description")
+    if description and description != summary:
+        parts.append(f"\nDescription: {description}")
+
+    suspected = annotations.get("suspected_symptom")
+    if suspected:
+        parts.append(f"\nObserved symptom: {suspected}")
+
+    return "\n".join(parts)
+
+
+def _build_evidence(
+    scenario_dir: Path,
+    available_evidence: list[str],
+    base_dir: Path | None = None,
+) -> K8sScenarioEvidence:
+    """Load only the evidence sources declared in scenario.yml:available_evidence.
+
+    When *base_dir* is set, evidence files missing from *scenario_dir* are
+    resolved from the base scenario directory (file-level fallback).
+    """
+    eks_pods = None
+    eks_events = None
+    eks_deployments = None
+    eks_node_health = None
+    eks_pod_logs = None
+    datadog_logs = None
+    datadog_monitors = None
+
+    if "eks_pods" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "eks_pods.json")
+        eks_pods = validate_eks_pods(_read_json(path))
+
+    if "eks_events" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "eks_events.json")
+        eks_events = validate_eks_events(_read_json(path))
+
+    if "eks_deployments" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "eks_deployments.json")
+        eks_deployments = validate_eks_deployments(_read_json(path))
+
+    if "eks_node_health" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "eks_node_health.json")
+        eks_node_health = validate_eks_node_health(_read_json(path))
+
+    if "eks_pod_logs" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "eks_pod_logs.json")
+        eks_pod_logs = validate_eks_pod_logs(_read_json(path))
+
+    if "datadog_logs" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "datadog_logs.json")
+        datadog_logs = validate_datadog_logs(_read_json(path))
+
+    if "datadog_monitors" in available_evidence:
+        path = _resolve_evidence_path(scenario_dir, base_dir, "datadog_monitors.json")
+        datadog_monitors = validate_datadog_monitors(_read_json(path))
+
+    return K8sScenarioEvidence(
+        eks_pods=eks_pods,
+        eks_events=eks_events,
+        eks_deployments=eks_deployments,
+        eks_node_health=eks_node_health,
+        eks_pod_logs=eks_pod_logs,
+        datadog_logs=datadog_logs,
+        datadog_monitors=datadog_monitors,
+    )
+
+
+def load_scenario(scenario_dir: Path) -> K8sScenarioFixture:
+    metadata, base_dir = _parse_scenario_yaml(scenario_dir / "scenario.yml")
+
+    alert_path = _resolve_evidence_path(scenario_dir, base_dir, "alert.json")
+    alert = cast(dict[str, Any], validate_k8s_alert(_read_json(alert_path)))
+
+    evidence = _build_evidence(scenario_dir, metadata.available_evidence, base_dir)
+    answer_key = _parse_answer_yaml(scenario_dir / "answer.yml")
+    problem_md = _build_problem_md(alert, metadata)
+
+    return K8sScenarioFixture(
+        scenario_id=scenario_dir.name,
+        scenario_dir=scenario_dir,
+        alert=alert,
+        evidence=evidence,
+        metadata=metadata,
+        answer_key=answer_key,
+        problem_md=problem_md,
+    )
+
+
+def load_all_scenarios(root_dir: Path | None = None) -> list[K8sScenarioFixture]:
+    base_dir = root_dir or SUITE_DIR
+    scenario_dirs = sorted(
+        path for path in base_dir.iterdir() if path.is_dir() and path.name[:3].isdigit()
+    )
+    return [load_scenario(path) for path in scenario_dirs]

--- a/tests/synthetic/eks/test_suite.py
+++ b/tests/synthetic/eks/test_suite.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.nodes.plan_actions.node import InvestigationPlan
+from tests.synthetic.eks.run_suite import run_scenario, score_result
+from tests.synthetic.eks.scenario_loader import (
+    SUITE_DIR,
+    load_all_scenarios,
+    load_scenario,
+)
+from tests.synthetic.k8s_schemas import VALID_K8S_EVIDENCE_SOURCES
+from tests.synthetic.mock_datadog_backend.backend import FixtureDatadogBackend
+from tests.synthetic.mock_eks_backend.backend import FixtureEKSBackend
+
+# ---------------------------------------------------------------------------
+# Loader and fixture validation
+# ---------------------------------------------------------------------------
+
+
+def test_load_all_scenarios_reads_benchmark_cases() -> None:
+    fixtures = load_all_scenarios()
+
+    scenario_ids = [fixture.scenario_id for fixture in fixtures]
+    assert "000-healthy" in scenario_ids
+
+
+def test_scenario_metadata_is_valid() -> None:
+    fixtures = load_all_scenarios()
+
+    for fixture in fixtures:
+        meta = fixture.metadata
+        assert meta.schema_version, f"{fixture.scenario_id}: schema_version must be set"
+        assert meta.engine, f"{fixture.scenario_id}: engine must be set"
+        assert meta.cluster_name, f"{fixture.scenario_id}: cluster_name must be set"
+        assert meta.namespace, f"{fixture.scenario_id}: namespace must be set"
+        assert meta.workload_type, f"{fixture.scenario_id}: workload_type must be set"
+        assert meta.workload_name, f"{fixture.scenario_id}: workload_name must be set"
+        assert meta.failure_mode, f"{fixture.scenario_id}: failure_mode must be set"
+        assert meta.region, f"{fixture.scenario_id}: region must be set"
+        assert meta.available_evidence, (
+            f"{fixture.scenario_id}: available_evidence must not be empty"
+        )
+        unknown = set(meta.available_evidence) - VALID_K8S_EVIDENCE_SOURCES
+        assert not unknown, f"{fixture.scenario_id}: unknown evidence sources {unknown}"
+
+
+def test_scenario_evidence_matches_available_evidence() -> None:
+    fixtures = load_all_scenarios()
+
+    for fixture in fixtures:
+        evidence_dict = fixture.evidence.as_dict()
+        assert set(evidence_dict.keys()) == set(fixture.metadata.available_evidence), (
+            f"{fixture.scenario_id}: evidence keys {set(evidence_dict.keys())} "
+            f"do not match available_evidence {fixture.metadata.available_evidence}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mock backend shape tests
+# ---------------------------------------------------------------------------
+
+
+class TestMockBackendShapes:
+    """Verify each mock backend method returns the exact envelope the real tool would."""
+
+    @pytest.fixture
+    def placeholder(self):
+        return load_scenario(SUITE_DIR / "000-healthy")
+
+    def test_eks_list_pods_shape(self, placeholder) -> None:
+        backend = FixtureEKSBackend(placeholder)
+        result = backend.list_pods(cluster_name="override", namespace="override-ns")
+        assert result["source"] == "eks"
+        assert result["available"] is True
+        assert result["error"] is None
+        assert "total_pods" in result
+        assert "pods" in result
+        assert "failing_pods" in result
+        assert "high_restart_pods" in result
+        assert result["cluster_name"] == "override"
+        assert result["namespace"] == "override-ns"
+
+    def test_eks_list_pods_falls_back_to_metadata(self, placeholder) -> None:
+        backend = FixtureEKSBackend(placeholder)
+        result = backend.list_pods()
+        assert result["cluster_name"] == placeholder.metadata.cluster_name
+        assert result["namespace"] == placeholder.metadata.namespace
+
+    def test_eks_get_events_shape(self, placeholder) -> None:
+        backend = FixtureEKSBackend(placeholder)
+        result = backend.get_events()
+        assert result["source"] == "eks"
+        assert result["available"] is True
+        assert result["error"] is None
+        assert "warning_events" in result
+        assert "total_warning_count" in result
+        assert result["total_warning_count"] == len(result["warning_events"])
+
+    def test_eks_list_deployments_shape(self, placeholder) -> None:
+        backend = FixtureEKSBackend(placeholder)
+        result = backend.list_deployments()
+        assert result["source"] == "eks"
+        assert result["available"] is True
+        assert "deployments" in result
+        assert "degraded_deployments" in result
+        assert "total_deployments" in result
+        for deployment in result["deployments"]:
+            for field in ("name", "namespace", "desired", "ready", "available", "unavailable", "degraded"):
+                assert field in deployment, f"missing field {field}"
+
+    def test_eks_node_health_shape(self, placeholder) -> None:
+        backend = FixtureEKSBackend(placeholder)
+        result = backend.get_node_health()
+        assert result["source"] == "eks"
+        assert result["available"] is True
+        assert "nodes" in result
+        assert "not_ready_count" in result
+        assert "total_nodes" in result
+        assert result["not_ready_count"] == 0
+
+    def test_eks_missing_evidence_raises(self, placeholder) -> None:
+        """Calling a method whose evidence source wasn't declared raises ValueError."""
+        backend = FixtureEKSBackend(placeholder)
+        # The placeholder deliberately omits eks_pod_logs; calling get_pod_logs must fail.
+        assert "eks_pod_logs" not in placeholder.metadata.available_evidence
+        with pytest.raises(ValueError, match="eks_pod_logs"):
+            backend.get_pod_logs(pod_name="payments-api-7f9dd-x7gr9")
+
+    def test_datadog_query_logs_shape(self, placeholder) -> None:
+        backend = FixtureDatadogBackend(placeholder)
+        result = backend.query_logs(query="service:payments-api")
+        assert result["source"] == "datadog_logs"
+        assert result["available"] is True
+        assert "logs" in result
+        assert "error_logs" in result
+        assert result["query"] == "service:payments-api"
+
+    def test_datadog_query_monitors_shape(self, placeholder) -> None:
+        backend = FixtureDatadogBackend(placeholder)
+        result = backend.query_monitors()
+        assert result["source"] == "datadog_monitors"
+        assert result["available"] is True
+        assert "monitors" in result
+        assert "total" in result
+
+
+# ---------------------------------------------------------------------------
+# Scorer unit tests (no agent run required)
+# ---------------------------------------------------------------------------
+
+
+class TestScorer:
+    """Feed canned final_state dicts into the scorer and verify the result."""
+
+    @pytest.fixture
+    def placeholder(self):
+        return load_scenario(SUITE_DIR / "000-healthy")
+
+    def test_matching_root_cause_passes(self, placeholder) -> None:
+        final_state = {
+            "root_cause": "The Kubernetes workload is operating within normal parameters. "
+            "No failure detected across pods, events, deployments, or monitors.",
+            "root_cause_category": "healthy",
+            "validated_claims": [],
+            "non_validated_claims": [],
+            "causal_chain": [],
+            "evidence": {},
+            "executed_hypotheses": [],
+            "investigation_loop_count": 0,
+        }
+        score = score_result(placeholder, final_state)
+        assert score.passed is True, score.failure_reason
+        assert score.actual_category == "healthy"
+        assert not score.missing_keywords
+
+    def test_wrong_category_fails(self, placeholder) -> None:
+        final_state = {
+            "root_cause": "Some narrative.",
+            "root_cause_category": "crashloop_backoff",
+            "validated_claims": [],
+            "non_validated_claims": [],
+            "causal_chain": [],
+            "evidence": {},
+            "executed_hypotheses": [],
+            "investigation_loop_count": 0,
+        }
+        score = score_result(placeholder, final_state)
+        assert score.passed is False
+        assert "wrong category" in score.failure_reason
+
+    def test_missing_keyword_fails(self, placeholder) -> None:
+        final_state = {
+            "root_cause": "nothing important to report",
+            "root_cause_category": "healthy",
+            "validated_claims": [],
+            "non_validated_claims": [],
+            "causal_chain": [],
+            "evidence": {},
+            "executed_hypotheses": [],
+            "investigation_loop_count": 0,
+        }
+        score = score_result(placeholder, final_state)
+        assert score.passed is False
+        assert "missing required keywords" in score.failure_reason
+
+
+# ---------------------------------------------------------------------------
+# End-to-end harness smoke test — runs the full pipeline with mocked planner
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessEndToEnd:
+    """Drive the full ``run_investigation`` pipeline against 000-healthy.
+
+    The LLM planner is monkey-patched with a canned :class:`InvestigationPlan`
+    pointing at the 6 EKS + Datadog tools the placeholder declares.  Everything
+    else runs for real: ``detect_sources`` picks up the injected ``_backend``,
+    the tool executor invokes each action, and each wired EKS / Datadog tool
+    short-circuits to its fixture backend.  The ``diagnose_root_cause`` healthy
+    short-circuit then produces a deterministic final state without calling
+    the reasoning LLM.
+
+    This test proves the harness wiring end-to-end without requiring an
+    Anthropic / OpenAI API key.
+
+    **Scope note on evidence assertions:** the assertions below only cover
+    the Datadog evidence keys because ``merge_evidence`` in
+    ``app/nodes/investigate/processing/post_process.py`` has mappers for the
+    Datadog tools but not yet for the EKS tools.  The EKS tools still execute
+    (their calls to the fixture backend are visible on the mock backend
+    instances) but their return dicts are currently dropped by the
+    post-processor.  That is a pre-existing gap tracked separately; see the
+    open issue for the EKS evidence mappers.  Once it lands, the assertions
+    in this test should be extended to cover ``eks_pods``, ``eks_events``,
+    ``eks_deployments``, ``eks_node_health`` and the derived count fields.
+    """
+
+    @staticmethod
+    def _canned_plan(**_: object) -> InvestigationPlan:
+        return InvestigationPlan(
+            actions=[
+                "list_eks_pods",
+                "get_eks_events",
+                "list_eks_deployments",
+                "get_eks_node_health",
+                "query_datadog_logs",
+                "query_datadog_monitors",
+            ],
+            rationale="Canned plan for harness end-to-end smoke test.",
+        )
+
+    def test_placeholder_runs_through_full_pipeline(self, monkeypatch) -> None:
+        # The conftest disables the system keyring for tests, so LLMSettings
+        # won't find any provider credentials unless one is present in the
+        # environment.  A dummy value is enough here because every LLM call in
+        # the pipeline is either mocked (plan_actions) or bypassed entirely by
+        # the healthy short-circuit (diagnose_root_cause).
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-dummy")
+        monkeypatch.setenv("HEALTHY_SHORT_CIRCUIT", "true")
+
+        fixture = load_scenario(SUITE_DIR / "000-healthy")
+        eks_backend = FixtureEKSBackend(fixture)
+        datadog_backend = FixtureDatadogBackend(fixture)
+
+        with patch(
+            "app.nodes.plan_actions.plan_actions.plan_actions_with_llm",
+            side_effect=self._canned_plan,
+        ):
+            final_state, score = run_scenario(
+                fixture,
+                use_mock_backends=True,
+                eks_backend=eks_backend,
+                datadog_backend=datadog_backend,
+            )
+
+        # Scorer should grade the placeholder as passed: category + keywords match.
+        assert score.passed is True, (
+            f"000-healthy scored FAIL: {score.failure_reason!r} "
+            f"(category={score.actual_category!r}, missing={score.missing_keywords})"
+        )
+        assert score.actual_category == "healthy"
+        assert score.missing_keywords == []
+
+        # The diagnose_root_cause healthy short-circuit should have produced a
+        # deterministic root cause without invoking the LLM.
+        root_cause = str(final_state.get("root_cause") or "")
+        assert root_cause, "expected a non-empty root cause"
+        assert "normal" in root_cause.lower()
+        assert final_state.get("root_cause_category") == "healthy"
+        assert final_state.get("validity_score") == 1.0
+
+        # Datadog tools have evidence mappers, so their output should flow into
+        # state["evidence"] through the normal post-processing path.
+        evidence = final_state.get("evidence") or {}
+        for required in ("datadog_logs", "datadog_monitors"):
+            assert required in evidence, (
+                f"expected {required!r} in evidence after tool execution; "
+                f"got {sorted(evidence.keys())}"
+            )
+        assert evidence.get("datadog_monitors_count") == 2
+
+
+# ---------------------------------------------------------------------------
+# Parametrized LLM runs — gated behind scenarios existing at each difficulty level.
+# The placeholder 000-healthy uses scenario_difficulty: 0, so these collections
+# are empty until scenarios #261+ land with real difficulty-tiered content.
+# ---------------------------------------------------------------------------
+
+
+_ALL_SCENARIOS = load_all_scenarios()
+
+
+def _by_difficulty(level: int) -> list:
+    return [f for f in _ALL_SCENARIOS if f.metadata.scenario_difficulty == level]
+
+
+def _run_scenario_test(fixture) -> None:
+    """Run scenario with real LLM and mock backends, then assert scoring."""
+    final_state, score = run_scenario(fixture, use_mock_backends=True)
+
+    assert final_state["root_cause"]
+    assert score.passed is True, (
+        f"{fixture.scenario_id} FAILED: {score.failure_reason}\n"
+        f"  actual_category={score.actual_category!r}  "
+        f"  missing_keywords={score.missing_keywords}"
+    )
+
+    if score.trajectory is not None:
+        assert score.trajectory.efficiency_score >= 1.0, (
+            f"{fixture.scenario_id} TRAJECTORY FAIL: "
+            f"sequencing={score.trajectory.sequencing_ok} "
+            f"calibration={score.trajectory.calibration_ok}\n"
+            f"  expected={score.trajectory.expected_sequence}\n"
+            f"  actual={score.trajectory.actual_sequence}"
+        )
+
+
+_LEVEL1_SCENARIOS = _by_difficulty(1)
+_LEVEL2_SCENARIOS = _by_difficulty(2)
+_LEVEL3_SCENARIOS = _by_difficulty(3)
+_LEVEL4_SCENARIOS = _by_difficulty(4)
+
+
+@pytest.mark.synthetic
+@pytest.mark.skipif(not _LEVEL1_SCENARIOS, reason="no Level 1 K8s scenarios yet")
+@pytest.mark.parametrize(
+    "fixture", _LEVEL1_SCENARIOS or [None], ids=lambda f: f.scenario_id if f else "none"
+)
+def test_level1_scenario(fixture) -> None:
+    """Level 1 — single dominant signal, all evidence consistent."""
+    _run_scenario_test(fixture)
+
+
+@pytest.mark.synthetic
+@pytest.mark.skipif(not _LEVEL2_SCENARIOS, reason="no Level 2 K8s scenarios yet")
+@pytest.mark.parametrize(
+    "fixture", _LEVEL2_SCENARIOS or [None], ids=lambda f: f.scenario_id if f else "none"
+)
+def test_level2_scenario(fixture) -> None:
+    """Level 2 — one confounder present, second evidence source needed to rule it out."""
+    _run_scenario_test(fixture)
+
+
+@pytest.mark.synthetic
+@pytest.mark.skipif(not _LEVEL3_SCENARIOS, reason="no Level 3 K8s scenarios yet")
+@pytest.mark.parametrize(
+    "fixture", _LEVEL3_SCENARIOS or [None], ids=lambda f: f.scenario_id if f else "none"
+)
+def test_level3_scenario(fixture) -> None:
+    """Level 3 — absent or indirect evidence, key signal missing."""
+    _run_scenario_test(fixture)
+
+
+@pytest.mark.synthetic
+@pytest.mark.skipif(not _LEVEL4_SCENARIOS, reason="no Level 4 K8s scenarios yet")
+@pytest.mark.parametrize(
+    "fixture", _LEVEL4_SCENARIOS or [None], ids=lambda f: f.scenario_id if f else "none"
+)
+def test_level4_scenario(fixture) -> None:
+    """Level 4 — compositional fault, two failure modes causally linked."""
+    _run_scenario_test(fixture)
+
+
+# ---------------------------------------------------------------------------
+# Scenario inheritance unit tests
+# ---------------------------------------------------------------------------
+
+
+_BASE_SCENARIO_YML = textwrap.dedent("""\
+    base: 000-healthy
+    scenario_id: 999-test-scenario
+    failure_mode: crashloop_backoff
+    severity: critical
+""")
+
+
+def _write_minimal_answer_yml(scenario_dir: Path) -> None:
+    (scenario_dir / "answer.yml").write_text(textwrap.dedent("""\
+        root_cause_category: test_category
+        required_keywords:
+          - test_keyword
+        model_response: "Test model response."
+    """))
+
+
+class TestScenarioInheritance:
+    """Verify base-inheritance and evidence-file fallback in scenario_loader."""
+
+    def test_metadata_inherited_from_base(self) -> None:
+        """Scenario with base: 000-healthy inherits metadata fields it omits."""
+        real_dir = SUITE_DIR / "999-test-inherit"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-inherit
+                failure_mode: crashloop_backoff
+                severity: critical
+            """))
+            _write_minimal_answer_yml(real_dir)
+
+            fixture = load_scenario(real_dir)
+
+            assert fixture.metadata.scenario_id == "999-test-inherit"
+            assert fixture.metadata.failure_mode == "crashloop_backoff"
+            assert fixture.metadata.severity == "critical"
+            assert fixture.metadata.engine == "eks"
+            assert fixture.metadata.cluster_name == "payments-prod-eks"
+            assert fixture.metadata.namespace == "payments"
+            assert fixture.metadata.workload_type == "deployment"
+            assert fixture.metadata.workload_name == "payments-api"
+            assert fixture.metadata.region == "us-east-1"
+            assert fixture.metadata.schema_version == "1.0"
+            assert "eks_pods" in fixture.metadata.available_evidence
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()
+
+    def test_evidence_falls_back_to_base(self) -> None:
+        """Scenario without evidence files loads them from the base."""
+        real_dir = SUITE_DIR / "999-test-fallback"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-fallback
+                failure_mode: healthy
+                severity: info
+            """))
+            _write_minimal_answer_yml(real_dir)
+
+            fixture = load_scenario(real_dir)
+
+            assert fixture.evidence.eks_pods is not None
+            assert fixture.evidence.eks_events is not None
+            assert fixture.evidence.datadog_logs is not None
+
+            assert fixture.alert["state"] == "normal"
+            assert "payments" in fixture.alert["title"].lower()
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()
+
+    def test_local_evidence_overrides_base(self) -> None:
+        """Scenario with its own evidence file uses it instead of the base's."""
+        real_dir = SUITE_DIR / "999-test-override"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-override
+                failure_mode: healthy
+                severity: info
+            """))
+            _write_minimal_answer_yml(real_dir)
+
+            custom_events = {
+                "warning_events": [
+                    {
+                        "namespace": "payments",
+                        "reason": "TestEvent",
+                        "message": "Custom test event",
+                        "type": "Warning",
+                        "count": 1,
+                        "involved_object": "Pod/custom-test",
+                        "first_time": "2026-04-01T00:00:00Z",
+                        "last_time": "2026-04-01T00:00:00Z",
+                    }
+                ]
+            }
+            (real_dir / "eks_events.json").write_text(json.dumps(custom_events))
+
+            fixture = load_scenario(real_dir)
+
+            assert fixture.evidence.eks_events is not None
+            assert len(fixture.evidence.eks_events["warning_events"]) == 1
+            assert fixture.evidence.eks_events["warning_events"][0]["message"] == "Custom test event"
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()
+
+    def test_chained_inheritance_rejected(self) -> None:
+        """Declaring base on a scenario that itself has a base raises ValueError."""
+        real_dir_a = SUITE_DIR / "999-test-chain-a"
+        real_dir_b = SUITE_DIR / "999-test-chain-b"
+        real_dir_a.mkdir(exist_ok=True)
+        real_dir_b.mkdir(exist_ok=True)
+        try:
+            (real_dir_a / "scenario.yml").write_text(textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-chain-a
+                failure_mode: healthy
+                severity: info
+            """))
+            (real_dir_b / "scenario.yml").write_text(textwrap.dedent("""\
+                base: 999-test-chain-a
+                scenario_id: 999-test-chain-b
+                failure_mode: healthy
+                severity: info
+            """))
+            _write_minimal_answer_yml(real_dir_b)
+
+            with pytest.raises(ValueError, match="Chained inheritance is not supported"):
+                load_scenario(real_dir_b)
+        finally:
+            for d in (real_dir_a, real_dir_b):
+                for f in d.iterdir():
+                    f.unlink()
+                d.rmdir()
+
+    def test_missing_base_raises(self) -> None:
+        """Referencing a non-existent base scenario raises ValueError."""
+        real_dir = SUITE_DIR / "999-test-missing-base"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(textwrap.dedent("""\
+                base: 999-nonexistent
+                scenario_id: 999-test-missing-base
+                failure_mode: healthy
+                severity: info
+            """))
+            _write_minimal_answer_yml(real_dir)
+
+            with pytest.raises(ValueError, match="Base scenario '999-nonexistent' not found"):
+                load_scenario(real_dir)
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()
+
+    def test_no_base_works_unchanged(self) -> None:
+        """Scenarios without a base field still load normally."""
+        fixture = load_scenario(SUITE_DIR / "000-healthy")
+        assert fixture.metadata.scenario_id == "000-healthy"
+        assert fixture.metadata.failure_mode == "healthy"
+        assert fixture.evidence.eks_pods is not None

--- a/tests/synthetic/eks/test_suite.py
+++ b/tests/synthetic/eks/test_suite.py
@@ -392,14 +392,6 @@ def test_level4_scenario(fixture) -> None:
 # ---------------------------------------------------------------------------
 
 
-_BASE_SCENARIO_YML = textwrap.dedent("""\
-    base: 000-healthy
-    scenario_id: 999-test-scenario
-    failure_mode: crashloop_backoff
-    severity: critical
-""")
-
-
 def _write_minimal_answer_yml(scenario_dir: Path) -> None:
     (scenario_dir / "answer.yml").write_text(textwrap.dedent("""\
         root_cause_category: test_category

--- a/tests/synthetic/eks/test_suite_axis2.py
+++ b/tests/synthetic/eks/test_suite_axis2.py
@@ -1,0 +1,127 @@
+"""Axis 2 adversarial test suite for synthetic Kubernetes RCA scenarios.
+
+Differences from test_suite.py (Axis 1):
+
+1. Uses SelectiveEKSBackend + SelectiveDatadogBackend instead of the
+   straight fixture-backed versions.
+   - Each selective backend records every tool invocation into an audit log
+     so tests can assert the agent called the right methods.
+
+2. Asserts two additional dimensions from ReasoningScore:
+   - ruling_out_ok: the agent's output contains all ruling_out_keywords
+     declared in the scenario's answer.yml (proves it dismissed alternatives).
+   - queries_ok: the agent invoked all required_queries entries (proves it
+     checked the right evidence source before concluding).
+
+3. Runs all scenarios with ruling_out_keywords or required_queries declared.
+   Scenarios without Axis 2 fields are skipped from the Axis 2-specific
+   assertions.  Higher difficulty scenarios are wrapped with xfail(strict=False)
+   so expected failures do not gate CI but passes are recorded as xpass.
+
+Run with:
+    pytest -m axis2 tests/synthetic/eks/test_suite_axis2.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.synthetic.eks.run_suite import run_scenario, score_reasoning
+from tests.synthetic.eks.scenario_loader import load_all_scenarios
+from tests.synthetic.mock_datadog_backend.selective_backend import SelectiveDatadogBackend
+from tests.synthetic.mock_eks_backend.selective_backend import SelectiveEKSBackend
+
+_ALL_SCENARIOS = load_all_scenarios()
+
+# Difficulty threshold above which the LLM is expected to struggle.
+# Failures at or above this difficulty are the gap signal —
+# they should not gate CI (strict=False xfail).
+_XFAIL_DIFFICULTY = 3
+
+
+def _axis2_scenarios() -> list:
+    """Return pytest params for all Axis 2 scenarios.
+
+    Scenarios at difficulty >= _XFAIL_DIFFICULTY are wrapped with
+    pytest.mark.xfail(strict=False) so that:
+    - Failures keep CI green (expected, part of the gap metric).
+    - Passes are recorded as bonuses (xpass).
+    """
+    params = []
+    for f in _ALL_SCENARIOS:
+        if not (f.answer_key.ruling_out_keywords or f.answer_key.required_queries):
+            continue
+        if f.metadata.scenario_difficulty >= _XFAIL_DIFFICULTY:
+            params.append(
+                pytest.param(
+                    f,
+                    id=f.scenario_id,
+                    marks=pytest.mark.xfail(
+                        strict=False,
+                        reason=(
+                            f"difficulty={f.metadata.scenario_difficulty}: "
+                            "expected to challenge real LLMs — failure is the gap signal"
+                        ),
+                    ),
+                )
+            )
+        else:
+            params.append(pytest.param(f, id=f.scenario_id))
+    return params
+
+
+def _run_axis2_scenario_test(fixture) -> None:
+    """Run Axis 2 scenario with real LLM and selective backends, then assert reasoning."""
+    eks_backend = SelectiveEKSBackend(fixture)
+    datadog_backend = SelectiveDatadogBackend(fixture)
+
+    final_state, score = run_scenario(
+        fixture,
+        use_mock_backends=True,
+        eks_backend=eks_backend,
+        datadog_backend=datadog_backend,
+    )
+
+    assert final_state["root_cause"], f"{fixture.scenario_id}: agent produced no root_cause"
+    assert score.passed is True, (
+        f"{fixture.scenario_id} FAILED: {score.failure_reason}\n"
+        f"  actual_category={score.actual_category!r}  "
+        f"  missing_keywords={score.missing_keywords}"
+    )
+
+    if score.trajectory is not None:
+        assert score.trajectory.efficiency_score >= 1.0, (
+            f"{fixture.scenario_id} TRAJECTORY FAIL: "
+            f"sequencing={score.trajectory.sequencing_ok} "
+            f"calibration={score.trajectory.calibration_ok}\n"
+            f"  expected={score.trajectory.expected_sequence}\n"
+            f"  actual={score.trajectory.actual_sequence}"
+        )
+
+    queried_tools = list(eks_backend.queried_tools) + list(datadog_backend.queried_tools)
+    reasoning = score_reasoning(fixture, final_state, queried_tools=queried_tools)
+
+    if reasoning is not None:
+        assert reasoning.ruling_out_ok, (
+            f"{fixture.scenario_id} REASONING FAIL — missing ruling-out tokens: "
+            f"{reasoning.missing_ruling_out}\n"
+            f"  (agent must mention these to demonstrate it considered and dismissed alternatives)"
+        )
+        assert reasoning.queries_ok, (
+            f"{fixture.scenario_id} REASONING FAIL — agent never invoked: "
+            f"{reasoning.missing_queries}\n"
+            f"  queried_tools audit log: "
+            f"eks={sorted(eks_backend.unique_queried_tools)} "
+            f"datadog={sorted(datadog_backend.unique_queried_tools)}"
+        )
+
+
+_AXIS2_PARAMS = _axis2_scenarios()
+
+
+@pytest.mark.axis2
+@pytest.mark.skipif(not _AXIS2_PARAMS, reason="no Axis 2 K8s scenarios yet")
+@pytest.mark.parametrize("fixture", _AXIS2_PARAMS or [None])
+def test_axis2_scenario(fixture) -> None:
+    """Axis 2 adversarial test: selective backends + reasoning quality checks."""
+    _run_axis2_scenario_test(fixture)

--- a/tests/synthetic/k8s_schemas.py
+++ b/tests/synthetic/k8s_schemas.py
@@ -1,0 +1,588 @@
+"""
+Schema definitions for Kubernetes synthetic testing fixtures.
+
+All scenario fixture files (alert.json, eks_pods.json, eks_events.json,
+eks_deployments.json, eks_node_health.json, eks_pod_logs.json,
+datadog_logs.json, datadog_monitors.json, answer.yml, scenario.yml) must
+conform to these TypedDicts.  Validators enforce required fields so every
+scenario is structurally consistent.
+
+The Kubernetes controlled vocabularies (engines, failure modes, evidence
+sources, trajectory actions) are distinct from the RDS suite's and live
+here rather than in ``tests/synthetic/schemas.py`` to keep the two suites
+independently evolvable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, NotRequired
+
+from typing_extensions import TypedDict
+
+# ---------------------------------------------------------------------------
+# Controlled vocabularies for scenario metadata
+# ---------------------------------------------------------------------------
+
+VALID_K8S_ENGINES = frozenset({"eks", "gke", "aks", "kubernetes"})
+
+VALID_K8S_WORKLOAD_TYPES = frozenset(
+    {"deployment", "statefulset", "daemonset", "job", "cronjob", "replicaset"}
+)
+
+VALID_K8S_FAILURE_MODES = frozenset(
+    {
+        "healthy",
+        "crashloop_backoff",
+        "oom_killed",
+        "image_pull_backoff",
+        "node_not_ready",
+        "pending_pod",
+        "deployment_rollout_stuck",
+        "evicted_pods",
+        "dns_resolution_failure",
+        "probe_failure",
+        "resource_quota_exceeded",
+    }
+)
+
+VALID_K8S_EVIDENCE_SOURCES = frozenset(
+    {
+        "eks_pods",
+        "eks_events",
+        "eks_deployments",
+        "eks_node_health",
+        "eks_pod_logs",
+        "datadog_logs",
+        "datadog_monitors",
+    }
+)
+
+VALID_K8S_TRAJECTORY_ACTIONS = frozenset(
+    {
+        "list_eks_pods",
+        "get_eks_events",
+        "list_eks_deployments",
+        "get_eks_node_health",
+        "get_eks_pod_logs",
+        "query_datadog_logs",
+        "query_datadog_monitors",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Alert fixture  (alert.json)
+# ---------------------------------------------------------------------------
+
+
+class K8sAlertLabels(TypedDict, total=False):
+    alertname: str
+    severity: str
+    pipeline_name: str
+    service: str
+    cluster_name: str
+    namespace: str
+    workload_type: str
+    workload_name: str
+
+
+class K8sAlertAnnotations(TypedDict, total=False):
+    summary: str
+    description: str
+    error: str
+    suspected_symptom: str
+    cluster_name: str
+    kube_namespace: str
+    kube_deployment: str
+    kube_job: str
+    kube_pod: str
+    kube_node: str
+    k8s_failure_mode: str
+    context_sources: str
+
+
+class K8sAlertFixture(TypedDict):
+    title: str
+    state: str
+    alert_source: str
+    commonLabels: K8sAlertLabels
+    commonAnnotations: K8sAlertAnnotations
+
+
+# ---------------------------------------------------------------------------
+# EKS pods fixture  (eks_pods.json)
+# Mirrors the shape returned by ``app.tools.EKSListPodsTool.list_eks_pods``.
+# ---------------------------------------------------------------------------
+
+
+class PodContainerState(TypedDict, total=False):
+    running: bool
+    waiting: bool
+    terminated: bool
+    reason: str
+    message: str
+    started_at: str
+    exit_code: int
+
+
+class PodContainer(TypedDict):
+    name: str
+    ready: bool
+    restart_count: int
+    state: PodContainerState
+
+
+class PodCondition(TypedDict):
+    type: str
+    status: str
+    reason: str
+    message: str
+
+
+class PodFixture(TypedDict):
+    name: str
+    namespace: str
+    phase: str
+    node_name: str
+    containers: list[PodContainer]
+    conditions: list[PodCondition]
+    start_time: str
+
+
+class EKSPodsFixture(TypedDict):
+    pods: list[PodFixture]
+
+
+# ---------------------------------------------------------------------------
+# EKS events fixture  (eks_events.json)
+# Mirrors the shape returned by ``app.tools.EKSEventsTool.get_eks_events``
+# for a single Warning event record.
+# ---------------------------------------------------------------------------
+
+
+class EKSEvent(TypedDict):
+    namespace: str
+    reason: str
+    message: str
+    type: str
+    count: int
+    involved_object: str
+    first_time: str
+    last_time: str
+
+
+class EKSEventsFixture(TypedDict):
+    warning_events: list[EKSEvent]
+
+
+# ---------------------------------------------------------------------------
+# EKS deployments fixture  (eks_deployments.json)
+# ---------------------------------------------------------------------------
+
+
+class DeploymentFixture(TypedDict):
+    """Matches the per-deployment shape returned by ``list_eks_deployments``."""
+
+    name: str
+    namespace: str
+    desired: int
+    ready: int
+    available: int
+    unavailable: int
+
+
+class EKSDeploymentsFixture(TypedDict):
+    deployments: list[DeploymentFixture]
+
+
+# ---------------------------------------------------------------------------
+# EKS node health fixture  (eks_node_health.json)
+# ---------------------------------------------------------------------------
+
+
+class NodeFixture(TypedDict, total=False):
+    """Matches the per-node shape returned by ``get_eks_node_health``.
+
+    Condition status fields (``ready``, ``memory_pressure``, etc.) are string
+    values — Kubernetes condition statuses are ``"True"`` / ``"False"`` /
+    ``"Unknown"``, not Python booleans.
+    """
+
+    name: str
+    internal_ip: str
+    ready: str
+    memory_pressure: str
+    disk_pressure: str
+    pid_pressure: str
+    capacity_cpu: str
+    capacity_memory: str
+    allocatable_cpu: str
+    allocatable_memory: str
+    instance_type: str
+
+
+class EKSNodeHealthFixture(TypedDict):
+    nodes: list[NodeFixture]
+
+
+# ---------------------------------------------------------------------------
+# EKS pod logs fixture  (eks_pod_logs.json)
+# ---------------------------------------------------------------------------
+
+
+class EKSPodLogsFixture(TypedDict):
+    pod_name: str
+    namespace: str
+    logs: str
+
+
+# ---------------------------------------------------------------------------
+# Datadog logs fixture  (datadog_logs.json)
+# Mirrors ``app.tools.DataDogLogsTool.query_datadog_logs``.
+# ---------------------------------------------------------------------------
+
+
+class DatadogLogEntry(TypedDict, total=False):
+    timestamp: str
+    message: str
+    status: str
+    service: str
+    host: str
+    tags: list[str]
+
+
+class DatadogLogsFixture(TypedDict):
+    logs: list[DatadogLogEntry]
+
+
+# ---------------------------------------------------------------------------
+# Datadog monitors fixture  (datadog_monitors.json)
+# Mirrors ``app.tools.DataDogMonitorsTool.query_datadog_monitors``.
+# ---------------------------------------------------------------------------
+
+
+class DatadogMonitor(TypedDict, total=False):
+    id: int
+    name: str
+    type: str
+    query: str
+    message: str
+    overall_state: str
+    tags: list[str]
+
+
+class DatadogMonitorsFixture(TypedDict):
+    monitors: list[DatadogMonitor]
+
+
+# ---------------------------------------------------------------------------
+# Answer key  (answer.yml)
+# Same shape as the RDS answer key — duplicated here so the K8s suite is not
+# coupled to the RDS trajectory vocabulary.
+# ---------------------------------------------------------------------------
+
+
+class K8sAnswerKeySchema(TypedDict):
+    root_cause_category: str
+    required_keywords: list[str]
+    model_response: str
+    forbidden_categories: NotRequired[list[str]]
+    forbidden_keywords: NotRequired[list[str]]
+    required_evidence_sources: NotRequired[list[str]]
+    optimal_trajectory: NotRequired[list[str]]
+    max_investigation_loops: NotRequired[int]
+    ruling_out_keywords: NotRequired[list[str]]
+    required_queries: NotRequired[list[str]]
+
+
+# ---------------------------------------------------------------------------
+# Scenario metadata  (scenario.yml)
+# ---------------------------------------------------------------------------
+
+
+class K8sScenarioMetadataSchema(TypedDict):
+    schema_version: str
+    scenario_id: str
+    engine: str
+    cluster_name: str
+    namespace: str
+    workload_type: str
+    workload_name: str
+    region: str
+    failure_mode: str
+    severity: str
+    available_evidence: list[str]
+    scenario_difficulty: NotRequired[int]
+    adversarial_signals: NotRequired[list[str]]
+    depends_on: NotRequired[str]
+
+
+# ---------------------------------------------------------------------------
+# Typed evidence container
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class K8sScenarioEvidence:
+    """Typed container for all evidence sources in a K8s scenario fixture.
+
+    Each attribute is None when the corresponding file was not listed in
+    scenario.yml:available_evidence, making evidence presence explicit.
+    """
+
+    eks_pods: EKSPodsFixture | None
+    eks_events: EKSEventsFixture | None
+    eks_deployments: EKSDeploymentsFixture | None
+    eks_node_health: EKSNodeHealthFixture | None
+    eks_pod_logs: EKSPodLogsFixture | None
+    datadog_logs: DatadogLogsFixture | None
+    datadog_monitors: DatadogMonitorsFixture | None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return only the non-None sources as a plain dict."""
+        result: dict[str, Any] = {}
+        if self.eks_pods is not None:
+            result["eks_pods"] = self.eks_pods
+        if self.eks_events is not None:
+            result["eks_events"] = self.eks_events
+        if self.eks_deployments is not None:
+            result["eks_deployments"] = self.eks_deployments
+        if self.eks_node_health is not None:
+            result["eks_node_health"] = self.eks_node_health
+        if self.eks_pod_logs is not None:
+            result["eks_pod_logs"] = self.eks_pod_logs
+        if self.datadog_logs is not None:
+            result["datadog_logs"] = self.datadog_logs
+        if self.datadog_monitors is not None:
+            result["datadog_monitors"] = self.datadog_monitors
+        return result
+
+    def get(self, key: str) -> Any:
+        return self.as_dict().get(key)
+
+
+# ---------------------------------------------------------------------------
+# Validators — raise ValueError with a descriptive message on bad data
+# ---------------------------------------------------------------------------
+
+
+def validate_k8s_alert(data: dict[str, Any]) -> K8sAlertFixture:
+    _require_str(data, "title", ctx="alert.json")
+    _require_str(data, "state", ctx="alert.json")
+    _require_str(data, "alert_source", ctx="alert.json")
+    if not isinstance(data.get("commonLabels"), dict):
+        raise ValueError("alert.json: 'commonLabels' must be an object")
+    if not isinstance(data.get("commonAnnotations"), dict):
+        raise ValueError("alert.json: 'commonAnnotations' must be an object")
+    return data  # type: ignore[return-value]
+
+
+def validate_eks_pods(data: dict[str, Any]) -> EKSPodsFixture:
+    ctx = "eks_pods.json"
+    pods = data.get("pods")
+    if not isinstance(pods, list):
+        raise ValueError(f"{ctx}: 'pods' must be a list")
+    for i, pod in enumerate(pods):
+        pctx = f"{ctx}:pods[{i}]"
+        for field in ("name", "namespace", "phase", "node_name", "start_time"):
+            _require_str(pod, field, ctx=pctx)
+        if not isinstance(pod.get("containers"), list):
+            raise ValueError(f"{pctx}: 'containers' must be a list")
+        if not isinstance(pod.get("conditions"), list):
+            raise ValueError(f"{pctx}: 'conditions' must be a list")
+        for j, container in enumerate(pod["containers"]):
+            cctx = f"{pctx}:containers[{j}]"
+            _require_str(container, "name", ctx=cctx)
+            if not isinstance(container.get("ready"), bool):
+                raise ValueError(f"{cctx}: 'ready' must be a boolean")
+            if not isinstance(container.get("restart_count"), int):
+                raise ValueError(f"{cctx}: 'restart_count' must be an integer")
+            if not isinstance(container.get("state"), dict):
+                raise ValueError(f"{cctx}: 'state' must be an object")
+    return data  # type: ignore[return-value]
+
+
+def validate_eks_events(data: dict[str, Any]) -> EKSEventsFixture:
+    ctx = "eks_events.json"
+    events = data.get("warning_events")
+    if not isinstance(events, list):
+        raise ValueError(f"{ctx}: 'warning_events' must be a list")
+    for i, event in enumerate(events):
+        ectx = f"{ctx}:warning_events[{i}]"
+        for field in ("namespace", "reason", "message", "type", "involved_object", "first_time", "last_time"):
+            _require_str(event, field, ctx=ectx)
+        if not isinstance(event.get("count"), int):
+            raise ValueError(f"{ectx}: 'count' must be an integer")
+    return data  # type: ignore[return-value]
+
+
+def validate_eks_deployments(data: dict[str, Any]) -> EKSDeploymentsFixture:
+    ctx = "eks_deployments.json"
+    deployments = data.get("deployments")
+    if not isinstance(deployments, list):
+        raise ValueError(f"{ctx}: 'deployments' must be a list")
+    for i, deployment in enumerate(deployments):
+        dctx = f"{ctx}:deployments[{i}]"
+        _require_str(deployment, "name", ctx=dctx)
+        _require_str(deployment, "namespace", ctx=dctx)
+        for int_field in ("desired", "ready", "available", "unavailable"):
+            if not isinstance(deployment.get(int_field), int):
+                raise ValueError(f"{dctx}: '{int_field}' must be an integer")
+    return data  # type: ignore[return-value]
+
+
+def validate_eks_node_health(data: dict[str, Any]) -> EKSNodeHealthFixture:
+    ctx = "eks_node_health.json"
+    nodes = data.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError(f"{ctx}: 'nodes' must be a list")
+    for i, node in enumerate(nodes):
+        nctx = f"{ctx}:nodes[{i}]"
+        _require_str(node, "name", ctx=nctx)
+        ready = node.get("ready")
+        if not isinstance(ready, str) or ready not in ("True", "False", "Unknown"):
+            raise ValueError(
+                f"{nctx}: 'ready' must be the string 'True', 'False', or 'Unknown' "
+                "(Kubernetes condition status)"
+            )
+    return data  # type: ignore[return-value]
+
+
+def validate_eks_pod_logs(data: dict[str, Any]) -> EKSPodLogsFixture:
+    ctx = "eks_pod_logs.json"
+    _require_str(data, "pod_name", ctx=ctx)
+    _require_str(data, "namespace", ctx=ctx)
+    if not isinstance(data.get("logs"), str):
+        raise ValueError(f"{ctx}: 'logs' must be a string")
+    return data  # type: ignore[return-value]
+
+
+def validate_datadog_logs(data: dict[str, Any]) -> DatadogLogsFixture:
+    ctx = "datadog_logs.json"
+    logs = data.get("logs")
+    if not isinstance(logs, list):
+        raise ValueError(f"{ctx}: 'logs' must be a list")
+    for i, entry in enumerate(logs):
+        lctx = f"{ctx}:logs[{i}]"
+        for field in ("timestamp", "message"):
+            _require_str(entry, field, ctx=lctx)
+        if "tags" in entry and not isinstance(entry["tags"], list):
+            raise ValueError(f"{lctx}: 'tags' must be a list when present")
+    return data  # type: ignore[return-value]
+
+
+def validate_datadog_monitors(data: dict[str, Any]) -> DatadogMonitorsFixture:
+    ctx = "datadog_monitors.json"
+    monitors = data.get("monitors")
+    if not isinstance(monitors, list):
+        raise ValueError(f"{ctx}: 'monitors' must be a list")
+    for i, monitor in enumerate(monitors):
+        mctx = f"{ctx}:monitors[{i}]"
+        for field in ("name", "type", "query", "overall_state"):
+            _require_str(monitor, field, ctx=mctx)
+    return data  # type: ignore[return-value]
+
+
+def validate_k8s_answer_key(data: dict[str, Any]) -> K8sAnswerKeySchema:
+    _require_str(data, "root_cause_category", ctx="answer.yml")
+    _require_non_empty_str_list(data, "required_keywords", "answer.yml", required=True)
+    _require_str(data, "model_response", ctx="answer.yml")
+    for opt_list_field in ("forbidden_categories", "forbidden_keywords", "required_evidence_sources"):
+        val = data.get(opt_list_field)
+        if val is not None and not isinstance(val, list):
+            raise ValueError(f"answer.yml: '{opt_list_field}' must be a list when present")
+    trajectory = data.get("optimal_trajectory")
+    if trajectory is not None:
+        if not isinstance(trajectory, list) or not trajectory:
+            raise ValueError("answer.yml: 'optimal_trajectory' must be a non-empty list when present")
+        unknown_actions = [a for a in trajectory if a not in VALID_K8S_TRAJECTORY_ACTIONS]
+        if unknown_actions:
+            raise ValueError(
+                f"answer.yml: unknown action(s) in optimal_trajectory {unknown_actions}; "
+                f"expected subset of {sorted(VALID_K8S_TRAJECTORY_ACTIONS)}"
+            )
+    max_loops = data.get("max_investigation_loops")
+    if max_loops is not None and (not isinstance(max_loops, int) or max_loops < 1):
+        raise ValueError("answer.yml: 'max_investigation_loops' must be a positive integer when present")
+    for axis2_list_field in ("ruling_out_keywords", "required_queries"):
+        _require_non_empty_str_list(data, axis2_list_field, "answer.yml")
+    return data  # type: ignore[return-value]
+
+
+def validate_k8s_scenario_metadata(data: dict[str, Any]) -> K8sScenarioMetadataSchema:
+    ctx = "scenario.yml"
+    for field in (
+        "schema_version",
+        "scenario_id",
+        "engine",
+        "cluster_name",
+        "namespace",
+        "workload_type",
+        "workload_name",
+        "region",
+        "failure_mode",
+        "severity",
+    ):
+        _require_str(data, field, ctx=ctx)
+
+    engine = data["engine"]
+    if engine not in VALID_K8S_ENGINES:
+        raise ValueError(f"{ctx}: unknown engine {engine!r}; expected one of {sorted(VALID_K8S_ENGINES)}")
+
+    workload_type = data["workload_type"]
+    if workload_type not in VALID_K8S_WORKLOAD_TYPES:
+        raise ValueError(
+            f"{ctx}: unknown workload_type {workload_type!r}; expected one of {sorted(VALID_K8S_WORKLOAD_TYPES)}"
+        )
+
+    failure_mode = data["failure_mode"]
+    if failure_mode not in VALID_K8S_FAILURE_MODES:
+        raise ValueError(
+            f"{ctx}: unknown failure_mode {failure_mode!r}; expected one of {sorted(VALID_K8S_FAILURE_MODES)}"
+        )
+
+    sources = data.get("available_evidence")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError(f"{ctx}: 'available_evidence' must be a non-empty list")
+    unknown = [s for s in sources if s not in VALID_K8S_EVIDENCE_SOURCES]
+    if unknown:
+        raise ValueError(
+            f"{ctx}: unknown evidence source(s) {unknown}; "
+            f"expected subset of {sorted(VALID_K8S_EVIDENCE_SOURCES)}"
+        )
+
+    return data  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_str(obj: dict[str, Any], key: str, ctx: str = "") -> None:
+    value = obj.get(key)
+    prefix = f"{ctx}: " if ctx else ""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{prefix}missing or empty required string field '{key}'")
+
+
+def _require_non_empty_str_list(
+    obj: dict[str, Any],
+    key: str,
+    ctx: str,
+    *,
+    required: bool = False,
+) -> None:
+    value = obj.get(key)
+
+    if value is None:
+        if required:
+            raise ValueError(f"{ctx}: '{key}' must be a non-empty list")
+        return
+
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{ctx}: '{key}' must be a non-empty list")
+
+    if not all(isinstance(item, str) and item.strip() for item in value):
+        raise ValueError(f"{ctx}: all '{key}' entries must be non-empty strings")

--- a/tests/synthetic/mock_datadog_backend/__init__.py
+++ b/tests/synthetic/mock_datadog_backend/__init__.py
@@ -1,0 +1,8 @@
+"""Mock Datadog backend for synthetic Kubernetes testing."""
+
+from tests.synthetic.mock_datadog_backend.backend import (
+    DatadogBackend,
+    FixtureDatadogBackend,
+)
+
+__all__ = ["DatadogBackend", "FixtureDatadogBackend"]

--- a/tests/synthetic/mock_datadog_backend/backend.py
+++ b/tests/synthetic/mock_datadog_backend/backend.py
@@ -1,0 +1,106 @@
+"""DatadogBackend Protocol and FixtureDatadogBackend for synthetic K8s testing.
+
+The Protocol defines the minimal Datadog surface the Kubernetes investigation
+agent uses.  FixtureDatadogBackend satisfies it by serving scenario fixture
+data in the exact shape the Datadog tools under ``app/tools/DataDog*/`` return.
+
+Usage
+-----
+    resolved_integrations = {
+        "datadog": {
+            "api_key": "",
+            "app_key": "",
+            "_backend": FixtureDatadogBackend(fixture),
+        }
+    }
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tests.synthetic.eks.scenario_loader import K8sScenarioFixture
+
+
+_ERROR_KEYWORDS = (
+    "error",
+    "fail",
+    "exception",
+    "traceback",
+    "pipeline_error",
+    "critical",
+    "killed",
+    "oomkilled",
+    "crash",
+    "panic",
+    "timeout",
+)
+
+
+@runtime_checkable
+class DatadogBackend(Protocol):
+    """Minimal Datadog interface used by the Kubernetes investigation agent.
+
+    Two methods — one per evidence source under ``app/tools/DataDog*/``:
+        query_logs     → DataDogLogsTool response shape
+        query_monitors → DataDogMonitorsTool response shape
+    """
+
+    def query_logs(self, query: str = "", **kwargs: Any) -> dict[str, Any]:
+        """Return a response matching ``query_datadog_logs``."""
+        ...
+
+    def query_monitors(self, query: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        """Return a response matching ``query_datadog_monitors``."""
+        ...
+
+
+class FixtureDatadogBackend:
+    """DatadogBackend implementation backed by a K8sScenarioFixture.
+
+    Each method wraps the corresponding fixture file in the envelope that the
+    real tool function returns.  Calling a method for an evidence source that
+    the scenario did not declare in ``available_evidence`` raises ValueError.
+    """
+
+    def __init__(self, fixture: K8sScenarioFixture) -> None:
+        self._fixture = fixture
+
+    def query_logs(self, query: str = "", **_: Any) -> dict[str, Any]:
+        logs_fixture = self._fixture.evidence.datadog_logs
+        if logs_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: query_logs called but "
+                "'datadog_logs' is not declared in available_evidence"
+            )
+        logs = list(logs_fixture.get("logs", []))
+        error_logs = [
+            log
+            for log in logs
+            if any(kw in str(log.get("message", "")).lower() for kw in _ERROR_KEYWORDS)
+        ]
+        return {
+            "source": "datadog_logs",
+            "available": True,
+            "logs": logs,
+            "error_logs": error_logs,
+            "total": len(logs),
+            "query": query,
+        }
+
+    def query_monitors(self, query: str | None = None, **_: Any) -> dict[str, Any]:
+        monitors_fixture = self._fixture.evidence.datadog_monitors
+        if monitors_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: query_monitors called but "
+                "'datadog_monitors' is not declared in available_evidence"
+            )
+        monitors = list(monitors_fixture.get("monitors", []))
+        return {
+            "source": "datadog_monitors",
+            "available": True,
+            "monitors": monitors,
+            "total": len(monitors),
+            "query_filter": query,
+        }

--- a/tests/synthetic/mock_datadog_backend/backend.py
+++ b/tests/synthetic/mock_datadog_backend/backend.py
@@ -49,11 +49,9 @@ class DatadogBackend(Protocol):
 
     def query_logs(self, query: str = "", **kwargs: Any) -> dict[str, Any]:
         """Return a response matching ``query_datadog_logs``."""
-        ...
 
     def query_monitors(self, query: str | None = None, **kwargs: Any) -> dict[str, Any]:
         """Return a response matching ``query_datadog_monitors``."""
-        ...
 
 
 class FixtureDatadogBackend:

--- a/tests/synthetic/mock_datadog_backend/selective_backend.py
+++ b/tests/synthetic/mock_datadog_backend/selective_backend.py
@@ -1,0 +1,65 @@
+"""SelectiveDatadogBackend — query-aware mock for Axis 2 adversarial tests.
+
+Records every query string and filter passed to ``query_logs`` and
+``query_monitors`` so tests can assert the agent searched for the right things.
+Returns the full fixture data on every call; filtering is deferred to a later
+iteration.
+
+Usage in test_suite_axis2.py
+-----------------------------
+    backend = SelectiveDatadogBackend(fixture)
+    final_state, score = run_scenario(fixture, use_mock_backends=True, datadog_backend=backend)
+    assert any("pipeline_error" in q.lower() for q in backend.queried_log_queries)
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from tests.synthetic.mock_datadog_backend.backend import FixtureDatadogBackend
+
+if TYPE_CHECKING:
+    from tests.synthetic.eks.scenario_loader import K8sScenarioFixture
+
+
+class SelectiveDatadogBackend(FixtureDatadogBackend):
+    """Query-aware DatadogBackend for Axis 2 adversarial testing."""
+
+    def __init__(self, fixture: K8sScenarioFixture) -> None:
+        super().__init__(fixture)
+        self.queried_log_queries: list[str] = []
+        self.queried_monitor_filters: list[str] = []
+        self.queried_tools: list[str] = []
+
+    def query_logs(self, query: str = "", **kwargs: Any) -> dict[str, Any]:
+        self.queried_tools.append("query_logs")
+        self.queried_log_queries.append(query)
+        return super().query_logs(query=query, **kwargs)
+
+    def query_monitors(self, query: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        self.queried_tools.append("query_monitors")
+        self.queried_monitor_filters.append(query or "")
+        return super().query_monitors(query=query, **kwargs)
+
+    def reset(self) -> None:
+        """Clear the audit log (useful for re-running a scenario)."""
+        self.queried_log_queries = []
+        self.queried_monitor_filters = []
+        self.queried_tools = []
+
+    @property
+    def unique_queried_tools(self) -> set[str]:
+        """Deduplicated set of all tool methods that were invoked."""
+        return set(self.queried_tools)
+
+    def queried(self, tool_name: str) -> bool:
+        """Return True if ``tool_name`` was ever invoked (exact match)."""
+        return tool_name in self.queried_tools
+
+    def __deepcopy__(self, memo: dict) -> SelectiveDatadogBackend:
+        new = SelectiveDatadogBackend(self._fixture)
+        new.queried_log_queries = copy.deepcopy(self.queried_log_queries, memo)
+        new.queried_monitor_filters = copy.deepcopy(self.queried_monitor_filters, memo)
+        new.queried_tools = copy.deepcopy(self.queried_tools, memo)
+        return new

--- a/tests/synthetic/mock_eks_backend/__init__.py
+++ b/tests/synthetic/mock_eks_backend/__init__.py
@@ -1,0 +1,5 @@
+"""Mock EKS backend for synthetic Kubernetes testing."""
+
+from tests.synthetic.mock_eks_backend.backend import EKSBackend, FixtureEKSBackend
+
+__all__ = ["EKSBackend", "FixtureEKSBackend"]

--- a/tests/synthetic/mock_eks_backend/backend.py
+++ b/tests/synthetic/mock_eks_backend/backend.py
@@ -1,0 +1,206 @@
+"""EKSBackend Protocol and FixtureEKSBackend for synthetic K8s testing.
+
+The Protocol defines the minimal surface the Kubernetes investigation agent
+uses to query EKS workload state.  FixtureEKSBackend satisfies it by serving
+scenario fixture data in the exact shape the EKS tools under ``app/tools/EKS*/``
+return — no HTTP calls, no AWS credentials required.
+
+Usage
+-----
+    resolved_integrations = {
+        "eks": {
+            "cluster_name": "",
+            "role_arn": "",
+            "_backend": FixtureEKSBackend(fixture),
+        }
+    }
+
+Each tool's production resolver checks the ``_backend`` key first and delegates
+to it when present, falling back to real EKS API calls when absent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tests.synthetic.eks.scenario_loader import K8sScenarioFixture
+
+
+@runtime_checkable
+class EKSBackend(Protocol):
+    """Minimal EKS interface used by the Kubernetes investigation agent.
+
+    One method per evidence source under ``app/tools/EKS*/``:
+        list_pods        → EKSListPodsTool response shape
+        get_events       → EKSEventsTool response shape
+        list_deployments → EKSListDeploymentsTool response shape
+        get_node_health  → EKSNodeHealthTool response shape
+        get_pod_logs     → EKSPodLogsTool response shape
+    """
+
+    def list_pods(self, cluster_name: str = "", namespace: str = "", **kwargs: Any) -> dict[str, Any]:
+        """Return a response matching ``list_eks_pods``."""
+        ...
+
+    def get_events(self, cluster_name: str = "", namespace: str = "", **kwargs: Any) -> dict[str, Any]:
+        """Return a response matching ``get_eks_events``."""
+        ...
+
+    def list_deployments(
+        self, cluster_name: str = "", namespace: str = "", **kwargs: Any
+    ) -> dict[str, Any]:
+        """Return a response matching ``list_eks_deployments``."""
+        ...
+
+    def get_node_health(self, cluster_name: str = "", **kwargs: Any) -> dict[str, Any]:
+        """Return a response matching ``get_eks_node_health``."""
+        ...
+
+    def get_pod_logs(
+        self, cluster_name: str = "", namespace: str = "", pod_name: str = "", **kwargs: Any
+    ) -> dict[str, Any]:
+        """Return a response matching ``get_eks_pod_logs``."""
+        ...
+
+
+class FixtureEKSBackend:
+    """EKSBackend implementation backed by a K8sScenarioFixture.
+
+    Each method wraps the corresponding fixture file in the envelope that the
+    real tool function returns.  Calling a method for an evidence source that
+    the scenario did not declare in ``available_evidence`` raises ValueError.
+    """
+
+    def __init__(self, fixture: K8sScenarioFixture) -> None:
+        self._fixture = fixture
+
+    def _cluster_name(self, override: str) -> str:
+        return override or self._fixture.metadata.cluster_name
+
+    def _namespace(self, override: str) -> str:
+        return override or self._fixture.metadata.namespace
+
+    def list_pods(self, cluster_name: str = "", namespace: str = "", **_: Any) -> dict[str, Any]:
+        pods_fixture = self._fixture.evidence.eks_pods
+        if pods_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: list_pods called but "
+                "'eks_pods' is not declared in available_evidence"
+            )
+        pods = list(pods_fixture.get("pods", []))
+        failing_pods = [p for p in pods if p.get("phase") not in ("Running", "Succeeded")]
+        high_restart_pods = [
+            p
+            for p in pods
+            if any(c.get("restart_count", 0) > 3 for c in p.get("containers", []))
+        ]
+        return {
+            "source": "eks",
+            "available": True,
+            "cluster_name": self._cluster_name(cluster_name),
+            "namespace": self._namespace(namespace),
+            "total_pods": len(pods),
+            "pods": pods,
+            "failing_pods": failing_pods,
+            "high_restart_pods": high_restart_pods,
+            "error": None,
+        }
+
+    def get_events(self, cluster_name: str = "", namespace: str = "", **_: Any) -> dict[str, Any]:
+        events_fixture = self._fixture.evidence.eks_events
+        if events_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: get_events called but "
+                "'eks_events' is not declared in available_evidence"
+            )
+        warning_events = list(events_fixture.get("warning_events", []))
+        return {
+            "source": "eks",
+            "available": True,
+            "cluster_name": self._cluster_name(cluster_name),
+            "namespace": self._namespace(namespace),
+            "warning_events": warning_events,
+            "total_warning_count": len(warning_events),
+            "error": None,
+        }
+
+    def list_deployments(
+        self, cluster_name: str = "", namespace: str = "", **_: Any
+    ) -> dict[str, Any]:
+        deployments_fixture = self._fixture.evidence.eks_deployments
+        if deployments_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: list_deployments called but "
+                "'eks_deployments' is not declared in available_evidence"
+            )
+        deployments: list[dict[str, Any]] = []
+        for raw in deployments_fixture.get("deployments", []):
+            desired = int(raw.get("desired", 0))
+            ready = int(raw.get("ready", 0))
+            available = int(raw.get("available", 0))
+            unavailable = int(raw.get("unavailable", 0))
+            deployments.append(
+                {
+                    "name": raw.get("name", ""),
+                    "namespace": raw.get("namespace", ""),
+                    "desired": desired,
+                    "ready": ready,
+                    "available": available,
+                    "unavailable": unavailable,
+                    "degraded": unavailable > 0 or ready < desired,
+                }
+            )
+        degraded = [d for d in deployments if d["degraded"]]
+        return {
+            "source": "eks",
+            "available": True,
+            "cluster_name": self._cluster_name(cluster_name),
+            "namespace": self._namespace(namespace),
+            "total_deployments": len(deployments),
+            "deployments": deployments,
+            "degraded_deployments": degraded,
+            "error": None,
+        }
+
+    def get_node_health(self, cluster_name: str = "", **_: Any) -> dict[str, Any]:
+        nodes_fixture = self._fixture.evidence.eks_node_health
+        if nodes_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: get_node_health called but "
+                "'eks_node_health' is not declared in available_evidence"
+            )
+        nodes = list(nodes_fixture.get("nodes", []))
+        not_ready_count = sum(1 for n in nodes if n.get("ready") != "True")
+        return {
+            "source": "eks",
+            "available": True,
+            "cluster_name": self._cluster_name(cluster_name),
+            "nodes": nodes,
+            "total_nodes": len(nodes),
+            "not_ready_count": not_ready_count,
+            "error": None,
+        }
+
+    def get_pod_logs(
+        self,
+        cluster_name: str = "",
+        namespace: str = "",
+        pod_name: str = "",
+        **_: Any,
+    ) -> dict[str, Any]:
+        logs_fixture = self._fixture.evidence.eks_pod_logs
+        if logs_fixture is None:
+            raise ValueError(
+                f"{self._fixture.scenario_id}: get_pod_logs called but "
+                "'eks_pod_logs' is not declared in available_evidence"
+            )
+        return {
+            "source": "eks",
+            "available": True,
+            "cluster_name": self._cluster_name(cluster_name),
+            "namespace": self._namespace(namespace) or logs_fixture.get("namespace", ""),
+            "pod_name": pod_name or logs_fixture.get("pod_name", ""),
+            "logs": logs_fixture.get("logs", ""),
+            "error": None,
+        }

--- a/tests/synthetic/mock_eks_backend/backend.py
+++ b/tests/synthetic/mock_eks_backend/backend.py
@@ -41,27 +41,22 @@ class EKSBackend(Protocol):
 
     def list_pods(self, cluster_name: str = "", namespace: str = "", **kwargs: Any) -> dict[str, Any]:
         """Return a response matching ``list_eks_pods``."""
-        ...
 
     def get_events(self, cluster_name: str = "", namespace: str = "", **kwargs: Any) -> dict[str, Any]:
         """Return a response matching ``get_eks_events``."""
-        ...
 
     def list_deployments(
         self, cluster_name: str = "", namespace: str = "", **kwargs: Any
     ) -> dict[str, Any]:
         """Return a response matching ``list_eks_deployments``."""
-        ...
 
     def get_node_health(self, cluster_name: str = "", **kwargs: Any) -> dict[str, Any]:
         """Return a response matching ``get_eks_node_health``."""
-        ...
 
     def get_pod_logs(
         self, cluster_name: str = "", namespace: str = "", pod_name: str = "", **kwargs: Any
     ) -> dict[str, Any]:
         """Return a response matching ``get_eks_pod_logs``."""
-        ...
 
 
 class FixtureEKSBackend:

--- a/tests/synthetic/mock_eks_backend/selective_backend.py
+++ b/tests/synthetic/mock_eks_backend/selective_backend.py
@@ -1,0 +1,97 @@
+"""SelectiveEKSBackend — query-aware mock for Axis 2 adversarial tests.
+
+Unlike FixtureEKSBackend (which returns every available pod, event, and
+deployment on each call), this backend records every namespace and pod name
+the agent requested so tests can assert the agent asked for the right things.
+
+Filtering the returned slice by the requested namespace / pod is reserved for
+a future iteration — the current action registry does not yet narrow requests
+tightly enough for meaningful filtering to help.
+
+Usage in test_suite_axis2.py
+-----------------------------
+    backend = SelectiveEKSBackend(fixture)
+    final_state, score = run_scenario(fixture, use_mock_backends=True, eks_backend=backend)
+    assert "payments" in backend.queried_namespaces
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from tests.synthetic.mock_eks_backend.backend import FixtureEKSBackend
+
+if TYPE_CHECKING:
+    from tests.synthetic.eks.scenario_loader import K8sScenarioFixture
+
+
+class SelectiveEKSBackend(FixtureEKSBackend):
+    """Query-aware EKSBackend for Axis 2 adversarial testing.
+
+    Satisfies the EKSBackend Protocol by inheriting every method from
+    FixtureEKSBackend, then augments each call with an audit record.
+    """
+
+    def __init__(self, fixture: K8sScenarioFixture) -> None:
+        super().__init__(fixture)
+        self.queried_namespaces: list[str] = []
+        self.queried_pod_names: list[str] = []
+        self.queried_tools: list[str] = []
+
+    def list_pods(self, cluster_name: str = "", namespace: str = "", **kwargs: Any) -> dict[str, Any]:
+        self.queried_tools.append("list_pods")
+        self.queried_namespaces.append(self._namespace(namespace))
+        return super().list_pods(cluster_name=cluster_name, namespace=namespace, **kwargs)
+
+    def get_events(self, cluster_name: str = "", namespace: str = "", **kwargs: Any) -> dict[str, Any]:
+        self.queried_tools.append("get_events")
+        self.queried_namespaces.append(self._namespace(namespace))
+        return super().get_events(cluster_name=cluster_name, namespace=namespace, **kwargs)
+
+    def list_deployments(
+        self, cluster_name: str = "", namespace: str = "", **kwargs: Any
+    ) -> dict[str, Any]:
+        self.queried_tools.append("list_deployments")
+        self.queried_namespaces.append(self._namespace(namespace))
+        return super().list_deployments(cluster_name=cluster_name, namespace=namespace, **kwargs)
+
+    def get_node_health(self, cluster_name: str = "", **kwargs: Any) -> dict[str, Any]:
+        self.queried_tools.append("get_node_health")
+        return super().get_node_health(cluster_name=cluster_name, **kwargs)
+
+    def get_pod_logs(
+        self,
+        cluster_name: str = "",
+        namespace: str = "",
+        pod_name: str = "",
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.queried_tools.append("get_pod_logs")
+        self.queried_namespaces.append(self._namespace(namespace))
+        self.queried_pod_names.append(pod_name)
+        return super().get_pod_logs(
+            cluster_name=cluster_name, namespace=namespace, pod_name=pod_name, **kwargs
+        )
+
+    def reset(self) -> None:
+        """Clear the audit log (useful for re-running a scenario)."""
+        self.queried_namespaces = []
+        self.queried_pod_names = []
+        self.queried_tools = []
+
+    @property
+    def unique_queried_tools(self) -> set[str]:
+        """Deduplicated set of all tool methods that were invoked."""
+        return set(self.queried_tools)
+
+    def queried(self, tool_name: str) -> bool:
+        """Return True if ``tool_name`` was ever invoked (exact match)."""
+        return tool_name in self.queried_tools
+
+    def __deepcopy__(self, memo: dict) -> SelectiveEKSBackend:
+        new = SelectiveEKSBackend(self._fixture)
+        new.queried_namespaces = copy.deepcopy(self.queried_namespaces, memo)
+        new.queried_pod_names = copy.deepcopy(self.queried_pod_names, memo)
+        new.queried_tools = copy.deepcopy(self.queried_tools, memo)
+        return new


### PR DESCRIPTION
Fixes #260

#### Describe the changes you have made in this PR -

Adds a fully-wired Kubernetes synthetic RCA test harness under `tests/synthetic/eks/`, mirroring the existing RDS Postgres suite at `tests/synthetic/rds_postgres/`. Future Kubernetes failure scenarios (issues #261, #262, #263) can now plug in as scenario directories rather than hand-rolled one-off test files, and `detect_sources` plus the wired EKS and Datadog tools transparently accept injected fixture backends in test mode while leaving real-credential behaviour untouched.

## What this PR adds

### New files — harness infrastructure (under `tests/synthetic/`)

1. **`tests/synthetic/k8s_schemas.py`** — controlled vocabularies (4 engines, 6 workload types, 11 failure modes, 7 evidence sources, 7 trajectory actions), TypedDicts for the alert envelope and every evidence fixture, a `K8sScenarioEvidence` dataclass, and validators following the same patterns as `tests/synthetic/schemas.py` in the RDS suite. Kept deliberately separate from the RDS schemas so the two suites can evolve independently.

2. **`tests/synthetic/mock_eks_backend/`** — `EKSBackend` `@runtime_checkable` Protocol plus `FixtureEKSBackend` and `SelectiveEKSBackend`. The fixture backend exposes `list_pods`, `get_events`, `list_deployments`, `get_node_health`, `get_pod_logs`, each returning the exact envelope the real tool function in `app/tools/EKS*/` produces. The selective subclass records every tool invocation into an audit log for Axis 2 reasoning-quality scoring.

3. **`tests/synthetic/mock_datadog_backend/`** — `DatadogBackend` Protocol plus `FixtureDatadogBackend` and `SelectiveDatadogBackend`, wrapping `datadog_logs.json` / `datadog_monitors.json` fixtures in the envelopes that `query_datadog_logs` and `query_datadog_monitors` return in production.

4. **`tests/synthetic/eks/scenario_loader.py`** — mirror of `tests/synthetic/rds_postgres/scenario_loader.py`: `load_all_scenarios`, `load_scenario`, single-level base inheritance with chained-inheritance rejection, file-level evidence fallback from scenario directory to base directory.

5. **`tests/synthetic/eks/run_suite.py`** — CLI runner plus scorer. `TrajectoryScore` / `ReasoningScore` / `ScenarioScore` dataclasses and `score_trajectory` / `score_reasoning` / `score_result` functions parallel the RDS suite. `run_scenario` builds `resolved_integrations` with both `aws` (EKS) and `datadog` entries containing the injected `_backend` objects, then delegates to `run_investigation`.

6. **`tests/synthetic/eks/test_suite.py`** — pytest coverage. Loader validation, schema compliance, mock backend shape assertions, scorer unit tests, a `TestScenarioInheritance` class mirroring the RDS suite (metadata inheritance, evidence fallback, local override, chained-inheritance rejection, missing-base rejection), and a `TestHarnessEndToEnd` class that drives the full `run_investigation` pipeline against the placeholder with a monkey-patched planner (no real LLM call required). The parametrised `test_level1..4_scenario` tests use `skipif` guards so they collect zero cases while only the placeholder scenario exists.

7. **`tests/synthetic/eks/test_suite_axis2.py`** — Axis 2 pytest module using the selective backends and `score_reasoning` for adversarial reasoning-quality checks. Parameter set is empty until scenarios declare `ruling_out_keywords` or `required_queries`.

8. **`tests/synthetic/eks/000-healthy/`** — placeholder scenario directory with `scenario_difficulty: 0` so it stays out of the level-1..4 parametrizations. Contains `scenario.yml`, `alert.json`, `answer.yml`, and every declared evidence fixture (`eks_pods.json`, `eks_events.json`, `eks_deployments.json`, `eks_node_health.json`, `datadog_logs.json`, `datadog_monitors.json`). `eks_pod_logs` is deliberately omitted from `available_evidence` to exercise the "missing evidence source raises ValueError" path in the mock backend.

### Modified files — minimal agent-side wiring

The harness has to feed the fixture backends into the real pipeline the same way the RDS synthetic suite feeds `FixtureGrafanaBackend` into the Grafana tools. That pattern was not yet present for EKS or Datadog, so:

1. **`app/nodes/plan_actions/detect_sources.py`** — extend the EKS and Datadog paths to accept a pre-injected `_backend` key, matching how the existing Grafana path already works. The EKS integration continues to live under `resolved_integrations[\"aws\"]` as before; `detect_sources` now reads `_backend` from that dict and propagates it to `sources[\"eks\"][\"_backend\"]`. Same treatment for Datadog. Critically, backend-only mode deliberately does NOT set `connection_verified: True` — this keeps the 6 unwired EKS tools and the 4 unwired Datadog tools inactive in test mode, so a scenario cannot accidentally trigger a real AWS or Datadog call.

2. **`app/tools/EKSListClustersTool/__init__.py`** — introduce a new `_eks_available_or_backend(sources)` helper that returns `True` when either `connection_verified` or `_backend` is present. Only the 5 wired tools import this helper; the other 6 EKS tools keep using the existing `_eks_available` check. Also relaxes `_eks_creds` from `eks[\"role_arn\"]` to `eks.get(\"role_arn\", \"\")` so it no longer KeyErrors when called from the backend-only path.

3. **5 EKS tools** (`EKSListPodsTool`, `EKSEventsTool`, `EKSListDeploymentsTool`, `EKSNodeHealthTool`, `EKSPodLogsTool`) — each gets an `eks_backend: Any = None` kwarg added to its function signature (plus an `eks_backend = eks.get(\"_backend\")` line in its `extract_params` helper). The function body short-circuits to `eks_backend.<method>(...)` when the kwarg is set, before any call to `build_k8s_clients`. The result is cast to `dict[str, Any]` to satisfy mypy's `warn_return_any`. `role_arn` was also loosened from positional-required to default-empty to support the backend-only call path.

4. **`app/tools/DataDogLogsTool/__init__.py`** and **`app/tools/DataDogMonitorsTool/__init__.py`** — add a `_dd_available_or_backend` helper in `DataDogLogsTool` (imported by `DataDogMonitorsTool`), plus a `datadog_backend: Any = None` kwarg on each tool function and a short-circuit to `datadog_backend.query_logs(...)` / `datadog_backend.query_monitors(...)` before the real `make_client` path. Same cast pattern as the EKS tools.

5. **`Makefile`** — add a `test-k8s-synthetic` target mirroring `test-rds-synthetic`:

    ```
    test-k8s-synthetic:
    	\$(PYTHON) -m tests.synthetic.eks.run_suite \$(if \$(SCENARIO),--scenario \$(SCENARIO),)
    ```

### Out of scope for this PR

* **Real Kubernetes failure scenarios (#261, #262, #263).** The issue description is explicit: _\"This issue covers the test harness itself, not the individual scenarios.\"_ This PR ships the harness plus a single `000-healthy` placeholder whose only job is to prove the harness wiring works end-to-end. Difficulty-level parametrizations stay empty until those issues add real scenarios.

* **Wiring the 6 remaining EKS tools and 4 remaining Datadog tools.** Only the tools whose output corresponds to a declared evidence source in the issue scope are wired; this keeps the blast radius minimal. When future scenarios need additional sources, the same short 3-line pattern copied from the wired tools applies.

## Pre-existing gaps flagged separately (not fixed in this PR)

While building the harness I identified two pre-existing gaps in the existing EKS plumbing. Both are NOT part of the harness scope, but #261 / #262 / #263 will need them to work end-to-end. Both have been filed as standalone bug reports before this PR was opened so they can be picked up in parallel by any contributor:

* **#581 — \`[BUG] EKS tool output silently dropped by merge_evidence — no mappers in post_process.py\`** — `EVIDENCE_MAPPERS` in `app/nodes/investigate/processing/post_process.py` has mappers for Grafana, Datadog, CloudWatch, S3, Lambda, GitHub, Honeycomb, Coralogix and Vercel, but no entries for any `list_eks_*` / `get_eks_*` / `describe_eks_*` action name. Tool output is silently discarded by `merge_evidence()`. Small additive fix (~50 lines in a single file). Complete proposed patch in the issue body.

* **#582 — \`[BUG] is_clearly_healthy short-circuit never fires for pure-EKS healthy states\`** — `_INVESTIGATED_EVIDENCE_KEYS` in `app/nodes/root_cause_diagnosis/evidence_checker.py` has no `eks_*` entries, so a pure-Kubernetes healthy state never short-circuits out of the reasoning LLM. Five-line fix. Ordering-depends on #581 landing first. Complete proposed patch in the issue body.

Because these are pre-existing and independent, this PR's end-to-end smoke test (`TestHarnessEndToEnd::test_placeholder_runs_through_full_pipeline`) only asserts on `datadog_*` evidence keys — the existing Datadog mappers are enough to trigger the healthy short-circuit for the 000-healthy placeholder. A scope-note in that test's class docstring points forward to the follow-up issues so the EKS assertions can be enabled once #581 lands.

## Testing

All three gate commands pass locally on Python 3.12 and are the same commands CI runs:

```
make lint         # ruff check app/ tests/  → All checks passed!
make typecheck    # mypy app/               → Success: no issues found in 340 source files
make test-cov     # pytest -n auto --ignore tests/synthetic -m \"not synthetic\"  → 2137 passed, 1 skipped
```

Targeted verification of the new suite and every touched tool file:

```
pytest tests/synthetic/eks/                                           → 21 passed, 5 skipped
pytest tests/tools/test_eks_list_pods_tool.py                         → passed (contract + happy path + error path)
pytest tests/tools/test_eks_events_tool.py                            → passed
pytest tests/tools/test_eks_list_deployments_tool.py                  → passed
pytest tests/tools/test_eks_node_health_tool.py                       → passed
pytest tests/tools/test_eks_pod_logs_tool.py                          → passed
pytest tests/tools/test_datadog_logs_tool.py                          → passed
pytest tests/tools/test_datadog_monitors_tool.py                      → passed
pytest tests/nodes/plan_actions/                                      → 32 passed
```

The end-to-end smoke test drives the full LangGraph pipeline against 000-healthy with a canned planner plan, asserting that `detect_sources` picks up the injected backends, the executor routes each of `list_eks_pods` / `get_eks_events` / `list_eks_deployments` / `get_eks_node_health` / `query_datadog_logs` / `query_datadog_monitors` to its fixture mock, Datadog evidence flows into state, and `diagnose_root_cause` returns `root_cause_category: healthy` via the healthy short-circuit without any real LLM call. No Anthropic or OpenAI API key is required — `monkeypatch.setenv(\"ANTHROPIC_API_KEY\", \"sk-test-dummy\")` is enough to satisfy `LLMSettings` because every real LLM call in the run is either mocked (plan_actions) or bypassed (diagnose_root_cause healthy short-circuit).

### Screenshots of the UI changes (If any) -

N/A — no user-facing UI changes. This PR touches only test infrastructure plus the backend-injection seams in a handful of tool files and `detect_sources`. Production behaviour against real EKS / Datadog credentials is identical; the new code paths are only reachable when a \`_backend\` object is present in the integration dict, which is only produced by the synthetic harness.

## Impact analysis

* **Backward compatibility:** fully preserved. Every app-side change is either a new additive helper (`_eks_available_or_backend`, `_dd_available_or_backend`) or an additive kwarg with a default (`eks_backend=None`, `datadog_backend=None`) that only matters when explicitly set. Real-credential investigations take the unchanged code path.
* **Coverage of existing EKS / Datadog tool tests:** unchanged — the 81 existing tests across the 7 touched tool files all still pass.
* **Performance:** no measurable impact on real investigations. Each tool gains a single `if eks_backend is not None:` / `if datadog_backend is not None:` check at the top of its function, taken once per invocation.
* **Secrets:** no new environment variables, no `.env` writes, no credentials stored anywhere.
* **Dependencies:** no new runtime or dev dependencies added.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem solved:** OpenSRE already has an RDS Postgres synthetic suite under `tests/synthetic/rds_postgres/` that gives the team a reproducible, offline way to benchmark the agent's root-cause reasoning against fixture data — no real cloud calls, no flaky APIs, clear pass/fail per scenario. There was no equivalent for Kubernetes, so any improvement to the K8s investigation path could not be measured the same way. This PR adds the parallel infrastructure so follow-up issues can drop in K8s failure scenarios as scenario directories.

**Alternatives considered:**

1. *Mock at the Kubernetes Python SDK layer instead of the tool-function layer.* Rejected: mocking `build_k8s_clients` would force every test to reason about raw K8s SDK objects rather than the higher-level tool response shapes the pipeline actually consumes. The issue text is explicit that _\"Response shapes must match what the EKS tools in \`app/tools/EKS*/\` and Datadog tools return\"_, which points at the tool-function layer as the right seam.

2. *Mock at the `run_investigation` entry point using `unittest.mock.patch`.* Rejected: it only exercises the glue and gives zero confidence that real scenarios will actually drive `detect_sources` → `plan_actions` → executor → tools correctly, which is the whole point of a synthetic suite.

3. *Wire backends into every EKS and Datadog tool upfront, even the ones the initial placeholder does not declare.* Rejected to minimise blast radius. Only the 5 EKS tools and 2 Datadog tools whose output corresponds to a declared evidence source in the issue scope are wired. The unwired tools continue to use `connection_verified` alone as their availability gate, so they stay completely inactive in test mode and cannot accidentally hit real AWS or Datadog. When future scenarios need additional sources, the same short 3-line pattern is trivial to copy.

**Why this implementation:**

* **Mirrors RDS exactly.** The loader, scorer, runner, pytest suite, and fixture layout are structural copies of the RDS suite with K8s-specific substitutions. This makes the review straightforward — reviewers already know the patterns — and keeps both suites easy to maintain side by side.
* **Uses the same `_backend` injection seam that the Grafana tools already use.** No new abstractions are introduced; the pattern is one the team has already accepted during the RDS harness work, which minimises cognitive load for reviewers.
* **Placeholder is intentionally `scenario_difficulty: 0`.** The `test_level1..4_scenario` parametrizations collect zero cases until real failure scenarios land in follow-up issues. The placeholder's only job is to exercise the harness plumbing once, not to grade an LLM on a synthetic case the LLM was not trained or evaluated on.
* **Pre-existing gaps were kept strictly out of scope.** The two bug reports (#581, #582) were filed before opening this PR so the harness work stays cleanly scoped, and the pre-existing gaps can be reviewed and fixed on their own merits by any contributor.

**Key components and their jobs:**

* `K8sScenarioEvidence` + validators (`k8s_schemas.py`) — structural gate between raw JSON fixture files and the typed container the loader returns. Raises `ValueError` with file-qualified context on any malformed fixture.
* `K8sScenarioFixture` + `load_scenario` / `load_all_scenarios` (`scenario_loader.py`) — discover, validate, and return a typed snapshot of a scenario directory. Handles single-level base inheritance and file-level evidence fallback.
* `FixtureEKSBackend` / `FixtureDatadogBackend` — satisfy runtime-checkable Protocols, wrap scenario fixtures in the exact envelopes the real tool functions produce, and raise `ValueError` when the caller requests a source the scenario did not declare.
* `SelectiveEKSBackend` / `SelectiveDatadogBackend` — subclass their non-selective counterparts and record each tool invocation into an audit log for Axis 2 reasoning-quality checks.
* `run_scenario` in `run_suite.py` — builds the `resolved_integrations` dict with either fresh fixture backends or pre-built selective backends, delegates to `run_investigation`, collects any audit log produced by selective backends, and calls `score_result`.
* `score_trajectory` / `score_reasoning` / `score_result` — Axis 1 correctness (category, keywords, forbidden terms, required evidence sources, trajectory efficiency) and Axis 2 adversarial reasoning (ruling-out keywords plus required-query audit). Direct parallel of the RDS scorer with `_EVIDENCE_KEY_MAP` adjusted for K8s.
* `detect_sources.py` EKS and Datadog path changes — accept `_backend` in the incoming `resolved_integrations` dict, propagate it to the relevant `sources[...]` entry, and deliberately skip setting `connection_verified` in backend-only mode so only fixture-aware tools activate.
* 5 EKS tools plus 2 Datadog tools — each gains a `*_backend: Any = None` kwarg that short-circuits to the mock when set. Real-credential behaviour is completely untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---