### PR TITLE
Ask for Ollama host URL instead of API key during onboard

### DIFF
--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from app.config import (
     ANTHROPIC_REASONING_MODEL,
+    DEFAULT_OLLAMA_HOST,
     DEFAULT_OLLAMA_MODEL,
     GEMINI_REASONING_MODEL,
     NVIDIA_REASONING_MODEL,
@@ -40,6 +41,16 @@ class ProviderOption:
     models: tuple[ModelOption, ...]
     #: If set, ``sync_provider_env`` also writes this key (same value) for legacy .env files.
     legacy_model_env: str | None = None
+    #: Human-readable name for the credential requested during onboarding. Most
+    #: providers want an API key; Ollama wants a host URL. Used as the wizard
+    #: prompt label, e.g. ``{label} {credential_label} ({api_key_env})``.
+    credential_label: str = "API key"
+    #: Whether the credential should be prompted as a secret (hidden input).
+    #: API keys are secrets; a local Ollama host URL is not.
+    credential_secret: bool = True
+    #: Optional hint shown as the default value in the prompt (e.g. the
+    #: default Ollama host URL). Empty string means no default.
+    credential_default: str = ""
 
 
 ANTHROPIC_MODELS = (
@@ -156,6 +167,9 @@ SUPPORTED_PROVIDERS = (
         model_env="OLLAMA_MODEL",
         default_model=DEFAULT_OLLAMA_MODEL,
         models=OLLAMA_MODELS,
+        credential_label="host URL",
+        credential_secret=False,
+        credential_default=DEFAULT_OLLAMA_HOST,
     ),
 )
 

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -1416,11 +1416,12 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             )
         ]
         model = provider.default_model
-        _step("API Key")
+        _step(provider.credential_label.title())
         try:
             api_key = _prompt_value(
-                f"{provider.label} API key ({provider.api_key_env})",
-                secret=True,
+                f"{provider.label} {provider.credential_label} ({provider.api_key_env})",
+                default=provider.credential_default,
+                secret=provider.credential_secret,
             )
         except KeyboardInterrupt:
             _console.print("\n[yellow]Setup cancelled.[/]")
@@ -1438,11 +1439,12 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 return 1
             has_api_key = True
         if not has_api_key:
-            _step("API Key")
+            _step(provider.credential_label.title())
             try:
                 api_key = _prompt_value(
-                    f"{provider.label} API key ({provider.api_key_env})",
-                    secret=True,
+                    f"{provider.label} {provider.credential_label} ({provider.api_key_env})",
+                    default=provider.credential_default,
+                    secret=provider.credential_secret,
                 )
             except KeyboardInterrupt:
                 _console.print("\n[yellow]Setup cancelled.[/]")


### PR DESCRIPTION
Fixes #612

## Problem

During `opensre onboard`, selecting the Ollama (local) provider surfaces a prompt that reads

```
Ollama (local) API key (OLLAMA_HOST)
```

and treats the input as a secret (hidden characters). Ollama has no API key — it just needs a host URL such as `http://localhost:11434`, which is exactly what `OLLAMA_HOST` stores. The generic `{label} API key ({env})` formatter in `app/cli/wizard/flow.py` never knew Ollama was different.

## Change

Two files, no new dependencies.

`app/cli/wizard/config.py` — extend `ProviderOption` with three optional fields:

- `credential_label: str = "API key"` — what the wizard asks for.
- `credential_secret: bool = True` — whether the input is hidden.
- `credential_default: str = ""` — prefilled default value.

Hosted providers (`anthropic`, `openai`, `openrouter`, `gemini`, `nvidia`) keep the defaults, so their onboarding prompt and secret-masking are unchanged. The `ollama` entry overrides:

- `credential_label="host URL"`
- `credential_secret=False`
- `credential_default=DEFAULT_OLLAMA_HOST`

`app/cli/wizard/flow.py` — wire the two `_prompt_value` call sites (fresh onboarding and re-entry when no key is persisted) to use the provider-specific metadata:

```python
_step(provider.credential_label.title())
api_key = _prompt_value(
    f"{provider.label} {provider.credential_label} ({provider.api_key_env})",
    default=provider.credential_default,
    secret=provider.credential_secret,
)
```

Ollama users now see:

```
Ollama (local) host URL (OLLAMA_HOST)  [http://localhost:11434]
```

with visible input and the default prefilled. Hosted providers are unaffected.

## Testing

- `python3 -m ast` parses both modified files cleanly.
- `tests/cli_smoke_test.py` still expects the Anthropic prompt to contain "Anthropic API key" — that path uses the default `credential_label="API key"` and keeps working.
- No new tests were added; the behaviour change is a label/secret-flag override that is exercised by any onboarding run that chooses Ollama.

## Scope notes

- No refactoring of unrelated prompt code, no changes to the integration prompts (Grafana, Datadog, etc.).
- `OLLAMA_API_KEY` usage in `app/services/llm_client.py` is untouched; this PR only changes the wizard prompt, not the runtime client behaviour.
