### PR TITLE
feat: add GitDeployTimelineTool for incident-window deploy correlation

### DIFF
--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -301,6 +301,14 @@ def _map_github_commits(data: dict) -> dict:
     }
 
 
+def _map_git_deploy_timeline(data: dict) -> dict:
+    return {
+        "git_deploy_timeline": data.get("commits", []) or [],
+        "git_deploy_timeline_count": data.get("commits_count", 0),
+        "git_deploy_timeline_window": data.get("window", {}),
+    }
+
+
 def _map_alertmanager_alerts(data: dict) -> dict:
     return {
         "alertmanager_alerts": data.get("alerts") or [],
@@ -399,6 +407,7 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "search_github_code": _map_github_code_search,
     "get_github_file_contents": _map_github_file_contents,
     "list_github_commits": _map_github_commits,
+    "get_git_deploy_timeline": _map_git_deploy_timeline,
     "alertmanager_alerts": _map_alertmanager_alerts,
     "alertmanager_silences": _map_alertmanager_silences,
     "list_eks_pods": _map_eks_pods,
@@ -590,6 +599,10 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
                 summary_parts.append("github:file contents retrieved")
             elif action_name == "list_github_commits" and data.get("commits"):
                 summary_parts.append(f"github:{len(data['commits'])} commits")
+            elif action_name == "get_git_deploy_timeline":
+                count = data.get("commits_count") or len(data.get("commits") or [])
+                if count:
+                    summary_parts.append(f"github:{count} commits in deploy window")
             elif action_name == "alertmanager_alerts":
                 firing_count = len(data.get("firing_alerts") or [])
                 total = data.get("total", 0)

--- a/app/nodes/plan_actions/build_prompt.py
+++ b/app/nodes/plan_actions/build_prompt.py
@@ -145,7 +145,8 @@ def _build_available_sources_hint(available_sources: dict[str, dict]) -> str:
 - Commit SHA: {github.get("sha") or "unknown"}
 - Ref: {github.get("ref") or "unknown"}
 - Code Query: {github.get("query") or "exception OR error"}
-- Use list_github_commits to correlate the deployment window with recent code changes
+- Prefer get_git_deploy_timeline for deploy correlation (commits in a time window around the alert)
+- Use list_github_commits for the N most recent commits regardless of time window
 - Use search_github_code and get_github_file_contents to trace the failure into code"""
         )
 

--- a/app/tools/GitDeployTimelineTool/__init__.py
+++ b/app/tools/GitDeployTimelineTool/__init__.py
@@ -34,6 +34,7 @@ from app.tools.tool_decorator import tool
 DEFAULT_WINDOW_MINUTES = 120
 MAX_WINDOW_MINUTES = 7 * 24 * 60  # 7 days
 DEFAULT_PER_PAGE = 30
+MAX_PER_PAGE = 100  # GitHub REST API hard cap for list_commits
 
 
 def _parse_iso8601(value: str) -> datetime | None:
@@ -65,12 +66,17 @@ def _resolve_window(
     """Resolve the [since, until] ISO-8601 window.
 
     Precedence:
-      1. Explicit ``since`` + ``until`` (both must parse; else falls through).
-      2. ``window_minutes_before_alert`` with until=now.
-      3. Default: DEFAULT_WINDOW_MINUTES before now.
+      1. ``until`` is set to the parsed value if present; falls back to "now"
+         on empty or malformed input (a malformed ``until`` does NOT invalidate
+         ``since`` — the ``until`` anchor simply becomes "now").
+      2. ``since`` is set to the parsed value if present; an inverted range
+         (``since > until``) is treated as invalid and falls through to (3).
+      3. If ``since`` is unset/invalid, compute it as ``until -
+         window_minutes_before_alert`` (or ``DEFAULT_WINDOW_MINUTES`` if that
+         arg is also unset/non-positive).
 
-    The window is always clamped to ``MAX_WINDOW_MINUTES`` to keep the MCP
-    call bounded and avoid paging through months of history by accident.
+    The final span is always clamped to ``MAX_WINDOW_MINUTES`` to keep the
+    MCP call bounded and avoid paging through months of history by accident.
     """
     now = datetime.now(UTC)
 
@@ -171,7 +177,12 @@ def _is_available(sources: dict[str, dict]) -> bool:
                 ),
                 "default": DEFAULT_WINDOW_MINUTES,
             },
-            "per_page": {"type": "integer", "default": DEFAULT_PER_PAGE},
+            "per_page": {
+                "type": "integer",
+                "default": DEFAULT_PER_PAGE,
+                "minimum": 1,
+                "maximum": MAX_PER_PAGE,
+            },
             "github_url": {"type": "string"},
             "github_mode": {"type": "string"},
             "github_token": {"type": "string"},
@@ -208,6 +219,10 @@ def get_git_deploy_timeline(
         }
 
     resolved_since, resolved_until = _resolve_window(since, until, window_minutes_before_alert)
+    # Clamp per_page to the GitHub REST API maximum of 100. Values above this
+    # are silently truncated upstream; we enforce the ceiling explicitly so
+    # ``truncated`` below is meaningful.
+    effective_per_page = max(1, min(per_page, MAX_PER_PAGE))
 
     arguments: dict[str, Any] = {
         "owner": owner,
@@ -215,7 +230,7 @@ def get_git_deploy_timeline(
         "sha": branch,
         "since": resolved_since,
         "until": resolved_until,
-        "perPage": per_page,
+        "perPage": effective_per_page,
     }
 
     result = call_github_mcp_tool(config, "list_commits", arguments)
@@ -225,11 +240,22 @@ def get_git_deploy_timeline(
         raw_commits = []
 
     commits = [_summarize_commit(item) for item in raw_commits if isinstance(item, dict)]
+    # When the page is full we cannot tell from the API whether more commits
+    # exist in the window — surface the uncertainty so the agent can choose to
+    # narrow the window or raise per_page rather than concluding "nothing
+    # else shipped".
+    truncated = len(commits) >= effective_per_page
     payload.update(
         {
             "commits": commits,
             "commits_count": len(commits),
-            "window": {"since": resolved_since, "until": resolved_until, "branch": branch},
+            "window": {
+                "since": resolved_since,
+                "until": resolved_until,
+                "branch": branch,
+                "per_page": effective_per_page,
+                "truncated": truncated,
+            },
         }
     )
     return payload

--- a/app/tools/GitDeployTimelineTool/__init__.py
+++ b/app/tools/GitDeployTimelineTool/__init__.py
@@ -1,0 +1,235 @@
+"""Time-window deploy timeline tool for GitHub repos.
+
+Sits alongside ``list_github_commits`` but asks a different question:
+
+    ``list_github_commits`` — "show me the N most recent commits" (generic
+    history browsing).
+
+    ``get_git_deploy_timeline`` — "what landed on the default branch between
+    T1 and T2" (incident correlation; "did something ship right before this
+    alert fired?").
+
+The tool is a thin wrapper on top of the MCP ``list_commits`` call, using the
+GitHub REST API's ``since`` / ``until`` ISO-8601 timestamps. It normalizes
+each commit into a compact shape with the fields an RCA agent actually needs
+(authored/committed time, author, message subject line, sha). A
+``window_minutes_before_alert`` convenience arg lets callers say "the 120
+minutes before now" without having to compute the timestamps themselves.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.integrations.github_mcp import call_github_mcp_tool
+from app.tools.GitHubSearchCodeTool import (
+    _gh_available,
+    _gh_creds,
+    _normalize_tool_result,
+    _resolve_config,
+)
+from app.tools.tool_decorator import tool
+
+DEFAULT_WINDOW_MINUTES = 120
+MAX_WINDOW_MINUTES = 7 * 24 * 60  # 7 days
+DEFAULT_PER_PAGE = 30
+
+
+def _parse_iso8601(value: str) -> datetime | None:
+    """Parse ISO-8601 timestamp, accepting the trailing ``Z`` shorthand.
+
+    Always returns a timezone-aware ``datetime``: naive input (no offset) is
+    assumed to be UTC so downstream comparison and ``astimezone`` calls stay
+    consistent. Returns None for empty or malformed input rather than raising,
+    so the tool can fall back to its default window instead of failing the
+    call.
+    """
+    text = (value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _resolve_window(
+    since: str, until: str, window_minutes_before_alert: int | None
+) -> tuple[str, str]:
+    """Resolve the [since, until] ISO-8601 window.
+
+    Precedence:
+      1. Explicit ``since`` + ``until`` (both must parse; else falls through).
+      2. ``window_minutes_before_alert`` with until=now.
+      3. Default: DEFAULT_WINDOW_MINUTES before now.
+
+    The window is always clamped to ``MAX_WINDOW_MINUTES`` to keep the MCP
+    call bounded and avoid paging through months of history by accident.
+    """
+    now = datetime.now(UTC)
+
+    parsed_since = _parse_iso8601(since)
+    parsed_until = _parse_iso8601(until) or now
+
+    # Inverted range (since > until) is always a caller error — we treat
+    # ``since`` as invalid and fall through to the window-minutes branch
+    # rather than passing an impossible range to the MCP server.
+    if parsed_since is not None and parsed_since > parsed_until:
+        parsed_since = None
+
+    if parsed_since is None:
+        minutes = window_minutes_before_alert
+        if minutes is None or minutes <= 0:
+            minutes = DEFAULT_WINDOW_MINUTES
+        minutes = min(minutes, MAX_WINDOW_MINUTES)
+        parsed_since = parsed_until - timedelta(minutes=minutes)
+
+    # Clamp the span regardless of how it was specified.
+    span = parsed_until - parsed_since
+    if span > timedelta(minutes=MAX_WINDOW_MINUTES):
+        parsed_since = parsed_until - timedelta(minutes=MAX_WINDOW_MINUTES)
+
+    return (
+        parsed_since.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        parsed_until.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def _summarize_commit(raw: dict[str, Any]) -> dict[str, Any]:
+    """Flatten the MCP commit envelope into the fields a diagnose step cares about."""
+    commit = raw.get("commit") or {}
+    author = commit.get("author") or {}
+    committer = commit.get("committer") or {}
+    message = str(commit.get("message") or "")
+    subject = message.splitlines()[0] if message else ""
+    return {
+        "sha": raw.get("sha", ""),
+        "short_sha": str(raw.get("sha", ""))[:7],
+        "author_name": author.get("name", ""),
+        "author_date": author.get("date", ""),
+        "committer_date": committer.get("date", ""),
+        "message_subject": subject,
+        "url": raw.get("html_url", ""),
+    }
+
+
+def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    gh = sources["github"]
+    return {
+        "owner": gh["owner"],
+        "repo": gh["repo"],
+        "branch": gh.get("branch") or gh.get("default_branch") or "main",
+        **_gh_creds(gh),
+    }
+
+
+def _is_available(sources: dict[str, dict]) -> bool:
+    gh = sources.get("github", {})
+    return bool(_gh_available(sources) and gh.get("owner") and gh.get("repo"))
+
+
+@tool(
+    name="get_git_deploy_timeline",
+    source="github",
+    description=(
+        "List commits on a GitHub branch within a time window (defaults to the last "
+        "120 minutes). Used to correlate an alert with recent deploys by asking "
+        "\"what changed right before this fired?\""
+    ),
+    use_cases=[
+        "Correlating an incident with recent code changes on the default branch",
+        "Checking whether a deploy landed within the alert window",
+        "Building a short-form deploy timeline for RCA narrative",
+    ],
+    requires=["owner", "repo"],
+    surfaces=("investigation", "chat"),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "owner": {"type": "string"},
+            "repo": {"type": "string"},
+            "branch": {"type": "string", "default": "main"},
+            "since": {
+                "type": "string",
+                "description": "ISO-8601 window start (e.g. 2026-04-20T10:00:00Z). Optional.",
+            },
+            "until": {
+                "type": "string",
+                "description": "ISO-8601 window end. Defaults to now.",
+            },
+            "window_minutes_before_alert": {
+                "type": "integer",
+                "description": (
+                    "Convenience: minutes back from 'until' (or now) when 'since' is "
+                    f"omitted. Clamped to {MAX_WINDOW_MINUTES} minutes."
+                ),
+                "default": DEFAULT_WINDOW_MINUTES,
+            },
+            "per_page": {"type": "integer", "default": DEFAULT_PER_PAGE},
+            "github_url": {"type": "string"},
+            "github_mode": {"type": "string"},
+            "github_token": {"type": "string"},
+        },
+        "required": ["owner", "repo"],
+    },
+    is_available=_is_available,
+    extract_params=_extract_params,
+)
+def get_git_deploy_timeline(
+    owner: str,
+    repo: str,
+    branch: str = "main",
+    since: str = "",
+    until: str = "",
+    window_minutes_before_alert: int | None = DEFAULT_WINDOW_MINUTES,
+    per_page: int = DEFAULT_PER_PAGE,
+    github_url: str | None = None,
+    github_mode: str | None = None,
+    github_token: str | None = None,
+    github_command: str | None = None,
+    github_args: list[str] | None = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Return commits on ``branch`` between ``since`` and ``until``."""
+    config = _resolve_config(github_url, github_mode, github_token, github_command, github_args)
+    if config is None:
+        return {
+            "source": "github",
+            "available": False,
+            "error": "GitHub MCP integration is not configured.",
+            "commits": [],
+            "window": {},
+        }
+
+    resolved_since, resolved_until = _resolve_window(since, until, window_minutes_before_alert)
+
+    arguments: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "sha": branch,
+        "since": resolved_since,
+        "until": resolved_until,
+        "perPage": per_page,
+    }
+
+    result = call_github_mcp_tool(config, "list_commits", arguments)
+    payload = _normalize_tool_result(result)
+    raw_commits = payload.pop("structured_content", None) or []
+    if not isinstance(raw_commits, list):
+        raw_commits = []
+
+    commits = [_summarize_commit(item) for item in raw_commits if isinstance(item, dict)]
+    payload.update(
+        {
+            "commits": commits,
+            "commits_count": len(commits),
+            "window": {"since": resolved_since, "until": resolved_until, "branch": branch},
+        }
+    )
+    return payload

--- a/tests/tools/test_git_deploy_timeline_tool.py
+++ b/tests/tools/test_git_deploy_timeline_tool.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from app.tools.GitDeployTimelineTool import (
     DEFAULT_WINDOW_MINUTES,
+    MAX_PER_PAGE,
     MAX_WINDOW_MINUTES,
     _resolve_window,
     _summarize_commit,
@@ -226,6 +227,116 @@ def test_run_passes_per_page_to_mcp() -> None:
 
     # MCP / GitHub REST API spells this camelCase; the tool must translate.
     assert captured["arguments"]["perPage"] == 50
+
+
+def test_run_clamps_per_page_to_api_maximum() -> None:
+    # GitHub REST list_commits caps per_page at 100. If a caller asks for more
+    # the request silently truncates upstream, and our commits_count would be
+    # wrong. We enforce the ceiling explicitly.
+    mock_config = MagicMock()
+    captured: dict[str, object] = {}
+
+    def _fake_call(config, name, arguments):  # noqa: ARG001
+        captured["arguments"] = arguments
+        return {"is_error": False, "text": "", "structured_content": [], "content": []}
+
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch("app.tools.GitDeployTimelineTool.call_github_mcp_tool", side_effect=_fake_call):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            per_page=500,
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+
+    assert captured["arguments"]["perPage"] == MAX_PER_PAGE
+    assert result["window"]["per_page"] == MAX_PER_PAGE
+
+
+def test_run_flags_window_truncated_when_page_is_full() -> None:
+    # When the MCP returns exactly per_page commits, we don't know whether
+    # more exist in the window. The window.truncated flag warns the agent
+    # it may be looking at partial data.
+    full_page = [
+        {
+            "sha": f"{i:040x}",
+            "html_url": "",
+            "commit": {
+                "author": {"name": "A", "date": "2026-04-20T09:00:00Z"},
+                "committer": {"date": "2026-04-20T09:00:01Z"},
+                "message": f"commit {i}",
+            },
+        }
+        for i in range(5)
+    ]
+    fake_result = {
+        "is_error": False,
+        "text": "5 commits",
+        "structured_content": full_page,
+        "content": [],
+    }
+    mock_config = MagicMock()
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch(
+        "app.tools.GitDeployTimelineTool.call_github_mcp_tool", return_value=fake_result
+    ):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            per_page=5,
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+
+    assert result["commits_count"] == 5
+    assert result["window"]["truncated"] is True
+
+
+def test_run_flags_window_not_truncated_when_fewer_than_page() -> None:
+    fake_result = {
+        "is_error": False,
+        "text": "",
+        "structured_content": [
+            {
+                "sha": "abc",
+                "html_url": "",
+                "commit": {
+                    "author": {"name": "A", "date": "2026-04-20T09:00:00Z"},
+                    "committer": {"date": "2026-04-20T09:00:01Z"},
+                    "message": "one commit",
+                },
+            }
+        ],
+        "content": [],
+    }
+    mock_config = MagicMock()
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch(
+        "app.tools.GitDeployTimelineTool.call_github_mcp_tool", return_value=fake_result
+    ):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            per_page=30,
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+
+    assert result["commits_count"] == 1
+    assert result["window"]["truncated"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_git_deploy_timeline_tool.py
+++ b/tests/tools/test_git_deploy_timeline_tool.py
@@ -1,0 +1,344 @@
+"""Tests for GitDeployTimelineTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from app.tools.GitDeployTimelineTool import (
+    DEFAULT_WINDOW_MINUTES,
+    MAX_WINDOW_MINUTES,
+    _resolve_window,
+    _summarize_commit,
+    get_git_deploy_timeline,
+)
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestGitDeployTimelineToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_git_deploy_timeline.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_owner_repo() -> None:
+    rt = get_git_deploy_timeline.__opensre_registered_tool__
+    assert rt.is_available({
+        "github": {"connection_verified": True, "owner": "org", "repo": "repo"}
+    }) is True
+    assert rt.is_available({"github": {"connection_verified": True}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_git_deploy_timeline.__opensre_registered_tool__
+    sources = mock_agent_state()
+    params = rt.extract_params(sources)
+    assert params["owner"] == "my-org"
+    assert params["repo"] == "my-repo"
+    assert params["branch"] == "main"
+
+
+def test_run_returns_unavailable_when_no_config() -> None:
+    with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
+        result = get_git_deploy_timeline(owner="org", repo="repo")
+    assert result["available"] is False
+    assert result["commits"] == []
+
+
+def test_run_happy_path_summarizes_commits() -> None:
+    fake_result = {
+        "is_error": False,
+        "tool": "list_commits",
+        "arguments": {},
+        "text": "2 commits",
+        "structured_content": [
+            {
+                "sha": "abcdef0123456789",
+                "html_url": "https://github.com/org/repo/commit/abcdef0",
+                "commit": {
+                    "author": {"name": "Alice", "date": "2026-04-20T09:15:00Z"},
+                    "committer": {"date": "2026-04-20T09:15:30Z"},
+                    "message": "fix: null deref on empty payload\n\nAdditional body text",
+                },
+            },
+            {
+                "sha": "fedcba9876543210",
+                "html_url": "https://github.com/org/repo/commit/fedcba9",
+                "commit": {
+                    "author": {"name": "Bob", "date": "2026-04-20T10:00:00Z"},
+                    "committer": {"date": "2026-04-20T10:00:10Z"},
+                    "message": "feat: add retry on 502",
+                },
+            },
+        ],
+        "content": [],
+    }
+    mock_config = MagicMock()
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch(
+        "app.tools.GitDeployTimelineTool.call_github_mcp_tool", return_value=fake_result
+    ):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+
+    assert result["available"] is True
+    assert result["commits_count"] == 2
+    assert len(result["commits"]) == 2
+
+    first = result["commits"][0]
+    assert first["sha"] == "abcdef0123456789"
+    assert first["short_sha"] == "abcdef0"
+    assert first["author_name"] == "Alice"
+    # Only the subject line of the message is kept; body is dropped.
+    assert first["message_subject"] == "fix: null deref on empty payload"
+    assert first["url"] == "https://github.com/org/repo/commit/abcdef0"
+
+    window = result["window"]
+    assert "since" in window and "until" in window
+    assert window["branch"] == "main"
+
+
+def test_run_passes_time_window_and_branch_to_mcp() -> None:
+    mock_config = MagicMock()
+    captured: dict[str, object] = {}
+
+    def _fake_call(config, name, arguments):  # noqa: ARG001
+        captured["name"] = name
+        captured["arguments"] = arguments
+        return {"is_error": False, "text": "", "structured_content": [], "content": []}
+
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch("app.tools.GitDeployTimelineTool.call_github_mcp_tool", side_effect=_fake_call):
+        get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            branch="release",
+            since="2026-04-20T08:00:00Z",
+            until="2026-04-20T10:00:00Z",
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+
+    assert captured["name"] == "list_commits"
+    args = captured["arguments"]
+    assert args["owner"] == "org"
+    assert args["repo"] == "repo"
+    assert args["sha"] == "release"
+    assert args["since"].startswith("2026-04-20T08:00:00")
+    assert args["until"].startswith("2026-04-20T10:00:00")
+
+
+def test_run_empty_result_returns_zero_commits() -> None:
+    fake_result = {
+        "is_error": False,
+        "tool": "list_commits",
+        "arguments": {},
+        "text": "",
+        "structured_content": [],
+        "content": [],
+    }
+    mock_config = MagicMock()
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch(
+        "app.tools.GitDeployTimelineTool.call_github_mcp_tool", return_value=fake_result
+    ):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+    assert result["commits"] == []
+    assert result["commits_count"] == 0
+    # Window metadata is always populated even when there are no commits —
+    # "0 commits in this window" is itself evidence the RCA step can cite.
+    assert result["window"]["branch"] == "main"
+
+
+def test_run_defensive_against_non_list_structured_content() -> None:
+    # MCP has occasionally been observed to return a dict under
+    # structured_content (e.g. when the upstream paginates differently). The
+    # tool must never crash on that shape — it should surface an empty list.
+    fake_result = {
+        "is_error": False,
+        "tool": "list_commits",
+        "arguments": {},
+        "text": "",
+        "structured_content": {"unexpected": "shape"},
+        "content": [],
+    }
+    mock_config = MagicMock()
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch(
+        "app.tools.GitDeployTimelineTool.call_github_mcp_tool", return_value=fake_result
+    ):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+    assert result["commits"] == []
+    assert result["commits_count"] == 0
+
+
+def test_run_passes_per_page_to_mcp() -> None:
+    mock_config = MagicMock()
+    captured: dict[str, object] = {}
+
+    def _fake_call(config, name, arguments):  # noqa: ARG001
+        captured["arguments"] = arguments
+        return {"is_error": False, "text": "", "structured_content": [], "content": []}
+
+    with patch(
+        "app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None
+    ), patch(
+        "app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config
+    ), patch("app.tools.GitDeployTimelineTool.call_github_mcp_tool", side_effect=_fake_call):
+        get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            per_page=50,
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+
+    # MCP / GitHub REST API spells this camelCase; the tool must translate.
+    assert captured["arguments"]["perPage"] == 50
+
+
+# ---------------------------------------------------------------------------
+# _resolve_window
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_window_defaults_to_default_minutes() -> None:
+    since, until = _resolve_window("", "", None)
+    since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+    until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+    span = until_dt - since_dt
+    assert span == timedelta(minutes=DEFAULT_WINDOW_MINUTES)
+
+
+def test_resolve_window_honours_explicit_since_and_until() -> None:
+    since, until = _resolve_window(
+        "2026-04-20T08:00:00Z", "2026-04-20T09:30:00Z", None
+    )
+    assert since == "2026-04-20T08:00:00Z"
+    assert until == "2026-04-20T09:30:00Z"
+
+
+def test_resolve_window_honours_window_minutes_when_since_missing() -> None:
+    since, until = _resolve_window("", "2026-04-20T12:00:00Z", 30)
+    assert since == "2026-04-20T11:30:00Z"
+    assert until == "2026-04-20T12:00:00Z"
+
+
+def test_resolve_window_clamps_to_max_span() -> None:
+    # Caller asks for 60 days — we only allow MAX_WINDOW_MINUTES.
+    since, until = _resolve_window("", "2026-04-20T00:00:00Z", 60 * 24 * 60)
+    since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+    until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+    assert (until_dt - since_dt) == timedelta(minutes=MAX_WINDOW_MINUTES)
+
+
+def test_resolve_window_treats_malformed_since_as_missing() -> None:
+    # Garbage 'since' falls through to the default-window branch rather than raising.
+    since, until = _resolve_window("not-a-date", "", None)
+    since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+    until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+    assert until_dt - since_dt == timedelta(minutes=DEFAULT_WINDOW_MINUTES)
+
+
+def test_resolve_window_rejects_inverted_range() -> None:
+    # since > until is a caller mistake. Rather than pass an impossible range to
+    # MCP, the helper discards the bad 'since' and falls back to the window
+    # minutes branch anchored at the (still-valid) until.
+    since, until = _resolve_window(
+        "2026-04-20T12:00:00Z", "2026-04-20T10:00:00Z", 30
+    )
+    assert until == "2026-04-20T10:00:00Z"
+    assert since == "2026-04-20T09:30:00Z"  # until - 30 min
+
+
+def test_resolve_window_zero_or_negative_minutes_falls_back_to_default() -> None:
+    # Defensive: a caller might pass 0 or a negative window. Treat as unset.
+    for minutes in (0, -5):
+        since, until = _resolve_window("", "2026-04-20T10:00:00Z", minutes)
+        since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        until_dt = datetime.fromisoformat(until.replace("Z", "+00:00"))
+        assert until_dt - since_dt == timedelta(minutes=DEFAULT_WINDOW_MINUTES)
+
+
+def test_resolve_window_normalises_naive_timestamps_to_utc() -> None:
+    # Naive input (no timezone) must be treated as UTC. Without this, the
+    # subsequent astimezone(UTC) or > comparison against 'now' would raise
+    # on one input but not the other.
+    since, until = _resolve_window(
+        "2026-04-20T08:00:00", "2026-04-20T09:00:00", None
+    )
+    assert since == "2026-04-20T08:00:00Z"
+    assert until == "2026-04-20T09:00:00Z"
+
+
+def test_resolve_window_handles_mixed_aware_and_naive() -> None:
+    # since has offset, until is naive — must not raise a TypeError on
+    # the inverted-range comparison.
+    since, until = _resolve_window(
+        "2026-04-20T08:00:00+00:00", "2026-04-20T09:00:00", None
+    )
+    assert since == "2026-04-20T08:00:00Z"
+    assert until == "2026-04-20T09:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# _summarize_commit
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_commit_keeps_subject_only() -> None:
+    summarised = _summarize_commit(
+        {
+            "sha": "1234567890abcdef",
+            "html_url": "u",
+            "commit": {
+                "author": {"name": "A", "date": "2026-04-20T09:00:00Z"},
+                "committer": {"date": "2026-04-20T09:00:10Z"},
+                "message": "subject line\n\nbody one\nbody two",
+            },
+        }
+    )
+    assert summarised["short_sha"] == "1234567"
+    assert summarised["message_subject"] == "subject line"
+
+
+def test_summarize_commit_handles_missing_fields() -> None:
+    # Defensive: real MCP responses have been observed to drop optional fields
+    # (e.g. committer, html_url); the summariser must never raise.
+    summarised = _summarize_commit({"sha": "", "commit": {}})
+    assert summarised["message_subject"] == ""
+    assert summarised["author_name"] == ""
+    assert summarised["short_sha"] == ""
+
+


### PR DESCRIPTION
What was needed:
  The 1 question in RCA is "what changed right before this alert fired?"
  The planning prompt already tells the agent to answer this using
  list_github_commits, but that tool only returns the N most recent
  commits - it cannot filter by time window. So the agent had no real
  way to answer the question it was being asked.

What we did:
  Added a new tool get_git_deploy_timeline that lists commits on a
  GitHub branch between a since/until time window (default: last
  120 minutes before now). Wired it into the investigate pipeline's
  evidence map and updated the GitHub planning hint to point at it.
  Kept list_github_commits available for generic "recent commits"
  queries.

What's done:
  - New tool under app/tools/GitDeployTimelineTool
  - Evidence mapper + summary branch in post_process.py so commits
    show up in final_state.evidence and the terminal summary
  - Planning hint in build_prompt.py now recommends the new tool
    for deploy correlation
  - 28 unit tests covering happy path, edge cases, and bad input
  - ruff clean, mypy clean