### PR TITLE
fix(mysql): wire is_available + extract_params into MySQL @tool decorators

### DIFF
--- a/app/integrations/mysql.py
+++ b/app/integrations/mysql.py
@@ -216,7 +216,7 @@ def mysql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     return {
         "host": str(my.get("host", "")).strip(),
         "database": str(my.get("database", "")).strip(),
-        "port": int(my.get("port", DEFAULT_MYSQL_PORT)),
+        "port": int(my.get("port") or DEFAULT_MYSQL_PORT),
     }
 
 

--- a/app/integrations/mysql.py
+++ b/app/integrations/mysql.py
@@ -199,6 +199,27 @@ def _truncate(text: str, max_len: int = _QUERY_TRUNCATE_LEN) -> str:
     return text[:max_len] + "..."
 
 
+def mysql_is_available(sources: dict[str, dict]) -> bool:
+    """Check if MySQL integration identifying params are present."""
+    my = sources.get("mysql", {})
+    return bool(my.get("host") and my.get("database"))
+
+
+def mysql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Extract MySQL identifying params (host, database, port) from resolved integrations.
+
+    Credentials (username, password, ssl_mode) are resolved internally by
+    ``resolve_mysql_config`` from the integration store or environment, so
+    they never appear in tool signatures and are never seen by the LLM.
+    """
+    my = sources.get("mysql", {})
+    return {
+        "host": str(my.get("host", "")).strip(),
+        "database": str(my.get("database", "")).strip(),
+        "port": int(my.get("port", DEFAULT_MYSQL_PORT)),
+    }
+
+
 def get_server_status(config: MySQLConfig) -> dict[str, Any]:
     """Retrieve server status (connections, uptime, InnoDB buffer pool metrics).
 

--- a/app/tools/MySQLCurrentProcessesTool/__init__.py
+++ b/app/tools/MySQLCurrentProcessesTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.mysql import get_current_processes, resolve_mysql_config
+from app.integrations.mysql import (
+    get_current_processes,
+    mysql_extract_params,
+    mysql_is_available,
+    resolve_mysql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Investigating lock contention or deadlock situations",
         "Spotting runaway queries during an incident",
     ],
+    is_available=mysql_is_available,
+    extract_params=mysql_extract_params,
 )
 def get_mysql_current_processes(
     host: str,

--- a/app/tools/MySQLReplicationStatusTool/__init__.py
+++ b/app/tools/MySQLReplicationStatusTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.mysql import get_replication_status, resolve_mysql_config
+from app.integrations.mysql import (
+    get_replication_status,
+    mysql_extract_params,
+    mysql_is_available,
+    resolve_mysql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Verifying replication IO and SQL threads are running",
         "Diagnosing replication errors and identifying last error details",
     ],
+    is_available=mysql_is_available,
+    extract_params=mysql_extract_params,
 )
 def get_mysql_replication_status(
     host: str,

--- a/app/tools/MySQLServerStatusTool/__init__.py
+++ b/app/tools/MySQLServerStatusTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.mysql import get_server_status, resolve_mysql_config
+from app.integrations.mysql import (
+    get_server_status,
+    mysql_extract_params,
+    mysql_is_available,
+    resolve_mysql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Identifying connection saturation or exhaustion issues",
         "Reviewing InnoDB buffer pool hit ratio and deadlock counts",
     ],
+    is_available=mysql_is_available,
+    extract_params=mysql_extract_params,
 )
 def get_mysql_server_status(
     host: str,

--- a/app/tools/MySQLSlowQueriesTool/__init__.py
+++ b/app/tools/MySQLSlowQueriesTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.mysql import get_slow_queries, resolve_mysql_config
+from app.integrations.mysql import (
+    get_slow_queries,
+    mysql_extract_params,
+    mysql_is_available,
+    resolve_mysql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Analyzing query execution patterns during incident timeframes",
         "Finding poorly optimized queries with high execution times or full-table scans",
     ],
+    is_available=mysql_is_available,
+    extract_params=mysql_extract_params,
 )
 def get_mysql_slow_queries(
     host: str,

--- a/app/tools/MySQLTableStatsTool/__init__.py
+++ b/app/tools/MySQLTableStatsTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.mysql import get_table_stats, resolve_mysql_config
+from app.integrations.mysql import (
+    get_table_stats,
+    mysql_extract_params,
+    mysql_is_available,
+    resolve_mysql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Reviewing table sizes and growth patterns for capacity planning",
         "Finding tables with unexpectedly high row counts or index overhead",
     ],
+    is_available=mysql_is_available,
+    extract_params=mysql_extract_params,
 )
 def get_mysql_table_stats(
     host: str,


### PR DESCRIPTION
References #702

Part 2 of 2. Continues the fix from #703 for the MySQL side of the same bug.

## Summary

Adds the missing `is_available` and `extract_params` callbacks to the `@tool(...)` decorators on all 5 MySQL diagnostic tools. Same bug pattern and same fix approach as #703 for PostgreSQL. Mirrors the working MariaDB pattern at `app/integrations/mariadb.py:160-176`.

## What changed

- Added `mysql_is_available` and `mysql_extract_params` to `app/integrations/mysql.py`.
- Wired both helpers into the `@tool(...)` decorator of all 5 MySQL tools (current processes, replication status, server status, slow queries, table stats).

MySQL integration resolves credentials internally via `resolve_mysql_config` (reading from the store/env), so `extract_params` only surfaces the three identifying params: `host`, `database`, `port`. Credentials stay out of tool signatures and are never seen by the LLM.

Scope: 6 files, +61 / -5 lines.

## Evidence

No MySQL-specific synthetic scenario suite exists, but during the end-to-end audit (`make test-rds-synthetic` on origin/main with Gemini 2.5-flash) the agent opportunistically invoked `get_mysql_replication_status` on RDS PostgreSQL scenarios, which failed with the same `TypeError` pattern — 6 failures across the suite. After this fix, those failures drop to 0 (the tool now correctly reports unavailable when no MySQL source is configured, so the agent no longer tries it on PG scenarios).

- `make test-cov` → 2725 passed, 1 skipped, 10 warnings (no regressions)
- `ruff check` on all changed files → clean
- `mypy` on all changed files → clean
- Pattern match with #703 (PostgreSQL side) and with MariaDB's existing working wiring

## Test plan

- [x] `make test-cov` passes with no regressions
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] MariaDB tools still work (not touched)
- [ ] Live MySQL integration verification — not possible in my local env (no MySQL configured); happy to do a sanity-check if the maintainer has a live MySQL to point at