### PR TITLE
fix: add Windows .venv/Scripts support to Makefile venv detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ export
 ifneq ($(wildcard .venv/bin/python),)
 PYTHON = .venv/bin/python
 PIP = .venv/bin/python -m pip
+else ifneq ($(wildcard .venv/Scripts/python.exe),)
+PYTHON = .venv/Scripts/python.exe
+PIP = .venv/Scripts/python.exe -m pip
 else
 PYTHON = python3
 PIP = python3 -m pip
@@ -13,7 +16,7 @@ endif
 # PIP_INSTALL_FLAGS = --user --break-system-packages
 USER_BASE := $(shell $(PYTHON) -m site --user-base)
 USER_BIN := $(USER_BASE)/bin
-export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,)$(USER_BIN):$(PATH)
+export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,)$(if $(wildcard .venv/Scripts),$(CURDIR)/.venv/Scripts:,)$(USER_BIN):$(PATH)
 
 # Create venv and install dependencies
 install:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PIP = python3 -m pip
 endif
 # PIP_INSTALL_FLAGS = --user --break-system-packages
 USER_BASE := $(shell $(PYTHON) -m site --user-base)
-USER_BIN := $(USER_BASE)/bin
+USER_BIN := $(if $(wildcard .venv/Scripts),$(USER_BASE)/Scripts,$(USER_BASE)/bin)
 export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,)$(if $(wildcard .venv/Scripts),$(CURDIR)/.venv/Scripts:,)$(USER_BIN):$(PATH)
 
 # Create venv and install dependencies


### PR DESCRIPTION
## Summary

Fixes #721. Fixes #763.

The Makefile's venv detection only checks for `.venv/bin/python` (the Unix/macOS path). On Windows, Python's `venv` module places executables under `.venv\Scripts\`, so the check always fails on Windows and every `make` target silently falls back to the system `python3`, bypassing the project virtualenv entirely.

## Changes

### Before
```makefile
ifneq ($(wildcard .venv/bin/python),)
PYTHON = .venv/bin/python
PIP = .venv/bin/python -m pip
else
PYTHON = python3
PIP = python3 -m pip
endif
export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,)$(USER_BIN):$(PATH)
```

### After
```makefile
ifneq ($(wildcard .venv/bin/python),)
PYTHON = .venv/bin/python
PIP = .venv/bin/python -m pip
else ifneq ($(wildcard .venv/Scripts/python.exe),)
PYTHON = .venv/Scripts/python.exe
PIP = .venv/Scripts/python.exe -m pip
else
PYTHON = python3
PIP = python3 -m pip
endif
export PATH := $(if $(wildcard .venv/bin),$(CURDIR)/.venv/bin:,)$(if $(wildcard .venv/Scripts),$(CURDIR)/.venv/Scripts:,)$(USER_BIN):$(PATH)
```

## Priority order

1. `.venv/bin/python` → Unix/macOS venv (unchanged)
2. `.venv/Scripts/python.exe` → Windows venv (new)
3. `python3` → system fallback (unchanged)

The PATH export is extended by the same logic so that venv-installed CLI tools (e.g. `opensre`, `langgraph`) are found without a full path on both platforms.

## What is unchanged

- Behaviour on Unix/macOS is identical — the first `ifneq` branch is taken as before.
- No recipe lines are modified; only the `PYTHON`/`PIP` variable assignment and `PATH` export change.