### PR TITLE
fix: plumb EKS tool output into state evidence via post_process mappers

### DIFF
--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -180,6 +180,46 @@ def _map_grafana_service_names(data: dict) -> dict:
     }
 
 
+def _map_eks_pods(data: dict) -> dict:
+    return {
+        "eks_pods": data.get("pods", []),
+        "eks_failing_pods": data.get("failing_pods", []),
+        "eks_high_restart_pods": data.get("high_restart_pods", []),
+        "eks_total_pods": data.get("total_pods", 0),
+    }
+
+
+def _map_eks_events(data: dict) -> dict:
+    return {
+        "eks_events": data.get("warning_events", []),
+        "eks_total_warning_count": data.get("total_warning_count", 0),
+    }
+
+
+def _map_eks_deployments(data: dict) -> dict:
+    return {
+        "eks_deployments": data.get("deployments", []),
+        "eks_degraded_deployments": data.get("degraded_deployments", []),
+        "eks_total_deployments": data.get("total_deployments", 0),
+    }
+
+
+def _map_eks_node_health(data: dict) -> dict:
+    return {
+        "eks_node_health": data.get("nodes", []),
+        "eks_not_ready_count": data.get("not_ready_count", 0),
+        "eks_total_nodes": data.get("total_nodes", 0),
+    }
+
+
+def _map_eks_pod_logs(data: dict) -> dict:
+    return {
+        "eks_pod_logs": data.get("logs", ""),
+        "eks_pod_logs_pod_name": data.get("pod_name", ""),
+        "eks_pod_logs_namespace": data.get("namespace", ""),
+    }
+
+
 def _map_datadog_logs(data: dict) -> dict:
     return {
         "datadog_logs": data.get("logs", []),
@@ -318,6 +358,11 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "query_grafana_metrics": _map_grafana_metrics,
     "query_grafana_alert_rules": _map_grafana_alert_rules,
     "query_grafana_service_names": _map_grafana_service_names,
+    "list_eks_pods": _map_eks_pods,
+    "get_eks_events": _map_eks_events,
+    "list_eks_deployments": _map_eks_deployments,
+    "get_eks_node_health": _map_eks_node_health,
+    "get_eks_pod_logs": _map_eks_pod_logs,
     "query_datadog_logs": _map_datadog_logs,
     "query_datadog_monitors": _map_datadog_monitors,
     "query_datadog_events": _map_datadog_events,
@@ -440,6 +485,26 @@ def build_evidence_summary(execution_results: dict) -> str:
                 summary_parts.append(f"grafana:{len(data['rules'])} alert rules")
             elif action_name == "query_grafana_service_names" and data.get("service_names"):
                 summary_parts.append(f"grafana:{len(data['service_names'])} services")
+            elif action_name == "list_eks_pods" and data.get("pods") is not None:
+                failing = len(data.get("failing_pods", []))
+                summary_parts.append(f"eks:{data.get('total_pods', 0)} pods ({failing} failing)")
+            elif action_name == "get_eks_events" and data.get("warning_events") is not None:
+                summary_parts.append(
+                    f"eks:{data.get('total_warning_count', 0)} warning events"
+                )
+            elif action_name == "list_eks_deployments" and data.get("deployments") is not None:
+                degraded = len(data.get("degraded_deployments", []))
+                summary_parts.append(
+                    f"eks:{data.get('total_deployments', 0)} deployments ({degraded} degraded)"
+                )
+            elif action_name == "get_eks_node_health" and data.get("nodes") is not None:
+                not_ready = data.get("not_ready_count", 0)
+                summary_parts.append(
+                    f"eks:{data.get('total_nodes', 0)} nodes ({not_ready} not ready)"
+                )
+            elif action_name == "get_eks_pod_logs" and data.get("logs"):
+                line_count = len(str(data.get("logs", "")).splitlines())
+                summary_parts.append(f"eks:{line_count} log lines from {data.get('pod_name', '')}")
             elif action_name == "query_datadog_logs" and data.get("logs"):
                 error_count = len(data.get("error_logs", []))
                 summary_parts.append(f"datadog:{len(data['logs'])} logs ({error_count} errors)")

--- a/tests/nodes/investigate/test_post_process.py
+++ b/tests/nodes/investigate/test_post_process.py
@@ -1,0 +1,251 @@
+"""Tests for evidence mapping in ``app/nodes/investigate/processing/post_process.py``.
+
+These tests verify that each registered mapper converts a successfully-executed
+tool result into the expected state-evidence shape, and that
+``merge_evidence`` correctly merges the mapped fields into the agent's
+evidence dict.
+"""
+
+from __future__ import annotations
+
+from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
+from app.nodes.investigate.processing.post_process import (
+    EVIDENCE_MAPPERS,
+    build_evidence_summary,
+    merge_evidence,
+)
+
+
+def _result(action_name: str, data: dict, success: bool = True) -> ActionExecutionResult:
+    return ActionExecutionResult(
+        action_name=action_name,
+        success=success,
+        data=data,
+        error=None,
+    )
+
+
+class TestEKSMappersRegistered:
+    """Every fixture-backed EKS tool must have an entry in ``EVIDENCE_MAPPERS``."""
+
+    def test_list_eks_pods_registered(self) -> None:
+        assert "list_eks_pods" in EVIDENCE_MAPPERS
+
+    def test_get_eks_events_registered(self) -> None:
+        assert "get_eks_events" in EVIDENCE_MAPPERS
+
+    def test_list_eks_deployments_registered(self) -> None:
+        assert "list_eks_deployments" in EVIDENCE_MAPPERS
+
+    def test_get_eks_node_health_registered(self) -> None:
+        assert "get_eks_node_health" in EVIDENCE_MAPPERS
+
+    def test_get_eks_pod_logs_registered(self) -> None:
+        assert "get_eks_pod_logs" in EVIDENCE_MAPPERS
+
+
+class TestListEKSPodsMapper:
+    """list_eks_pods → eks_pods / eks_failing_pods / eks_high_restart_pods / eks_total_pods."""
+
+    def test_populates_all_pod_keys(self) -> None:
+        data = {
+            "source": "eks",
+            "available": True,
+            "cluster_name": "payments-prod-eks",
+            "namespace": "payments",
+            "total_pods": 3,
+            "pods": [
+                {"name": "pod-1", "phase": "Running", "containers": []},
+                {"name": "pod-2", "phase": "CrashLoopBackOff", "containers": []},
+                {"name": "pod-3", "phase": "Running", "containers": []},
+            ],
+            "failing_pods": [{"name": "pod-2", "phase": "CrashLoopBackOff", "containers": []}],
+            "high_restart_pods": [],
+            "error": None,
+        }
+        evidence = merge_evidence({}, {"list_eks_pods": _result("list_eks_pods", data)})
+        assert evidence["eks_total_pods"] == 3
+        assert len(evidence["eks_pods"]) == 3
+        assert evidence["eks_failing_pods"] == [
+            {"name": "pod-2", "phase": "CrashLoopBackOff", "containers": []}
+        ]
+        assert evidence["eks_high_restart_pods"] == []
+
+    def test_defaults_when_fields_missing(self) -> None:
+        evidence = merge_evidence({}, {"list_eks_pods": _result("list_eks_pods", {})})
+        assert evidence["eks_pods"] == []
+        assert evidence["eks_failing_pods"] == []
+        assert evidence["eks_high_restart_pods"] == []
+        assert evidence["eks_total_pods"] == 0
+
+
+class TestGetEKSEventsMapper:
+    """get_eks_events → eks_events / eks_total_warning_count."""
+
+    def test_populates_event_keys(self) -> None:
+        data = {
+            "source": "eks",
+            "available": True,
+            "warning_events": [
+                {
+                    "namespace": "payments",
+                    "reason": "OOMKilled",
+                    "message": "container exceeded memory limit",
+                    "type": "Warning",
+                    "count": 1,
+                    "involved_object": "Pod/payments-api-7f9-x7g",
+                    "first_time": "2026-04-14T10:12:00Z",
+                    "last_time": "2026-04-14T10:12:00Z",
+                }
+            ],
+            "total_warning_count": 1,
+            "error": None,
+        }
+        evidence = merge_evidence({}, {"get_eks_events": _result("get_eks_events", data)})
+        assert len(evidence["eks_events"]) == 1
+        assert evidence["eks_events"][0]["reason"] == "OOMKilled"
+        assert evidence["eks_total_warning_count"] == 1
+
+    def test_empty_events_for_healthy_state(self) -> None:
+        data = {"warning_events": [], "total_warning_count": 0}
+        evidence = merge_evidence({}, {"get_eks_events": _result("get_eks_events", data)})
+        assert evidence["eks_events"] == []
+        assert evidence["eks_total_warning_count"] == 0
+
+
+class TestListEKSDeploymentsMapper:
+    """list_eks_deployments → eks_deployments / eks_degraded_deployments / eks_total_deployments."""
+
+    def test_populates_deployment_keys_with_degraded_subset(self) -> None:
+        data = {
+            "source": "eks",
+            "deployments": [
+                {"name": "payments-api", "desired": 3, "ready": 3, "available": 3, "unavailable": 0, "degraded": False},
+                {"name": "payments-worker", "desired": 2, "ready": 0, "available": 0, "unavailable": 2, "degraded": True},
+            ],
+            "degraded_deployments": [
+                {"name": "payments-worker", "desired": 2, "ready": 0, "available": 0, "unavailable": 2, "degraded": True}
+            ],
+            "total_deployments": 2,
+        }
+        evidence = merge_evidence(
+            {}, {"list_eks_deployments": _result("list_eks_deployments", data)}
+        )
+        assert evidence["eks_total_deployments"] == 2
+        assert len(evidence["eks_deployments"]) == 2
+        assert len(evidence["eks_degraded_deployments"]) == 1
+        assert evidence["eks_degraded_deployments"][0]["name"] == "payments-worker"
+
+
+class TestGetEKSNodeHealthMapper:
+    """get_eks_node_health → eks_node_health / eks_not_ready_count / eks_total_nodes."""
+
+    def test_populates_node_keys(self) -> None:
+        data = {
+            "source": "eks",
+            "nodes": [
+                {"name": "node-1", "ready": "True"},
+                {"name": "node-2", "ready": "False"},
+            ],
+            "total_nodes": 2,
+            "not_ready_count": 1,
+        }
+        evidence = merge_evidence(
+            {}, {"get_eks_node_health": _result("get_eks_node_health", data)}
+        )
+        assert evidence["eks_total_nodes"] == 2
+        assert evidence["eks_not_ready_count"] == 1
+        assert len(evidence["eks_node_health"]) == 2
+
+
+class TestGetEKSPodLogsMapper:
+    """get_eks_pod_logs → eks_pod_logs / eks_pod_logs_pod_name / eks_pod_logs_namespace."""
+
+    def test_populates_log_keys(self) -> None:
+        data = {
+            "source": "eks",
+            "cluster_name": "payments-prod-eks",
+            "namespace": "payments",
+            "pod_name": "payments-api-7f9-x7g",
+            "logs": "line 1\nline 2\nfatal: out of memory",
+        }
+        evidence = merge_evidence(
+            {}, {"get_eks_pod_logs": _result("get_eks_pod_logs", data)}
+        )
+        assert "fatal: out of memory" in evidence["eks_pod_logs"]
+        assert evidence["eks_pod_logs_pod_name"] == "payments-api-7f9-x7g"
+        assert evidence["eks_pod_logs_namespace"] == "payments"
+
+
+class TestMergeEvidenceSkipsFailedResults:
+    """``merge_evidence`` must not apply the mapper when ``result.success`` is False."""
+
+    def test_failed_list_eks_pods_is_skipped(self) -> None:
+        data = {"pods": [{"name": "pod-1"}], "total_pods": 1}
+        result = ActionExecutionResult(
+            action_name="list_eks_pods",
+            success=False,
+            data=data,
+            error="Unable to assume IAM role",
+        )
+        evidence = merge_evidence({}, {"list_eks_pods": result})
+        assert "eks_pods" not in evidence
+        assert "eks_total_pods" not in evidence
+
+
+class TestBuildEvidenceSummaryEKS:
+    """``build_evidence_summary`` must emit human-readable EKS entries."""
+
+    def test_list_eks_pods_summary_with_failing(self) -> None:
+        data = {"pods": [{}, {}, {}], "failing_pods": [{}], "total_pods": 3}
+        summary = build_evidence_summary(
+            {"list_eks_pods": _result("list_eks_pods", data)}
+        )
+        assert "eks:3 pods" in summary
+        assert "(1 failing)" in summary
+
+    def test_list_eks_pods_summary_with_no_failing(self) -> None:
+        data = {"pods": [{}], "failing_pods": [], "total_pods": 1}
+        summary = build_evidence_summary(
+            {"list_eks_pods": _result("list_eks_pods", data)}
+        )
+        assert "eks:1 pods" in summary
+        assert "(0 failing)" in summary
+
+    def test_get_eks_events_summary(self) -> None:
+        data = {"warning_events": [{}, {}], "total_warning_count": 2}
+        summary = build_evidence_summary(
+            {"get_eks_events": _result("get_eks_events", data)}
+        )
+        assert "eks:2 warning events" in summary
+
+    def test_list_eks_deployments_summary(self) -> None:
+        data = {
+            "deployments": [{}, {}],
+            "degraded_deployments": [{}],
+            "total_deployments": 2,
+        }
+        summary = build_evidence_summary(
+            {"list_eks_deployments": _result("list_eks_deployments", data)}
+        )
+        assert "eks:2 deployments" in summary
+        assert "(1 degraded)" in summary
+
+    def test_get_eks_node_health_summary(self) -> None:
+        data = {"nodes": [{}, {}, {}], "total_nodes": 3, "not_ready_count": 1}
+        summary = build_evidence_summary(
+            {"get_eks_node_health": _result("get_eks_node_health", data)}
+        )
+        assert "eks:3 nodes" in summary
+        assert "(1 not ready)" in summary
+
+    def test_get_eks_pod_logs_summary(self) -> None:
+        data = {
+            "pod_name": "payments-api-7f9",
+            "logs": "line 1\nline 2\nline 3",
+        }
+        summary = build_evidence_summary(
+            {"get_eks_pod_logs": _result("get_eks_pod_logs", data)}
+        )
+        assert "eks:3 log lines" in summary
+        assert "payments-api-7f9" in summary


### PR DESCRIPTION
Fixes #581

#### Describe the changes you have made in this PR -

The EKS investigation tools under `app/tools/EKS*/` already return their results in a consistent envelope shape, but `merge_evidence()` in `app/nodes/investigate/processing/post_process.py` has no `EVIDENCE_MAPPERS` entries for any of the `list_eks_*` / `get_eks_*` / `describe_eks_*` action names. The mapper dict contains entries for Grafana, Datadog, CloudWatch, S3, Lambda, GitHub, Honeycomb, Coralogix and Vercel — EKS was missed.

As a result, successfully-executed EKS tools silently drop their data on the floor: `merge_evidence` loops over `execution_results`, looks up the action name in `EVIDENCE_MAPPERS`, gets `None` back, and never stores the result in `state["evidence"]`. Downstream, `diagnose_root_cause` builds its prompt from a state dict that has zero `eks_*` keys regardless of what the tools returned. The agent effectively investigates Kubernetes incidents without access to the data it just gathered — the opposite of what the EKS toolset was added for.

`build_evidence_summary()` had the same gap: no `elif` branches for EKS, so the tracker message emitted at the end of `node_investigate` never mentioned any EKS activity either.

### What this PR changes

**`app/nodes/investigate/processing/post_process.py`** — five new mapper functions, five new registry entries, and five new summary branches. No other files under `app/` are touched.

1. New mapper functions (placed next to the existing `_map_datadog_*` mappers, same shape):

    - `_map_eks_pods(data)` → `{eks_pods, eks_failing_pods, eks_high_restart_pods, eks_total_pods}`
    - `_map_eks_events(data)` → `{eks_events, eks_total_warning_count}`
    - `_map_eks_deployments(data)` → `{eks_deployments, eks_degraded_deployments, eks_total_deployments}`
    - `_map_eks_node_health(data)` → `{eks_node_health, eks_not_ready_count, eks_total_nodes}`
    - `_map_eks_pod_logs(data)` → `{eks_pod_logs, eks_pod_logs_pod_name, eks_pod_logs_namespace}`

    Each one reads the fields the corresponding tool function populates (verified by reading each tool's `return` statement in `app/tools/EKS*Tool/__init__.py`) and writes them to dedicated state keys with `.get(..., <sensible default>)` so a missing or partial tool result does not raise.

2. Registered in `EVIDENCE_MAPPERS` alongside the existing entries:

    ```python
    "list_eks_pods": _map_eks_pods,
    "get_eks_events": _map_eks_events,
    "list_eks_deployments": _map_eks_deployments,
    "get_eks_node_health": _map_eks_node_health,
    "get_eks_pod_logs": _map_eks_pod_logs,
    ```

3. New `elif` branches in `build_evidence_summary()` so the tracker output mirrors the existing Grafana / Datadog style:

    - `eks:3 pods (1 failing)` — `list_eks_pods`
    - `eks:2 warning events` — `get_eks_events`
    - `eks:2 deployments (1 degraded)` — `list_eks_deployments`
    - `eks:3 nodes (1 not ready)` — `get_eks_node_health`
    - `eks:42 log lines from payments-api-7f9` — `get_eks_pod_logs`

### Scope boundary

Wiring the remaining six EKS tools (`list_eks_clusters`, `list_eks_namespaces`, `describe_eks_cluster`, `describe_eks_addon`, `get_eks_deployment_status`, `get_eks_nodegroup_health`) is deliberately out of scope for this PR. Those tools surface supplementary data (cluster inventory, addon versions, nodegroup health metadata) that no current investigation or synthetic scenario consumes. When a future scenario or code path needs one, the same 5-line mapper pattern applies and can be added in a follow-up PR.

### Testing

All three gate commands pass locally on Python 3.12:

```
make lint         # ruff check app/ tests/  → All checks passed!
make typecheck    # mypy app/               → Success: no issues found in 340 source files
make test-cov     # pytest -n auto --ignore tests/synthetic -m "not synthetic"  → 2156 passed, 1 skipped
```

The baseline before this PR was 2137 passed. The delta of 19 matches the 19 new tests added in `tests/nodes/investigate/test_post_process.py`:

```
pytest tests/nodes/investigate/test_post_process.py -v  → 19 passed
```

The new test module covers:

* **`TestEKSMappersRegistered`** — asserts each of the 5 EKS action names is present in `EVIDENCE_MAPPERS` (one test per action, so adding a sixth mapper later catches removal regressions cleanly).
* **`TestListEKSPodsMapper`** — feeds a representative `list_eks_pods` result (3 pods, 1 failing, 0 high-restart) and asserts all four `eks_*` keys appear with the expected values; a second test covers the "missing fields" defaults path.
* **`TestGetEKSEventsMapper`** — a Warning-events-present case (OOMKilled) and a healthy no-events case.
* **`TestListEKSDeploymentsMapper`** — mixed case with one healthy and one degraded deployment, asserts the `degraded_deployments` subset is the right one.
* **`TestGetEKSNodeHealthMapper`** — two nodes, one not ready, asserts `eks_not_ready_count == 1` and `eks_total_nodes == 2`.
* **`TestGetEKSPodLogsMapper`** — three-line log fixture with a fatal marker, asserts the marker round-trips to `eks_pod_logs`.
* **`TestMergeEvidenceSkipsFailedResults`** — passes a failed `ActionExecutionResult` for `list_eks_pods` and asserts no `eks_*` keys appear in the returned evidence dict (matches the existing `if not result.success: continue` behaviour at `post_process.py:349`).
* **`TestBuildEvidenceSummaryEKS`** — six cases, one per tool summary branch, asserting the exact substring the tracker will emit.

### Screenshots of the UI changes (If any) -

N/A — no user-facing UI changes. This PR touches the evidence post-processing layer only. Production behaviour for Grafana, Datadog, CloudWatch and every other existing evidence source is identical: the change is additive.

## Impact analysis

* **Backward compatibility:** fully preserved. Every change is additive — five new mapper functions, five new dict entries, five new `elif` branches. No existing keys, functions or code paths are modified. Real-credential EKS investigations that were previously silently discarding tool output will now populate `state["evidence"]["eks_*"]` as they should always have done. If any downstream consumer was coincidentally relying on the absence of `eks_*` keys (unlikely but possible), they would see the new keys appear — hence flagged in this section rather than assumed to be a non-issue.
* **Performance:** negligible. Each mapper is a dict comprehension over at most a handful of fields; called at most once per EKS tool execution.
* **Secrets:** no new environment variables, no `.env` writes, no credentials handled.
* **Dependencies:** no new runtime or dev dependencies added.

## Related issues

* **#260** — Kubernetes synthetic test harness (parallel PR #583): the synthetic harness depends on EKS evidence actually flowing into `state["evidence"]` before `diagnose_root_cause` runs. Without the mappers added here, scenarios declaring `required_evidence_sources: [eks_pods, eks_events, ...]` in their `answer.yml` fail the scorer's evidence check regardless of whether the agent called the right tools. Once both #583 and this PR land, the end-to-end smoke test in the harness PR can be extended to assert on the `eks_*` evidence keys.

* **#582** — sister gap in `app/nodes/root_cause_diagnosis/evidence_checker.py`: `_INVESTIGATED_EVIDENCE_KEYS` has no `eks_*` entries so `is_clearly_healthy` never fires the healthy short-circuit for pure-Kubernetes healthy states. Filed as a separate bug and handled in its own PR to keep scopes clean. The ordering is: this PR first (so `state["evidence"]` actually gets `eks_*` keys), then #582 (so the short-circuit recognises them).

* **#261 / #262 / #263** — real Kubernetes failure scenarios. These depend on the plumbing in this PR to run end-to-end and grade correctly.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem solved:** EKS investigation tools were silently dropping their output at the `merge_evidence` step because the `EVIDENCE_MAPPERS` registry in `post_process.py` had no entries for any EKS action name. This was discovered while scoping the Kubernetes synthetic test harness work (#260): I noticed the harness would never see EKS evidence in `state["evidence"]` no matter what the tools returned, traced it back to the mapper gap, and filed this issue so the fix could be reviewed as a standalone scoped change rather than bundled into the harness PR.

**Alternatives considered:**

1. *Add a fallback in `merge_evidence` that stores raw tool results under `<action_name>_raw` keys when no mapper exists.* Rejected: it hides the real bug (missing mapper) and creates a different problem (`diagnose_root_cause` does not look at arbitrary `*_raw` keys), so the agent still would not see the data.

2. *Write a single generic EKS mapper that stores the entire result dict under one key per tool.* Rejected: breaks the pattern every other evidence family follows (one dict key per conceptual evidence slice, e.g. `datadog_logs` and `datadog_error_logs` are separate keys), and makes downstream consumers in `diagnose_root_cause` / `build_diagnosis_prompt` harder to write.

3. *Fix all 11 EKS tools' mappers in one pass, including the six tools whose output no current scenario consumes.* Rejected to keep the PR focused. The unused six can land in a follow-up whenever a scenario needs them. Shipping the five that matter now unblocks #260 / #261 / #262 / #263 immediately.

**Why this implementation:**

* **Follows the exact pattern of the existing Datadog mappers.** `_map_datadog_logs` and `_map_datadog_monitors` are the closest analogues because Datadog tools return similar envelope shapes (a top-level dict with `source`, `available`, typed fields, `error`). Each new mapper mirrors that style so the whole file remains visually consistent and reviewers already know what to look for.

* **Uses `.get()` with sensible defaults rather than `data["key"]`** so a partial tool result (e.g. an EKS call that succeeded structurally but returned zero pods) populates the evidence dict cleanly with empty collections instead of raising `KeyError`. The existing Datadog mappers do the same thing (`data.get("logs", [])`, `data.get("total", 0)`).

* **`build_evidence_summary` branches use `data.get(X) is not None` rather than truthiness** for list fields that can legitimately be empty on healthy scenarios (`warning_events` = `[]`, `failing_pods` = `[]`). This avoids the tracker silently swallowing healthy-state summaries. The counting cases (`"eks:3 pods (0 failing)"`) are more informative than an empty summary line.

**Key components and their jobs:**

* `_map_eks_pods(data)` — projects a `list_eks_pods` tool result into four state keys. `eks_total_pods` is the raw count, `eks_pods` is the full list, `eks_failing_pods` is the subset whose phase is not `Running` or `Succeeded`, `eks_high_restart_pods` is the subset whose containers have more than 3 restarts. These subset splits are computed by the tool itself in `app/tools/EKSListPodsTool/__init__.py:81-83`, so the mapper just passes them through.

* `_map_eks_events(data)` — projects `get_eks_events` output. `eks_events` is the Warning-event list, `eks_total_warning_count` is the raw count. The tool filters at source so only `type == "Warning"` events appear.

* `_map_eks_deployments(data)` — projects `list_eks_deployments`. `eks_deployments` is all deployments, `eks_degraded_deployments` is the subset where `unavailable > 0 or ready < desired` (computed by the tool at `app/tools/EKSListDeploymentsTool/__init__.py:70-72`).

* `_map_eks_node_health(data)` — projects `get_eks_node_health`. `eks_node_health` is the full node list (with flattened string condition fields, per the tool's output shape), `eks_not_ready_count` is the integer count of nodes whose `Ready` condition is not `"True"` (computed by the tool at `app/tools/EKSNodeHealthTool/__init__.py:72`).

* `_map_eks_pod_logs(data)` — projects `get_eks_pod_logs`. Flat string log output plus the pod name and namespace so downstream consumers can cite the source.

* The `EVIDENCE_MAPPERS` registry additions are inserted alphabetically-adjacent to the existing Datadog block, matching the file's implicit grouping-by-evidence-family ordering.

* The new `build_evidence_summary` branches are placed in the same Datadog-adjacent block so they show up in the same relative position when the tracker emits them.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---