### PR TITLE
fix: clarify Railway deployment prerequisites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,11 +167,27 @@ JIRA_PROJECT_KEY=
 # Optional: only required for the Tracer Web App path.
 JWT_TOKEN=
 
-# LangGraph / LangSmith deployment
-# LangGraph runtime requires a database. For a local Docker Postgres started via
-# `docker compose -f docker-compose.database.yml up -d`, use:
-# DATABASE_URI=postgresql://opensre:opensre@localhost:5432/opensre
+# LangGraph deployment database
+# PostgreSQL and Redis are required for deployed OpenSRE / LangGraph services.
+#
+# Local hosting:
+#   docker compose -f docker-compose.database.yml up -d
+#   DATABASE_URI=postgresql://opensre:opensre@localhost:5432/opensre
+#   REDIS_URI=redis://localhost:6379/0
+#
+# Railway hosted deployment:
+# 1. Create Postgres and Redis services in your Railway project.
+# 2. Copy the Postgres and Redis connection strings from Railway.
+# 3. Set DATABASE_URI and REDIS_URI on your OpenSRE service, for example:
+#    railway variables set DATABASE_URI=postgresql://user:pass@prod-db.railway.app:5432/opensre
+#    railway variables set REDIS_URI=redis://default:pass@prod-redis.railway.app:6379
+#
+# Then deploy with:
+#   opensre deploy railway
 DATABASE_URI=
+REDIS_URI=
+
+# LangSmith integration (optional)
 LANGSMITH_API_KEY=
 LANGSMITH_DEPLOYMENT_NAME=open-sre-agent
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,48 @@ opensre update
 
 ---
 
+## Railway Deployment
+
+Before running `opensre deploy railway`, make sure the target Railway project has
+both Postgres and Redis services, and that your OpenSRE service has `DATABASE_URI`
+and `REDIS_URI` set to those connection strings. The containerized LangGraph
+runtime will not boot without those backing services wired in.
+
+```bash
+# create/link Railway Postgres and Redis first, then set DATABASE_URI and REDIS_URI
+opensre deploy railway --project <project> --service <service> --yes
+```
+
+If the deploy starts but the service never becomes healthy, verify that
+`DATABASE_URI` and `REDIS_URI` are present on the Railway service and point to the
+project Postgres and Redis instances.
+
+### Remote Hosted Ops
+
+After deploying a hosted service, you can run post-deploy operations from the CLI:
+
+```bash
+# inspect service status, URL, deployment metadata
+opensre remote ops --provider railway --project <project> --service <service> status
+
+# tail recent logs
+opensre remote ops --provider railway --project <project> --service <service> logs --lines 200
+
+# stream logs live
+opensre remote ops --provider railway --project <project> --service <service> logs --follow
+
+# trigger restart/redeploy
+opensre remote ops --provider railway --project <project> --service <service> restart --yes
+```
+
+OpenSRE saves your last used `provider`/`project`/`service`, so you can run:
+
+```bash
+opensre remote ops status
+opensre remote ops logs --follow
+```
+
+---
 
 ## Development
 

--- a/app/cli/deploy.py
+++ b/app/cli/deploy.py
@@ -18,14 +18,23 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 READINESS_PATH = "/ok"
+RAILWAY_DATABASE_HINTS = (
+    "Railway prerequisites: provision Postgres and Redis services for the target project.",
+    "Set DATABASE_URI and REDIS_URI on the OpenSRE service before retrying `opensre deploy railway`.",
+)
 
 
-class DeployResult(TypedDict, total=False):
-    """Result type for deploy_to_railway function."""
+class DeployResultRequired(TypedDict):
+    """Required fields for deploy_to_railway results."""
 
     success: bool
     url: str | None
     logs: list[str]
+
+
+class DeployResult(DeployResultRequired, total=False):
+    """Result type for deploy_to_railway function."""
+
     dry_run: bool
     health_ok: bool
     error: str | None
@@ -200,7 +209,7 @@ def deploy_to_railway(
         return {
             "success": False,
             "url": None,
-            "logs": logs + [f"Deployment failed: {deploy_result.stderr}"],
+            "logs": logs + [f"Deployment failed: {deploy_result.stderr}", *RAILWAY_DATABASE_HINTS],
             "error": f"Deployment failed: {deploy_result.stderr}",
         }
 
@@ -249,6 +258,7 @@ def deploy_to_railway(
             time.sleep(health_interval)
         else:
             logs.append(f"Health check timed out after {health_timeout}s")
+            logs.extend(RAILWAY_DATABASE_HINTS)
     elif wait_for_health and not url:
         logs.append("Skipping health check: no URL available")
 

--- a/app/cli/deploy_test.py
+++ b/app/cli/deploy_test.py
@@ -121,6 +121,25 @@ class TestDeployToRailway:
         assert result["dry_run"] is True
         assert "dry-run" in result["logs"][0].lower()
 
+    def test_failed_deploy_includes_database_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+            class Result:
+                returncode = 1
+                stdout = ""
+                stderr = "container failed to boot"
+
+            return Result()
+
+        monkeypatch.setattr("app.cli.deploy._run_command", mock_run_command)
+
+        result = deploy_to_railway(wait_for_health=False, auth_detail="user@example.com")
+
+        assert result["success"] is False
+        logs = "\n".join(result["logs"])
+        assert "Postgres and Redis services" in logs
+        assert "DATABASE_URI" in logs
+        assert "REDIS_URI" in logs
+
     def test_successful_deploy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("app.cli.deploy.is_railway_cli_installed", lambda: True)
         monkeypatch.setattr(
@@ -188,6 +207,42 @@ class TestDeployToRailway:
         result = deploy_to_railway(wait_for_health=True)
         assert result["success"] is True
         assert requested_urls == ["https://myapp.up.railway.app/ok"]
+
+    def test_health_check_timeout_includes_database_hint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+            class Result:
+                returncode = 0
+                stdout = "https://myapp.up.railway.app"
+                stderr = ""
+
+            return Result()
+
+        class MockResponse:
+            status_code = 503
+
+        monkeypatch.setattr("app.cli.deploy._run_command", mock_run_command)
+        monkeypatch.setattr("httpx.get", lambda *_args, **_kwargs: MockResponse())
+        monkeypatch.setattr("time.sleep", lambda _x: None)
+
+        times = iter([0.0, 0.0, 0.02])
+        monkeypatch.setattr("time.time", lambda: next(times))
+
+        result = deploy_to_railway(
+            wait_for_health=True,
+            health_timeout=0.01,
+            health_interval=0.0,
+            auth_detail="user@example.com",
+        )
+
+        assert result["success"] is True
+        logs = "\n".join(result["logs"])
+        assert "Health check timed out" in logs
+        assert "Postgres and Redis services" in logs
+        assert "DATABASE_URI" in logs
+        assert "REDIS_URI" in logs
 
     def test_domain_fallback_adds_https_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("app.cli.deploy.is_railway_cli_installed", lambda: True)


### PR DESCRIPTION
Fixes #487

#### Describe the changes you have made in this PR -
This PR clarifies the required Railway backing services for the containerized deploy path.

Changes included:
- document that Railway deployments require both Postgres and Redis
- document the expected environment variables: `DATABASE_URI` and `REDIS_URI`
- add clearer CLI guidance when Railway deploy fails or never becomes healthy, so users can identify missing backing services without digging through runtime logs
- add regression tests covering both failure and health-timeout guidance

### Screenshots of the UI changes (If any) -
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I updated the user-facing Railway deployment documentation in `README.md` and `.env.example` so contributors can see the required backing services and environment variables before deploying. I also updated the Railway deploy failure and health-timeout messaging in `app/cli/deploy.py` so the CLI points users directly to missing Postgres/Redis setup instead of leaving them to infer it from runtime logs. I added focused tests in `app/cli/deploy_test.py` to verify both failure paths.

Validation performed:
- `python -m pytest app/cli/deploy_test.py`
- `make lint`
- `make typecheck`

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions