### PR TITLE
test(auth): add AsyncJWKSCache TTL unit test to prevent redundant JWKS fetches within cache window

### DIFF
--- a/tests/app/auth/test_jwt_auth.py
+++ b/tests/app/auth/test_jwt_auth.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.auth.jwt_auth import AsyncJWKSCache
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_fetches_once_and_uses_cache_within_ttl() -> None:
+    """Lock in JWKS cache behavior so refactors do not refetch per request."""
+    cache = AsyncJWKSCache(_cache_ttl=3600)
+    jwks_url = "https://example.com/.well-known/jwks.json"
+    jwks_payload = {
+        "keys": [
+            {
+                "kid": "kid-1",
+                "kty": "RSA",
+            }
+        ]
+    }
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = jwks_payload
+
+    with (
+        patch("app.auth.jwt_auth.time.time", side_effect=[1000.0, 1001.0]),
+        patch("app.auth.jwt_auth.httpx.AsyncClient") as mock_async_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=response)
+        mock_async_client_cls.return_value.__aenter__.return_value = mock_client
+
+        first = await cache.get_jwks(jwks_url)
+        second = await cache.get_jwks(jwks_url)
+
+    assert first == jwks_payload
+    assert second == jwks_payload
+    assert mock_client.get.await_count == 1
+    response.raise_for_status.assert_called_once()


### PR DESCRIPTION


Fixes #741 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -
This PR adds one focused unit test to lock in JWKS cache behavior:
1. Added `test_jwt_auth.py` with an async test for AsyncJWKSCache.get_jwks.
2. The test mocks HTTP calls by patching httpx AsyncClient get, and controls time to simulate two calls within TTL.
3. It verifies first call fetches JWKS, second call returns cached data, and only one HTTP fetch occurs.

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
Implementation approach used in this PR:
1. Added a focused unit test in test_jwt_auth.py instead of changing runtime code in jwt_auth.py, so behavior is locked in safely.
2. Used deterministic time control (`patch("app.auth.jwt_auth.time.time", side_effect=[1000.0, 1001.0])`) to guarantee both calls occur within TTL.
3. Mocked network at the boundary (`httpx.AsyncClient` and async `get`) so no real HTTP requests are made.
4. Called `get_jwks()` twice with the same URL and asserted one fetch only (`await_count == 1`) plus same returned JWKS payload both times.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
