### PR TITLE
fix: resolve CodeQL unreachable-code warnings (#396, #397)

### DIFF
--- a/tests/services/opsgenie/test_client.py
+++ b/tests/services/opsgenie/test_client.py
@@ -266,11 +266,15 @@ def test_context_manager_closes_on_exit() -> None:
     assert c._client is None
 
 
+def _raise_value_error() -> None:
+    raise ValueError("test error")
+
+
 def test_context_manager_closes_on_exception() -> None:
     c = _client()
     _ = c._get_client()
     with pytest.raises(ValueError), c:
-        raise ValueError("test error")
+        _raise_value_error()
     assert c._client is None
 
 

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -537,9 +537,13 @@ def test_make_vercel_client_forwards_team_id() -> None:
     assert client.config.team_id == "team_xyz"
 
 
+def _raise_value_error() -> None:
+    raise ValueError("test error")
+
+
 def test_context_manager_closes_on_exception() -> None:
     c = _client()
     _ = c._get_client()
     with pytest.raises(ValueError), c:
-        raise ValueError("test error")
+        _raise_value_error()
     assert c._client is None


### PR DESCRIPTION
## Summary

- Fixes 2 open CodeQL "Unreachable code" warnings on `main`:
  - **#397** in `tests/services/vercel/test_client.py:545`
  - **#396** in `tests/services/opsgenie/test_client.py:274`
- Extracts the bare `raise ValueError(...)` inside `with pytest.raises(...)` into a helper function `_raise_value_error()`, so CodeQL no longer sees an unconditional raise making the post-`with` assertion unreachable.
- Test behavior is unchanged — `pytest.raises` catches the exception at runtime and execution continues to the assertion.

## Test plan

- [x] `ruff check` passes on both files
- [x] Both `test_context_manager_closes_on_exception` tests pass

Made with [Cursor](https://cursor.com)