### PR TITLE
fix: restore RunnableConfig annotation fix regressed by #594

### DIFF
--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -5,8 +5,6 @@ integration credentials available for all downstream nodes. This replaces
 per-node credential fetching with a single upfront resolution.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from typing import Any


### PR DESCRIPTION
Fixes #695

## Summary

- Removes `from __future__ import annotations` from `app/nodes/resolve_integrations/node.py`.
- PEP 563 stringification of `RunnableConfig | None` does not match LangGraph 1.1.6's whitelist (which accepts `"RunnableConfig"` and `"Optional[RunnableConfig]"` but not `"RunnableConfig | None"`), causing 12 repeated `UserWarning` lines on every `make test-cov` run.
- This is the same fix that was merged in #589, then reintroduced by #594 during a refactor.

## Test plan

- [x] `make test-cov` — **2725 passed, 1 skipped**; warning count drops from **22 → 10** (the 12 RunnableConfig warnings are eliminated)
- [x] `ruff check app/nodes/resolve_integrations/` passes
- [x] `mypy app/nodes/resolve_integrations/node.py` passes

## Follow-up suggestion (out of scope)

Since this fix has now regressed once, a lightweight lint rule or pre-commit check forbidding `from __future__ import annotations` in files containing LangGraph node functions would prevent a third regression. Happy to file as a separate issue if that's useful.