### PR TITLE
fix: remove duplicate EKS mapper definitions and dict keys (CodeQL alerts)

### DIFF
--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -182,46 +182,6 @@ def _map_grafana_service_names(data: dict) -> dict:
     }
 
 
-def _map_eks_pods(data: dict) -> dict:
-    return {
-        "eks_pods": data.get("pods", []),
-        "eks_failing_pods": data.get("failing_pods", []),
-        "eks_high_restart_pods": data.get("high_restart_pods", []),
-        "eks_total_pods": data.get("total_pods", 0),
-    }
-
-
-def _map_eks_events(data: dict) -> dict:
-    return {
-        "eks_events": data.get("warning_events", []),
-        "eks_total_warning_count": data.get("total_warning_count", 0),
-    }
-
-
-def _map_eks_deployments(data: dict) -> dict:
-    return {
-        "eks_deployments": data.get("deployments", []),
-        "eks_degraded_deployments": data.get("degraded_deployments", []),
-        "eks_total_deployments": data.get("total_deployments", 0),
-    }
-
-
-def _map_eks_node_health(data: dict) -> dict:
-    return {
-        "eks_node_health": data.get("nodes", []),
-        "eks_not_ready_count": data.get("not_ready_count", 0),
-        "eks_total_nodes": data.get("total_nodes", 0),
-    }
-
-
-def _map_eks_pod_logs(data: dict) -> dict:
-    return {
-        "eks_pod_logs": data.get("logs", ""),
-        "eks_pod_logs_pod_name": data.get("pod_name", ""),
-        "eks_pod_logs_namespace": data.get("namespace", ""),
-    }
-
-
 def _map_datadog_logs(data: dict) -> dict:
     return {
         "datadog_logs": data.get("logs", []),
@@ -412,11 +372,6 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "query_grafana_metrics": _map_grafana_metrics,
     "query_grafana_alert_rules": _map_grafana_alert_rules,
     "query_grafana_service_names": _map_grafana_service_names,
-    "list_eks_pods": _map_eks_pods,
-    "get_eks_events": _map_eks_events,
-    "list_eks_deployments": _map_eks_deployments,
-    "get_eks_node_health": _map_eks_node_health,
-    "get_eks_pod_logs": _map_eks_pod_logs,
     "query_datadog_logs": _map_datadog_logs,
     "query_datadog_monitors": _map_datadog_monitors,
     "query_datadog_events": _map_datadog_events,
@@ -617,19 +572,6 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
                 summary_parts.append("github:file contents retrieved")
             elif action_name == "list_github_commits" and data.get("commits"):
                 summary_parts.append(f"github:{len(data['commits'])} commits")
-            elif action_name == "list_eks_pods" and data.get("pods"):
-                failing = len(data.get("failing_pods", []))
-                summary_parts.append(f"eks:{data.get('total_pods', 0)} pods ({failing} failing)")
-            elif action_name == "get_eks_events" and data.get("warning_events"):
-                summary_parts.append(f"eks:{data.get('total_warning_count', 0)} warning events")
-            elif action_name == "list_eks_deployments" and data.get("deployments"):
-                degraded = len(data.get("degraded_deployments", []))
-                summary_parts.append(f"eks:{data.get('total_deployments', 0)} deployments ({degraded} degraded)")
-            elif action_name == "get_eks_node_health" and data.get("nodes"):
-                not_ready = data.get("not_ready_count", 0)
-                summary_parts.append(f"eks:{data.get('total_nodes', 0)} nodes ({not_ready} not ready)")
-            elif action_name == "get_eks_pod_logs" and data.get("logs"):
-                summary_parts.append("eks:pod logs retrieved")
             elif action_name == "get_eks_deployment_status" and data.get("deployment_name"):
                 summary_parts.append("eks:deployment status retrieved")
         else:

--- a/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
+++ b/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
@@ -1,5 +1,3 @@
-import pytest
-
 from app.nodes.root_cause_diagnosis.evidence_checker import is_clearly_healthy
 
 


### PR DESCRIPTION
## Summary

- Remove 5 duplicate EKS mapper function definitions (`_map_eks_pods`, `_map_eks_events`, `_map_eks_deployments`, `_map_eks_node_health`, `_map_eks_pod_logs`) that were defined twice in `post_process.py`
- Remove 5 duplicate EKS keys in the `EVIDENCE_MAPPERS` dict literal that overwrote earlier entries
- Remove unreachable duplicate EKS `elif` branches in `build_evidence_summary` (dead code since earlier branches already matched those action names)
- Remove unused `import pytest` in `test_evidence_checker.py`

Resolves all 11 open CodeQL code-scanning alerts: https://github.com/Tracer-Cloud/opensre/security/code-scanning

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test-cov` passes (2354 passed, 1 pre-existing unrelated failure)
- [x] No functional change — only duplicate/dead code removed

Made with [Cursor](https://cursor.com)