### PR TITLE
test(synthetic): add 5 EKS noise scenarios

### DIFF
--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/alert.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] Pod restarted — payments-api-7f9dd8b6c4-x7gr9",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodRestarting",
+    "severity": "warning",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Pod payments-api-7f9dd8b6c4-x7gr9 reported a single container restart in the last hour.",
+    "description": "Datadog restart-count alert fired on a 1-restart threshold. No further restarts since.",
+    "error": "",
+    "suspected_symptom": "Possible CrashLoopBackOff.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-7f9dd8b6c4-x7gr9",
+    "k8s_failure_mode": "crashloop_backoff",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/answer.yml
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/answer.yml
@@ -1,0 +1,36 @@
+root_cause_category: healthy
+required_keywords:
+  - restart
+forbidden_categories:
+  - unknown
+  - resource_exhaustion
+  - configuration_error
+  - infrastructure
+optimal_trajectory:
+  - list_eks_pods
+  - get_eks_events
+  - query_datadog_monitors
+max_investigation_loops: 3
+ruling_out_keywords:
+  - not OOMKilled
+  - not currently restarting
+  - monitors are OK
+required_queries:
+  - list_eks_pods
+  - get_eks_events
+model_response: |
+  ROOT_CAUSE: No active failure detected. Pod payments-api-7f9dd8b6c4-x7gr9 had a single container restart over an hour ago, after which the container has been Running and Ready continuously. The remaining two replicas have restart_count=0. The Datadog restart-rate alert fired on a 1-restart threshold but the situation has self-resolved.
+  ROOT_CAUSE_CATEGORY: healthy
+
+  VALIDATED_CLAIMS:
+  - All 3 pods of payments-api are currently Running and Ready. [evidence: eks_pods]
+  - Pod payments-api-7f9dd8b6c4-x7gr9 has restart_count=1 with state.running=true and started_at over 60 minutes ago — no further restarts. [evidence: eks_pods]
+  - Only one historical Warning event (BackOff) exists for that pod, with last_time ~60 minutes ago. No new events. [evidence: eks_events]
+  - Datadog monitors for error rate, latency, and restart rate are all in OK state. [evidence: datadog_monitors]
+
+  NON_VALIDATED_CLAIMS:
+  - The transient restart may have been caused by a brief network or resource hiccup; without per-restart context it cannot be conclusively attributed.
+  - The alert threshold of 1 restart in an hour is sensitive enough to surface this transient event without distinguishing a CrashLoopBackOff.
+
+  CAUSAL_CHAIN:
+  - No active causal chain — system is healthy. A single transient restart over an hour ago triggered a low-threshold alert that has not re-armed.

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_logs.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_logs.json
@@ -18,7 +18,7 @@
     },
     {
       "timestamp": "2026-04-18T10:30:00Z",
-      "message": "[payments-api] no further restarts observed since 09:45:00Z; container_uptime > 60 minutes; healthy",
+      "message": "[payments-api] no further restarts observed since 09:25:00Z; container_uptime > 60 minutes; healthy",
       "status": "info",
       "service": "payments-api",
       "host": "payments-api-7f9dd8b6c4-x7gr9",

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_logs.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_logs.json
@@ -1,7 +1,7 @@
 {
   "logs": [
     {
-      "timestamp": "2026-04-18T09:45:00Z",
+      "timestamp": "2026-04-18T09:25:00Z",
       "message": "[payments-api] container started cleanly after a single restart event; service operational on :8080",
       "status": "info",
       "service": "payments-api",

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_logs.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_logs.json
@@ -1,0 +1,28 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T09:45:00Z",
+      "message": "[payments-api] container started cleanly after a single restart event; service operational on :8080",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:00:00Z",
+      "message": "[payments-api] POST /api/v1/charge 200 71ms — sustained normal traffic with zero errors",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:30:00Z",
+      "message": "[payments-api] no further restarts observed since 09:45:00Z; container_uptime > 60 minutes; healthy",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_monitors.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/datadog_monitors.json
@@ -1,0 +1,31 @@
+{
+  "monitors": [
+    {
+      "id": 9001,
+      "name": "payments-api error rate",
+      "type": "query alert",
+      "query": "avg(last_5m):sum:trace.http.errors{service:payments-api}.as_rate() > 0.05",
+      "message": "User-facing error rate.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api"]
+    },
+    {
+      "id": 9002,
+      "name": "payments-api p95 latency",
+      "type": "query alert",
+      "query": "avg(last_5m):avg:trace.http.duration.p95{service:payments-api} > 2",
+      "message": "p95 latency above 2s.",
+      "overall_state": "OK",
+      "tags": ["service:payments-api"]
+    },
+    {
+      "id": 9003,
+      "name": "payments-api pod restart rate",
+      "type": "query alert",
+      "query": "sum(last_30m):sum:kubernetes.containers.restarts{kube_deployment:payments-api}.as_count() > 0",
+      "message": "Any restart in the last 30 minutes — fired on a single historical restart that has since recovered.",
+      "overall_state": "OK",
+      "tags": ["kube_deployment:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_events.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_events.json
@@ -1,0 +1,14 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-7f9dd8b6c4-x7gr9 (single transient restart, container has since been Running for 60+ minutes)",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-x7gr9",
+      "first_time": "2026-04-18T09:44:30Z",
+      "last_time": "2026-04-18T09:44:50Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_events.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_events.json
@@ -7,8 +7,8 @@
       "type": "Warning",
       "count": 1,
       "involved_object": "Pod/payments-api-7f9dd8b6c4-x7gr9",
-      "first_time": "2026-04-18T09:44:30Z",
-      "last_time": "2026-04-18T09:44:50Z"
+      "first_time": "2026-04-18T09:24:30Z",
+      "last_time": "2026-04-18T09:24:50Z"
     }
   ]
 }

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_pods.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_pods.json
@@ -11,7 +11,7 @@
           "name": "payments-api",
           "ready": true,
           "restart_count": 1,
-          "state": {"running": true, "started_at": "2026-04-18T09:45:00Z"}
+          "state": {"running": true, "started_at": "2026-04-18T09:25:00Z"}
         }
       ],
       "conditions": [

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_pods.json
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/eks_pods.json
@@ -1,0 +1,57 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": true,
+          "restart_count": 1,
+          "state": {"running": true, "started_at": "2026-04-18T09:45:00Z"}
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:14Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:22Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-9bvlq",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:17Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:25Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/009-noisy-healthy-restart-recovered/scenario.yml
+++ b/tests/synthetic/eks/009-noisy-healthy-restart-recovered/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 009-noisy-healthy-restart-recovered
+failure_mode: healthy
+severity: warning
+scenario_difficulty: 2
+adversarial_signals:
+  - stale_restart_count
+  - alertname_implies_crashloop
+  - one_pod_with_history_two_clean
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/010-red-herring-old-rollout/alert.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] CrashLoopBackOff — payments-api-6c4ab5d9c-old1",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodCrashLooping",
+    "severity": "warning",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Pod payments-api-6c4ab5d9c-old1 reports CrashLoopBackOff state.",
+    "description": "Datadog flagged a pod in CrashLoopBackOff matching the payments-api deployment label.",
+    "error": "",
+    "suspected_symptom": "Container restart loop on a payments-api pod.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-6c4ab5d9c-old1",
+    "k8s_failure_mode": "crashloop_backoff",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/010-red-herring-old-rollout/answer.yml
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/answer.yml
@@ -1,0 +1,38 @@
+root_cause_category: healthy
+required_keywords:
+  - ReplicaSet
+  - rollout
+forbidden_categories:
+  - unknown
+  - resource_exhaustion
+  - configuration_error
+  - infrastructure
+optimal_trajectory:
+  - list_eks_pods
+  - list_eks_deployments
+  - get_eks_events
+max_investigation_loops: 3
+ruling_out_keywords:
+  - not OOM
+  - not a current failure
+  - terminating
+required_queries:
+  - list_eks_pods
+  - list_eks_deployments
+model_response: |
+  ROOT_CAUSE: No active workload failure. The pod payments-api-6c4ab5d9c-old1 belongs to the OLD ReplicaSet (payments-api-6c4ab5d9c) which is being terminated as part of a completed rollout. The NEW ReplicaSet (payments-api-7f9dd8b6c4) has 3/3 pods Running and Ready, the deployment reports desired=3 ready=3 available=3, and Datadog monitors are all OK. The CrashLoopBackOff signal is a transient state of an old pod being torn down.
+  ROOT_CAUSE_CATEGORY: healthy
+
+  VALIDATED_CLAIMS:
+  - Deployment payments-api reports desired=3, ready=3, available=3, unavailable=0. [evidence: eks_deployments]
+  - All 3 pods of the new ReplicaSet (payments-api-7f9dd8b6c4-*) are Running and Ready with restart_count=0. [evidence: eks_pods]
+  - The pod cited in the alert (payments-api-6c4ab5d9c-old1) belongs to the older ReplicaSet 6c4ab5d9c and shows phase=Running with deletion_timestamp set, indicating kubelet is tearing it down. [evidence: eks_pods]
+  - Recent events show ScalingReplicaSet for the old RS scaled to 0; no current FailedCreate or BackOff on the new RS. [evidence: eks_events]
+  - Datadog monitors for error rate and latency are OK. [evidence: datadog_monitors]
+
+  NON_VALIDATED_CLAIMS:
+  - The Datadog rule that flagged the old pod likely matches by deployment label without filtering on ReplicaSet generation, producing a false-positive alert during the brief termination window.
+  - Tightening the alert query to exclude pods with a deletion_timestamp would suppress this class of noise.
+
+  CAUSAL_CHAIN:
+  - No active failure causal chain — workload is healthy. A terminating old-ReplicaSet pod briefly entered a CrashLoopBackOff-shaped state during graceful shutdown, triggering a label-matched alert that does not reflect the deployment's actual health.

--- a/tests/synthetic/eks/010-red-herring-old-rollout/answer.yml
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/answer.yml
@@ -27,7 +27,8 @@ model_response: |
   - Deployment payments-api reports desired=3, ready=3, available=3, unavailable=0. [evidence: eks_deployments]
   - All 3 pods of the new ReplicaSet (payments-api-7f9dd8b6c4-*) are Running and Ready with restart_count=0. [evidence: eks_pods]
   - The pod cited in the alert (payments-api-6c4ab5d9c-old1) belongs to the older ReplicaSet 6c4ab5d9c and shows phase=Running with deletion_timestamp set, indicating kubelet is tearing it down. [evidence: eks_pods]
-  - Recent events show ScalingReplicaSet for the old RS scaled to 0; no current FailedCreate or BackOff on the new RS. [evidence: eks_events]
+  - The only Warning event present is BackOff on the terminating old-RS pod; no FailedCreate or BackOff on the new-RS pods. [evidence: eks_events]
+  - Control-plane logs confirm the rollout completed at 09:33Z and the old pod is in graceful shutdown. [evidence: datadog_logs]
   - Datadog monitors for error rate and latency are OK. [evidence: datadog_monitors]
 
   NON_VALIDATED_CLAIMS:

--- a/tests/synthetic/eks/010-red-herring-old-rollout/datadog_logs.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/datadog_logs.json
@@ -1,0 +1,28 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T09:33:00Z",
+      "message": "[kube-controller-manager] Deployment payments-api rollout completed: ReplicaSet payments-api-7f9dd8b6c4 has all 3 replicas Ready, old ReplicaSet payments-api-6c4ab5d9c scaled to 0",
+      "status": "info",
+      "service": "kube-controller-manager",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_namespace:payments", "kube_deployment:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T09:35:00Z",
+      "message": "[kubelet] Pod payments-api-6c4ab5d9c-old1 container terminated during graceful shutdown (rollout cleanup)",
+      "status": "info",
+      "service": "kubelet",
+      "host": "ip-10-0-1-42.us-east-1.compute.internal",
+      "tags": ["kube_pod:payments-api-6c4ab5d9c-old1"]
+    },
+    {
+      "timestamp": "2026-04-18T10:00:00Z",
+      "message": "[payments-api] POST /api/v1/charge 200 65ms",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/010-red-herring-old-rollout/eks_deployments.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/eks_deployments.json
@@ -1,0 +1,12 @@
+{
+  "deployments": [
+    {
+      "name": "payments-api",
+      "namespace": "payments",
+      "desired": 3,
+      "ready": 3,
+      "available": 3,
+      "unavailable": 0
+    }
+  ]
+}

--- a/tests/synthetic/eks/010-red-herring-old-rollout/eks_events.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/eks_events.json
@@ -9,26 +9,6 @@
       "involved_object": "Pod/payments-api-6c4ab5d9c-old1",
       "first_time": "2026-04-18T09:35:00Z",
       "last_time": "2026-04-18T09:38:00Z"
-    },
-    {
-      "namespace": "payments",
-      "reason": "ScalingReplicaSet",
-      "message": "Scaled down replica set payments-api-6c4ab5d9c to 0 from 3",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Deployment/payments-api",
-      "first_time": "2026-04-18T09:33:00Z",
-      "last_time": "2026-04-18T09:33:00Z"
-    },
-    {
-      "namespace": "payments",
-      "reason": "ScalingReplicaSet",
-      "message": "Scaled up replica set payments-api-7f9dd8b6c4 to 3",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Deployment/payments-api",
-      "first_time": "2026-04-18T09:29:30Z",
-      "last_time": "2026-04-18T09:29:30Z"
     }
   ]
 }

--- a/tests/synthetic/eks/010-red-herring-old-rollout/eks_events.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/eks_events.json
@@ -1,0 +1,34 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-6c4ab5d9c-old1 (pod is terminating during rollout)",
+      "type": "Warning",
+      "count": 2,
+      "involved_object": "Pod/payments-api-6c4ab5d9c-old1",
+      "first_time": "2026-04-18T09:35:00Z",
+      "last_time": "2026-04-18T09:38:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled down replica set payments-api-6c4ab5d9c to 0 from 3",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T09:33:00Z",
+      "last_time": "2026-04-18T09:33:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set payments-api-7f9dd8b6c4 to 3",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T09:29:30Z",
+      "last_time": "2026-04-18T09:29:30Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/010-red-herring-old-rollout/eks_pods.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/eks_pods.json
@@ -6,6 +6,7 @@
       "phase": "Running",
       "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
       "start_time": "2026-04-12T08:00:00Z",
+      "deletion_timestamp": "2026-04-18T09:38:00Z",
       "containers": [
         {
           "name": "payments-api",

--- a/tests/synthetic/eks/010-red-herring-old-rollout/eks_pods.json
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/eks_pods.json
@@ -1,0 +1,73 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-6c4ab5d9c-old1",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-12T08:00:00Z",
+      "containers": [
+        {
+          "name": "payments-api",
+          "ready": false,
+          "restart_count": 2,
+          "state": {"waiting": true, "reason": "CrashLoopBackOff", "message": "back-off 10s restarting failed container (terminating during rollout)"}
+        }
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "ContainersReady", "status": "False", "reason": "ContainersNotReady", "message": "containers with unready status: [payments-api]"},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-18T09:30:00Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-18T09:30:08Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-18T09:30:30Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-18T09:30:38Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-9bvlq",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-18T09:31:00Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-18T09:31:08Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/010-red-herring-old-rollout/scenario.yml
+++ b/tests/synthetic/eks/010-red-herring-old-rollout/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 010-red-herring-old-rollout
+failure_mode: healthy
+severity: warning
+scenario_difficulty: 3
+adversarial_signals:
+  - old_replicaset_terminating_visible
+  - alert_targets_terminating_pod
+  - new_replicaset_fully_healthy
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/011-recovered-rollout/alert.json
+++ b/tests/synthetic/eks/011-recovered-rollout/alert.json
@@ -1,0 +1,26 @@
+{
+  "title": "[synthetic-k8s] Rollout progress deadline exceeded — payments-api",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesDeploymentRolloutStuck",
+    "severity": "warning",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Deployment payments-api emitted ProgressDeadlineExceeded for ReplicaSet payments-api-newrs-7c.",
+    "description": "Datadog flagged the historical ProgressDeadlineExceeded condition. Deployment status has not been re-checked since.",
+    "error": "",
+    "suspected_symptom": "Stuck deployment rollout.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "k8s_failure_mode": "deployment_rollout_stuck",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/011-recovered-rollout/answer.yml
+++ b/tests/synthetic/eks/011-recovered-rollout/answer.yml
@@ -1,8 +1,6 @@
 root_cause_category: healthy
 required_keywords:
   - rolled back
-  - previous revision
-  - no active failure
 forbidden_categories:
   - unknown
   - configuration_error

--- a/tests/synthetic/eks/011-recovered-rollout/answer.yml
+++ b/tests/synthetic/eks/011-recovered-rollout/answer.yml
@@ -1,0 +1,38 @@
+root_cause_category: healthy
+required_keywords:
+  - rolled back
+  - previous revision
+  - no active failure
+forbidden_categories:
+  - unknown
+  - configuration_error
+  - resource_exhaustion
+  - infrastructure
+optimal_trajectory:
+  - list_eks_deployments
+  - get_eks_events
+  - list_eks_pods
+max_investigation_loops: 3
+ruling_out_keywords:
+  - rolled back
+  - not currently stuck
+  - no active failure
+required_queries:
+  - list_eks_deployments
+  - get_eks_events
+model_response: |
+  ROOT_CAUSE: No active failure. The deployment payments-api attempted a rollout to revision v3.2.0 which failed and emitted ProgressDeadlineExceeded ~25 minutes ago. The bad ReplicaSet was automatically rolled back to the previous revision and the deployment now reports desired=3, ready=3, available=3 with the prior-version pods serving traffic. The Datadog alert fired on the historical event without re-checking current state.
+  ROOT_CAUSE_CATEGORY: healthy
+
+  VALIDATED_CLAIMS:
+  - Deployment payments-api reports desired=3, ready=3, available=3, unavailable=0. [evidence: eks_deployments]
+  - All 3 pods are from the prior-revision ReplicaSet (payments-api-7f9dd8b6c4-*) and are Running and Ready. [evidence: eks_pods]
+  - Event timeline: ProgressDeadlineExceeded at 10:40Z, then DeploymentRollback to revision N-1 at 10:42Z, then ScalingReplicaSet of the bad RS down to 0. [evidence: eks_events]
+  - Datadog monitors for error rate and latency are OK. [evidence: datadog_monitors]
+
+  NON_VALIDATED_CLAIMS:
+  - The bad revision likely had a regression that should be investigated separately, but the production deployment is no longer affected.
+  - The Datadog alert rule could re-evaluate against current deployment status to suppress this class of stale alert.
+
+  CAUSAL_CHAIN:
+  - No active failure causal chain. A bad rollout was attempted, ProgressDeadlineExceeded fired, the deployment auto-rolled back to the previous revision, and the workload is now stable. The alert reflects a historical event that has already been resolved.

--- a/tests/synthetic/eks/011-recovered-rollout/answer.yml
+++ b/tests/synthetic/eks/011-recovered-rollout/answer.yml
@@ -27,7 +27,8 @@ model_response: |
   VALIDATED_CLAIMS:
   - Deployment payments-api reports desired=3, ready=3, available=3, unavailable=0. [evidence: eks_deployments]
   - All 3 pods are from the prior-revision ReplicaSet (payments-api-7f9dd8b6c4-*) and are Running and Ready. [evidence: eks_pods]
-  - Event timeline: ProgressDeadlineExceeded at 10:40Z, then DeploymentRollback to revision N-1 at 10:42Z, then ScalingReplicaSet of the bad RS down to 0. [evidence: eks_events]
+  - The Warning event ProgressDeadlineExceeded at 10:40Z is the only K8s event present. [evidence: eks_events]
+  - Control-plane log timeline shows DeploymentRollback to revision N-1 at 10:42Z and the deployment subsequently marked Available. [evidence: datadog_logs]
   - Datadog monitors for error rate and latency are OK. [evidence: datadog_monitors]
 
   NON_VALIDATED_CLAIMS:

--- a/tests/synthetic/eks/011-recovered-rollout/datadog_logs.json
+++ b/tests/synthetic/eks/011-recovered-rollout/datadog_logs.json
@@ -1,0 +1,28 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:42:00Z",
+      "message": "[kube-controller-manager] DeploymentRollback successful: payments-api restored to revision N-1 (ReplicaSet payments-api-7f9dd8b6c4); rollout marked Available",
+      "status": "info",
+      "service": "kube-controller-manager",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_namespace:payments", "kube_deployment:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:43:00Z",
+      "message": "[kube-controller-manager] Deployment payments-api status: desired=3 ready=3 available=3 unavailable=0 (stable on prior revision)",
+      "status": "info",
+      "service": "kube-controller-manager",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_namespace:payments", "kube_deployment:payments-api"]
+    },
+    {
+      "timestamp": "2026-04-18T10:55:00Z",
+      "message": "[payments-api] POST /api/v1/charge 200 71ms — handled by payments-api-7f9dd8b6c4-x7gr9 (revision N-1)",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-x7gr9",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/011-recovered-rollout/eks_deployments.json
+++ b/tests/synthetic/eks/011-recovered-rollout/eks_deployments.json
@@ -1,0 +1,12 @@
+{
+  "deployments": [
+    {
+      "name": "payments-api",
+      "namespace": "payments",
+      "desired": 3,
+      "ready": 3,
+      "available": 3,
+      "unavailable": 0
+    }
+  ]
+}

--- a/tests/synthetic/eks/011-recovered-rollout/eks_events.json
+++ b/tests/synthetic/eks/011-recovered-rollout/eks_events.json
@@ -1,0 +1,34 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "ProgressDeadlineExceeded",
+      "message": "Deployment payments-api ReplicaSet payments-api-newrs-7c exceeded its progress deadline",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T10:40:00Z",
+      "last_time": "2026-04-18T10:40:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "DeploymentRollback",
+      "message": "Rolled back deployment payments-api to revision N-1 (payments-api-7f9dd8b6c4) after progress deadline exceeded",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T10:42:00Z",
+      "last_time": "2026-04-18T10:42:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled down replica set payments-api-newrs-7c to 0 from 3 (rollback complete)",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Deployment/payments-api",
+      "first_time": "2026-04-18T10:43:00Z",
+      "last_time": "2026-04-18T10:43:00Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/011-recovered-rollout/eks_events.json
+++ b/tests/synthetic/eks/011-recovered-rollout/eks_events.json
@@ -3,32 +3,12 @@
     {
       "namespace": "payments",
       "reason": "ProgressDeadlineExceeded",
-      "message": "Deployment payments-api ReplicaSet payments-api-newrs-7c exceeded its progress deadline",
+      "message": "Deployment payments-api ReplicaSet payments-api-newrs-7c exceeded its progress deadline (deployment has since auto-rolled back; see datadog_logs)",
       "type": "Warning",
       "count": 1,
       "involved_object": "Deployment/payments-api",
       "first_time": "2026-04-18T10:40:00Z",
       "last_time": "2026-04-18T10:40:00Z"
-    },
-    {
-      "namespace": "payments",
-      "reason": "DeploymentRollback",
-      "message": "Rolled back deployment payments-api to revision N-1 (payments-api-7f9dd8b6c4) after progress deadline exceeded",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Deployment/payments-api",
-      "first_time": "2026-04-18T10:42:00Z",
-      "last_time": "2026-04-18T10:42:00Z"
-    },
-    {
-      "namespace": "payments",
-      "reason": "ScalingReplicaSet",
-      "message": "Scaled down replica set payments-api-newrs-7c to 0 from 3 (rollback complete)",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Deployment/payments-api",
-      "first_time": "2026-04-18T10:43:00Z",
-      "last_time": "2026-04-18T10:43:00Z"
     }
   ]
 }

--- a/tests/synthetic/eks/011-recovered-rollout/scenario.yml
+++ b/tests/synthetic/eks/011-recovered-rollout/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 011-recovered-rollout
+failure_mode: healthy
+severity: warning
+scenario_difficulty: 3
+adversarial_signals:
+  - progress_deadline_exceeded_in_history
+  - rolled_back_event_present
+  - alert_implies_rollout_stuck
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/012-pending-recovered/alert.json
+++ b/tests/synthetic/eks/012-pending-recovered/alert.json
@@ -1,0 +1,27 @@
+{
+  "title": "[synthetic-k8s] Pod was Pending — payments-api-7f9dd8b6c4-late1",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesPodPending",
+    "severity": "warning",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Pod payments-api-7f9dd8b6c4-late1 was Pending for over 5 minutes earlier today.",
+    "description": "Datadog flagged the historical Pending state. Current pod state has not been re-checked since.",
+    "error": "",
+    "suspected_symptom": "Possible scheduling failure.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "kube_pod": "payments-api-7f9dd8b6c4-late1",
+    "k8s_failure_mode": "pending_pod",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/012-pending-recovered/answer.yml
+++ b/tests/synthetic/eks/012-pending-recovered/answer.yml
@@ -1,0 +1,37 @@
+root_cause_category: healthy
+required_keywords:
+  - autoscaler
+forbidden_categories:
+  - unknown
+  - resource_exhaustion
+  - infrastructure
+  - configuration_error
+optimal_trajectory:
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_node_health
+max_investigation_loops: 3
+ruling_out_keywords:
+  - not insufficient
+  - now Running
+  - no active failure
+required_queries:
+  - list_eks_pods
+  - get_eks_events
+  - get_eks_node_health
+model_response: |
+  ROOT_CAUSE: No active failure. Pod payments-api-7f9dd8b6c4-late1 was briefly Pending due to insufficient CPU on the existing nodes. The cluster autoscaler triggered a node scale-up, the pod was Scheduled onto the new node, and it has been Running and Ready for over 15 minutes. The Datadog alert fired on the historical Pending event without re-checking current state.
+  ROOT_CAUSE_CATEGORY: healthy
+
+  VALIDATED_CLAIMS:
+  - Pod payments-api-7f9dd8b6c4-late1 currently has phase=Running with container.ready=true, restart_count=0. [evidence: eks_pods]
+  - Event timeline: FailedScheduling at 10:25Z, TriggeredScaleUp by cluster-autoscaler at 10:26Z, Scheduled onto ip-10-0-1-99 at 10:28Z. [evidence: eks_events]
+  - Three nodes are now Ready, including the freshly-added ip-10-0-1-99 with ample allocatable CPU. [evidence: eks_node_health]
+  - Datadog monitors for error rate and latency are OK. [evidence: datadog_monitors]
+
+  NON_VALIDATED_CLAIMS:
+  - The transient scheduling pressure may recur if traffic spikes regularly without pre-warmed capacity; rightsizing or PDB review could be considered.
+  - The Datadog alert rule could re-evaluate against current pod phase to suppress this class of stale alert.
+
+  CAUSAL_CHAIN:
+  - No active causal chain. A pod was briefly Pending; the cluster autoscaler resolved it; the pod has been healthy since. The alert reflects a historical state that has already been resolved.

--- a/tests/synthetic/eks/012-pending-recovered/answer.yml
+++ b/tests/synthetic/eks/012-pending-recovered/answer.yml
@@ -25,7 +25,8 @@ model_response: |
 
   VALIDATED_CLAIMS:
   - Pod payments-api-7f9dd8b6c4-late1 currently has phase=Running with container.ready=true, restart_count=0. [evidence: eks_pods]
-  - Event timeline: FailedScheduling at 10:25Z, TriggeredScaleUp by cluster-autoscaler at 10:26Z, Scheduled onto ip-10-0-1-99 at 10:28Z. [evidence: eks_events]
+  - The only Warning event present is the historical FailedScheduling at 10:25Z on the late1 pod. [evidence: eks_events]
+  - Control-plane logs show the cluster autoscaler triggered a node scale-up at 10:26Z and the pod was successfully Scheduled onto ip-10-0-1-99 at 10:28Z. [evidence: datadog_logs]
   - Three nodes are now Ready, including the freshly-added ip-10-0-1-99 with ample allocatable CPU. [evidence: eks_node_health]
   - Datadog monitors for error rate and latency are OK. [evidence: datadog_monitors]
 

--- a/tests/synthetic/eks/012-pending-recovered/datadog_logs.json
+++ b/tests/synthetic/eks/012-pending-recovered/datadog_logs.json
@@ -1,0 +1,28 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:26:00Z",
+      "message": "[cluster-autoscaler] Triggered scale-up of node group eks-payments-prod-nodegroup-default from 2 to 3 (resolving Pending pod payments-api-7f9dd8b6c4-late1)",
+      "status": "info",
+      "service": "cluster-autoscaler",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_cluster:payments-prod-eks"]
+    },
+    {
+      "timestamp": "2026-04-18T10:28:25Z",
+      "message": "[scheduler] Successfully assigned payments/payments-api-7f9dd8b6c4-late1 to ip-10-0-1-99.us-east-1.compute.internal (Pending state resolved)",
+      "status": "info",
+      "service": "scheduler",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_pod:payments-api-7f9dd8b6c4-late1"]
+    },
+    {
+      "timestamp": "2026-04-18T10:30:00Z",
+      "message": "[payments-api] startup complete, listening on :8080 — handled by payments-api-7f9dd8b6c4-late1",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-late1",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/012-pending-recovered/eks_events.json
+++ b/tests/synthetic/eks/012-pending-recovered/eks_events.json
@@ -1,0 +1,34 @@
+{
+  "warning_events": [
+    {
+      "namespace": "payments",
+      "reason": "FailedScheduling",
+      "message": "0/2 nodes are available: 2 Insufficient cpu",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-late1",
+      "first_time": "2026-04-18T10:25:10Z",
+      "last_time": "2026-04-18T10:25:10Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "TriggeredScaleUp",
+      "message": "pod triggered cluster-autoscaler scale-up: [{eks-payments-prod-nodegroup-default 2->3 (max: 5)}]",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-late1",
+      "first_time": "2026-04-18T10:26:00Z",
+      "last_time": "2026-04-18T10:26:00Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "Scheduled",
+      "message": "Successfully assigned payments/payments-api-7f9dd8b6c4-late1 to ip-10-0-1-99.us-east-1.compute.internal",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-late1",
+      "first_time": "2026-04-18T10:28:25Z",
+      "last_time": "2026-04-18T10:28:25Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/012-pending-recovered/eks_events.json
+++ b/tests/synthetic/eks/012-pending-recovered/eks_events.json
@@ -3,32 +3,12 @@
     {
       "namespace": "payments",
       "reason": "FailedScheduling",
-      "message": "0/2 nodes are available: 2 Insufficient cpu",
+      "message": "0/2 nodes are available: 2 Insufficient cpu (cluster autoscaler subsequently added a node; pod is now Running — see datadog_logs)",
       "type": "Warning",
       "count": 1,
       "involved_object": "Pod/payments-api-7f9dd8b6c4-late1",
       "first_time": "2026-04-18T10:25:10Z",
       "last_time": "2026-04-18T10:25:10Z"
-    },
-    {
-      "namespace": "payments",
-      "reason": "TriggeredScaleUp",
-      "message": "pod triggered cluster-autoscaler scale-up: [{eks-payments-prod-nodegroup-default 2->3 (max: 5)}]",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Pod/payments-api-7f9dd8b6c4-late1",
-      "first_time": "2026-04-18T10:26:00Z",
-      "last_time": "2026-04-18T10:26:00Z"
-    },
-    {
-      "namespace": "payments",
-      "reason": "Scheduled",
-      "message": "Successfully assigned payments/payments-api-7f9dd8b6c4-late1 to ip-10-0-1-99.us-east-1.compute.internal",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Pod/payments-api-7f9dd8b6c4-late1",
-      "first_time": "2026-04-18T10:28:25Z",
-      "last_time": "2026-04-18T10:28:25Z"
     }
   ]
 }

--- a/tests/synthetic/eks/012-pending-recovered/eks_node_health.json
+++ b/tests/synthetic/eks/012-pending-recovered/eks_node_health.json
@@ -1,0 +1,43 @@
+{
+  "nodes": [
+    {
+      "name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.42",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "200m",
+      "allocatable_memory": "2Gi",
+      "instance_type": "m5.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.73",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "200m",
+      "allocatable_memory": "2Gi",
+      "instance_type": "m5.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-99.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.99",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    }
+  ]
+}

--- a/tests/synthetic/eks/012-pending-recovered/eks_pods.json
+++ b/tests/synthetic/eks/012-pending-recovered/eks_pods.json
@@ -1,0 +1,52 @@
+{
+  "pods": [
+    {
+      "name": "payments-api-7f9dd8b6c4-late1",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-99.us-east-1.compute.internal",
+      "start_time": "2026-04-18T10:28:30Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-18T10:28:38Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-x7gr9",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:11Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:19Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    },
+    {
+      "name": "payments-api-7f9dd8b6c4-k2m4p",
+      "namespace": "payments",
+      "phase": "Running",
+      "node_name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "start_time": "2026-04-13T14:02:14Z",
+      "containers": [
+        {"name": "payments-api", "ready": true, "restart_count": 0, "state": {"running": true, "started_at": "2026-04-13T14:02:22Z"}}
+      ],
+      "conditions": [
+        {"type": "Initialized", "status": "True", "reason": "", "message": ""},
+        {"type": "Ready", "status": "True", "reason": "", "message": ""},
+        {"type": "ContainersReady", "status": "True", "reason": "", "message": ""},
+        {"type": "PodScheduled", "status": "True", "reason": "", "message": ""}
+      ]
+    }
+  ]
+}

--- a/tests/synthetic/eks/012-pending-recovered/scenario.yml
+++ b/tests/synthetic/eks/012-pending-recovered/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 012-pending-recovered
+failure_mode: healthy
+severity: warning
+scenario_difficulty: 2
+adversarial_signals:
+  - failed_scheduling_in_history
+  - autoscaler_resolved
+  - pod_now_running_alert_stale
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors

--- a/tests/synthetic/eks/013-spurious-alert-storm/alert.json
+++ b/tests/synthetic/eks/013-spurious-alert-storm/alert.json
@@ -1,0 +1,26 @@
+{
+  "title": "[synthetic-k8s] Multiple warning events — payments-prod-eks",
+  "state": "alerting",
+  "alert_source": "datadog",
+  "commonLabels": {
+    "alertname": "KubernetesWarningEventBurst",
+    "severity": "critical",
+    "pipeline_name": "k8s-eks-synthetic",
+    "service": "payments-api",
+    "cluster_name": "payments-prod-eks",
+    "namespace": "payments",
+    "workload_type": "deployment",
+    "workload_name": "payments-api"
+  },
+  "commonAnnotations": {
+    "summary": "Multiple Kubernetes warning events fired in the last 30 minutes (NodeNotReady, BackOff, Unhealthy).",
+    "description": "Datadog burst detector flagged a sudden cluster of warning events in the payments namespace.",
+    "error": "",
+    "suspected_symptom": "Possible major cluster incident.",
+    "cluster_name": "payments-prod-eks",
+    "kube_namespace": "payments",
+    "kube_deployment": "payments-api",
+    "k8s_failure_mode": "node_not_ready",
+    "context_sources": "eks,datadog"
+  }
+}

--- a/tests/synthetic/eks/013-spurious-alert-storm/answer.yml
+++ b/tests/synthetic/eks/013-spurious-alert-storm/answer.yml
@@ -1,0 +1,38 @@
+root_cause_category: healthy
+required_keywords:
+  - flap
+  - recovered
+forbidden_categories:
+  - unknown
+  - infrastructure
+  - resource_exhaustion
+  - configuration_error
+optimal_trajectory:
+  - get_eks_node_health
+  - get_eks_events
+  - list_eks_pods
+max_investigation_loops: 3
+ruling_out_keywords:
+  - transient
+  - not a real failure
+  - currently Ready
+required_queries:
+  - get_eks_node_health
+  - get_eks_events
+  - list_eks_pods
+model_response: |
+  ROOT_CAUSE: No active failure. Node ip-10-0-1-73 experienced a brief NotReady flap (~30 seconds) about 25 minutes ago. During the flap window kubelet emitted a burst of secondary warning events (BackOff and Unhealthy on pods running on that node) which Datadog's burst detector aggregated into a single alert. The node has been Ready continuously since recovery, all pods are Running and Ready, and Datadog monitors are OK.
+  ROOT_CAUSE_CATEGORY: healthy
+
+  VALIDATED_CLAIMS:
+  - Both nodes are currently Ready=True with no pressure conditions. [evidence: eks_node_health]
+  - All 3 pods of payments-api are Running and Ready with restart_count=0. [evidence: eks_pods]
+  - Event timeline: NodeNotReady on ip-10-0-1-73 at 10:25:00Z, NodeReady on the same node at 10:25:30Z, with several BackOff/Unhealthy events on pods scheduled to that node clustered in the same 30-second window. No events since 10:26:00Z. [evidence: eks_events]
+  - Datadog monitors for error rate, latency, and pod restarts are all OK. [evidence: datadog_monitors]
+
+  NON_VALIDATED_CLAIMS:
+  - The flap was likely caused by a transient kubelet-to-control-plane network blip; underlying infrastructure metrics would need to be checked to confirm.
+  - The Datadog burst detector could be tuned to require sustained event activity rather than a single short window to suppress this class of false alert.
+
+  CAUSAL_CHAIN:
+  - No active failure causal chain. A 30-second node flap caused kubelet to emit a burst of secondary warnings during the unreachable window; the node and all pods recovered automatically; the burst detector aggregated those secondary events into one alert that does not reflect any current failure.

--- a/tests/synthetic/eks/013-spurious-alert-storm/answer.yml
+++ b/tests/synthetic/eks/013-spurious-alert-storm/answer.yml
@@ -27,7 +27,8 @@ model_response: |
   VALIDATED_CLAIMS:
   - Both nodes are currently Ready=True with no pressure conditions. [evidence: eks_node_health]
   - All 3 pods of payments-api are Running and Ready with restart_count=0. [evidence: eks_pods]
-  - Event timeline: NodeNotReady on ip-10-0-1-73 at 10:25:00Z, NodeReady on the same node at 10:25:30Z, with several BackOff/Unhealthy events on pods scheduled to that node clustered in the same 30-second window. No events since 10:26:00Z. [evidence: eks_events]
+  - Warning events present: NodeNotReady on ip-10-0-1-73 at 10:25:00Z plus a cluster of BackOff and Unhealthy events on pods scheduled to that node, all timestamped within the 30-second flap window (10:25:05Z–10:25:28Z). No Warning events since. [evidence: eks_events]
+  - Node-controller logs confirm the node recovered to Ready at 10:25:30Z and pods returned to Ready post-flap. [evidence: datadog_logs]
   - Datadog monitors for error rate, latency, and pod restarts are all OK. [evidence: datadog_monitors]
 
   NON_VALIDATED_CLAIMS:

--- a/tests/synthetic/eks/013-spurious-alert-storm/datadog_logs.json
+++ b/tests/synthetic/eks/013-spurious-alert-storm/datadog_logs.json
@@ -1,0 +1,28 @@
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-18T10:25:30Z",
+      "message": "[node-controller] Node ip-10-0-1-73.us-east-1.compute.internal recovered: status now Ready after 30s NotReady flap; kubelet heartbeat restored",
+      "status": "info",
+      "service": "node-controller",
+      "host": "payments-prod-eks-control-plane",
+      "tags": ["kube_node:ip-10-0-1-73.us-east-1.compute.internal"]
+    },
+    {
+      "timestamp": "2026-04-18T10:26:00Z",
+      "message": "[kubelet] All payments-api pods on ip-10-0-1-73 returned to Ready state (post-flap reconciliation)",
+      "status": "info",
+      "service": "kubelet",
+      "host": "ip-10-0-1-73.us-east-1.compute.internal",
+      "tags": ["kube_namespace:payments"]
+    },
+    {
+      "timestamp": "2026-04-18T10:40:00Z",
+      "message": "[payments-api] POST /api/v1/charge 200 68ms — sustained normal traffic, no errors observed since flap recovery",
+      "status": "info",
+      "service": "payments-api",
+      "host": "payments-api-7f9dd8b6c4-k2m4p",
+      "tags": ["env:prod", "service:payments-api"]
+    }
+  ]
+}

--- a/tests/synthetic/eks/013-spurious-alert-storm/eks_events.json
+++ b/tests/synthetic/eks/013-spurious-alert-storm/eks_events.json
@@ -1,0 +1,44 @@
+{
+  "warning_events": [
+    {
+      "namespace": "default",
+      "reason": "NodeNotReady",
+      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeNotReady",
+      "type": "Warning",
+      "count": 1,
+      "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
+      "first_time": "2026-04-18T10:25:00Z",
+      "last_time": "2026-04-18T10:25:00Z"
+    },
+    {
+      "namespace": "default",
+      "reason": "NodeReady",
+      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeReady (recovered after 30s)",
+      "type": "Normal",
+      "count": 1,
+      "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
+      "first_time": "2026-04-18T10:25:30Z",
+      "last_time": "2026-04-18T10:25:30Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-7f9dd8b6c4-k2m4p (transient kubelet flap)",
+      "type": "Warning",
+      "count": 2,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-k2m4p",
+      "first_time": "2026-04-18T10:25:05Z",
+      "last_time": "2026-04-18T10:25:25Z"
+    },
+    {
+      "namespace": "payments",
+      "reason": "Unhealthy",
+      "message": "Liveness probe failed: dial tcp 10.0.1.73:8080: connect: connection refused (during node flap window)",
+      "type": "Warning",
+      "count": 3,
+      "involved_object": "Pod/payments-api-7f9dd8b6c4-k2m4p",
+      "first_time": "2026-04-18T10:25:08Z",
+      "last_time": "2026-04-18T10:25:28Z"
+    }
+  ]
+}

--- a/tests/synthetic/eks/013-spurious-alert-storm/eks_events.json
+++ b/tests/synthetic/eks/013-spurious-alert-storm/eks_events.json
@@ -3,7 +3,7 @@
     {
       "namespace": "default",
       "reason": "NodeNotReady",
-      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeNotReady",
+      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeNotReady (recovered after 30s — see datadog_logs)",
       "type": "Warning",
       "count": 1,
       "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
@@ -11,19 +11,9 @@
       "last_time": "2026-04-18T10:25:00Z"
     },
     {
-      "namespace": "default",
-      "reason": "NodeReady",
-      "message": "Node ip-10-0-1-73.us-east-1.compute.internal status is now: NodeReady (recovered after 30s)",
-      "type": "Normal",
-      "count": 1,
-      "involved_object": "Node/ip-10-0-1-73.us-east-1.compute.internal",
-      "first_time": "2026-04-18T10:25:30Z",
-      "last_time": "2026-04-18T10:25:30Z"
-    },
-    {
       "namespace": "payments",
       "reason": "BackOff",
-      "message": "Back-off restarting failed container payments-api in pod payments-api-7f9dd8b6c4-k2m4p (transient kubelet flap)",
+      "message": "Back-off restarting failed container payments-api in pod payments-api-7f9dd8b6c4-k2m4p (transient kubelet flap during 30s node NotReady window)",
       "type": "Warning",
       "count": 2,
       "involved_object": "Pod/payments-api-7f9dd8b6c4-k2m4p",
@@ -33,7 +23,7 @@
     {
       "namespace": "payments",
       "reason": "Unhealthy",
-      "message": "Liveness probe failed: dial tcp 10.0.1.73:8080: connect: connection refused (during node flap window)",
+      "message": "Liveness probe failed: dial tcp 10.0.1.73:8080: connect: connection refused (during node flap window; recovered)",
       "type": "Warning",
       "count": 3,
       "involved_object": "Pod/payments-api-7f9dd8b6c4-k2m4p",

--- a/tests/synthetic/eks/013-spurious-alert-storm/eks_node_health.json
+++ b/tests/synthetic/eks/013-spurious-alert-storm/eks_node_health.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "name": "ip-10-0-1-42.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.42",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    },
+    {
+      "name": "ip-10-0-1-73.us-east-1.compute.internal",
+      "internal_ip": "10.0.1.73",
+      "ready": "True",
+      "memory_pressure": "False",
+      "disk_pressure": "False",
+      "pid_pressure": "False",
+      "capacity_cpu": "4",
+      "capacity_memory": "16Gi",
+      "allocatable_cpu": "3500m",
+      "allocatable_memory": "14Gi",
+      "instance_type": "m5.xlarge"
+    }
+  ]
+}

--- a/tests/synthetic/eks/013-spurious-alert-storm/scenario.yml
+++ b/tests/synthetic/eks/013-spurious-alert-storm/scenario.yml
@@ -1,0 +1,16 @@
+base: 000-healthy
+scenario_id: 013-spurious-alert-storm
+failure_mode: healthy
+severity: critical
+scenario_difficulty: 3
+adversarial_signals:
+  - many_warning_events_in_window
+  - all_traceable_to_one_node_flap
+  - everything_currently_healthy
+available_evidence:
+  - eks_pods
+  - eks_events
+  - eks_deployments
+  - eks_node_health
+  - datadog_logs
+  - datadog_monitors


### PR DESCRIPTION
## Summary
- Adds 5 noise/false-positive scenarios to the EKS synthetic suite. Each one looks like a real failure on the surface but the cluster is actually healthy — the agent should NOT diagnose a problem.
- Brings EKS noise coverage closer to RDS Postgres (which already has 5).

## The 5 scenarios

| # | Scenario | The trap |
|---|---|---|
| 009 | noisy-healthy-restart-recovered | One pod restarted an hour ago - currently fine |
| 010 | red-herring-old-rollout | Old pod being torn down looks broken - new pods are healthy |
| 011 | recovered-rollout | A bad rollout already auto-rolled back - deployment is stable |
| 012 | pending-recovered | A pod was Pending - autoscaler added a node, now Running |
| 013 | spurious-alert-storm | A 30-second node flap caused many warnings - all recovered |

## Real-LLM scoring (mock backends)
**5/5 pass** on the latest evidence state.

Note: 011 and 013 were initially flaky — the agent returned `unknown` / `infrastructure` on some runs. Mirroring critical recovery context into `datadog_logs` (the diagnose step weights Datadog evidence more heavily than EKS events for confident classification) got both to consistently pass.

The underlying behaviour is still worth tightening: the diagnose prompt in `app/nodes/root_cause_diagnosis/prompt_builder.py` could weight current-state signals above historical Warning events more aggressively. Happy to follow up in a separate PR.

## What's in each scenario folder
- `scenario.yml` - base inheritance from `000-healthy` + adversarial signal metadata
- `alert.json` - symptom-level alert (e.g. KubernetesPodCrashLooping)
- `answer.yml` - expected category `healthy`, with negative-evidence rule-outs (e.g. "not OOM", "not insufficient")
- 1–3 evidence file overrides showing the noise (everything else inherits from `000-healthy`)
- `eks_events.json` is kept strictly Warning-typed; recovery context lives in `datadog_logs`

## Test plan
- [x] `pytest tests/synthetic/eks/` - all 14 scenarios load
- [x] Real-LLM run - 5/5 pass
- [ ] Reviewer can re-run scoring to verify