### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -106,10 +106,15 @@ GEMINI_TOOLCALL_MODEL = "gemini-3.1-flash-lite-preview"
 NVIDIA_REASONING_MODEL = "nvidia/nemotron-3-super-120b-a12b"
 NVIDIA_TOOLCALL_MODEL = "nvidia/nemotron-3-nano-30b-a3b"
 
+# MiniMax model constants
+MINIMAX_REASONING_MODEL = "MiniMax-M2.7"
+MINIMAX_TOOLCALL_MODEL = "MiniMax-M2.7-highspeed"
+
 # Base URLs for OpenAI-compatible providers
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 
 # Amazon Bedrock model constants (US cross-region inference profile IDs)
 BEDROCK_REASONING_MODEL = "us.anthropic.claude-sonnet-4-6"
@@ -119,7 +124,7 @@ BEDROCK_TOOLCALL_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 DEFAULT_OLLAMA_MODEL = "llama3.2"
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 
-LLMProvider = Literal["anthropic", "openai", "openrouter", "gemini", "nvidia", "ollama", "bedrock"]
+LLMProvider = Literal["anthropic", "openai", "openrouter", "gemini", "nvidia", "ollama", "bedrock", "minimax"]
 
 
 class LLMSettings(StrictConfigModel):
@@ -131,6 +136,7 @@ class LLMSettings(StrictConfigModel):
     openrouter_api_key: str = ""
     gemini_api_key: str = ""
     nvidia_api_key: str = ""
+    minimax_api_key: str = ""
     ollama_model: str = DEFAULT_OLLAMA_MODEL
     ollama_host: str = DEFAULT_OLLAMA_HOST
     anthropic_reasoning_model: str = ANTHROPIC_REASONING_MODEL
@@ -143,6 +149,8 @@ class LLMSettings(StrictConfigModel):
     gemini_toolcall_model: str = GEMINI_TOOLCALL_MODEL
     nvidia_reasoning_model: str = NVIDIA_REASONING_MODEL
     nvidia_toolcall_model: str = NVIDIA_TOOLCALL_MODEL
+    minimax_reasoning_model: str = MINIMAX_REASONING_MODEL
+    minimax_toolcall_model: str = MINIMAX_TOOLCALL_MODEL
     bedrock_reasoning_model: str = BEDROCK_REASONING_MODEL
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
     max_tokens: int = Field(default=DEFAULT_MAX_TOKENS, gt=0)
@@ -151,7 +159,7 @@ class LLMSettings(StrictConfigModel):
     @classmethod
     def _normalize_provider(cls, value: object) -> str:
         provider = str(value or "anthropic").strip().lower() or "anthropic"
-        valid_providers = ("anthropic", "openai", "openrouter", "gemini", "nvidia", "ollama", "bedrock")
+        valid_providers = ("anthropic", "openai", "openrouter", "gemini", "nvidia", "ollama", "bedrock", "minimax")
         if provider in valid_providers:
             return provider
         suggestion = get_close_matches(provider, valid_providers, n=1)
@@ -171,6 +179,7 @@ class LLMSettings(StrictConfigModel):
             "openrouter": self.openrouter_api_key,
             "gemini": self.gemini_api_key,
             "nvidia": self.nvidia_api_key,
+            "minimax": self.minimax_api_key,
         }
         if provider_to_key[self.provider]:
             return self
@@ -181,6 +190,7 @@ class LLMSettings(StrictConfigModel):
             "openrouter": "OPENROUTER_API_KEY",
             "gemini": "GEMINI_API_KEY",
             "nvidia": "NVIDIA_API_KEY",
+            "minimax": "MINIMAX_API_KEY",
         }[self.provider]
         raise ValueError(f"LLM provider '{self.provider}' requires {env_var} to be set.")
 
@@ -194,6 +204,7 @@ class LLMSettings(StrictConfigModel):
             "openrouter_api_key": resolve_llm_api_key("OPENROUTER_API_KEY"),
             "gemini_api_key": resolve_llm_api_key("GEMINI_API_KEY"),
             "nvidia_api_key": resolve_llm_api_key("NVIDIA_API_KEY"),
+            "minimax_api_key": resolve_llm_api_key("MINIMAX_API_KEY"),
             "anthropic_reasoning_model": os.getenv("ANTHROPIC_REASONING_MODEL", ANTHROPIC_REASONING_MODEL).strip()
             or ANTHROPIC_REASONING_MODEL,
             "anthropic_toolcall_model": os.getenv("ANTHROPIC_TOOLCALL_MODEL", ANTHROPIC_TOOLCALL_MODEL).strip()
@@ -232,6 +243,16 @@ class LLMSettings(StrictConfigModel):
                 os.getenv("NVIDIA_MODEL", NVIDIA_TOOLCALL_MODEL),
             ).strip()
             or NVIDIA_TOOLCALL_MODEL,
+            "minimax_reasoning_model": os.getenv(
+                "MINIMAX_REASONING_MODEL",
+                os.getenv("MINIMAX_MODEL", MINIMAX_REASONING_MODEL),
+            ).strip()
+            or MINIMAX_REASONING_MODEL,
+            "minimax_toolcall_model": os.getenv(
+                "MINIMAX_TOOLCALL_MODEL",
+                os.getenv("MINIMAX_MODEL", MINIMAX_TOOLCALL_MODEL),
+            ).strip()
+            or MINIMAX_TOOLCALL_MODEL,
             "bedrock_reasoning_model": os.getenv(
                 "BEDROCK_REASONING_MODEL", BEDROCK_REASONING_MODEL
             ).strip()
@@ -272,6 +293,12 @@ GEMINI_LLM_CONFIG = LLMModelConfig(
 NVIDIA_LLM_CONFIG = LLMModelConfig(
     reasoning_model=NVIDIA_REASONING_MODEL,
     toolcall_model=NVIDIA_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
+MINIMAX_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=MINIMAX_REASONING_MODEL,
+    toolcall_model=MINIMAX_TOOLCALL_MODEL,
     max_tokens=DEFAULT_MAX_TOKENS,
 )
 

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ValidationError
 from app.config import (
     ANTHROPIC_LLM_CONFIG,
     GEMINI_BASE_URL,
+    MINIMAX_BASE_URL,
     NVIDIA_BASE_URL,
     OPENAI_LLM_CONFIG,
     OPENROUTER_BASE_URL,
@@ -478,6 +479,18 @@ def _create_llm_client(model_type: str) -> _LLMClientType:
             max_tokens=config.max_tokens,
             base_url=NVIDIA_BASE_URL,
             api_key_env="NVIDIA_API_KEY",
+        )
+    elif provider == "minimax":
+        from app.config import MINIMAX_LLM_CONFIG
+
+        config = MINIMAX_LLM_CONFIG
+        model = settings.minimax_reasoning_model if model_type == "reasoning" else settings.minimax_toolcall_model
+        return OpenAILLMClient(
+            model=model,
+            max_tokens=config.max_tokens,
+            base_url=MINIMAX_BASE_URL,
+            api_key_env="MINIMAX_API_KEY",
+            temperature=1.0,
         )
     elif provider == "ollama":
         from app.config import OLLAMA_LLM_CONFIG

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -29,9 +29,11 @@ class _FakeOpenAIChat:
 
 class _FakeOpenAI:
     last_api_key: str | None = None
+    last_base_url: str | None = None
 
     def __init__(self, *, api_key: str, base_url: str | None = None, timeout: float) -> None:
         _FakeOpenAI.last_api_key = api_key
+        _FakeOpenAI.last_base_url = base_url
         self.base_url = base_url
         self.timeout = timeout
         self.chat = _FakeOpenAIChat()
@@ -63,3 +65,41 @@ def test_anthropic_llm_client_reads_secure_local_api_key(monkeypatch) -> None:
     client._ensure_client()
 
     assert _FakeAnthropic.last_api_key == "stored-anthropic-key"
+
+
+def test_minimax_llm_client_reads_api_key_and_base_url(monkeypatch) -> None:
+    monkeypatch.setattr(
+        llm_client,
+        "resolve_llm_api_key",
+        lambda env_var: "minimax-test-key" if env_var == "MINIMAX_API_KEY" else "",
+    )
+    monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
+
+    client = llm_client.OpenAILLMClient(
+        model="MiniMax-M2.7",
+        base_url="https://api.minimax.io/v1",
+        api_key_env="MINIMAX_API_KEY",
+        temperature=1.0,
+    )
+    client._ensure_client()
+
+    assert _FakeOpenAI.last_api_key == "minimax-test-key"
+    assert _FakeOpenAI.last_base_url == "https://api.minimax.io/v1"
+
+
+def test_minimax_llm_client_temperature_is_set(monkeypatch) -> None:
+    monkeypatch.setattr(
+        llm_client,
+        "resolve_llm_api_key",
+        lambda env_var: "minimax-test-key" if env_var == "MINIMAX_API_KEY" else "",
+    )
+    monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
+
+    client = llm_client.OpenAILLMClient(
+        model="MiniMax-M2.7",
+        base_url="https://api.minimax.io/v1",
+        api_key_env="MINIMAX_API_KEY",
+        temperature=1.0,
+    )
+    assert client._temperature == 1.0
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,3 +31,34 @@ def test_llm_settings_from_env_uses_secure_local_api_key(monkeypatch) -> None:
 
     assert settings.provider == "openai"
     assert settings.openai_api_key == "stored-secret"
+
+
+def test_llm_settings_require_minimax_api_key() -> None:
+    with pytest.raises(ValidationError, match="MINIMAX_API_KEY"):
+        LLMSettings.model_validate({"provider": "minimax"})
+
+
+def test_llm_settings_minimax_provider_accepted() -> None:
+    settings = LLMSettings.model_validate({
+        "provider": "minimax",
+        "minimax_api_key": "mm-test-key",
+    })
+    assert settings.provider == "minimax"
+    assert settings.minimax_api_key == "mm-test-key"
+    assert settings.minimax_reasoning_model == "MiniMax-M2.7"
+    assert settings.minimax_toolcall_model == "MiniMax-M2.7-highspeed"
+
+
+def test_llm_settings_from_env_minimax(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "minimax")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "mm-stored-key" if env_var == "MINIMAX_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.provider == "minimax"
+    assert settings.minimax_api_key == "mm-stored-key"
+


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

This PR adds MiniMax as a new LLM provider option for OpenSRE, using MiniMax's OpenAI-compatible API.

**Changes:**
- `app/config.py`: Added `minimax` to `LLMProvider` type, `MINIMAX_REASONING_MODEL` (`MiniMax-M2.7`), `MINIMAX_TOOLCALL_MODEL` (`MiniMax-M2.7-highspeed`), `MINIMAX_BASE_URL` (`https://api.minimax.io/v1`), `MINIMAX_LLM_CONFIG`, and `minimax_api_key`/`minimax_reasoning_model`/`minimax_toolcall_model` fields in `LLMSettings`
- `app/services/llm_client.py`: Added `minimax` case in `_create_llm_client` using `OpenAILLMClient` with MiniMax base URL and `temperature=1.0` (MiniMax requires temperature in `(0.0, 1.0]`)
- `tests/test_config.py`: Added 3 tests for MiniMax provider validation
- `tests/services/test_llm_client.py`: Added 2 tests for MiniMax API key/base URL resolution

**Usage:**
```bash
export LLM_PROVIDER=minimax
export MINIMAX_API_KEY=your-key-here
opensre investigate ...
```

**MiniMax API reference:** https://platform.minimax.io/docs/api-reference/text-openai-api

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The MiniMax provider follows exactly the same pattern as the existing OpenAI-compatible providers (OpenRouter, Gemini, NVIDIA, Ollama). It reuses the `OpenAILLMClient` class with a custom `base_url` pointing to `https://api.minimax.io/v1`.

Key design decisions:
- Reused `OpenAILLMClient` since MiniMax exposes an OpenAI-compatible API — no new class needed
- Set `temperature=1.0` explicitly because MiniMax's API requires temperature in `(0.0, 1.0]` and disallows 0
- Added `minimax_reasoning_model` and `minimax_toolcall_model` fields to `LLMSettings` for consistency with other providers
- Used `MINIMAX_API_KEY` env var consistent with the project's naming convention (`{PROVIDER}_API_KEY`)

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I have added tests for the new provider
- [x] All new tests pass (`tests/test_config.py` — 6 passed)
- [x] Code follows project style (ruff check passes)