### PR TITLE
fix: align integrations count to 60+ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ make benchmark
 
 ## Integrations
 
-OpenSRE connects to 40+ tools and services across the modern cloud stack, from LLM providers and observability platforms to infrastructure, databases, and incident management.
+OpenSRE connects to 60+ tools and services across the modern cloud stack, from LLM providers and observability platforms to infrastructure, databases, and incident management.
 
 | Category | Integrations | Roadmap |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- The intro paragraph states "Connect the **60+** tools you already run" 
- But the Integrations section header said "OpenSRE connects to **40+** tools"
- This PR aligns both to `60+` for consistency

## Changes

`README.md` line 196: `40+` → `60+`