### PR TITLE
fix(eks): detect EKS source when AWS integration uses IAM user credentials

### DIFF
--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -657,7 +657,9 @@ def detect_sources(
     # the role_arn credential gate the same way the Grafana path does.
     _eks_int = (resolved_integrations or {}).get("aws")
     _has_injected_eks_backend = bool(_eks_int and "_backend" in _eks_int)
-    if _eks_int and (_eks_int.get("role_arn") or _has_injected_eks_backend):
+    if _eks_int and (
+        _eks_int.get("role_arn") or _has_injected_eks_backend or _eks_int.get("credentials")
+    ):
         eks_cluster = annotations.get("eks_cluster") or annotations.get("cluster_name")
         # When a backend is injected but the alert omits cluster_name from its
         # annotations, fall back to the first cluster_names entry on the


### PR DESCRIPTION
Fixes #723

## Summary

When the AWS integration is configured with IAM user credentials (env AK/SK or a stored `access_key_id`/`secret_access_key` with no `role_arn`, no injected `_backend`), `opensre investigate` on a Kubernetes alert silently plans **zero EKS tools** — EKS pods/events/nodes are never queried even though `cluster_name` is present in the alert and the credentials work for STS.

This PR fixes that by letting `_eks_int.get("credentials")` gate the EKS branch in `detect_sources`, matching the pattern already used by `models.py`, `verify.py`, and `integration_health.py`.

Full problem statement, reproduction, and root-cause analysis are in #723.

## Change

One-line change in `app/nodes/plan_actions/detect_sources.py` (plus `ruff format` wrapping it across three lines for line-length):

```python
 if _eks_int and (
-    _eks_int.get("role_arn") or _has_injected_eks_backend
+    _eks_int.get("role_arn") or _has_injected_eks_backend or _eks_int.get("credentials")
 ):
```

## Risk / Backward Compatibility

Strict superset of current behaviour:

- Every integration previously accepted (role_arn or injected backend) is still accepted verbatim.
- The new branch only activates for integrations that already carry a `credentials` dict produced by `catalog.resolve_integrations`.
- Downstream code (`detect_sources.py` L693) already tolerates an empty `role_arn` via `_eks_int.get("role_arn", "")`, so the planning layer needs no other change.

## Same-pattern audit

I grepped the codebase for the same `role_arn` / `_backend`-without-`credentials` gate pattern. `detect_sources.py:660` is the only remaining site. Other auth gates already include `credentials`:

- `app/integrations/models.py::_require_auth_method` — `self.role_arn or self.credentials` ✔
- `app/integrations/verify.py::_build_sts_client` — `if role_arn: ... else credentials branch` ✔
- `app/cli/wizard/integration_health.py` — same two-branch pattern ✔

## Local checks

```
ruff check app/nodes/plan_actions/detect_sources.py   # All checks passed!
ruff format --check app/nodes/plan_actions/detect_sources.py   # 1 file already formatted
python -m py_compile app/nodes/plan_actions/detect_sources.py  # OK
```

## Follow-up

The EKS k8s client that consumes these credentials still needs to learn to honour them (currently calls `_assume_role(role_arn, ...)` unconditionally with an empty `RoleArn`, fails before describe_cluster). A follow-up PR will address that and will explicitly declare `Depends on #<this PR>` in its body.
