### PR TITLE
fix: hide unimplemented DataDogMetricsTool stub from planner

### DIFF
--- a/app/tools/DataDogMetricsTool/__init__.py
+++ b/app/tools/DataDogMetricsTool/__init__.py
@@ -7,8 +7,11 @@ from typing import Any
 from app.tools.tool_decorator import tool
 
 
-def _metrics_is_available(sources: dict[str, dict]) -> bool:
-    return bool(sources.get("datadog", {}).get("connection_verified"))
+def _metrics_is_available(_sources: dict[str, dict]) -> bool:
+    # Hidden from the planner until the Metrics API v2 implementation lands (see #669).
+    # Flip back to `bool(sources.get("datadog", {}).get("connection_verified"))` once
+    # the stub body below is replaced with a real request.
+    return False
 
 
 def _metrics_extract_params(sources: dict[str, dict]) -> dict[str, Any]:

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -11,9 +11,13 @@ class TestDataDogMetricsToolContract(BaseToolContract):
         return query_datadog_metrics.__opensre_registered_tool__
 
 
-def test_is_available_requires_connection_verified() -> None:
+def test_is_available_returns_false_until_implemented() -> None:
+    # Stub is hidden from the planner (see issue #669) so that the LLM never
+    # burns a tool-call budget slot on a tool that always returns a "not yet
+    # implemented" error.  Flip this expectation back to the connection_verified
+    # gate once the Metrics API v2 body is in place.
     rt = query_datadog_metrics.__opensre_registered_tool__
-    assert rt.is_available({"datadog": {"connection_verified": True}}) is True
+    assert rt.is_available({"datadog": {"connection_verified": True}}) is False
     assert rt.is_available({"datadog": {}}) is False
     assert rt.is_available({}) is False
 


### PR DESCRIPTION
## Summary

- `query_datadog_metrics` is a stub that always returns `"DataDogMetricsTool is not yet implemented."` but was registered to the investigation surface with an `is_available` gate that returned `True` whenever Datadog was configured. The planner LLM therefore kept picking it for CPU/memory/throughput investigations and burning a tool-call budget slot on an error response.
- Flip `_metrics_is_available` to hard-`False` so the planner doesn't see it. Decorator, schema, and tests stay in place so the follow-up Metrics-API-v2 implementation only needs to swap the body and revert this one gate.
- Updates the existing test that asserted the (buggy) `connection_verified → True` expectation.

Fixes #669.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] `pytest tests/tools/test_datadog_metrics_tool.py` — 10 passed
- [x] Reproduction from the issue now prints `in planner toolbox? False`