### PR TITLE
feat: support LLM_MAX_TOKENS env var in LLMSettings.from_env()

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -273,10 +273,10 @@ class LLMSettings(StrictConfigModel):
                 or BEDROCK_TOOLCALL_MODEL,
                 "ollama_model": os.getenv("OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL).strip()
                 or DEFAULT_OLLAMA_MODEL,
-                "ollama_host": os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).strip()
-                or DEFAULT_OLLAMA_HOST,
-                "max_tokens": DEFAULT_MAX_TOKENS,
-            }
+        "ollama_host": os.getenv("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).strip()
+        or DEFAULT_OLLAMA_HOST,
+        "max_tokens": _parse_max_tokens(),
+    }
         )
 
 
@@ -333,6 +333,25 @@ OLLAMA_LLM_CONFIG = LLMModelConfig(
 TRACER_BASE_URL_DEV = "https://staging.tracer.cloud"
 TRACER_BASE_URL_PROD = "https://app.tracer.cloud"
 SLACK_CHANNEL = "tracer-rca-report-alerts"
+
+
+def _parse_max_tokens() -> int:
+    """Parse LLM_MAX_TOKENS from environment variable.
+    
+    Returns:
+        int: The max_tokens value from LLM_MAX_TOKENS env var, or DEFAULT_MAX_TOKENS if not set or invalid.
+    """
+    max_tokens_str = os.getenv("LLM_MAX_TOKENS")
+    if max_tokens_str is None:
+        return DEFAULT_MAX_TOKENS
+    
+    try:
+        max_tokens = int(max_tokens_str)
+        if max_tokens <= 0:
+            return DEFAULT_MAX_TOKENS
+        return max_tokens
+    except (ValueError, TypeError):
+        return DEFAULT_MAX_TOKENS
 
 
 def get_tracer_base_url() -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,3 +65,73 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
 
     assert settings.provider == "minimax"
     assert settings.minimax_api_key == "mm-stored-key"
+
+
+def test_llm_settings_from_env_max_tokens_default(monkeypatch) -> None:
+    """Test that max_tokens defaults to DEFAULT_MAX_TOKENS when LLM_MAX_TOKENS is not set."""
+    monkeypatch.delenv("LLM_MAX_TOKENS", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "test-key" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.max_tokens == 4096  # DEFAULT_MAX_TOKENS
+
+
+def test_llm_settings_from_env_max_tokens_custom(monkeypatch) -> None:
+    """Test that LLM_MAX_TOKENS env var is respected."""
+    monkeypatch.setenv("LLM_MAX_TOKENS", "8192")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "test-key" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.max_tokens == 8192
+
+
+def test_llm_settings_from_env_max_tokens_invalid_fallback(monkeypatch) -> None:
+    """Test that invalid LLM_MAX_TOKENS falls back to DEFAULT_MAX_TOKENS."""
+    monkeypatch.setenv("LLM_MAX_TOKENS", "invalid")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "test-key" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.max_tokens == 4096  # DEFAULT_MAX_TOKENS
+
+
+def test_llm_settings_from_env_max_tokens_negative_fallback(monkeypatch) -> None:
+    """Test that negative LLM_MAX_TOKENS falls back to DEFAULT_MAX_TOKENS."""
+    monkeypatch.setenv("LLM_MAX_TOKENS", "-100")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "test-key" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.max_tokens == 4096  # DEFAULT_MAX_TOKENS
+
+
+def test_llm_settings_from_env_max_tokens_zero_fallback(monkeypatch) -> None:
+    """Test that zero LLM_MAX_TOKENS falls back to DEFAULT_MAX_TOKENS."""
+    monkeypatch.setenv("LLM_MAX_TOKENS", "0")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "test-key" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.max_tokens == 4096  # DEFAULT_MAX_TOKENS


### PR DESCRIPTION
Fixes #739

#### Describe the changes you have made in this PR -

This PR adds support for the `LLM_MAX_TOKENS` environment variable in `LLMSettings.from_env()`, allowing users to configure token limits via environment variables instead of being hardcoded to `DEFAULT_MAX_TOKENS`.

**Changes:**
- Added `_parse_max_tokens()` function to parse `LLM_MAX_TOKENS` env var
- Validates as positive integer
- Falls back to `DEFAULT_MAX_TOKENS` (4096) if:
  - Env var is not set
  - Value is invalid (non-numeric)
  - Value is zero or negative
- Added 5 unit tests covering all edge cases

**Testing:**
- ✅ test_llm_settings_from_env_max_tokens_default
- ✅ test_llm_settings_from_env_max_tokens_custom
- ✅ test_llm_settings_from_env_max_tokens_invalid_fallback
- ✅ test_llm_settings_from_env_max_tokens_negative_fallback
- ✅ test_llm_settings_from_env_max_tokens_zero_fallback

---

## Code Understanding and AI Usage
**Did you use AI assistance?**
- [x] No, I wrote all the code myself

---

## Checklist
- [x] Linked to issue
- [x] Self-review completed
- [x] All tests passing
- [x] Code follows style guidelines

---

**Status:** Draft - awaiting assignment confirmation.