### PR TITLE
feat(mcp): return stable error shape with error_type in run_rca

### DIFF
--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -19,6 +19,7 @@ class RunRCAOutput(BaseModel):
     ok: bool
     result: dict[str, Any] | None = None
     error: str | None = None
+    error_type: str | None = None
 
 
 mcp = FastMCP("opensre")
@@ -84,9 +85,9 @@ def run_rca(
 
         return RunRCAOutput(ok=True, result=result).model_dump()
     except ValidationError as err:
-        return RunRCAOutput(ok=False, error=str(err)).model_dump()
+        return RunRCAOutput(ok=False, error=str(err), error_type=type(err).__name__).model_dump()
     except Exception as err:  # noqa: BLE001
-        return RunRCAOutput(ok=False, error=str(err)).model_dump()
+        return RunRCAOutput(ok=False, error=str(err), error_type=type(err).__name__).model_dump()
 
 
 def main() -> None:

--- a/app/integrations/posthog.py
+++ b/app/integrations/posthog.py
@@ -153,7 +153,11 @@ def validate_posthog_config(config: PostHogConfig) -> PostHogValidationResult:
         return PostHogValidationResult(ok=True, detail="PostHog validated.")
     except httpx.HTTPStatusError as err:
         snippet = err.response.text[:200].strip()
-        detail = f"HTTP {err.response.status_code}: {snippet}" if snippet else f"HTTP {err.response.status_code}"
+        detail = (
+            f"HTTP {err.response.status_code}: {snippet}"
+            if snippet
+            else f"HTTP {err.response.status_code}"
+        )
         return PostHogValidationResult(ok=False, detail=detail)
     except Exception as err:  # noqa: BLE001
         return PostHogValidationResult(ok=False, detail=str(err))

--- a/tests/entrypoints/test_mcp.py
+++ b/tests/entrypoints/test_mcp.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from pydantic import ValidationError
 
 from app.entrypoints.mcp import RunRCAOutput, run_rca
 

--- a/tests/entrypoints/test_mcp.py
+++ b/tests/entrypoints/test_mcp.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from pydantic import ValidationError
 
-from app.entrypoints.mcp import run_rca
+from app.entrypoints.mcp import RunRCAOutput, run_rca
 
 
 def test_run_rca_malformed_input() -> None:
@@ -13,6 +15,7 @@ def test_run_rca_malformed_input() -> None:
     assert result["ok"] is False
     assert result["result"] is None
     assert result["error"]
+    assert result["error_type"] == "ValidationError"
 
 
 def test_run_rca_happy_path(monkeypatch: MonkeyPatch) -> None:
@@ -54,6 +57,7 @@ def test_run_rca_happy_path(monkeypatch: MonkeyPatch) -> None:
 
     assert result["ok"] is True
     assert result["error"] is None
+    assert result["error_type"] is None
     assert result["result"] is not None
 
     response = result["result"]
@@ -64,3 +68,65 @@ def test_run_rca_happy_path(monkeypatch: MonkeyPatch) -> None:
     assert response["payload_seen"]["commonLabels"]["alertname"] == "HighCPU"
     assert response["payload_seen"]["commonLabels"]["pipeline_name"] == "prod-pipeline"
     assert response["payload_seen"]["commonLabels"]["severity"] == "critical"
+
+
+def test_run_rca_unexpected_exception_includes_error_type(monkeypatch: MonkeyPatch) -> None:
+    def fake_run_cli(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("something went wrong")
+
+    monkeypatch.setattr("app.entrypoints.mcp._run_cli", fake_run_cli)
+
+    payload: dict[str, Any] = {"title": "test", "state": "firing", "alert_source": "grafana"}
+    result = run_rca(alert_payload=payload)
+
+    assert result["ok"] is False
+    assert result["error"] == "something went wrong"
+    assert result["error_type"] == "RuntimeError"
+    assert result["result"] is None
+
+
+def test_run_rca_error_type_reflects_actual_exception_class(monkeypatch: MonkeyPatch) -> None:
+    def fake_run_cli(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise ValueError("bad value")
+
+    monkeypatch.setattr("app.entrypoints.mcp._run_cli", fake_run_cli)
+
+    payload: dict[str, Any] = {"title": "test", "state": "firing", "alert_source": "grafana"}
+    result = run_rca(alert_payload=payload)
+
+    assert result["ok"] is False
+    assert result["error_type"] == "ValueError"
+
+
+def test_run_rca_output_shape_on_success(monkeypatch: MonkeyPatch) -> None:
+    """Success response always has ok, result, error, and error_type keys."""
+    monkeypatch.setattr("app.entrypoints.mcp._run_cli", lambda *a, **kw: {"report": "done"})
+
+    payload: dict[str, Any] = {"title": "test", "state": "firing", "alert_source": "grafana"}
+    result = run_rca(alert_payload=payload)
+
+    assert set(result.keys()) >= {"ok", "result", "error", "error_type"}
+    assert result["ok"] is True
+    assert result["error"] is None
+    assert result["error_type"] is None
+
+
+def test_run_rca_output_shape_on_error() -> None:
+    """Error response always has ok, result, error, and error_type keys."""
+    result = run_rca(alert_payload="not-a-dict")  # type: ignore[arg-type]
+
+    assert set(result.keys()) >= {"ok", "result", "error", "error_type"}
+    assert result["ok"] is False
+    assert result["error"] is not None
+    assert result["error_type"] is not None
+
+
+def test_run_rca_output_model_has_error_type_field() -> None:
+    """RunRCAOutput model includes error_type in its schema."""
+    fields = RunRCAOutput.model_fields
+    assert "error_type" in fields
+
+
+def test_run_rca_output_model_error_type_defaults_to_none() -> None:
+    out = RunRCAOutput(ok=True)
+    assert out.error_type is None

--- a/tests/entrypoints/test_mcp.py
+++ b/tests/entrypoints/test_mcp.py
@@ -100,7 +100,7 @@ def test_run_rca_error_type_reflects_actual_exception_class(monkeypatch: MonkeyP
 
 def test_run_rca_output_shape_on_success(monkeypatch: MonkeyPatch) -> None:
     """Success response always has ok, result, error, and error_type keys."""
-    monkeypatch.setattr("app.entrypoints.mcp._run_cli", lambda *a, **kw: {"report": "done"})
+    monkeypatch.setattr("app.entrypoints.mcp._run_cli", lambda *_a, **_kw: {"report": "done"})
 
     payload: dict[str, Any] = {"title": "test", "state": "firing", "alert_source": "grafana"}
     result = run_rca(alert_payload=payload)

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -102,7 +102,9 @@ def test_validate_posthog_config_forbidden(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/123/")
-    response = httpx.Response(403, text='{"detail": "You do not have permission."}', request=request)
+    response = httpx.Response(
+        403, text='{"detail": "You do not have permission."}', request=request
+    )
 
     def fake_request_json(*args, **kwargs):
         raise httpx.HTTPStatusError(
@@ -154,7 +156,7 @@ def test_validate_posthog_config_http_error_detail_starts_with_http(
 
     monkeypatch.setattr(
         "app.integrations.posthog._request_json",
-        lambda *a, **kw: (_ for _ in ()).throw(
+        lambda *_a, **_kw: (_ for _ in ()).throw(
             httpx.HTTPStatusError("401", request=request, response=response)
         ),
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,9 +68,9 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', '8192')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "8192")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     settings = LLMSettings.from_env()
 
@@ -78,20 +78,21 @@ def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_invalid_raises(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', 'not-a-number')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "not-a-number")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     with pytest.raises((ValueError, ValidationError)):
         LLMSettings.from_env()
 
 
 def test_llm_settings_from_env_max_tokens_default(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.delenv('LLM_MAX_TOKENS', raising=False)
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.delenv("LLM_MAX_TOKENS", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     from app.config import DEFAULT_MAX_TOKENS
+
     settings = LLMSettings.from_env()
 
     assert settings.max_tokens == DEFAULT_MAX_TOKENS


### PR DESCRIPTION
## Summary

Closes #746

Extends `RunRCAOutput` and the `run_rca()` exception handlers to include a stable `error_type` field, so MCP clients can categorise failures without parsing the `error` string.

### Changes

**`app/entrypoints/mcp.py`**
- Added `error_type: str | None = None` to `RunRCAOutput` (lines 18–22)
- `ValidationError` handler now sets `error_type=type(err).__name__` → `"ValidationError"`
- Generic `Exception` handler now sets `error_type=type(err).__name__` (e.g. `"RuntimeError"`, `"ValueError"`)
- Success path leaves `error_type=None`

**`tests/entrypoints/test_mcp.py`**
- Updated `test_run_rca_malformed_input` to assert `error_type == "ValidationError"`
- Updated `test_run_rca_happy_path` to assert `error_type is None`
- Added `test_run_rca_unexpected_exception_includes_error_type` — `RuntimeError` path
- Added `test_run_rca_error_type_reflects_actual_exception_class` — `ValueError` path
- Added `test_run_rca_output_shape_on_success` — all four keys present on success
- Added `test_run_rca_output_shape_on_error` — all four keys present on error
- Added `test_run_rca_output_model_has_error_type_field` — schema check
- Added `test_run_rca_output_model_error_type_defaults_to_none` — default value check

## Test plan

- [x] All 8 tests pass: `pytest tests/entrypoints/test_mcp.py -v`
- [x] No regressions in existing tests

Made with [Cursor](https://cursor.com)