### PR TITLE
test(vercel): add unit tests for _safe_vercel_path_segment

### DIFF
--- a/app/integrations/posthog.py
+++ b/app/integrations/posthog.py
@@ -153,7 +153,11 @@ def validate_posthog_config(config: PostHogConfig) -> PostHogValidationResult:
         return PostHogValidationResult(ok=True, detail="PostHog validated.")
     except httpx.HTTPStatusError as err:
         snippet = err.response.text[:200].strip()
-        detail = f"HTTP {err.response.status_code}: {snippet}" if snippet else f"HTTP {err.response.status_code}"
+        detail = (
+            f"HTTP {err.response.status_code}: {snippet}"
+            if snippet
+            else f"HTTP {err.response.status_code}"
+        )
         return PostHogValidationResult(ok=False, detail=detail)
     except Exception as err:  # noqa: BLE001
         return PostHogValidationResult(ok=False, detail=str(err))

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -154,7 +154,7 @@ def test_validate_posthog_config_http_error_detail_starts_with_http(
 
     monkeypatch.setattr(
         "app.integrations.posthog._request_json",
-        lambda *a, **kw: (_ for _ in ()).throw(
+        lambda *_a, **_kw: (_ for _ in ()).throw(
             httpx.HTTPStatusError("401", request=request, response=response)
         ),
     )

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -102,7 +102,9 @@ def test_validate_posthog_config_forbidden(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/123/")
-    response = httpx.Response(403, text='{"detail": "You do not have permission."}', request=request)
+    response = httpx.Response(
+        403, text='{"detail": "You do not have permission."}', request=request
+    )
 
     def fake_request_json(*args, **kwargs):
         raise httpx.HTTPStatusError(

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -9,8 +9,10 @@ import pytest
 from app.services.vercel.client import (
     VercelClient,
     VercelConfig,
+    _MAX_VERCEL_PATH_SEGMENT_LEN,
     _append_parsed_runtime_stream_value,
     _ingest_runtime_log_stream_line,
+    _safe_vercel_path_segment,
     make_vercel_client,
 )
 
@@ -704,3 +706,105 @@ def test_append_parsed_runtime_stream_value_respects_limit_with_list() -> None:
     assert len(bucket) == 2
     assert bucket[0]["id"] == "log_0"
     assert bucket[1]["id"] == "log_1"
+
+
+# ---------------------------------------------------------------------------
+# _safe_vercel_path_segment
+# ---------------------------------------------------------------------------
+
+
+class TestSafeVercelPathSegment:
+    """Unit tests for _safe_vercel_path_segment()."""
+
+    # -- invalid inputs that must return None --
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("   ") is None
+
+    def test_tab_only_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("\t") is None
+
+    def test_too_long_string_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("a" * (_MAX_VERCEL_PATH_SEGMENT_LEN + 1)) is None
+
+    def test_exactly_max_length_is_valid(self) -> None:
+        segment = "a" * _MAX_VERCEL_PATH_SEGMENT_LEN
+        assert _safe_vercel_path_segment(segment) == segment
+
+    def test_contains_double_dot_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl_abc..def") is None
+
+    def test_path_traversal_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("../secret") is None
+
+    def test_double_dot_at_end_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl_abc..") is None
+
+    def test_double_slash_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl_abc//def") is None
+
+    def test_single_slash_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl/abc") is None
+
+    def test_starts_with_dot_returns_none(self) -> None:
+        assert _safe_vercel_path_segment(".hidden") is None
+
+    def test_starts_with_hyphen_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("-abc") is None
+
+    def test_starts_with_underscore_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("_abc") is None
+
+    def test_space_in_middle_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl abc") is None
+
+    def test_null_byte_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl\x00abc") is None
+
+    def test_newline_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl\nabc") is None
+
+    def test_special_chars_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl@abc!") is None
+
+    def test_colon_returns_none(self) -> None:
+        assert _safe_vercel_path_segment("dpl:abc") is None
+
+    # -- valid inputs that must return the cleaned string --
+
+    def test_simple_alphanumeric_id(self) -> None:
+        assert _safe_vercel_path_segment("dpl123") == "dpl123"
+
+    def test_id_with_underscores_and_hyphens(self) -> None:
+        assert _safe_vercel_path_segment("dpl_abc-123") == "dpl_abc-123"
+
+    def test_id_with_dots(self) -> None:
+        assert _safe_vercel_path_segment("dpl.abc.1") == "dpl.abc.1"
+
+    def test_single_character_id(self) -> None:
+        assert _safe_vercel_path_segment("a") == "a"
+
+    def test_mixed_case_id(self) -> None:
+        assert _safe_vercel_path_segment("DplAbc123") == "DplAbc123"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert _safe_vercel_path_segment("  dpl_abc  ") == "dpl_abc"
+
+    def test_strips_leading_whitespace(self) -> None:
+        assert _safe_vercel_path_segment("   dpl123") == "dpl123"
+
+    def test_strips_trailing_whitespace(self) -> None:
+        assert _safe_vercel_path_segment("dpl123   ") == "dpl123"
+
+    def test_realistic_vercel_deployment_id(self) -> None:
+        assert _safe_vercel_path_segment("dpl_7JtoAHRqD4xSGBDT6MrFxXZH") == "dpl_7JtoAHRqD4xSGBDT6MrFxXZH"
+
+    def test_realistic_vercel_project_id(self) -> None:
+        assert _safe_vercel_path_segment("prj_AbCdEfGh12345678") == "prj_AbCdEfGh12345678"
+
+    def test_single_dot_is_valid(self) -> None:
+        """A single dot between characters is allowed; only '..' triggers the guard."""
+        assert _safe_vercel_path_segment("a.b") == "a.b"

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -7,9 +7,9 @@ import httpx
 import pytest
 
 from app.services.vercel.client import (
+    _MAX_VERCEL_PATH_SEGMENT_LEN,
     VercelClient,
     VercelConfig,
-    _MAX_VERCEL_PATH_SEGMENT_LEN,
     _append_parsed_runtime_stream_value,
     _ingest_runtime_log_stream_line,
     _safe_vercel_path_segment,

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -800,7 +800,10 @@ class TestSafeVercelPathSegment:
         assert _safe_vercel_path_segment("dpl123   ") == "dpl123"
 
     def test_realistic_vercel_deployment_id(self) -> None:
-        assert _safe_vercel_path_segment("dpl_7JtoAHRqD4xSGBDT6MrFxXZH") == "dpl_7JtoAHRqD4xSGBDT6MrFxXZH"
+        assert (
+            _safe_vercel_path_segment("dpl_7JtoAHRqD4xSGBDT6MrFxXZH")
+            == "dpl_7JtoAHRqD4xSGBDT6MrFxXZH"
+        )
 
     def test_realistic_vercel_project_id(self) -> None:
         assert _safe_vercel_path_segment("prj_AbCdEfGh12345678") == "prj_AbCdEfGh12345678"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,9 +68,9 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', '8192')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "8192")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     settings = LLMSettings.from_env()
 
@@ -78,20 +78,21 @@ def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_invalid_raises(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', 'not-a-number')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "not-a-number")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     with pytest.raises((ValueError, ValidationError)):
         LLMSettings.from_env()
 
 
 def test_llm_settings_from_env_max_tokens_default(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.delenv('LLM_MAX_TOKENS', raising=False)
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.delenv("LLM_MAX_TOKENS", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     from app.config import DEFAULT_MAX_TOKENS
+
     settings = LLMSettings.from_env()
 
     assert settings.max_tokens == DEFAULT_MAX_TOKENS


### PR DESCRIPTION
## Summary

Closes #747

Adds 29 unit tests for `_safe_vercel_path_segment()` in `app/services/vercel/client.py` (lines 40–48), organised under a `TestSafeVercelPathSegment` class in `tests/services/vercel/test_client.py`.

### Invalid inputs (must return `None`)
- Empty string and whitespace-only / tab-only strings
- Strings exceeding `_MAX_VERCEL_PATH_SEGMENT_LEN` (256 chars)
- Strings containing `..` (path traversal: `dpl_abc..def`, `../secret`, `dpl_abc..`)
- Strings containing `//`
- Strings containing a single `/`
- Strings starting with `.`, `-`, or `_` (disallowed by the regex)
- Strings with embedded spaces, null bytes, newlines, or special characters (`@`, `!`, `:`)

### Valid inputs (must return the cleaned string)
- Simple alphanumeric IDs
- IDs with underscores, hyphens, or single dots
- Single-character IDs, mixed-case IDs
- Strings with surrounding whitespace (stripped to valid segment)
- Realistic Vercel deployment IDs (`dpl_7JtoAHRqD4xSGBDT6MrFxXZH`) and project IDs (`prj_AbCdEfGh12345678`)
- Exactly `_MAX_VERCEL_PATH_SEGMENT_LEN` characters (boundary case)

## Test plan

- [x] All 29 new tests pass: `pytest tests/services/vercel/test_client.py -v`
- [x] All 76 tests in the file pass (no regressions)

Made with [Cursor](https://cursor.com)