### PR TITLE
chore: consolidate ruff config into ruff.toml, stop silently ignoring pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,23 +110,6 @@ include = ["app*", "tests*"]
 [tool.coverage.run]
 data_file = ".pytest_cache/.coverage"
 
-[tool.ruff.lint]
-select = ["E", "F", "I", "S"]
-
-[tool.ruff.lint.per-file-ignores]
-# assert is idiomatic in pytest
-"*_test.py" = ["S101"]
-"tests/**/*_test.py" = ["S101"]
-"tests/**/test_*.py" = ["S101"]
-# vendored third-party pipeline code — not ours to fix
-"tests/e2e/upstream_lambda/pipeline_code/**" = ["S"]
-"tests/e2e/upstream_apache_flink_ecs/pipeline_code/**" = ["S"]
-"tests/e2e/upstream_prefect_ecs_fargate/pipeline_code/**" = ["S"]
-# subprocess / url-open / temp-file usage in infra helpers is intentional
-"tests/shared/**" = ["S108", "S310", "S603", "S607"]
-"tests/**/infrastructure_sdk/**" = ["S108", "S603", "S607"]
-"tests/**/trigger_lambda/**" = ["S108", "S603", "S607"]
-
 [tool.vulture]
 paths = ["app"]
 exclude = [


### PR DESCRIPTION
Fixes #701

Follow-up to #700 — same dual-config pattern, ruff side.

## Summary

Removes the dead `[tool.ruff.lint]` and `[tool.ruff.lint.per-file-ignores]` blocks from `pyproject.toml`. `ruff.toml` takes precedence, so those blocks were silently ignored, and the two configs had drifted: pyproject enabled `S` (flake8-bandit) which ruff.toml doesn't, and declared `S101`/`S*` per-file-ignores that were silently dropped.

Practical behavior is unchanged — `S` was never actually enforced, so its dead ignores didn't matter — but the block looked deliberate and any future edit to `[tool.ruff.lint]` in `pyproject.toml` would be silently lost. Same contributor footgun as the pytest duplication fixed in #700.

Takes the same "keep the dedicated config file" approach (Option A) as #700 for consistency.

## What changed

- Removed 16 lines of dead config from `pyproject.toml`:
  - `[tool.ruff.lint]` block (the `S` rule)
  - `[tool.ruff.lint.per-file-ignores]` block (8 pattern ignores)
- `ruff.toml` is untouched and remains the single source of truth.

## Test plan

- [x] `ruff check` clean on `app/` and `tests/` — no new lint errors surfaced (because `S` was never enforced via the ignored pyproject block)
- [x] `make test-cov` — 2736 passed, 1 skipped, 0 warnings (no regressions)
- [x] `mypy` clean
- [x] Re-ran `make test-cov` on fresh checkout to confirm no hidden dependency on the removed ignores

No behavioral change is expected since the removed config was already being ignored by ruff's precedence rules.