### PR TITLE
Fix: Add missing EVIDENCE_MAPPERS for EKS tools (Fixes #581)

### DIFF
--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -301,6 +301,46 @@ def _map_github_commits(data: dict) -> dict:
     }
 
 
+def _map_eks_pods(data: dict) -> dict:
+    return {
+        "eks_pods": data.get("pods", []),
+        "eks_failing_pods": data.get("failing_pods", []),
+        "eks_high_restart_pods": data.get("high_restart_pods", []),
+        "eks_total_pods": data.get("total_pods", 0),
+    }
+
+
+def _map_eks_events(data: dict) -> dict:
+    return {
+        "eks_events": data.get("warning_events", []),
+        "eks_total_warning_count": data.get("total_warning_count", 0),
+    }
+
+
+def _map_eks_deployments(data: dict) -> dict:
+    return {
+        "eks_deployments": data.get("deployments", []),
+        "eks_degraded_deployments": data.get("degraded_deployments", []),
+        "eks_total_deployments": data.get("total_deployments", 0),
+    }
+
+
+def _map_eks_node_health(data: dict) -> dict:
+    return {
+        "eks_node_health": data.get("nodes", []),
+        "eks_not_ready_count": data.get("not_ready_count", 0),
+        "eks_total_nodes": data.get("total_nodes", 0),
+    }
+
+
+def _map_eks_pod_logs(data: dict) -> dict:
+    return {
+        "eks_pod_logs": data.get("logs", ""),
+        "eks_pod_logs_pod_name": data.get("pod_name", ""),
+        "eks_pod_logs_namespace": data.get("namespace", ""),
+    }
+
+
 EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "get_failed_jobs": _map_failed_jobs,
     "get_failed_tools": _map_failed_tools,
@@ -331,6 +371,11 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "search_github_code": _map_github_code_search,
     "get_github_file_contents": _map_github_file_contents,
     "list_github_commits": _map_github_commits,
+    "list_eks_pods": _map_eks_pods,
+    "get_eks_events": _map_eks_events,
+    "list_eks_deployments": _map_eks_deployments,
+    "get_eks_node_health": _map_eks_node_health,
+    "get_eks_pod_logs": _map_eks_pod_logs,
 }
 
 
@@ -494,6 +539,19 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
                 summary_parts.append("github:file contents retrieved")
             elif action_name == "list_github_commits" and data.get("commits"):
                 summary_parts.append(f"github:{len(data['commits'])} commits")
+            elif action_name == "list_eks_pods" and data.get("pods") is not None:
+                failing = len(data.get("failing_pods", []))
+                summary_parts.append(f"eks:{data.get('total_pods', 0)} pods ({failing} failing)")
+            elif action_name == "get_eks_events" and data.get("warning_events") is not None:
+                summary_parts.append(f"eks:{data.get('total_warning_count', 0)} warning events")
+            elif action_name == "list_eks_deployments" and data.get("deployments") is not None:
+                degraded = len(data.get("degraded_deployments", []))
+                summary_parts.append(f"eks:{data.get('total_deployments', 0)} deployments ({degraded} degraded)")
+            elif action_name == "get_eks_node_health" and data.get("nodes") is not None:
+                not_ready = data.get("not_ready_count", 0)
+                summary_parts.append(f"eks:{data.get('total_nodes', 0)} nodes ({not_ready} not ready)")
+            elif action_name == "get_eks_pod_logs" and data.get("logs"):
+                summary_parts.append("eks:pod logs retrieved")
         else:
             # Log action failures for debugging
             error_msg = f"{action_name}:FAILED({result.error[:50] if result.error else 'unknown'})"

--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -344,10 +344,10 @@ def _map_eks_pod_logs(data: dict) -> dict:
 def _map_eks_deployment_status(data: dict) -> dict:
     return {
         "eks_deployment_status": {
-            "deployment_name": data.get("deployment_name"),
-            "desired_replicas": data.get("desired_replicas"),
-            "ready_replicas": data.get("ready_replicas"),
-            "unavailable_replicas": data.get("unavailable_replicas"),
+            "deployment_name": data.get("deployment_name", ""),
+            "desired_replicas": data.get("desired_replicas", 0),
+            "ready_replicas": data.get("ready_replicas", 0),
+            "unavailable_replicas": data.get("unavailable_replicas", 0),
             "conditions": data.get("conditions", []),
         }
     }

--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -341,6 +341,18 @@ def _map_eks_pod_logs(data: dict) -> dict:
     }
 
 
+def _map_eks_deployment_status(data: dict) -> dict:
+    return {
+        "eks_deployment_status": {
+            "deployment_name": data.get("deployment_name"),
+            "desired_replicas": data.get("desired_replicas"),
+            "ready_replicas": data.get("ready_replicas"),
+            "unavailable_replicas": data.get("unavailable_replicas"),
+            "conditions": data.get("conditions", []),
+        }
+    }
+
+
 EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "get_failed_jobs": _map_failed_jobs,
     "get_failed_tools": _map_failed_tools,
@@ -376,6 +388,7 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "list_eks_deployments": _map_eks_deployments,
     "get_eks_node_health": _map_eks_node_health,
     "get_eks_pod_logs": _map_eks_pod_logs,
+    "get_eks_deployment_status": _map_eks_deployment_status,
 }
 
 
@@ -539,19 +552,21 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
                 summary_parts.append("github:file contents retrieved")
             elif action_name == "list_github_commits" and data.get("commits"):
                 summary_parts.append(f"github:{len(data['commits'])} commits")
-            elif action_name == "list_eks_pods" and data.get("pods") is not None:
+            elif action_name == "list_eks_pods" and data.get("pods"):
                 failing = len(data.get("failing_pods", []))
                 summary_parts.append(f"eks:{data.get('total_pods', 0)} pods ({failing} failing)")
-            elif action_name == "get_eks_events" and data.get("warning_events") is not None:
+            elif action_name == "get_eks_events" and data.get("warning_events"):
                 summary_parts.append(f"eks:{data.get('total_warning_count', 0)} warning events")
-            elif action_name == "list_eks_deployments" and data.get("deployments") is not None:
+            elif action_name == "list_eks_deployments" and data.get("deployments"):
                 degraded = len(data.get("degraded_deployments", []))
                 summary_parts.append(f"eks:{data.get('total_deployments', 0)} deployments ({degraded} degraded)")
-            elif action_name == "get_eks_node_health" and data.get("nodes") is not None:
+            elif action_name == "get_eks_node_health" and data.get("nodes"):
                 not_ready = data.get("not_ready_count", 0)
                 summary_parts.append(f"eks:{data.get('total_nodes', 0)} nodes ({not_ready} not ready)")
             elif action_name == "get_eks_pod_logs" and data.get("logs"):
                 summary_parts.append("eks:pod logs retrieved")
+            elif action_name == "get_eks_deployment_status" and data.get("deployment_name"):
+                summary_parts.append("eks:deployment status retrieved")
         else:
             # Log action failures for debugging
             error_msg = f"{action_name}:FAILED({result.error[:50] if result.error else 'unknown'})"

--- a/tests/nodes/investigate/test_post_process.py
+++ b/tests/nodes/investigate/test_post_process.py
@@ -1,0 +1,60 @@
+import pytest
+from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
+from app.nodes.investigate.processing.post_process import merge_evidence
+
+@pytest.mark.parametrize(
+    "action_name, data, expected_keys",
+    [
+        (
+            "list_eks_pods",
+            {
+                "pods": [{"name": "fake-pod-1"}],
+                "failing_pods": [{"name": "fake-pod-2"}],
+                "high_restart_pods": [],
+                "total_pods": 2
+            },
+            ["eks_pods", "eks_failing_pods", "eks_high_restart_pods", "eks_total_pods"]
+        ),
+        (
+            "get_eks_events",
+            {
+                "warning_events": [{"message": "Back-off restarting failed container"}],
+                "total_warning_count": 1
+            },
+            ["eks_events", "eks_total_warning_count"]
+        ),
+        (
+            "list_eks_deployments",
+            {
+                "deployments": [{"name": "api"}],
+                "degraded_deployments": [],
+                "total_deployments": 1
+            },
+            ["eks_deployments", "eks_degraded_deployments", "eks_total_deployments"]
+        ),
+        (
+            "get_eks_node_health",
+            {
+                "nodes": [{"name": "ip-10-0-0-1.ec2.internal"}],
+                "not_ready_count": 0,
+                "total_nodes": 1
+            },
+            ["eks_node_health", "eks_not_ready_count", "eks_total_nodes"]
+        ),
+        (
+            "get_eks_pod_logs",
+            {
+                "logs": "Error: Connection refused...",
+                "pod_name": "fake-pod-1",
+                "namespace": "default"
+            },
+            ["eks_pod_logs", "eks_pod_logs_pod_name", "eks_pod_logs_namespace"]
+        )
+    ]
+)
+def test_merge_evidence_eks_tools(action_name, data, expected_keys):
+    result = ActionExecutionResult(action_name=action_name, success=True, data=data)
+    evidence = merge_evidence({}, {action_name: result})
+    
+    for key in expected_keys:
+        assert key in evidence

--- a/tests/nodes/investigate/test_post_process.py
+++ b/tests/nodes/investigate/test_post_process.py
@@ -49,6 +49,17 @@ from app.nodes.investigate.processing.post_process import merge_evidence
                 "namespace": "default"
             },
             ["eks_pod_logs", "eks_pod_logs_pod_name", "eks_pod_logs_namespace"]
+        ),
+        (
+            "get_eks_deployment_status",
+            {
+                "deployment_name": "api",
+                "desired_replicas": 3,
+                "ready_replicas": 3,
+                "unavailable_replicas": 0,
+                "conditions": []
+            },
+            ["eks_deployment_status"]
         )
     ]
 )
@@ -58,3 +69,21 @@ def test_merge_evidence_eks_tools(action_name, data, expected_keys):
     
     for key in expected_keys:
         assert key in evidence
+        
+    # Validate the data content itself
+    if action_name == "list_eks_pods":
+        assert evidence["eks_pods"][0]["name"] == "fake-pod-1"
+        assert evidence["eks_failing_pods"][0]["name"] == "fake-pod-2"
+    elif action_name == "get_eks_events":
+        assert evidence["eks_events"][0]["message"] == "Back-off restarting failed container"
+    elif action_name == "list_eks_deployments":
+        assert evidence["eks_deployments"][0]["name"] == "api"
+    elif action_name == "get_eks_node_health":
+        assert evidence["eks_node_health"][0]["name"] == "ip-10-0-0-1.ec2.internal"
+        assert evidence["eks_not_ready_count"] == 0
+    elif action_name == "get_eks_pod_logs":
+        assert evidence["eks_pod_logs"] == "Error: Connection refused..."
+        assert evidence["eks_pod_logs_pod_name"] == "fake-pod-1"
+    elif action_name == "get_eks_deployment_status":
+        assert evidence["eks_deployment_status"]["deployment_name"] == "api"
+        assert evidence["eks_deployment_status"]["ready_replicas"] == 3


### PR DESCRIPTION
Fixes #581

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What changed and why
The `EVIDENCE_MAPPERS` dict in `post_process.py` was missing mapping functions for several EKS tools. Because of this gap, even when the agent successfully executed tools like `list_eks_pods` or `get_eks_events`, the data was silently dropped and never made it into the investigation state. 

This PR:
1. Adds the missing EKS mapping functions (`_map_eks_pods`, `_map_eks_events`, `_map_eks_deployments`, `_map_eks_node_health`, `_map_eks_pod_logs`).
2. Registers them into `EVIDENCE_MAPPERS`.
3. Updates `build_evidence_summary()` so the EKS tracker appropriately reports the data in the summary logs.

## Testing steps with evidence
- Added parameterized unit tests in `tests/nodes/investigate/test_post_process.py`.
- The tests verify that executing each EKS action correctly merges the expected keys (`eks_pods`, `eks_events`, etc.) into the main evidence dictionary.

## Impact analysis
- **Backward Compatibility:** Yes, fully compatible.
- **Breaking Changes:** None. This strictly appends newly fetched data safely.

## AI-Assisted Contribution
- [x] I have reviewed every line of code.
- [x] I understand the logic.
- [x] I have tested edge cases.
- [x] I have verified the code matches the project conventions.