### PR TITLE
ci: skip Windows runners on PR builds, run them only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows is significantly slower than Linux; only run it on push to main
+        # (post-merge) to keep PR feedback fast.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -58,7 +60,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows is significantly slower than Linux; only run it on push to main
+        # (post-merge) to keep PR feedback fast.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -87,7 +91,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Windows is significantly slower than Linux; only run it on push to main
+        # (post-merge) to keep PR feedback fast.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     needs: [quality, typecheck]
     env:


### PR DESCRIPTION
## Summary

- Windows runners are significantly slower than Linux runners and were gating every PR.
- Switch the `quality`, `typecheck`, and `test` matrices to dynamically include `windows-latest` **only** when the workflow is triggered by `push` to `main` (post-merge).
- PR builds now run only on `ubuntu-latest` for fast feedback; Windows-specific regressions are still caught on `main`.

## Implementation

The matrix uses a conditional `fromJSON` expression:

```yaml
os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
```

Since `push` is configured to fire only on `branches: [main]` in this workflow, this is equivalent to "Windows runs only when merged to main".

## Note on branch protection

If branch protection currently requires status checks named `quality (windows-latest)`, `typecheck (windows-latest)`, or `test (windows-latest)`, those required checks should be removed (they will no longer run on PRs). Only the `ubuntu-latest` variants should be required for merge.

## Test plan

- [ ] CI on this PR runs only `ubuntu-latest` jobs (no Windows jobs scheduled).
- [ ] After merge, the `push` to `main` schedules both `ubuntu-latest` and `windows-latest` jobs.

Made with [Cursor](https://cursor.com)