### PR TITLE
fix: ensure .env file ends with newline before appending env vars

### DIFF
--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -42,6 +42,9 @@ def sync_env_values(
     )
 
     lines = existing
+    # Ensure file ends with newline before appending new content
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] = f"{lines[-1]}\n"
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
@@ -121,6 +124,10 @@ def sync_provider_env(
         keys_to_remove.discard(provider.api_key_env)
 
     lines = _remove_keys(existing, keys_to_remove)
+
+    # Ensure file ends with newline before appending new content
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] = f"{lines[-1]}\n"
 
     values: dict[str, str] = {"LLM_PROVIDER": provider.value, provider.model_env: model}
     if provider.legacy_model_env:


### PR DESCRIPTION
Fixes #718

Problem
The onboarding process corrupts .env when the file lacks a final newline.
New environment variables are appended directly onto the last line instead
of being added as a new line.

Example of corruption:
VAR1=value1LLM_PROVIDER=gemini  (should be two separate lines)

Root cause
splitlines(keepends=True) preserves newlines, but if the last line has no
newline, appending content merges it with the last line.

Fix
Check if the last line ends with \n before writing. If not, add one to
the last line itself (not as a separate element, to avoid extra blank lines).

Applied to both sync_env_values() and sync_provider_env() since they
both modify .env files.