### PR TITLE
fix(postgresql): wire is_available + extract_params into PostgreSQL @tool decorators

### DIFF
--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -194,7 +194,7 @@ def postgresql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     return {
         "host": str(pg.get("host", "")).strip(),
         "database": str(pg.get("database", "")).strip(),
-        "port": int(pg.get("port", DEFAULT_POSTGRESQL_PORT)),
+        "port": int(pg.get("port") or DEFAULT_POSTGRESQL_PORT),
     }
 
 

--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -177,6 +177,27 @@ def validate_postgresql_config(config: PostgreSQLConfig) -> PostgreSQLValidation
         return PostgreSQLValidationResult(ok=False, detail=f"PostgreSQL connection failed: {err}")
 
 
+def postgresql_is_available(sources: dict[str, dict]) -> bool:
+    """Check if PostgreSQL integration identifying params are present."""
+    pg = sources.get("postgresql", {})
+    return bool(pg.get("host") and pg.get("database"))
+
+
+def postgresql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Extract PostgreSQL identifying params (host, database, port) from resolved integrations.
+
+    Credentials (username, password, ssl_mode) are resolved internally by
+    ``resolve_postgresql_config`` from the integration store or environment, so
+    they never appear in tool signatures and are never seen by the LLM.
+    """
+    pg = sources.get("postgresql", {})
+    return {
+        "host": str(pg.get("host", "")).strip(),
+        "database": str(pg.get("database", "")).strip(),
+        "port": int(pg.get("port", DEFAULT_POSTGRESQL_PORT)),
+    }
+
+
 def get_server_status(config: PostgreSQLConfig) -> dict[str, Any]:
     """Retrieve server status (connections, databases, uptime, cache hit ratio).
 

--- a/app/tools/PostgreSQLCurrentQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLCurrentQueriesTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.postgresql import get_current_queries, resolve_postgresql_config
+from app.integrations.postgresql import (
+    get_current_queries,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Investigating database locks and blocking queries during incidents",
         "Finding resource-intensive queries correlating with alert timeframes",
     ],
+    is_available=postgresql_is_available,
+    extract_params=postgresql_extract_params,
 )
 def get_postgresql_current_queries(
     host: str,

--- a/app/tools/PostgreSQLReplicationStatusTool/__init__.py
+++ b/app/tools/PostgreSQLReplicationStatusTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.postgresql import get_replication_status, resolve_postgresql_config
+from app.integrations.postgresql import (
+    get_replication_status,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Checking replica health and synchronization status",
         "Monitoring WAL streaming and replica connectivity problems",
     ],
+    is_available=postgresql_is_available,
+    extract_params=postgresql_extract_params,
 )
 def get_postgresql_replication_status(
     host: str,

--- a/app/tools/PostgreSQLServerStatusTool/__init__.py
+++ b/app/tools/PostgreSQLServerStatusTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.postgresql import get_server_status, resolve_postgresql_config
+from app.integrations.postgresql import (
+    get_server_status,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Identifying connection saturation or exhaustion issues",
         "Reviewing transaction rates and cache efficiency metrics",
     ],
+    is_available=postgresql_is_available,
+    extract_params=postgresql_extract_params,
 )
 def get_postgresql_server_status(
     host: str,

--- a/app/tools/PostgreSQLSlowQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLSlowQueriesTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.postgresql import get_slow_queries, resolve_postgresql_config
+from app.integrations.postgresql import (
+    get_slow_queries,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Analyzing query execution patterns during incident timeframes",
         "Finding poorly optimized queries with high execution times or low cache hit rates",
     ],
+    is_available=postgresql_is_available,
+    extract_params=postgresql_extract_params,
 )
 def get_postgresql_slow_queries(
     host: str,

--- a/app/tools/PostgreSQLTableStatsTool/__init__.py
+++ b/app/tools/PostgreSQLTableStatsTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.postgresql import get_table_stats, resolve_postgresql_config
+from app.integrations.postgresql import (
+    get_table_stats,
+    postgresql_extract_params,
+    postgresql_is_available,
+    resolve_postgresql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Analyzing table scan patterns and index usage efficiency",
         "Checking table maintenance status like vacuum and analyze operations",
     ],
+    is_available=postgresql_is_available,
+    extract_params=postgresql_extract_params,
 )
 def get_postgresql_table_stats(
     host: str,


### PR DESCRIPTION
References #702

Part 1 of 2. MySQL side ships in a separate PR opened alongside this one.

## Summary

Adds the missing `is_available` and `extract_params` callbacks to the `@tool(...)` decorators on all 5 PostgreSQL diagnostic tools. Before this change, every one of them raised `TypeError: missing 2 required positional arguments: 'host' and 'database'` the moment the agent tried to invoke them. Mirrors the existing working pattern used by the MariaDB tool family at `app/integrations/mariadb.py:160-176`.

## What changed

- Added `postgresql_is_available` and `postgresql_extract_params` to `app/integrations/postgresql.py`.
- Wired both helpers into the `@tool(...)` decorator of all 5 PostgreSQL tools (current queries, replication status, server status, slow queries, table stats).

PostgreSQL integration resolves credentials internally via `resolve_postgresql_config` (reading from the store/env), so `extract_params` only surfaces the three identifying params: `host`, `database`, `port`. Credentials stay out of tool signatures and are never seen by the LLM.

Scope: 6 files, +61 / -5 lines.

## Evidence

### Baseline (origin/main @ `6b02982`, full RDS synthetic suite on Gemini 2.5-flash)

- `make test-rds-synthetic` → **0/15 scenarios passed**
- Wall time: 838 s
- 184 PostgreSQL `TypeError` failures during the run:
  - `get_postgresql_server_status`: 92
  - `get_postgresql_current_queries`: 40
  - `get_postgresql_replication_status`: 32
  - `get_postgresql_table_stats`: 20

### After fix (this branch)

- `make test-rds-synthetic` → **0 PostgreSQL TypeErrors** (was 184)
- Suite still shows 0/15 passing — RDS-specific diagnostic tooling over the CloudWatch / Performance Insights mock data is a separate gap. Failure reasons are now about real diagnostic quality (wrong category, missing keywords) rather than masked tool plumbing.
- `make test-cov` → 2725 passed, 1 skipped, 10 warnings (no regressions)
- `ruff check` on all changed files → clean
- `mypy` on all changed files → clean

## Test plan

- [x] `make test-cov` passes with no regressions
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] Full `make test-rds-synthetic` run shows zero TypeError failures from PostgreSQL tools
- [x] MariaDB tools still work (not touched)