### PR TITLE
Fix: remove invalid --service flag from integrations verify docs

### DIFF
--- a/docs/aws.mdx
+++ b/docs/aws.mdx
@@ -89,7 +89,7 @@ For least-privilege, the minimum services used are:
 ## Verify
 
 ```bash
-opensre integrations verify --service aws
+opensre integrations verify aws
 ```
 
 Expected output:

--- a/docs/bitbucket.mdx
+++ b/docs/bitbucket.mdx
@@ -81,7 +81,7 @@ All operations are read-only.
 ## Verify
 
 ```bash
-opensre integrations verify --service bitbucket
+opensre integrations verify bitbucket
 ```
 
 Expected output:

--- a/docs/clickhouse.mdx
+++ b/docs/clickhouse.mdx
@@ -87,7 +87,7 @@ All operations are read-only.
 ## Verify
 
 ```bash
-opensre integrations verify --service clickhouse
+opensre integrations verify clickhouse
 ```
 
 Expected output:

--- a/docs/coralogix.mdx
+++ b/docs/coralogix.mdx
@@ -79,7 +79,7 @@ CORALOGIX_SUBSYSTEM_NAME=my-service           # optional filter
 ## Verify
 
 ```bash
-opensre integrations verify --service coralogix
+opensre integrations verify coralogix
 ```
 
 Expected output:

--- a/docs/github.mdx
+++ b/docs/github.mdx
@@ -81,7 +81,7 @@ For GitHub Enterprise Server, set `GITHUB_MCP_URL` to your enterprise MCP endpoi
 ## Verify
 
 ```bash
-opensre integrations verify --service github
+opensre integrations verify github
 ```
 
 Expected output:

--- a/docs/google-docs.mdx
+++ b/docs/google-docs.mdx
@@ -77,7 +77,7 @@ The folder ID appears in the Drive URL:
 ## Verify
 
 ```bash
-opensre integrations verify --service google_docs
+opensre integrations verify google_docs
 ```
 
 Expected output:

--- a/docs/honeycomb.mdx
+++ b/docs/honeycomb.mdx
@@ -70,7 +70,7 @@ Use `__all__` as the dataset to query across all datasets in an environment. For
 ## Verify
 
 ```bash
-opensre integrations verify --service honeycomb
+opensre integrations verify honeycomb
 ```
 
 Expected output:

--- a/docs/intergrations-overview.mdx
+++ b/docs/intergrations-overview.mdx
@@ -70,5 +70,5 @@ opensre integrations verify
 To check a specific integration:
 
 ```bash
-opensre integrations verify --service mongodb
+opensre integrations verify mongodb
 ```

--- a/docs/kafka.mdx
+++ b/docs/kafka.mdx
@@ -94,7 +94,7 @@ All operations are read-only.
 ## Verify
 
 ```bash
-opensre integrations verify --service kafka
+opensre integrations verify kafka
 ```
 
 Expected output:

--- a/docs/mongodb.mdx
+++ b/docs/mongodb.mdx
@@ -122,7 +122,7 @@ Returns document count, storage size, index count, and average object size for a
 ## Verify
 
 ```bash
-opensre integrations verify --service mongodb
+opensre integrations verify mongodb
 ```
 
 Expected output:

--- a/docs/mysql.mdx
+++ b/docs/mysql.mdx
@@ -120,7 +120,7 @@ Returns row count estimates, data size, and index size for all base tables in th
 ## Verify
 
 ```bash
-opensre integrations verify --service mysql
+opensre integrations verify mysql
 ```
 
 Expected output:

--- a/docs/opsgenie.mdx
+++ b/docs/opsgenie.mdx
@@ -67,7 +67,7 @@ EU accounts use a different endpoint. Set `OPSGENIE_REGION=eu` if your OpsGenie 
 ## Verify
 
 ```bash
-opensre integrations verify --service opsgenie
+opensre integrations verify opsgenie
 ```
 
 Expected output:

--- a/docs/postgresql.mdx
+++ b/docs/postgresql.mdx
@@ -134,7 +134,7 @@ Reads `pg_stat_user_tables` and `pg_class` for a given schema (default `public`)
 ## Verify
 
 ```bash
-opensre integrations verify --service postgresql
+opensre integrations verify postgresql
 ```
 
 Expected output:

--- a/docs/sentry.mdx
+++ b/docs/sentry.mdx
@@ -79,7 +79,7 @@ The organization slug appears in your Sentry URL: `https://sentry.io/organizatio
 ## Verify
 
 ```bash
-opensre integrations verify --service sentry
+opensre integrations verify sentry
 ```
 
 Expected output:

--- a/docs/vercel.mdx
+++ b/docs/vercel.mdx
@@ -67,7 +67,7 @@ For team accounts, find your Team ID in **Team Settings** → **General** → **
 ## Verify
 
 ```bash
-opensre integrations verify --service vercel
+opensre integrations verify vercel
 ```
 
 Expected output:


### PR DESCRIPTION
## What problem are you trying to solve?

15 integration docs incorrectly show `opensre integrations verify --service <name>` which errors with `No such option: --service`.

Correct syntax is: `opensre integrations verify <name>`

## What does this PR change?

Remove the `--service` flag from all 15 affected integration docs:
aws.mdx, bitbucket.mdx, clickhouse.mdx, coralogix.mdx, github.mdx, google-docs.mdx, honeycomb.mdx, intergrations-overview.mdx, kafka.mdx, mongodb.mdx, mysql.mdx, opsgenie.mdx, postgresql.mdx, sentry.mdx, vercel.mdx

Closes #635