### PR TITLE
feat: add telegram integration to delivery messages

### DIFF
--- a/app/cli/constants.py
+++ b/app/cli/constants.py
@@ -60,6 +60,7 @@ VERIFY_SERVICES: tuple[str, ...] = (
     "coralogix",
     "datadog",
     "discord",
+    "telegram",
     "github",
     "google_docs",
     "grafana",

--- a/app/integrations/catalog.py
+++ b/app/integrations/catalog.py
@@ -25,6 +25,7 @@ from app.integrations.models import (
     JiraIntegrationConfig,
     OpsGenieIntegrationConfig,
     SlackWebhookConfig,
+    TelegramBotConfig,
 )
 from app.integrations.mongodb import build_mongodb_config
 from app.integrations.mongodb_atlas import build_mongodb_atlas_config
@@ -69,6 +70,7 @@ _SERVICE_KEY_MAP = {
     "opsgenie": "opsgenie",
     "jira": "jira",
     "discord": "discord",
+    "telegram": "telegram",
     "openclaw": "openclaw",
     "mysql": "mysql",
     "azure_sql": "azure_sql",
@@ -479,6 +481,20 @@ def _classify_service_instance(
             return None, None
         if discord_config.bot_token:
             return discord_config.model_dump(), "discord"
+        return None, None
+
+    if key == "telegram":
+        try:
+            tg_config = TelegramBotConfig.model_validate(
+                {
+                    "bot_token": credentials.get("bot_token", ""),
+                    "default_chat_id": credentials.get("default_chat_id"),
+                }
+            )
+        except Exception:
+            return None, None
+        if tg_config.bot_token:
+            return tg_config.model_dump(), "telegram"
         return None, None
 
     if key == "openclaw":
@@ -1105,6 +1121,23 @@ def load_env_integrations() -> list[dict[str, Any]]:
             }
         )
 
+    telegram_bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    if telegram_bot_token:
+        tg_config = TelegramBotConfig.model_validate(
+            {
+                "bot_token": telegram_bot_token,
+                "default_chat_id": os.getenv("TELEGRAM_DEFAULT_CHAT_ID", "").strip() or None,
+            }
+        )
+        integrations.append(
+            {
+                "id": "env-telegram",
+                "service": "telegram",
+                "status": "active",
+                "credentials": tg_config.model_dump(),
+            }
+        )
+
     atlas_pub = os.getenv("MONGODB_ATLAS_PUBLIC_KEY", "").strip()
     atlas_priv = os.getenv("MONGODB_ATLAS_PRIVATE_KEY", "").strip()
     atlas_project = os.getenv("MONGODB_ATLAS_PROJECT_ID", "").strip()
@@ -1503,6 +1536,7 @@ def resolve_effective_integrations(
         "opsgenie",
         "jira",
         "discord",
+        "telegram",
         "openclaw",
         "mysql",
         "azure_sql",

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -613,6 +613,7 @@ class EffectiveIntegrations(StrictConfigModel):
     bitbucket: EffectiveIntegrationEntry | None = None
     trello: EffectiveIntegrationEntry | None = None
     discord: EffectiveIntegrationEntry | None = None
+    telegram: EffectiveIntegrationEntry | None = None
     openclaw: EffectiveIntegrationEntry | None = None
     mysql: EffectiveIntegrationEntry | None = None
     snowflake: EffectiveIntegrationEntry | None = None

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -488,6 +488,21 @@ class DiscordBotConfig(StrictConfigModel):
         return stripped
 
 
+class TelegramBotConfig(StrictConfigModel):
+    """Telegram Bot runtime config."""
+
+    bot_token: str
+    default_chat_id: str | None = None
+
+    @field_validator("bot_token", mode="before")
+    @classmethod
+    def _validate_bot_token(cls, v: object) -> str:
+        stripped = str(v or "").strip()
+        if not stripped:
+            raise ValueError("bot_token cannot be empty or just whitespace")
+        return stripped
+
+
 class AlertmanagerIntegrationConfig(StrictConfigModel):
     """Normalized Alertmanager credentials used by resolution and verification flows."""
 

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -67,6 +67,7 @@ SUPPORTED_VERIFY_SERVICES = (
     "clickhouse",
     "bitbucket",
     "discord",
+    "telegram",
     "mysql",
     "openclaw",
     "snowflake",
@@ -683,6 +684,38 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     )
 
 
+def _verify_telegram(source: str, config: dict[str, Any]) -> dict[str, str]:
+    bot_token = str(config.get("bot_token", "")).strip()
+    if not bot_token:
+        return _result("telegram", source, "missing", "Missing bot token.")
+
+    try:
+        response = httpx.get(
+            f"https://api.telegram.org/bot{bot_token}/getMe",
+            timeout=10.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _result("telegram", source, "failed", f"Bot token validation failed: {exc}")
+
+    if not response.is_success:
+        return _result(
+            "telegram",
+            source,
+            "failed",
+            f"Telegram API returned {response.status_code}: {response.text[:200]}",
+        )
+
+    data = response.json().get("result", {})
+    username = str(data.get("username", "")).strip()
+    bot_id = str(data.get("id", "")).strip()
+    return _result(
+        "telegram",
+        source,
+        "passed",
+        f"Connected to Telegram API as bot @{username} (id {bot_id}).",
+    )
+
+
 def _verify_openclaw(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         openclaw_config = build_openclaw_config(config)
@@ -849,6 +882,8 @@ def verify_integrations(
             results.append(_verify_bitbucket(source, config))
         elif current_service == "discord":
             results.append(_verify_discord(source, config))
+        elif current_service == "telegram":
+            results.append(_verify_telegram(source, config))
         elif current_service == "openclaw":
             results.append(_verify_openclaw(source, config))
         elif current_service == "mysql":

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -695,7 +695,8 @@ def _verify_telegram(source: str, config: dict[str, Any]) -> dict[str, str]:
             timeout=10.0,
         )
     except Exception as exc:  # noqa: BLE001
-        return _result("telegram", source, "failed", f"Bot token validation failed: {exc}")
+        safe_exc = str(exc).replace(bot_token, "<redacted>") if bot_token else str(exc)
+        return _result("telegram", source, "failed", f"Bot token validation failed: {safe_exc}")
 
     if not response.is_success:
         return _result(

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -156,6 +156,44 @@ def generate_report(state: InvestigationState) -> dict:
     else:
         logger.debug("[publish] discord delivery: no discord integration configured")
 
+    # Telegram delivery — uses integration credentials if configured
+    telegram_creds = resolved.get("telegram", {})
+    if telegram_creds:
+        from app.utils.telegram_delivery import send_telegram_report
+
+        telegram_ctx = state.get("telegram_context") or {}
+        bot_token = telegram_ctx.get("bot_token") or telegram_creds.get("bot_token", "")
+        chat_id = telegram_ctx.get("chat_id") or telegram_creds.get("default_chat_id", "")
+        reply_to = str(telegram_ctx.get("reply_to_message_id") or "")
+        logger.debug(
+            "[publish] telegram delivery: chat_id=%s reply_to=%s bot_token_present=%s",
+            chat_id,
+            reply_to,
+            bool(bot_token),
+        )
+        if bot_token and chat_id:
+            tg_posted, tg_error = send_telegram_report(
+                slack_message,
+                {"bot_token": bot_token, "chat_id": chat_id, "reply_to_message_id": reply_to},
+            )
+            logger.debug(
+                "[publish] telegram delivery: posted=%s error=%s", tg_posted, tg_error
+            )
+            if not tg_posted:
+                logger.warning(
+                    "[publish] Telegram delivery failed: chat_id=%s error=%s",
+                    chat_id,
+                    tg_error,
+                )
+        else:
+            logger.debug(
+                "[publish] telegram delivery: skipped — bot_token_present=%s chat_id=%s",
+                bool(bot_token),
+                chat_id,
+            )
+    else:
+        logger.debug("[publish] telegram delivery: no telegram integration configured")
+
     # GitLab MR write-back (opt-in via GITLAB_MR_WRITEBACK env var)
     if os.getenv("GITLAB_MR_WRITEBACK", "").lower() in ("true", "1", "yes"):
         _gl = (state.get("available_sources") or {}).get("gitlab", {})

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -176,9 +176,7 @@ def generate_report(state: InvestigationState) -> dict:
                 slack_message,
                 {"bot_token": bot_token, "chat_id": chat_id, "reply_to_message_id": reply_to},
             )
-            logger.debug(
-                "[publish] telegram delivery: posted=%s error=%s", tg_posted, tg_error
-            )
+            logger.debug("[publish] telegram delivery: posted=%s error=%s", tg_posted, tg_error)
             if not tg_posted:
                 logger.warning(
                     "[publish] Telegram delivery failed: chat_id=%s error=%s",

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -93,6 +93,9 @@ class AgentState(TypedDict, total=False):
     # Discord context (when triggered from Discord interaction)
     discord_context: dict[str, Any]
 
+    # Telegram context (when triggered from Telegram message)
+    telegram_context: dict[str, Any]
+
     # LangGraph context (injected from config by inject_auth_node)
     thread_id: str
     run_id: str

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -160,6 +160,7 @@ class AgentStateModel(StrictConfigModel):
     masking_map: dict[str, str] = Field(default_factory=dict)
     slack_context: dict[str, Any] = Field(default_factory=dict)
     discord_context: dict[str, Any] = Field(default_factory=dict)
+    telegram_context: dict[str, Any] = Field(default_factory=dict)
     thread_id: str = ""
     run_id: str = ""
     auth_token: str = Field(default="", alias="_auth_token", exclude=True)

--- a/app/state/factory.py
+++ b/app/state/factory.py
@@ -38,6 +38,7 @@ STATE_DEFAULTS: dict[str, Any] = {
     "masking_map": {},
     "slack_context": {},
     "discord_context": {},
+    "telegram_context": {},
     "thread_id": "",
     "run_id": "",
     "_auth_token": "",

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -46,9 +46,7 @@ def post_telegram_message(
         if resp.status_code not in (200, 201):
             logger.warning("[telegram] post message failed: %s", resp.status_code)
             logger.warning("[telegram] api response %s", data)
-            error_message = str(
-                data.get("description", data.get("error", "unknown"))
-            )
+            error_message = str(data.get("description", data.get("error", "unknown")))
             logger.warning("[telegram] post message failed: %s", error_message)
             return False, error_message, ""
         result = data.get("result", {})

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -17,6 +17,13 @@ def _truncate(text: str, limit: int) -> str:
     return (text[: limit - 1] + "…") if len(text) > limit else text
 
 
+def _redact_token(text: str, bot_token: str) -> str:
+    """Replace bot token with <redacted> to prevent accidental log/error leakage."""
+    if bot_token and bot_token in text:
+        return text.replace(bot_token, "<redacted>")
+    return text
+
+
 def post_telegram_message(
     chat_id: str,
     text: str,
@@ -53,8 +60,9 @@ def post_telegram_message(
         message_id: str = str(result.get("message_id") or "")
         return True, error_message, message_id
     except Exception as exc:  # noqa: BLE001
-        logger.warning("[telegram] post message exception: %s", exc)
-        return False, str(exc), ""
+        error = _redact_token(str(exc), bot_token)
+        logger.warning("[telegram] post message exception: %s", error)
+        return False, error, ""
 
 
 def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[bool, str]:

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -50,7 +50,7 @@ def post_telegram_message(
         )
         data = resp.json()
         error_message = ""
-        if resp.status_code not in (200, 201):
+        if resp.status_code != 200:
             logger.warning("[telegram] post message failed: %s", resp.status_code)
             logger.warning("[telegram] api response %s", data)
             error_message = str(data.get("description", data.get("error", "unknown")))

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -1,0 +1,70 @@
+"""Telegram delivery helper - posts investigation findings to Telegram Bot API."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_MESSAGE_LIMIT = 4096
+
+
+def _truncate(text: str, limit: int) -> str:
+    return (text[: limit - 1] + "…") if len(text) > limit else text
+
+
+def post_telegram_message(
+    chat_id: str,
+    text: str,
+    bot_token: str,
+    parse_mode: str = "",
+    reply_to_message_id: str = "",
+) -> tuple[bool, str, str]:
+    """Call Telegram Bot API sendMessage endpoint.
+
+    Returns (success, error, message_id).
+    """
+    logger.debug("[telegram] post message params chat_id: %s", chat_id)
+    payload: dict[str, Any] = {"chat_id": chat_id, "text": text}
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    if reply_to_message_id:
+        with contextlib.suppress(ValueError, TypeError):
+            payload["reply_to_message_id"] = int(reply_to_message_id)
+    try:
+        resp = httpx.post(
+            url=f"https://api.telegram.org/bot{bot_token}/sendMessage",
+            json=payload,
+            timeout=15.0,
+        )
+        data = resp.json()
+        error_message = ""
+        if resp.status_code not in (200, 201):
+            logger.warning("[telegram] post message failed: %s", resp.status_code)
+            logger.warning("[telegram] api response %s", data)
+            error_message = str(
+                data.get("description", data.get("error", "unknown"))
+            )
+            logger.warning("[telegram] post message failed: %s", error_message)
+            return False, error_message, ""
+        result = data.get("result", {})
+        message_id: str = str(result.get("message_id") or "")
+        return True, error_message, message_id
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[telegram] post message exception: %s", exc)
+        return False, str(exc), ""
+
+
+def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[bool, str]:
+    bot_token: str = str(telegram_ctx.get("bot_token") or "")
+    chat_id: str = str(telegram_ctx.get("chat_id") or "")
+    reply_to_message_id: str = str(telegram_ctx.get("reply_to_message_id") or "")
+    text = _truncate(report, _MESSAGE_LIMIT)
+    post_success, error, _ = post_telegram_message(
+        chat_id, text, bot_token, reply_to_message_id=reply_to_message_id
+    )
+    return (True, "") if post_success else (False, error)

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 from typing import Any
 
 import httpx
@@ -11,6 +12,36 @@ import httpx
 logger = logging.getLogger(__name__)
 
 _MESSAGE_LIMIT = 4096
+_BOT_TOKEN_RE = re.compile(r"(bot)[^/]+(/)")
+
+
+def _redact_arg(a: object) -> object:
+    """Redact bot token from a log arg, preserving the original type if no match."""
+    s = str(a)
+    redacted = _BOT_TOKEN_RE.sub(r"\1<redacted>\2", s)
+    return redacted if redacted != s else a
+
+
+class _TelegramTokenFilter(logging.Filter):
+    """Scrub Telegram bot tokens from httpx/httpcore log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = _BOT_TOKEN_RE.sub(r"\1<redacted>\2", str(record.msg))
+        if record.args:
+            if isinstance(record.args, tuple):
+                record.args = tuple(_redact_arg(a) for a in record.args)
+            elif isinstance(record.args, dict):
+                record.args = {k: _redact_arg(v) for k, v in record.args.items()}
+        return True
+
+
+def _install_httpx_token_filter() -> None:
+    _filter = _TelegramTokenFilter()
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).addFilter(_filter)
+
+
+_install_httpx_token_filter()
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -39,7 +70,7 @@ def post_telegram_message(
     payload: dict[str, Any] = {"chat_id": chat_id, "text": text}
     if parse_mode:
         payload["parse_mode"] = parse_mode
-    if reply_to_message_id:
+    if reply_to_message_id and reply_to_message_id != "0":
         with contextlib.suppress(ValueError, TypeError):
             payload["reply_to_message_id"] = int(reply_to_message_id)
     try:
@@ -48,17 +79,19 @@ def post_telegram_message(
             json=payload,
             timeout=15.0,
         )
-        data = resp.json()
-        error_message = ""
         if resp.status_code != 200:
             logger.warning("[telegram] post message failed: %s", resp.status_code)
-            logger.warning("[telegram] api response %s", data)
-            error_message = str(data.get("description", data.get("error", "unknown")))
+            try:
+                data = resp.json()
+                error_message = str(data.get("description", data.get("error", "unknown")))
+            except Exception:  # noqa: BLE001
+                error_message = resp.text or f"HTTP {resp.status_code}"
             logger.warning("[telegram] post message failed: %s", error_message)
             return False, error_message, ""
+        data = resp.json()
         result = data.get("result", {})
         message_id: str = str(result.get("message_id") or "")
-        return True, error_message, message_id
+        return True, "", message_id
     except Exception as exc:  # noqa: BLE001
         error = _redact_token(str(exc), bot_token)
         logger.warning("[telegram] post message exception: %s", error)
@@ -66,8 +99,11 @@ def post_telegram_message(
 
 
 def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[bool, str]:
+    """Send a truncated report to Telegram. Returns (success, error)."""
     bot_token: str = str(telegram_ctx.get("bot_token") or "")
     chat_id: str = str(telegram_ctx.get("chat_id") or "")
+    if not bot_token or not chat_id:
+        return False, "Missing bot_token or chat_id"
     reply_to_message_id: str = str(telegram_ctx.get("reply_to_message_id") or "")
     text = _truncate(report, _MESSAGE_LIMIT)
     post_success, error, _ = post_telegram_message(

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -1,0 +1,159 @@
+"""Tests for app/utils/telegram_delivery.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.utils.telegram_delivery import (
+    post_telegram_message,
+    send_telegram_report,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int, body: dict[str, Any]) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# post_telegram_message
+# ---------------------------------------------------------------------------
+
+
+def test_post_telegram_message_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.utils.telegram_delivery.httpx.post",
+        lambda *_a, **_kw: _mock_response(200, {"ok": True, "result": {"message_id": 42}}),
+    )
+    ok, error, message_id = post_telegram_message("chat-1", "hello", "bot-token")
+    assert ok is True
+    assert error == ""
+    assert message_id == "42"
+
+
+def test_post_telegram_message_sends_correct_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, *, json: dict[str, Any], **_kw: Any) -> MagicMock:
+        captured["url"] = url
+        captured["json"] = json
+        return _mock_response(200, {"ok": True, "result": {"message_id": 1}})
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    post_telegram_message("chat-42", "test text", "my-token")
+
+    assert "my-token" in captured["url"]
+    assert "sendMessage" in captured["url"]
+    assert captured["json"]["chat_id"] == "chat-42"
+    assert captured["json"]["text"] == "test text"
+
+
+def test_post_telegram_message_with_reply_to(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, *, json: dict[str, Any], **_kw: Any) -> MagicMock:
+        captured["json"] = json
+        return _mock_response(200, {"ok": True, "result": {"message_id": 2}})
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    post_telegram_message("chat-1", "text", "token", reply_to_message_id="99")
+    assert captured["json"]["reply_to_message_id"] == 99
+
+
+def test_post_telegram_message_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.utils.telegram_delivery.httpx.post",
+        lambda *_a, **_kw: _mock_response(
+            400, {"ok": False, "description": "Bad Request: chat not found"}
+        ),
+    )
+    ok, error, message_id = post_telegram_message("chat-1", "text", "bot-token")
+    assert ok is False
+    assert "Bad Request" in error
+    assert message_id == ""
+
+
+def test_post_telegram_message_exception_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise ConnectionError("network down")
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _raise)
+    ok, error, message_id = post_telegram_message("chat-1", "text", "bot-token")
+    assert ok is False
+    assert "network down" in error
+    assert message_id == ""
+
+
+# ---------------------------------------------------------------------------
+# send_telegram_report
+# ---------------------------------------------------------------------------
+
+
+def test_send_telegram_report_posts_to_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, *, json: dict[str, Any], **_kw: Any) -> MagicMock:
+        captured["url"] = url
+        captured["json"] = json
+        return _mock_response(200, {"ok": True, "result": {"message_id": 5}})
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    ok, error = send_telegram_report(
+        "Report text", {"bot_token": "tok", "chat_id": "chat-1"}
+    )
+
+    assert ok is True
+    assert error == ""
+    assert "tok" in captured["url"]
+    assert captured["json"]["chat_id"] == "chat-1"
+    assert captured["json"]["text"] == "Report text"
+
+
+def test_send_telegram_report_uses_reply_to_message_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, *, json: dict[str, Any], **_kw: Any) -> MagicMock:
+        captured["json"] = json
+        return _mock_response(200, {"ok": True, "result": {"message_id": 6}})
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    send_telegram_report(
+        "Report",
+        {"bot_token": "tok", "chat_id": "chat-1", "reply_to_message_id": "77"},
+    )
+    assert captured["json"].get("reply_to_message_id") == 77
+
+
+def test_send_telegram_report_returns_false_on_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.utils.telegram_delivery.httpx.post",
+        lambda *_a, **_kw: _mock_response(403, {"ok": False, "description": "Forbidden"}),
+    )
+    ok, error = send_telegram_report("Report", {"bot_token": "tok", "chat_id": "chat-1"})
+    assert ok is False
+    assert "Forbidden" in error
+
+
+def test_send_telegram_report_truncates_to_4096(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "app.utils.telegram_delivery.httpx.post",
+        lambda *_a, **kw: (
+            captured.update({"text": kw["json"].get("text", "")})
+            or _mock_response(200, {"ok": True, "result": {"message_id": 7}})
+        ),  # type: ignore[misc]
+    )
+    long_report = "x" * 5000
+    send_telegram_report(long_report, {"bot_token": "tok", "chat_id": "chat-1"})
+    assert len(captured["text"]) == 4096
+    assert captured["text"].endswith("…")

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -93,6 +93,19 @@ def test_post_telegram_message_exception_returns_false(monkeypatch: pytest.Monke
     assert message_id == ""
 
 
+def test_post_telegram_message_exception_redacts_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "secret-bot-token-123"
+
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise ConnectionError(f"failed to connect to api.telegram.org/bot{secret}/sendMessage")
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _raise)
+    ok, error, _ = post_telegram_message("chat-1", "text", secret)
+    assert ok is False
+    assert secret not in error
+    assert "<redacted>" in error
+
+
 # ---------------------------------------------------------------------------
 # send_telegram_report
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from app.utils.telegram_delivery import (
+    _TelegramTokenFilter,
     post_telegram_message,
     send_telegram_report,
 )
@@ -152,6 +154,128 @@ def test_send_telegram_report_returns_false_on_api_error(monkeypatch: pytest.Mon
     ok, error = send_telegram_report("Report", {"bot_token": "tok", "chat_id": "chat-1"})
     assert ok is False
     assert "Forbidden" in error
+
+
+# ---------------------------------------------------------------------------
+# fix 1 – httpx log token filter
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_token_filter_scrubs_url_from_msg() -> None:
+    f = _TelegramTokenFilter()
+    record = logging.LogRecord(
+        name="httpx",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="HTTP Request: POST https://api.telegram.org/botSECRET123/sendMessage",
+        args=(),
+        exc_info=None,
+    )
+    f.filter(record)
+    assert "SECRET123" not in record.msg
+    assert "bot<redacted>/sendMessage" in record.msg
+
+
+def test_telegram_token_filter_scrubs_token_in_args() -> None:
+    f = _TelegramTokenFilter()
+    record = logging.LogRecord(
+        name="httpcore",
+        level=logging.DEBUG,
+        pathname="",
+        lineno=0,
+        msg="send %s",
+        args=("https://api.telegram.org/botSECRET123/sendMessage",),
+        exc_info=None,
+    )
+    f.filter(record)
+    assert isinstance(record.args, tuple)
+    assert "SECRET123" not in record.args[0]
+    assert "bot<redacted>/sendMessage" in record.args[0]
+
+
+def test_telegram_token_filter_scrubs_non_string_url_arg() -> None:
+    """httpx passes request.url as an httpx.URL object, not a plain str."""
+
+    class FakeURL:
+        def __str__(self) -> str:
+            return "https://api.telegram.org/botSECRET123/sendMessage"
+
+    f = _TelegramTokenFilter()
+    record = logging.LogRecord(
+        name="httpx",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='HTTP Request: %s %s "%s %d %s"',
+        args=("POST", FakeURL(), "HTTP/1.1", 200, "OK"),
+        exc_info=None,
+    )
+    f.filter(record)
+    assert isinstance(record.args, tuple)
+    assert "SECRET123" not in str(record.args[1])
+    assert "bot<redacted>/sendMessage" in str(record.args[1])
+
+
+# ---------------------------------------------------------------------------
+# fix 2 – send_telegram_report guards missing creds
+# ---------------------------------------------------------------------------
+
+
+def test_send_telegram_report_missing_bot_token() -> None:
+    ok, error = send_telegram_report("report", {"bot_token": "", "chat_id": "chat-1"})
+    assert ok is False
+    assert "Missing" in error
+
+
+def test_send_telegram_report_missing_chat_id() -> None:
+    ok, error = send_telegram_report("report", {"bot_token": "tok", "chat_id": ""})
+    assert ok is False
+    assert "Missing" in error
+
+
+def test_send_telegram_report_missing_both_creds() -> None:
+    ok, error = send_telegram_report("report", {})
+    assert ok is False
+    assert "Missing" in error
+
+
+# ---------------------------------------------------------------------------
+# fix 3 – resp.json() only called after status check (non-JSON error body)
+# ---------------------------------------------------------------------------
+
+
+def test_post_telegram_message_non_json_error_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    resp = MagicMock()
+    resp.status_code = 502
+    resp.json.side_effect = ValueError("not JSON")
+    resp.text = "Bad Gateway"
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", lambda *_a, **_kw: resp)
+    ok, error, message_id = post_telegram_message("chat-1", "text", "tok")
+
+    assert ok is False
+    assert "Bad Gateway" in error
+    assert message_id == ""
+
+
+# ---------------------------------------------------------------------------
+# fix 4 – reply_to_message_id="0" must not be sent to the API
+# ---------------------------------------------------------------------------
+
+
+def test_post_telegram_message_reply_to_zero_string_not_sent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, *, json: dict[str, Any], **_kw: Any) -> MagicMock:
+        captured["json"] = json
+        return _mock_response(200, {"ok": True, "result": {"message_id": 1}})
+
+    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    post_telegram_message("chat-1", "text", "tok", reply_to_message_id="0")
+    assert "reply_to_message_id" not in captured["json"]
 
 
 def test_send_telegram_report_truncates_to_4096(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -107,9 +107,7 @@ def test_send_telegram_report_posts_to_chat(monkeypatch: pytest.MonkeyPatch) -> 
         return _mock_response(200, {"ok": True, "result": {"message_id": 5}})
 
     monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
-    ok, error = send_telegram_report(
-        "Report text", {"bot_token": "tok", "chat_id": "chat-1"}
-    )
+    ok, error = send_telegram_report("Report text", {"bot_token": "tok", "chat_id": "chat-1"})
 
     assert ok is True
     assert error == ""


### PR DESCRIPTION
Fixes #731 

  ## Summary

  Adds a Telegram Bot integration that delivers investigation findings to a Telegram chat when an investigation completes. The pattern mirrors the existing Discord integration.

  The Telegram integration follows the same delivery pattern as Discord. `post_telegram_message` calls the Bot API `sendMessage` endpoint and returns `(success, error, message_id)`. `send_telegram_report` wraps it with truncation to Telegram's message limit and reads credentials from `telegram_context` (runtime) or integration config (default). The publish node picks up `telegram` from `resolved_integrations` and calls `send_telegram_report` after the Discord block. Verification uses the `getMe` endpoint — same approach as Discord's `users/@me`. The `reply_to_message_id` field supports threading replies to the original alert message.

  ---
  ## Testing

  ```bash
  make lint
  make typecheck
  make test-cov
  make verify-integrations
  opensre integrations verify telegram
  make investigate-alert ALERT=tests/e2e/rca/grafana_pipeline_failure.md
  ```

  **Evidence from the tests:**

<img width="642" height="53" alt="image" src="https://github.com/user-attachments/assets/40d5de86-6267-4d0f-9810-9710b330337e" />



<img width="499" height="927" alt="image" src="https://github.com/user-attachments/assets/4c3504c2-f34c-4060-ac1f-202317198991" />