### PR TITLE
fix: recognise grafana_alert_rules in check_evidence_availability (#684)

### DIFF
--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -59,6 +59,7 @@ def check_evidence_availability(
         or evidence.get("grafana_error_logs") is not None
         or evidence.get("grafana_traces") is not None
         or evidence.get("grafana_metrics") is not None
+        or evidence.get("grafana_alert_rules") is not None
         or evidence.get("datadog_logs") is not None
         or evidence.get("datadog_monitors") is not None
         or evidence.get("datadog_events") is not None


### PR DESCRIPTION
## Summary
- Adds `grafana_alert_rules` to the `has_cloudwatch_evidence` OR-chain in `check_evidence_availability` so it matches `_INVESTIGATED_EVIDENCE_KEYS`.
- Closes #684.

## Context
Same drift-bug class as commit 3dbfb521 (EKS keys) and open PR #672 (Alertmanager / Coralogix / Honeycomb keys): the key is in the frozenset and emitted by `_map_grafana_alert_rules`, but the OR-chain guard was not updated in lockstep. A healthy Grafana alert whose only evidence is `grafana_alert_rules` fell through to `_handle_insufficient_evidence` instead of satisfying the evidence gate.

## Test plan
- [x] `pytest tests/nodes/root_cause_diagnosis/test_evidence_checker.py` — 22 passed
- [x] `ruff check app/nodes/root_cause_diagnosis/evidence_checker.py` — clean
- [x] `mypy app/nodes/root_cause_diagnosis/evidence_checker.py` — clean