### PR TITLE
feat: add Windows CI coverage and fix Windows test portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,26 +30,36 @@ concurrency:
 
 jobs:
   quality:
-    runs-on: ubuntu-latest
+    name: quality (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
       - name: Lint with ruff
-        run: ruff check app/ tests/
+        run: python -m ruff check app/ tests/
 
   typecheck:
-    runs-on: ubuntu-latest
+    name: typecheck (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
 
@@ -65,7 +75,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Type check with mypy
-        run: make typecheck
+        run: python -m mypy app/
         continue-on-error: false
 
   # ---------------------------------------------------------------
@@ -73,7 +83,12 @@ jobs:
   # minutes on a run that would be discarded anyway)
   # ---------------------------------------------------------------
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     needs: [quality, typecheck]
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -93,32 +108,35 @@ jobs:
       GCLOUD_RW_API_KEY: ${{ secrets.GCLOUD_RW_API_KEY }}
       GCLOUD_OTLP_ENDPOINT: ${{ secrets.GCLOUD_OTLP_ENDPOINT }}
       GCLOUD_OTLP_AUTH_HEADER: ${{ secrets.GCLOUD_OTLP_AUTH_HEADER }}
+      PYTHONUTF8: "1"
 
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
       - name: Run pytest with coverage
-        env:
-          PYTEST_ADDOPTS: --ignore=tests/synthetic
-        run: make test-cov
+        run: >-
+          python -m pytest -n auto -v --cov=app --cov-report=term-missing
+          --ignore=tests/e2e/kubernetes_local_alert_simulation
+          --ignore=tests/synthetic
+          -m "not synthetic"
         continue-on-error: false
 
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: coverage-report-${{ runner.os }}
           path: |
             htmlcov/
             .coverage

--- a/app/cli/wizard/prompts.py
+++ b/app/cli/wizard/prompts.py
@@ -79,6 +79,15 @@ class _CheckboxControl(InquirerControl):
         return tokens
 
 
+def _layout_kwargs(*, input: Any | None = None, output: Any | None = None) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if input is not None:
+        kwargs["input"] = input
+    if output is not None:
+        kwargs["output"] = output
+    return kwargs
+
+
 def _base_bindings(
     ic: InquirerControl,
     *,
@@ -136,6 +145,8 @@ def select(
     style: Style | None = None,
     instruction: str | None = None,
     escape_result: Any | None = None,
+    input: Any | None = None,
+    output: Any | None = None,
 ) -> Question:
     """Render a single-select prompt with navigation-only movement."""
     ic = InquirerControl(
@@ -168,9 +179,15 @@ def select(
 
     return Question(
         Application(
-            layout=common.create_inquirer_layout(ic, _tokens),
+            layout=common.create_inquirer_layout(
+                ic,
+                _tokens,
+                **_layout_kwargs(input=input, output=output),
+            ),
             key_bindings=bindings,
             style=merge_styles_default([style]),
+            input=input,
+            output=output,
         )
     )
 
@@ -183,6 +200,8 @@ def checkbox(
     instruction: str | None = None,
     initial_choice: str | None = None,
     default: Any | None = None,
+    input: Any | None = None,
+    output: Any | None = None,
 ) -> Question:
     """Render a multi-select prompt with explicit space-to-toggle behavior."""
     # If no explicit initial_choice, place cursor on first choice
@@ -225,8 +244,14 @@ def checkbox(
 
     return Question(
         Application(
-            layout=common.create_inquirer_layout(ic, _tokens),
+            layout=common.create_inquirer_layout(
+                ic,
+                _tokens,
+                **_layout_kwargs(input=input, output=output),
+            ),
             key_bindings=bindings,
             style=merge_styles_default([style]),
+            input=input,
+            output=output,
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "rich>=15.0.0",
     "questionary>=2.1.1",
     "PyYAML>=6.0",
+    "tzdata>=2026.1",
     # OpenTelemetry
     "opentelemetry-api>=1.41.0",
     "opentelemetry-sdk>=1.20.0",

--- a/tests/app/remote/test_system_metrics.py
+++ b/tests/app/remote/test_system_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from app.remote.system_metrics import (
@@ -45,7 +46,11 @@ class TestCollectSystemMetrics:
         assert disk["free_gb"] >= 0
 
     def test_cpu_returns_none_when_unavailable(self) -> None:
-        with patch("os.getloadavg", side_effect=OSError):
+        def _raise_loadavg() -> tuple[float, float, float]:
+            raise OSError
+
+        fake_os = SimpleNamespace(getloadavg=_raise_loadavg, cpu_count=lambda: 1)
+        with patch("app.remote.system_metrics.os", fake_os):
             assert _collect_cpu() is None
 
     def test_disk_returns_none_when_unavailable(self) -> None:
@@ -57,7 +62,11 @@ class TestCollectSystemMetrics:
             assert _collect_uptime() is None
 
     def test_process_returns_none_on_failure(self) -> None:
-        with patch("resource.getrusage", side_effect=Exception("no")):
+        def _raise_getrusage(_rusage_self: object) -> None:
+            raise Exception("no")
+
+        fake_resource = SimpleNamespace(getrusage=_raise_getrusage, RUSAGE_SELF=object())
+        with patch("app.remote.system_metrics._resource", fake_resource):
             assert _collect_process() is None
 
 

--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -16,8 +16,13 @@ def test_install_questionary_escape_cancel_is_idempotent() -> None:
 
 def test_stock_questionary_select_escape_cancels() -> None:
     install_questionary_escape_cancel()
-    q = questionary.select("Pick", choices=["a", "b"])
     with create_pipe_input() as pipe_input:
+        q = questionary.select(
+            "Pick",
+            choices=["a", "b"],
+            input=pipe_input,
+            output=DummyOutput(),
+        )
         pipe_input.send_bytes(b"\x1b")
         app = q.application
         app.input = pipe_input

--- a/tests/cli/wizard/test_prompts.py
+++ b/tests/cli/wizard/test_prompts.py
@@ -8,24 +8,37 @@ from questionary import Choice
 from app.cli.wizard.prompts import checkbox, select
 
 
-def test_select_prompt_registers_tab_navigation() -> None:
-    question = select("Provider", [Choice("Anthropic", value="anthropic"), Choice("OpenAI", value="openai")])
-    key_bindings = question.application.key_bindings
-    assert key_bindings is not None
-    bindings = {binding.keys for binding in key_bindings.bindings}
+def _build_select_question(message: str, choices, *, pipe_input):
+    return select(message, choices, input=pipe_input, output=DummyOutput())
 
-    assert (Keys.ControlI,) in bindings
-    assert (Keys.BackTab,) in bindings
-    assert (Keys.Right,) in bindings
-    assert (Keys.Left,) in bindings
+
+def _build_checkbox_question(message: str, choices, *, pipe_input):
+    return checkbox(message, choices, input=pipe_input, output=DummyOutput())
+
+
+def test_select_prompt_registers_tab_navigation() -> None:
+    with create_pipe_input() as pipe_input:
+        question = _build_select_question(
+            "Provider",
+            [Choice("Anthropic", value="anthropic"), Choice("OpenAI", value="openai")],
+            pipe_input=pipe_input,
+        )
+        key_bindings = question.application.key_bindings
+        assert key_bindings is not None
+        bindings = {binding.keys for binding in key_bindings.bindings}
+
+        assert (Keys.ControlI,) in bindings
+        assert (Keys.BackTab,) in bindings
+        assert (Keys.Right,) in bindings
+        assert (Keys.Left,) in bindings
 
 
 def test_select_prompt_tab_navigation_changes_selection() -> None:
     # Simulate pressing Tab to move from the first to the second option, then Enter to select it.
     choices = [Choice("Anthropic", value="anthropic"), Choice("OpenAI", value="openai")]
-    question = select("Provider", choices)
 
     with create_pipe_input() as pipe_input:
+        question = _build_select_question("Provider", choices, pipe_input=pipe_input)
         # Tab followed by Enter
         pipe_input.send_text("\t\n")
 
@@ -40,9 +53,9 @@ def test_select_prompt_tab_navigation_changes_selection() -> None:
 
 def test_select_prompt_escape_cancels() -> None:
     choices = [Choice("Anthropic", value="anthropic"), Choice("OpenAI", value="openai")]
-    question = select("Provider", choices)
 
     with create_pipe_input() as pipe_input:
+        question = _build_select_question("Provider", choices, pipe_input=pipe_input)
         pipe_input.send_bytes(b"\x1b")
 
         application = question.application
@@ -56,9 +69,9 @@ def test_select_prompt_escape_cancels() -> None:
 
 def test_select_prompt_arrow_navigation_changes_selection() -> None:
     choices = [Choice("Anthropic", value="anthropic"), Choice("OpenAI", value="openai")]
-    question = select("Provider", choices)
 
     with create_pipe_input() as pipe_input:
+        question = _build_select_question("Provider", choices, pipe_input=pipe_input)
         pipe_input.send_bytes(b"\x1b[B")
         pipe_input.send_text("\n")
 
@@ -72,22 +85,27 @@ def test_select_prompt_arrow_navigation_changes_selection() -> None:
 
 
 def test_checkbox_prompt_registers_tab_navigation() -> None:
-    question = checkbox("Integrations", [Choice("Grafana", value="grafana"), Choice("Slack", value="slack")])
-    key_bindings = question.application.key_bindings
-    assert key_bindings is not None
-    bindings = {binding.keys for binding in key_bindings.bindings}
+    with create_pipe_input() as pipe_input:
+        question = _build_checkbox_question(
+            "Integrations",
+            [Choice("Grafana", value="grafana"), Choice("Slack", value="slack")],
+            pipe_input=pipe_input,
+        )
+        key_bindings = question.application.key_bindings
+        assert key_bindings is not None
+        bindings = {binding.keys for binding in key_bindings.bindings}
 
-    assert (Keys.ControlI,) in bindings
-    assert (Keys.BackTab,) in bindings
-    assert (Keys.Right,) in bindings
-    assert (Keys.Left,) in bindings
+        assert (Keys.ControlI,) in bindings
+        assert (Keys.BackTab,) in bindings
+        assert (Keys.Right,) in bindings
+        assert (Keys.Left,) in bindings
 
 
 def test_checkbox_prompt_escape_cancels() -> None:
     choices = [Choice("Grafana", value="grafana"), Choice("Slack", value="slack")]
-    question = checkbox("Integrations", choices)
 
     with create_pipe_input() as pipe_input:
+        question = _build_checkbox_question("Integrations", choices, pipe_input=pipe_input)
         pipe_input.send_bytes(b"\x1b")
 
         application = question.application
@@ -101,9 +119,9 @@ def test_checkbox_prompt_escape_cancels() -> None:
 
 def test_checkbox_prompt_space_toggles_current_choice() -> None:
     choices = [Choice("Grafana", value="grafana"), Choice("Slack", value="slack")]
-    question = checkbox("Integrations", choices)
 
     with create_pipe_input() as pipe_input:
+        question = _build_checkbox_question("Integrations", choices, pipe_input=pipe_input)
         pipe_input.send_text(" \n")
 
         application = question.application

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -111,6 +111,8 @@ class CliSandbox:
 
 
 def _clean_terminal_output(text: str) -> str:
+    if not text:
+        return ""
     cleaned = _ANSI_RE.sub("", text)
     cleaned = cleaned.replace("\r", "\n").replace("\x00", "")
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
@@ -153,6 +155,7 @@ def _cli_env(home: Path, project_env_path: Path) -> dict[str, str]:
     env["OPENSRE_NO_TELEMETRY"] = "1"
     env["OPENSRE_PROJECT_ENV_PATH"] = str(project_env_path)
     env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
     env["TERM"] = "xterm-256color"
     env.pop("OPENSRE_DISABLE_KEYRING", None)
     env["PYTHON_KEYRING_BACKEND"] = "tests.shared.keyring_backend.MemoryKeyring"
@@ -192,6 +195,8 @@ def _run_cli(
         env=env,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
         check=False,
     )

--- a/tests/integrations/test_store.py
+++ b/tests/integrations/test_store.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 from unittest.mock import patch
 
 import pytest
 
 from app.integrations.store import _save
+
+
+def _assert_private_permissions(store_file) -> None:
+    mode = stat.S_IMODE(store_file.stat().st_mode)
+    if os.name == "nt":
+        # Windows file access is governed by ACLs; chmod-style mode bits are not portable here.
+        assert mode & stat.S_IWRITE
+        return
+    assert mode == 0o600, f"Expected 0o600, got 0o{mode:o}"
 
 
 class TestSavePermissions:
@@ -19,8 +29,7 @@ class TestSavePermissions:
         with patch("app.integrations.store.STORE_PATH", store_file):
             _save(data)
 
-        mode = stat.S_IMODE(store_file.stat().st_mode)
-        assert mode == 0o600, f"Expected 0o600, got 0o{mode:o}"
+        _assert_private_permissions(store_file)
 
     def test_saved_file_content_is_valid_json(self, tmp_path: pytest.TempPathFactory) -> None:
         store_file = tmp_path / "integrations.json"  # type: ignore[operator]
@@ -50,6 +59,5 @@ class TestSavePermissions:
         with patch("app.integrations.store.STORE_PATH", store_file):
             _save({"updated": True})
 
-        mode = stat.S_IMODE(store_file.stat().st_mode)
-        assert mode == 0o600
+        _assert_private_permissions(store_file)
         assert json.loads(store_file.read_text())["updated"] is True


### PR DESCRIPTION
Fixes #580

### Describe the changes you have made in this PR -

This PR adds Windows coverage to the core CI pipeline and fixes the Windows-specific portability issues that were preventing the core non-synthetic test suite from passing on Windows.

Changes included in this PR:
- Added `tzdata` to project dependencies so `ZoneInfo("Europe/London")` works reliably on Windows
- Updated the core CI workflow to run `quality`, `typecheck`, and `test` on both `ubuntu-latest` and `windows-latest`
- Kept Linux-only infrastructure jobs such as Kubernetes and thorough E2E coverage on Ubuntu only
- Replaced `make`-based core CI commands with cross-platform `python -m ...` invocations for Windows compatibility
- Fixed system metrics tests to avoid patching Unix-only APIs directly on Windows
- Updated interactive prompt tests and wizard prompt helpers so they can run with injected headless IO instead of assuming a native Windows console
- Made integration store permission assertions portable across POSIX and Windows ACL behavior
- Hardened CLI smoke tests to use UTF-8-safe subprocess decoding on Windows



### Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem was not only missing Windows CI coverage, but also a small set of Windows-specific failures in the existing test and runtime paths. I scoped the implementation to issue `#580` by fixing only the portability problems required for the core CI path to run cleanly on both Linux and Windows, while intentionally leaving Linux-only infra workflows unchanged.

I considered two broad approaches:
1. Add a Windows CI lane first and let it fail, then fix issues incrementally.
2. Fix the known Windows portability issues first, verify the core non-synthetic suite locally on Windows, and then expand CI.

I chose the second approach because it reduces noise in CI and makes the PR safer to review and merge. The implementation focuses on a few targeted areas:
- dependency portability via `tzdata`
- test portability for system metrics and prompt handling
- subprocess output handling in CLI smoke tests
- cross-platform CI command execution

Validation performed for this PR:
- `python -m pip install -e ".[dev]"`
- `python -m ruff check app tests`
- `python -m mypy app`
- `python -m pytest -q -m "not synthetic"`

On Windows, the non-synthetic suite passed after these changes.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
