### PR TITLE
chore: align Python baseline on 3.13 across mypy and ruff (#727)

### DIFF
--- a/app/integrations/mcp_streamable_http_compat.py
+++ b/app/integrations/mcp_streamable_http_compat.py
@@ -32,7 +32,7 @@ async def streamable_http_client(
     timeout: float = 30.0,
     sse_read_timeout: float = 300.0,
     terminate_on_close: bool = True,
-) -> AsyncGenerator[tuple[Any, Any, Any], None]:
+) -> AsyncGenerator[tuple[Any, Any, Any]]:
     del headers, timeout, sse_read_timeout
     async with _mcp_streamable_http_client(
         url,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.12
+python_version = 3.13
 enable_incomplete_feature = NewGenericSyntax
 warn_return_any = True
 warn_unused_configs = True

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,7 @@
 # Ruff configuration
 # https://docs.astral.sh/ruff/configuration/
 
-target-version = "py312"
+target-version = "py313"
 line-length = 100
 
 # Exclude vendored dependencies in Lambda code and build artifacts

--- a/tests/deployment/bedrock/conftest.py
+++ b/tests/deployment/bedrock/conftest.py
@@ -15,7 +15,7 @@ from tests.shared.infra import infrastructure_available
 
 
 @pytest.fixture(scope="session")
-def bedrock_agent() -> Generator[dict[str, Any], None, None]:
+def bedrock_agent() -> Generator[dict[str, Any]]:
     """Deploy a Bedrock Agent, yield outputs, then tear down.
 
     Skips when running in CI or when SKIP_INFRA_TESTS is set.

--- a/tests/deployment/ec2/conftest.py
+++ b/tests/deployment/ec2/conftest.py
@@ -15,7 +15,7 @@ from tests.shared.infra import infrastructure_available
 
 
 @pytest.fixture(scope="session")
-def ec2_deployment() -> Generator[dict[str, Any], None, None]:
+def ec2_deployment() -> Generator[dict[str, Any]]:
     """Deploy OpenSRE on EC2, yield outputs, then terminate.
 
     Skips when running in CI or when SKIP_INFRA_TESTS is set.

--- a/tests/deployment/langsmith/conftest.py
+++ b/tests/deployment/langsmith/conftest.py
@@ -25,7 +25,7 @@ def _langsmith_available() -> bool:
 
 
 @pytest.fixture(scope="session")
-def langsmith_deployment() -> Generator[dict[str, Any], None, None]:
+def langsmith_deployment() -> Generator[dict[str, Any]]:
     """Deploy to LangSmith, yield outputs, then clean up.
 
     Skips when running in CI, when SKIP_INFRA_TESTS is set, or when

--- a/tests/deployment/vercel/conftest.py
+++ b/tests/deployment/vercel/conftest.py
@@ -23,7 +23,7 @@ def _vercel_available() -> bool:
 
 
 @pytest.fixture(scope="session")
-def vercel_deployment() -> Generator[dict[str, Any], None, None]:
+def vercel_deployment() -> Generator[dict[str, Any]]:
     """Deploy to Vercel, yield outputs, then tear down.
 
     Skips when running in CI, when SKIP_INFRA_TESTS is set, or when

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -15,7 +15,7 @@ from app.types.retrieval import RetrievalControls
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry_cache() -> Generator[None, None, None]:
+def _reset_registry_cache() -> Generator[None]:
     registry_module.clear_tool_registry_cache()
     yield
     registry_module.clear_tool_registry_cache()


### PR DESCRIPTION
## Summary

Resolves #727.

OpenSRE was signalling 4 different Python baselines:

| Location | Value |
| --- | --- |
| `.github/workflows/ci.yml` | 3.13 |
| `.tool-versions` | 3.13.11 |
| `mypy.ini` `python_version` | 3.12 |
| `ruff.toml` `target-version` | py312 |
| `pyproject.toml` `requires-python` | >=3.11 |

The issue recommended matching CI, so this PR bumps `mypy.ini` and `ruff.toml` to 3.13.

## Changes

- `mypy.ini`: `python_version = 3.12` -> `3.13`
- `ruff.toml`: `target-version = \"py312\"` -> `\"py313\"`
- Auto-fix of 6 `UP043` 'Unnecessary default type arguments' warnings that surfaced once ruff was pointed at py313 (PEP 696 defaults: `Generator[T, None, None]` -> `Generator[T]`, `AsyncGenerator[T, None]` -> `AsyncGenerator[T]`). Affected files: `app/integrations/mcp_streamable_http_compat.py`, `tests/deployment/{bedrock,ec2,langsmith,vercel}/conftest.py`, `tests/tools/test_registry.py`.

## Not changed

- `pyproject.toml` `requires-python` stays at `>=3.11`. The issue listed it as 'only if you decide to raise requires-python' and `SETUP.md` still documents 3.11+ as the supported floor for manual setup, so raising the runtime floor felt out of scope for this cleanup.
- Other workflows (`tracer-demo*`, `benchmark-readme`, `tracer-grafana`) were left on 3.12 - they're demo/benchmark pipelines, not the CI baseline the issue references.
- `SETUP.md`'s existing note \"The devcontainer uses Python 3.13 to match CI and `.tool-versions`\" already documents the baseline, so no new docs text was added (per the issue's \"exactly one obvious place\" rule).

## Acceptance criteria check

- [x] CI Python version, `mypy.ini` `python_version`, and `ruff.toml` `target-version` all agree on 3.13.
- [x] The baseline is documented in exactly one obvious place (`SETUP.md`, unchanged).
- [x] `ruff check app/ tests/` passes (0 errors).

## Test plan

- `ruff check app/ tests/` -> `All checks passed!`
- Python syntax check on each of the 6 auto-fixed files.
- `make typecheck` not runnable locally (no mypy installed in this env); CI will execute it against the new 3.13 config.

Fixes #727