### PR TITLE
feat: mask sensitive infrastructure identifiers before model calls (#…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,16 @@ SLACK_BOT_TOKEN=
 
 ENV=development
 
+# Reversible masking of sensitive infrastructure identifiers before external LLM calls.
+# See docs/masking.mdx for details. Off by default; enable per operator.
+OPENSRE_MASK_ENABLED=false
+# Comma-separated kinds to mask. Empty = all defaults
+# (pod,namespace,cluster,hostname,account_id,ip_address,email,service_name).
+OPENSRE_MASK_KINDS=
+# Optional JSON object of label→regex for custom identifier patterns.
+# Example: '{"jira_key": "\\b[A-Z]+-\\d+\\b"}'
+OPENSRE_MASK_EXTRA_REGEX=
+
 #Gitlab
 GITLAB_BASE_URL=https://gitlab.com/api/v4
 GITLAB_MR_WRITEBACK=false

--- a/app/masking/__init__.py
+++ b/app/masking/__init__.py
@@ -1,0 +1,25 @@
+"""Reversible masking of sensitive infrastructure identifiers.
+
+Replaces pod names, cluster names, hostnames, account ids, service names,
+IP addresses, and emails with stable placeholders (``<POD_0>``, ``<CLUSTER_1>``)
+before sending text to external LLMs, and restores the originals in any
+user-facing output. Complementary to ``app/guardrails`` which performs
+one-way redaction for hard-block rules.
+
+Activated per operator by ``OPENSRE_MASK_ENABLED=true``. Off by default.
+"""
+
+from __future__ import annotations
+
+from app.masking.context import MaskingContext
+from app.masking.detectors import DetectedIdentifier, find_identifiers
+from app.masking.policy import ALL_KINDS, IdentifierKind, MaskingPolicy
+
+__all__ = [
+    "ALL_KINDS",
+    "DetectedIdentifier",
+    "IdentifierKind",
+    "MaskingContext",
+    "MaskingPolicy",
+    "find_identifiers",
+]

--- a/app/masking/context.py
+++ b/app/masking/context.py
@@ -8,10 +8,11 @@ over strings, lists, and dicts. The placeholder map is serialized to
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from app.masking.detectors import DetectedIdentifier, find_identifiers
-from app.masking.policy import MaskingPolicy
+from app.masking.policy import MaskingPolicy, compile_extra_patterns
 
 
 class MaskingContext:
@@ -32,6 +33,8 @@ class MaskingContext:
         }
         # running counter per kind so placeholder numbers stay stable within a run
         self._counters: dict[str, int] = self._derive_counters()
+        # Compile extra regex patterns once per context to avoid per-call work
+        self._compiled_extras: dict[str, re.Pattern[str]] = compile_extra_patterns(policy)
 
     @classmethod
     def from_state(cls, state: dict[str, Any]) -> MaskingContext:
@@ -52,14 +55,18 @@ class MaskingContext:
         return dict(self._placeholder_map)
 
     def _derive_counters(self) -> dict[str, int]:
-        counters: dict[str, int] = {}
+        # Accumulate the maximum index per kind across the whole map first,
+        # then add 1 once at the end. Doing "+1" inside the loop would
+        # over-count when the map is iterated out of ascending order
+        # (e.g. <NS_2>, <NS_0> would yield 4 instead of 3).
+        max_index: dict[str, int] = {}
         for placeholder in self._placeholder_map:
             kind, _, index = placeholder.strip("<>").rpartition("_")
             if not kind or not index.isdigit():
                 continue
             key = kind.lower()
-            counters[key] = max(counters.get(key, -1), int(index)) + 1
-        return counters
+            max_index[key] = max(max_index.get(key, -1), int(index))
+        return {key: value + 1 for key, value in max_index.items()}
 
     def _new_placeholder(self, kind: str) -> str:
         index = self._counters.get(kind, 0)
@@ -81,7 +88,7 @@ class MaskingContext:
         """
         if not self.policy.enabled or not text:
             return text
-        matches = find_identifiers(text, self.policy)
+        matches = find_identifiers(text, self.policy, self._compiled_extras)
         if not matches:
             return text
         return self._apply_replacements(text, matches)

--- a/app/masking/context.py
+++ b/app/masking/context.py
@@ -1,0 +1,138 @@
+"""Per-investigation masking context.
+
+``MaskingContext`` holds a ``MaskingPolicy`` and a stable placeholder map
+for the lifetime of a single investigation. Mask and unmask operations run
+over strings, lists, and dicts. The placeholder map is serialized to
+``AgentState["masking_map"]`` so it survives node-to-node transitions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.masking.detectors import DetectedIdentifier, find_identifiers
+from app.masking.policy import MaskingPolicy
+
+
+class MaskingContext:
+    """Stable masking state for one investigation."""
+
+    def __init__(
+        self,
+        policy: MaskingPolicy,
+        placeholder_map: dict[str, str] | None = None,
+    ) -> None:
+        self.policy = policy
+        # placeholder -> original value
+        self._placeholder_map: dict[str, str] = dict(placeholder_map or {})
+        # original value -> placeholder (reverse for reuse/stability)
+        self._reverse_map: dict[str, str] = {
+            original: placeholder
+            for placeholder, original in self._placeholder_map.items()
+        }
+        # running counter per kind so placeholder numbers stay stable within a run
+        self._counters: dict[str, int] = self._derive_counters()
+
+    @classmethod
+    def from_state(cls, state: dict[str, Any]) -> MaskingContext:
+        """Reconstruct a context from an investigation state dict.
+
+        Policy is re-read from the environment so env changes are honoured.
+        ``placeholder_map`` carries the mappings accumulated by earlier nodes
+        in the same investigation.
+        """
+        policy = MaskingPolicy.from_env()
+        existing = state.get("masking_map") or {}
+        if not isinstance(existing, dict):
+            existing = {}
+        return cls(policy=policy, placeholder_map=dict(existing))
+
+    @property
+    def placeholder_map(self) -> dict[str, str]:
+        return dict(self._placeholder_map)
+
+    def _derive_counters(self) -> dict[str, int]:
+        counters: dict[str, int] = {}
+        for placeholder in self._placeholder_map:
+            kind, _, index = placeholder.strip("<>").rpartition("_")
+            if not kind or not index.isdigit():
+                continue
+            key = kind.lower()
+            counters[key] = max(counters.get(key, -1), int(index)) + 1
+        return counters
+
+    def _new_placeholder(self, kind: str) -> str:
+        index = self._counters.get(kind, 0)
+        self._counters[kind] = index + 1
+        return f"<{kind.upper()}_{index}>"
+
+    def _ensure_placeholder(self, kind: str, value: str) -> str:
+        if value in self._reverse_map:
+            return self._reverse_map[value]
+        placeholder = self._new_placeholder(kind)
+        self._placeholder_map[placeholder] = value
+        self._reverse_map[value] = placeholder
+        return placeholder
+
+    def mask(self, text: str) -> str:
+        """Return ``text`` with sensitive identifiers replaced by placeholders.
+
+        Pass-through (identity) when the policy is disabled.
+        """
+        if not self.policy.enabled or not text:
+            return text
+        matches = find_identifiers(text, self.policy)
+        if not matches:
+            return text
+        return self._apply_replacements(text, matches)
+
+    def _apply_replacements(
+        self, text: str, matches: list[DetectedIdentifier]
+    ) -> str:
+        # Replace in reverse order so earlier positions remain valid.
+        result = text
+        for m in sorted(matches, key=lambda x: x.start, reverse=True):
+            placeholder = self._ensure_placeholder(m.kind, m.value)
+            result = result[: m.start] + placeholder + result[m.end :]
+        return result
+
+    def unmask(self, text: str) -> str:
+        """Restore any known placeholders in ``text`` to their original values."""
+        if not text or not self._placeholder_map:
+            return text
+        result = text
+        for placeholder, original in self._placeholder_map.items():
+            if placeholder in result:
+                result = result.replace(placeholder, original)
+        return result
+
+    def mask_value(self, value: Any) -> Any:
+        """Recursively mask strings inside dicts/lists/tuples."""
+        if isinstance(value, str):
+            return self.mask(value)
+        if isinstance(value, dict):
+            return {k: self.mask_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self.mask_value(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self.mask_value(v) for v in value)
+        return value
+
+    def unmask_value(self, value: Any) -> Any:
+        """Recursively unmask strings inside dicts/lists/tuples."""
+        if isinstance(value, str):
+            return self.unmask(value)
+        if isinstance(value, dict):
+            return {k: self.unmask_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self.unmask_value(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self.unmask_value(v) for v in value)
+        return value
+
+    def to_state(self) -> dict[str, str]:
+        """Return the placeholder map in a form suitable for state storage."""
+        return dict(self._placeholder_map)
+
+
+__all__ = ["MaskingContext"]

--- a/app/masking/detectors.py
+++ b/app/masking/detectors.py
@@ -1,0 +1,133 @@
+"""Regex detectors for sensitive infrastructure identifiers.
+
+Each detector contributes zero or more ``DetectedIdentifier`` matches when
+``find_identifiers(text, policy)`` is called. Contextual detectors (namespace,
+cluster, service_name) only match when preceded by a recognized label so
+that generic words like ``frontend`` are not mistakenly masked.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from app.masking.policy import IdentifierKind, MaskingPolicy, _compile_extra_patterns
+
+
+@dataclass(frozen=True)
+class DetectedIdentifier:
+    """A single identifier found in text."""
+
+    kind: str
+    start: int
+    end: int
+    value: str
+
+
+# Built-in detectors. Each entry maps an ``IdentifierKind`` to a compiled
+# regex. Contextual detectors capture the VALUE in group(1) so we only mask
+# the identifier itself (not the preceding label like "kube_namespace:").
+
+_POD_RE = re.compile(
+    r"\b([a-z0-9](?:[-a-z0-9]*[a-z0-9])?-[a-f0-9]{5,10}(?:-[a-z0-9]{3,10})?)\b"
+)
+_NAMESPACE_RE = re.compile(
+    r"\b(?:kube_namespace|namespace|ns)[=:\s]+([a-z0-9][-a-z0-9]*)\b", re.IGNORECASE
+)
+_CLUSTER_RE = re.compile(
+    r"\b(?:kube_cluster|eks_cluster|cluster(?:_name)?)[=:\s]+"
+    r"([a-zA-Z0-9][-a-zA-Z0-9_]{1,})\b",
+    re.IGNORECASE,
+)
+_SERVICE_NAME_RE = re.compile(
+    r"\b(?:service|service_name|app|deployment)[=:\s]+([a-zA-Z0-9][-a-zA-Z0-9_]{1,})\b",
+    re.IGNORECASE,
+)
+_HOSTNAME_RE = re.compile(
+    r"\b("
+    r"kind-[a-z0-9][-a-z0-9]*"  # local kind clusters
+    r"|ip-\d+-\d+-\d+-\d+(?:\.[a-z0-9.-]+)*"  # ec2-style internal hostnames
+    r"|[a-z0-9][-a-z0-9]*(?:\.[a-z0-9][-a-z0-9]*)+\.(?:com|net|org|io|internal|local|cloud)"
+    r")\b",
+    re.IGNORECASE,
+)
+_ACCOUNT_RE = re.compile(r"\b(\d{12})\b")
+_IP_RE = re.compile(
+    r"\b((?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[01]?\d?\d)){3})\b"
+)
+_EMAIL_RE = re.compile(r"\b([\w.+-]+@[\w-]+\.[\w.-]+)\b")
+
+
+_BUILTIN_DETECTORS: dict[IdentifierKind, re.Pattern[str]] = {
+    "pod": _POD_RE,
+    "namespace": _NAMESPACE_RE,
+    "cluster": _CLUSTER_RE,
+    "service_name": _SERVICE_NAME_RE,
+    "hostname": _HOSTNAME_RE,
+    "account_id": _ACCOUNT_RE,
+    "ip_address": _IP_RE,
+    "email": _EMAIL_RE,
+}
+
+
+def find_identifiers(text: str, policy: MaskingPolicy) -> list[DetectedIdentifier]:
+    """Return all identifiers found in ``text`` under ``policy``.
+
+    Matches are returned sorted by start position. When two detectors match
+    overlapping regions, the longer match wins so we do not partially mask
+    a substring of a larger identifier.
+    """
+    if not policy.enabled or not text:
+        return []
+
+    found: list[DetectedIdentifier] = []
+
+    for kind, pattern in _BUILTIN_DETECTORS.items():
+        if not policy.is_kind_enabled(kind):
+            continue
+        for match in pattern.finditer(text):
+            # Prefer group(1) if defined, else the full match.
+            if match.groups():
+                start, end = match.span(1)
+                value = match.group(1)
+            else:
+                start, end = match.span()
+                value = match.group()
+            if value:
+                found.append(
+                    DetectedIdentifier(kind=kind, start=start, end=end, value=value)
+                )
+
+    for label, extra in _compile_extra_patterns(policy).items():
+        for match in extra.finditer(text):
+            if match.groups():
+                start, end = match.span(1)
+                value = match.group(1)
+            else:
+                start, end = match.span()
+                value = match.group()
+            if value:
+                found.append(
+                    DetectedIdentifier(kind=label, start=start, end=end, value=value)
+                )
+
+    return _resolve_overlaps(found)
+
+
+def _resolve_overlaps(matches: list[DetectedIdentifier]) -> list[DetectedIdentifier]:
+    """Drop matches that are fully contained inside a longer sibling match."""
+    if not matches:
+        return []
+    by_start = sorted(matches, key=lambda m: (m.start, -(m.end - m.start)))
+    result: list[DetectedIdentifier] = []
+    for m in by_start:
+        if any(kept.start <= m.start and kept.end >= m.end and kept is not m for kept in result):
+            continue
+        result.append(m)
+    return sorted(result, key=lambda m: m.start)
+
+
+__all__ = [
+    "DetectedIdentifier",
+    "find_identifiers",
+]

--- a/app/masking/detectors.py
+++ b/app/masking/detectors.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from app.masking.policy import IdentifierKind, MaskingPolicy, _compile_extra_patterns
+from app.masking.policy import IdentifierKind, MaskingPolicy, compile_extra_patterns
 
 
 @dataclass(frozen=True)
@@ -46,7 +46,11 @@ _SERVICE_NAME_RE = re.compile(
 _HOSTNAME_RE = re.compile(
     r"\b("
     r"kind-[a-z0-9][-a-z0-9]*"  # local kind clusters
-    r"|ip-\d+-\d+-\d+-\d+(?:\.[a-z0-9.-]+)*"  # ec2-style internal hostnames
+    # ec2-style internal hostnames: ip-10-0-1-23.ec2.internal
+    # Note: the inner character class excludes '.' so the outer (?:\.LABEL)*
+    # has no ambiguity and cannot backtrack exponentially (CodeQL ReDoS).
+    r"|ip-\d+-\d+-\d+-\d+(?:\.[a-z0-9][a-z0-9-]*)*"
+    # Generic DNS-style: label(.label)+.(tld)
     r"|[a-z0-9][-a-z0-9]*(?:\.[a-z0-9][-a-z0-9]*)+\.(?:com|net|org|io|internal|local|cloud)"
     r")\b",
     re.IGNORECASE,
@@ -70,12 +74,21 @@ _BUILTIN_DETECTORS: dict[IdentifierKind, re.Pattern[str]] = {
 }
 
 
-def find_identifiers(text: str, policy: MaskingPolicy) -> list[DetectedIdentifier]:
+def find_identifiers(
+    text: str,
+    policy: MaskingPolicy,
+    compiled_extras: dict[str, re.Pattern[str]] | None = None,
+) -> list[DetectedIdentifier]:
     """Return all identifiers found in ``text`` under ``policy``.
 
     Matches are returned sorted by start position. When two detectors match
-    overlapping regions, the longer match wins so we do not partially mask
-    a substring of a larger identifier.
+    overlapping regions (fully contained *or partially overlapping*), the
+    longer earlier match wins so we never corrupt the output in
+    ``_apply_replacements``.
+
+    ``compiled_extras`` may be passed by callers that want to compile the
+    policy's extra regex patterns once per investigation instead of on
+    every call.
     """
     if not policy.enabled or not text:
         return []
@@ -85,43 +98,52 @@ def find_identifiers(text: str, policy: MaskingPolicy) -> list[DetectedIdentifie
     for kind, pattern in _BUILTIN_DETECTORS.items():
         if not policy.is_kind_enabled(kind):
             continue
-        for match in pattern.finditer(text):
-            # Prefer group(1) if defined, else the full match.
-            if match.groups():
-                start, end = match.span(1)
-                value = match.group(1)
-            else:
-                start, end = match.span()
-                value = match.group()
-            if value:
-                found.append(
-                    DetectedIdentifier(kind=kind, start=start, end=end, value=value)
-                )
+        _append_matches(pattern, text, kind, found)
 
-    for label, extra in _compile_extra_patterns(policy).items():
-        for match in extra.finditer(text):
-            if match.groups():
-                start, end = match.span(1)
-                value = match.group(1)
-            else:
-                start, end = match.span()
-                value = match.group()
-            if value:
-                found.append(
-                    DetectedIdentifier(kind=label, start=start, end=end, value=value)
-                )
+    extras = compiled_extras if compiled_extras is not None else compile_extra_patterns(policy)
+    for label, extra in extras.items():
+        _append_matches(extra, text, label, found)
 
     return _resolve_overlaps(found)
 
 
+def _append_matches(
+    pattern: re.Pattern[str],
+    text: str,
+    kind: str,
+    out: list[DetectedIdentifier],
+) -> None:
+    for match in pattern.finditer(text):
+        # Prefer group(1) if defined (contextual detectors), else the full match.
+        if match.groups():
+            start, end = match.span(1)
+            value = match.group(1)
+        else:
+            start, end = match.span()
+            value = match.group()
+        if value:
+            out.append(DetectedIdentifier(kind=kind, start=start, end=end, value=value))
+
+
 def _resolve_overlaps(matches: list[DetectedIdentifier]) -> list[DetectedIdentifier]:
-    """Drop matches that are fully contained inside a longer sibling match."""
+    """Drop matches that overlap (fully or partially) a longer earlier match.
+
+    Sort by start ASC, then by length DESC so the longest match at each
+    start position is considered first. For each candidate, drop it if any
+    already-kept match shares even a single character — this prevents
+    ``_apply_replacements`` from processing overlapping spans and producing
+    corrupted output when replacements are spliced in reverse.
+    """
     if not matches:
         return []
     by_start = sorted(matches, key=lambda m: (m.start, -(m.end - m.start)))
     result: list[DetectedIdentifier] = []
     for m in by_start:
-        if any(kept.start <= m.start and kept.end >= m.end and kept is not m for kept in result):
+        # Partial-overlap check: kept.start < m.end AND kept.end > m.start
+        # means [kept.start, kept.end) and [m.start, m.end) share characters.
+        if any(
+            kept.start < m.end and kept.end > m.start and kept is not m for kept in result
+        ):
             continue
         result.append(m)
     return sorted(result, key=lambda m: m.start)

--- a/app/masking/policy.py
+++ b/app/masking/policy.py
@@ -134,8 +134,12 @@ def _parse_bool(value: str | None) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _compile_extra_patterns(policy: MaskingPolicy) -> dict[str, re.Pattern[str]]:
-    """Compile extra regex patterns once, with the label as the key."""
+def compile_extra_patterns(policy: MaskingPolicy) -> dict[str, re.Pattern[str]]:
+    """Compile a policy's extra regex patterns into a label→Pattern dict.
+
+    Public helper so callers (e.g. MaskingContext) can compile once per
+    investigation rather than on every mask call.
+    """
     compiled: dict[str, re.Pattern[str]] = {}
     for label, pattern in policy.extra_patterns.items():
         try:
@@ -151,4 +155,5 @@ __all__ = [
     "ALL_KINDS",
     "IdentifierKind",
     "MaskingPolicy",
+    "compile_extra_patterns",
 ]

--- a/app/masking/policy.py
+++ b/app/masking/policy.py
@@ -1,0 +1,154 @@
+"""Masking policy — configurable via environment variables.
+
+A ``MaskingPolicy`` decides which kinds of sensitive infrastructure
+identifiers are masked and what extra regex patterns apply. It is built
+fresh per investigation, so env-var changes between investigations are
+picked up. No module-level singleton.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import ClassVar, Literal
+
+from pydantic import Field, field_validator
+
+from app.strict_config import StrictConfigModel
+
+logger = logging.getLogger(__name__)
+
+IdentifierKind = Literal[
+    "pod",
+    "namespace",
+    "cluster",
+    "hostname",
+    "account_id",
+    "ip_address",
+    "email",
+    "service_name",
+]
+
+ALL_KINDS: tuple[IdentifierKind, ...] = (
+    "pod",
+    "namespace",
+    "cluster",
+    "hostname",
+    "account_id",
+    "ip_address",
+    "email",
+    "service_name",
+)
+
+
+class MaskingPolicy(StrictConfigModel):
+    """Configuration that drives what gets masked before LLM calls."""
+
+    enabled: bool = False
+    kinds: tuple[IdentifierKind, ...] = ALL_KINDS
+    extra_patterns: dict[str, str] = Field(default_factory=dict)
+
+    _ENV_ENABLED: ClassVar[str] = "OPENSRE_MASK_ENABLED"
+    _ENV_KINDS: ClassVar[str] = "OPENSRE_MASK_KINDS"
+    _ENV_EXTRA_REGEX: ClassVar[str] = "OPENSRE_MASK_EXTRA_REGEX"
+
+    @field_validator("kinds", mode="before")
+    @classmethod
+    def _coerce_kinds(cls, value: object) -> tuple[IdentifierKind, ...]:
+        if value is None or value == "":
+            return ALL_KINDS
+        if isinstance(value, str):
+            parts = tuple(p.strip() for p in value.split(",") if p.strip())
+            return cls._filter_valid_kinds(parts)
+        if isinstance(value, list | tuple):
+            parts = tuple(str(p).strip() for p in value if str(p).strip())
+            return cls._filter_valid_kinds(parts)
+        raise ValueError(f"kinds must be a string or list, got {type(value).__name__}")
+
+    @classmethod
+    def _filter_valid_kinds(cls, parts: tuple[str, ...]) -> tuple[IdentifierKind, ...]:
+        valid: list[IdentifierKind] = []
+        for p in parts:
+            if p in ALL_KINDS:
+                valid.append(p)  # type: ignore[arg-type]
+            else:
+                logger.warning("[masking] ignoring unknown identifier kind: %r", p)
+        return tuple(valid) if valid else ALL_KINDS
+
+    @field_validator("extra_patterns")
+    @classmethod
+    def _validate_extra_patterns(cls, value: dict[str, str]) -> dict[str, str]:
+        for label, pattern in value.items():
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(
+                    f"extra_patterns[{label!r}] is not a valid regex: {exc}"
+                ) from exc
+        return value
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> MaskingPolicy:
+        """Build a policy from the current environment (or an injected dict)."""
+        source = env if env is not None else os.environ
+        enabled = _parse_bool(source.get(cls._ENV_ENABLED, ""))
+        kinds_raw = source.get(cls._ENV_KINDS, "") or ""
+        extra_raw = source.get(cls._ENV_EXTRA_REGEX, "") or ""
+
+        extra_patterns: dict[str, str] = {}
+        if extra_raw.strip():
+            try:
+                parsed = json.loads(extra_raw)
+                if isinstance(parsed, dict):
+                    extra_patterns = {str(k): str(v) for k, v in parsed.items()}
+                else:
+                    logger.warning(
+                        "[masking] %s must be a JSON object, got %s; ignoring",
+                        cls._ENV_EXTRA_REGEX,
+                        type(parsed).__name__,
+                    )
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "[masking] failed to parse %s as JSON: %s; ignoring",
+                    cls._ENV_EXTRA_REGEX,
+                    exc,
+                )
+
+        return cls.model_validate(
+            {
+                "enabled": enabled,
+                "kinds": kinds_raw,
+                "extra_patterns": extra_patterns,
+            }
+        )
+
+    def is_kind_enabled(self, kind: IdentifierKind) -> bool:
+        return self.enabled and kind in self.kinds
+
+
+def _parse_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _compile_extra_patterns(policy: MaskingPolicy) -> dict[str, re.Pattern[str]]:
+    """Compile extra regex patterns once, with the label as the key."""
+    compiled: dict[str, re.Pattern[str]] = {}
+    for label, pattern in policy.extra_patterns.items():
+        try:
+            compiled[label] = re.compile(pattern)
+        except re.error as exc:
+            logger.warning(
+                "[masking] skipping extra pattern %r (invalid regex): %s", label, exc
+            )
+    return compiled
+
+
+__all__ = [
+    "ALL_KINDS",
+    "IdentifierKind",
+    "MaskingPolicy",
+]

--- a/app/nodes/investigate/node.py
+++ b/app/nodes/investigate/node.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from langsmith import traceable
 
+from app.masking import MaskingContext
 from app.nodes.investigate.execution import execute_actions
 from app.nodes.investigate.models import InvestigateInput, InvestigateOutput
 from app.nodes.investigate.processing import (
@@ -89,11 +90,23 @@ def node_investigate(state: InvestigationState) -> dict:
             )
             available_sources["grafana"]["service_name"] = best
 
+    # Apply reversible masking to evidence before it flows to downstream LLM
+    # nodes. No-op when OPENSRE_MASK_ENABLED is not set.
+    masking_ctx = MaskingContext.from_state(cast(dict[str, object], state))
+    masked_evidence = masking_ctx.mask_value(evidence)
+    masking_map = masking_ctx.to_state()
+
     tracker.complete(
         "investigate",
         fields_updated=["evidence", "executed_hypotheses"],
         message=evidence_summary,
     )
 
-    output = InvestigateOutput(evidence=evidence, executed_hypotheses=executed_hypotheses)
-    return {**output.to_dict(), "available_sources": available_sources}
+    output = InvestigateOutput(evidence=masked_evidence, executed_hypotheses=executed_hypotheses)
+    result: dict[str, object] = {
+        **output.to_dict(),
+        "available_sources": available_sources,
+    }
+    if masking_map:
+        result["masking_map"] = masking_map
+    return result

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from langsmith import traceable
 
+from app.masking import MaskingContext
 from app.nodes.publish_findings.formatters.report import (
     build_slack_blocks,
     format_slack_message,
@@ -35,6 +36,13 @@ def generate_report(state: InvestigationState) -> dict:
     short_summary = state.get("problem_md")
     slack_message = format_slack_message(ctx)
 
+    # Restore any masked infrastructure identifiers in user-facing output.
+    # No-op when masking is disabled or the state has no placeholders.
+    masking_ctx = MaskingContext.from_state(dict(state))
+    slack_message = masking_ctx.unmask(slack_message)
+    if isinstance(short_summary, str):
+        short_summary = masking_ctx.unmask(short_summary)
+
     # First ingest: persist the report and get back the investigation_id
     investigation_id: str | None = None
     try:
@@ -54,6 +62,7 @@ def generate_report(state: InvestigationState) -> dict:
             logger.warning("[publish] ingest url update failed: %s", exc)
 
     all_blocks = build_slack_blocks(ctx) + build_action_blocks(investigation_url, investigation_id)
+    all_blocks = masking_ctx.unmask_value(all_blocks)
     render_report(slack_message, root_cause_category=state.get("root_cause_category"))
     open_in_editor(slack_message)
 

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -4,6 +4,7 @@ import os
 
 from langsmith import traceable
 
+from app.masking import MaskingContext
 from app.output import debug_print, get_tracker
 from app.services import get_llm_for_reasoning, parse_root_cause
 from app.state import InvestigationState
@@ -89,14 +90,19 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
         message=f"validity:{validity_score:.0%}",
     )
 
+    # Unmask any placeholders the LLM passed through so state carries real
+    # identifiers for user-facing display. No-op when masking is disabled.
+    masking_ctx = MaskingContext.from_state(dict(state))
     return {
-        "root_cause": result.root_cause,
+        "root_cause": masking_ctx.unmask(result.root_cause),
         "root_cause_category": result.root_cause_category,
-        "causal_chain": result.causal_chain,
-        "validated_claims": validated_claims_list,
-        "non_validated_claims": non_validated_claims_list,
+        "causal_chain": [masking_ctx.unmask(step) for step in result.causal_chain],
+        "validated_claims": masking_ctx.unmask_value(validated_claims_list),
+        "non_validated_claims": masking_ctx.unmask_value(non_validated_claims_list),
         "validity_score": validity_score,
-        "investigation_recommendations": recommendations,
+        "investigation_recommendations": [
+            masking_ctx.unmask(rec) for rec in recommendations
+        ],
         "remediation_steps": [],
         "investigation_loop_count": next_loop_count,
     }

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -81,6 +81,9 @@ class AgentState(TypedDict, total=False):
     executed_hypotheses: list[dict[str, Any]]
     investigation_started_at: float
 
+    # Placeholder→original map for reversible infrastructure identifier masking
+    masking_map: dict[str, str]
+
     # Slack context (when triggered from Slack message)
     slack_context: dict[str, Any]
 
@@ -147,6 +150,7 @@ class AgentStateModel(StrictConfigModel):
     hypotheses: list[str] = Field(default_factory=list)
     executed_hypotheses: list[dict[str, Any]] = Field(default_factory=list)
     investigation_started_at: float = 0.0
+    masking_map: dict[str, str] = Field(default_factory=dict)
     slack_context: dict[str, Any] = Field(default_factory=dict)
     discord_context: dict[str, Any] = Field(default_factory=dict)
     thread_id: str = ""

--- a/app/state/factory.py
+++ b/app/state/factory.py
@@ -35,6 +35,7 @@ STATE_DEFAULTS: dict[str, Any] = {
     "investigation_loop_count": 0,
     "hypotheses": [],
     "executed_hypotheses": [],
+    "masking_map": {},
     "slack_context": {},
     "discord_context": {},
     "thread_id": "",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,7 +80,8 @@
         "group": "Investigations",
         "pages": [
           "investigation-overview",
-          "remote-runtime-investigation"
+          "remote-runtime-investigation",
+          "masking"
         ]
       },
       {

--- a/docs/masking.mdx
+++ b/docs/masking.mdx
@@ -1,0 +1,62 @@
+---
+title: 'Masking Sensitive Identifiers'
+description: 'Reversible masking of pod, cluster, and account identifiers before external LLM calls'
+---
+
+## Overview
+
+OpenSRE can mask sensitive infrastructure identifiers (pod names, cluster names, hostnames, account IDs, service names, IP addresses, emails) **before** sending text to external LLMs, and restore the originals in any user-facing output (Slack report, problem MD, ingest). This lets teams use external models while keeping raw identifiers private to the investigation runtime.
+
+Masking is **off by default**. Enable it per investigation via environment variables — no code changes required.
+
+## How it works
+
+1. When masking is enabled, `node_investigate` replaces sensitive identifiers in the `evidence` dict with stable placeholders like `<POD_0>`, `<NAMESPACE_0>`, `<CLUSTER_1>`. The placeholder→original map is stored in the investigation state under `masking_map`.
+2. The diagnosis LLM receives masked evidence, so raw identifiers never hit the model.
+3. After the LLM returns its root-cause analysis, `diagnose_root_cause` unmasks the output so downstream state and display code see real identifiers.
+4. `publish_findings` runs a final unmask pass on the Slack message and blocks before delivery, as defence in depth.
+
+The same identifier always maps to the same placeholder within a single investigation, so the LLM's reasoning about `<POD_0>` remains coherent.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENSRE_MASK_ENABLED` | `false` | Master switch. Set to `true` / `1` / `yes` / `on` to activate masking. |
+| `OPENSRE_MASK_KINDS` | `pod,namespace,cluster,hostname,account_id,ip_address,email,service_name` | Comma-separated list of identifier kinds to mask. Unknown kinds are ignored with a warning. Empty value uses all defaults. |
+| `OPENSRE_MASK_EXTRA_REGEX` | *(empty)* | Optional JSON object mapping a label → regex for custom identifiers. Example: `'{"jira_key": "\\\\b[A-Z]+-\\\\d+\\\\b"}'`. Group 1 of the regex, if present, defines the span to mask. |
+
+Policies are read fresh from the environment at the start of each investigation — changes take effect on the next run without a restart.
+
+## Built-in identifier kinds
+
+| Kind | Example input | Example placeholder |
+| --- | --- | --- |
+| `pod` | `etl-worker-7d9f8b-xkp2q` | `<POD_0>` |
+| `namespace` | `kube_namespace:tracer-test` | `kube_namespace:<NAMESPACE_0>` |
+| `cluster` | `eks_cluster:prod-us-east-1` | `eks_cluster:<CLUSTER_0>` |
+| `service_name` | `service:checkout-api` | `service:<SERVICE_NAME_0>` |
+| `hostname` | `kind-control-plane`, `ip-10-0-1-23.ec2.internal` | `<HOSTNAME_0>` |
+| `account_id` | `123456789012` | `<ACCOUNT_ID_0>` |
+| `ip_address` | `192.168.1.50` | `<IP_ADDRESS_0>` |
+| `email` | `alice@example.com` | `<EMAIL_0>` |
+
+## Round-trip guarantee
+
+For the built-in detectors and extra regex patterns, `mask → unmask` round-trips the original payload byte-for-byte. See `tests/masking/test_integration_with_k8s_fixture.py` for a worked example against a realistic Datadog k8s alert.
+
+## Relationship to guardrails
+
+The masking layer is complementary to the one-way `GuardrailEngine`. Guardrails handle hard-block rules (credit cards, API keys) and replace matches with `[REDACTED]` irreversibly. Masking handles infrastructure identifiers reversibly so they can be restored for user-facing output.
+
+Both can be active together: guardrails apply first at the LLM client layer, then masking at the node layer.
+
+## Example
+
+```bash
+export OPENSRE_MASK_ENABLED=true
+export OPENSRE_MASK_KINDS=pod,namespace,cluster,hostname
+opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
+```
+
+During the investigation the LLM sees masked evidence; the final Slack report shows the original pod, namespace, and cluster names.

--- a/tests/masking/test_context.py
+++ b/tests/masking/test_context.py
@@ -113,3 +113,45 @@ def test_empty_string_masked_to_empty_string() -> None:
     ctx = _enabled_ctx()
     assert ctx.mask("") == ""
     assert ctx.unmask("") == ""
+
+
+def test_counters_stable_when_map_iterated_out_of_order() -> None:
+    """Regression: a placeholder map with <NS_2> before <NS_0> must not
+    inflate the counter (previously yielded 4 instead of 3)."""
+    policy = MaskingPolicy.model_validate({"enabled": True, "kinds": ALL_KINDS})
+    # Intentionally insert in non-ascending index order
+    seeded = {
+        "<NAMESPACE_2>": "gamma",
+        "<NAMESPACE_0>": "alpha",
+        "<NAMESPACE_1>": "beta",
+    }
+    ctx = MaskingContext(policy=policy, placeholder_map=seeded)
+    # Allocate a fresh namespace; its index must be exactly 3 (one past the max).
+    masked = ctx.mask("kube_namespace:delta fresh")
+    fresh_placeholder = next(
+        p for p, v in ctx.placeholder_map.items() if v == "delta"
+    )
+    assert fresh_placeholder == "<NAMESPACE_3>"
+    assert "<NAMESPACE_3>" in masked
+
+
+def test_partial_overlap_matches_do_not_corrupt_text() -> None:
+    """Regression: if a custom extra regex overlaps partially with a built-in
+    detector, both matches must not survive or _apply_replacements splices
+    overlapping spans and produces corrupted output."""
+    # Custom pattern that partially overlaps with the IP detector region.
+    policy = MaskingPolicy.model_validate(
+        {
+            "enabled": True,
+            "kinds": ("ip_address",),
+            # Matches "192.168.1." inside "192.168.1.50" — partial overlap with
+            # the IP detector's full 192.168.1.50 span.
+            "extra_patterns": {"partial": r"(192\.168\.1\.)"},
+        }
+    )
+    ctx = MaskingContext(policy=policy)
+    masked = ctx.mask("host 192.168.1.50 online")
+    # Exactly one placeholder used; the other overlap was dropped.
+    assert masked.count("<") == 1
+    # Round trip returns the original text byte-for-byte.
+    assert ctx.unmask(masked) == "host 192.168.1.50 online"

--- a/tests/masking/test_context.py
+++ b/tests/masking/test_context.py
@@ -1,0 +1,115 @@
+"""Tests for MaskingContext — mask/unmask round-trip, stability, structured payloads."""
+
+from __future__ import annotations
+
+from app.masking.context import MaskingContext
+from app.masking.policy import ALL_KINDS, MaskingPolicy
+
+
+def _enabled_ctx() -> MaskingContext:
+    policy = MaskingPolicy.model_validate({"enabled": True, "kinds": ALL_KINDS})
+    return MaskingContext(policy=policy)
+
+
+def _disabled_ctx() -> MaskingContext:
+    policy = MaskingPolicy.model_validate({"enabled": False, "kinds": ALL_KINDS})
+    return MaskingContext(policy=policy)
+
+
+def test_disabled_policy_is_identity() -> None:
+    ctx = _disabled_ctx()
+    text = "pod etl-worker-7d9f8b-xkp2q failing in kube_namespace:tracer-test"
+    assert ctx.mask(text) == text
+    assert ctx.placeholder_map == {}
+
+
+def test_repeated_identifier_maps_to_same_placeholder() -> None:
+    ctx = _enabled_ctx()
+    text_a = ctx.mask("kube_namespace:payments-prod saw error")
+    text_b = ctx.mask("second alert also in kube_namespace:payments-prod")
+    # Same real value should reuse the same placeholder.
+    ns_placeholder = next(
+        ph for ph, original in ctx.placeholder_map.items() if original == "payments-prod"
+    )
+    assert ns_placeholder in text_a
+    assert ns_placeholder in text_b
+    assert sum(1 for _ in ctx.placeholder_map.values() if _ == "payments-prod") == 1
+
+
+def test_round_trip_restores_originals() -> None:
+    ctx = _enabled_ctx()
+    original = (
+        "pod etl-worker-7d9f8b-xkp2q in kube_namespace:tracer-test from "
+        "host kind-control-plane account 123456789012 email alice@example.com"
+    )
+    masked = ctx.mask(original)
+    assert masked != original
+    assert ctx.unmask(masked) == original
+
+
+def test_structured_payload_recursive_mask_and_unmask() -> None:
+    ctx = _enabled_ctx()
+    payload = {
+        "alert_name": "PodCrashLoop",
+        "tags": ["kube_namespace:prod", "pod:worker-7d9f8b-abcde"],
+        "nested": {
+            "host": "kind-control-plane",
+            "ip": "192.168.1.50",
+        },
+    }
+    masked = ctx.mask_value(payload)
+    assert masked["alert_name"] == "PodCrashLoop"
+    # kube_namespace now contains a placeholder, not "prod"
+    assert all("prod" not in tag for tag in masked["tags"] if "kube_namespace" in tag)
+    assert "kind-control-plane" not in str(masked["nested"])
+    assert "192.168.1.50" not in str(masked["nested"])
+
+    restored = ctx.unmask_value(masked)
+    assert restored == payload
+
+
+def test_placeholder_format_is_stable() -> None:
+    ctx = _enabled_ctx()
+    ctx.mask("kube_namespace:alpha")
+    ctx.mask("kube_namespace:bravo")
+    placeholders = list(ctx.placeholder_map.keys())
+    assert any(p.startswith("<NAMESPACE_") for p in placeholders)
+    # Unique placeholders for distinct originals
+    assert len(placeholders) == len(set(placeholders))
+
+
+def test_placeholder_collisions_are_prevented() -> None:
+    ctx = _enabled_ctx()
+    ctx.mask("host kind-control-plane")
+    ctx.mask("kube_namespace:kind-control-plane")  # different kind, same value
+    # Even though the same string "kind-control-plane" appears in two contexts,
+    # the reverse_map prevents allocating a new placeholder.
+    values = list(ctx.placeholder_map.values())
+    assert values.count("kind-control-plane") == 1
+
+
+def test_from_state_reconstructs_context() -> None:
+    ctx = _enabled_ctx()
+    masked = ctx.mask("kube_namespace:prod incident")
+    # Simulate state carrying the map between nodes
+    state = {"masking_map": ctx.to_state()}
+    reconstructed = MaskingContext.from_state(state)
+    assert reconstructed.unmask(masked) == "kube_namespace:prod incident"
+
+
+def test_unmask_empty_map_is_identity() -> None:
+    ctx = _enabled_ctx()
+    assert ctx.unmask("nothing here") == "nothing here"
+
+
+def test_non_string_values_pass_through() -> None:
+    ctx = _enabled_ctx()
+    assert ctx.mask_value(42) == 42
+    assert ctx.mask_value(None) is None
+    assert ctx.mask_value(True) is True
+
+
+def test_empty_string_masked_to_empty_string() -> None:
+    ctx = _enabled_ctx()
+    assert ctx.mask("") == ""
+    assert ctx.unmask("") == ""

--- a/tests/masking/test_detectors.py
+++ b/tests/masking/test_detectors.py
@@ -114,6 +114,23 @@ def test_overlapping_matches_resolved_longest_wins() -> None:
     assert len(hostnames) == 1
 
 
+def test_hostname_regex_handles_adversarial_input_quickly() -> None:
+    """Regression test for ReDoS flagged by CodeQL on the hostname regex.
+
+    A string with many alternating '-' and '.' characters should not cause
+    exponential backtracking. We cap the runtime at 1 second; with the
+    previous vulnerable pattern this would hang well beyond that.
+    """
+    import time
+
+    adversarial = "ip-10-0-1-23" + ("-." * 50) + "X"
+    start = time.perf_counter()
+    # Trigger all detectors — the hostname detector was the vulnerable one.
+    find_identifiers(adversarial, _policy())
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"hostname regex took {elapsed:.2f}s on adversarial input"
+
+
 def test_extra_regex_pattern_is_applied() -> None:
     policy = MaskingPolicy.model_validate(
         {

--- a/tests/masking/test_detectors.py
+++ b/tests/masking/test_detectors.py
@@ -1,0 +1,127 @@
+"""Tests for identifier detectors — coverage and false-positive bounds."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.masking.detectors import find_identifiers
+from app.masking.policy import ALL_KINDS, MaskingPolicy
+
+
+def _policy(kinds: tuple[str, ...] = ALL_KINDS) -> MaskingPolicy:
+    return MaskingPolicy.model_validate({"enabled": True, "kinds": kinds})
+
+
+def test_no_matches_when_disabled() -> None:
+    disabled = MaskingPolicy.model_validate({"enabled": False, "kinds": ALL_KINDS})
+    assert find_identifiers("pod etl-worker-7d9f8b-xkp2q is crashing", disabled) == []
+
+
+def test_pod_name_detected() -> None:
+    matches = find_identifiers("pod etl-worker-7d9f8b-xkp2q is crashing", _policy())
+    kinds = {m.kind for m in matches}
+    assert "pod" in kinds
+    pod_match = next(m for m in matches if m.kind == "pod")
+    assert pod_match.value == "etl-worker-7d9f8b-xkp2q"
+
+
+def test_namespace_detected_with_colon_syntax() -> None:
+    matches = find_identifiers("kube_namespace:tracer-test failing", _policy())
+    ns_match = next(m for m in matches if m.kind == "namespace")
+    assert ns_match.value == "tracer-test"
+
+
+def test_namespace_detected_with_equals_syntax() -> None:
+    matches = find_identifiers("ns=payments-prod error", _policy())
+    ns_match = next(m for m in matches if m.kind == "namespace")
+    assert ns_match.value == "payments-prod"
+
+
+def test_cluster_detected() -> None:
+    matches = find_identifiers("eks_cluster:prod-us-east-1 has issues", _policy())
+    cluster_match = next(m for m in matches if m.kind == "cluster")
+    assert cluster_match.value == "prod-us-east-1"
+
+
+def test_service_name_detected() -> None:
+    matches = find_identifiers("service:checkout-api response timeout", _policy())
+    svc_match = next(m for m in matches if m.kind == "service_name")
+    assert svc_match.value == "checkout-api"
+
+
+def test_hostname_kind_kind_control_plane() -> None:
+    matches = find_identifiers("host kind-control-plane is down", _policy())
+    host = next(m for m in matches if m.kind == "hostname")
+    assert host.value == "kind-control-plane"
+
+
+def test_hostname_ec2_internal_style() -> None:
+    matches = find_identifiers("from ip-10-0-1-23.ec2.internal", _policy())
+    host = next(m for m in matches if m.kind == "hostname")
+    assert host.value.startswith("ip-10-0-1-23")
+
+
+def test_account_id_detected() -> None:
+    matches = find_identifiers("aws account 123456789012 alert", _policy())
+    account_match = next(m for m in matches if m.kind == "account_id")
+    assert account_match.value == "123456789012"
+
+
+def test_ip_address_detected() -> None:
+    matches = find_identifiers("connected from 192.168.1.100", _policy())
+    ip_match = next(m for m in matches if m.kind == "ip_address")
+    assert ip_match.value == "192.168.1.100"
+
+
+def test_email_detected() -> None:
+    matches = find_identifiers("alert triggered by alice@example.com", _policy())
+    email_match = next(m for m in matches if m.kind == "email")
+    assert email_match.value == "alice@example.com"
+
+
+@pytest.mark.parametrize(
+    "benign",
+    [
+        "happy birthday alice",
+        "the quick brown fox jumps",
+        "logs from 2026-04-17 show errors",
+        "count was 1234 today",
+        "version 3.9.18 released",
+    ],
+)
+def test_benign_text_is_not_masked(benign: str) -> None:
+    matches = find_identifiers(benign, _policy())
+    assert matches == [], f"unexpected match on benign text: {benign!r} -> {matches}"
+
+
+def test_only_selected_kinds_run() -> None:
+    matches = find_identifiers(
+        "kube_namespace:prod host kind-control-plane",
+        _policy(kinds=("namespace",)),
+    )
+    kinds = {m.kind for m in matches}
+    assert kinds == {"namespace"}
+
+
+def test_overlapping_matches_resolved_longest_wins() -> None:
+    # "ip-10-0-1-23.ec2.internal" should match as a single hostname even though
+    # "10.0.1.23" would match the IP regex inside the larger string. The
+    # hostname regex doesn't produce that, but the resolver should still
+    # correctly return a single hostname span without an embedded IP match.
+    text = "from host ip-10-0-1-23.ec2.internal node"
+    matches = find_identifiers(text, _policy())
+    hostnames = [m for m in matches if m.kind == "hostname"]
+    assert len(hostnames) == 1
+
+
+def test_extra_regex_pattern_is_applied() -> None:
+    policy = MaskingPolicy.model_validate(
+        {
+            "enabled": True,
+            "kinds": ("email",),
+            "extra_patterns": {"jira_key": r"\b([A-Z]+-\d+)\b"},
+        }
+    )
+    matches = find_identifiers("ticket OPS-1234 assigned", policy)
+    jira = next(m for m in matches if m.kind == "jira_key")
+    assert jira.value == "OPS-1234"

--- a/tests/masking/test_integration_with_k8s_fixture.py
+++ b/tests/masking/test_integration_with_k8s_fixture.py
@@ -1,0 +1,91 @@
+"""Integration test: mask a realistic k8s alert payload and round-trip it.
+
+Uses the repo's existing Datadog k8s alert fixture — no live k8s required.
+Verifies that pod/namespace/cluster/host identifiers are all replaced by
+placeholders, and that unmasking reproduces the original payload.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.masking.context import MaskingContext
+from app.masking.policy import ALL_KINDS, MaskingPolicy
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "e2e"
+    / "kubernetes"
+    / "fixtures"
+    / "datadog_k8s_alert.json"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _enabled_ctx() -> MaskingContext:
+    return MaskingContext(
+        policy=MaskingPolicy.model_validate({"enabled": True, "kinds": ALL_KINDS})
+    )
+
+
+def test_fixture_file_exists() -> None:
+    assert FIXTURE.exists(), f"expected fixture at {FIXTURE}"
+
+
+def test_round_trip_reproduces_fixture_exactly() -> None:
+    original = _load_fixture()
+    ctx = _enabled_ctx()
+    masked = ctx.mask_value(original)
+    restored = ctx.unmask_value(masked)
+    assert restored == original
+
+
+def test_namespace_value_is_masked() -> None:
+    original = _load_fixture()
+    ctx = _enabled_ctx()
+    masked = ctx.mask_value(original)
+    masked_text = json.dumps(masked)
+    # 'tracer-test' is the namespace value mentioned in the fixture's
+    # annotation summary ("namespace tracer-test"); after masking, the raw
+    # value should not appear on its own in contexts that the namespace
+    # detector recognises.
+    assert (
+        any("tracer-test" in original_value for original_value in ctx.placeholder_map.values())
+        or "tracer-test" not in masked_text
+    )
+
+
+def test_masking_produces_at_least_one_placeholder() -> None:
+    ctx = _enabled_ctx()
+    ctx.mask_value(_load_fixture())
+    assert ctx.placeholder_map, "expected at least one placeholder from a realistic k8s alert"
+
+
+def test_disabled_policy_leaves_fixture_unchanged() -> None:
+    original = _load_fixture()
+    disabled = MaskingContext(
+        policy=MaskingPolicy.model_validate({"enabled": False, "kinds": ALL_KINDS})
+    )
+    assert disabled.mask_value(original) == original
+    assert disabled.placeholder_map == {}
+
+
+def test_extra_regex_policy_activates_new_kind_without_code_change() -> None:
+    """Acceptance criterion #2: configuration without editing code."""
+    ctx = MaskingContext(
+        policy=MaskingPolicy.from_env(
+            {
+                "OPENSRE_MASK_ENABLED": "true",
+                "OPENSRE_MASK_KINDS": "",  # use defaults
+                "OPENSRE_MASK_EXTRA_REGEX": '{"run_name": "([a-z]+-[a-z]+-[a-z]+)"}',
+            }
+        )
+    )
+    masked = ctx.mask("run_name=etl-transform-error completed")
+    # Custom pattern matched and produced a placeholder
+    assert any(p.startswith("<RUN_NAME_") for p in ctx.placeholder_map)
+    assert ctx.unmask(masked) == "run_name=etl-transform-error completed"

--- a/tests/masking/test_policy.py
+++ b/tests/masking/test_policy.py
@@ -1,0 +1,95 @@
+"""Tests for MaskingPolicy — validation and env-var loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.masking.policy import ALL_KINDS, MaskingPolicy
+
+
+def test_default_policy_is_disabled() -> None:
+    policy = MaskingPolicy()
+    assert policy.enabled is False
+    assert policy.kinds == ALL_KINDS
+    assert policy.extra_patterns == {}
+
+
+def test_from_env_enabled_true() -> None:
+    policy = MaskingPolicy.from_env({"OPENSRE_MASK_ENABLED": "true"})
+    assert policy.enabled is True
+    assert policy.kinds == ALL_KINDS
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("", False),
+        ("garbage", False),
+    ],
+)
+def test_from_env_bool_parsing(raw: str, expected: bool) -> None:
+    policy = MaskingPolicy.from_env({"OPENSRE_MASK_ENABLED": raw})
+    assert policy.enabled is expected
+
+
+def test_from_env_kinds_subset() -> None:
+    policy = MaskingPolicy.from_env(
+        {"OPENSRE_MASK_ENABLED": "true", "OPENSRE_MASK_KINDS": "pod,namespace"}
+    )
+    assert policy.kinds == ("pod", "namespace")
+
+
+def test_from_env_kinds_unknown_kind_is_ignored() -> None:
+    policy = MaskingPolicy.from_env(
+        {"OPENSRE_MASK_ENABLED": "true", "OPENSRE_MASK_KINDS": "pod,not_a_real_kind,email"}
+    )
+    assert policy.kinds == ("pod", "email")
+
+
+def test_from_env_kinds_all_invalid_falls_back_to_defaults() -> None:
+    policy = MaskingPolicy.from_env(
+        {"OPENSRE_MASK_ENABLED": "true", "OPENSRE_MASK_KINDS": "nope,also_nope"}
+    )
+    assert policy.kinds == ALL_KINDS
+
+
+def test_from_env_extra_regex_parsed() -> None:
+    policy = MaskingPolicy.from_env(
+        {
+            "OPENSRE_MASK_ENABLED": "true",
+            "OPENSRE_MASK_EXTRA_REGEX": '{"jira_key": "\\\\b[A-Z]+-\\\\d+\\\\b"}',
+        }
+    )
+    assert "jira_key" in policy.extra_patterns
+
+
+def test_from_env_invalid_json_extra_regex_ignored() -> None:
+    policy = MaskingPolicy.from_env(
+        {"OPENSRE_MASK_ENABLED": "true", "OPENSRE_MASK_EXTRA_REGEX": "not valid json"}
+    )
+    assert policy.extra_patterns == {}
+
+
+def test_invalid_regex_in_extra_patterns_raises() -> None:
+    with pytest.raises(ValueError, match="not a valid regex"):
+        MaskingPolicy.model_validate(
+            {"enabled": True, "kinds": ALL_KINDS, "extra_patterns": {"bad": "["}}
+        )
+
+
+def test_is_kind_enabled_respects_enabled_flag() -> None:
+    policy = MaskingPolicy.model_validate({"enabled": False, "kinds": ("pod",)})
+    assert policy.is_kind_enabled("pod") is False
+
+
+def test_is_kind_enabled_filters_by_selected_kinds() -> None:
+    policy = MaskingPolicy.model_validate({"enabled": True, "kinds": ("pod", "namespace")})
+    assert policy.is_kind_enabled("pod") is True
+    assert policy.is_kind_enabled("email") is False

--- a/tests/nodes/publish_findings/test_masking_unmask.py
+++ b/tests/nodes/publish_findings/test_masking_unmask.py
@@ -1,0 +1,84 @@
+"""Test: generate_report unmasks slack_message before delivery."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_masking(monkeypatch) -> None:
+    monkeypatch.setenv("OPENSRE_MASK_ENABLED", "true")
+
+
+def _state_with_masking() -> dict[str, object]:
+    return {
+        "alert_name": "pipeline failure",
+        "pipeline_name": "pipeline",
+        "severity": "warning",
+        "problem_md": "# Incident in <NAMESPACE_0>",
+        "slack_message": "",
+        "report": "",
+        "masking_map": {
+            "<POD_0>": "etl-worker-7d9f8b-xkp2q",
+            "<NAMESPACE_0>": "tracer-test",
+        },
+        "root_cause": "etl-worker-7d9f8b-xkp2q OOMKilled in tracer-test",
+        "evidence": {},
+        "context": {},
+        "resolved_integrations": {},
+        "slack_context": {},
+        "discord_context": {},
+        "validated_claims": [],
+        "non_validated_claims": [],
+    }
+
+
+def test_slack_message_is_unmasked_before_delivery() -> None:
+    from app.nodes.publish_findings import node as pub_node
+
+    masked_message = (
+        "Root cause: <POD_0> crashed in <NAMESPACE_0>. Impact: customer-facing."
+    )
+
+    with (
+        patch.object(pub_node, "build_report_context", return_value=MagicMock()),
+        patch.object(pub_node, "format_slack_message", return_value=masked_message),
+        patch.object(pub_node, "build_slack_blocks", return_value=[]),
+        patch.object(pub_node, "render_report"),
+        patch.object(pub_node, "open_in_editor"),
+        patch.object(pub_node, "send_ingest", return_value=None),
+        patch("app.utils.slack_delivery.send_slack_report", return_value=(False, None)),
+        patch("app.utils.slack_delivery.build_action_blocks", return_value=[]),
+    ):
+        result = pub_node.generate_report(_state_with_masking())  # type: ignore[arg-type]
+
+    assert "<POD_0>" not in result["slack_message"]
+    assert "<NAMESPACE_0>" not in result["slack_message"]
+    assert "etl-worker-7d9f8b-xkp2q" in result["slack_message"]
+    assert "tracer-test" in result["slack_message"]
+
+
+def test_empty_masking_map_is_passthrough() -> None:
+    from app.nodes.publish_findings import node as pub_node
+
+    state = _state_with_masking()
+    state["masking_map"] = {}
+    message_without_placeholders = "Plain report with no placeholders."
+
+    with (
+        patch.object(pub_node, "build_report_context", return_value=MagicMock()),
+        patch.object(
+            pub_node, "format_slack_message", return_value=message_without_placeholders
+        ),
+        patch.object(pub_node, "build_slack_blocks", return_value=[]),
+        patch.object(pub_node, "render_report"),
+        patch.object(pub_node, "open_in_editor"),
+        patch.object(pub_node, "send_ingest", return_value=None),
+        patch("app.utils.slack_delivery.send_slack_report", return_value=(False, None)),
+        patch("app.utils.slack_delivery.build_action_blocks", return_value=[]),
+    ):
+        result = pub_node.generate_report(state)  # type: ignore[arg-type]
+
+    assert result["slack_message"] == message_without_placeholders

--- a/tests/nodes/root_cause_diagnosis/test_masking_integration.py
+++ b/tests/nodes/root_cause_diagnosis/test_masking_integration.py
@@ -1,0 +1,133 @@
+"""Integration test: diagnose_root_cause unmasks LLM output.
+
+With a seeded ``masking_map`` in state and masking enabled, verifies that
+the fields returned by ``diagnose_root_cause`` contain the original
+identifiers (unmasked) so user-facing display and downstream nodes work
+with real values.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_masking(monkeypatch) -> None:
+    """Ensure masking is active for these tests regardless of host env."""
+    monkeypatch.setenv("OPENSRE_MASK_ENABLED", "true")
+
+
+def _state_with_masking(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "alert_name": "etl failure",
+        "pipeline_name": "pipeline",
+        "severity": "warning",
+        "raw_alert": {"alert_name": "etl failure"},
+        "evidence": {"error_logs": ["<POD_0> failing"]},
+        "context": {"some": "context"},
+        "investigation_loop_count": 0,
+        "masking_map": {
+            "<POD_0>": "etl-worker-7d9f8b-xkp2q",
+            "<NAMESPACE_0>": "tracer-test",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_llm_response(text: str) -> object:
+    response = MagicMock()
+    response.content = text
+    return response
+
+
+def _mock_parse_result(root_cause: str) -> object:
+    result = MagicMock()
+    result.root_cause = root_cause
+    result.root_cause_category = "deployment"
+    result.causal_chain = [f"step referencing {root_cause}"]
+    result.validated_claims = [
+        {"claim": "<POD_0> entered CrashLoopBackOff", "validation_status": "validated"}
+    ]
+    result.non_validated_claims = []
+    return result
+
+
+def test_diagnose_unmasks_root_cause_and_claims() -> None:
+    from app.nodes.root_cause_diagnosis import node as diag_node
+
+    state = _state_with_masking()
+    llm_response = _mock_llm_response(
+        "ROOT_CAUSE: <POD_0> in <NAMESPACE_0> OOMKilled"
+    )
+    parsed = _mock_parse_result("<POD_0> in <NAMESPACE_0> OOMKilled")
+
+    with (
+        patch.object(diag_node, "get_llm_for_reasoning") as mock_llm_factory,
+        patch.object(diag_node, "parse_root_cause", return_value=parsed),
+        patch.object(diag_node, "is_clearly_healthy", return_value=False),
+        patch.object(
+            diag_node,
+            "check_evidence_availability",
+            return_value=(False, False, True),
+        ),
+        patch.object(diag_node, "validate_and_categorize_claims", return_value=([
+            {"claim": "<POD_0> entered CrashLoopBackOff", "validation_status": "validated"}
+        ], [])),
+        patch.object(diag_node, "calculate_validity_score", return_value=0.9),
+        patch.object(diag_node, "check_vendor_evidence_missing", return_value=False),
+        patch.object(diag_node, "build_diagnosis_prompt", return_value="masked prompt"),
+    ):
+        # Build a chained mock: with_config(...).invoke(prompt) -> response
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = llm_response
+        mock_llm = MagicMock()
+        mock_llm.with_config.return_value = mock_chain
+        mock_llm_factory.return_value = mock_llm
+
+        result = diag_node.diagnose_root_cause(state)  # type: ignore[arg-type]
+
+    # Root cause is now unmasked — contains the real pod + namespace
+    assert "etl-worker-7d9f8b-xkp2q" in result["root_cause"]
+    assert "tracer-test" in result["root_cause"]
+    assert "<POD_0>" not in result["root_cause"]
+    assert "<NAMESPACE_0>" not in result["root_cause"]
+
+    # Validated claims also unmasked
+    validated = result["validated_claims"]
+    assert isinstance(validated, list)
+    assert "etl-worker-7d9f8b-xkp2q" in validated[0]["claim"]
+
+
+def test_diagnose_with_empty_masking_map_is_passthrough() -> None:
+    from app.nodes.root_cause_diagnosis import node as diag_node
+
+    state = _state_with_masking(masking_map={})
+    llm_response = _mock_llm_response("ROOT_CAUSE: nothing to unmask")
+    parsed = _mock_parse_result("plain root cause text")
+
+    with (
+        patch.object(diag_node, "get_llm_for_reasoning") as mock_llm_factory,
+        patch.object(diag_node, "parse_root_cause", return_value=parsed),
+        patch.object(diag_node, "is_clearly_healthy", return_value=False),
+        patch.object(
+            diag_node,
+            "check_evidence_availability",
+            return_value=(False, False, True),
+        ),
+        patch.object(diag_node, "validate_and_categorize_claims", return_value=([], [])),
+        patch.object(diag_node, "calculate_validity_score", return_value=1.0),
+        patch.object(diag_node, "check_vendor_evidence_missing", return_value=False),
+        patch.object(diag_node, "build_diagnosis_prompt", return_value="prompt"),
+    ):
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = llm_response
+        mock_llm = MagicMock()
+        mock_llm.with_config.return_value = mock_chain
+        mock_llm_factory.return_value = mock_llm
+
+        result = diag_node.diagnose_root_cause(state)  # type: ignore[arg-type]
+
+    assert result["root_cause"] == "plain root cause text"


### PR DESCRIPTION
Adds a reversible masking layer that swaps pod/cluster/host/account/IP/
email identifiers with stable placeholders before sending prompts to the
LLM, and restores the originals in the final Slack report.

Configurable via OPENSRE_MASK_ENABLED and OPENSRE_MASK_KINDS env vars.
Off by default - no behavior change for existing users.


Closes #478