### PR TITLE
feat(tests): Chaos Mesh lab via Make and tests/chaos_engineering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert verify-integrations check-docker check-langgraph check-langsmith-api-key grafana-local-up grafana-local-down grafana-local-seed langgraph-build langgraph-deploy clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-langsmith destroy-langsmith test-langsmith deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock
+.PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert verify-integrations check-docker check-langgraph check-langsmith-api-key grafana-local-up grafana-local-down grafana-local-seed langgraph-build langgraph-deploy clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-langsmith destroy-langsmith test-langsmith deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock
 
 ifneq ($(wildcard .venv/bin/python),)
 PYTHON = .venv/bin/python
@@ -128,6 +128,59 @@ test-k8s:
 # Run Kubernetes + Datadog test (kind + DD Agent)
 test-k8s-datadog:
 	$(PYTHON) -m tests.e2e.kubernetes.test_datadog
+
+# Chaos Mesh on the kube context (default: kind-tracer-k8s-test). Override: make chaos-mesh-up KUBECTL_CONTEXT=...
+# CHAOS_MESH_RUNTIME=containerd matches kind; use docker only on older clusters.
+CHAOS_MESH_NS ?= chaos-mesh
+KUBECTL_CONTEXT ?= kind-tracer-k8s-test
+CHAOS_MESH_RUNTIME ?= containerd
+HELM_KUBE := $(if $(KUBECTL_CONTEXT),--kube-context $(KUBECTL_CONTEXT),)
+KUBECTL_FLAGS := $(if $(KUBECTL_CONTEXT),--context=$(KUBECTL_CONTEXT),)
+
+chaos-mesh-up:
+	@helm repo list 2>/dev/null | grep -q '^chaos-mesh' || helm repo add chaos-mesh https://charts.chaos-mesh.org
+	helm repo update
+	kubectl create namespace $(CHAOS_MESH_NS) --dry-run=client -o yaml | kubectl apply -f - $(KUBECTL_FLAGS)
+	helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh -n $(CHAOS_MESH_NS) \
+		--set chaosDaemon.runtime=$(CHAOS_MESH_RUNTIME) \
+		$(HELM_KUBE)
+
+chaos-mesh-down:
+	-helm uninstall chaos-mesh -n $(CHAOS_MESH_NS) $(HELM_KUBE)
+	-kubectl delete namespace $(CHAOS_MESH_NS) $(KUBECTL_FLAGS)
+
+# Apply chaos-engineering manifests on KUBECTL_CONTEXT (nginx target, CrashLoop deployment, PodChaos).
+# Requires Chaos Mesh CRDs for pod-kill-demo.yaml (run make chaos-mesh-up first).
+chaos-engineering-apply:
+	kubectl apply -f tests/chaos_engineering/chaos-demo.yaml $(KUBECTL_FLAGS)
+	kubectl apply -f tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml $(KUBECTL_FLAGS)
+	kubectl apply -f tests/chaos_engineering/pod-kill-demo.yaml $(KUBECTL_FLAGS)
+
+chaos-engineering-delete:
+	-kubectl delete -f tests/chaos_engineering/pod-kill-demo.yaml $(KUBECTL_FLAGS)
+	-kubectl delete -f tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml $(KUBECTL_FLAGS)
+	-kubectl delete -f tests/chaos_engineering/chaos-demo.yaml $(KUBECTL_FLAGS)
+
+# Full chaos lab: kind + Datadog + Chaos Mesh + baseline workloads (same defaults as README).
+# Optional flags: CHAOS_LAB_FLAGS='--skip-kind' '--skip-datadog' '--no-wait-datadog' etc.
+chaos-lab-up:
+	$(PYTHON) -m tests.chaos_engineering lab up $(CHAOS_LAB_FLAGS)
+
+# Tear down lab (baseline, Chaos Mesh, Datadog namespace, kind cluster). Optional: CHAOS_LAB_DOWN_FLAGS='--keep-kind' '--keep-datadog'
+chaos-lab-down:
+	$(PYTHON) -m tests.chaos_engineering lab down $(CHAOS_LAB_DOWN_FLAGS)
+
+chaos-experiment-list:
+	$(PYTHON) -m tests.chaos_engineering experiment list
+
+# Apply experiments/<EXPERIMENT>/ (*-demo.yaml then *-chaos.yaml). Example: make chaos-experiment-up EXPERIMENT=pod-failure
+chaos-experiment-up:
+	@test -n "$(EXPERIMENT)" || (echo "Set EXPERIMENT=name (see: make chaos-experiment-list)" && false)
+	$(PYTHON) -m tests.chaos_engineering experiment apply $(EXPERIMENT)
+
+chaos-experiment-down:
+	@test -n "$(EXPERIMENT)" || (echo "Set EXPERIMENT=name (see: make chaos-experiment-list)" && false)
+	$(PYTHON) -m tests.chaos_engineering experiment delete $(EXPERIMENT)
 
 # Deploy Datadog monitors (requires DD_API_KEY + DD_APP_KEY)
 deploy-dd-monitors:
@@ -388,6 +441,12 @@ help:
 	@echo "  make test-k8s-local  - Run Kubernetes local test (kind)"
 	@echo "  make test-k8s        - Run Kubernetes test (matches CI)"
 	@echo "  make test-k8s-datadog - Run Kubernetes + Datadog test"
+	@echo "  make chaos-mesh-up - Install Chaos Mesh (Helm; default context kind-tracer-k8s-test)"
+	@echo "  make chaos-mesh-down - Uninstall Chaos Mesh + namespace"
+	@echo "  make chaos-engineering-apply - Apply chaos-demo + crashloop + PodChaos (same context)"
+	@echo "  make chaos-engineering-delete - Remove those workloads (PodChaos first)"
+	@echo "  make chaos-lab-up / chaos-lab-down - Full lab (kind+DD+mesh+baseline; runs python -m tests.chaos_engineering)"
+	@echo "  make chaos-experiment-list / chaos-experiment-up EXPERIMENT=... - Per-experiment apply"
 	@echo "  make deploy-dd-monitors - Deploy Datadog monitors (DD_API_KEY + DD_APP_KEY)"
 	@echo "  make cleanup-dd-monitors - Remove Datadog test monitors"
 	@echo "  make deploy-eks      - Deploy EKS cluster + ECR image"

--- a/tests/chaos_engineering/README.md
+++ b/tests/chaos_engineering/README.md
@@ -1,0 +1,113 @@
+# Chaos engineering + Datadog (kind)
+
+**Defaults:** cluster `tracer-k8s-test` · context `kind-tracer-k8s-test` · Datadog Helm namespace `tracer-test`.
+
+This directory holds Kubernetes manifests (`chaos-demo.yaml`, `pod-kill-demo.yaml`, `experiments/<name>/`), JSON samples for `opensre investigate -i`, and the Python helpers behind **`make chaos-lab-*`** / **`make chaos-experiment-*`** (`python -m tests.chaos_engineering`). Alert paths in JSON use the repo-relative form `tests/chaos_engineering/experiments/.../foo-alert.json`.
+
+## Quick start (recommended)
+
+From **repo root**: Docker, `kind`, `kubectl`, `helm`, and a venv with the repo installed (`pip install -e ".[dev]"`).
+
+```bash
+export DD_API_KEY='your-api-key'   # omit if using CHAOS_LAB_FLAGS=--skip-datadog
+# export KUBECTL_CONTEXT=kind-tracer-k8s-test   # optional
+
+make chaos-lab-up
+
+make chaos-experiment-list
+make chaos-experiment-up EXPERIMENT=pod-failure
+make chaos-experiment-down EXPERIMENT=pod-failure
+
+make chaos-lab-down
+```
+
+**Flags (via Make):** `CHAOS_LAB_FLAGS='--skip-datadog'`, `'--skip-kind'`, `'--no-wait-datadog'`. **Teardown:** `CHAOS_LAB_DOWN_FLAGS='--keep-kind'` or `'--keep-datadog'`.
+
+**Debugging (same as Make):** `python -m tests.chaos_engineering lab up`, `experiment list`, etc.
+
+**Convention:** Each experiment uses sorted `*-demo.yaml` then `*-chaos.yaml`. On delete, chaos CRs first (`make chaos-experiment-down`).
+
+**Baselines:** `make chaos-engineering-apply` applies `chaos-demo`, crashloop workload, and `pod-kill-demo` PodChaos only. Other scenarios use `make chaos-experiment-up EXPERIMENT=<name>` or raw `kubectl` (workload before chaos; delete chaos before workload if doing it manually).
+
+**Discover experiments:** `make chaos-experiment-list` (or browse `experiments/`). Examples include network faults (`network-delay`, `network-partition`, …), `crashloop`, `pod-failure`, `stress-cpu`, `dns-error`, `http-abort`, and others.
+
+| Example directory | Chaos Mesh (illustrative) |
+| --- | --- |
+| `experiments/network-delay/` | `NetworkChaos` delay |
+| `experiments/crashloop/` | CrashLoopBackOff + optional PodChaos |
+| `experiments/pod-failure/` | `PodChaos` pod-failure (pause image) |
+| `experiments/dns-error/` | `DNSChaos` (needs Chaos DNS Server) |
+
+## Manual setup (without `make chaos-lab-up`)
+
+Use this if you want to run the same steps by hand. Sections 1–2 mirror what `chaos-lab-up` does before Chaos Mesh and baselines.
+
+### 1. Cluster
+
+```bash
+kind create cluster --name tracer-k8s-test --wait 60s
+kubectl config use-context kind-tracer-k8s-test
+```
+
+### 2. Datadog
+
+```bash
+export DD_API_KEY='your-api-key'
+# export DD_SITE=datadoghq.eu   # if not US1
+
+kubectl create namespace tracer-test --context=kind-tracer-k8s-test --dry-run=client -o yaml \
+  | kubectl apply -f - --context=kind-tracer-k8s-test
+
+helm repo add datadog https://helm.datadoghq.com
+helm repo update datadog
+
+helm upgrade --install datadog datadog/datadog \
+  --kube-context kind-tracer-k8s-test \
+  -n tracer-test \
+  -f tests/e2e/kubernetes/k8s_manifests/datadog-values.yaml \
+  --set "datadog.apiKey=${DD_API_KEY}" \
+  ${DD_SITE:+--set datadog.site=${DD_SITE}} \
+  --wait --timeout 10m
+```
+
+Confirm a node Agent exists (`kubectl get daemonset,pods -n tracer-test --context=kind-tracer-k8s-test`). If there is no agent DaemonSet, fix `datadog-values.yaml` (e.g. `datadog.operator.enabled: false`) and upgrade again.
+
+### 3. Chaos Mesh + baseline workloads
+
+```bash
+make chaos-mesh-up
+kubectl get pods -n chaos-mesh --context=kind-tracer-k8s-test
+make chaos-engineering-apply
+kubectl get pods -n default --context=kind-tracer-k8s-test
+```
+
+Optional extra PodChaos on crashloop: `make chaos-experiment-up EXPERIMENT=crashloop`, or apply `experiments/crashloop/pod-kill-crashloop-chaos.yaml` after the crashloop demo workload is up.
+
+**Pod-failure** (not part of `chaos-engineering-apply`): `make chaos-experiment-up EXPERIMENT=pod-failure`, or apply `experiments/pod-failure/*-demo.yaml` then `*-chaos.yaml`. Expect **0/1 READY** while chaos is active (pause image). Teardown: delete chaos CR first.
+
+### 4. Datadog logs
+
+After the crashloop pod runs, wait a few minutes, then query logs e.g. `kube_cluster_name:tracer-k8s-test kube_namespace:default crashloop-demo` or `kube_deployment:crashloop-demo`.
+
+### 5. OpenSRE
+
+```bash
+opensre onboard   # Datadog keys as needed
+opensre investigate -i tests/chaos_engineering/experiments/crashloop/crashloop-demo-alert.json
+```
+
+Use the matching `*-alert.json` under `experiments/<name>/` for other scenarios. Local kind is observed via Datadog (or a richer synthetic payload), not EKS APIs.
+
+## Cleanup
+
+```bash
+make chaos-engineering-delete
+make chaos-mesh-down
+helm uninstall datadog -n tracer-test --kube-context kind-tracer-k8s-test
+kubectl delete namespace tracer-test --context=kind-tracer-k8s-test
+kind delete cluster --name tracer-k8s-test
+```
+
+Or use `make chaos-lab-down` (and flags) if you brought the lab up with `chaos-lab-up`.
+
+**Make targets:** `chaos-lab-up`, `chaos-lab-down`, `chaos-experiment-list`, `chaos-experiment-up`, `chaos-experiment-down`, `chaos-mesh-up`, `chaos-mesh-down`, `chaos-engineering-apply`, `chaos-engineering-delete`. Override context with `KUBECTL_CONTEXT=...` when needed.

--- a/tests/chaos_engineering/__init__.py
+++ b/tests/chaos_engineering/__init__.py
@@ -1,0 +1,5 @@
+"""Chaos lab orchestration for Makefile targets (kind, Datadog, Chaos Mesh, experiment YAML order).
+
+Kubernetes YAML, JSON alert payloads, and ``experiments/`` live in this same package directory.
+``make chaos-lab-up`` and related targets run ``python -m tests.chaos_engineering``.
+"""

--- a/tests/chaos_engineering/__main__.py
+++ b/tests/chaos_engineering/__main__.py
@@ -1,0 +1,8 @@
+"""Makefile invokes ``python -m tests.chaos_engineering``; you normally use ``make chaos-*`` instead."""
+
+from __future__ import annotations
+
+from tests.chaos_engineering.cli import cli
+
+if __name__ == "__main__":
+    cli.main(prog_name="python -m tests.chaos_engineering")

--- a/tests/chaos_engineering/chaos-demo.yaml
+++ b/tests/chaos_engineering/chaos-demo.yaml
@@ -1,0 +1,26 @@
+# Target for PodChaos in pod-kill-demo.yaml (app=chaos-demo).
+#
+# Same cluster/context as experiments/crashloop/crashloop-demo.yaml and make chaos-mesh-up
+# (default: kind-tracer-k8s-test). Example:
+#   kubectl apply -f tests/chaos_engineering/chaos-demo.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chaos-demo
+  namespace: default
+  labels:
+    app: chaos-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chaos-demo
+  template:
+    metadata:
+      labels:
+        app: chaos-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine

--- a/tests/chaos_engineering/cli.py
+++ b/tests/chaos_engineering/cli.py
@@ -1,0 +1,143 @@
+"""Click CLI backing the Makefile chaos-* targets (``python -m tests.chaos_engineering``)."""
+
+from __future__ import annotations
+
+import os
+
+import click
+
+from tests.chaos_engineering import experiment_ops, orchestrator
+from tests.chaos_engineering.paths import (
+    KUBECTL_CONTEXT_DEFAULT,
+    ExperimentNotFoundError,
+    experiment_summary_line,
+    list_experiment_names,
+)
+
+
+def _effective_context(kube_context: str | None) -> str | None:
+    if kube_context:
+        return kube_context
+    env_ctx = os.environ.get("KUBECTL_CONTEXT", "").strip()
+    if env_ctx:
+        return env_ctx
+    return KUBECTL_CONTEXT_DEFAULT
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli() -> None:
+    """Chaos Mesh lab on kind. Prefer Make: ``make chaos-lab-up``, ``make chaos-experiment-up``, etc."""
+
+
+@cli.group("lab")
+def lab_group() -> None:
+    """Create or tear down the full lab (cluster, Datadog, Chaos Mesh, baseline workloads)."""
+
+
+@lab_group.command("up")
+@click.option(
+    "--context",
+    "kube_context",
+    default=None,
+    help="kubectl / helm kube-context (default: $KUBECTL_CONTEXT or kind-tracer-k8s-test).",
+)
+@click.option("--skip-kind", is_flag=True, help="Do not create kind cluster (reuse existing).")
+@click.option(
+    "--skip-datadog",
+    is_flag=True,
+    help="Skip Datadog Helm install (no DD_API_KEY required for lab up).",
+)
+@click.option(
+    "--chaos-runtime",
+    default="containerd",
+    show_default=True,
+    help="Chaos Daemon runtime (use containerd for modern kind).",
+)
+@click.option(
+    "--no-wait-datadog",
+    is_flag=True,
+    help="Do not wait for Datadog Agent ready (faster when skipping agent checks).",
+)
+def lab_up(
+    kube_context: str | None,
+    skip_kind: bool,
+    skip_datadog: bool,
+    chaos_runtime: str,
+    no_wait_datadog: bool,
+) -> None:
+    """Provision kind (optional), Datadog (optional), Chaos Mesh, and baseline chaos workloads."""
+    ctx = _effective_context(kube_context)
+    try:
+        orchestrator.lab_up(
+            kube_context=ctx,
+            skip_kind=skip_kind,
+            skip_datadog=skip_datadog,
+            chaos_runtime=chaos_runtime,
+            wait_datadog_agent=not no_wait_datadog,
+        )
+    except OSError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@lab_group.command("down")
+@click.option("--context", "kube_context", default=None, help="kubectl / helm kube-context.")
+@click.option("--keep-kind", is_flag=True, help="Leave kind cluster running.")
+@click.option(
+    "--keep-datadog",
+    is_flag=True,
+    help="Do not uninstall Datadog or delete tracer-test namespace.",
+)
+def lab_down(
+    kube_context: str | None,
+    keep_kind: bool,
+    keep_datadog: bool,
+) -> None:
+    """Remove baseline workloads, Chaos Mesh, Datadog (optional), and kind (optional)."""
+    ctx = _effective_context(kube_context)
+    orchestrator.lab_down(
+        kube_context=ctx,
+        skip_kind=keep_kind,
+        skip_datadog=keep_datadog,
+    )
+
+
+@cli.group("experiment")
+def experiment_group() -> None:
+    """Apply or delete manifests for one experiment under experiments/<name>/."""
+
+
+@experiment_group.command("list")
+def experiment_list() -> None:
+    """Print experiment directory names (YAML discoverable)."""
+    for name in list_experiment_names():
+        click.echo(experiment_summary_line(name))
+
+
+@experiment_group.command("apply")
+@click.argument("name")
+@click.option("--context", "kube_context", default=None, help="kubectl context.")
+def experiment_apply(name: str, kube_context: str | None) -> None:
+    """Apply *-demo.yaml then *-chaos.yaml for experiments/<name>/."""
+    ctx = _effective_context(kube_context)
+    try:
+        experiment_ops.apply_experiment(name, context=ctx)
+    except ExperimentNotFoundError as exc:
+        raise click.ClickException(
+            f"{exc}\n"
+            "Run 'make chaos-experiment-list' (or 'python -m tests.chaos_engineering experiment list')."
+        ) from exc
+
+
+@experiment_group.command("delete")
+@click.argument("name")
+@click.option("--context", "kube_context", default=None, help="kubectl context.")
+def experiment_delete(name: str, kube_context: str | None) -> None:
+    """Delete *-chaos.yaml then *-demo.yaml for experiments/<name>/."""
+    ctx = _effective_context(kube_context)
+    try:
+        experiment_ops.delete_experiment(name, context=ctx)
+    except ExperimentNotFoundError as exc:
+        raise click.ClickException(
+            f"{exc}\n"
+            "Run 'make chaos-experiment-list' (or 'python -m tests.chaos_engineering experiment list')."
+        ) from exc

--- a/tests/chaos_engineering/experiment_ops.py
+++ b/tests/chaos_engineering/experiment_ops.py
@@ -1,0 +1,26 @@
+"""Apply and delete per-experiment manifests in convention order."""
+
+from __future__ import annotations
+
+from tests.chaos_engineering import kubectl
+from tests.chaos_engineering.paths import (
+    experiment_chaos_yaml_paths,
+    experiment_demo_yaml_paths,
+    validate_experiment,
+)
+
+
+def apply_experiment(name: str, *, context: str | None) -> None:
+    validate_experiment(name)
+    for path in experiment_demo_yaml_paths(name):
+        kubectl.kubectl_apply(path, context=context)
+    for path in experiment_chaos_yaml_paths(name):
+        kubectl.kubectl_apply(path, context=context)
+
+
+def delete_experiment(name: str, *, context: str | None) -> None:
+    validate_experiment(name)
+    for path in reversed(experiment_chaos_yaml_paths(name)):
+        kubectl.kubectl_delete(path, context=context)
+    for path in reversed(experiment_demo_yaml_paths(name)):
+        kubectl.kubectl_delete(path, context=context)

--- a/tests/chaos_engineering/experiments/container-kill/container-kill-alert.json
+++ b/tests/chaos_engineering/experiments/container-kill/container-kill-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for container-kill chaos demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/container-kill/container-kill-alert.json"
+  },
+  "title": "[Triggered] Container restart storm - container-kill-demo",
+  "alert_name": "Datadog monitor: restarts container-kill-demo",
+  "pipeline_name": "container-kill-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "Container restarts on container-kill-demo",
+  "text": "PodChaos container-kill causes kubelet to restart the nginx container.",
+  "commonLabels": {
+    "pipeline_name": "container-kill-demo",
+    "severity": "warning",
+    "kube_deployment": "container-kill-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Elevated restarts on deployment container-kill-demo",
+    "query": "kube_namespace:default kube_deployment:container-kill-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "container-kill-demo",
+    "correlation_id": "container-kill-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/container-kill/container-kill-chaos.yaml
+++ b/tests/chaos_engineering/experiments/container-kill/container-kill-chaos.yaml
@@ -1,0 +1,18 @@
+# PodChaos container-kill: kills container `nginx` in matching pods once per apply.
+# Re-apply the CR or use Chaos Dashboard schedules to repeat.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: container-kill-demo
+  namespace: default
+spec:
+  action: container-kill
+  mode: all
+  containerNames:
+    - nginx
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: container-kill-demo

--- a/tests/chaos_engineering/experiments/container-kill/container-kill-demo.yaml
+++ b/tests/chaos_engineering/experiments/container-kill/container-kill-demo.yaml
@@ -1,0 +1,39 @@
+# Single-container nginx for PodChaos (action: container-kill). Kills the nginx container;
+# kubelet restarts it (unlike whole-pod pod-kill semantics).
+#
+# Prereq: `make chaos-mesh-up`.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: container-kill-demo
+  namespace: default
+  labels:
+    app: container-kill-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: container-kill-demo
+  template:
+    metadata:
+      labels:
+        app: container-kill-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/crashloop/crashloop-demo-alert.json
+++ b/tests/chaos_engineering/experiments/crashloop/crashloop-demo-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Local CrashLoopBackOff demo; pair with crashloop-demo.yaml on kind",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/crashloop/crashloop-demo-alert.json"
+  },
+  "title": "[Triggered] Pod CrashLoopBackOff - crashloop-demo",
+  "alert_name": "Datadog monitor: Pod crashloop-demo CrashLoopBackOff",
+  "pipeline_name": "crashloop-demo",
+  "severity": "critical",
+  "alert_source": "datadog",
+  "message": "Pod crashloop-demo is in CrashLoopBackOff in namespace default",
+  "text": "Container exits with code 1 immediately on every start; kubelet keeps restarting the pod.",
+  "commonLabels": {
+    "pipeline_name": "crashloop-demo",
+    "severity": "critical",
+    "kube_deployment": "crashloop-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Deployment crashloop-demo pod failing: CrashLoopBackOff",
+    "query": "kube_namespace:default pod_name:crashloop-demo*",
+    "kube_namespace": "default",
+    "kube_deployment": "crashloop-demo",
+    "correlation_id": "crashloop-demo-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml
+++ b/tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml
@@ -1,0 +1,43 @@
+# Intentional CrashLoopBackOff for observability / alert testing.
+#
+# Plain Kubernetes Deployment (not a Chaos Mesh CR). Use the same kube context as
+# chaos-demo.yaml / pod-kill-demo.yaml and `make chaos-mesh-up` (default kind-tracer-k8s-test).
+# Apply everything at once: `make chaos-engineering-apply`.
+# To also pod-kill these pods via Chaos Mesh (not nginx), apply:
+#   tests/chaos_engineering/experiments/crashloop/pod-kill-crashloop-chaos.yaml
+#
+# From repo root:
+#   kubectl apply -f tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml \
+#     --context=kind-tracer-k8s-test
+#
+# Watch until STATUS shows CrashLoopBackOff:
+#   kubectl get pods -l app=crashloop-demo -w
+#
+# Logs (repeating crash reason):
+#   kubectl logs -l app=crashloop-demo --tail=20
+#
+# Remove:
+#   kubectl delete -f tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml \
+#     --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crashloop-demo
+  namespace: default
+  labels:
+    app: crashloop-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crashloop-demo
+  template:
+    metadata:
+      labels:
+        app: crashloop-demo
+    spec:
+      containers:
+        - name: crash
+          image: busybox:1.36
+          command: ["/bin/sh", "-c", "echo 'crashloop-demo: exiting with error' && exit 1"]

--- a/tests/chaos_engineering/experiments/crashloop/pod-kill-crashloop-chaos.yaml
+++ b/tests/chaos_engineering/experiments/crashloop/pod-kill-crashloop-chaos.yaml
@@ -1,0 +1,27 @@
+# Optional PodChaos on crashloop-demo pods (app=crashloop-demo).
+# Prereq: Chaos Mesh (`make chaos-mesh-up` or `make chaos-lab-up`).
+#
+# Apply workload + chaos together:
+#   make chaos-experiment-up EXPERIMENT=crashloop
+#
+# Manual kubectl (repo root):
+#   kubectl apply -f tests/chaos_engineering/experiments/crashloop/crashloop-demo.yaml --context=kind-tracer-k8s-test
+#   kubectl apply -f tests/chaos_engineering/experiments/crashloop/pod-kill-crashloop-chaos.yaml --context=kind-tracer-k8s-test
+#
+# Teardown (chaos CR first):
+#   kubectl delete -f tests/chaos_engineering/experiments/crashloop/pod-kill-crashloop-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: kill-crashloop-demo
+  namespace: default
+spec:
+  action: pod-kill
+  mode: one
+  duration: "15s"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: crashloop-demo

--- a/tests/chaos_engineering/experiments/dns-error/dns-error-alert.json
+++ b/tests/chaos_engineering/experiments/dns-error/dns-error-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for DNSChaos error demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/dns-error/dns-error-alert.json"
+  },
+  "title": "[Triggered] DNS resolution failures - dns-error-demo",
+  "alert_name": "Datadog monitor: DNS errors from dns-error-demo",
+  "pipeline_name": "dns-error-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "Outbound DNS lookups failing from dns-error-demo",
+  "text": "DNSChaos error action; external name resolution may fail for matched domains.",
+  "commonLabels": {
+    "pipeline_name": "dns-error-demo",
+    "severity": "warning",
+    "kube_deployment": "dns-error-demo"
+  },
+  "commonAnnotations": {
+    "summary": "DNS faults affecting dns-error-demo pods",
+    "query": "kube_namespace:default kube_deployment:dns-error-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "dns-error-demo",
+    "correlation_id": "dns-error-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/dns-error/dns-error-chaos.yaml
+++ b/tests/chaos_engineering/experiments/dns-error/dns-error-chaos.yaml
@@ -1,0 +1,19 @@
+# DNSChaos: return DNS errors for matching patterns from selected pods.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: DNSChaos
+metadata:
+  name: dns-error-demo
+  namespace: default
+spec:
+  action: error
+  mode: all
+  duration: "3m"
+  patterns:
+    - google.com
+    - github.com
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: dns-error-demo

--- a/tests/chaos_engineering/experiments/dns-error/dns-error-demo.yaml
+++ b/tests/chaos_engineering/experiments/dns-error/dns-error-demo.yaml
@@ -1,0 +1,39 @@
+# Workload targeted by DNSChaos (action: error). Fault applies to DNS lookups from this pod
+# (e.g. patterns in the chaos CR). Requires Chaos DNS Server (default in Chaos Mesh >= 2.6).
+#
+# Prereq: `make chaos-mesh-up`. Verify: kubectl get pods -n chaos-mesh -l app.kubernetes.io/component=chaos-dns-server
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-error-demo
+  namespace: default
+  labels:
+    app: dns-error-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-error-demo
+  template:
+    metadata:
+      labels:
+        app: dns-error-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/dns-random/dns-random-alert.json
+++ b/tests/chaos_engineering/experiments/dns-random/dns-random-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for DNSChaos random responses",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/dns-random/dns-random-alert.json"
+  },
+  "title": "[Triggered] DNS poisoning - dns-random-demo",
+  "alert_name": "Datadog monitor: bad upstream resolution",
+  "pipeline_name": "dns-random-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "dns-random-demo sidecar sees failed or wrong resolutions",
+  "text": "DNSChaos random returns incorrect addresses for matched patterns; egress calls may hang or hit blackholes.",
+  "commonLabels": {
+    "pipeline_name": "dns-random-demo",
+    "severity": "high",
+    "kube_deployment": "dns-random-demo"
+  },
+  "commonAnnotations": {
+    "summary": "DNS random chaos on dns-random-demo",
+    "query": "kube_namespace:default kube_deployment:dns-random-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "dns-random-demo",
+    "correlation_id": "dns-random-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/dns-random/dns-random-chaos.yaml
+++ b/tests/chaos_engineering/experiments/dns-random/dns-random-chaos.yaml
@@ -1,0 +1,20 @@
+# DNSChaos random: poisoned A records for matched names (clients may connect to wrong IPs).
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: DNSChaos
+metadata:
+  name: dns-random-demo
+  namespace: default
+spec:
+  action: random
+  mode: all
+  duration: "3m"
+  patterns:
+    - google.com
+    - github.com
+    - example.com
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: dns-random-demo

--- a/tests/chaos_engineering/experiments/dns-random/dns-random-demo.yaml
+++ b/tests/chaos_engineering/experiments/dns-random/dns-random-demo.yaml
@@ -1,0 +1,51 @@
+# Pod generates DNS lookups while nginx stays ready; DNSChaos random returns bogus IPs for patterns.
+# Requires Chaos DNS Server (same as dns-error experiment).
+#
+# kubectl apply -f .../dns-random-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../dns-random-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-random-demo
+  namespace: default
+  labels:
+    app: dns-random-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-random-demo
+  template:
+    metadata:
+      labels:
+        app: dns-random-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+        - name: lookup
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                nslookup google.com >/dev/null 2>&1 || echo "dns-random: lookup failed $(date -Iseconds)" >&2
+                nslookup github.com >/dev/null 2>&1 || echo "dns-random: lookup failed $(date -Iseconds)" >&2
+                sleep 4
+              done

--- a/tests/chaos_engineering/experiments/http-abort/http-abort-alert.json
+++ b/tests/chaos_engineering/experiments/http-abort/http-abort-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for HTTPChaos abort demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/http-abort/http-abort-alert.json"
+  },
+  "title": "[Triggered] HTTP resets - http-abort-demo",
+  "alert_name": "Datadog monitor: HTTP failures http-abort-demo",
+  "pipeline_name": "http-abort-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "Clients see connection errors to http-abort-demo",
+  "text": "HTTPChaos abort; GETs to port 80 may be cut mid-flight.",
+  "commonLabels": {
+    "pipeline_name": "http-abort-demo",
+    "severity": "high",
+    "kube_deployment": "http-abort-demo"
+  },
+  "commonAnnotations": {
+    "summary": "HTTP errors for deployment http-abort-demo",
+    "query": "kube_namespace:default kube_deployment:http-abort-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "http-abort-demo",
+    "correlation_id": "http-abort-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/http-abort/http-abort-chaos.yaml
+++ b/tests/chaos_engineering/experiments/http-abort/http-abort-chaos.yaml
@@ -1,0 +1,20 @@
+# HTTPChaos: abort HTTP requests matching port/path/method on target pods.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: HTTPChaos
+metadata:
+  name: http-abort-demo
+  namespace: default
+spec:
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: http-abort-demo
+  target: Request
+  port: 80
+  path: "*"
+  method: GET
+  abort: true

--- a/tests/chaos_engineering/experiments/http-abort/http-abort-demo.yaml
+++ b/tests/chaos_engineering/experiments/http-abort/http-abort-demo.yaml
@@ -1,0 +1,38 @@
+# Nginx HTTP server for HTTPChaos (abort on port 80). HTTPChaos does not support HTTPS.
+#
+# Prereq: `make chaos-mesh-up`. No Chaos control-plane pods on the target (see Chaos Mesh docs).
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-abort-demo
+  namespace: default
+  labels:
+    app: http-abort-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-abort-demo
+  template:
+    metadata:
+      labels:
+        app: http-abort-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/http-response-fault/http-response-fault-alert.json
+++ b/tests/chaos_engineering/experiments/http-response-fault/http-response-fault-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for HTTPChaos response delay +503 replace",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/http-response-fault/http-response-fault-alert.json"
+  },
+  "title": "[Triggered] HTTP 503 / SLA breach - http-response-fault-demo",
+  "alert_name": "Datadog monitor: 5xx spike on demo service",
+  "pipeline_name": "http-response-fault-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "http-response-fault-demo returning errors or high latency",
+  "text": "HTTPChaos modifies outbound HTTP responses: added delay and replaced status with 503.",
+  "commonLabels": {
+    "pipeline_name": "http-response-fault-demo",
+    "severity": "high",
+    "kube_deployment": "http-response-fault-demo"
+  },
+  "commonAnnotations": {
+    "summary": "HTTP response fault chaos on http-response-fault-demo",
+    "query": "kube_namespace:default kube_deployment:http-response-fault-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "http-response-fault-demo",
+    "correlation_id": "http-response-fault-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/http-response-fault/http-response-fault-chaos.yaml
+++ b/tests/chaos_engineering/experiments/http-response-fault/http-response-fault-chaos.yaml
@@ -1,0 +1,21 @@
+# HTTPChaos: slow responses and synthetic 503s (target: Response). More subtle than abort.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: HTTPChaos
+metadata:
+  name: http-response-fault-demo
+  namespace: default
+spec:
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: http-response-fault-demo
+  target: Response
+  port: 80
+  path: "*"
+  delay: "1200ms"
+  replace:
+    code: 503

--- a/tests/chaos_engineering/experiments/http-response-fault/http-response-fault-demo.yaml
+++ b/tests/chaos_engineering/experiments/http-response-fault/http-response-fault-demo.yaml
@@ -1,0 +1,41 @@
+# Nginx for HTTPChaos on Responses (delay + status rewrite). HTTP only, port 80.
+#
+# kubectl apply -f .../http-response-fault-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../http-response-fault-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-response-fault-demo
+  namespace: default
+  labels:
+    app: http-response-fault-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-response-fault-demo
+  template:
+    metadata:
+      labels:
+        app: http-response-fault-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 4
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5

--- a/tests/chaos_engineering/experiments/io-latency/io-latency-alert.json
+++ b/tests/chaos_engineering/experiments/io-latency/io-latency-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for IOChaos latency",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/io-latency/io-latency-alert.json"
+  },
+  "title": "[Triggered] Disk latency - io-latency-demo",
+  "alert_name": "Datadog monitor: slow I/O workload",
+  "pipeline_name": "io-latency-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "io-latency-demo backlog or stalls",
+  "text": "IOChaos injects latency into filesystem operations on the mounted volume; throughput collapses.",
+  "commonLabels": {
+    "pipeline_name": "io-latency-demo",
+    "severity": "high",
+    "kube_deployment": "io-latency-demo"
+  },
+  "commonAnnotations": {
+    "summary": "IO latency chaos on io-latency-demo",
+    "query": "kube_namespace:default kube_deployment:io-latency-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "io-latency-demo",
+    "correlation_id": "io-latency-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/io-latency/io-latency-chaos.yaml
+++ b/tests/chaos_engineering/experiments/io-latency/io-latency-chaos.yaml
@@ -1,0 +1,22 @@
+# IOChaos latency on /data mount (FUSE/toda injection into filesystem calls).
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: IOChaos
+metadata:
+  name: io-latency-demo
+  namespace: default
+spec:
+  action: latency
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: io-latency-demo
+  containerNames:
+    - workload
+  volumePath: /data
+  path: "/data/**/*"
+  delay: "350ms"
+  percent: 55

--- a/tests/chaos_engineering/experiments/io-latency/io-latency-demo.yaml
+++ b/tests/chaos_engineering/experiments/io-latency/io-latency-demo.yaml
@@ -1,0 +1,45 @@
+# Busybox churning disk I/O on emptyDir; IOChaos injects latency on that mount.
+#
+# kubectl apply -f .../io-latency-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../io-latency-chaos.yaml --context=kind-tracer-k8s-test
+#
+# IOChaos can be destructive; use only on disposable test clusters.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: io-latency-demo
+  namespace: default
+  labels:
+    app: io-latency-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: io-latency-demo
+  template:
+    metadata:
+      labels:
+        app: io-latency-demo
+    spec:
+      containers:
+        - name: workload
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /data/churn
+              while true; do
+                for i in $(seq 1 30); do
+                  echo "line-$i-$(date +%s%N)" >> /data/churn/log.txt
+                  sync
+                done
+                sleep 0.1
+              done
+          volumeMounts:
+            - name: chaos-vol
+              mountPath: /data
+      volumes:
+        - name: chaos-vol
+          emptyDir: {}

--- a/tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-alert.json
+++ b/tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for network-bandwidth chaos demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-alert.json"
+  },
+  "title": "[Triggered] Throughput collapse - network-bandwidth-demo",
+  "alert_name": "Datadog monitor: low throughput network-bandwidth-demo",
+  "pipeline_name": "network-bandwidth-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "Sustained low throughput to network-bandwidth-demo",
+  "text": "NetworkChaos bandwidth limit injected; connections may be slow.",
+  "commonLabels": {
+    "pipeline_name": "network-bandwidth-demo",
+    "severity": "warning",
+    "kube_deployment": "network-bandwidth-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Bandwidth saturation for deployment network-bandwidth-demo",
+    "query": "kube_namespace:default kube_deployment:network-bandwidth-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-bandwidth-demo",
+    "correlation_id": "network-bandwidth-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-chaos.yaml
@@ -1,0 +1,20 @@
+# NetworkChaos bandwidth cap on pods labeled app=network-bandwidth-demo.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-bandwidth-demo
+  namespace: default
+spec:
+  action: bandwidth
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-bandwidth-demo
+  bandwidth:
+    rate: 1mbps
+    limit: 20971520
+    buffer: 10000

--- a/tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-bandwidth/network-bandwidth-demo.yaml
@@ -1,0 +1,40 @@
+# Nginx target for NetworkChaos (action: bandwidth / tc tbf).
+#
+# Prereq: `make chaos-mesh-up`. Apply workload, then chaos CR.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-bandwidth-demo
+  namespace: default
+  labels:
+    app: network-bandwidth-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-bandwidth-demo
+  template:
+    metadata:
+      labels:
+        app: network-bandwidth-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5

--- a/tests/chaos_engineering/experiments/network-corrupt/network-corrupt-alert.json
+++ b/tests/chaos_engineering/experiments/network-corrupt/network-corrupt-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for network-corrupt chaos demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-corrupt/network-corrupt-alert.json"
+  },
+  "title": "[Triggered] Corrupt responses - network-corrupt-demo",
+  "alert_name": "Datadog monitor: HTTP errors network-corrupt-demo",
+  "pipeline_name": "network-corrupt-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "Malformed or failed responses from network-corrupt-demo",
+  "text": "NetworkChaos corrupt injected; payloads may be invalid.",
+  "commonLabels": {
+    "pipeline_name": "network-corrupt-demo",
+    "severity": "warning",
+    "kube_deployment": "network-corrupt-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Possible data corruption path to network-corrupt-demo",
+    "query": "kube_namespace:default kube_deployment:network-corrupt-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-corrupt-demo",
+    "correlation_id": "network-corrupt-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-corrupt/network-corrupt-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-corrupt/network-corrupt-chaos.yaml
@@ -1,0 +1,19 @@
+# NetworkChaos packet corruption on pods labeled app=network-corrupt-demo.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-corrupt-demo
+  namespace: default
+spec:
+  action: corrupt
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-corrupt-demo
+  corrupt:
+    corrupt: "25"
+    correlation: "0"

--- a/tests/chaos_engineering/experiments/network-corrupt/network-corrupt-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-corrupt/network-corrupt-demo.yaml
@@ -1,0 +1,39 @@
+# Nginx target for NetworkChaos (action: corrupt).
+#
+# Prereq: `make chaos-mesh-up`. Apply workload, then chaos CR.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-corrupt-demo
+  namespace: default
+  labels:
+    app: network-corrupt-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-corrupt-demo
+  template:
+    metadata:
+      labels:
+        app: network-corrupt-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/network-delay/network-delay-alert.json
+++ b/tests/chaos_engineering/experiments/network-delay/network-delay-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for network-delay chaos demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-delay/network-delay-alert.json"
+  },
+  "title": "[Triggered] High latency - network-delay-demo",
+  "alert_name": "Datadog monitor: elevated latency network-delay-demo",
+  "pipeline_name": "network-delay-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "HTTP readiness for network-delay-demo is flaky or slow",
+  "text": "NetworkChaos delay injected; probes or clients may time out.",
+  "commonLabels": {
+    "pipeline_name": "network-delay-demo",
+    "severity": "warning",
+    "kube_deployment": "network-delay-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Possible network degradation for deployment network-delay-demo",
+    "query": "kube_namespace:default kube_deployment:network-delay-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-delay-demo",
+    "correlation_id": "network-delay-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-delay/network-delay-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-delay/network-delay-chaos.yaml
@@ -1,0 +1,22 @@
+# NetworkChaos delay on pods labeled app=network-delay-demo.
+#
+#   kubectl apply -f .../network-delay-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-delay-demo
+  namespace: default
+spec:
+  action: delay
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-delay-demo
+  delay:
+    latency: "800ms"
+    correlation: "100"
+    jitter: "100ms"

--- a/tests/chaos_engineering/experiments/network-delay/network-delay-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-delay/network-delay-demo.yaml
@@ -1,0 +1,44 @@
+# Nginx target for NetworkChaos (action: delay). HTTP probes surface slow readiness under latency.
+#
+# Prereq: `make chaos-mesh-up`. Apply workload, then chaos CR.
+#
+#   kubectl apply -f .../network-delay-demo.yaml --context=kind-tracer-k8s-test
+#   kubectl apply -f .../network-delay-chaos.yaml --context=kind-tracer-k8s-test
+#
+# Teardown: delete chaos CR, then deployment.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-delay-demo
+  namespace: default
+  labels:
+    app: network-delay-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-delay-demo
+  template:
+    metadata:
+      labels:
+        app: network-delay-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/network-duplicate/network-duplicate-alert.json
+++ b/tests/chaos_engineering/experiments/network-duplicate/network-duplicate-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for NetworkChaos duplicate",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-duplicate/network-duplicate-alert.json"
+  },
+  "title": "[Triggered] Erratic HTTP - network-duplicate-demo",
+  "alert_name": "Datadog monitor: duplicate / flaky traffic",
+  "pipeline_name": "network-duplicate-demo",
+  "severity": "medium",
+  "alert_source": "datadog",
+  "message": "Unusual latency or errors for deployment network-duplicate-demo",
+  "text": "NetworkChaos duplicate injects duplicated packets; clients may observe retries or unstable connections.",
+  "commonLabels": {
+    "pipeline_name": "network-duplicate-demo",
+    "severity": "medium",
+    "kube_deployment": "network-duplicate-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Packet duplication chaos on network-duplicate-demo",
+    "query": "kube_namespace:default kube_deployment:network-duplicate-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-duplicate-demo",
+    "correlation_id": "network-duplicate-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-duplicate/network-duplicate-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-duplicate/network-duplicate-chaos.yaml
@@ -1,0 +1,19 @@
+# NetworkChaos duplicate: probabilistic packet duplication (TCP may see retransmits / weirdness).
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-duplicate-demo
+  namespace: default
+spec:
+  action: duplicate
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-duplicate-demo
+  duplicate:
+    duplicate: "45"
+    correlation: "30"

--- a/tests/chaos_engineering/experiments/network-duplicate/network-duplicate-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-duplicate/network-duplicate-demo.yaml
@@ -1,0 +1,40 @@
+# Nginx target for NetworkChaos action: duplicate (packet duplication).
+#
+# kubectl apply -f .../network-duplicate-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../network-duplicate-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-duplicate-demo
+  namespace: default
+  labels:
+    app: network-duplicate-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-duplicate-demo
+  template:
+    metadata:
+      labels:
+        app: network-duplicate-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/network-loss/network-loss-alert.json
+++ b/tests/chaos_engineering/experiments/network-loss/network-loss-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for network-loss chaos demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-loss/network-loss-alert.json"
+  },
+  "title": "[Triggered] Packet loss / flaky probes - network-loss-demo",
+  "alert_name": "Datadog monitor: flaky network-loss-demo",
+  "pipeline_name": "network-loss-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "Intermittent failures reaching network-loss-demo",
+  "text": "NetworkChaos loss injected; TCP/HTTP may reset or retry.",
+  "commonLabels": {
+    "pipeline_name": "network-loss-demo",
+    "severity": "warning",
+    "kube_deployment": "network-loss-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Intermittent errors for deployment network-loss-demo",
+    "query": "kube_namespace:default kube_deployment:network-loss-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-loss-demo",
+    "correlation_id": "network-loss-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-loss/network-loss-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-loss/network-loss-chaos.yaml
@@ -1,0 +1,19 @@
+# NetworkChaos packet loss on pods labeled app=network-loss-demo.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-loss-demo
+  namespace: default
+spec:
+  action: loss
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-loss-demo
+  loss:
+    loss: "40"
+    correlation: "0"

--- a/tests/chaos_engineering/experiments/network-loss/network-loss-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-loss/network-loss-demo.yaml
@@ -1,0 +1,41 @@
+# Nginx target for NetworkChaos (action: loss).
+#
+# Prereq: `make chaos-mesh-up`. Apply workload, then chaos CR.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-loss-demo
+  namespace: default
+  labels:
+    app: network-loss-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-loss-demo
+  template:
+    metadata:
+      labels:
+        app: network-loss-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3

--- a/tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-alert.json
+++ b/tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for NetworkChaos netem combo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-alert.json"
+  },
+  "title": "[Triggered] Severe network degradation - network-netem-combo-demo",
+  "alert_name": "Datadog monitor: SLO burn on netem combo",
+  "pipeline_name": "network-netem-combo-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "High latency and errors for deployment network-netem-combo-demo",
+  "text": "NetworkChaos netem combines delay, loss, and rate limiting; probes and user traffic may time out together.",
+  "commonLabels": {
+    "pipeline_name": "network-netem-combo-demo",
+    "severity": "high",
+    "kube_deployment": "network-netem-combo-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Combined netem chaos on network-netem-combo-demo",
+    "query": "kube_namespace:default kube_deployment:network-netem-combo-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-netem-combo-demo",
+    "correlation_id": "network-netem-combo-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-chaos.yaml
@@ -1,0 +1,25 @@
+# Combined poor-network profile: latency + loss + throughput cap (single netem experiment).
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-netem-combo-demo
+  namespace: default
+spec:
+  action: netem
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-netem-combo-demo
+  delay:
+    latency: "90ms"
+    correlation: "100"
+    jitter: "35ms"
+  loss:
+    loss: "8"
+    correlation: "35"
+  rate:
+    rate: 8mbps

--- a/tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-netem-combo/network-netem-combo-demo.yaml
@@ -1,0 +1,41 @@
+# Nginx for NetworkChaos action: netem (combined delay + loss + rate cap).
+#
+# kubectl apply -f .../network-netem-combo-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../network-netem-combo-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-netem-combo-demo
+  namespace: default
+  labels:
+    app: network-netem-combo-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-netem-combo-demo
+  template:
+    metadata:
+      labels:
+        app: network-netem-combo-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5

--- a/tests/chaos_engineering/experiments/network-partition/network-partition-alert.json
+++ b/tests/chaos_engineering/experiments/network-partition/network-partition-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for NetworkChaos partition (client cannot reach server)",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-partition/network-partition-alert.json"
+  },
+  "title": "[Triggered] Network partition - client to server",
+  "alert_name": "Datadog monitor: partition client connectivity",
+  "pipeline_name": "network-partition-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "Client workload cannot reach network-partition-server in namespace default",
+  "text": "NetworkChaos partition injected between app=network-partition-client and app=network-partition-server; in-cluster HTTP may fail while chaos is active.",
+  "commonLabels": {
+    "pipeline_name": "network-partition-demo",
+    "severity": "high",
+    "kube_deployment": "network-partition-client"
+  },
+  "commonAnnotations": {
+    "summary": "Partition between client and server deployments",
+    "query": "kube_namespace:default kube_deployment:network-partition-*",
+    "kube_namespace": "default",
+    "kube_deployment": "network-partition-client",
+    "correlation_id": "network-partition-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-partition/network-partition-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-partition/network-partition-chaos.yaml
@@ -1,0 +1,26 @@
+# Blocks traffic from partition-client pods to partition-server pods.
+#
+# kubectl apply -f .../network-partition-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-partition-demo
+  namespace: default
+spec:
+  action: partition
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-partition-client
+  direction: to
+  target:
+    mode: all
+    selector:
+      namespaces:
+        - default
+      labelSelectors:
+        app: network-partition-server

--- a/tests/chaos_engineering/experiments/network-partition/network-partition-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-partition/network-partition-demo.yaml
@@ -1,0 +1,77 @@
+# Client + server for NetworkChaos partition: blocks client -> server pods (direction: to).
+# Apply this file first, then network-partition-chaos.yaml.
+#
+# kubectl apply -f .../network-partition-demo.yaml --context=kind-tracer-k8s-test
+#
+# Teardown: delete chaos CR, then this manifest.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: network-partition-server
+  namespace: default
+  labels:
+    app: network-partition-server
+spec:
+  selector:
+    app: network-partition-server
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-partition-server
+  namespace: default
+  labels:
+    app: network-partition-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-partition-server
+  template:
+    metadata:
+      labels:
+        app: network-partition-server
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-partition-client
+  namespace: default
+  labels:
+    app: network-partition-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-partition-client
+  template:
+    metadata:
+      labels:
+        app: network-partition-client
+    spec:
+      containers:
+        - name: probe
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              URL="http://network-partition-server.default.svc.cluster.local"
+              while true; do
+                if wget -q -O- -T 3 --tries=1 "$URL" >/dev/null 2>&1; then
+                  echo "partition-client: ok $(date -Iseconds)"
+                else
+                  echo "partition-client: FAIL $(date -Iseconds)" >&2
+                fi
+                sleep 2
+              done

--- a/tests/chaos_engineering/experiments/network-reorder/network-reorder-alert.json
+++ b/tests/chaos_engineering/experiments/network-reorder/network-reorder-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for NetworkChaos reorder",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/network-reorder/network-reorder-alert.json"
+  },
+  "title": "[Triggered] Unstable TCP - network-reorder-demo",
+  "alert_name": "Datadog monitor: reorder / tail latency",
+  "pipeline_name": "network-reorder-demo",
+  "severity": "medium",
+  "alert_source": "datadog",
+  "message": "Elevated errors or latency for deployment network-reorder-demo",
+  "text": "NetworkChaos reorder injects out-of-order delivery; long-tail latency and connection churn are common.",
+  "commonLabels": {
+    "pipeline_name": "network-reorder-demo",
+    "severity": "medium",
+    "kube_deployment": "network-reorder-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Packet reorder chaos on network-reorder-demo",
+    "query": "kube_namespace:default kube_deployment:network-reorder-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "network-reorder-demo",
+    "correlation_id": "network-reorder-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/network-reorder/network-reorder-chaos.yaml
+++ b/tests/chaos_engineering/experiments/network-reorder/network-reorder-chaos.yaml
@@ -1,0 +1,20 @@
+# NetworkChaos reorder: shuffles delivery order (stress for TCP stack and app assumptions).
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-reorder-demo
+  namespace: default
+spec:
+  action: reorder
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: network-reorder-demo
+  reorder:
+    reorder: "0.35"
+    correlation: "40"
+    gap: 6

--- a/tests/chaos_engineering/experiments/network-reorder/network-reorder-demo.yaml
+++ b/tests/chaos_engineering/experiments/network-reorder/network-reorder-demo.yaml
@@ -1,0 +1,40 @@
+# Nginx target for NetworkChaos action: reorder (packet reordering).
+#
+# kubectl apply -f .../network-reorder-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../network-reorder-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: network-reorder-demo
+  namespace: default
+  labels:
+    app: network-reorder-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: network-reorder-demo
+  template:
+    metadata:
+      labels:
+        app: network-reorder-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/pod-failure/pod-failure-alert.json
+++ b/tests/chaos_engineering/experiments/pod-failure/pod-failure-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Local pod-failure chaos demo; pair with pod-failure-demo + pod-failure-chaos on kind",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/pod-failure/pod-failure-alert.json"
+  },
+  "title": "[Triggered] Pod failing - pod-failure-demo",
+  "alert_name": "Datadog monitor: Pod pod-failure-demo not ready",
+  "pipeline_name": "pod-failure-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "Pod for deployment pod-failure-demo is not ready in namespace default",
+  "text": "Chaos Mesh pod-failure (pause image) or workload degradation; readiness may fail while HTTP probes cannot succeed.",
+  "commonLabels": {
+    "pipeline_name": "pod-failure-demo",
+    "severity": "high",
+    "kube_deployment": "pod-failure-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Deployment pod-failure-demo pods not passing readiness",
+    "query": "kube_namespace:default pod_name:pod-failure-demo*",
+    "kube_namespace": "default",
+    "kube_deployment": "pod-failure-demo",
+    "correlation_id": "pod-failure-demo-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/pod-failure/pod-failure-chaos.yaml
+++ b/tests/chaos_engineering/experiments/pod-failure/pod-failure-chaos.yaml
@@ -1,0 +1,26 @@
+# PodChaos with action pod-failure: swaps target containers to Chaos Mesh pause image
+# (see pod-failure-demo.yaml HTTP probes so READY reflects unavailability).
+# Prereq: pod-failure-demo.yaml applied + Chaos Mesh (`make chaos-mesh-up`).
+#
+# From repo root:
+#   kubectl apply -f tests/chaos_engineering/experiments/pod-failure/pod-failure-chaos.yaml \
+#     --context=kind-tracer-k8s-test
+#
+# Remove:
+#   kubectl delete -f tests/chaos_engineering/experiments/pod-failure/pod-failure-chaos.yaml \
+#     --context=kind-tracer-k8s-test
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: inject-pod-failure-demo
+  namespace: default
+spec:
+  action: pod-failure
+  mode: all
+  duration: "5m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: pod-failure-demo

--- a/tests/chaos_engineering/experiments/pod-failure/pod-failure-demo.yaml
+++ b/tests/chaos_engineering/experiments/pod-failure/pod-failure-demo.yaml
@@ -1,0 +1,55 @@
+# Stable nginx workload targeted by Chaos Mesh PodChaos (action: pod-failure).
+# Different from crashloop (process exit) and from pod-kill (immediate delete).
+#
+# Chaos Mesh pod-failure swaps containers to a pause image. Without probes, many
+# images still look Running + Ready; HTTP probes fail once nginx is replaced so
+# `kubectl get pods` shows 0/1 READY during the experiment.
+#
+# Prereq: same cluster/context as chaos-demo.yaml; Chaos Mesh installed (`make chaos-mesh-up`).
+#
+# From repo root:
+#   kubectl apply -f tests/chaos_engineering/experiments/pod-failure/pod-failure-demo.yaml \
+#     --context=kind-tracer-k8s-test
+#   kubectl apply -f tests/chaos_engineering/experiments/pod-failure/pod-failure-chaos.yaml \
+#     --context=kind-tracer-k8s-test
+#
+# Remove chaos first, then workload:
+#   kubectl delete -f tests/chaos_engineering/experiments/pod-failure/pod-failure-chaos.yaml \
+#     --context=kind-tracer-k8s-test
+#   kubectl delete -f tests/chaos_engineering/experiments/pod-failure/pod-failure-demo.yaml \
+#     --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-failure-demo
+  namespace: default
+  labels:
+    app: pod-failure-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod-failure-demo
+  template:
+    metadata:
+      labels:
+        app: pod-failure-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-alert.json
+++ b/tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for pod-kill victim demo",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-alert.json"
+  },
+  "title": "[Triggered] Pod restarted - pod-kill-victim-demo",
+  "alert_name": "Datadog monitor: pod churn pod-kill-victim-demo",
+  "pipeline_name": "pod-kill-victim-demo",
+  "severity": "warning",
+  "alert_source": "datadog",
+  "message": "Pod for pod-kill-victim-demo was deleted and recreated",
+  "text": "PodChaos pod-kill removes the pod; ReplicaSet creates a new one.",
+  "commonLabels": {
+    "pipeline_name": "pod-kill-victim-demo",
+    "severity": "warning",
+    "kube_deployment": "pod-kill-victim-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Pod lifecycle event on deployment pod-kill-victim-demo",
+    "query": "kube_namespace:default kube_deployment:pod-kill-victim-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "pod-kill-victim-demo",
+    "correlation_id": "pod-kill-victim-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-chaos.yaml
+++ b/tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-chaos.yaml
@@ -1,0 +1,15 @@
+# PodChaos pod-kill: deletes matching pods once; Deployment replaces them.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: pod-kill-victim-demo
+  namespace: default
+spec:
+  action: pod-kill
+  mode: all
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: pod-kill-victim-demo

--- a/tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-demo.yaml
+++ b/tests/chaos_engineering/experiments/pod-kill-victim/pod-kill-victim-demo.yaml
@@ -1,0 +1,38 @@
+# Nginx deployment targeted by PodChaos (action: pod-kill). Separate from shared chaos-demo.
+#
+# Prereq: `make chaos-mesh-up`.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-kill-victim-demo
+  namespace: default
+  labels:
+    app: pod-kill-victim-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod-kill-victim-demo
+  template:
+    metadata:
+      labels:
+        app: pod-kill-victim-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/tests/chaos_engineering/experiments/stress-cpu/stress-cpu-alert.json
+++ b/tests/chaos_engineering/experiments/stress-cpu/stress-cpu-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for StressChaos CPU saturation",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/stress-cpu/stress-cpu-alert.json"
+  },
+  "title": "[Triggered] CPU saturation - stress-cpu-demo",
+  "alert_name": "Datadog monitor: CPU throttle / probe failures",
+  "pipeline_name": "stress-cpu-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "stress-cpu-demo not meeting SLO under CPU pressure",
+  "text": "StressChaos CPU load inside the nginx container; cgroup CPU limits can delay HTTP probes.",
+  "commonLabels": {
+    "pipeline_name": "stress-cpu-demo",
+    "severity": "high",
+    "kube_deployment": "stress-cpu-demo"
+  },
+  "commonAnnotations": {
+    "summary": "CPU stress chaos on stress-cpu-demo",
+    "query": "kube_namespace:default kube_deployment:stress-cpu-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "stress-cpu-demo",
+    "correlation_id": "stress-cpu-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/stress-cpu/stress-cpu-chaos.yaml
+++ b/tests/chaos_engineering/experiments/stress-cpu/stress-cpu-chaos.yaml
@@ -1,0 +1,21 @@
+# StressChaos CPU: competes with nginx worker; readiness may flake under throttle.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: StressChaos
+metadata:
+  name: stress-cpu-demo
+  namespace: default
+spec:
+  mode: all
+  duration: "3m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: stress-cpu-demo
+  containerNames:
+    - nginx
+  stressors:
+    cpu:
+      workers: 2
+      load: 90

--- a/tests/chaos_engineering/experiments/stress-cpu/stress-cpu-demo.yaml
+++ b/tests/chaos_engineering/experiments/stress-cpu/stress-cpu-demo.yaml
@@ -1,0 +1,48 @@
+# Nginx bounded by CPU limits; StressChaos raises CPU load inside the container.
+#
+# kubectl apply -f .../stress-cpu-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../stress-cpu-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stress-cpu-demo
+  namespace: default
+  labels:
+    app: stress-cpu-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stress-cpu-demo
+  template:
+    metadata:
+      labels:
+        app: stress-cpu-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 4

--- a/tests/chaos_engineering/experiments/stress-memory/stress-memory-alert.json
+++ b/tests/chaos_engineering/experiments/stress-memory/stress-memory-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for StressChaos memory pressure",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/stress-memory/stress-memory-alert.json"
+  },
+  "title": "[Triggered] Memory pressure - stress-memory-demo",
+  "alert_name": "Datadog monitor: OOM / restarts",
+  "pipeline_name": "stress-memory-demo",
+  "severity": "high",
+  "alert_source": "datadog",
+  "message": "stress-memory-demo instability or restarts",
+  "text": "StressChaos memory allocation competes with nginx inside the same cgroup; may hit limit and evict.",
+  "commonLabels": {
+    "pipeline_name": "stress-memory-demo",
+    "severity": "high",
+    "kube_deployment": "stress-memory-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Memory stress chaos on stress-memory-demo",
+    "query": "kube_namespace:default kube_deployment:stress-memory-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "stress-memory-demo",
+    "correlation_id": "stress-memory-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/stress-memory/stress-memory-chaos.yaml
+++ b/tests/chaos_engineering/experiments/stress-memory/stress-memory-chaos.yaml
@@ -1,0 +1,21 @@
+# StressChaos memory: approaches pod memory limit; risk of OOMKill depending on node pressure.
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: StressChaos
+metadata:
+  name: stress-memory-demo
+  namespace: default
+spec:
+  mode: all
+  duration: "2m30s"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: stress-memory-demo
+  containerNames:
+    - nginx
+  stressors:
+    memory:
+      workers: 3
+      size: "180MB"

--- a/tests/chaos_engineering/experiments/stress-memory/stress-memory-demo.yaml
+++ b/tests/chaos_engineering/experiments/stress-memory/stress-memory-demo.yaml
@@ -1,0 +1,48 @@
+# Nginx with a tight memory limit; StressChaos allocates heap inside the same container.
+#
+# kubectl apply -f .../stress-memory-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../stress-memory-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stress-memory-demo
+  namespace: default
+  labels:
+    app: stress-memory-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stress-memory-demo
+  template:
+    metadata:
+      labels:
+        app: stress-memory-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 25
+            periodSeconds: 15
+            timeoutSeconds: 4

--- a/tests/chaos_engineering/experiments/time-skew/time-skew-alert.json
+++ b/tests/chaos_engineering/experiments/time-skew/time-skew-alert.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "purpose": "Synthetic alert for TimeChaos clock skew",
+    "run": "opensre investigate -i tests/chaos_engineering/experiments/time-skew/time-skew-alert.json"
+  },
+  "title": "[Triggered] Clock skew - time-skew-demo",
+  "alert_name": "Datadog monitor: time drift / auth anomalies",
+  "pipeline_name": "time-skew-demo",
+  "severity": "medium",
+  "alert_source": "datadog",
+  "message": "Observed skew or odd timestamps for time-skew-demo",
+  "text": "TimeChaos offsets container clock; log correlation and token TTL checks may diverge from wall clock.",
+  "commonLabels": {
+    "pipeline_name": "time-skew-demo",
+    "severity": "medium",
+    "kube_deployment": "time-skew-demo"
+  },
+  "commonAnnotations": {
+    "summary": "Time skew chaos on time-skew-demo",
+    "query": "kube_namespace:default kube_deployment:time-skew-demo",
+    "kube_namespace": "default",
+    "kube_deployment": "time-skew-demo",
+    "correlation_id": "time-skew-local-001"
+  }
+}

--- a/tests/chaos_engineering/experiments/time-skew/time-skew-chaos.yaml
+++ b/tests/chaos_engineering/experiments/time-skew/time-skew-chaos.yaml
@@ -1,0 +1,20 @@
+# TimeChaos: shifts CLOCK_REALTIME for processes in the container (nginx master/workers as children of PID 1).
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: TimeChaos
+metadata:
+  name: time-skew-demo
+  namespace: default
+spec:
+  mode: all
+  duration: "2m"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: time-skew-demo
+  containerNames:
+    - nginx
+  timeOffset: "+19m15s"
+  clockIds:
+    - CLOCK_REALTIME

--- a/tests/chaos_engineering/experiments/time-skew/time-skew-demo.yaml
+++ b/tests/chaos_engineering/experiments/time-skew/time-skew-demo.yaml
@@ -1,0 +1,39 @@
+# Nginx target for TimeChaos (clock offset in PID 1 namespace). Cache/TLS apps are more sensitive.
+#
+# kubectl apply -f .../time-skew-demo.yaml --context=kind-tracer-k8s-test
+# kubectl apply -f .../time-skew-chaos.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: time-skew-demo
+  namespace: default
+  labels:
+    app: time-skew-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: time-skew-demo
+  template:
+    metadata:
+      labels:
+        app: time-skew-demo
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 15
+            periodSeconds: 15

--- a/tests/chaos_engineering/kubectl.py
+++ b/tests/chaos_engineering/kubectl.py
@@ -1,0 +1,86 @@
+"""kubectl / helm subprocess helpers with optional context."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def kubectl_base(context: str | None) -> list[str]:
+    cmd = ["kubectl"]
+    if context:
+        cmd.extend(["--context", context])
+    return cmd
+
+
+def kubectl_apply(manifest: Path | str, *, context: str | None) -> None:
+    path = Path(manifest) if isinstance(manifest, str) else manifest
+    subprocess.run(
+        [*kubectl_base(context), "apply", "-f", str(path)],
+        check=True,
+    )
+
+
+def kubectl_delete(manifest: Path | str, *, context: str | None) -> None:
+    path = Path(manifest) if isinstance(manifest, str) else manifest
+    subprocess.run(
+        [*kubectl_base(context), "delete", "-f", str(path), "--ignore-not-found"],
+        check=False,
+    )
+
+
+def kubectl_create_namespace(name: str, *, context: str | None) -> None:
+    p_create = subprocess.run(
+        [
+            *kubectl_base(context),
+            "create",
+            "namespace",
+            name,
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [*kubectl_base(context), "apply", "-f", "-"],
+        check=True,
+        input=p_create.stdout,
+    )
+
+
+def helm_upgrade_install(
+    *,
+    release: str,
+    chart: str,
+    namespace: str,
+    extra_args: Sequence[str],
+    kube_context: str | None,
+) -> None:
+    cmd = [
+        "helm",
+        "upgrade",
+        "--install",
+        release,
+        chart,
+        "-n",
+        namespace,
+        *extra_args,
+    ]
+    if kube_context:
+        cmd.extend(["--kube-context", kube_context])
+    subprocess.run(cmd, check=True)
+
+
+def helm_uninstall(release: str, *, namespace: str, kube_context: str | None) -> None:
+    cmd = ["helm", "uninstall", release, "-n", namespace]
+    if kube_context:
+        cmd.extend(["--kube-context", kube_context])
+    subprocess.run(cmd, check=False)
+
+
+def helm_repo_add(name: str, url: str) -> None:
+    subprocess.run(["helm", "repo", "add", name, url], check=False)
+    subprocess.run(["helm", "repo", "update"], check=True)

--- a/tests/chaos_engineering/orchestrator.py
+++ b/tests/chaos_engineering/orchestrator.py
@@ -1,0 +1,137 @@
+"""Full chaos lab lifecycle: kind, Datadog, Chaos Mesh, baseline workloads."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from tests.chaos_engineering import kubectl
+from tests.chaos_engineering.paths import (
+    BASE_MANIFESTS_APPLY_ORDER,
+    BASE_MANIFESTS_DELETE_ORDER,
+    CHAOS_MESH_NAMESPACE_DEFAULT,
+    CLUSTER_NAME_DEFAULT,
+    DATADOG_NAMESPACE_DEFAULT,
+    chaos_engineering_path,
+)
+from tests.e2e.kubernetes.infrastructure_sdk.local import (
+    check_prerequisites,
+    cluster_exists,
+    create_kind_cluster,
+    delete_kind_cluster,
+    deploy_datadog_helm,
+    wait_for_datadog_agent,
+)
+
+CHAOS_MESH_HELM_REPO = "https://charts.chaos-mesh.org"
+CHAOS_MESH_RELEASE = "chaos-mesh"
+CHAOS_MESH_CHART = "chaos-mesh/chaos-mesh"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _datadog_values_path() -> str:
+    return str(_repo_root() / "tests/e2e/kubernetes/k8s_manifests/datadog-values.yaml")
+
+
+def install_chaos_mesh(*, kube_context: str | None, runtime: str = "containerd") -> None:
+    kubectl.helm_repo_add("chaos-mesh", CHAOS_MESH_HELM_REPO)
+    kubectl.kubectl_create_namespace(CHAOS_MESH_NAMESPACE_DEFAULT, context=kube_context)
+    kubectl.helm_upgrade_install(
+        release=CHAOS_MESH_RELEASE,
+        chart=CHAOS_MESH_CHART,
+        namespace=CHAOS_MESH_NAMESPACE_DEFAULT,
+        extra_args=["--set", f"chaosDaemon.runtime={runtime}"],
+        kube_context=kube_context,
+    )
+
+
+def uninstall_chaos_mesh(*, kube_context: str | None) -> None:
+    kubectl.helm_uninstall(
+        CHAOS_MESH_RELEASE,
+        namespace=CHAOS_MESH_NAMESPACE_DEFAULT,
+        kube_context=kube_context,
+    )
+    subprocess.run(
+        [
+            *kubectl.kubectl_base(kube_context),
+            "delete",
+            "namespace",
+            CHAOS_MESH_NAMESPACE_DEFAULT,
+            "--ignore-not-found",
+        ],
+        check=False,
+    )
+
+
+def apply_baseline_manifests(*, context: str | None) -> None:
+    for rel in BASE_MANIFESTS_APPLY_ORDER:
+        kubectl.kubectl_apply(chaos_engineering_path(*rel.split("/")), context=context)
+
+
+def delete_baseline_manifests(*, context: str | None) -> None:
+    for rel in BASE_MANIFESTS_DELETE_ORDER:
+        kubectl.kubectl_delete(chaos_engineering_path(*rel.split("/")), context=context)
+
+
+def lab_up(
+    *,
+    kube_context: str | None,
+    skip_kind: bool = False,
+    skip_datadog: bool = False,
+    chaos_runtime: str = "containerd",
+    wait_datadog_agent: bool = True,
+) -> None:
+    missing = check_prerequisites()
+    if missing:
+        raise OSError(f"Missing tools: {', '.join(missing)}")
+
+    if not skip_kind:
+        create_kind_cluster(CLUSTER_NAME_DEFAULT)
+
+    if not skip_datadog:
+        deploy_datadog_helm(
+            _datadog_values_path(),
+            DATADOG_NAMESPACE_DEFAULT,
+            kube_context=kube_context,
+        )
+        if wait_datadog_agent:
+            wait_for_datadog_agent(
+                DATADOG_NAMESPACE_DEFAULT,
+                kube_context=kube_context,
+            )
+
+    install_chaos_mesh(kube_context=kube_context, runtime=chaos_runtime)
+    apply_baseline_manifests(context=kube_context)
+
+
+def lab_down(
+    *,
+    kube_context: str | None,
+    skip_kind: bool = False,
+    skip_datadog: bool = False,
+) -> None:
+    delete_baseline_manifests(context=kube_context)
+    uninstall_chaos_mesh(kube_context=kube_context)
+
+    if not skip_datadog:
+        kubectl.helm_uninstall(
+            "datadog",
+            namespace=DATADOG_NAMESPACE_DEFAULT,
+            kube_context=kube_context,
+        )
+        subprocess.run(
+            [
+                *kubectl.kubectl_base(kube_context),
+                "delete",
+                "namespace",
+                DATADOG_NAMESPACE_DEFAULT,
+                "--ignore-not-found",
+            ],
+            check=False,
+        )
+
+    if not skip_kind and cluster_exists(CLUSTER_NAME_DEFAULT):
+        delete_kind_cluster(CLUSTER_NAME_DEFAULT)

--- a/tests/chaos_engineering/paths.py
+++ b/tests/chaos_engineering/paths.py
@@ -63,7 +63,7 @@ def validate_experiment(name: str) -> None:
     """Raise ExperimentNotFoundError if directory or YAML is missing."""
     demos = experiment_demo_yaml_paths(name)
     chaos = experiment_chaos_yaml_paths(name)
-    if not demos and not chaos:
+    if not demos or not chaos:
         raise ExperimentNotFoundError(f"No *-demo.yaml or *-chaos.yaml in experiment: {name!r}")
 
 

--- a/tests/chaos_engineering/paths.py
+++ b/tests/chaos_engineering/paths.py
@@ -1,0 +1,100 @@
+"""Paths and experiment manifest ordering (YAML/JSON live in this package directory)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Kubernetes manifests and experiments/ tree sit next to this module (see README.md).
+CHAOS_ENGINEERING_DIR: Path = Path(__file__).resolve().parent
+EXPERIMENTS_DIR: Path = CHAOS_ENGINEERING_DIR / "experiments"
+
+CLUSTER_NAME_DEFAULT = "tracer-k8s-test"
+KUBECTL_CONTEXT_DEFAULT = f"kind-{CLUSTER_NAME_DEFAULT}"
+DATADOG_NAMESPACE_DEFAULT = "tracer-test"
+CHAOS_MESH_NAMESPACE_DEFAULT = "chaos-mesh"
+
+BASE_MANIFESTS_APPLY_ORDER: tuple[str, ...] = (
+    "chaos-demo.yaml",
+    "experiments/crashloop/crashloop-demo.yaml",
+    "pod-kill-demo.yaml",
+)
+
+BASE_MANIFESTS_DELETE_ORDER: tuple[str, ...] = (
+    "pod-kill-demo.yaml",
+    "experiments/crashloop/crashloop-demo.yaml",
+    "chaos-demo.yaml",
+)
+
+
+def chaos_engineering_path(*parts: str) -> Path:
+    return CHAOS_ENGINEERING_DIR.joinpath(*parts)
+
+
+def list_experiment_names() -> list[str]:
+    """Directory names under experiments/ that contain at least one YAML file."""
+    if not EXPERIMENTS_DIR.is_dir():
+        return []
+    names: list[str] = []
+    for p in sorted(EXPERIMENTS_DIR.iterdir()):
+        if p.is_dir() and any(p.glob("*.yaml")):
+            names.append(p.name)
+    return names
+
+
+class ExperimentNotFoundError(FileNotFoundError):
+    """No experiment directory or no YAML under experiments/<name>."""
+
+
+def experiment_demo_yaml_paths(name: str) -> list[Path]:
+    exp = EXPERIMENTS_DIR / name
+    if not exp.is_dir():
+        raise ExperimentNotFoundError(f"No experiment directory: {name!r}")
+    return sorted(exp.glob("*-demo.yaml"))
+
+
+def experiment_chaos_yaml_paths(name: str) -> list[Path]:
+    exp = EXPERIMENTS_DIR / name
+    if not exp.is_dir():
+        raise ExperimentNotFoundError(f"No experiment directory: {name!r}")
+    return sorted(exp.glob("*-chaos.yaml"))
+
+
+def validate_experiment(name: str) -> None:
+    """Raise ExperimentNotFoundError if directory or YAML is missing."""
+    demos = experiment_demo_yaml_paths(name)
+    chaos = experiment_chaos_yaml_paths(name)
+    if not demos and not chaos:
+        raise ExperimentNotFoundError(f"No *-demo.yaml or *-chaos.yaml in experiment: {name!r}")
+
+
+def experiment_has_manifests(name: str) -> bool:
+    try:
+        validate_experiment(name)
+    except ExperimentNotFoundError:
+        return False
+    return True
+
+
+def infer_chaos_kind(chaos_yaml: Path) -> str | None:
+    """Best-effort parse of the first document's kind: field."""
+    try:
+        import yaml
+
+        text = chaos_yaml.read_text(encoding="utf-8")
+        for doc in yaml.safe_load_all(text):
+            if isinstance(doc, dict) and doc.get("kind"):
+                return str(doc["kind"])
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def experiment_summary_line(name: str) -> str:
+    """One-line description for list output."""
+    kinds: list[str] = []
+    for p in experiment_chaos_yaml_paths(name):
+        k = infer_chaos_kind(p)
+        if k:
+            kinds.append(k)
+    kinds_str = ", ".join(kinds) if kinds else "—"
+    return f"{name} ({kinds_str})"

--- a/tests/chaos_engineering/pod-kill-demo.yaml
+++ b/tests/chaos_engineering/pod-kill-demo.yaml
@@ -1,0 +1,23 @@
+# Prereq: chaos-demo workload (same cluster as experiments/crashloop/crashloop-demo):
+#   kubectl apply -f tests/chaos_engineering/chaos-demo.yaml --context=kind-tracer-k8s-test
+# Or: make chaos-engineering-apply (applies chaos-demo + crashloop + this PodChaos).
+#
+# From repo root (optional context for kind):
+#   kubectl apply -f tests/chaos_engineering/pod-kill-demo.yaml --context=kind-tracer-k8s-test
+# Remove:
+#   kubectl delete -f tests/chaos_engineering/pod-kill-demo.yaml --context=kind-tracer-k8s-test
+#
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: kill-chaos-demo
+  namespace: default
+spec:
+  action: pod-kill
+  mode: one
+  duration: "15s"
+  selector:
+    namespaces:
+      - default
+    labelSelectors:
+      app: chaos-demo

--- a/tests/e2e/kubernetes/infrastructure_sdk/local.py
+++ b/tests/e2e/kubernetes/infrastructure_sdk/local.py
@@ -117,7 +117,12 @@ def add_datadog_helm_repo() -> None:
     _run(["helm", "repo", "update", "datadog"], capture=False)
 
 
-def deploy_datadog_helm(values_file: str, namespace: str) -> None:
+def deploy_datadog_helm(
+    values_file: str,
+    namespace: str,
+    *,
+    kube_context: str | None = None,
+) -> None:
     """Install Datadog via official Helm chart."""
     api_key = os.environ.get("DD_API_KEY", "")
     if not api_key:
@@ -125,9 +130,12 @@ def deploy_datadog_helm(values_file: str, namespace: str) -> None:
 
     add_datadog_helm_repo()
 
-    _run(["kubectl", "create", "namespace", namespace], check=False)
+    ns_cmd: list[str] = ["kubectl", "create", "namespace", namespace]
+    if kube_context:
+        ns_cmd[1:1] = ["--context", kube_context]
+    _run(ns_cmd, check=False)
 
-    cmd = [
+    cmd: list[str] = [
         "helm", "upgrade", "--install", DATADOG_HELM_RELEASE, DATADOG_HELM_CHART,
         "-n", namespace,
         "-f", values_file,
@@ -138,6 +146,9 @@ def deploy_datadog_helm(values_file: str, namespace: str) -> None:
     site = os.environ.get("DD_SITE", "")
     if site:
         cmd.extend(["--set", f"datadog.site={site}"])
+
+    if kube_context:
+        cmd.extend(["--kube-context", kube_context])
 
     print("Installing Datadog Helm chart...")
     try:
@@ -151,18 +162,26 @@ def deploy_datadog_helm(values_file: str, namespace: str) -> None:
     print("Datadog Helm chart installed")
 
 
-def wait_for_datadog_agent(namespace: str, timeout: int = 180) -> bool:
+def wait_for_datadog_agent(
+    namespace: str,
+    timeout: int = 180,
+    *,
+    kube_context: str | None = None,
+) -> bool:
     """Wait for Datadog Agent DaemonSet to have at least one ready pod."""
     print("Waiting for Datadog Agent to be ready...")
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
+        ds_cmd: list[str] = [
+            "kubectl", "get", "daemonset",
+            "-n", namespace,
+            "-l", "app.kubernetes.io/component=agent",
+            "-o", "jsonpath={.items[0].status.numberReady}",
+        ]
+        if kube_context:
+            ds_cmd[1:1] = ["--context", kube_context]
         result = _run(
-            [
-                "kubectl", "get", "daemonset",
-                "-n", namespace,
-                "-l", "app.kubernetes.io/component=agent",
-                "-o", "jsonpath={.items[0].status.numberReady}",
-            ],
+            ds_cmd,
             check=False,
         )
         ready = result.stdout.strip()

--- a/tests/test_chaos_engineering_paths.py
+++ b/tests/test_chaos_engineering_paths.py
@@ -1,0 +1,87 @@
+"""Unit tests for chaos manifest path resolution and ordering (no cluster required)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.chaos_engineering.orchestrator import _datadog_values_path
+from tests.chaos_engineering.paths import (
+    CHAOS_ENGINEERING_DIR,
+    EXPERIMENTS_DIR,
+    ExperimentNotFoundError,
+    experiment_chaos_yaml_paths,
+    experiment_demo_yaml_paths,
+    experiment_summary_line,
+    infer_chaos_kind,
+    list_experiment_names,
+    validate_experiment,
+)
+
+
+def test_repo_root_contains_datadog_values() -> None:
+    values = Path(_datadog_values_path())
+    assert values.is_file(), f"expected {_datadog_values_path()}"
+    assert values.name == "datadog-values.yaml"
+
+
+def test_chaos_engineering_dir_exists() -> None:
+    assert CHAOS_ENGINEERING_DIR.is_dir()
+    assert (CHAOS_ENGINEERING_DIR / "experiments").is_dir()
+
+
+def test_list_experiment_names_includes_crashloop() -> None:
+    names = list_experiment_names()
+    assert "crashloop" in names
+    assert "pod-failure" in names
+
+
+def test_pod_failure_yaml_ordering() -> None:
+    validate_experiment("pod-failure")
+    demos = experiment_demo_yaml_paths("pod-failure")
+    chaos = experiment_chaos_yaml_paths("pod-failure")
+    assert len(demos) == 1
+    assert demos[0].name == "pod-failure-demo.yaml"
+    assert len(chaos) == 1
+    assert chaos[0].name == "pod-failure-chaos.yaml"
+
+
+def test_crashloop_has_demo_then_chaos_glob_order() -> None:
+    validate_experiment("crashloop")
+    demos = experiment_demo_yaml_paths("crashloop")
+    chaos = experiment_chaos_yaml_paths("crashloop")
+    assert [p.name for p in demos] == ["crashloop-demo.yaml"]
+    assert [p.name for p in chaos] == ["pod-kill-crashloop-chaos.yaml"]
+
+
+def test_validate_experiment_missing_raises() -> None:
+    with pytest.raises(ExperimentNotFoundError):
+        validate_experiment("not-a-real-experiment-dir-xyz")
+
+
+def test_infer_chaos_kind_first_document(tmp_path: Path) -> None:
+    y = tmp_path / "x-chaos.yaml"
+    y.write_text(
+        "---\n"
+        "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: a}\n---\n"
+        "apiVersion: chaos-mesh.org/v1alpha1\nkind: NetworkChaos\nmetadata: {name: n}\n",
+        encoding="utf-8",
+    )
+    assert infer_chaos_kind(y) == "ConfigMap"
+
+
+def test_experiment_summary_line_pod_failure() -> None:
+    line = experiment_summary_line("pod-failure")
+    assert line.startswith("pod-failure")
+    assert "PodChaos" in line
+
+
+def test_experiments_dir_matches_list() -> None:
+    """Every subdirectory with YAML is listed."""
+    disk = sorted(
+        p.name
+        for p in EXPERIMENTS_DIR.iterdir()
+        if p.is_dir() and any(p.glob("*.yaml"))
+    )
+    assert list_experiment_names() == disk


### PR DESCRIPTION
## Summary
Adds a single place under `tests/chaos_engineering/` for Chaos Mesh demos (YAML + JSON alert payloads) and a small Python helper `python -m tests.chaos_engineering` that **Makefile** targets invoke so users do not hand-order `kubectl apply`.

## Makefile
- `make chaos-lab-up` / `chaos-lab-down` — kind (optional), Datadog (optional), Chaos Mesh, baseline workloads
- `make chaos-experiment-list` / `chaos-experiment-up EXPERIMENT=...` / `chaos-experiment-down`
- `chaos-engineering-apply` / `delete` point at `tests/chaos_engineering/` manifests

## Implementation
- `tests/chaos_engineering/`: paths, kubectl/helm helpers, `experiment_ops` (apply `*-demo.yaml` then `*-chaos.yaml`), orchestration reusing `tests/e2e/kubernetes/infrastructure_sdk/local.py`
- `deploy_datadog_helm` / `wait_for_datadog_agent` accept optional `kube_context`
- `tests/test_chaos_engineering_paths.py` — unit tests for manifest ordering (no cluster)

## Docs
- `tests/chaos_engineering/README.md` — quick start (Make), manual setup, cleanup

## How to test
- `pytest tests/test_chaos_engineering_paths.py -q`
- `make chaos-experiment-list` (from repo root with venv + deps)

---
**Note:** This commit only includes chaos-related files; other local WIP (e.g. `app/nodes/*`) was left unstaged.

Made with [Cursor](https://cursor.com)