### PR TITLE
fix: resolve LangGraph config parameter type warning

### DIFF
--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -5,8 +5,6 @@ integration credentials available for all downstream nodes. This replaces
 per-node credential fetching with a single upfront resolution.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from typing import Any


### PR DESCRIPTION
## Summary

- Fixes `UserWarning: The 'config' parameter should be typed as 'RunnableConfig' or 'RunnableConfig | None'` at `app/pipeline/graph.py:46`
- Root cause: `from __future__ import annotations` in `app/nodes/resolve_integrations/node.py` turns the `RunnableConfig | None` annotation into a string `"RunnableConfig | None"` at runtime. LangGraph inspects runtime annotations to validate node signatures and can't match the stringified form.
- Fix: Remove the unnecessary `from __future__ import annotations` import. All PEP 604 (`X | Y`) and generic (`dict[str, Any]`) syntax works natively on Python 3.11+, which is this project's minimum version.

## Test plan

- [x] `ruff check` passes
- [x] Graph compiles without the warning (`python -c "from app.pipeline.graph import build_graph; build_graph()"`)
- [x] `mypy` shows no new errors (pre-existing stub issues for pymysql/pymongo remain)

Made with [Cursor](https://cursor.com)