### PR TITLE
fix(snowflake): rename tool param schema to db_schema to silence Pydantic warning

### DIFF
--- a/app/tools/SnowflakeQueryHistoryTool/__init__.py
+++ b/app/tools/SnowflakeQueryHistoryTool/__init__.py
@@ -33,7 +33,7 @@ def _snowflake_extract_params(sources: dict[str, dict[str, Any]]) -> dict[str, A
         "warehouse": str(sf.get("warehouse", "")).strip(),
         "role": str(sf.get("role", "")).strip(),
         "database": str(sf.get("database", "")).strip(),
-        "schema": str(sf.get("schema", "")).strip(),
+        "db_schema": str(sf.get("schema", "")).strip(),
         "query": str(sf.get("query", "")).strip(),
         "limit": 50,
         "max_results": int(sf.get("max_results", _DEFAULT_MAX_RESULTS) or _DEFAULT_MAX_RESULTS),
@@ -109,7 +109,7 @@ def _normalize_rows(response_payload: dict[str, Any]) -> list[dict[str, Any]]:
             "warehouse": {"type": "string"},
             "role": {"type": "string"},
             "database": {"type": "string"},
-            "schema": {"type": "string"},
+            "db_schema": {"type": "string"},
             "integration_id": {"type": "string"},
             "timeout_seconds": {"type": "number", "default": 20.0},
         },
@@ -129,7 +129,7 @@ def query_snowflake_history(
     warehouse: str = "",
     role: str = "",
     database: str = "",
-    schema: str = "",
+    db_schema: str = "",
     integration_id: str = "",
     timeout_seconds: float = 20.0,
     **_kwargs: Any,
@@ -159,8 +159,8 @@ def query_snowflake_history(
         payload["role"] = role
     if database:
         payload["database"] = database
-    if schema:
-        payload["schema"] = schema
+    if db_schema:
+        payload["schema"] = db_schema
 
     try:
         response = httpx.post(endpoint, headers=headers, json=payload, timeout=max(1.0, timeout_seconds))


### PR DESCRIPTION
Fixes #697

## Summary

- Renames the `schema` parameter of `query_snowflake_history` to `db_schema` to stop shadowing Pydantic's `BaseModel.schema()` method.
- Keeps the outbound Snowflake `/api/v2/statements` payload key as `"schema"` (required by the Snowflake REST API).
- Only `app/tools/SnowflakeQueryHistoryTool/__init__.py` changes (4 hunks, 8 lines).

## Why not `Field(alias="schema")`

LangChain's `StructuredTool.from_function` inspects the raw Python signature via `create_schema_from_function` and ignores `Annotated` / `Field(alias=...)` metadata — so an alias still triggers the shadow warning. Rename is the minimal robust fix.

## Test plan

- [x] `make test-cov` — **2725 passed, 1 skipped, 0 warnings** (was 10 Pydantic UserWarnings referencing `schema` / `shadows` / `QuerySnowflakeHistory`)
- [x] `ruff check app/tools/SnowflakeQueryHistoryTool/` passes
- [x] `mypy app/tools/SnowflakeQueryHistoryTool/` passes
- [x] `query_snowflake_history` still callable; still forwards the renamed parameter to Snowflake's API under the `"schema"` key