### PR TITLE
fix(detect-sources): populate sources["azure_sql"] from resolved integrations

### DIFF
--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -1265,4 +1265,29 @@ def detect_sources(
             "connection_verified": True,
         }
 
+    azure_sql_int = (resolved_integrations or {}).get("azure_sql")
+    if (
+        azure_sql_int
+        and str(azure_sql_int.get("server", "")).strip()
+        and str(azure_sql_int.get("database", "")).strip()
+    ):
+        azure_sql_server = str(azure_sql_int.get("server", "")).strip()
+        # Prefer the alert-specified database (multi-tenant Azure SQL pools often
+        # name the affected database in annotations), fall back to the configured
+        # database from the integration store.  Credentials stay in
+        # resolve_azure_sql_config — do not leak them here.
+        azure_sql_database = (
+            str(annotations.get("azure_sql_database") or "").strip()
+            or str(annotations.get("database") or "").strip()
+            or str(azure_sql_int.get("database", "")).strip()
+        )
+        # `or 1433` rather than `get("port", 1433)` so an explicit-None stored
+        # port collapses to the default (matches azure_sql_extract_params).
+        sources["azure_sql"] = {
+            "server": azure_sql_server,
+            "port": azure_sql_int.get("port") or 1433,
+            "database": azure_sql_database,
+            "connection_verified": True,
+        }
+
     return sources

--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse
 
+from app.integrations.azure_sql import DEFAULT_AZURE_SQL_PORT
 from app.services.coralogix import build_coralogix_logs_query
 from app.tools.GrafanaLogsTool import _map_pipeline_to_service_name
 
@@ -1281,11 +1282,12 @@ def detect_sources(
             or str(annotations.get("database") or "").strip()
             or str(azure_sql_int.get("database", "")).strip()
         )
-        # `or 1433` rather than `get("port", 1433)` so an explicit-None stored
-        # port collapses to the default (matches azure_sql_extract_params).
+        # `or DEFAULT_AZURE_SQL_PORT` rather than `get("port", ...)` so an
+        # explicit-None stored port collapses to the default (matches
+        # azure_sql_extract_params in app/integrations/azure_sql.py).
         sources["azure_sql"] = {
             "server": azure_sql_server,
-            "port": azure_sql_int.get("port") or 1433,
+            "port": azure_sql_int.get("port") or DEFAULT_AZURE_SQL_PORT,
             "database": azure_sql_database,
             "connection_verified": True,
         }

--- a/tests/nodes/plan_actions/test_detect_sources_azure_sql.py
+++ b/tests/nodes/plan_actions/test_detect_sources_azure_sql.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from app.integrations.azure_sql import DEFAULT_AZURE_SQL_PORT
+from app.nodes.plan_actions.detect_sources import detect_sources
+
+
+def test_detect_sources_includes_azure_sql_from_resolved_integrations() -> None:
+    sources = detect_sources(
+        raw_alert={"annotations": {}},
+        context={},
+        resolved_integrations={
+            "azure_sql": {
+                "server": "prod.db.windows.net",
+                "database": "orders",
+                "port": DEFAULT_AZURE_SQL_PORT,
+                "username": "svc-user",
+                "password": "secret",
+            }
+        },
+    )
+
+    assert sources["azure_sql"] == {
+        "server": "prod.db.windows.net",
+        "database": "orders",
+        "port": DEFAULT_AZURE_SQL_PORT,
+        "connection_verified": True,
+    }
+
+
+def test_detect_sources_azure_sql_uses_annotation_database_override() -> None:
+    sources = detect_sources(
+        raw_alert={"commonAnnotations": {"azure_sql_database": "tenant_a"}},
+        context={},
+        resolved_integrations={
+            "azure_sql": {
+                "server": "prod.db.windows.net",
+                "database": "orders",
+                "port": DEFAULT_AZURE_SQL_PORT,
+            }
+        },
+    )
+
+    assert sources["azure_sql"]["database"] == "tenant_a"
+
+
+def test_detect_sources_azure_sql_ignores_blank_annotation_override() -> None:
+    sources = detect_sources(
+        raw_alert={"commonAnnotations": {"azure_sql_database": "   "}},
+        context={},
+        resolved_integrations={
+            "azure_sql": {
+                "server": "prod.db.windows.net",
+                "database": "orders",
+                "port": DEFAULT_AZURE_SQL_PORT,
+            }
+        },
+    )
+
+    assert sources["azure_sql"]["database"] == "orders"
+
+
+def test_detect_sources_azure_sql_defaults_port_when_missing_or_falsy() -> None:
+    sources_with_none = detect_sources(
+        raw_alert={"annotations": {}},
+        context={},
+        resolved_integrations={
+            "azure_sql": {
+                "server": "prod.db.windows.net",
+                "database": "orders",
+                "port": None,
+            }
+        },
+    )
+    sources_with_zero = detect_sources(
+        raw_alert={"annotations": {}},
+        context={},
+        resolved_integrations={
+            "azure_sql": {
+                "server": "prod.db.windows.net",
+                "database": "orders",
+                "port": 0,
+            }
+        },
+    )
+
+    assert sources_with_none["azure_sql"]["port"] == DEFAULT_AZURE_SQL_PORT
+    assert sources_with_zero["azure_sql"]["port"] == DEFAULT_AZURE_SQL_PORT
+
+
+def test_detect_sources_azure_sql_requires_server_and_database() -> None:
+    missing_server = detect_sources(
+        raw_alert={"annotations": {}},
+        context={},
+        resolved_integrations={"azure_sql": {"server": "", "database": "orders"}},
+    )
+    missing_database = detect_sources(
+        raw_alert={"annotations": {}},
+        context={},
+        resolved_integrations={"azure_sql": {"server": "prod.db.windows.net", "database": ""}},
+    )
+
+    assert "azure_sql" not in missing_server
+    assert "azure_sql" not in missing_database

--- a/tests/nodes/plan_actions/test_detect_sources_azure_sql.py
+++ b/tests/nodes/plan_actions/test_detect_sources_azure_sql.py
@@ -43,6 +43,25 @@ def test_detect_sources_azure_sql_uses_annotation_database_override() -> None:
     assert sources["azure_sql"]["database"] == "tenant_a"
 
 
+def test_detect_sources_azure_sql_uses_generic_database_annotation_fallback() -> None:
+    """Tier-2 fallback: a generic `database` annotation (with no
+    `azure_sql_database` key) should override the stored database, matching
+    the behaviour of the mysql/postgresql branches."""
+    sources = detect_sources(
+        raw_alert={"annotations": {"database": "tenant_b"}},
+        context={},
+        resolved_integrations={
+            "azure_sql": {
+                "server": "prod.db.windows.net",
+                "database": "orders",
+                "port": DEFAULT_AZURE_SQL_PORT,
+            }
+        },
+    )
+
+    assert sources["azure_sql"]["database"] == "tenant_b"
+
+
 def test_detect_sources_azure_sql_ignores_blank_annotation_override() -> None:
     sources = detect_sources(
         raw_alert={"commonAnnotations": {"azure_sql_database": "   "}},


### PR DESCRIPTION
Closes #711.

## Summary

Adds the missing `azure_sql` branch in `detect_sources.py`. Before this PR, `sources["azure_sql"]` was never populated at runtime — the postgresql / mariadb / mysql branches all exist, but there was no equivalent for Azure SQL. As a result, `azure_sql_is_available(sources)` always returned `False`, and the five Azure SQL tools fixed by PR #707 never fired even when the integration was fully configured.

This PR flips that false-negative: when a user has Azure SQL wired up via the integration store, the detection layer now surfaces `server`, `port`, and `database` to the tool layer, honoring alert-annotation overrides the same way postgresql and mysql do.

## Changes

- `app/nodes/plan_actions/detect_sources.py` — new `azure_sql` branch placed immediately after the mysql branch. Guards on both `server` and `database` being truthy. Uses `or 1433` for port so explicit-`None` collapses to the default (matches `azure_sql_extract_params` in PR #707). Credentials stay in `resolve_azure_sql_config` — only the LLM-visible params (`server`, `port`, `database`) appear in the resulting source dict.
- `tests/nodes/plan_actions/test_detect_sources_azure_sql.py` — 5 unit tests:
  - Happy path: `server`/`database`/`port` populated, no credentials leaked
  - Annotation override: `azure_sql_database` annotation wins over stored database
  - Blank annotation override is ignored (falls back to stored database)
  - `port: None` and `port: 0` both collapse to `1433` (DEFAULT_AZURE_SQL_PORT)
  - Missing `server` or missing `database` leaves `azure_sql` absent from `sources`

## Verification

- `make lint` — clean
- `make typecheck` — clean (379 source files)
- `tests/nodes/plan_actions/` — 60 passed (+5 new)

## Test plan

- [ ] Reviewer confirms `azure_sql_is_available(sources)` returns `True` on a scenario with Azure SQL resolved in `resolved_integrations`
- [ ] Reviewer confirms credentials do not leak into `sources["azure_sql"]` (only `server`, `port`, `database`, `connection_verified`)
- [ ] Reviewer optionally reruns `make test-rds-synthetic` on an Azure SQL scenario family to confirm the existing zero-TypeError baseline from #707 still holds