### PR TITLE
fix(azure-sql): wire is_available + extract_params into Azure SQL @tool decorators

### DIFF
--- a/app/integrations/azure_sql.py
+++ b/app/integrations/azure_sql.py
@@ -209,6 +209,27 @@ def validate_azure_sql_config(config: AzureSQLConfig) -> AzureSQLValidationResul
         return AzureSQLValidationResult(ok=False, detail=f"Azure SQL connection failed: {err}")
 
 
+def azure_sql_is_available(sources: dict[str, dict]) -> bool:
+    """Check if Azure SQL integration identifying params are present."""
+    az = sources.get("azure_sql", {})
+    return bool(az.get("server") and az.get("database"))
+
+
+def azure_sql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Extract Azure SQL identifying params (server, database, port) from resolved integrations.
+
+    Credentials (username, password, driver, encrypt) are resolved internally by
+    ``resolve_azure_sql_config`` from the integration store or environment, so
+    they never appear in tool signatures and are never seen by the LLM.
+    """
+    az = sources.get("azure_sql", {})
+    return {
+        "server": str(az.get("server", "")).strip(),
+        "database": str(az.get("database", "")).strip(),
+        "port": int(az.get("port") or DEFAULT_AZURE_SQL_PORT),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Read-only diagnostic queries (Azure SQL DMVs)
 # ---------------------------------------------------------------------------

--- a/app/integrations/azure_sql.py
+++ b/app/integrations/azure_sql.py
@@ -224,8 +224,8 @@ def azure_sql_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     """
     az = sources.get("azure_sql", {})
     return {
-        "server": str(az.get("server", "")).strip(),
-        "database": str(az.get("database", "")).strip(),
+        "server": str(az.get("server") or "").strip(),
+        "database": str(az.get("database") or "").strip(),
         "port": int(az.get("port") or DEFAULT_AZURE_SQL_PORT),
     }
 

--- a/app/tools/AzureSQLCurrentQueriesTool/__init__.py
+++ b/app/tools/AzureSQLCurrentQueriesTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.azure_sql import get_current_queries, resolve_azure_sql_config
+from app.integrations.azure_sql import (
+    azure_sql_extract_params,
+    azure_sql_is_available,
+    get_current_queries,
+    resolve_azure_sql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Diagnosing blocking chains during an Azure SQL incident",
         "Finding queries consuming excessive CPU or IO",
     ],
+    is_available=azure_sql_is_available,
+    extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_current_queries(
     server: str,

--- a/app/tools/AzureSQLResourceStatsTool/__init__.py
+++ b/app/tools/AzureSQLResourceStatsTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.azure_sql import get_resource_stats, resolve_azure_sql_config
+from app.integrations.azure_sql import (
+    azure_sql_extract_params,
+    azure_sql_is_available,
+    get_resource_stats,
+    resolve_azure_sql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Identifying resource saturation causing query timeouts",
         "Reviewing historical resource trends to determine if tier upgrade is needed",
     ],
+    is_available=azure_sql_is_available,
+    extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_resource_stats(
     server: str,

--- a/app/tools/AzureSQLServerStatusTool/__init__.py
+++ b/app/tools/AzureSQLServerStatusTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.azure_sql import get_server_status, resolve_azure_sql_config
+from app.integrations.azure_sql import (
+    azure_sql_extract_params,
+    azure_sql_is_available,
+    get_server_status,
+    resolve_azure_sql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Identifying DTU/vCore throttling or resource exhaustion",
         "Reviewing service tier and connection saturation",
     ],
+    is_available=azure_sql_is_available,
+    extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_server_status(
     server: str,

--- a/app/tools/AzureSQLSlowQueriesTool/__init__.py
+++ b/app/tools/AzureSQLSlowQueriesTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.azure_sql import get_slow_queries, resolve_azure_sql_config
+from app.integrations.azure_sql import (
+    azure_sql_extract_params,
+    azure_sql_is_available,
+    get_slow_queries,
+    resolve_azure_sql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Finding resource-intensive queries causing DTU throttling",
         "Reviewing query performance trends for capacity planning",
     ],
+    is_available=azure_sql_is_available,
+    extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_slow_queries(
     server: str,

--- a/app/tools/AzureSQLWaitStatsTool/__init__.py
+++ b/app/tools/AzureSQLWaitStatsTool/__init__.py
@@ -2,7 +2,12 @@
 
 from typing import Any
 
-from app.integrations.azure_sql import get_wait_stats, resolve_azure_sql_config
+from app.integrations.azure_sql import (
+    azure_sql_extract_params,
+    azure_sql_is_available,
+    get_wait_stats,
+    resolve_azure_sql_config,
+)
 from app.tools.tool_decorator import tool
 
 
@@ -16,6 +21,8 @@ from app.tools.tool_decorator import tool
         "Diagnosing lock contention or IO bottlenecks",
         "Understanding resource governance limits on Azure SQL",
     ],
+    is_available=azure_sql_is_available,
+    extract_params=azure_sql_extract_params,
 )
 def get_azure_sql_wait_stats(
     server: str,

--- a/tests/integrations/test_azure_sql.py
+++ b/tests/integrations/test_azure_sql.py
@@ -271,3 +271,14 @@ class TestAzureSQLExtractParams:
     def test_port_as_numeric_string(self) -> None:
         sources = {"azure_sql": {"server": "s", "database": "d", "port": "1434"}}
         assert azure_sql_extract_params(sources)["port"] == 1434
+
+    def test_server_none_returns_empty_string(self) -> None:
+        # A stored integration persisting {"server": null} must not yield the
+        # literal string "None" through str(None). The `or ""` fallback keeps
+        # the result empty, matching the AzureSQLConfig._normalize_server validator.
+        sources = {"azure_sql": {"server": None, "database": "d"}}
+        assert azure_sql_extract_params(sources)["server"] == ""
+
+    def test_database_none_returns_empty_string(self) -> None:
+        sources = {"azure_sql": {"server": "s", "database": None}}
+        assert azure_sql_extract_params(sources)["database"] == ""

--- a/tests/integrations/test_azure_sql.py
+++ b/tests/integrations/test_azure_sql.py
@@ -1,9 +1,12 @@
 """Unit tests for the Azure SQL integration module."""
 
 from app.integrations.azure_sql import (
+    DEFAULT_AZURE_SQL_PORT,
     AzureSQLConfig,
     AzureSQLValidationResult,
     azure_sql_config_from_env,
+    azure_sql_extract_params,
+    azure_sql_is_available,
     build_azure_sql_config,
 )
 
@@ -177,3 +180,94 @@ class TestAzureSQLConfigFromEnv:
                     os.environ[k] = v
                 else:
                     os.environ.pop(k, None)
+
+
+class TestAzureSQLIsAvailable:
+    def test_true_with_server_and_database(self) -> None:
+        sources = {"azure_sql": {"server": "myserver.database.windows.net", "database": "mydb"}}
+        assert azure_sql_is_available(sources) is True
+
+    def test_false_when_missing_server(self) -> None:
+        assert azure_sql_is_available({"azure_sql": {"server": "", "database": "mydb"}}) is False
+
+    def test_false_when_missing_database(self) -> None:
+        assert azure_sql_is_available({"azure_sql": {"server": "s", "database": ""}}) is False
+
+    def test_false_when_azure_sql_key_absent(self) -> None:
+        assert azure_sql_is_available({}) is False
+
+    def test_false_when_azure_sql_is_empty_dict(self) -> None:
+        assert azure_sql_is_available({"azure_sql": {}}) is False
+
+    def test_false_when_server_is_none(self) -> None:
+        assert azure_sql_is_available({"azure_sql": {"server": None, "database": "mydb"}}) is False
+
+
+class TestAzureSQLExtractParams:
+    def test_all_identifying_fields_returned(self) -> None:
+        sources = {
+            "azure_sql": {
+                "server": "myserver.database.windows.net",
+                "database": "mydb",
+                "port": 1434,
+            }
+        }
+        params = azure_sql_extract_params(sources)
+        assert params == {
+            "server": "myserver.database.windows.net",
+            "database": "mydb",
+            "port": 1434,
+        }
+
+    def test_credentials_are_never_surfaced(self) -> None:
+        # Even if the source dict contains credentials, extract_params must only
+        # expose identifying params. Credentials belong in resolve_azure_sql_config,
+        # not on the LLM-visible tool signature.
+        sources = {
+            "azure_sql": {
+                "server": "s",
+                "database": "d",
+                "port": 1433,
+                "username": "admin",
+                "password": "secret",
+                "driver": "ODBC Driver 18 for SQL Server",
+            }
+        }
+        params = azure_sql_extract_params(sources)
+        assert set(params) == {"server", "database", "port"}
+        assert "username" not in params
+        assert "password" not in params
+        assert "driver" not in params
+
+    def test_defaults_when_keys_missing(self) -> None:
+        params = azure_sql_extract_params({"azure_sql": {}})
+        assert params["server"] == ""
+        assert params["database"] == ""
+        assert params["port"] == DEFAULT_AZURE_SQL_PORT
+
+    def test_empty_sources_dict(self) -> None:
+        params = azure_sql_extract_params({})
+        assert params["server"] == ""
+        assert params["database"] == ""
+        assert params["port"] == DEFAULT_AZURE_SQL_PORT
+
+    def test_server_whitespace_stripped(self) -> None:
+        sources = {"azure_sql": {"server": "  myserver.database.windows.net  ", "database": "d"}}
+        assert azure_sql_extract_params(sources)["server"] == "myserver.database.windows.net"
+
+    def test_port_none_collapses_to_default(self) -> None:
+        # A stored integration persisting {"port": null} must not crash
+        # extract_params with TypeError from int(None). The `or` fallback
+        # collapses both missing and explicit-None ports to the default.
+        sources = {"azure_sql": {"server": "s", "database": "d", "port": None}}
+        assert azure_sql_extract_params(sources)["port"] == DEFAULT_AZURE_SQL_PORT
+
+    def test_port_zero_also_collapses_to_default(self) -> None:
+        # Port 0 is a sentinel for "unconfigured" in this context; treat
+        # the same as None to match the `or` idiom.
+        sources = {"azure_sql": {"server": "s", "database": "d", "port": 0}}
+        assert azure_sql_extract_params(sources)["port"] == DEFAULT_AZURE_SQL_PORT
+
+    def test_port_as_numeric_string(self) -> None:
+        sources = {"azure_sql": {"server": "s", "database": "d", "port": "1434"}}
+        assert azure_sql_extract_params(sources)["port"] == 1434


### PR DESCRIPTION
Fixes #706

Follow-up to #703 and #704. Third of three SQL tool families sharing the same `@tool` decorator wiring bug. Completes the cleanup.

## Summary

Adds the missing `is_available` and `extract_params` callbacks to the `@tool(...)` decorators on all 5 Azure SQL diagnostic tools. Mirrors the approach already landed for PostgreSQL in #703 and MySQL in #704, and the working MariaDB pattern at `app/integrations/mariadb.py:160-176`.

## What changed

- Added `azure_sql_is_available` and `azure_sql_extract_params` to `app/integrations/azure_sql.py`.
- Wired both helpers into the `@tool(...)` decorator of all 5 Azure SQL tools: current queries, resource stats, server status, slow queries, wait stats.
- Added 14 unit tests covering both helpers.

Azure SQL integration resolves credentials internally via `resolve_azure_sql_config` (reading from the store/env), so `extract_params` only surfaces the three identifying params: `server`, `database`, `port`. Credentials (username, password, driver, encrypt) stay out of tool signatures and are never seen by the LLM.

Scope: 7 files, +155 / -5 lines.

## Port-None hardening applied preemptively

Used the `or` fallback for the port cast that Greptile flagged on #704:

```python
"port": int(az.get("port") or DEFAULT_AZURE_SQL_PORT),
```

Both missing and explicit-`None` port values collapse to the default, avoiding a `TypeError` if a stored integration holds `{"port": null}`. Covered by a dedicated unit test (`test_port_none_collapses_to_default`).

## Evidence

During the end-to-end audit (`make test-rds-synthetic` on Gemini 2.5-flash, post-#703/#704 baseline), the agent opportunistically invoked Azure SQL tools on RDS PostgreSQL scenarios, producing **92 Azure SQL TypeError failures** across the 15 scenarios:

| Tool | Before | After |
|---|---|---|
| `get_azure_sql_resource_stats` | 38 | 0 |
| `get_azure_sql_current_queries` | 34 | 0 |
| `get_azure_sql_server_status` | 14 | 0 |
| `get_azure_sql_wait_stats` | 6 | 0 |
| **Total** | **92** | **0** |

After this fix, the agent no longer attempts Azure SQL tools on unrelated scenarios — the tools correctly report unavailable when no Azure SQL integration is present.

## Test plan

- [x] `make test-cov` — **2739 passed, 1 skipped** (added 14 new unit tests for `azure_sql_is_available` and `azure_sql_extract_params`, no regressions elsewhere)
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] Full `make test-rds-synthetic` run shows 0 Azure SQL TypeError failures (was 92 in post-#704 baseline)
- [x] Unit tests cover: happy path, empty sources, missing fields, None port (Greptile's finding on #704), zero port, port-as-string, credential isolation (ensures username/password/driver never leak into tool signatures)
- [x] PostgreSQL / MySQL / MariaDB tools still work (not touched)

## Out-of-scope adjacent gap (will file separately)

While verifying, I noticed `app/nodes/plan_actions/detect_sources.py` has no Azure SQL branch — `sources["azure_sql"]` is never populated at runtime even when a user configures the integration. This fix makes the tools correctly report unavailable when they shouldn't fire, but they also won't fire when they should until that gap closes. Will file as a follow-up issue after this lands.