### PR TITLE
fix(server): anchor _SAFE_INV_ID regex and add invalid-ID tests

### DIFF
--- a/app/integrations/posthog.py
+++ b/app/integrations/posthog.py
@@ -153,7 +153,11 @@ def validate_posthog_config(config: PostHogConfig) -> PostHogValidationResult:
         return PostHogValidationResult(ok=True, detail="PostHog validated.")
     except httpx.HTTPStatusError as err:
         snippet = err.response.text[:200].strip()
-        detail = f"HTTP {err.response.status_code}: {snippet}" if snippet else f"HTTP {err.response.status_code}"
+        detail = (
+            f"HTTP {err.response.status_code}: {snippet}"
+            if snippet
+            else f"HTTP {err.response.status_code}"
+        )
         return PostHogValidationResult(ok=False, detail=detail)
     except Exception as err:  # noqa: BLE001
         return PostHogValidationResult(ok=False, detail=str(err))

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -527,7 +527,7 @@ def get_investigation(inv_id: str) -> Response:
 # ---------------------------------------------------------------------------
 
 
-_SAFE_INV_ID = re.compile(r"[\w\-]+")
+_SAFE_INV_ID = re.compile(r"^[\w\-]+$")
 
 
 def _safe_investigation_path(inv_id: str) -> Path:

--- a/tests/app/remote/test_server.py
+++ b/tests/app/remote/test_server.py
@@ -11,6 +11,7 @@ from app.remote import server as remote_server
 from app.remote.server import (
     InvestigateRequest,
     _lifespan,
+    _safe_investigation_path,
     investigate,
     investigate_stream,
 )
@@ -212,3 +213,98 @@ async def test_lifespan_starts_and_cancels_vercel_poller(
         await asyncio.wait_for(started.wait(), timeout=1)
 
     assert cancelled.is_set()
+
+
+# ---------------------------------------------------------------------------
+# _safe_investigation_path — invalid ID tests (issue #743)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeInvestigationPath:
+    """Invalid IDs must raise HTTP 400; valid IDs must not raise."""
+
+    # -- invalid IDs --
+
+    def test_path_traversal_dotdot_slash(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("../x")
+        assert exc_info.value.status_code == 400
+
+    def test_path_traversal_slash_dotdot(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x/..")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_md_extension(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x.md")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_newline(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x\ny")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_space(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x y")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_slash(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x/y")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_null_byte(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x\x00y")
+        assert exc_info.value.status_code == 400
+
+    def test_empty_id(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_special_chars(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x@y!z")
+        assert exc_info.value.status_code == 400
+
+    def test_id_with_double_dot(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        with pytest.raises(HTTPException) as exc_info:
+            _safe_investigation_path("x..y")
+        assert exc_info.value.status_code == 400
+
+    # -- valid IDs (must not raise) --
+
+    def test_valid_alphanumeric_id(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        # Should not raise — file simply won't exist yet
+        try:
+            _safe_investigation_path("20260421_163054_investigation")
+        except HTTPException:
+            pytest.fail("Valid ID raised HTTPException unexpectedly")
+
+    def test_valid_id_with_hyphens(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        try:
+            _safe_investigation_path("abc-123-def")
+        except HTTPException:
+            pytest.fail("Valid ID raised HTTPException unexpectedly")
+
+    def test_valid_id_with_underscores(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(remote_server, "INVESTIGATIONS_DIR", tmp_path)
+        try:
+            _safe_investigation_path("abc_123_def")
+        except HTTPException:
+            pytest.fail("Valid ID raised HTTPException unexpectedly")

--- a/tests/integrations/test_posthog.py
+++ b/tests/integrations/test_posthog.py
@@ -102,7 +102,9 @@ def test_validate_posthog_config_forbidden(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     request = httpx.Request("GET", "https://us.i.posthog.com/api/projects/123/")
-    response = httpx.Response(403, text='{"detail": "You do not have permission."}', request=request)
+    response = httpx.Response(
+        403, text='{"detail": "You do not have permission."}', request=request
+    )
 
     def fake_request_json(*args, **kwargs):
         raise httpx.HTTPStatusError(
@@ -154,7 +156,7 @@ def test_validate_posthog_config_http_error_detail_starts_with_http(
 
     monkeypatch.setattr(
         "app.integrations.posthog._request_json",
-        lambda *a, **kw: (_ for _ in ()).throw(
+        lambda *_a, **_kw: (_ for _ in ()).throw(
             httpx.HTTPStatusError("401", request=request, response=response)
         ),
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,9 +68,9 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', '8192')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "8192")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     settings = LLMSettings.from_env()
 
@@ -78,20 +78,21 @@ def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
 
 
 def test_llm_settings_from_env_max_tokens_invalid_raises(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.setenv('LLM_MAX_TOKENS', 'not-a-number')
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "not-a-number")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     with pytest.raises((ValueError, ValidationError)):
         LLMSettings.from_env()
 
 
 def test_llm_settings_from_env_max_tokens_default(monkeypatch) -> None:
-    monkeypatch.setenv('LLM_PROVIDER', 'ollama')
-    monkeypatch.delenv('LLM_MAX_TOKENS', raising=False)
-    monkeypatch.setattr('app.config.resolve_llm_api_key', lambda _: '')
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.delenv("LLM_MAX_TOKENS", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
 
     from app.config import DEFAULT_MAX_TOKENS
+
     settings = LLMSettings.from_env()
 
     assert settings.max_tokens == DEFAULT_MAX_TOKENS


### PR DESCRIPTION
## Summary

Closes #743

### Changes

**`app/remote/server.py`**
- Changed `_SAFE_INV_ID = re.compile(r"[\w\-]+")` → `re.compile(r"^[\w\-]+$")` — explicit `^...$` anchors make the full-string intent immediately clear to readers (the behaviour was already correct via `fullmatch()`, this is a readability improvement)

**`tests/app/remote/test_server.py`**
- Imported `_safe_investigation_path` for direct unit testing
- Added `TestSafeInvestigationPath` class with 13 tests:

| Test | Input | Expected |
|------|-------|----------|
| `test_path_traversal_dotdot_slash` | `../x` | 400 |
| `test_path_traversal_slash_dotdot` | `x/..` | 400 |
| `test_id_with_md_extension` | `x.md` | 400 |
| `test_id_with_newline` | `x\ny` | 400 |
| `test_id_with_space` | `x y` | 400 |
| `test_id_with_slash` | `x/y` | 400 |
| `test_id_with_null_byte` | `x\x00y` | 400 |
| `test_empty_id` | `""` | 400 |
| `test_id_with_special_chars` | `x@y!z` | 400 |
| `test_id_with_double_dot` | `x..y` | 400 |
| `test_valid_alphanumeric_id` | `20260421_163054_investigation` | no raise |
| `test_valid_id_with_hyphens` | `abc-123-def` | no raise |
| `test_valid_id_with_underscores` | `abc_123_def` | no raise |

## Test plan

- [x] All 13 new tests pass: `pytest tests/app/remote/test_server.py -k TestSafe`
- [x] All 36 tests in the file pass (no regressions)
- [x] `ruff check app/ tests/` — clean
- [x] `ruff format --check app/ tests/` — clean

Made with [Cursor](https://cursor.com)