### PR TITLE
feat: add remote runtime investigation with Slack thread context (#301)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,11 @@ LANGSMITH_DEPLOYMENT_NAME=open-sre-agent
 
 # Optional: only required if you want to post RCA reports to Slack.
 SLACK_WEBHOOK_URL=
+
+# Optional: required for 'opensre investigate --service --slack-thread CHANNEL/TS'.
+# Used to pull a Slack thread via conversations.replies as runtime investigation context.
+SLACK_BOT_TOKEN=
+
 ENV=development
 
 #Gitlab

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -183,7 +183,7 @@ def investigate_command(
             output=output,
         )
         return
-    if slack_thread and not service:
+    if slack_thread:
         from app.cli.errors import OpenSREError
 
         raise OpenSREError(

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -141,6 +141,23 @@ def health_command(watch: bool, rate: int) -> None:
     help="Print a starter alert JSON template and exit.",
 )
 @click.option(
+    "--service",
+    default=None,
+    help=(
+        "Start a runtime investigation for a deployed service by name. "
+        "Pulls status, recent logs, and health from the configured remote ops provider."
+    ),
+)
+@click.option(
+    "--slack-thread",
+    default=None,
+    help=(
+        "Optional Slack thread reference in 'CHANNEL/TS' format. When set with --service, "
+        "the thread's messages are pulled via Slack's conversations.replies API "
+        "(requires SLACK_BOT_TOKEN in the environment) and included as investigation context."
+    ),
+)
+@click.option(
     "--output", "-o", default=None, type=click.Path(), help="Output JSON file (default: stdout)."
 )
 def investigate_command(
@@ -148,9 +165,32 @@ def investigate_command(
     input_json: str | None,
     interactive: bool,
     print_template: str | None,
+    service: str | None,
+    slack_thread: str | None,
     output: str | None,
 ) -> None:
     """Run an RCA investigation against an alert payload."""
+    if service:
+        _run_service_investigation(
+            service=service,
+            slack_thread=slack_thread,
+            other_inputs={
+                "input_path": input_path,
+                "input_json": input_json,
+                "interactive": interactive,
+                "print_template": print_template,
+            },
+            output=output,
+        )
+        return
+    if slack_thread and not service:
+        from app.cli.errors import OpenSREError
+
+        raise OpenSREError(
+            "--slack-thread requires --service.",
+            suggestion="Pass --service <name> alongside --slack-thread CHANNEL/TS.",
+        )
+
     from app.main import main as investigate_main
 
     capture_investigation_started(
@@ -177,3 +217,63 @@ def investigate_command(
     else:
         capture_investigation_failed()
     raise SystemExit(exit_code)
+
+
+def _run_service_investigation(
+    *,
+    service: str,
+    slack_thread: str | None,
+    other_inputs: dict[str, object],
+    output: str | None,
+) -> None:
+    """Run a runtime investigation for a deployed service by name."""
+    import os
+
+    from app.cli.args import write_json
+    from app.cli.errors import OpenSREError
+    from app.cli.investigate import run_investigation_cli
+    from app.remote.runtime_alert import build_runtime_alert_payload
+
+    conflicting = [
+        flag
+        for flag, value in (
+            ("--input", other_inputs.get("input_path")),
+            ("--input-json", other_inputs.get("input_json")),
+            ("--interactive", other_inputs.get("interactive")),
+            ("--print-template", other_inputs.get("print_template")),
+        )
+        if value
+    ]
+    if conflicting:
+        raise OpenSREError(
+            f"--service cannot be combined with {', '.join(conflicting)}.",
+            suggestion="Run 'opensre investigate --service <name>' on its own.",
+        )
+
+    slack_bot_token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    if slack_thread and not slack_bot_token:
+        raise OpenSREError(
+            "--slack-thread was provided but SLACK_BOT_TOKEN is not set.",
+            suggestion="Export SLACK_BOT_TOKEN=xoxb-... in your environment and retry.",
+        )
+
+    capture_investigation_started(input_path=None, input_json=None, interactive=False)
+    try:
+        raw_alert = build_runtime_alert_payload(
+            service,
+            slack_thread_ref=slack_thread,
+            slack_bot_token=slack_bot_token or None,
+        )
+        result = run_investigation_cli(
+            raw_alert=raw_alert,
+            alert_name=raw_alert.get("alert_name"),
+            pipeline_name=raw_alert.get("pipeline_name"),
+            severity=raw_alert.get("severity"),
+        )
+    except Exception:
+        capture_investigation_failed()
+        raise
+
+    capture_investigation_completed()
+    write_json(result, output)
+    raise SystemExit(SUCCESS)

--- a/app/remote/ops.py
+++ b/app/remote/ops.py
@@ -211,7 +211,13 @@ class RailwayRemoteOpsProvider(RemoteOpsProvider):
             scope=scope,
             capture_output=True,
         )
-        return (result.stdout or "").strip()
+        stdout = (result.stdout or "").strip()
+        stderr = (result.stderr or "").strip()
+        if stderr and not stdout:
+            return stderr
+        if stderr:
+            return f"{stdout}\n[stderr: {stderr}]"
+        return stdout
 
     def restart(self, scope: RemoteServiceScope) -> RestartResult:
         data = self._read_json(["redeploy", "--json"], scope=scope)

--- a/app/remote/ops.py
+++ b/app/remote/ops.py
@@ -63,6 +63,16 @@ class RemoteOpsProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def fetch_logs(self, scope: RemoteServiceScope, *, lines: int) -> str:
+        """Return the last ``lines`` log entries as text for programmatic use.
+
+        Unlike ``logs()`` which streams to stdout for interactive CLI use,
+        ``fetch_logs()`` captures the output and returns it so callers can
+        feed it into an investigation or other pipeline.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def restart(self, scope: RemoteServiceScope) -> RestartResult:
         raise NotImplementedError
 
@@ -194,6 +204,14 @@ class RailwayRemoteOpsProvider(RemoteOpsProvider):
         if follow:
             args.append("--follow")
         self._railway_command(args, scope=scope, capture_output=False)
+
+    def fetch_logs(self, scope: RemoteServiceScope, *, lines: int) -> str:
+        result = self._railway_command(
+            ["logs", "--tail", str(lines)],
+            scope=scope,
+            capture_output=True,
+        )
+        return (result.stdout or "").strip()
 
     def restart(self, scope: RemoteServiceScope) -> RestartResult:
         data = self._read_json(["redeploy", "--json"], scope=scope)

--- a/app/remote/runtime_alert.py
+++ b/app/remote/runtime_alert.py
@@ -1,0 +1,158 @@
+"""Build a raw_alert payload for a deployed service runtime investigation.
+
+Gathers service status, recent logs, and live health from the configured
+remote ops provider, then packages them into a ``raw_alert`` dict that the
+existing investigation pipeline can consume.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.cli.errors import OpenSREError
+from app.cli.wizard.store import load_named_remotes, load_remote_ops_config
+from app.deployment.health import poll_deployment_health
+from app.remote.ops import (
+    RemoteOpsError,
+    RemoteServiceScope,
+    ServiceStatus,
+    resolve_remote_ops_provider,
+)
+from app.remote.slack_context import fetch_slack_thread, parse_slack_thread_ref
+
+_DEFAULT_LOG_LINES = 100
+_HEALTH_MAX_ATTEMPTS = 2
+_HEALTH_INTERVAL_SECONDS = 2.0
+
+
+def _service_dict(status: ServiceStatus) -> dict[str, Any]:
+    return {
+        "provider": status.provider,
+        "project": status.project,
+        "service": status.service,
+        "url": status.url,
+        "deployment_id": status.deployment_id,
+        "deployment_status": status.deployment_status,
+        "environment": status.environment,
+        "health": status.health,
+        "metadata": dict(status.metadata),
+    }
+
+
+def _probe_health(url: str | None) -> dict[str, Any]:
+    if not url:
+        return {"error": "no service URL available"}
+    try:
+        result = poll_deployment_health(
+            url,
+            max_attempts=_HEALTH_MAX_ATTEMPTS,
+            interval_seconds=_HEALTH_INTERVAL_SECONDS,
+        )
+    except TimeoutError as exc:
+        return {"error": str(exc)}
+    return {
+        "url": result.url,
+        "status_code": result.status_code,
+        "attempts": result.attempts,
+        "elapsed_seconds": result.elapsed_seconds,
+    }
+
+
+def build_runtime_alert_payload(
+    service_name: str,
+    *,
+    slack_thread_ref: str | None = None,
+    slack_bot_token: str | None = None,
+) -> dict[str, Any]:
+    """Return a ``raw_alert`` dict for a deployed service runtime investigation.
+
+    Resolves the service from the named-remote registry and stored ops config,
+    fetches deployment status + recent logs + health probe (best-effort), and
+    returns a dict suitable for ``run_investigation_cli(raw_alert=...)``.
+
+    If ``slack_thread_ref`` is provided (format ``CHANNEL/TS``), the thread's
+    messages are also pulled via Slack's ``conversations.replies`` API using
+    ``slack_bot_token`` and included under the ``slack_thread`` key. Failures
+    are captured in that key rather than raised, so the investigation can
+    still proceed without Slack context.
+    """
+    name = (service_name or "").strip()
+    if not name:
+        raise OpenSREError(
+            "Service name is required.",
+            suggestion="Pass --service <name> with a configured remote name.",
+        )
+
+    named = load_named_remotes()
+    if name not in named:
+        available = ", ".join(sorted(named)) or "(none configured)"
+        raise OpenSREError(
+            f"No remote named '{name}' is configured.",
+            suggestion=(
+                f"Configured remotes: {available}. "
+                f"Deploy with 'opensre deploy' or add one with 'opensre remote'."
+            ),
+        )
+
+    stored = load_remote_ops_config()
+    provider_name = (stored.get("provider") or "railway").strip().lower()
+    project = stored.get("project")
+    service = stored.get("service") or name
+
+    try:
+        provider = resolve_remote_ops_provider(provider_name)
+    except RemoteOpsError as exc:
+        raise OpenSREError(
+            f"Unsupported remote ops provider '{provider_name}': {exc}",
+            suggestion="Run 'opensre remote ops status' to reconfigure the provider.",
+        ) from exc
+    scope = RemoteServiceScope(provider=provider_name, project=project, service=service)
+
+    try:
+        status = provider.status(scope)
+    except RemoteOpsError as exc:
+        raise OpenSREError(
+            f"Failed to fetch deployment status for '{name}': {exc}",
+            suggestion=(
+                "Verify the remote ops provider is configured correctly "
+                "('opensre remote ops status' to check)."
+            ),
+        ) from exc
+
+    try:
+        recent_logs = provider.fetch_logs(scope, lines=_DEFAULT_LOG_LINES)
+    except RemoteOpsError as exc:
+        recent_logs = f"(logs unavailable: {exc})"
+
+    health_probe = _probe_health(status.url)
+
+    slack_thread: dict[str, Any] | None = None
+    if slack_thread_ref:
+        try:
+            channel, ts = parse_slack_thread_ref(slack_thread_ref)
+        except ValueError as exc:
+            slack_thread = {"error": str(exc)}
+        else:
+            slack_thread = fetch_slack_thread(channel, ts, slack_bot_token or "")
+
+    payload: dict[str, Any] = {
+        "alert_name": f"Remote runtime investigation: {name}",
+        "pipeline_name": service or name,
+        "severity": "warning",
+        # Note: alert_source is intentionally left empty. detect_sources.py
+        # filters integrations by alert_source (e.g. suppresses Grafana when
+        # alert_source not in ("grafana", "")). Leaving it empty keeps all
+        # integrations available; the LLM in extract_alert may re-infer an
+        # alert_source from log text, which is expected and correct.
+        "investigation_origin": "remote_runtime",
+        "message": (
+            f"Manual runtime investigation for deployed service '{name}'. "
+            f"Health={status.health}, deployment_status={status.deployment_status}."
+        ),
+        "service": _service_dict(status),
+        "recent_logs": recent_logs,
+        "health_probe": health_probe,
+    }
+    if slack_thread is not None:
+        payload["slack_thread"] = slack_thread
+    return payload

--- a/app/remote/slack_context.py
+++ b/app/remote/slack_context.py
@@ -1,0 +1,95 @@
+"""Read a Slack thread's messages for inclusion in runtime investigations.
+
+This module provides a narrow helper — not a full Slack integration. It lets
+``opensre investigate --service <name> --slack-thread <ref>`` pull the text
+of a specific Slack thread so the investigation agent has that conversational
+context alongside service logs and health.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_SLACK_API_URL = "https://slack.com/api/conversations.replies"
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+_DEFAULT_MESSAGE_LIMIT = 50
+
+
+def parse_slack_thread_ref(ref: str) -> tuple[str, str]:
+    """Parse a ``CHANNEL/TS`` reference into ``(channel, ts)``.
+
+    Raises ``ValueError`` if the reference is not well-formed.
+    """
+    value = (ref or "").strip()
+    if "/" not in value:
+        raise ValueError(
+            f"Expected Slack thread ref as 'CHANNEL/TS' (e.g. C0123/1712345.000001), got: {ref!r}"
+        )
+    channel, ts = value.split("/", 1)
+    channel = channel.strip()
+    ts = ts.strip()
+    if not channel or not ts:
+        raise ValueError(f"Slack thread ref must have both CHANNEL and TS, got: {ref!r}")
+    return channel, ts
+
+
+def fetch_slack_thread(
+    channel: str,
+    ts: str,
+    bot_token: str,
+    *,
+    limit: int = _DEFAULT_MESSAGE_LIMIT,
+) -> dict[str, Any]:
+    """Fetch a Slack thread's messages via ``conversations.replies``.
+
+    Returns a dict with either ``{"error": "..."}`` on any failure, or
+    ``{"channel", "ts", "messages": [...], "count": int}`` on success.
+    """
+    if not bot_token:
+        return {"error": "SLACK_BOT_TOKEN not configured"}
+
+    try:
+        resp = httpx.get(
+            _SLACK_API_URL,
+            params={"channel": channel, "ts": ts, "limit": min(limit, 100)},
+            headers={"Authorization": f"Bearer {bot_token}"},
+            timeout=_DEFAULT_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        logger.warning("[slack] thread fetch HTTP error status=%s", exc.response.status_code)
+        return {"error": f"HTTP {exc.response.status_code}"}
+    except Exception as exc:
+        logger.warning("[slack] thread fetch error: %s", exc)
+        return {"error": str(exc)}
+
+    if not data.get("ok"):
+        return {"error": data.get("error", "slack API returned ok=false")}
+
+    messages: list[dict[str, Any]] = []
+    for msg in data.get("messages", []):
+        messages.append(
+            {
+                "user": msg.get("user", ""),
+                "text": msg.get("text", ""),
+                "ts": msg.get("ts", ""),
+                "reactions": [
+                    r.get("name", "")
+                    for r in msg.get("reactions", [])
+                    if isinstance(r, dict)
+                ],
+            }
+        )
+
+    return {
+        "channel": channel,
+        "ts": ts,
+        "messages": messages,
+        "count": len(messages),
+    }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,7 +79,8 @@
       {
         "group": "Investigations",
         "pages": [
-          "investigation-overview"
+          "investigation-overview",
+          "remote-runtime-investigation"
         ]
       },
       {

--- a/docs/remote-runtime-investigation.mdx
+++ b/docs/remote-runtime-investigation.mdx
@@ -1,0 +1,76 @@
+---
+title: 'Remote Runtime Investigation'
+description: 'Start an RCA investigation for a deployed service by name'
+---
+
+## Overview
+
+`opensre investigate --service <name>` kicks off a runtime investigation for a deployed service. Instead of passing an alert payload, OpenSRE gathers live signals from the service (deployment status, recent logs, health probe) and feeds them into the existing investigation pipeline as evidence.
+
+## Prerequisites
+
+You must have deployed a service via `opensre deploy` (or registered a named remote) and configured a remote ops provider.
+
+1. **Deploy or register a named remote:**
+   ```bash
+   opensre deploy ec2        # creates a named remote "ec2"
+   # or register manually:
+   opensre remote health https://my-service.up.railway.app
+   ```
+
+2. **Configure the remote ops provider (once):**
+   ```bash
+   opensre remote ops status     # prompts for provider/project/service on first run
+   ```
+
+## Usage
+
+```bash
+opensre investigate --service <name>
+```
+
+For example:
+```bash
+opensre investigate --service api-backend
+opensre investigate --service api-backend --output ./rca.json
+```
+
+The command will:
+
+1. Resolve `<name>` against your named-remote registry
+2. Fetch deployment status via the configured ops provider (e.g. Railway)
+3. Fetch the most recent ~100 log lines
+4. Probe the service's `/health` or `/ok` endpoint
+5. Package all of this into an alert payload
+6. Run the standard RCA pipeline against it
+
+The output is the same structured RCA report you'd get from running `opensre investigate -i <alert-file>`.
+
+## Incorporating Slack thread context
+
+Pass `--slack-thread CHANNEL/TS` to also pull the messages from a specific Slack thread as investigation context. This is useful when an incident originated in a Slack conversation.
+
+```bash
+export SLACK_BOT_TOKEN=xoxb-...
+opensre investigate --service api-backend --slack-thread C01234/1712345.000001
+```
+
+Requirements:
+- `SLACK_BOT_TOKEN` must be set in the environment. The bot must have the `channels:history` and `groups:history` OAuth scopes for the channel you're reading.
+- The `CHANNEL/TS` reference can be obtained from Slack's "Copy link to message" option — it's the last two path segments of the link.
+
+The thread's messages, users, timestamps, and reactions are fetched via Slack's `conversations.replies` API and included under the `slack_thread` key in the alert payload. If fetching fails (bad token, wrong channel, network error), the investigation still proceeds with the error recorded in the payload.
+
+## Mutual exclusion
+
+`--service` cannot be combined with `--input`, `--input-json`, `--interactive`, or `--print-template`. Use `--service` on its own.
+
+## Extending to other providers
+
+The `RemoteOpsProvider` abstract class (in `app/remote/ops.py`) defines the provider interface. To add support for another provider (EC2, ECS, Vercel, etc.), implement a new subclass with `status()`, `logs()`, `fetch_logs()`, and `restart()` methods, then register it in `resolve_remote_ops_provider()`.
+
+## Known limitations
+
+- **Currently supports only Railway** — other providers have `status`/`logs` hooks but no `fetch_logs` implementation yet.
+- **Slack context is thread-scoped** — this initial version pulls a specific thread via `--slack-thread`. It does not search Slack history or resolve linked runbooks.
+- **`alert_source` is re-inferred by the LLM** — the LLM in the extract-alert step may infer an `alert_source` from the log text (e.g. "datadog" if the logs mention Datadog), which routes to provider-specific tools. This is the intended behavior.

--- a/tests/cli/test_investigate_service_flag.py
+++ b/tests/cli/test_investigate_service_flag.py
@@ -31,7 +31,8 @@ def _fake_result() -> dict[str, object]:
     }
 
 
-def test_service_flag_invokes_runtime_investigation() -> None:
+def test_service_flag_invokes_runtime_investigation(monkeypatch) -> None:
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
     runner = CliRunner()
     with (
         patch(
@@ -55,7 +56,8 @@ def test_service_flag_invokes_runtime_investigation() -> None:
     assert kwargs["raw_alert"]["service"]["provider"] == "railway"
 
 
-def test_service_flag_writes_output_file(tmp_path) -> None:
+def test_service_flag_writes_output_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
     runner = CliRunner()
     output_path = tmp_path / "result.json"
 

--- a/tests/cli/test_investigate_service_flag.py
+++ b/tests/cli/test_investigate_service_flag.py
@@ -1,0 +1,175 @@
+"""Tests for the --service flag on the investigate CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from app.cli.commands.general import investigate_command
+
+
+def _fake_payload(service: str) -> dict[str, object]:
+    return {
+        "alert_name": f"Remote runtime investigation: {service}",
+        "pipeline_name": service,
+        "severity": "warning",
+        "investigation_origin": "remote_runtime",
+        "service": {"provider": "railway"},
+        "recent_logs": "sample logs",
+        "health_probe": {"status_code": 200},
+    }
+
+
+def _fake_result() -> dict[str, object]:
+    return {
+        "report": "report body",
+        "problem_md": "# problem",
+        "root_cause": "bad deploy",
+        "is_noise": False,
+    }
+
+
+def test_service_flag_invokes_runtime_investigation() -> None:
+    runner = CliRunner()
+    with (
+        patch(
+            "app.remote.runtime_alert.build_runtime_alert_payload",
+            return_value=_fake_payload("my-svc"),
+        ) as mock_build,
+        patch(
+            "app.cli.investigate.run_investigation_cli",
+            return_value=_fake_result(),
+        ) as mock_run,
+    ):
+        result = runner.invoke(investigate_command, ["--service", "my-svc"])
+
+    assert result.exit_code == 0
+    mock_build.assert_called_once_with(
+        "my-svc", slack_thread_ref=None, slack_bot_token=None
+    )
+    mock_run.assert_called_once()
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs["alert_name"] == "Remote runtime investigation: my-svc"
+    assert kwargs["raw_alert"]["service"]["provider"] == "railway"
+
+
+def test_service_flag_writes_output_file(tmp_path) -> None:
+    runner = CliRunner()
+    output_path = tmp_path / "result.json"
+
+    with (
+        patch(
+            "app.remote.runtime_alert.build_runtime_alert_payload",
+            return_value=_fake_payload("my-svc"),
+        ),
+        patch(
+            "app.cli.investigate.run_investigation_cli",
+            return_value=_fake_result(),
+        ),
+    ):
+        result = runner.invoke(
+            investigate_command,
+            ["--service", "my-svc", "--output", str(output_path)],
+        )
+
+    assert result.exit_code == 0
+    content = output_path.read_text(encoding="utf-8")
+    assert "report body" in content
+    assert "bad deploy" in content
+
+
+@pytest.mark.parametrize(
+    "conflict_flag,conflict_value",
+    [
+        ("--input", "/tmp/alert.json"),
+        ("--input-json", '{"alert_name":"x"}'),
+        ("--interactive", None),
+        ("--print-template", "generic"),
+    ],
+)
+def test_service_flag_rejects_other_input_modes(conflict_flag, conflict_value) -> None:
+    runner = CliRunner()
+    args = ["--service", "my-svc", conflict_flag]
+    if conflict_value is not None:
+        args.append(conflict_value)
+
+    with (
+        patch("app.remote.runtime_alert.build_runtime_alert_payload"),
+        patch("app.cli.investigate.run_investigation_cli"),
+    ):
+        result = runner.invoke(investigate_command, args)
+
+    assert result.exit_code != 0
+    assert "--service cannot be combined with" in (result.output + str(result.exception))
+
+
+def test_service_flag_surfaces_errors_from_payload_builder() -> None:
+    from app.cli.errors import OpenSREError
+
+    runner = CliRunner()
+    with (
+        patch(
+            "app.remote.runtime_alert.build_runtime_alert_payload",
+            side_effect=OpenSREError("unknown service", suggestion="add it"),
+        ),
+        patch("app.cli.investigate.run_investigation_cli"),
+    ):
+        result = runner.invoke(investigate_command, ["--service", "missing"])
+
+    assert result.exit_code != 0
+
+
+def test_slack_thread_without_service_is_rejected() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        investigate_command,
+        ["--slack-thread", "C01234/1712345.000001"],
+    )
+    assert result.exit_code != 0
+    assert "--slack-thread requires --service" in (result.output + str(result.exception))
+
+
+def test_slack_thread_without_bot_token_is_rejected(monkeypatch) -> None:
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    runner = CliRunner()
+
+    with (
+        patch(
+            "app.remote.runtime_alert.build_runtime_alert_payload",
+            return_value=_fake_payload("my-svc"),
+        ),
+        patch("app.cli.investigate.run_investigation_cli", return_value=_fake_result()),
+    ):
+        result = runner.invoke(
+            investigate_command,
+            ["--service", "my-svc", "--slack-thread", "C01234/1712345.000001"],
+        )
+
+    assert result.exit_code != 0
+    assert "SLACK_BOT_TOKEN is not set" in (result.output + str(result.exception))
+
+
+def test_slack_thread_passed_to_payload_builder(monkeypatch) -> None:
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-fake-token")
+    runner = CliRunner()
+
+    with (
+        patch(
+            "app.remote.runtime_alert.build_runtime_alert_payload",
+            return_value=_fake_payload("my-svc"),
+        ) as mock_build,
+        patch("app.cli.investigate.run_investigation_cli", return_value=_fake_result()),
+    ):
+        result = runner.invoke(
+            investigate_command,
+            ["--service", "my-svc", "--slack-thread", "C01234/1712345.000001"],
+        )
+
+    assert result.exit_code == 0
+    mock_build.assert_called_once_with(
+        "my-svc",
+        slack_thread_ref="C01234/1712345.000001",
+        slack_bot_token="xoxb-fake-token",
+    )

--- a/tests/remote/test_ops_fetch_logs.py
+++ b/tests/remote/test_ops_fetch_logs.py
@@ -98,6 +98,39 @@ def test_fetch_logs_raises_on_non_zero_exit() -> None:
         provider.fetch_logs(scope, lines=10)
 
 
+def test_fetch_logs_appends_stderr_when_both_present() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch(
+            "app.remote.ops.subprocess.run",
+            side_effect=_make_run(log_output="main log line", log_stderr="advisory message"),
+        ),
+    ):
+        result = provider.fetch_logs(scope, lines=10)
+
+    assert "main log line" in result
+    assert "[stderr: advisory message]" in result
+
+
+def test_fetch_logs_returns_stderr_when_stdout_empty() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch(
+            "app.remote.ops.subprocess.run",
+            side_effect=_make_run(log_output="", log_stderr="warning: logs delayed"),
+        ),
+    ):
+        result = provider.fetch_logs(scope, lines=10)
+
+    assert result == "warning: logs delayed"
+
+
 def test_fetch_logs_passes_tail_argument() -> None:
     provider = RailwayRemoteOpsProvider()
     scope = RemoteServiceScope(provider="railway", project="proj", service="svc")

--- a/tests/remote/test_ops_fetch_logs.py
+++ b/tests/remote/test_ops_fetch_logs.py
@@ -1,0 +1,121 @@
+"""Tests for RailwayRemoteOpsProvider.fetch_logs()."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.remote.ops import RailwayRemoteOpsProvider, RemoteOpsError, RemoteServiceScope
+
+
+class _Result:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _make_run(log_output: str = "", log_returncode: int = 0, log_stderr: str = ""):
+    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+        _ = (check, text, capture_output)
+        if cmd[:2] == ["railway", "link"]:
+            return _Result(0, stdout="{}")
+        if cmd[:2] == ["railway", "logs"]:
+            return _Result(log_returncode, stdout=log_output, stderr=log_stderr)
+        return _Result(1, stderr="unexpected command")
+
+    return _run
+
+
+def test_fetch_logs_returns_captured_output() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    log_text = "2026-04-17 10:00:00 INFO app started\n2026-04-17 10:01:00 ERROR db timeout"
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch("app.remote.ops.subprocess.run", side_effect=_make_run(log_output=log_text)),
+    ):
+        result = provider.fetch_logs(scope, lines=50)
+
+    assert result == log_text
+
+
+def test_fetch_logs_strips_whitespace() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch(
+            "app.remote.ops.subprocess.run",
+            side_effect=_make_run(log_output="\n\n  log content  \n\n"),
+        ),
+    ):
+        result = provider.fetch_logs(scope, lines=10)
+
+    assert result == "log content"
+
+
+def test_fetch_logs_returns_empty_string_when_no_output() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch("app.remote.ops.subprocess.run", side_effect=_make_run(log_output="")),
+    ):
+        result = provider.fetch_logs(scope, lines=10)
+
+    assert result == ""
+
+
+def test_fetch_logs_raises_when_railway_cli_missing() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value=None),
+        pytest.raises(RemoteOpsError, match="Railway CLI is not installed"),
+    ):
+        provider.fetch_logs(scope, lines=10)
+
+
+def test_fetch_logs_raises_on_non_zero_exit() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch(
+            "app.remote.ops.subprocess.run",
+            side_effect=_make_run(log_returncode=1, log_stderr="not linked"),
+        ),
+        pytest.raises(RemoteOpsError, match="Railway command failed"),
+    ):
+        provider.fetch_logs(scope, lines=10)
+
+
+def test_fetch_logs_passes_tail_argument() -> None:
+    provider = RailwayRemoteOpsProvider()
+    scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
+
+    captured: list[list[str]] = []
+
+    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+        _ = (check, text, capture_output)
+        captured.append(list(cmd))
+        if cmd[:2] == ["railway", "link"]:
+            return _Result(0, stdout="{}")
+        return _Result(0, stdout="logs")
+
+    with (
+        patch("app.remote.ops.shutil.which", return_value="/usr/local/bin/railway"),
+        patch("app.remote.ops.subprocess.run", side_effect=_run),
+    ):
+        provider.fetch_logs(scope, lines=42)
+
+    logs_cmd = next(c for c in captured if c[:2] == ["railway", "logs"])
+    assert logs_cmd == ["railway", "logs", "--tail", "42"]

--- a/tests/remote/test_runtime_alert.py
+++ b/tests/remote/test_runtime_alert.py
@@ -1,0 +1,283 @@
+"""Tests for build_runtime_alert_payload()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.cli.errors import OpenSREError
+from app.deployment.health import HealthPollStatus
+from app.remote.ops import RemoteOpsError, ServiceStatus
+from app.remote.runtime_alert import build_runtime_alert_payload
+
+
+def _status(**overrides: object) -> ServiceStatus:
+    defaults: dict[str, object] = {
+        "provider": "railway",
+        "project": "proj-a",
+        "service": "svc-a",
+        "deployment_id": "dep-123",
+        "deployment_status": "SUCCESS",
+        "environment": "production",
+        "url": "https://svc-a.up.railway.app",
+        "health": "healthy",
+        "metadata": {"region": "us-east"},
+    }
+    defaults.update(overrides)
+    return ServiceStatus(**defaults)  # type: ignore[arg-type]
+
+
+def _patch_registry(service_name: str, *, configured: bool = True) -> object:
+    remotes = {service_name: "https://svc-a.up.railway.app"} if configured else {}
+    return patch(
+        "app.remote.runtime_alert.load_named_remotes",
+        return_value=remotes,
+    )
+
+
+def _patch_ops_config(
+    *, provider: str = "railway", project: str = "proj-a", service: str = "svc-a"
+) -> object:
+    return patch(
+        "app.remote.runtime_alert.load_remote_ops_config",
+        return_value={"provider": provider, "project": project, "service": service},
+    )
+
+
+def _patch_provider(provider_mock: MagicMock) -> object:
+    return patch(
+        "app.remote.runtime_alert.resolve_remote_ops_provider",
+        return_value=provider_mock,
+    )
+
+
+def test_happy_path_returns_payload_with_service_logs_and_health() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status()
+    provider_mock.fetch_logs.return_value = "log line 1\nlog line 2"
+
+    health_result = HealthPollStatus(
+        url="https://svc-a.up.railway.app/health",
+        attempts=1,
+        status_code=200,
+        elapsed_seconds=0.25,
+    )
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        patch(
+            "app.remote.runtime_alert.poll_deployment_health",
+            return_value=health_result,
+        ),
+    ):
+        payload = build_runtime_alert_payload("my-svc")
+
+    assert payload["alert_name"] == "Remote runtime investigation: my-svc"
+    assert payload["pipeline_name"] == "svc-a"
+    assert payload["severity"] == "warning"
+    assert "alert_source" not in payload
+    assert payload["investigation_origin"] == "remote_runtime"
+    assert payload["service"]["provider"] == "railway"
+    assert payload["service"]["deployment_id"] == "dep-123"
+    assert payload["service"]["health"] == "healthy"
+    assert payload["recent_logs"] == "log line 1\nlog line 2"
+    assert payload["health_probe"]["status_code"] == 200
+    assert payload["health_probe"]["attempts"] == 1
+
+
+def test_missing_service_name_raises() -> None:
+    with pytest.raises(OpenSREError, match="Service name is required"):
+        build_runtime_alert_payload("")
+
+
+def test_unknown_service_raises_with_suggestion() -> None:
+    with (
+        _patch_registry("other-svc"),
+        pytest.raises(OpenSREError, match="No remote named 'my-svc'"),
+    ):
+        build_runtime_alert_payload("my-svc")
+
+
+def test_status_failure_raises_with_suggestion() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.side_effect = RemoteOpsError("railway down")
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        pytest.raises(OpenSREError, match="Failed to fetch deployment status"),
+    ):
+        build_runtime_alert_payload("my-svc")
+
+
+def test_logs_unavailable_is_graceful() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status()
+    provider_mock.fetch_logs.side_effect = RemoteOpsError("no deployment")
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        patch(
+            "app.remote.runtime_alert.poll_deployment_health",
+            return_value=HealthPollStatus(
+                url="https://svc-a.up.railway.app/health",
+                attempts=1,
+                status_code=200,
+                elapsed_seconds=0.1,
+            ),
+        ),
+    ):
+        payload = build_runtime_alert_payload("my-svc")
+
+    assert "logs unavailable" in payload["recent_logs"]
+    assert payload["health_probe"]["status_code"] == 200
+
+
+def test_health_timeout_is_graceful() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status()
+    provider_mock.fetch_logs.return_value = "some logs"
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        patch(
+            "app.remote.runtime_alert.poll_deployment_health",
+            side_effect=TimeoutError("Deployment health check timed out"),
+        ),
+    ):
+        payload = build_runtime_alert_payload("my-svc")
+
+    assert payload["recent_logs"] == "some logs"
+    assert "timed out" in payload["health_probe"]["error"]
+
+
+def test_unsupported_provider_raises_friendly_error() -> None:
+    with (
+        _patch_registry("my-svc"),
+        patch(
+            "app.remote.runtime_alert.load_remote_ops_config",
+            return_value={"provider": "unknown-provider", "project": None, "service": None},
+        ),
+        patch(
+            "app.remote.runtime_alert.resolve_remote_ops_provider",
+            side_effect=RemoteOpsError("Unsupported remote ops provider: unknown-provider"),
+        ),
+        pytest.raises(OpenSREError, match="Unsupported remote ops provider"),
+    ):
+        build_runtime_alert_payload("my-svc")
+
+
+def test_missing_status_url_skips_health_probe() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status(url=None)
+    provider_mock.fetch_logs.return_value = ""
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+    ):
+        payload = build_runtime_alert_payload("my-svc")
+
+    assert payload["health_probe"] == {"error": "no service URL available"}
+
+
+def test_slack_thread_included_when_ref_and_token_provided() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status()
+    provider_mock.fetch_logs.return_value = "logs"
+
+    slack_payload = {
+        "channel": "C01234",
+        "ts": "1712345.000001",
+        "messages": [{"user": "U1", "text": "help", "ts": "1712345.000001", "reactions": []}],
+        "count": 1,
+    }
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        patch(
+            "app.remote.runtime_alert.poll_deployment_health",
+            return_value=HealthPollStatus(
+                url="https://svc-a.up.railway.app/health",
+                attempts=1,
+                status_code=200,
+                elapsed_seconds=0.1,
+            ),
+        ),
+        patch(
+            "app.remote.runtime_alert.fetch_slack_thread",
+            return_value=slack_payload,
+        ),
+    ):
+        payload = build_runtime_alert_payload(
+            "my-svc",
+            slack_thread_ref="C01234/1712345.000001",
+            slack_bot_token="xoxb-fake",
+        )
+
+    assert payload["slack_thread"]["count"] == 1
+    assert payload["slack_thread"]["channel"] == "C01234"
+
+
+def test_slack_thread_captures_parse_error() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status()
+    provider_mock.fetch_logs.return_value = ""
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        patch(
+            "app.remote.runtime_alert.poll_deployment_health",
+            return_value=HealthPollStatus(
+                url="https://svc-a.up.railway.app/health",
+                attempts=1,
+                status_code=200,
+                elapsed_seconds=0.1,
+            ),
+        ),
+    ):
+        payload = build_runtime_alert_payload(
+            "my-svc",
+            slack_thread_ref="malformed-ref",
+            slack_bot_token="xoxb-fake",
+        )
+
+    assert "error" in payload["slack_thread"]
+    assert "CHANNEL/TS" in payload["slack_thread"]["error"]
+
+
+def test_slack_thread_not_included_when_ref_absent() -> None:
+    provider_mock = MagicMock()
+    provider_mock.status.return_value = _status()
+    provider_mock.fetch_logs.return_value = ""
+
+    with (
+        _patch_registry("my-svc"),
+        _patch_ops_config(),
+        _patch_provider(provider_mock),
+        patch(
+            "app.remote.runtime_alert.poll_deployment_health",
+            return_value=HealthPollStatus(
+                url="https://svc-a.up.railway.app/health",
+                attempts=1,
+                status_code=200,
+                elapsed_seconds=0.1,
+            ),
+        ),
+    ):
+        payload = build_runtime_alert_payload("my-svc")
+
+    assert "slack_thread" not in payload

--- a/tests/remote/test_slack_context.py
+++ b/tests/remote/test_slack_context.py
@@ -1,0 +1,110 @@
+"""Tests for Slack thread context helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.remote.slack_context import fetch_slack_thread, parse_slack_thread_ref
+
+
+def test_parse_thread_ref_splits_channel_and_ts() -> None:
+    channel, ts = parse_slack_thread_ref("C01234/1712345.000001")
+    assert channel == "C01234"
+    assert ts == "1712345.000001"
+
+
+def test_parse_thread_ref_strips_whitespace() -> None:
+    channel, ts = parse_slack_thread_ref("  C01234/1712345.000001  ")
+    assert channel == "C01234"
+    assert ts == "1712345.000001"
+
+
+@pytest.mark.parametrize(
+    "bad_ref",
+    ["", "no-slash-here", "/missing-channel", "channel-only/", "/"],
+)
+def test_parse_thread_ref_rejects_malformed(bad_ref: str) -> None:
+    with pytest.raises(ValueError):
+        parse_slack_thread_ref(bad_ref)
+
+
+def test_fetch_thread_returns_error_when_token_missing() -> None:
+    result = fetch_slack_thread("C01234", "1712345.000001", bot_token="")
+    assert result == {"error": "SLACK_BOT_TOKEN not configured"}
+
+
+def test_fetch_thread_returns_messages_on_success() -> None:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "ok": True,
+        "messages": [
+            {
+                "user": "U123",
+                "text": "something broke",
+                "ts": "1712345.000001",
+                "reactions": [{"name": "eyes"}, {"name": "fire"}],
+            },
+            {
+                "user": "U456",
+                "text": "investigating",
+                "ts": "1712345.000002",
+            },
+        ],
+    }
+
+    with patch("app.remote.slack_context.httpx.get", return_value=mock_resp):
+        result = fetch_slack_thread("C01234", "1712345.000001", "xoxb-fake", limit=10)
+
+    assert result["channel"] == "C01234"
+    assert result["ts"] == "1712345.000001"
+    assert result["count"] == 2
+    assert result["messages"][0]["text"] == "something broke"
+    assert result["messages"][0]["reactions"] == ["eyes", "fire"]
+    assert result["messages"][1]["reactions"] == []
+
+
+def test_fetch_thread_returns_error_when_ok_false() -> None:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"ok": False, "error": "channel_not_found"}
+
+    with patch("app.remote.slack_context.httpx.get", return_value=mock_resp):
+        result = fetch_slack_thread("C01234", "1712345.000001", "xoxb-fake")
+
+    assert result == {"error": "channel_not_found"}
+
+
+def test_fetch_thread_returns_error_on_http_failure() -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 403
+
+    with patch(
+        "app.remote.slack_context.httpx.get",
+        side_effect=httpx.HTTPStatusError("err", request=MagicMock(), response=mock_resp),
+    ):
+        result = fetch_slack_thread("C01234", "1712345.000001", "xoxb-fake")
+
+    assert result == {"error": "HTTP 403"}
+
+
+def test_fetch_thread_returns_error_on_unexpected_exception() -> None:
+    with patch("app.remote.slack_context.httpx.get", side_effect=RuntimeError("boom")):
+        result = fetch_slack_thread("C01234", "1712345.000001", "xoxb-fake")
+
+    assert result == {"error": "boom"}
+
+
+def test_fetch_thread_caps_limit_at_100() -> None:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"ok": True, "messages": []}
+
+    with patch("app.remote.slack_context.httpx.get", return_value=mock_resp) as mock_get:
+        fetch_slack_thread("C01234", "1712345.000001", "xoxb-fake", limit=500)
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["limit"] == 100


### PR DESCRIPTION
## Summary

Adds `opensre investigate --service <name>` — a runtime investigation workflow for deployed services. Instead of passing an alert file, OpenSRE pulls live signals (deployment status, recent logs, health probe) from the configured remote ops provider and feeds them into the existing RCA pipeline as evidence. Optionally incorporates Slack thread context via `--slack-thread`.

Fixes #301.

## What changed

### New capability: `opensre investigate --service <name>`
Gathers per-service evidence and runs the standard RCA pipeline against it:
1. Resolves `<name>` against the existing named-remote registry (`load_named_remotes()`)
2. Fetches deployment status via `RemoteOpsProvider.status()`
3. Pulls the most recent ~100 log lines via the new `fetch_logs()` method
4. Probes `/health` / `/ok` via existing `poll_deployment_health()`
5. Packages everything into a rich `raw_alert` dict the investigation graph already knows how to consume

### New capability: `--slack-thread CHANNEL/TS`
Optional flag that pulls a specific Slack thread via `conversations.replies` and includes the messages as investigation context. Requires `SLACK_BOT_TOKEN` in the environment. Graceful: Slack fetch failures are captured in the payload instead of failing the investigation.

### Extensible provider interface
Added `fetch_logs(scope, *, lines) -> str` as an abstract method on `RemoteOpsProvider`. Unlike the existing `logs()` (which streams to stdout for interactive use), `fetch_logs()` captures output so it can feed the agent. Implemented for Railway; other providers follow the same pattern.

### Graceful fallbacks
- Logs unavailable → `(logs unavailable: <reason>)` in the payload
- Health probe timeout → error captured in `health_probe`
- Missing service URL → health probe skipped
- Slack fetch errors → captured in `slack_thread.error`
- Unsupported provider → friendly `OpenSREError` with remediation hint
- Mutual exclusion with `--input` / `--input-json` / `--interactive` / `--print-template` → rejected with clear message

## Acceptance criteria coverage (from #301)

| # | Criterion | Implementation |
|---|-----------|----------------|
| 1 | User can start remote investigation for deployed service | `opensre investigate --service <name>` |
| 2 | Pulls logs, health, deploy metadata from hosting provider | `fetch_logs`, `poll_deployment_health`, `provider.status` |
| 3 | Incorporates Slack context | `--slack-thread CHANNEL/TS` + `SLACK_BOT_TOKEN` |
| 4 | Output highlights likely causes, recent changes, next steps | Standard RCA pipeline (now with richer evidence) |
| 5 | Initial implementation documented and designed to extend | New docs page + nav entry; `RemoteOpsProvider` ABC extensible |

## Design notes

- **`alert_source` is deliberately left unset** in the payload. `detect_sources.py` filters core integrations (Grafana/Datadog/Honeycomb/Coralogix) by `alert_source`, so setting it to `"remote_runtime"` would silently suppress all four. The LLM in `extract_alert` may infer an `alert_source` from the log contents, which is the correct behavior.
- **No new state fields**: extra context (`service`, `recent_logs`, `health_probe`, `slack_thread`) rides on `raw_alert`. Avoids the `AgentState` TypedDict / Pydantic drift-test churn and keeps the change local.
- **`investigation_origin = "remote_runtime"`**: purely informational marker for future tooling; no routing impact.
- **Narrow Slack approach**: this PR does not add a full Slack read integration (config + catalog + detect_sources + agent tool). It exposes exactly what #301 calls for — the investigation workflow can incorporate a specific Slack thread — via a CLI flag and env var. A full Slack integration (so the agent can dynamically search/fetch more Slack context) is a natural follow-up.

## Files changed

**New (7):**
- `app/remote/runtime_alert.py` — `build_runtime_alert_payload()` helper
- `app/remote/slack_context.py` — `parse_slack_thread_ref()` + `fetch_slack_thread()`
- `docs/remote-runtime-investigation.mdx` — user-facing documentation
- `tests/remote/test_ops_fetch_logs.py` — 6 tests
- `tests/remote/test_runtime_alert.py` — 11 tests
- `tests/remote/test_slack_context.py` — 13 tests
- `tests/cli/test_investigate_service_flag.py` — 10 tests

**Modified (4):**
- `app/remote/ops.py` — new `fetch_logs()` abstract + Railway impl
- `app/cli/commands/general.py` — `--service` and `--slack-thread` flags + handler
- `docs/docs.json` — nav entry under "Investigations"
- `.env.example` — `SLACK_BOT_TOKEN` documented

## Test plan

- [x] `ruff check app/ tests/` — clean
- [x] `python -m mypy app/` — 0 issues in 356 files
- [x] `python -m pytest tests/remote/test_ops_fetch_logs.py tests/remote/test_runtime_alert.py tests/remote/test_slack_context.py tests/cli/test_investigate_service_flag.py -v` — **40 / 40 passing**
- [x] Full suite with coverage — zero regressions (same 6 failed / 176 errors as main, all pre-existing `TypedDict` issues on Python 3.11)
- [x] Manual smoke: `opensre investigate --service <deployed-railway-service>` against a real Railway deployment (local env required; reviewers with access please confirm)
- [x] Manual smoke: `--slack-thread CHANNEL/TS` with a real `SLACK_BOT_TOKEN` + `channels:history` scope

## Follow-ups

- Add `fetch_logs()` implementations for other providers (EC2, ECS, Vercel) — currently Railway-only.
- Full Slack read integration (bot token in integration store, agent tool for dynamic thread/search queries) if the team wants the agent to pull Slack context proactively rather than only when the user specifies a thread.
