### PR TITLE
Fix MaskingContext.unmask() prefix collision

### DIFF
--- a/app/masking/context.py
+++ b/app/masking/context.py
@@ -104,11 +104,14 @@ class MaskingContext:
         return result
 
     def unmask(self, text: str) -> str:
-        """Restore any known placeholders in ``text`` to their original values."""
+        """"Restore any known placeholders in ``text`` to their original values."""
         if not text or not self._placeholder_map:
             return text
         result = text
-        for placeholder, original in self._placeholder_map.items():
+        # Sort longest-first to avoid prefix collisions (e.g. <NS_10> before <NS_1>)
+        for placeholder, original in sorted(
+            self._placeholder_map.items(), key=lambda x: len(x[0]), reverse=True
+        ):
             if placeholder in result:
                 result = result.replace(placeholder, original)
         return result


### PR DESCRIPTION
## Summary
Fixes a bug in `MaskingContext.unmask()` where placeholders sharing a name prefix (e.g. `<NS_1>` and `<NS_10>`) could cause corrupted output when the shorter placeholder was replaced first, partially matching the longer one.

## Fix
Sort placeholders longest-first before performing replacements, so `<NS_10>` is replaced before `<NS_1>`, eliminating prefix collisions.

## Testing
```python
from app.masking.context import MaskingContext
from app.masking.policy import MaskingPolicy

policy = MaskingPolicy(enabled=True)
ctx = MaskingContext(policy=policy, placeholder_map={
    "<NS_1>": "host-a",
    "<NS_10>": "host-b",
})
text = "Alert on <NS_10> and <NS_1>"
result = ctx.unmask(text)
assert result == "Alert on host-b and host-a"  # PASS
```

Fixes #639