### PR TITLE
feat: add VS Code devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.13-bookworm
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git make sudo \
+    && groupadd --gid "${USER_GID}" "${USERNAME}" \
+    && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}" --shell /bin/bash \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > "/etc/sudoers.d/${USERNAME}" \
+    && chmod 0440 "/etc/sudoers.d/${USERNAME}" \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+  "name": "OpenSRE",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+    "PATH": "${containerWorkspaceFolder}/.venv-devcontainer/bin:${containerEnv:PATH}"
+  },
+  "containerEnv": {
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONUTF8": "1"
+  },
+  "forwardPorts": [
+    2024
+  ],
+  "portsAttributes": {
+    "2024": {
+      "label": "LangGraph dev server",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker",
+        "editorconfig.editorconfig"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv-devcontainer/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
+      }
+    }
+  },
+  "postCreateCommand": "python -m venv --clear .venv-devcontainer && .venv-devcontainer/bin/python -m pip install -e '.[dev]'",
+  "remoteUser": "vscode"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 **/.mypy_cache
 **/.ruff_cache
 **/.venv
+**/.venv-devcontainer
 **/node_modules
 **/cdk.out
 tests/test_case_upstream_lambda/pipeline_code/api_ingester/certifi

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ ENV/
 env.bak/
 venv.bak/
 .venv/
+.venv-devcontainer/
 virtualenv/
 
 # Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ See **[SETUP.md](SETUP.md)** for detailed setup instructions including Windows-s
 3. Run checks: `make lint && make typecheck && make test-cov`
 4. Build release artifacts when needed: `make build`
 
+If you prefer VS Code, you can use the repo's devcontainer at [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) instead of setting up Python manually.
+
 ---
 
 **The full flow:**

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ opensre onboard
 opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
 ```
 
+If you use VS Code, the repo now includes a ready-to-use devcontainer under [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json). Open the repo in VS Code and run `Dev Containers: Reopen in Container` to get the project on Python 3.13 with the contributor toolchain preinstalled. Keep Docker Desktop, OrbStack, Colima, or another Docker-compatible runtime running on the host, since VS Code devcontainers rely on your local Docker engine.
+
 ---
 
 ## How OpenSRE Works

--- a/SETUP.md
+++ b/SETUP.md
@@ -41,6 +41,23 @@ All three must pass before you're ready to develop.
 
 ---
 
+## VS Code Dev Container Setup
+
+If you use VS Code, you can skip the manual Python setup and use the repo's devcontainer instead:
+
+1. Install the **Dev Containers** extension in VS Code.
+2. Start Docker Desktop, OrbStack, Colima, or another Docker-compatible runtime on your host machine.
+3. Open the repository in VS Code and run `Dev Containers: Reopen in Container`.
+4. Wait for the container's `postCreateCommand` to install `.[dev]`.
+5. Run the usual checks:
+   ```bash
+   make lint && make typecheck && make test-cov
+   ```
+
+The devcontainer uses Python 3.13 to match CI and `.tool-versions`. Manual host-based setup continues to work with any supported Python version (`>=3.11`).
+
+---
+
 ## Windows-Specific Setup
 
 Windows does not include `make` by default. Install it to use our development task runner.

--- a/app/cli/wizard/local_grafana_stack/docker-compose.yml
+++ b/app/cli/wizard/local_grafana_stack/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
     volumes:
-      - ${LOCAL_WORKSPACE_FOLDER:-.}/app/cli/wizard/local_grafana_stack/provisioning:/etc/grafana/provisioning
+      - ${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/local_grafana_stack/provisioning:/etc/grafana/provisioning

--- a/app/cli/wizard/local_grafana_stack/docker-compose.yml
+++ b/app/cli/wizard/local_grafana_stack/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
     volumes:
-      - ./provisioning:/etc/grafana/provisioning
+      - ${LOCAL_WORKSPACE_FOLDER:-.}/app/cli/wizard/local_grafana_stack/provisioning:/etc/grafana/provisioning

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_devcontainer_config_matches_local_dev_workflow() -> None:
+    config = json.loads((REPO_ROOT / ".devcontainer" / "devcontainer.json").read_text())
+    dockerfile = (REPO_ROOT / ".devcontainer" / "Dockerfile").read_text()
+
+    assert config["name"] == "OpenSRE"
+    assert config["build"]["dockerfile"] == "Dockerfile"
+    assert config["build"]["context"] == ".."
+    assert config["features"]["ghcr.io/devcontainers/features/docker-outside-of-docker:1"][
+        "dockerDashComposeVersion"
+    ] == "v2"
+    assert config["remoteEnv"]["LOCAL_WORKSPACE_FOLDER"] == "${localWorkspaceFolder}"
+    assert (
+        config["remoteEnv"]["PATH"]
+        == "${containerWorkspaceFolder}/.venv-devcontainer/bin:${containerEnv:PATH}"
+    )
+    assert config["customizations"]["vscode"]["settings"][
+        "python.defaultInterpreterPath"
+    ] == "${containerWorkspaceFolder}/.venv-devcontainer/bin/python"
+    assert "python -m venv --clear .venv-devcontainer" in config["postCreateCommand"]
+    assert "pip install --upgrade pip" not in config["postCreateCommand"]
+    assert ".venv-devcontainer/bin/python -m pip install -e '.[dev]'" in config["postCreateCommand"]
+    assert 2024 in config["forwardPorts"]
+    assert "FROM python:3.13-bookworm" in dockerfile
+    assert "apt-get install -y --no-install-recommends ca-certificates curl git make sudo" in dockerfile
+
+
+def test_local_grafana_compose_uses_workspace_override_for_devcontainers() -> None:
+    compose = (REPO_ROOT / "app/cli/wizard/local_grafana_stack/docker-compose.yml").read_text()
+
+    assert (
+        "${LOCAL_WORKSPACE_FOLDER:-.}/app/cli/wizard/local_grafana_stack/provisioning"
+        in compose
+    )

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -36,6 +36,6 @@ def test_local_grafana_compose_uses_workspace_override_for_devcontainers() -> No
     compose = (REPO_ROOT / "app/cli/wizard/local_grafana_stack/docker-compose.yml").read_text()
 
     assert (
-        "${LOCAL_WORKSPACE_FOLDER:-.}/app/cli/wizard/local_grafana_stack/provisioning"
+        "${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/local_grafana_stack/provisioning"
         in compose
     )


### PR DESCRIPTION
## Summary
- add a VS Code devcontainer and Dockerfile based on Python 3.13 to match CI and contributor tooling
- make devcontainer setup idempotent by clearing `.venv-devcontainer` before reinstalling dependencies
- fix the local Grafana compose bind mount so it resolves correctly from inside a devcontainer
- document the devcontainer workflow in `README.md`, `SETUP.md`, and `CONTRIBUTING.md`
- add regression coverage for the devcontainer config and Grafana compose path override

## Testing
- `make lint`
- `make typecheck`
- `make test-cov`
- `npx -y @devcontainers/cli up --workspace-folder . --remove-existing-container`
- `docker exec -u vscode <container> /bin/bash -lc "cd /workspaces/opensre && .venv-devcontainer/bin/python -m pytest tests/test_devcontainer.py -q"`

Fixes #682