### PR TITLE
fix: show Ollama host URL as visible, non-secret prompt

### DIFF
--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -40,6 +40,11 @@ class ProviderOption:
     models: tuple[ModelOption, ...]
     #: If set, ``sync_provider_env`` also writes this key (same value) for legacy .env files.
     legacy_model_env: str | None = None
+    #: Whether this credential is a secret (masked in the prompt). Set to False for
+    #: non-secret values such as host URLs (e.g. Ollama).
+    is_secret: bool = True
+    #: Custom prompt label. If None, defaults to "{label} API key ({api_key_env})"
+    prompt_label: str | None = None
 
 
 ANTHROPIC_MODELS = (
@@ -156,6 +161,8 @@ SUPPORTED_PROVIDERS = (
         model_env="OLLAMA_MODEL",
         default_model=DEFAULT_OLLAMA_MODEL,
         models=OLLAMA_MODELS,
+        is_secret=False,
+        prompt_label="Ollama host URL (OLLAMA_HOST, e.g. http://localhost:11434/)",
     ),
 )
 

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -1419,8 +1419,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         _step("API Key")
         try:
             api_key = _prompt_value(
-                f"{provider.label} API key ({provider.api_key_env})",
-                secret=True,
+                provider.prompt_label or f"{provider.label} API key ({provider.api_key_env})",
+                secret=provider.is_secret,
             )
         except KeyboardInterrupt:
             _console.print("\n[yellow]Setup cancelled.[/]")
@@ -1441,8 +1441,8 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             _step("API Key")
             try:
                 api_key = _prompt_value(
-                    f"{provider.label} API key ({provider.api_key_env})",
-                    secret=True,
+                    provider.prompt_label or f"{provider.label} API key ({provider.api_key_env})",
+                    secret=provider.is_secret,
                 )
             except KeyboardInterrupt:
                 _console.print("\n[yellow]Setup cancelled.[/]")


### PR DESCRIPTION
## Problem

During `opensre onboard`, the Ollama provider prompt incorrectly says "Ollama (local) API key (OLLAMA_HOST)" and masks the input as a secret. Ollama does not use an API key — it requires a host URL (e.g. http://localhost:11434).

## Solution

Adds `is_secret` (default `True`) and `prompt_label` (default `None`) fields to `ProviderOption`, then uses them in the wizard flow:

- `is_secret=False` and a descriptive `prompt_label` are set for the Ollama provider
- Other providers continue to behave identically (default `is_secret=True`, no `prompt_label`)

## Changes

- **config.py**: Added `is_secret` and `prompt_label` to `ProviderOption`
- **flow.py**: Uses `provider.prompt_label` and `provider.is_secret` for the credential prompt

Fixes #612