### PR TITLE
fix: use typing_extensions.TypedDict for Python 3.11 / Pydantic 2 compatibility

### DIFF
--- a/app/nodes/investigate/types.py
+++ b/app/nodes/investigate/types.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import Any
+
+from typing_extensions import TypedDict
 
 
 class PlanAudit(TypedDict, total=False):


### PR DESCRIPTION
Fixes #

<!-- New issue; see below for full root cause + repro -->

#### Describe the changes you have made in this PR -

## Problem

Running `opensre investigate` on Python 3.11 with Pydantic 2 crashes the moment the investigate loop touches the TypedDicts defined in `app/nodes/investigate/types.py`. The traceback terminates in `pydantic.errors.PydanticUserError` pointing at `typing.TypedDict`.

Reproduction (fresh venv, Python 3.11.x):

```
python3.11 -m venv .venv && source .venv/bin/activate
pip install -e .
opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
```

The process exits before any tool is planned.

## Root Cause

Pydantic 2 requires `typing_extensions.TypedDict` on Python < 3.12 in order to correctly validate TypedDict-based function signatures (see [pydantic/pydantic#8171](https://github.com/pydantic/pydantic/issues/8171)). The stdlib `typing.TypedDict` on 3.11 is missing the `__pydantic_config__` hook Pydantic needs; validation therefore raises a `PydanticUserError` instead of accepting the TypedDict.

`app/nodes/investigate/types.py` was importing `TypedDict` from `typing`, tripping this exact failure as soon as `PlanAudit` / `ExecutedHypothesis` are referenced downstream.

## Fix

Import `TypedDict` from `typing_extensions` instead of `typing`. `Any` stays on the stdlib import since it is unaffected. `typing_extensions` is already transitively pulled in by `pydantic`, so no new dependency is introduced and no `pyproject.toml` change is required.

## Test Plan

- `python -m py_compile app/nodes/investigate/types.py` — clean.
- `opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json` on Python 3.11 — no longer crashes at load; investigate loop proceeds.
- Suggested regression: add this import to any module touched by the existing type-annotation tests so CI picks up drift on Python 3.12+.

## Risk / Backward Compatibility

None. On every supported interpreter (3.11+), `typing_extensions.TypedDict` is a drop-in superset of `typing.TypedDict` and is what Pydantic 2 documents as required. Runtime behaviour for non-Pydantic consumers of these TypedDicts is unchanged.

## Related

Standalone fix — merges independently of the companion EKS PRs:
- fix(eks): detect EKS source when AWS integration uses IAM user credentials
- fix(eks): support ambient AWS credentials in build_k8s_clients

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**Explain your implementation approach:**

The investigate loop was crashing on Python 3.11 with a Pydantic TypedDict validation error. I traced it to `app/nodes/investigate/types.py` re-exporting the stdlib `TypedDict`, which Pydantic 2 explicitly requires to come from `typing_extensions` on interpreters before 3.12. The change is a one-line import swap; I kept `Any` on the stdlib `typing` import because it is unaffected.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
