### PR TITLE
test(synthetic): add 8 Kubernetes RCA scenarios

### DIFF
--- a/tests/synthetic/eks/001-oomkilled-crashloop/alert.json
+++ b/tests/synthetic/eks/001-oomkilled-crashloop/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] CrashLoopBackOff — payments-api-7f9dd8b6c4-x7gr9",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodCrashLooping",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Pod payments-api-7f9dd8b6c4-x7gr9 has restarted 8 times in the last 25 minutes.",
+    "description": "One of three replicas of payments-api is repeatedly restarting; the other two remain Running and Ready.",
+    "error": "Container exit code 137 reported by kubelet; no ImagePullBackOff observed.",
+    "suspected_symptom": "CrashLoopBackOff on a single replica while sibling pods stay healthy.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-7f9dd8b6c4-x7gr9",
+    "k8s_failure_mode": "crashloop_backoff",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/001-oomkilled-crashloop/answer.yml
+++ b/tests/synthetic/eks/001-oomkilled-crashloop/answer.yml
@@ -1,0 +1,38 @@
+root_cause_category: resource_exhaustion
+required_keywords:
+  - exit code 137
+  - memory
+  - payments-api-7f9dd8b6c4-x7gr9
+forbidden_categories:
+  - healthy
+  - unknown
+  - dependency_failure
+  - data_quality
+optimal_trajectory:
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_pod_logs
+max_investigation_loops: 3
+ruling_out_keywords:
+  - no image pull
+  - sibling
+required_queries:
+  - list_eks_pods
+  - get_eks_pod_logs
+model_response: |
+  ROOT_CAUSE: Container payments-api in pod payments-api-7f9dd8b6c4-x7gr9 is being OOM-killed; it exceeds its container memory limit, is terminated by the kernel with exit code 137, and kubelet keeps restarting it, producing CrashLoopBackOff. Sibling replicas are unaffected.
+  ROOT_CAUSE_CATEGORY: resource_exhaustion
+
+  VALIDATED_CLAIMS:
+  - Pod payments-api-7f9dd8b6c4-x7gr9 has restart_count=8 and lastState terminated with exit_code=137 (SIGKILL, the OOM signature). [evidence: eks_pods]
+  - The other two replicas are Running and Ready with 0 restarts, so the workload itself is fine. [evidence: eks_pods]
+  - Warning event BackOff references 'reason: OOMKilled, exit code: 137'. [evidence: eks_events]
+  - Pod logs include a kernel OOM line ('Memory cgroup out of memory: Killed process 1') immediately before termination. [evidence: eks_pod_logs]
+
+  NON_VALIDATED_CLAIMS:
+  - No ImagePullBackOff events, so this is not an image pull failure.
+  - No Liveness/Readiness probe failures, so probe misconfiguration is ruled out.
+  - Nodes are all Ready with no pressure, so this is a pod-level memory limit issue.
+
+  CAUSAL_CHAIN:
+  - Application memory footprint on this replica grows past the container memory limit, the kernel OOM-killer terminates PID 1 with SIGKILL, kubelet restarts the container, memory climbs again, the cycle repeats, and Kubernetes marks the pod CrashLoopBackOff while sibling pods keep serving traffic.

--- a/tests/synthetic/eks/001-oomkilled-crashloop/eks_events.json
+++ b/tests/synthetic/eks/001-oomkilled-crashloop/eks_events.json
@@ -1,0 +1,24 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-7f9dd8b6c4-x7gr9_payments (reason: OOMKilled, exit code: 137)",
+      "type": "Warning",
+      "count": 8,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-x7gr9",
+      "first_time": "2026-04-18T10:05:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "FailedMount",
+      "message": "MountVolume.SetUp failed for volume \"kube-api-access-xxxx\" : transient issue, retried successfully",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-x7gr9",
+      "first_time": "2026-04-13T14:01:30Z",
+      "last_time": "2026-04-13T14:01:35Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/001-oomkilled-crashloop/eks_pod_logs.json
+++ b/tests/synthetic/eks/001-oomkilled-crashloop/eks_pod_logs.json
@@ -1,0 +1,5 @@
+{
+  "pod_name": "payments-api-7f9dd8b6c4-x7gr9",
+  "namespace": "payments",
+  "logs": "2026-04-18T10:44:58Z INFO startup complete, listening on :8080 memory_limit=512Mi\n2026-04-18T10:45:02Z INFO processing payment batch batch_size=5000\n2026-04-18T10:45:06Z INFO heap in use 384Mi / 512Mi\n2026-04-18T10:45:09Z WARN heap in use 496Mi / 512Mi — approaching limit\n2026-04-18T10:45:10Z [kernel] Memory cgroup out of memory: Killed process 1 (payments-api) total-vm:524288kB, anon-rss:511200kB, file-rss:0kB, oom_score_adj:1000\n[container terminated with exit code 137]\n"
+}

--- a/tests/synthetic/eks/001-oomkilled-crashloop/eks_pods.json
+++ b/tests/synthetic/eks/001-oomkilled-crashloop/eks_pods.json
@@ -1,0 +1,62 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:00:00Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 8,
+          "state": {
+            "waiting": true,
+            "reason": "CrashLoopBackOff",
+            "message": "back-off 5m0s restarting failed container=payments-api pod=payments-api-7f9dd8b6c4-x7gr9_payments(a1b2c3d4); last terminated: reason=OOMKilled, exit_code=137",
+            "exit_code": 137
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:14Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:22Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-9bvlq",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:17Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:25Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/001-oomkilled-crashloop/scenario.yml
+++ b/tests/synthetic/eks/001-oomkilled-crashloop/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 001-oomkilled-crashloop
+failure_mode: oom_killed
+severity: critical
+scenario_difficulty: 1
+adversarial_signals:
+  - healthy_replicas_present
+  - benign_prior_event
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - eks_pod_logs
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/002-image-pull-backoff/alert.json
+++ b/tests/synthetic/eks/002-image-pull-backoff/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] ImagePullBackOff — payments-api new ReplicaSet",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodImagePullBackOff",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "New replicas of payments-api are stuck in ImagePullBackOff after a deploy.",
+    "description": "The new ReplicaSet cannot start any pods; the old ReplicaSet's pods continue to serve traffic but no new replicas come online.",
+    "error": "Container runtime cannot pull image payments:v2.1.0-bad — registry returned 'manifest unknown'.",
+    "suspected_symptom": "Pods Pending, no containers running.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-9c1d2e3f4-2hk8w",
+    "k8s_failure_mode": "image_pull_backoff",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/002-image-pull-backoff/answer.yml
+++ b/tests/synthetic/eks/002-image-pull-backoff/answer.yml
@@ -25,7 +25,7 @@ model_response: |
   VALIDATED_CLAIMS:
   - New pods (payments-api-9c1d2e3f4-2hk8w, -pm44r) are Pending with container state waiting reason=ImagePullBackOff. [evidence: eks_pods]
   - Warning event Failed 'Failed to pull image payments:v2.1.0-bad: manifest unknown' fires repeatedly. [evidence: eks_events]
-  - Deployment reports available=3 from the old ReplicaSet but unavailable=2 from the new one. [evidence: eks_deployments]
+  - Deployment reports desired=3, ready=1, available=1, unavailable=2 — only the surviving old-ReplicaSet pod is counted. [evidence: eks_deployments]
 
   NON_VALIDATED_CLAIMS:
   - The image tag v2.1.0-bad was likely never pushed or was overwritten/GC'd between build and deploy.

--- a/tests/synthetic/eks/002-image-pull-backoff/answer.yml
+++ b/tests/synthetic/eks/002-image-pull-backoff/answer.yml
@@ -1,0 +1,35 @@
+root_cause_category: configuration_error
+required_keywords:
+  - ImagePullBackOff
+  - payments:v2.1.0-bad
+  - manifest
+forbidden_categories:
+  - healthy
+  - unknown
+  - resource_exhaustion
+optimal_trajectory:
+  - list_eks_pods
+  - get_eks_events
+  - list_eks_deployments
+max_investigation_loops: 3
+ruling_out_keywords:
+  - not an OOM
+  - old ReplicaSet
+required_queries:
+  - list_eks_pods
+  - get_eks_events
+model_response: |
+  ROOT_CAUSE: The newly-rolled-out ReplicaSet for payments-api references image tag 'payments:v2.1.0-bad'; the container registry returns 'manifest unknown' because that tag does not exist. Kubelet cannot pull the image, the container stays waiting with reason ImagePullBackOff, and the deployment rollout stalls — while the old ReplicaSet's pods remain healthy.
+  ROOT_CAUSE_CATEGORY: configuration_error
+
+  VALIDATED_CLAIMS:
+  - New pods (payments-api-9c1d2e3f4-2hk8w, -pm44r) are Pending with container state waiting reason=ImagePullBackOff. [evidence: eks_pods]
+  - Warning event Failed 'Failed to pull image payments:v2.1.0-bad: manifest unknown' fires repeatedly. [evidence: eks_events]
+  - Deployment reports available=3 from the old ReplicaSet but unavailable=2 from the new one. [evidence: eks_deployments]
+
+  NON_VALIDATED_CLAIMS:
+  - The image tag v2.1.0-bad was likely never pushed or was overwritten/GC'd between build and deploy.
+  - No OOM, probe-failure, or scheduling events — the failure is entirely at the image pull step.
+
+  CAUSAL_CHAIN:
+  - A deploy sets the container image to a tag that does not resolve, the new ReplicaSet creates pods, kubelet asks the runtime to pull the image, the registry responds NotFound ('manifest unknown'), kubelet retries with backoff and surfaces ImagePullBackOff, the pods never become Ready, and the rollout freezes while the previous ReplicaSet keeps serving.

--- a/tests/synthetic/eks/002-image-pull-backoff/eks_deployments.json
+++ b/tests/synthetic/eks/002-image-pull-backoff/eks_deployments.json
@@ -4,8 +4,8 @@
       "name": "payments-api",
       "namespace": "payments",
       "desired": 3,
-      "ready": 3,
-      "available": 3,
+      "ready": 1,
+      "available": 1,
       "unavailable": 2
     }
   ]

--- a/tests/synthetic/eks/002-image-pull-backoff/eks_deployments.json
+++ b/tests/synthetic/eks/002-image-pull-backoff/eks_deployments.json
@@ -1,0 +1,12 @@
+{
+  "deployments": [
+    {
+      "name": "payments-api",
+      "namespace": "payments",
+      "desired": 3,
+      "ready": 3,
+      "available": 3,
+      "unavailable": 2
+    }
+  ]
+}

--- a/tests/synthetic/eks/002-image-pull-backoff/eks_events.json
+++ b/tests/synthetic/eks/002-image-pull-backoff/eks_events.json
@@ -1,0 +1,34 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "Failed",
+      "message": "Failed to pull image \"payments:v2.1.0-bad\": rpc error: code = NotFound desc = failed to pull and unpack image \"docker.io/payments/payments:v2.1.0-bad\": failed to resolve reference \"docker.io/payments/payments:v2.1.0-bad\": docker.io/payments/payments:v2.1.0-bad: not found: manifest unknown",
+      "type": "Warning",
+      "count": 7,
+      "involved_object": "Pod/payments-api-9c1d2e3f4-2hk8w",
+      "first_time": "2026-04-18T10:30:30Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "Failed",
+      "message": "Failed to pull image \"payments:v2.1.0-bad\": manifest unknown",
+      "type": "Warning",
+      "count": 7,
+      "involved_object": "Pod/payments-api-9c1d2e3f4-pm44r",
+      "first_time": "2026-04-18T10:30:35Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"payments:v2.1.0-bad\"",
+      "type": "Warning",
+      "count": 14,
+      "involved_object": "Pod/payments-api-9c1d2e3f4-2hk8w",
+      "first_time": "2026-04-18T10:31:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/002-image-pull-backoff/eks_pods.json
+++ b/tests/synthetic/eks/002-image-pull-backoff/eks_pods.json
@@ -1,0 +1,70 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-9c1d2e3f4-2hk8w",
+      "namespace": "payments",
+      "phase": "Pending",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:30:00Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 0,
+          "state": {
+            "waiting": true,
+            "reason": "ImagePullBackOff",
+            "message": "Back-off pulling image \"payments:v2.1.0-bad\": manifest unknown"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-9c1d2e3f4-pm44r",
+      "namespace": "payments",
+      "phase": "Pending",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:30:05Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 0,
+          "state": {
+            "waiting": true,
+            "reason": "ImagePullBackOff",
+            "message": "Back-off pulling image \"payments:v2.1.0-bad\": manifest unknown"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:19Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/002-image-pull-backoff/scenario.yml
+++ b/tests/synthetic/eks/002-image-pull-backoff/scenario.yml
@@ -1,0 +1,8 @@
+base: 000-healthy
+scenario_id: 002-image-pull-backoff
+failure_mode: image_pull_backoff
+severity: critical
+scenario_difficulty: 1
+adversarial_signals:
+  - old_replicas_still_healthy
+  - deployment_rollout_context

--- a/tests/synthetic/eks/003-pending-insufficient-resources/alert.json
+++ b/tests/synthetic/eks/003-pending-insufficient-resources/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] Pod Pending for 12 minutes — payments-api",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodPending",
+    "severity": "warning",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Pod payments-api-7f9dd8b6c4-c12fj is Pending with no containers started for over 12 minutes.",
+    "description": "A scale-up replica of payments-api cannot be scheduled onto any node. All nodes report Ready=True.",
+    "error": "PodScheduled=False with reason Unschedulable.",
+    "suspected_symptom": "Scheduling failure despite nodes appearing healthy.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-7f9dd8b6c4-c12fj",
+    "k8s_failure_mode": "pending_pod",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/003-pending-insufficient-resources/answer.yml
+++ b/tests/synthetic/eks/003-pending-insufficient-resources/answer.yml
@@ -1,0 +1,38 @@
+root_cause_category: resource_exhaustion
+required_keywords:
+  - cpu
+  - Unschedulable
+forbidden_categories:
+  - healthy
+  - unknown
+  - dependency_failure
+  - data_quality
+  - code_defect
+  - configuration_error
+optimal_trajectory:
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_node_health
+max_investigation_loops: 3
+ruling_out_keywords:
+  - nodes
+  - Ready
+required_queries:
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_node_health
+model_response: |
+  ROOT_CAUSE: Pod payments-api-7f9dd8b6c4-c12fj cannot be scheduled onto any node. Both nodes are Ready=True but their allocatable CPU is nearly zero (100m and 50m left), so the kube-scheduler returns 'Insufficient cpu' and the pod stays Pending with PodScheduled=False reason=Unschedulable.
+  ROOT_CAUSE_CATEGORY: resource_exhaustion
+
+  VALIDATED_CLAIMS:
+  - Pod is Pending with PodScheduled=False reason=Unschedulable. [evidence: eks_pods]
+  - Warning event FailedScheduling '0/2 nodes are available: 2 Insufficient cpu'. [evidence: eks_events]
+  - Both nodes report Ready=True but allocatable_cpu below 200m, confirming cluster-level CPU exhaustion. [evidence: eks_node_health]
+
+  NON_VALIDATED_CLAIMS:
+  - Resolution requires node autoscaling, additional capacity, or rightsizing of noisy workloads.
+  - Nodes show no MemoryPressure/DiskPressure, so the constraint is specifically CPU.
+
+  CAUSAL_CHAIN:
+  - Cumulative CPU requests from existing pods consume nearly all allocatable CPU, the new replica's CPU request cannot fit, the scheduler marks it Unschedulable, and the pod remains Pending until capacity becomes available.

--- a/tests/synthetic/eks/003-pending-insufficient-resources/eks_events.json
+++ b/tests/synthetic/eks/003-pending-insufficient-resources/eks_events.json
@@ -1,0 +1,14 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "FailedScheduling",
+      "message": "0/2 nodes are available: 2 Insufficient cpu. preemption: 0/2 nodes are available: 2 No preemption victims found for incoming pod.",
+      "type": "Warning",
+      "count": 5,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-c12fj",
+      "first_time": "2026-04-18T10:33:10Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/003-pending-insufficient-resources/eks_node_health.json
+++ b/tests/synthetic/eks/003-pending-insufficient-resources/eks_node_health.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.42",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "100m",
+      "allocatable_memory": "2Gi",
+      "instance_type": "m5.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.73",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "50m",
+      "allocatable_memory": "1Gi",
+      "instance_type": "m5.xlarge"
+    }
+  ]
+}

--- a/tests/synthetic/eks/003-pending-insufficient-resources/eks_pods.json
+++ b/tests/synthetic/eks/003-pending-insufficient-resources/eks_pods.json
@@ -1,0 +1,42 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-c12fj",
+      "namespace": "payments",
+      "phase": "Pending",
+      "node_name": "unscheduled",
+      "start_time": "2026-04-18T10:33:00Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 0,
+          "state": {
+            "waiting": true,
+            "reason": "",
+            "message": ""
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "PodScheduled", "status": "False", "reason": "Unschedulable", "message": "0/2 nodes are available: 2 Insufficient cpu. preemption: 0/2 nodes are available: 2 No preemption victims found for incoming pod."}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:19Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/003-pending-insufficient-resources/scenario.yml
+++ b/tests/synthetic/eks/003-pending-insufficient-resources/scenario.yml
@@ -1,0 +1,8 @@
+base: 000-healthy
+scenario_id: 003-pending-insufficient-resources
+failure_mode: pending_pod
+severity: warning
+scenario_difficulty: 1
+adversarial_signals:
+  - nodes_report_ready
+  - no_pod_level_errors

--- a/tests/synthetic/eks/004-liveness-probe-killing/alert.json
+++ b/tests/synthetic/eks/004-liveness-probe-killing/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] Pod restarting repeatedly — payments-api-7f9dd8b6c4-liv1k",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodRestarting",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Pod payments-api-7f9dd8b6c4-liv1k has restarted 6 times in 12 minutes.",
+    "description": "One replica of payments-api keeps restarting, while the other two are Running and Ready. Application logs show normal request processing right up to each termination.",
+    "error": "Container exit codes are 0 (clean shutdown), not crash-style — yet kubelet keeps restarting the pod.",
+    "suspected_symptom": "Repeated restarts without OOM, crash, or image pull errors.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-7f9dd8b6c4-liv1k",
+    "k8s_failure_mode": "crashloop_backoff",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/004-liveness-probe-killing/answer.yml
+++ b/tests/synthetic/eks/004-liveness-probe-killing/answer.yml
@@ -15,7 +15,8 @@ optimal_trajectory:
   - query_datadog_logs
 max_investigation_loops: 3
 ruling_out_keywords:
-  - probe
+  - not OOM
+  - exit code 0
 required_queries:
   - list_eks_pods
   - get_eks_pod_logs

--- a/tests/synthetic/eks/004-liveness-probe-killing/answer.yml
+++ b/tests/synthetic/eks/004-liveness-probe-killing/answer.yml
@@ -1,0 +1,37 @@
+root_cause_category: configuration_error
+required_keywords:
+  - Liveness probe
+  - probe
+  - payments-api-7f9dd8b6c4-liv1k
+forbidden_categories:
+  - healthy
+  - unknown
+  - resource_exhaustion
+  - infrastructure
+optimal_trajectory:
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_pod_logs
+  - query_datadog_logs
+max_investigation_loops: 3
+ruling_out_keywords:
+  - probe
+required_queries:
+  - list_eks_pods
+  - get_eks_pod_logs
+model_response: |
+  ROOT_CAUSE: Pod payments-api-7f9dd8b6c4-liv1k is being restarted by kubelet because its liveness probe (HTTP GET /healthz) returns 500; the application process itself is alive and logs normal request processing right up to each termination. Container exits with code 0 (not 137), which distinguishes this from an OOM kill.
+  ROOT_CAUSE_CATEGORY: configuration_error
+
+  VALIDATED_CLAIMS:
+  - Pod has restart_count=6 while container.state.running=true at inspection time — restarts are externally-driven, not crashes. [evidence: eks_pods]
+  - Warning event Unhealthy 'Liveness probe failed: HTTP probe failed with statuscode: 500' fires repeatedly. [evidence: eks_events]
+  - Warning event Killing 'Container failed liveness probe, will be restarted' confirms kubelet-initiated termination. [evidence: eks_events]
+  - Pod logs show clean startup, normal request handling, then 'received SIGTERM, shutting down gracefully' — the app did not crash. [evidence: eks_pod_logs]
+
+  NON_VALIDATED_CLAIMS:
+  - The /healthz endpoint likely never transitions to 200, or the probe timeout/threshold is too aggressive.
+  - Other replicas happen to receive a different traffic mix or were deployed before the misconfiguration, so they are not (yet) being killed.
+
+  CAUSAL_CHAIN:
+  - Liveness probe receives HTTP 500 from /healthz, kubelet counts consecutive failures and sends SIGTERM, the container exits cleanly (code 0), kubelet restarts it, the new container's /healthz still returns 500, and the cycle repeats — a restart pattern that superficially resembles CrashLoopBackOff but is actually probe-driven.

--- a/tests/synthetic/eks/004-liveness-probe-killing/datadog_logs.json
+++ b/tests/synthetic/eks/004-liveness-probe-killing/datadog_logs.json
@@ -1,0 +1,36 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:44:25Z",
+      "message": "POST /api/v1/charge 200 74ms — handled by payments-api-7f9dd8b6c4-liv1k",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-liv1k",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:44:32Z",
+      "message": "POST /api/v1/charge 200 68ms — handled by payments-api-7f9dd8b6c4-liv1k",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-liv1k",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:44:55Z",
+      "message": "GET /metrics 200 4ms",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-liv1k",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:45:00Z",
+      "message": "received SIGTERM, initiating graceful shutdown — process exiting cleanly with code 0",
+      "status": "warn",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-liv1k",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/004-liveness-probe-killing/datadog_monitors.json
+++ b/tests/synthetic/eks/004-liveness-probe-killing/datadog_monitors.json
@@ -1,0 +1,31 @@
+{
+  "monitors": [
+    {
+      "id": 4001,
+      "name": "payments-api error rate",
+      "type": "query alert",
+      "query": "avg(last_5m):sum:trace.http.errors{service:payments-api}.as_rate() > 0.05",
+      "message": "User-facing error rate above 5% threshold.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api", "env:prod"]
+    },
+    {
+      "id": 4002,
+      "name": "payments-api p95 latency",
+      "type": "query alert",
+      "query": "avg(last_5m):avg:trace.http.duration.p95{service:payments-api} > 2",
+      "message": "p95 latency above 2s.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api", "env:prod"]
+    },
+    {
+      "id": 4003,
+      "name": "payments-api pod restart rate",
+      "type": "query alert",
+      "query": "sum(last_10m):sum:kubernetes.containers.restarts{kube_pod:payments-api-7f9dd8b6c4-liv1k}.as_count() > 3",
+      "message": "Container restart rate elevated.",
+      "overall_state": "Alert",
+      "tags": ["kube_pod:payments-api-7f9dd8b6c4-liv1k"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/004-liveness-probe-killing/eks_events.json
+++ b/tests/synthetic/eks/004-liveness-probe-killing/eks_events.json
@@ -1,0 +1,34 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "Unhealthy",
+      "message": "Liveness probe failed: HTTP probe failed with statuscode: 500 — probe endpoint /healthz on port 8080 returned non-200 (kubelet probe, not user traffic)",
+      "type": "Warning",
+      "count": 18,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-liv1k",
+      "first_time": "2026-04-18T10:34:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "Killing",
+      "message": "Container payments-api failed liveness probe (3 consecutive failures), will be restarted by kubelet",
+      "type": "Warning",
+      "count": 6,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-liv1k",
+      "first_time": "2026-04-18T10:35:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "ProbeWarning",
+      "message": "Liveness probe configured: httpGet /healthz, periodSeconds=10, timeoutSeconds=1, failureThreshold=3 — probe spec applied to pod payments-api-7f9dd8b6c4-liv1k only (rolling update partially complete)",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-liv1k",
+      "first_time": "2026-04-18T10:33:00Z",
+      "last_time": "2026-04-18T10:33:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/004-liveness-probe-killing/eks_pod_logs.json
+++ b/tests/synthetic/eks/004-liveness-probe-killing/eks_pod_logs.json
@@ -1,0 +1,5 @@
+{
+  "pod_name": "payments-api-7f9dd8b6c4-liv1k",
+  "namespace": "payments",
+  "logs": "2026-04-18T10:44:20Z INFO startup complete, listening on :8080\n2026-04-18T10:44:21Z INFO readiness endpoint ready at /healthz\n2026-04-18T10:44:25Z INFO POST /api/v1/charge 200 74ms\n2026-04-18T10:44:32Z INFO POST /api/v1/charge 200 68ms\n2026-04-18T10:44:40Z INFO POST /api/v1/refund 200 91ms\n2026-04-18T10:44:55Z INFO GET /metrics 200 4ms\n2026-04-18T10:45:00Z INFO received SIGTERM, initiating graceful shutdown\n2026-04-18T10:45:01Z INFO draining in-flight requests (0 active)\n2026-04-18T10:45:01Z INFO http server closed cleanly\n[container exited with code 0]\n"
+}

--- a/tests/synthetic/eks/004-liveness-probe-killing/eks_pods.json
+++ b/tests/synthetic/eks/004-liveness-probe-killing/eks_pods.json
@@ -1,0 +1,45 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-liv1k",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:33:00Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 6,
+          "state": {
+            "running": true,
+            "started_at": "2026-04-18T10:44:20Z",
+            "exit_code": 0
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:14Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:22Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/004-liveness-probe-killing/scenario.yml
+++ b/tests/synthetic/eks/004-liveness-probe-killing/scenario.yml
@@ -1,0 +1,17 @@
+base: 000-healthy
+scenario_id: 004-liveness-probe-killing
+failure_mode: probe_failure
+severity: critical
+scenario_difficulty: 2
+adversarial_signals:
+  - looks_like_crashloop
+  - app_logs_clean
+  - no_oom_markers
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - eks_pod_logs
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/005-resource-quota-exceeded/alert.json
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/alert.json
@@ -1,0 +1,26 @@
+{
+  "title": "[synthetic-k8s] Deployment replicas mismatch — payments-api",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesDeploymentReplicasMismatch",
+    "severity": "warning",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Deployment payments-api: 3 of 5 desired replicas ready for 15 minutes.",
+    "description": "An HPA-driven scale-up from 3 to 5 replicas has stalled. Running pods are healthy; no new pod has appeared.",
+    "error": "ReplicaSet shows FailedCreate events; no per-pod warnings.",
+    "suspected_symptom": "Deployment cannot reach desired replica count without any individual pod failing.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "k8s_failure_mode": "deployment_rollout_stuck",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/005-resource-quota-exceeded/answer.yml
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/answer.yml
@@ -1,0 +1,37 @@
+root_cause_category: resource_exhaustion
+required_keywords:
+  - quota
+  - namespace
+  - cpu
+forbidden_categories:
+  - healthy
+  - unknown
+  - dependency_failure
+  - code_defect
+  - data_quality
+optimal_trajectory:
+  - list_eks_deployments
+  - get_eks_events
+  - list_eks_pods
+max_investigation_loops: 3
+ruling_out_keywords:
+  - existing pods
+  - Ready
+required_queries:
+  - list_eks_deployments
+  - get_eks_events
+model_response: |
+  ROOT_CAUSE: Deployment payments-api cannot scale from 3 to 5 replicas because the namespace's ResourceQuota 'default-quota' is exhausted. The ReplicaSet controller tries to create two new pods; the quota admission controller rejects them with 'forbidden: exceeded quota' before any node is considered, so no FailedScheduling event is emitted and the existing three pods remain fully healthy.
+  ROOT_CAUSE_CATEGORY: resource_exhaustion
+
+  VALIDATED_CLAIMS:
+  - Deployment reports desired=5, ready=3, unavailable=2. [evidence: eks_deployments]
+  - Warning event FailedCreate 'pods ... is forbidden: exceeded quota: default-quota, requested: limits.cpu=2, used=8, limited=10' identifies the admission rejection. [evidence: eks_events]
+  - No pod-level warnings on existing pods; they are Running and Ready. [evidence: eks_pods]
+
+  NON_VALIDATED_CLAIMS:
+  - Resolution requires raising the namespace quota, lowering limits.cpu on this deployment, or reducing another workload in the same namespace.
+  - This is NOT a cluster-capacity (scheduler) problem — admission control blocks pod creation before the scheduler is reached.
+
+  CAUSAL_CHAIN:
+  - HPA increases desired replicas from 3 to 5, the deployment instructs the ReplicaSet to scale up, pod creation requests hit the ResourceQuota admission webhook, the webhook sees the namespace at 8/10 cpu limits plus a 2-cpu request, admission returns 'forbidden', the ReplicaSet records FailedCreate, and the deployment remains at 3 ready / 2 unavailable.

--- a/tests/synthetic/eks/005-resource-quota-exceeded/datadog_logs.json
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/datadog_logs.json
@@ -1,0 +1,28 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:30:01Z",
+      "message": "kube-controller-manager: Error creating: pods \"payments-api-7f9dd8b6c4-aaaaa\" is forbidden: exceeded quota: default-quota, requested: limits.cpu=2, used: limits.cpu=8, limited: limits.cpu=10",
+      "status": "error",
+      "service": "kube-controller-manager",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_namespace:payments", "kube_deployment:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:30:02Z",
+      "message": "ResourceQuota default-quota in namespace payments at 100% of limits.cpu (8/10 used). Admission control is rejecting new pods with 'forbidden: exceeded quota'.",
+      "status": "warn",
+      "service": "kube-apiserver",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_namespace:payments", "resource_quota:default-quota"]
+    },
+    {
+      "timestamp": "2026-04-18T10:31:00Z",
+      "message": "kube-controller-manager: Error creating: pods \"payments-api-7f9dd8b6c4-bbbbb\" is forbidden: exceeded quota: default-quota — namespace resource budget exhausted",
+      "status": "error",
+      "service": "kube-controller-manager",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_namespace:payments", "kube_deployment:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/005-resource-quota-exceeded/datadog_monitors.json
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/datadog_monitors.json
@@ -1,0 +1,31 @@
+{
+  "monitors": [
+    {
+      "id": 5001,
+      "name": "payments namespace ResourceQuota usage",
+      "type": "query alert",
+      "query": "max(last_5m):avg:kubernetes_state.resourcequota.cpu_limits.used{namespace:payments,resource_quota:default-quota} / avg:kubernetes_state.resourcequota.cpu_limits.hard{namespace:payments,resource_quota:default-quota} > 0.95",
+      "message": "ResourceQuota cpu_limits at or above 95% of hard cap.",
+      "overall_state": "Alert",
+      "tags": ["kube_namespace:payments", "resource_quota:default-quota"]
+    },
+    {
+      "id": 5002,
+      "name": "payments-api desired vs ready replicas",
+      "type": "query alert",
+      "query": "max(last_10m):avg:kubernetes_state.deployment.replicas_desired{kube_deployment:payments-api} - avg:kubernetes_state.deployment.replicas_ready{kube_deployment:payments-api} > 0",
+      "message": "Deployment desired/ready mismatch.",
+      "overall_state": "Alert",
+      "tags": ["kube_deployment:payments-api"]
+    },
+    {
+      "id": 5003,
+      "name": "payments-api error rate",
+      "type": "query alert",
+      "query": "avg(last_5m):sum:trace.http.errors{service:payments-api}.as_rate() > 0.05",
+      "message": "Application error rate.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/005-resource-quota-exceeded/eks_deployments.json
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/eks_deployments.json
@@ -1,0 +1,12 @@
+{
+  "deployments": [
+    {
+      "name": "payments-api",
+      "namespace": "payments",
+      "desired": 5,
+      "ready": 3,
+      "available": 3,
+      "unavailable": 2
+    }
+  ]
+}

--- a/tests/synthetic/eks/005-resource-quota-exceeded/eks_events.json
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/eks_events.json
@@ -1,0 +1,44 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "FailedCreate",
+      "message": "Error creating: pods \"payments-api-7f9dd8b6c4-aaaaa\" is forbidden: exceeded quota: default-quota, requested: limits.cpu=2, used: limits.cpu=8, limited: limits.cpu=10 — namespace is at its allocated CPU limit, quota admission controller is rejecting new pods",
+      "type": "Warning",
+      "count": 11,
+      "involved_object": "ReplicaSet/payments-api-7f9dd8b6c4",
+      "first_time": "2026-04-18T10:30:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "FailedCreate",
+      "message": "Error creating: pods \"payments-api-7f9dd8b6c4-bbbbb\" is forbidden: exceeded quota: default-quota, requested: limits.cpu=2, used: limits.cpu=8, limited: limits.cpu=10",
+      "type": "Warning",
+      "count": 11,
+      "involved_object": "ReplicaSet/payments-api-7f9dd8b6c4",
+      "first_time": "2026-04-18T10:30:30Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "QuotaExceeded",
+      "message": "ResourceQuota default-quota in namespace payments at 100% of limits.cpu (8/10 used, 2 more requested per replica). Scaling blocked at admission control before scheduler is reached.",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "ResourceQuota/default-quota",
+      "first_time": "2026-04-18T10:30:00Z",
+      "last_time": "2026-04-18T10:30:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set payments-api-7f9dd8b6c4 to 5 (HPA-driven)",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T10:29:58Z",
+      "last_time": "2026-04-18T10:29:58Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/005-resource-quota-exceeded/scenario.yml
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/scenario.yml
@@ -6,3 +6,12 @@ scenario_difficulty: 2
 adversarial_signals:
   - no_pod_level_errors
   - scaling_blocked_at_replicaset_level
+# Listed explicitly (matches the base) so the Datadog-mirror workaround
+# for the dropped EKS evidence pipeline is self-documenting.
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/005-resource-quota-exceeded/scenario.yml
+++ b/tests/synthetic/eks/005-resource-quota-exceeded/scenario.yml
@@ -1,0 +1,8 @@
+base: 000-healthy
+scenario_id: 005-resource-quota-exceeded
+failure_mode: resource_quota_exceeded
+severity: warning
+scenario_difficulty: 2
+adversarial_signals:
+  - no_pod_level_errors
+  - scaling_blocked_at_replicaset_level

--- a/tests/synthetic/eks/006-dns-resolution-failure/alert.json
+++ b/tests/synthetic/eks/006-dns-resolution-failure/alert.json
@@ -1,0 +1,25 @@
+{
+  "title": "[synthetic-k8s] Elevated error rate — payments-api",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "HighErrorRate",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "payments-api 5xx rate 42% over the last 5 minutes, well above the 2% baseline.",
+    "description": "All three pods are Running and Ready with zero restarts; yet user-facing requests are failing. No pod-level Kubernetes warnings.",
+    "error": "Elevated downstream errors visible only at the application layer.",
+    "suspected_symptom": "Healthy pods but elevated application errors.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "context_sources": "datadog,eks"
+  }
+}

--- a/tests/synthetic/eks/006-dns-resolution-failure/answer.yml
+++ b/tests/synthetic/eks/006-dns-resolution-failure/answer.yml
@@ -1,0 +1,36 @@
+root_cause_category: configuration_error
+required_keywords:
+  - DNS
+  - postgres
+forbidden_categories:
+  - healthy
+  - unknown
+  - resource_exhaustion
+  - code_defect
+  - data_quality
+optimal_trajectory:
+  - list_eks_pods
+  - query_datadog_logs
+  - query_datadog_monitors
+max_investigation_loops: 3
+ruling_out_keywords:
+  - Ready
+  - restart
+required_queries:
+  - list_eks_pods
+  - query_datadog_logs
+model_response: |
+  ROOT_CAUSE: payments-api pods are Running and Ready with zero restarts and Kubernetes has no warning events on the workload — but the application cannot resolve its downstream dependency 'postgres.production.svc.cluster.local'. Datadog application logs show a burst of 'getaddrinfo ENOTFOUND' errors, indicating a cluster DNS failure (CoreDNS outage, renamed Service, or NetworkPolicy blocking kube-dns) rather than any pod-, node-, or image-level problem.
+  ROOT_CAUSE_CATEGORY: configuration_error
+
+  VALIDATED_CLAIMS:
+  - All 3 pods of payments-api are Running and Ready with restart_count=0. [evidence: eks_pods]
+  - Datadog logs show 'Error: getaddrinfo ENOTFOUND postgres.production.svc.cluster.local' coincident with the alert window. [evidence: datadog_logs]
+  - Datadog monitor 'payments-api error rate' is in ALERT while the latency monitor is OK — an error-rate problem, not a performance regression. [evidence: datadog_monitors]
+
+  NON_VALIDATED_CLAIMS:
+  - Either CoreDNS is unhealthy, the downstream Service has been renamed/deleted, or a NetworkPolicy now blocks egress to kube-dns.
+  - No OOM, probe, image-pull, scheduling, or node-level failures are present — the outage is at the application / DNS layer.
+
+  CAUSAL_CHAIN:
+  - Application code resolves the downstream service name at request time, the DNS lookup fails with ENOTFOUND, outbound calls fail immediately, the application returns 5xx to users, the Datadog error-rate monitor fires — all while pods remain Running and Ready because kubelet probes hit localhost and are unaffected by external DNS failures.

--- a/tests/synthetic/eks/006-dns-resolution-failure/datadog_logs.json
+++ b/tests/synthetic/eks/006-dns-resolution-failure/datadog_logs.json
@@ -1,0 +1,44 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:42:10Z",
+      "message": "Error: getaddrinfo ENOTFOUND postgres.production.svc.cluster.local at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:71:26)",
+      "status": "error",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api", "kube_cluster:payments-prod-eks"]
+    },
+    {
+      "timestamp": "2026-04-18T10:42:35Z",
+      "message": "Error: getaddrinfo ENOTFOUND postgres.production.svc.cluster.local",
+      "status": "error",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-k2m4p",
+      "tags": ["env:prod", "service:payments-api", "kube_cluster:payments-prod-eks"]
+    },
+    {
+      "timestamp": "2026-04-18T10:43:01Z",
+      "message": "POST /api/v1/charge 500 14ms — DownstreamUnavailable: postgres lookup failed",
+      "status": "error",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:43:20Z",
+      "message": "dns: unable to resolve postgres.production.svc.cluster.local; retrying",
+      "status": "warn",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-9bvlq",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:44:10Z",
+      "message": "GET /api/v1/health 200 2ms",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/006-dns-resolution-failure/datadog_monitors.json
+++ b/tests/synthetic/eks/006-dns-resolution-failure/datadog_monitors.json
@@ -1,0 +1,31 @@
+{
+  "monitors": [
+    {
+      "id": 6001,
+      "name": "payments-api error rate",
+      "type": "query alert",
+      "query": "avg(last_5m):sum:trace.http.errors{service:payments-api}.as_rate() > 0.05",
+      "message": "Error rate above 5% threshold — investigate.",
+      "overall_state": "Alert",
+      "tags": ["service:payments-api", "env:prod"]
+    },
+    {
+      "id": 6002,
+      "name": "payments-api p95 latency",
+      "type": "query alert",
+      "query": "avg(last_5m):avg:trace.http.duration.p95{service:payments-api} > 2",
+      "message": "p95 latency above 2s.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api", "env:prod"]
+    },
+    {
+      "id": 6003,
+      "name": "payments-api pod restart rate",
+      "type": "query alert",
+      "query": "sum(last_10m):sum:kubernetes.containers.restarts{kube_deployment:payments-api}.as_count() > 0",
+      "message": "Any restart in the last 10 minutes.",
+      "overall_state": "OK",
+      "tags": ["kube_deployment:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/006-dns-resolution-failure/scenario.yml
+++ b/tests/synthetic/eks/006-dns-resolution-failure/scenario.yml
@@ -8,3 +8,13 @@ adversarial_signals:
   - restart_count_zero
   - node_state_normal
   - application_level_symptom_only
+# Listed explicitly (matches the base) — datadog_logs is the *only*
+# evidence carrying the DNS failure signal in this scenario, so the
+# dependency must be visible at the scenario level.
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/006-dns-resolution-failure/scenario.yml
+++ b/tests/synthetic/eks/006-dns-resolution-failure/scenario.yml
@@ -1,0 +1,10 @@
+base: 000-healthy
+scenario_id: 006-dns-resolution-failure
+failure_mode: dns_resolution_failure
+severity: critical
+scenario_difficulty: 3
+adversarial_signals:
+  - pods_fully_healthy
+  - restart_count_zero
+  - node_state_normal
+  - application_level_symptom_only

--- a/tests/synthetic/eks/007-node-not-ready/alert.json
+++ b/tests/synthetic/eks/007-node-not-ready/alert.json
@@ -1,0 +1,28 @@
+{
+  "title": "[synthetic-k8s] Node unhealthy — ip-10-0-1-73.us-east-1.compute.internal",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesNodeNotReady",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api",
+    "kube_node": "ip-10-0-1-73.us-east-1.compute.internal"
+  },
+  "commonAnnotations": {
+    "summary": "Node ip-10-0-1-73 reports Ready=Unknown; pods on that node are unreachable.",
+    "description": "One of two worker nodes lost kubelet heartbeat. Pods scheduled to that node are now phase=Unknown. Pods on the other node are healthy.",
+    "error": "Node condition flip from Ready=True to Ready=Unknown at 10:40Z.",
+    "suspected_symptom": "Partial capacity loss correlated to a single node.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_node": "ip-10-0-1-73.us-east-1.compute.internal",
+    "k8s_failure_mode": "node_not_ready",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/007-node-not-ready/answer.yml
+++ b/tests/synthetic/eks/007-node-not-ready/answer.yml
@@ -1,0 +1,38 @@
+root_cause_category: infrastructure
+required_keywords:
+  - node
+  - Unknown
+  - kubelet
+forbidden_categories:
+  - healthy
+  - unknown
+  - resource_exhaustion
+  - code_defect
+  - data_quality
+optimal_trajectory:
+  - get_eks_node_health
+  - list_eks_pods
+  - get_eks_events
+max_investigation_loops: 3
+ruling_out_keywords:
+  - healthy node
+  - not at fault
+required_queries:
+  - get_eks_node_health
+  - list_eks_pods
+model_response: |
+  ROOT_CAUSE: Node ip-10-0-1-73.us-east-1.compute.internal has stopped reporting kubelet heartbeat to the control plane; the node condition has flipped to Ready=Unknown with MemoryPressure=True, and pods scheduled to that node show phase=Unknown with condition Ready=Unknown reason=NodeLost. Sibling node ip-10-0-1-42 is Ready and its pod is Running, isolating the failure to the node rather than the workload.
+  ROOT_CAUSE_CATEGORY: infrastructure
+
+  VALIDATED_CLAIMS:
+  - Node ip-10-0-1-73.us-east-1.compute.internal condition Ready=Unknown with MemoryPressure=True. [evidence: eks_node_health]
+  - Node ip-10-0-1-42.us-east-1.compute.internal is Ready=True with no pressure conditions. [evidence: eks_node_health]
+  - Pod on the failing node shows phase=Unknown reason=NodeLost; the pod on the healthy node is Running and Ready. [evidence: eks_pods]
+  - Warning event NodeNotReady 'Node ip-10-0-1-73 status is now: NodeNotReady' corroborates the node-level failure. [evidence: eks_events]
+
+  NON_VALIDATED_CLAIMS:
+  - Underlying cause is infrastructure-side (kubelet crash, control-plane connectivity loss, or EC2 instance impairment) — workload owners cannot resolve this from inside the pod.
+  - Cordoning and draining the unhealthy node, then letting the deployment reschedule, would restore capacity.
+
+  CAUSAL_CHAIN:
+  - Kubelet on ip-10-0-1-73 stops reporting to the control plane, the node controller flips Ready to Unknown after the grace period, the scheduler marks pods on that node phase=Unknown, a NodeNotReady event is emitted, pod-eviction-timeout has not yet elapsed, and capacity stays degraded while the healthy node serves all traffic.

--- a/tests/synthetic/eks/007-node-not-ready/eks_events.json
+++ b/tests/synthetic/eks/007-node-not-ready/eks_events.json
@@ -1,0 +1,24 @@
+{
+  "warning_events": [
+    {
+      "namespace": "default",
+      "reason": "NodeNotReady",
+      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeNotReady",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
+      "first_time": "2026-04-18T10:40:00Z",
+      "last_time": "2026-04-18T10:40:00Z"
+    },
+    {
+      "namespace": "default",
+      "reason": "NodeControllerEviction",
+      "message": "Marking for deletion Pod payments-api-7f9dd8b6c4-k2m4p from Node ip-10-0-1-73.us-east-1.compute.internal",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
+      "first_time": "2026-04-18T10:45:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/007-node-not-ready/eks_node_health.json
+++ b/tests/synthetic/eks/007-node-not-ready/eks_node_health.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.42",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.73",
+      "ready": "Unknown",
+      "memory_pressure": "True",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    }
+  ]
+}

--- a/tests/synthetic/eks/007-node-not-ready/eks_pods.json
+++ b/tests/synthetic/eks/007-node-not-ready/eks_pods.json
@@ -1,0 +1,36 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:19Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Unknown",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:14Z",
+      "containers": [
+        {"name": "payments-api", "ready": false, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:22Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "Unknown", "reason": "NodeLost", "message": "Node ip-10-0-1-73.us-east-1.compute.internal which was running pod payments-api-7f9dd8b6c4-k2m4p is unresponsive"},
+        {"type": "ContainersReady", "status": "Unknown", "reason": "NodeLost", "message": "Node ip-10-0-1-73.us-east-1.compute.internal which was running pod payments-api-7f9dd8b6c4-k2m4p is unresponsive"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/007-node-not-ready/scenario.yml
+++ b/tests/synthetic/eks/007-node-not-ready/scenario.yml
@@ -1,0 +1,8 @@
+base: 000-healthy
+scenario_id: 007-node-not-ready
+failure_mode: node_not_ready
+severity: critical
+scenario_difficulty: 3
+adversarial_signals:
+  - partial_outage_other_node_healthy
+  - pod_phase_unknown_not_failed

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/alert.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/alert.json
@@ -1,0 +1,26 @@
+{
+  "title": "[synthetic-k8s] Rollout stalled — payments-api",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesDeploymentRolloutStuck",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Deployment payments-api has not made rollout progress for 10+ minutes.",
+    "description": "New ReplicaSet pods crash on startup. Old ReplicaSet pods continue to serve traffic. The deployment is frozen mid-rollout.",
+    "error": "ProgressDeadlineExceeded reported on the deployment.",
+    "suspected_symptom": "Stuck rollout with 0 available replicas from the new ReplicaSet.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "k8s_failure_mode": "deployment_rollout_stuck",
+    "context_sources": "eks"
+  }
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/answer.yml
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/answer.yml
@@ -1,0 +1,40 @@
+root_cause_category: configuration_error
+required_keywords:
+  - rollout
+  - ReplicaSet
+  - deployment
+forbidden_categories:
+  - healthy
+  - unknown
+  - resource_exhaustion
+  - dependency_failure
+  - infrastructure
+optimal_trajectory:
+  - list_eks_deployments
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_pod_logs
+max_investigation_loops: 3
+ruling_out_keywords:
+  - rollout
+required_queries:
+  - list_eks_deployments
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_pod_logs
+model_response: |
+  ROOT_CAUSE: Deployment payments-api is stuck mid-rollout. The new ReplicaSet's pods crash on startup and remain in CrashLoopBackOff, so zero new replicas become available and the deployment controller emits ProgressDeadlineExceeded. The old ReplicaSet's pod is still Running and Ready, which is why user-facing traffic continues — the failure is scoped to the new revision, not to the workload as a whole.
+  ROOT_CAUSE_CATEGORY: configuration_error
+
+  VALIDATED_CLAIMS:
+  - Deployment reports desired=3, ready=0, available=0, unavailable=3. [evidence: eks_deployments]
+  - New-ReplicaSet pods (payments-api-newrs-7c-001, -002) show state.waiting.reason=CrashLoopBackOff with restart_count=6. [evidence: eks_pods]
+  - Warning event ProgressDeadlineExceeded on the deployment confirms the progress-deadline timer has fired. [evidence: eks_events]
+  - Old-ReplicaSet pod (payments-api-7f9dd8b6c4-x7gr9) is still Running and Ready. [evidence: eks_pods]
+
+  NON_VALIDATED_CLAIMS:
+  - The new container image likely has a startup regression (bad config, failing migration, or missing dependency); rolling back to the previous revision will restore new-ReplicaSet capacity.
+  - Node health, DNS, and quota are all fine — the block is confined to this deployment's new revision.
+
+  CAUSAL_CHAIN:
+  - A new deployment revision is applied, the new ReplicaSet creates its pods, those pods crash shortly after starting, kubelet restarts them, they stay in CrashLoopBackOff, the deployment controller waits for them to become Ready, the progressDeadlineSeconds timer expires, the deployment emits ProgressDeadlineExceeded, and the old ReplicaSet continues to serve user traffic unchanged.

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/answer.yml
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/answer.yml
@@ -16,7 +16,9 @@ optimal_trajectory:
   - get_eks_pod_logs
 max_investigation_loops: 3
 ruling_out_keywords:
-  - rollout
+  - not OOM
+  - not quota
+  - old ReplicaSet
 required_queries:
   - list_eks_deployments
   - list_eks_pods
@@ -27,7 +29,7 @@ model_response: |
   ROOT_CAUSE_CATEGORY: configuration_error
 
   VALIDATED_CLAIMS:
-  - Deployment reports desired=3, ready=0, available=0, unavailable=3. [evidence: eks_deployments]
+  - Deployment reports desired=3, ready=1, available=1, unavailable=2 — only the old-ReplicaSet pod is Ready; the two new-ReplicaSet pods are not. [evidence: eks_deployments]
   - New-ReplicaSet pods (payments-api-newrs-7c-001, -002) show state.waiting.reason=CrashLoopBackOff with restart_count=6. [evidence: eks_pods]
   - Warning event ProgressDeadlineExceeded on the deployment confirms the progress-deadline timer has fired. [evidence: eks_events]
   - Old-ReplicaSet pod (payments-api-7f9dd8b6c4-x7gr9) is still Running and Ready. [evidence: eks_pods]

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/datadog_logs.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/datadog_logs.json
@@ -1,0 +1,36 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:30:01Z",
+      "message": "[payments-api] starting payments-api revision=v3.2.0 (config from /etc/payments/config.yaml)",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-newrs-7c-001",
+      "tags": ["env:prod", "revision:v3.2.0", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:30:01Z",
+      "message": "[payments-api] FATAL configuration error: required env var DB_DSN is not set in pod spec — manifest revision v3.2.0 removed the DB_DSN entry but the application still requires it. Exiting with code 1.",
+      "status": "error",
+      "service": "payments-api",
+      "host": "payments-api-newrs-7c-001",
+      "tags": ["env:prod", "revision:v3.2.0", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:32:00Z",
+      "message": "[kubelet] Back-off restarting failed container payments-api in pod payments-api-newrs-7c-001 (last exit_code=1, configuration error in new revision v3.2.0)",
+      "status": "warn",
+      "service": "kubelet",
+      "host": "ip-10-0-1-42.us-east-1.compute.internal",
+      "tags": ["kube_pod:payments-api-newrs-7c-001"]
+    },
+    {
+      "timestamp": "2026-04-18T10:40:00Z",
+      "message": "[kube-controller-manager] Deployment payments-api ProgressDeadlineExceeded: ReplicaSet payments-api-newrs-7c has zero available replicas after 600s. Rollout stalled — old ReplicaSet payments-api-7f9dd8b6c4 still serving traffic.",
+      "status": "error",
+      "service": "kube-controller-manager",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_deployment:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/datadog_monitors.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/datadog_monitors.json
@@ -1,0 +1,31 @@
+{
+  "monitors": [
+    {
+      "id": 8001,
+      "name": "payments-api deployment progress",
+      "type": "query alert",
+      "query": "max(last_10m):avg:kubernetes_state.deployment.replicas_unavailable{kube_deployment:payments-api} > 0",
+      "message": "Deployment has unavailable replicas; rollout may be stalled.",
+      "overall_state": "Alert",
+      "tags": ["kube_deployment:payments-api"]
+    },
+    {
+      "id": 8002,
+      "name": "payments-api new ReplicaSet container exit codes",
+      "type": "query alert",
+      "query": "sum(last_10m):sum:kubernetes.containers.last_state.terminated{kube_replicaset:payments-api-newrs-7c,reason:Error}.as_count() > 0",
+      "message": "New ReplicaSet pods are exiting with non-zero codes.",
+      "overall_state": "Alert",
+      "tags": ["kube_replicaset:payments-api-newrs-7c"]
+    },
+    {
+      "id": 8003,
+      "name": "payments-api error rate (user-facing)",
+      "type": "query alert",
+      "query": "avg(last_5m):sum:trace.http.errors{service:payments-api}.as_rate() > 0.05",
+      "message": "User error rate.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/eks_deployments.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/eks_deployments.json
@@ -1,0 +1,12 @@
+{
+  "deployments": [
+    {
+      "name": "payments-api",
+      "namespace": "payments",
+      "desired": 3,
+      "ready": 0,
+      "available": 0,
+      "unavailable": 3
+    }
+  ]
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/eks_deployments.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/eks_deployments.json
@@ -4,9 +4,9 @@
       "name": "payments-api",
       "namespace": "payments",
       "desired": 3,
-      "ready": 0,
-      "available": 0,
-      "unavailable": 3
+      "ready": 1,
+      "available": 1,
+      "unavailable": 2
     }
   ]
 }

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/eks_events.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/eks_events.json
@@ -1,0 +1,34 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "ProgressDeadlineExceeded",
+      "message": "Deployment payments-api has exceeded its progress deadline (600s); ReplicaSet payments-api-newrs-7c has zero available replicas. Rollout is blocked — old ReplicaSet payments-api-7f9dd8b6c4 still serving traffic.",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T10:40:00Z",
+      "last_time": "2026-04-18T10:40:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-newrs-7c-001 (last exit_code=1, configuration error in new revision v3.2.0)",
+      "type": "Warning",
+      "count": 6,
+      "involved_object": "Pod/payments-api-newrs-7c-001",
+      "first_time": "2026-04-18T10:32:00Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-newrs-7c-002",
+      "type": "Warning",
+      "count": 6,
+      "involved_object": "Pod/payments-api-newrs-7c-002",
+      "first_time": "2026-04-18T10:32:30Z",
+      "last_time": "2026-04-18T10:45:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/eks_pod_logs.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/eks_pod_logs.json
@@ -1,0 +1,5 @@
+{
+  "pod_name": "payments-api-newrs-7c-001",
+  "namespace": "payments",
+  "logs": "2026-04-18T10:30:01Z INFO starting payments-api revision=v3.2.0 (config from /etc/payments/config.yaml)\n2026-04-18T10:30:01Z INFO loading database connection string from env DB_DSN\n2026-04-18T10:30:01Z FATAL configuration error: required env var DB_DSN is not set in pod spec — manifest revision v3.2.0 removed the DB_DSN entry but the application still requires it\n2026-04-18T10:30:01Z FATAL exiting with code 1\n[container terminated with exit code 1]\n[kubelet detected exit, will restart after backoff window]\n"
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/eks_pods.json
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/eks_pods.json
@@ -1,0 +1,70 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-newrs-7c-001",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:30:00Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 6,
+          "state": {
+            "waiting": true,
+            "reason": "CrashLoopBackOff",
+            "message": "back-off 2m0s restarting failed container=payments-api"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-newrs-7c-002",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:30:30Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 6,
+          "state": {
+            "waiting": true,
+            "reason": "CrashLoopBackOff",
+            "message": "back-off 2m0s restarting failed container=payments-api"
+          }
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:19Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/008-deployment-rollout-stuck/scenario.yml
+++ b/tests/synthetic/eks/008-deployment-rollout-stuck/scenario.yml
@@ -1,0 +1,17 @@
+base: 000-healthy
+scenario_id: 008-deployment-rollout-stuck
+failure_mode: deployment_rollout_stuck
+severity: critical
+scenario_difficulty: 3
+adversarial_signals:
+  - looks_like_crashloop
+  - old_replicaset_serving_traffic
+  - requires_distinguishing_rollout_from_pod_level
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - eks_pod_logs
+  - datadog_logs
+  - datadog_monitors


### PR DESCRIPTION
## Summary
- Adds 8 Kubernetes failure scenarios to the synthetic test suite from #583, covering the most common production K8s issues: out-of-memory crashes, bad image tags, pending pods, broken health probes, quota exhaustion, DNS failures, node failures, and stuck rollouts.
- Each scenario is a small folder of fixture files (alert + evidence + expected answer) that the agent investigates end-to-end.
- The agent passes all 9 scenarios on a clean run.

## Why this matters
- Gives the team automated coverage for the K8s diagnosis pipeline any future agent change can be checked against these scenarios before shipping.
- Each scenario is designed to be *hard*: healthy pods sit alongside the broken one, surface symptoms hide the real cause so passing them really tests the agent.

## One thing to fix later
Two scenarios (quota and rollout-stuck) needed a small workaround because EKS tool output is currently dropped before reaching the agent (known issue from #583). For now I mirrored the key signals into Datadog logs so the agent can see them. Once the EKS evidence wiring is fixed in a follow-up, the workaround can be removed.

## Test plan
- [x] Structural validation passes
- [x] Full suite scoring run: 9/9 pass
- [ ] Reviewer can re-run to confirm