### PR TITLE
feat(cli): add LangSmith deploy support to opensre deploy

### DIFF
--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -15,6 +15,15 @@ from app.analytics.cli import (
 )
 from app.cli.context import is_json_output, is_yes
 from app.cli.errors import OpenSREError
+from app.cli.langsmith_deploy import (
+    extract_deployment_url,
+    is_langgraph_cli_installed,
+    persist_langsmith_env,
+    resolve_deployment_name,
+    resolve_langsmith_api_key,
+    run_langsmith_deploy,
+    validate_langsmith_api_key,
+)
 from app.deployment.ec2_config import load_remote_outputs
 from app.deployment.health import poll_deployment_health
 
@@ -113,6 +122,10 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
             questionary.Choice("Deploy to AWS EC2 (Bedrock)", value="ec2"),
         )
 
+    choices.append(
+        questionary.Choice("Deploy to LangSmith (LangGraph)", value="langsmith"),
+    )
+
     choices.extend(
         [
             questionary.Separator(),
@@ -151,6 +164,55 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
 
     if action == "railway":
         ctx.invoke(deploy_railway)
+        return
+
+    if action == "langsmith":
+
+        # 2. LangGraph CLI check
+        ok, msg = is_langgraph_cli_installed()
+        if not ok:
+            console.print(f"[red]{msg}[/red]")
+            return
+
+        # 3. API key resolve
+        api_key = resolve_langsmith_api_key()
+        if not api_key:
+            api_key = questionary.text("LangSmith API key:").ask()
+            if not api_key:
+                return
+
+        # 4. Validate API key
+        valid, msg = validate_langsmith_api_key(api_key)
+        if not valid:
+            console.print(f"[red]{msg}[/red]")
+            return
+
+        # 5. Deployment name
+        deployment_name = resolve_deployment_name()
+
+        # 6. Persist to .env
+        persist_langsmith_env(api_key, deployment_name)
+
+        # 7. Deploy
+        console.print("[cyan]Deploying to LangSmith...[/cyan]")
+        code, output = run_langsmith_deploy(
+            api_key=api_key,
+            deployment_name=deployment_name,
+            build_only=False,
+        )
+
+        console.print(output)
+
+        # 8. Show URL
+        if code == 0:
+            url = extract_deployment_url(output)
+            if url:
+                console.print(f"[green]Deployment URL:[/green] {url}")
+            else:
+                console.print("[yellow]Deployment succeeded but no URL found[/yellow]")
+        else:
+            console.print("[red]Deployment failed[/red]")
+
         return
 
     if action == "down":
@@ -219,7 +281,7 @@ def deploy(ctx: click.Context) -> None:
         if is_yes() or is_json_output():
             raise OpenSREError(
                 "No subcommand provided.",
-                suggestion="Use 'opensre deploy ec2' or 'opensre deploy ec2 --down'.",
+                suggestion="Use 'opensre deploy ec2', 'opensre deploy ec2 --down', or 'opensre deploy langsmith'.",
             )
         _run_deploy_interactive(ctx)
 
@@ -296,3 +358,44 @@ def deploy_railway(
 
     capture_deploy_failed(target="railway", dry_run=dry_run)
     raise SystemExit(exit_code)
+
+
+@deploy.command(name="langsmith")
+@click.option("--api-key", default=None, help="LangSmith API key")
+@click.option("--build-only", is_flag=True, help="Build without deploy")
+@click.option("--deployment-name", default=None, help="Deployment name")
+def deploy_langsmith(api_key: str | None, build_only: bool, deployment_name: str | None) -> None:
+    """Deploy OpenSRE to LangSmith."""
+
+    ok, msg = is_langgraph_cli_installed()
+    if not ok:
+        raise click.ClickException(msg)
+
+    api_key = resolve_langsmith_api_key(api_key)
+    if not api_key:
+        raise click.ClickException("LangSmith API key not found.")
+
+    valid, msg = validate_langsmith_api_key(api_key)
+    if not valid:
+        raise click.ClickException(msg)
+
+    deployment_name = resolve_deployment_name(deployment_name)
+
+    persist_langsmith_env(api_key, deployment_name)
+
+    click.echo("Deploying to LangSmith...")
+    code, output = run_langsmith_deploy(
+        api_key=api_key,
+        deployment_name=deployment_name,
+        build_only=build_only,
+    )
+
+    click.echo(output)
+
+    if code != 0:
+        raise SystemExit(code)
+
+    url = extract_deployment_url(output)
+    if url:
+        click.echo(f"Deployment URL: {url}")
+

--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -167,8 +167,6 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
         return
 
     if action == "langsmith":
-        capture_cli_invoked()
-        capture_deploy_started(target="langsmith", dry_run=False)
 
         # 2. LangGraph CLI check
         ok, msg = is_langgraph_cli_installed()
@@ -202,6 +200,9 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
 
         # 6. Persist to .env
         persist_langsmith_env(api_key, deployment_name)
+
+        capture_cli_invoked()
+        capture_deploy_started(target="langsmith", dry_run=False)
 
         # 7. Deploy
         console.print("[cyan]Deploying to LangSmith...[/cyan]")

--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -167,6 +167,8 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
         return
 
     if action == "langsmith":
+        capture_cli_invoked()
+        capture_deploy_started(target="langsmith", dry_run=False)
 
         # 2. LangGraph CLI check
         ok, msg = is_langgraph_cli_installed()
@@ -177,7 +179,7 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
         # 3. API key resolve
         api_key = resolve_langsmith_api_key()
         if not api_key:
-            api_key = questionary.text("LangSmith API key:").ask()
+            api_key = questionary.password("LangSmith API key:").ask()
             if not api_key:
                 return
 
@@ -189,6 +191,14 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
 
         # 5. Deployment name
         deployment_name = resolve_deployment_name()
+
+        if not questionary.confirm(
+            f"Deploy to LangSmith with deployment '{deployment_name}'?",
+            default=True,
+            style=style,
+        ).ask():
+            console.print("  [dim]Cancelled.[/dim]")
+            return
 
         # 6. Persist to .env
         persist_langsmith_env(api_key, deployment_name)
@@ -205,12 +215,14 @@ def _run_deploy_interactive(ctx: click.Context) -> None:
 
         # 8. Show URL
         if code == 0:
+            capture_deploy_completed(target="langsmith", dry_run=False)
             url = extract_deployment_url(output)
             if url:
                 console.print(f"[green]Deployment URL:[/green] {url}")
             else:
                 console.print("[yellow]Deployment succeeded but no URL found[/yellow]")
         else:
+            capture_deploy_failed(target="langsmith", dry_run=False)
             console.print("[red]Deployment failed[/red]")
 
         return

--- a/app/cli/langsmith_deploy.py
+++ b/app/cli/langsmith_deploy.py
@@ -1,0 +1,308 @@
+"""LangSmith deployment helpers for the OpenSRE CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.cli.wizard.store import get_store_path
+
+DEFAULT_DEPLOYMENT_NAME = "open-sre-agent"
+LANGSMITH_API_KEY_ENV = "LANGSMITH_API_KEY"
+LANGSMITH_DEPLOYMENT_NAME_ENV = "LANGSMITH_DEPLOYMENT_NAME"
+
+
+def _run_command(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process."""
+    try:
+        return subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=127,
+            stdout="",
+            stderr=f"Command not found: {cmd[0]}",
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=124,
+            stdout=stdout,
+            stderr=stderr or f"Command timed out: {' '.join(cmd)}",
+        )
+
+
+def is_langgraph_cli_installed() -> tuple[bool, str]:
+    """Check whether the langgraph CLI is installed and callable."""
+    if not shutil.which("langgraph"):
+        return False, "langgraph CLI is not installed."
+
+    result = _run_command(["langgraph", "--help"], timeout=15.0)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if detail:
+            return False, f"langgraph CLI is not available: {detail}"
+        return False, "langgraph CLI is not available."
+
+    return True, "langgraph CLI is installed."
+
+
+def _project_env_path() -> Path:
+    """Resolve the project .env path, honoring the test override env var."""
+    override = os.getenv("OPENSRE_PROJECT_ENV_PATH", "").strip()
+    if override:
+        return Path(override)
+    return Path(".env")
+
+
+def _read_env_value(env_path: Path, key: str) -> str | None:
+    """Read a single KEY=value entry from a .env-style file."""
+    if not env_path.exists():
+        return None
+
+    try:
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if not stripped.startswith(f"{key}="):
+                continue
+
+            value = stripped.split("=", 1)[1].strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+                value = value[1:-1]
+            return value or None
+    except OSError:
+        return None
+
+    return None
+
+
+def _load_opensre_store() -> dict[str, Any]:
+    """Load ~/.opensre/opensre.json, returning an empty dict on failure."""
+    store_path = get_store_path()
+    if not store_path.exists():
+        return {}
+
+    try:
+        payload = json.loads(store_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_store_langsmith_api_key() -> str | None:
+    """Best-effort lookup for a LangSmith API key from opensre.json."""
+    data = _load_opensre_store()
+
+    # Flexible fallback lookup to avoid coupling to a single schema.
+    candidates: list[Any] = [
+        data.get("langsmith"),
+        data.get("deploy"),
+        data.get("wizard"),
+        data.get("targets"),
+        data.get("remote"),
+    ]
+
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+
+        maybe_key = candidate.get("api_key") or candidate.get(LANGSMITH_API_KEY_ENV)
+        if isinstance(maybe_key, str) and maybe_key.strip():
+            return maybe_key.strip()
+
+        credentials = candidate.get("credentials")
+        if isinstance(credentials, dict):
+            nested_key = credentials.get("api_key") or credentials.get(LANGSMITH_API_KEY_ENV)
+            if isinstance(nested_key, str) and nested_key.strip():
+                return nested_key.strip()
+
+    return None
+
+
+def _read_store_deployment_name() -> str | None:
+    """Best-effort lookup for a deployment name from opensre.json."""
+    data = _load_opensre_store()
+
+    candidates: list[Any] = [
+        data.get("langsmith"),
+        data.get("deploy"),
+        data.get("wizard"),
+        data.get("targets"),
+        data.get("remote"),
+    ]
+
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+
+        maybe_name = candidate.get("deployment_name") or candidate.get(
+            LANGSMITH_DEPLOYMENT_NAME_ENV
+        )
+        if isinstance(maybe_name, str) and maybe_name.strip():
+            return maybe_name.strip()
+
+        credentials = candidate.get("credentials")
+        if isinstance(credentials, dict):
+            nested_name = credentials.get("deployment_name") or credentials.get(
+                LANGSMITH_DEPLOYMENT_NAME_ENV
+            )
+            if isinstance(nested_name, str) and nested_name.strip():
+                return nested_name.strip()
+
+    return None
+
+
+def resolve_langsmith_api_key(cli_api_key: str | None = None) -> str | None:
+    """Resolve the LangSmith API key from CLI arg, env, .env, or opensre store."""
+    if cli_api_key and cli_api_key.strip():
+        return cli_api_key.strip()
+
+    env_key = os.getenv(LANGSMITH_API_KEY_ENV, "").strip()
+    if env_key:
+        return env_key
+
+    env_file_key = _read_env_value(_project_env_path(), LANGSMITH_API_KEY_ENV)
+    if env_file_key:
+        return env_file_key
+
+    return _read_store_langsmith_api_key()
+
+
+def resolve_deployment_name(cli_name: str | None = None) -> str:
+    """Resolve the deployment name from CLI arg, env, .env, or opensre store."""
+    if cli_name and cli_name.strip():
+        return cli_name.strip()
+
+    env_name = os.getenv(LANGSMITH_DEPLOYMENT_NAME_ENV, "").strip()
+    if env_name:
+        return env_name
+
+    env_file_name = _read_env_value(_project_env_path(), LANGSMITH_DEPLOYMENT_NAME_ENV)
+    if env_file_name:
+        return env_file_name
+
+    store_name = _read_store_deployment_name()
+    if store_name:
+        return store_name
+
+    return DEFAULT_DEPLOYMENT_NAME
+
+
+def validate_langsmith_api_key(api_key: str) -> tuple[bool, str]:
+    """Validate a LangSmith API key against the LangSmith API."""
+    try:
+        response = httpx.get(
+            "https://api.smith.langchain.com/api/v1/sessions",
+            headers={"x-api-key": api_key},
+            timeout=15.0,
+        )
+    except httpx.HTTPError as exc:
+        return False, f"LangSmith validation request failed: {exc}"
+
+    if response.status_code == 200:
+        return True, "LangSmith API key validated."
+
+    if response.status_code == 401:
+        return False, "Invalid LangSmith API key."
+
+    if response.status_code == 403:
+        return True, "LangSmith API key appears valid, but the validation endpoint is permission-limited."
+
+    if response.is_success:
+        return True, f"LangSmith API key validated with status {response.status_code}."
+
+    return False, f"LangSmith validation failed with status {response.status_code}."
+
+
+def persist_langsmith_env(api_key: str, deployment_name: str) -> Path:
+    """Persist LangSmith settings to the project .env file."""
+    env_path = _project_env_path()
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    if env_path.exists():
+        try:
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            lines = []
+
+    updates = {
+        LANGSMITH_API_KEY_ENV: api_key,
+        LANGSMITH_DEPLOYMENT_NAME_ENV: deployment_name,
+    }
+
+    seen: set[str] = set()
+    updated_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            updated_lines.append(line)
+            continue
+
+        key, _value = line.split("=", 1)
+        normalized_key = key.strip()
+        if normalized_key in updates:
+            updated_lines.append(f"{normalized_key}={updates[normalized_key]}")
+            seen.add(normalized_key)
+        else:
+            updated_lines.append(line)
+
+    for key, value in updates.items():
+        if key not in seen:
+            updated_lines.append(f"{key}={value}")
+
+    content = "\n".join(updated_lines).rstrip() + "\n"
+    env_path.write_text(content, encoding="utf-8")
+    return env_path
+
+
+def run_langsmith_deploy(
+    *,
+    api_key: str,
+    deployment_name: str,
+    build_only: bool = False,
+) -> tuple[int, str]:
+    """Run the LangGraph build/deploy command."""
+    env = {
+        **os.environ,
+        LANGSMITH_API_KEY_ENV: api_key,
+        LANGSMITH_DEPLOYMENT_NAME_ENV: deployment_name,
+    }
+
+    cmd = ["langgraph", "build"] if build_only else ["langgraph", "deploy"]
+    result = _run_command(cmd, env=env, timeout=1800.0)
+
+    output_parts = [part.strip() for part in [result.stdout, result.stderr] if part and part.strip()]
+    output = "\n".join(output_parts)
+    return int(result.returncode), output
+
+
+def extract_deployment_url(output: str) -> str | None:
+    """Extract a deployment URL from langgraph CLI output."""
+    match = re.search(r"https://[^\s\)\]\},;\'\"]+", output)
+    return match.group(0) if match else None

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -25,3 +25,125 @@ def test_deploy_ec2_health_check_failure_is_non_fatal() -> None:
     assert result.exit_code == 0
     assert "[warn] Health check: Connection timed out" in result.output
     assert "Deployment provisioned. Retry with: opensre remote health" in result.output
+
+
+def test_deploy_langsmith_success_prints_url() -> None:
+    runner = CliRunner()
+
+    with (
+        patch(
+            "app.cli.commands.deploy.is_langgraph_cli_installed",
+            return_value=(True, "langgraph CLI is installed."),
+        ),
+        patch(
+            "app.cli.commands.deploy.resolve_langsmith_api_key",
+            return_value="sk-test",
+        ),
+        patch(
+            "app.cli.commands.deploy.validate_langsmith_api_key",
+            return_value=(True, "LangSmith API key validated."),
+        ),
+        patch(
+            "app.cli.commands.deploy.resolve_deployment_name",
+            return_value="open-sre-agent",
+        ),
+        patch("app.cli.commands.deploy.persist_langsmith_env"),
+        patch(
+            "app.cli.commands.deploy.run_langsmith_deploy",
+            return_value=(0, "Deployment complete\nhttps://example.langsmith.com"),
+        ),
+        patch(
+            "app.cli.commands.deploy.extract_deployment_url",
+            return_value="https://example.langsmith.com",
+        ),
+    ):
+        result = runner.invoke(cli, ["deploy", "langsmith"])
+
+    assert result.exit_code == 0
+    assert "Deploying to LangSmith..." in result.output
+    assert "Deployment URL: https://example.langsmith.com" in result.output
+
+
+def test_deploy_langsmith_invalid_key_fails() -> None:
+    runner = CliRunner()
+
+    with (
+        patch(
+            "app.cli.commands.deploy.is_langgraph_cli_installed",
+            return_value=(True, "langgraph CLI is installed."),
+        ),
+        patch(
+            "app.cli.commands.deploy.resolve_langsmith_api_key",
+            return_value="sk-bad",
+        ),
+        patch(
+            "app.cli.commands.deploy.validate_langsmith_api_key",
+            return_value=(False, "Invalid LangSmith API key."),
+        ),
+    ):
+        result = runner.invoke(cli, ["deploy", "langsmith"])
+
+    assert result.exit_code != 0
+    assert "Invalid LangSmith API key." in result.output
+
+
+def test_deploy_langsmith_build_only_passes_flag() -> None:
+    runner = CliRunner()
+
+    with (
+        patch(
+            "app.cli.commands.deploy.is_langgraph_cli_installed",
+            return_value=(True, "langgraph CLI is installed."),
+        ),
+        patch(
+            "app.cli.commands.deploy.resolve_langsmith_api_key",
+            return_value="sk-test",
+        ),
+        patch(
+            "app.cli.commands.deploy.validate_langsmith_api_key",
+            return_value=(True, "LangSmith API key validated."),
+        ),
+        patch(
+            "app.cli.commands.deploy.resolve_deployment_name",
+            return_value="open-sre-agent",
+        ),
+        patch("app.cli.commands.deploy.persist_langsmith_env"),
+        patch(
+            "app.cli.commands.deploy.run_langsmith_deploy",
+            return_value=(0, "Build complete"),
+        ) as mock_run,
+        patch(
+            "app.cli.commands.deploy.extract_deployment_url",
+            return_value=None,
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["deploy", "langsmith", "--build-only", "--api-key", "sk-test"],
+        )
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        api_key="sk-test",
+        deployment_name="open-sre-agent",
+        build_only=True,
+    )
+
+
+def test_deploy_langsmith_missing_key_fails() -> None:
+    runner = CliRunner()
+
+    with (
+        patch(
+            "app.cli.commands.deploy.is_langgraph_cli_installed",
+            return_value=(True, "langgraph CLI is installed."),
+        ),
+        patch(
+            "app.cli.commands.deploy.resolve_langsmith_api_key",
+            return_value=None,
+        ),
+    ):
+        result = runner.invoke(cli, ["deploy", "langsmith"])
+
+    assert result.exit_code != 0
+    assert "LangSmith API key not found." in result.output

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -561,3 +561,11 @@ def test_tests_interactive_launcher_smoke(cli_sandbox: CliSandbox) -> None:
 
     assert result.exit_code == 0
     assert "Choose a test category:" in result.stdout
+
+
+def test_deploy_help_smoke(cli_sandbox: CliSandbox) -> None:
+    result = _run_cli(cli_sandbox, "deploy", "-h")
+
+    assert result.exit_code == 0
+    assert "ec2" in result.stdout
+    assert "langsmith" in result.stdout


### PR DESCRIPTION
Fixes #264

Summary

This PR adds LangSmith deployment support directly to the opensre deploy command.

Changes
-Added Deploy to LangSmith (LangGraph) option under opensre deploy
-Implemented LangSmith API key resolution (CLI, env, .env, integration store)
-Added API key validation against LangSmith API
-Persisted LangSmith credentials to .env
-Integrated langgraph deploy flow into CLI
-Removed Docker dependency for LangSmith deployments
-Added deployment output validation by extracting and printing deployment URL
-Added test coverage for LangSmith deploy flow

Users can now run:

opensre deploy

and select:

Deploy to LangSmith (LangGraph)