### PR TITLE
fix: replace placeholder NVIDIA NIM model IDs in config.py (#738)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,10 +89,10 @@ GEMINI_REASONING_MODEL = "gemini-3.1-pro-preview"
 GEMINI_TOOLCALL_MODEL = "gemini-3.1-flash-lite-preview"
 
 # NVIDIA NIM model constants
-# UNVERIFIED PLACEHOLDER — nemotron-3-super-120b-a12b / nemotron-3-nano-30b-a3b are
-# speculative IDs that may not yet be available on NVIDIA NIM. Override via NVIDIA_REASONING_MODEL env var.
-NVIDIA_REASONING_MODEL = "nvidia/nemotron-3-super-120b-a12b"
-NVIDIA_TOOLCALL_MODEL = "nvidia/nemotron-3-nano-30b-a3b"
+# Verified safe defaults from the NVIDIA API Catalog (build.nvidia.com).
+# Override via NVIDIA_REASONING_MODEL or NVIDIA_MODEL env vars.
+NVIDIA_REASONING_MODEL = "meta/llama-3.1-405b-instruct"
+NVIDIA_TOOLCALL_MODEL = "meta/llama-3.1-8b-instruct"
 
 # MiniMax model constants
 MINIMAX_REASONING_MODEL = "MiniMax-M2.7"

--- a/app/config.py
+++ b/app/config.py
@@ -90,7 +90,7 @@ GEMINI_TOOLCALL_MODEL = "gemini-3.1-flash-lite-preview"
 
 # NVIDIA NIM model constants
 # Verified safe defaults from the NVIDIA API Catalog (build.nvidia.com).
-# Override via NVIDIA_REASONING_MODEL or NVIDIA_MODEL env vars.
+# Override via NVIDIA_REASONING_MODEL, NVIDIA_TOOLCALL_MODEL, or NVIDIA_MODEL env vars.
 NVIDIA_REASONING_MODEL = "meta/llama-3.1-405b-instruct"
 NVIDIA_TOOLCALL_MODEL = "meta/llama-3.1-8b-instruct"
 


### PR DESCRIPTION
Replaces the speculative NVIDIA NIM placeholders with verified Llama 3.1 defaults (405B for reasoning, 8B for tool calling).
This ensures the NVIDIA provider works out-of-the-box without requiring immediate environment overrides.
Closes #738 