### PR TITLE
fix(mcp): include error_type in RunRCAOutput

### DIFF
--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -19,6 +19,7 @@ class RunRCAOutput(BaseModel):
     ok: bool
     result: dict[str, Any] | None = None
     error: str | None = None
+    error_type: str | None = None
 
 
 mcp = FastMCP("opensre")
@@ -84,9 +85,13 @@ def run_rca(
 
         return RunRCAOutput(ok=True, result=result).model_dump()
     except ValidationError as err:
-        return RunRCAOutput(ok=False, error=str(err)).model_dump()
+        return RunRCAOutput(
+            ok=False, error=str(err), error_type=type(err).__name__
+        ).model_dump()
     except Exception as err:  # noqa: BLE001
-        return RunRCAOutput(ok=False, error=str(err)).model_dump()
+        return RunRCAOutput(
+            ok=False, error=str(err), error_type=type(err).__name__
+        ).model_dump()
 
 
 def main() -> None:

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -85,13 +85,9 @@ def run_rca(
 
         return RunRCAOutput(ok=True, result=result).model_dump()
     except ValidationError as err:
-        return RunRCAOutput(
-            ok=False, error=str(err), error_type=type(err).__name__
-        ).model_dump()
+        return RunRCAOutput(ok=False, error=str(err), error_type=type(err).__name__).model_dump()
     except Exception as err:  # noqa: BLE001
-        return RunRCAOutput(
-            ok=False, error=str(err), error_type=type(err).__name__
-        ).model_dump()
+        return RunRCAOutput(ok=False, error=str(err), error_type=type(err).__name__).model_dump()
 
 
 def main() -> None:

--- a/app/integrations/posthog.py
+++ b/app/integrations/posthog.py
@@ -153,7 +153,11 @@ def validate_posthog_config(config: PostHogConfig) -> PostHogValidationResult:
         return PostHogValidationResult(ok=True, detail="PostHog validated.")
     except httpx.HTTPStatusError as err:
         snippet = err.response.text[:200].strip()
-        detail = f"HTTP {err.response.status_code}: {snippet}" if snippet else f"HTTP {err.response.status_code}"
+        detail = (
+            f"HTTP {err.response.status_code}: {snippet}"
+            if snippet
+            else f"HTTP {err.response.status_code}"
+        )
         return PostHogValidationResult(ok=False, detail=detail)
     except Exception as err:  # noqa: BLE001
         return PostHogValidationResult(ok=False, detail=str(err))

--- a/tests/entrypoints/test_mcp.py
+++ b/tests/entrypoints/test_mcp.py
@@ -13,6 +13,20 @@ def test_run_rca_malformed_input() -> None:
     assert result["ok"] is False
     assert result["result"] is None
     assert result["error"]
+    assert result["error_type"] == "ValidationError"
+
+
+def test_run_rca_unexpected_error_includes_error_type(monkeypatch: MonkeyPatch) -> None:
+    def exploding_cli(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("something broke")
+
+    monkeypatch.setattr("app.entrypoints.mcp._run_cli", exploding_cli)
+
+    result = run_rca(alert_payload={"commonLabels": {}, "commonAnnotations": {}})
+
+    assert result["ok"] is False
+    assert result["error"] == "something broke"
+    assert result["error_type"] == "RuntimeError"
 
 
 def test_run_rca_happy_path(monkeypatch: MonkeyPatch) -> None:
@@ -54,6 +68,7 @@ def test_run_rca_happy_path(monkeypatch: MonkeyPatch) -> None:
 
     assert result["ok"] is True
     assert result["error"] is None
+    assert result["error_type"] is None
     assert result["result"] is not None
 
     response = result["result"]

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -154,7 +154,7 @@ def test_validate_posthog_config_http_error_detail_starts_with_http(
 
     monkeypatch.setattr(
         "app.integrations.posthog._request_json",
-        lambda *a, **kw: (_ for _ in ()).throw(
+        lambda *_a, **_kw: (_ for _ in ()).throw(
             httpx.HTTPStatusError("401", request=request, response=response)
         ),
     )

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -102,7 +102,9 @@ def test_validate_posthog_config_forbidden(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/123/")
-    response = httpx.Response(403, text='{"detail": "You do not have permission."}', request=request)
+    response = httpx.Response(
+        403, text='{"detail": "You do not have permission."}', request=request
+    )
 
     def fake_request_json(*args, **kwargs):
         raise httpx.HTTPStatusError(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,9 +68,9 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', '8192')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "8192")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     settings = LLMSettings.from_env()
 
@@ -78,20 +78,21 @@ def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_invalid_raises(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', 'not-a-number')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "not-a-number")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     with pytest.raises((ValueError, ValidationError)):
         LLMSettings.from_env()
 
 
 def test_llm_settings_from_env_max_tokens_default(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.delenv('LLM_MAX_TOKENS', raising=False)
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.delenv("LLM_MAX_TOKENS", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     from app.config import DEFAULT_MAX_TOKENS
+
     settings = LLMSettings.from_env()
 
     assert settings.max_tokens == DEFAULT_MAX_TOKENS


### PR DESCRIPTION
Fixes #746

#### Describe the changes you have made in this PR -

Added `error_type: str | None` field to `RunRCAOutput`. On failures, it gets set to `type(err).__name__` so MCP clients can categorize errors without parsing the message string.

Both the `ValidationError` and generic `Exception` handlers now populate it. On success it stays `None`.

### Screenshots of the UI changes (If any) -
N/A

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

The issue asked for `error_type` in error responses. Simplest way is adding the field to the pydantic model with a default of `None`, then setting it via `type(err).__name__` in both except blocks. This gives clients a stable string like `"ValidationError"` or `"RuntimeError"` without changing the existing `error` field.

Added a test that monkeypatches `_run_cli` to raise `RuntimeError` and checks `error_type` comes back correctly. Also updated the existing tests to assert on the new field.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions