### PR TITLE
fix: handle empty alert_name in _make_id() with fallback

### DIFF
--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -657,8 +657,15 @@ def _check_memory_health() -> DeepHealthCheck:
 
 
 def _make_id(alert_name: str) -> str:
+    """Generate investigation ID from timestamp and alert name.
+
+    Uses 'investigation' as fallback when alert_name is empty/whitespace.
+    """
     ts = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
-    return f"{ts}_{_slugify(alert_name)}"
+    slug = _slugify(alert_name)
+    if not slug:
+        slug = "investigation"
+    return f"{ts}_{slug}"
 
 
 def _id_to_iso(inv_id: str) -> str:

--- a/tests/remote/test_make_id.py
+++ b/tests/remote/test_make_id.py
@@ -1,7 +1,5 @@
 """Tests for _make_id() and _slugify() functions."""
 
-import pytest
-
 from app.remote.server import _make_id, _slugify
 
 

--- a/tests/remote/test_make_id.py
+++ b/tests/remote/test_make_id.py
@@ -1,0 +1,81 @@
+"""Tests for _make_id() and _slugify() functions."""
+
+import pytest
+
+from app.remote.server import _make_id, _slugify
+
+
+class TestSlugify:
+    """Tests for _slugify() function."""
+
+    def test_empty_string(self):
+        """Empty string returns empty slug."""
+        assert _slugify("") == ""
+
+    def test_whitespace_only(self):
+        """Whitespace-only string returns empty slug."""
+        assert _slugify("   ") == ""
+        assert _slugify("\t") == ""
+        assert _slugify("\n") == ""
+
+    def test_normal_text(self):
+        """Normal text is lowercased and separated by hyphens."""
+        assert _slugify("Test Alert") == "test-alert"
+        assert _slugify("My Alert Name") == "my-alert-name"
+
+    def test_special_characters(self):
+        """Special characters are replaced with hyphens."""
+        assert _slugify("test@alert!") == "test-alert"
+        assert _slugify("alert#123") == "alert-123"
+
+    def test_leading_trailing_spaces(self):
+        """Leading and trailing spaces are stripped."""
+        assert _slugify("  alert  ") == "alert"
+        assert _slugify("  test alert  ") == "test-alert"
+
+    def test_max_length(self):
+        """Slug is truncated to 60 characters."""
+        long_text = "a" * 100
+        assert len(_slugify(long_text)) == 60
+
+    def test_numbers_preserved(self):
+        """Numbers are preserved in slug."""
+        assert _slugify("alert123") == "alert123"
+        assert _slugify("test2026") == "test2026"
+
+
+class TestMakeId:
+    """Tests for _make_id() function."""
+
+    def test_empty_alert_name_uses_fallback(self):
+        """Empty alert_name uses 'investigation' as fallback."""
+        result = _make_id("")
+        assert result.endswith("_investigation")
+        assert result.startswith("20")  # Starts with timestamp year
+
+    def test_whitespace_alert_name_uses_fallback(self):
+        """Whitespace-only alert_name uses 'investigation' as fallback."""
+        result = _make_id("   ")
+        assert result.endswith("_investigation")
+
+    def test_normal_alert_name(self):
+        """Normal alert_name is slugified and appended."""
+        result = _make_id("Test Alert")
+        assert "test-alert" in result
+
+    def test_format(self):
+        """ID format is YYYYMMDD_HHMMSS_slug."""
+        import re
+        result = _make_id("test")
+        # Pattern: 20260421_123456_test
+        pattern = r"^\d{8}_\d{6}_[a-z0-9-]+$"
+        assert re.match(pattern, result), f"ID '{result}' doesn't match expected format"
+
+    def test_unique_timestamps(self):
+        """Different calls produce different IDs (due to timestamp)."""
+        # Note: This test may rarely fail if called within same second
+        import time
+        result1 = _make_id("test")
+        time.sleep(1.1)  # Ensure different second
+        result2 = _make_id("test")
+        assert result1 != result2


### PR DESCRIPTION
Fixes #744

#### Describe the changes you have made in this PR -

This PR adds a fallback to `_make_id()` to handle empty or whitespace-only `alert_name` values. When `_slugify(alert_name)` returns an empty string, the function now uses "investigation" as the default slug instead of producing awkward IDs like `20260421_123456_`.

**Changes:**
- Modified `_make_id()` in `app/remote/server.py` to check if slug is empty
- Added fallback to "investigation" when slug is empty/whitespace
- Added comprehensive unit tests in `tests/remote/test_make_id.py`:
  - 7 tests for `_slugify()` (empty, whitespace, normal, special chars, max length, etc.)
  - 5 tests for `_make_id()` (fallback behavior, format validation, uniqueness)

**Testing:**
- ✅ All 12 new tests passing
- ✅ lint (ruff) passing
- ✅ typecheck (mypy) passing
- ✅ Existing tests unaffected

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

**Status:** Draft - awaiting assignment confirmation.