### PR TITLE
fix(auth): narrow Exception catch in JWK parsing

### DIFF
--- a/app/auth/jwt_auth.py
+++ b/app/auth/jwt_auth.py
@@ -201,7 +201,7 @@ def get_signing_key_from_jwks(jwks_data: dict[str, Any], token: str) -> Any:
             try:
                 jwk = jwt.PyJWK.from_dict(key_data)
                 return jwk.key
-            except Exception as e:
+            except (jwt.exceptions.InvalidKeyError, jwt.exceptions.PyJWKError) as e:
                 raise JWTVerificationError(f"Failed to parse JWK: {e}") from e
 
     raise JWTVerificationError(f"No matching key found for kid: {kid}")

--- a/tests/app/auth/test_jwt_auth.py
+++ b/tests/app/auth/test_jwt_auth.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jwt as pyjwt
 import pytest
 
-from app.auth.jwt_auth import AsyncJWKSCache
+from app.auth.jwt_auth import AsyncJWKSCache, JWTVerificationError, get_signing_key_from_jwks
 
 
 @pytest.mark.asyncio
@@ -40,3 +41,17 @@ async def test_get_jwks_fetches_once_and_uses_cache_within_ttl() -> None:
     assert second == jwks_payload
     assert mock_client.get.await_count == 1
     response.raise_for_status.assert_called_once()
+
+
+def test_get_signing_key_from_jwks_raises_on_invalid_jwk() -> None:
+    """Bad JWK data should raise JWTVerificationError, not a bare Exception."""
+    token = pyjwt.encode(
+        {"sub": "1"},
+        "secret",
+        algorithm="HS256",
+        headers={"kid": "bad-kid"},
+    )
+    jwks = {"keys": [{"kid": "bad-kid", "kty": "UNSUPPORTED"}]}
+
+    with pytest.raises(JWTVerificationError, match="Failed to parse JWK"):
+        get_signing_key_from_jwks(jwks, token)


### PR DESCRIPTION
Fixes #740

#### Describe the changes you have made in this PR -

`get_signing_key_from_jwks()` was catching bare `Exception` on line 204 when parsing a JWK via `PyJWK.from_dict()`. Narrowed it to `InvalidKeyError | PyJWKError` which are the actual exceptions PyJWT raises for malformed key data.

Added a unit test that feeds an unsupported kty and asserts `JWTVerificationError`.

### Screenshots of the UI changes (If any) -
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

Checked what `PyJWK.from_dict` actually raises by testing a few bad inputs - all of them throw `InvalidKeyError`. Added `PyJWKError` as well since it's the base class for JWK-specific failures in PyJWT and could show up in edge cases. The rest of the function already catches `DecodeError` separately for header parsing, so this keeps the pattern consistent.