### PR TITLE
fix(posthog): include HTTP status code in validate_posthog_config error detail

### DIFF
--- a/app/integrations/posthog.py
+++ b/app/integrations/posthog.py
@@ -151,6 +151,10 @@ def validate_posthog_config(config: PostHogConfig) -> PostHogValidationResult:
             f"/api/projects/{config.project_id}/",
         )
         return PostHogValidationResult(ok=True, detail="PostHog validated.")
+    except httpx.HTTPStatusError as err:
+        snippet = err.response.text[:200].strip()
+        detail = f"HTTP {err.response.status_code}: {snippet}" if snippet else f"HTTP {err.response.status_code}"
+        return PostHogValidationResult(ok=False, detail=detail)
     except Exception as err:  # noqa: BLE001
         return PostHogValidationResult(ok=False, detail=str(err))
 

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -92,7 +92,94 @@ def test_validate_posthog_config_unauthorized(monkeypatch: pytest.MonkeyPatch) -
     result = validate_posthog_config(config)
 
     assert result.ok is False
-    assert "401 Unauthorized" in result.detail
+    assert "HTTP 401" in result.detail
+
+
+def test_validate_posthog_config_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PostHogConfig(
+        project_id="123",
+        personal_api_key="restricted_key",
+    )
+
+    request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/123/")
+    response = httpx.Response(403, text='{"detail": "You do not have permission."}', request=request)
+
+    def fake_request_json(*args, **kwargs):
+        raise httpx.HTTPStatusError(
+            "Client error '403 Forbidden'",
+            request=request,
+            response=response,
+        )
+
+    monkeypatch.setattr("app.integrations.posthog._request_json", fake_request_json)
+
+    result = validate_posthog_config(config)
+
+    assert result.ok is False
+    assert "HTTP 403" in result.detail
+    assert "permission" in result.detail.lower()
+
+
+def test_validate_posthog_config_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = PostHogConfig(
+        project_id="999",
+        personal_api_key="phx_test",
+    )
+
+    request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/999/")
+    response = httpx.Response(404, text='{"detail": "Not found."}', request=request)
+
+    def fake_request_json(*args, **kwargs):
+        raise httpx.HTTPStatusError(
+            "Client error '404 Not Found'",
+            request=request,
+            response=response,
+        )
+
+    monkeypatch.setattr("app.integrations.posthog._request_json", fake_request_json)
+
+    result = validate_posthog_config(config)
+
+    assert result.ok is False
+    assert "HTTP 404" in result.detail
+
+
+def test_validate_posthog_config_http_error_detail_starts_with_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """detail always starts with 'HTTP <status_code>' for HTTPStatusError."""
+    config = PostHogConfig(project_id="123", personal_api_key="phx_test")
+    request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/123/")
+    response = httpx.Response(401, request=request)
+
+    monkeypatch.setattr(
+        "app.integrations.posthog._request_json",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            httpx.HTTPStatusError("401", request=request, response=response)
+        ),
+    )
+
+    result = validate_posthog_config(config)
+
+    assert result.ok is False
+    assert result.detail.startswith("HTTP ")
+
+
+def test_validate_posthog_config_generic_error_still_handled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-HTTP exceptions are still caught and returned as plain error detail."""
+    config = PostHogConfig(project_id="123", personal_api_key="phx_test")
+
+    def fake_request_json(*args, **kwargs):
+        raise ConnectionError("network unreachable")
+
+    monkeypatch.setattr("app.integrations.posthog._request_json", fake_request_json)
+
+    result = validate_posthog_config(config)
+
+    assert result.ok is False
+    assert "network unreachable" in result.detail
 
 
 def test_query_bounce_rate_success(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Closes #745

`validate_posthog_config()` previously caught all exceptions with a single `except Exception` handler and returned `str(err)` as the detail. For `httpx.HTTPStatusError` (401, 403, 404, …), the resulting string did not reliably surface the numeric status code in a predictable format.

### Changes

**`app/integrations/posthog.py`**
- Added an explicit `except httpx.HTTPStatusError` handler before the generic `except Exception` catch
- Detail is now formatted as `"HTTP <status_code>: <response_body_snippet>"` (or `"HTTP <status_code>"` if the body is empty)
- Response body is truncated to 200 chars to avoid bloated messages
- Generic `except Exception` handler is preserved unchanged for all non-HTTP errors

**`tests/integrations/test_posthog.py`**
- Updated `test_validate_posthog_config_unauthorized` to assert `"HTTP 401" in result.detail` (previously checked for `"401 Unauthorized"` from the raw exception string)
- Added `test_validate_posthog_config_forbidden` — 403 with body snippet
- Added `test_validate_posthog_config_not_found` — 404 response
- Added `test_validate_posthog_config_http_error_detail_starts_with_http` — shape assertion
- Added `test_validate_posthog_config_generic_error_still_handled` — `ConnectionError` still works

## Test plan

- [x] All 16 tests pass: `pytest tests/integrations/test_posthog.py -v`
- [x] No regressions in existing tests

Made with [Cursor](https://cursor.com)