### PR TITLE
docs: sort integrations in alphabetical order in local and enterprise group

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,37 +43,37 @@
             "group": "Enterprise",
             "defaultOpen": true,
             "pages": [
+              "aws",
               "datadog",
               "grafana",
-              "slack",
-              "aws"
+              "slack"
             ]
           },
           {
             "group": "Local",
             "defaultOpen": true,
             "pages": [
-              "mongodb",
-              "mariadb",
-              "honeycomb",
+              "alertmanager",
+              "bitbucket",
+              "clickhouse",
               "coralogix",
-              "sentry",
+              "discord",
               "github",
               "gitlab",
-              "bitbucket",
-              "vercel",
-              "kafka",
-              "rabbitmq",
-              "clickhouse",
-              "alertmanager",
-              "opsgenie",
-              "jira",
-              "prefect",
               "google-docs",
-              "discord",
+              "honeycomb",
+              "jira",
+              "kafka",
+              "mariadb",
+              "mongodb",
               "mysql",
               "openclaw",
-              "postgresql"
+              "opsgenie",
+              "postgresql",
+              "prefect",
+              "rabbitmq",
+              "sentry",
+              "vercel"
             ]
           }
         ]


### PR DESCRIPTION
Fixes #680 

## Summary

  Sorted the integration entries under both the **Enterprise** and **Local** sidebar groups in `docs/docs.json` in alphabetical order, as requested in the issue.

  - Enterprise: aws, datadog, grafana, slack
  - Local: alertmanager, bitbucket, clickhouse, coralogix, discord, github, gitlab, google-docs, honeycomb, jira, kafka, mariadb, mongodb, mysql, openclaw, opsgenie, postgresql, prefect, rabbitmq, sentry, vercel

<img width="165" height="682" alt="image" src="https://github.com/user-attachments/assets/7481a170-a9fd-44d3-a519-fd2ed2feda6a" />
