### PR TITLE
fix(tests): prevent flaky test_validation by preloading SDK error cla…

### DIFF
--- a/tests/cli/wizard/test_validation.py
+++ b/tests/cli/wizard/test_validation.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 from anthropic import AuthenticationError as AnthropicAuthError
 from openai import AuthenticationError as OpenAIAuthError
 
 from app.cli.wizard.config import PROVIDER_BY_VALUE
 from app.cli.wizard.validation import validate_provider_credentials
+
+
+@pytest.fixture(autouse=True)
+def _preload_sdk_error_classes(monkeypatch) -> None:
+    """Pre-populate the module-level ``*AuthError`` globals in validation.py.
+
+    ``_load_anthropic_client``/``_load_openai_client`` lazily import the SDKs
+    and override the module-level ``Anthropic``/``OpenAI`` names when their
+    matching ``*AuthError`` is ``None``. If a test monkeypatches only the
+    client class (``Anthropic`` / ``OpenAI``), the first call to the loader
+    re-imports and silently replaces that monkeypatch with the real SDK —
+    which then hits the real network using any ``ANTHROPIC_API_KEY`` /
+    ``OPENAI_API_KEY`` leaked in from the test environment.
+
+    By setting the ``*AuthError`` globals here to the real classes (already
+    imported at the top of this file), we short-circuit the loader's import
+    branch and make monkeypatches of ``Anthropic`` / ``OpenAI`` reliable.
+    """
+    monkeypatch.setattr("app.cli.wizard.validation.AnthropicAuthError", AnthropicAuthError)
+    monkeypatch.setattr("app.cli.wizard.validation.OpenAIAuthError", OpenAIAuthError)
 
 
 class _FakeAnthropicTextBlock:


### PR DESCRIPTION
prevent flaky test_validation by preloading SDK error classes

_load_anthropic_client() and _load_openai_client() in app/cli/wizard/
validation.py lazily import their SDKs and set both the client class
(Anthropic/OpenAI) and the matching *AuthError global. They re-import
whenever *AuthError is None, which silently overwrites any monkeypatch
of the client class.

The tests only patched Anthropic/OpenAI (not *AuthError), so on the
first call in a pytest-xdist worker the real SDK was re-injected, the
real API was called using ANTHROPIC_API_KEY/OPENAI_API_KEY leaked in
from the CI environment, and the test failed with 'rejected the API
key'. Pass/fail depended on xdist worker distribution — any PR that
added tests could trigger it.

Add an autouse fixture that pre-populates the *AuthError globals with
the real error classes so the loaders' import branch never fires in
tests. Subsequent monkeypatches of Anthropic/OpenAI are now stable.