### PR TITLE
fix: consolidate pytest config into pytest.ini, stop silently ignoring pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,6 @@ azure_sql = [
 [tool.setuptools.packages.find]
 include = ["app*", "tests*"]
 
-[tool.pytest.ini_options]
-markers = [
-    "synthetic: LLM-based synthetic RCA scenario tests (non-deterministic)",
-]
-
 # With pytest-xdist (-n auto), each worker writes a fragment; put them under
 # .pytest_cache/ (already gitignored) instead of .coverage.<hostname>.* at repo root.
 [tool.coverage.run]

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,6 @@ filterwarnings =
     ignore::DeprecationWarning
 markers =
     integration: marks tests as integration tests (may make API calls)
-    synthetic: fixture-based offline tests; no live infrastructure required
+    synthetic: LLM-based synthetic RCA scenario tests (non-deterministic)
     e2e: requires live infrastructure or external credentials (skip in offline CI)
     axis2: adversarial offline tests; uses SelectiveGrafanaBackend and asserts ruling-out reasoning


### PR DESCRIPTION
Fixes #699

## Summary

- Removes the dead `[tool.pytest.ini_options]` block from `pyproject.toml` that pytest has been silently ignoring (pytest picks `pytest.ini` over pyproject when both exist, emitting `WARNING: ignoring pytest config in pyproject.toml!` on every run of `make test-cov`).
- Copies the accurate `synthetic` marker description ("LLM-based synthetic RCA scenario tests (non-deterministic)") into `pytest.ini`, replacing the stale "fixture-based offline tests; no live infrastructure required" wording — the tests do make live LLM calls, which is why `make test-cov` excludes them via `-m "not synthetic"`.
- Leaves `[tool.coverage.run]` in `pyproject.toml` untouched — pytest-cov reads coverage config independently of pytest's ini resolver.
- Prevents a recurring contributor footgun where edits to `[tool.pytest.ini_options]` appear to take effect but are silently dropped.

## Test plan

- [x] `make test-cov` — **2725 passed, 1 skipped**; `WARNING: ignoring pytest config in pyproject.toml!` no longer appears
- [x] `ruff check` passes
- [x] `pytest --markers` lists `synthetic` with the corrected description