### PR TITLE
fix: use typing_extensions.TypedDict in remaining app modules (follow-up #668)

### DIFF
--- a/app/cli/deploy.py
+++ b/app/cli/deploy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import subprocess
 import time
 from typing import TYPE_CHECKING, Any
+
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:

--- a/app/cli/deploy.py
+++ b/app/cli/deploy.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 import subprocess
 import time
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import cast
+from typing_extensions import TypedDict
 
 from app.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement
 

--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from typing import cast
+
 from typing_extensions import TypedDict
 
 from app.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement

--- a/app/integrations/openclaw.py
+++ b/app/integrations/openclaw.py
@@ -18,7 +18,8 @@ from collections.abc import AsyncIterator, Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypedDict, cast
+from typing import Literal, cast
+from typing_extensions import TypedDict
 from urllib.parse import urlparse
 
 import httpx

--- a/app/integrations/openclaw.py
+++ b/app/integrations/openclaw.py
@@ -19,7 +19,6 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
-from typing_extensions import TypedDict
 from urllib.parse import urlparse
 
 import httpx
@@ -27,6 +26,7 @@ from mcp import ClientSession, StdioServerParameters, types  # type: ignore[impo
 from mcp.client.sse import sse_client  # type: ignore[import-not-found]
 from mcp.client.stdio import stdio_client  # type: ignore[import-not-found]
 from pydantic import Field, field_validator, model_validator
+from typing_extensions import TypedDict
 
 from app.integrations.mcp_streamable_http_compat import streamable_http_client
 from app.strict_config import StrictConfigModel

--- a/app/nodes/publish_findings/report_context.py
+++ b/app/nodes/publish_findings/report_context.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 import time
 from typing import Any
-from typing_extensions import TypedDict
 from urllib.parse import urlparse
+
+from typing_extensions import TypedDict
 
 from app.nodes.publish_findings.urls.aws import (
     build_datadog_logs_url,

--- a/app/nodes/publish_findings/report_context.py
+++ b/app/nodes/publish_findings/report_context.py
@@ -13,7 +13,8 @@ build_report_context runs four phases:
 from __future__ import annotations
 
 import time
-from typing import Any, TypedDict
+from typing import Any
+from typing_extensions import TypedDict
 from urllib.parse import urlparse
 
 from app.nodes.publish_findings.urls.aws import (

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -8,7 +8,8 @@ the same set of keys and will fail if they diverge.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any
+from typing_extensions import TypedDict
 
 from langgraph.graph import add_messages
 from pydantic import ConfigDict, Field

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -9,10 +9,10 @@ the same set of keys and will fail if they diverge.
 from __future__ import annotations
 
 from typing import Annotated, Any
-from typing_extensions import TypedDict
 
 from langgraph.graph import add_messages
 from pydantic import ConfigDict, Field
+from typing_extensions import TypedDict
 
 from app.state.types import AgentMode, ChatMessageModel
 from app.strict_config import StrictConfigModel

--- a/app/state/types.py
+++ b/app/state/types.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal
+from typing_extensions import TypedDict
 
 from pydantic import Field
 

--- a/app/state/types.py
+++ b/app/state/types.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from typing import Any, Literal
-from typing_extensions import TypedDict
 
 from pydantic import Field
+from typing_extensions import TypedDict
 
 from app.strict_config import StrictConfigModel
 


### PR DESCRIPTION
Follow-up to #668.

## Context

PR #668 fixed a Python 3.11 + Pydantic 2 `PydanticUserError` by switching `TypedDict` import from `typing` to `typing_extensions` in `app/nodes/investigate/types.py`. Greptile flagged (P1) that the same fix is needed in other app modules that follow the same pattern.

## Files updated (6)

All six apply the identical minimal migration — only the `TypedDict` symbol moves to `typing_extensions`; every other `typing` import stays put.

- `app/state/types.py`
- `app/state/agent_state.py`
- `app/integrations/openclaw.py`
- `app/nodes/publish_findings/report_context.py`
- `app/cli/tests/discover.py`
- `app/cli/deploy.py`

## Verification

- `python -m py_compile` — passes on all 6 files
- Import smoke test under the project `.venv` (Python 3.11, Pydantic 2): all 6 modules import cleanly

## Scope

- Imports only. No logic, formatting, or unrelated changes.
- No new test files (the behavior matches #668 which did not add tests).

cc @davincios — addresses the Greptile P1 comment on the merged #668.
