### PR TITLE
fix: use Optional[RunnableConfig] on all pipeline nodes to silence LangGraph warning

### DIFF
--- a/app/nodes/extract_alert/extract_node.py
+++ b/app/nodes/extract_alert/extract_node.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 def _make_problem_md(details: AlertDetails) -> str:
-    parts = [f"# {details.alert_name}", f"Pipeline: {details.pipeline_name} | Severity: {details.severity}"]
+    parts = [
+        f"# {details.alert_name}",
+        f"Pipeline: {details.pipeline_name} | Severity: {details.severity}",
+    ]
     if details.kube_namespace:
         parts.append(f"Namespace: {details.kube_namespace}")
     if details.error_message:
@@ -51,14 +54,18 @@ def _enrich_raw_alert(raw_alert: Any, details: AlertDetails) -> Any:
 
 
 @traceable(name="node_extract_alert")
-def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP045
+def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP007,UP045
     """Classify and extract alert details from raw input (single LLM call)."""
     tracker = get_tracker()
     tracker.start("extract_alert", "Classifying and extracting alert details")
 
     raw_input = state.get("raw_alert")
     if raw_input is not None:
-        formatted = json.dumps(raw_input, indent=2, default=str) if isinstance(raw_input, dict) else str(raw_input)
+        formatted = (
+            json.dumps(raw_input, indent=2, default=str)
+            if isinstance(raw_input, dict)
+            else str(raw_input)
+        )
         logger.info("[extract_alert] Raw alert input:\n%s", formatted)
         debug_print(f"Raw alert input:\n{formatted}")
 
@@ -73,6 +80,7 @@ def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfi
         _token = slack_ctx.get("access_token")
         if _token and _channel and _ts:
             from app.utils.slack_delivery import swap_reaction
+
             swap_reaction("eyes", "white_check_mark", _channel, _ts, _token)
         return {"is_noise": True}
 
@@ -85,6 +93,7 @@ def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfi
     _token = slack_ctx.get("access_token")
     if _token and _channel and _ts:
         from app.utils.slack_delivery import add_reaction
+
         add_reaction("eyes", _channel, _ts, _token)
 
     debug_print(
@@ -92,11 +101,24 @@ def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfi
         f"Severity: {details.severity} | namespace={details.kube_namespace} | Alert ID: {alert_id}"
     )
 
-    render_investigation_header(details.alert_name, details.pipeline_name, details.severity, alert_id=alert_id)
+    render_investigation_header(
+        details.alert_name, details.pipeline_name, details.severity, alert_id=alert_id
+    )
 
     enriched_alert = _enrich_raw_alert(raw_alert, details)
 
-    tracker.complete("extract_alert", fields_updated=["alert_name", "pipeline_name", "severity", "alert_source", "alert_json", "problem_md", "raw_alert"])
+    tracker.complete(
+        "extract_alert",
+        fields_updated=[
+            "alert_name",
+            "pipeline_name",
+            "severity",
+            "alert_source",
+            "alert_json",
+            "problem_md",
+            "raw_alert",
+        ],
+    )
 
     result: dict = {
         "is_noise": False,

--- a/app/nodes/extract_alert/extract_node.py
+++ b/app/nodes/extract_alert/extract_node.py
@@ -3,8 +3,9 @@
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, Optional
 
+from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.nodes.extract_alert.extract import extract_alert_details
@@ -50,7 +51,7 @@ def _enrich_raw_alert(raw_alert: Any, details: AlertDetails) -> Any:
 
 
 @traceable(name="node_extract_alert")
-def node_extract_alert(state: InvestigationState) -> dict:
+def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP045
     """Classify and extract alert details from raw input (single LLM call)."""
     tracker = get_tracker()
     tracker.start("extract_alert", "Classifying and extracting alert details")

--- a/app/nodes/plan_actions/node.py
+++ b/app/nodes/plan_actions/node.py
@@ -39,7 +39,7 @@ class InvestigationPlan(BaseModel):
 
 
 @traceable(name="node_plan_actions")
-def node_plan_actions(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP045
+def node_plan_actions(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP007,UP045
     """Plan investigation actions and write plan outputs to state.
 
     Supports rerouting when new evidence changes the likely source family,
@@ -88,7 +88,9 @@ def node_plan_actions(state: InvestigationState, config: Optional[RunnableConfig
         for candidate in fallback_candidates:
             if candidate in available_action_names:
                 planned_actions = [candidate]
-                plan_rationale = "Controller fallback: LLM returned empty plan. Forcing verification action."
+                plan_rationale = (
+                    "Controller fallback: LLM returned empty plan. Forcing verification action."
+                )
                 break
         if not planned_actions:
             planned_actions = [available_action_names[0]]

--- a/app/nodes/plan_actions/node.py
+++ b/app/nodes/plan_actions/node.py
@@ -1,7 +1,8 @@
 """Plan actions node - planning only."""
 
-from typing import cast
+from typing import Optional, cast
 
+from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 from pydantic import BaseModel, Field
 
@@ -38,7 +39,7 @@ class InvestigationPlan(BaseModel):
 
 
 @traceable(name="node_plan_actions")
-def node_plan_actions(state: InvestigationState) -> dict:
+def node_plan_actions(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP045
     """Plan investigation actions and write plan outputs to state.
 
     Supports rerouting when new evidence changes the likely source family,

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -189,7 +189,8 @@ def generate_report(state: InvestigationState) -> dict:
 
 @traceable(name="node_publish_findings")
 def node_publish_findings(
-    state: InvestigationState, config: Optional[RunnableConfig] = None  # noqa: ARG001,UP045
+    state: InvestigationState,
+    config: Optional[RunnableConfig] = None,  # noqa: ARG001,UP007,UP045
 ) -> dict:
     """LangGraph node wrapper with LangSmith tracking."""
     return generate_report(state)

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -2,8 +2,9 @@
 
 import logging
 import os
-from typing import cast
+from typing import Optional, cast
 
+from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.masking import MaskingContext
@@ -19,6 +20,7 @@ from app.state import InvestigationState
 from app.utils.ingest_delivery import send_ingest
 
 logger = logging.getLogger(__name__)
+
 
 def _build_mr_note(slack_message: str) -> str:
     body = slack_message.strip()
@@ -46,7 +48,10 @@ def generate_report(state: InvestigationState) -> dict:
     # First ingest: persist the report and get back the investigation_id
     investigation_id: str | None = None
     try:
-        state_with_report = cast(InvestigationState, {**state, "problem_report": {"report_md": slack_message}, "summary": short_summary})
+        state_with_report = cast(
+            InvestigationState,
+            {**state, "problem_report": {"report_md": slack_message}, "summary": short_summary},
+        )
         investigation_id = send_ingest(state_with_report)
     except Exception as exc:  # noqa: BLE001
         logger.warning("[publish] ingest failed: %s", exc)
@@ -56,7 +61,17 @@ def generate_report(state: InvestigationState) -> dict:
     # Second ingest: update the record with the investigation_url so the web app can link to it
     if investigation_id:
         try:
-            state_with_url = cast(InvestigationState, {**state, "problem_report": {"report_md": slack_message, "investigation_url": investigation_url}, "summary": short_summary})
+            state_with_url = cast(
+                InvestigationState,
+                {
+                    **state,
+                    "problem_report": {
+                        "report_md": slack_message,
+                        "investigation_url": investigation_url,
+                    },
+                    "summary": short_summary,
+                },
+            )
             send_ingest(state_with_url)
         except Exception as exc:  # noqa: BLE001
             logger.warning("[publish] ingest url update failed: %s", exc)
@@ -75,7 +90,11 @@ def generate_report(state: InvestigationState) -> dict:
     resolved = state.get("resolved_integrations") or {}
     discord_creds = resolved.get("discord", {})
     logger.debug("[publish] slack_ctx=%s", slack_ctx)
-    logger.debug("[publish] discord creds present=%s keys=%s", bool(discord_creds), list(discord_creds.keys()) if discord_creds else [])
+    logger.debug(
+        "[publish] discord creds present=%s keys=%s",
+        bool(discord_creds),
+        list(discord_creds.keys()) if discord_creds else [],
+    )
 
     report_posted, delivery_error = send_slack_report(
         slack_message,
@@ -85,9 +104,16 @@ def generate_report(state: InvestigationState) -> dict:
         blocks=all_blocks,
     )
 
-    logger.debug("[publish] slack delivery: posted=%s channel=%s thread_ts=%s error=%s", report_posted, _channel, thread_ts, delivery_error)
+    logger.debug(
+        "[publish] slack delivery: posted=%s channel=%s thread_ts=%s error=%s",
+        report_posted,
+        _channel,
+        thread_ts,
+        delivery_error,
+    )
     if report_posted and _token and _channel and _alert_ts:
         from app.utils.slack_delivery import swap_reaction
+
         swap_reaction("eyes", "clipboard", _channel, _alert_ts, _token)
     elif thread_ts and not report_posted:
         raise RuntimeError(
@@ -97,21 +123,37 @@ def generate_report(state: InvestigationState) -> dict:
     # Discord delivery — uses integration credentials if configured
     if discord_creds:
         from app.utils.discord_delivery import send_discord_report
+
         discord_ctx = state.get("discord_context") or {}
         bot_token = discord_ctx.get("bot_token") or discord_creds.get("bot_token", "")
         channel_id = discord_ctx.get("channel_id") or discord_creds.get("default_channel_id", "")
         thread_id = discord_ctx.get("thread_id", "")
-        logger.debug("[publish] discord delivery: channel_id=%s thread_id=%s bot_token_present=%s", channel_id, thread_id, bool(bot_token))
+        logger.debug(
+            "[publish] discord delivery: channel_id=%s thread_id=%s bot_token_present=%s",
+            channel_id,
+            thread_id,
+            bool(bot_token),
+        )
         if bot_token and channel_id:
             discord_posted, discord_error = send_discord_report(
                 slack_message,
                 {"bot_token": bot_token, "channel_id": channel_id, "thread_id": thread_id},
             )
-            logger.debug("[publish] discord delivery: posted=%s error=%s", discord_posted, discord_error)
+            logger.debug(
+                "[publish] discord delivery: posted=%s error=%s", discord_posted, discord_error
+            )
             if not discord_posted:
-                logger.warning("[publish] Discord delivery failed: channel=%s error=%s", channel_id, discord_error)
+                logger.warning(
+                    "[publish] Discord delivery failed: channel=%s error=%s",
+                    channel_id,
+                    discord_error,
+                )
         else:
-            logger.debug("[publish] discord delivery: skipped — bot_token_present=%s channel_id=%s", bool(bot_token), channel_id)
+            logger.debug(
+                "[publish] discord delivery: skipped — bot_token_present=%s channel_id=%s",
+                bool(bot_token),
+                channel_id,
+            )
     else:
         logger.debug("[publish] discord delivery: no discord integration configured")
 
@@ -123,17 +165,22 @@ def generate_report(state: InvestigationState) -> dict:
         if _mr_iid and _project_id:
             try:
                 from app.integrations.gitlab import build_gitlab_config, post_gitlab_mr_note
-                _gl_config = build_gitlab_config({
-                    "base_url": _gl.get("gitlab_url", ""),
-                    "auth_token": _gl.get("gitlab_token", ""),
-                })
+
+                _gl_config = build_gitlab_config(
+                    {
+                        "base_url": _gl.get("gitlab_url", ""),
+                        "auth_token": _gl.get("gitlab_token", ""),
+                    }
+                )
                 post_gitlab_mr_note(
                     config=_gl_config,
                     project_id=_project_id,
                     mr_iid=_mr_iid,
-                    body=_build_mr_note(slack_message)
+                    body=_build_mr_note(slack_message),
                 )
-                logger.info("[publish] GitLab MR note posted: project=%s mr_iid=%s", _project_id, _mr_iid)
+                logger.info(
+                    "[publish] GitLab MR note posted: project=%s mr_iid=%s", _project_id, _mr_iid
+                )
             except Exception as exc:  # noqa: BLE001
                 logger.warning("[publish] GitLab MR write-back failed: %s", exc)
 
@@ -141,6 +188,8 @@ def generate_report(state: InvestigationState) -> dict:
 
 
 @traceable(name="node_publish_findings")
-def node_publish_findings(state: InvestigationState) -> dict:
+def node_publish_findings(
+    state: InvestigationState, config: Optional[RunnableConfig] = None  # noqa: ARG001,UP045
+) -> dict:
     """LangGraph node wrapper with LangSmith tracking."""
     return generate_report(state)

--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -55,7 +55,7 @@ def _strip_bearer(token: str) -> str:
 @traceable(name="node_resolve_integrations")
 def node_resolve_integrations(
     state: InvestigationState,
-    config: Optional[RunnableConfig] = None,  # noqa: UP045
+    config: Optional[RunnableConfig] = None,  # noqa: UP007,UP045
 ) -> dict:
     """Fetch all org integrations and classify them by service.
 

--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
@@ -54,7 +54,8 @@ def _strip_bearer(token: str) -> str:
 
 @traceable(name="node_resolve_integrations")
 def node_resolve_integrations(
-    state: InvestigationState, config: RunnableConfig | None = None
+    state: InvestigationState,
+    config: Optional[RunnableConfig] = None,  # noqa: UP045
 ) -> dict:
     """Fetch all org integrations and classify them by service.
 

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -1,7 +1,9 @@
 """Root cause diagnosis node - orchestration and entry point."""
 
 import os
+from typing import Optional
 
+from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.investigation_constants import MAX_INVESTIGATION_LOOPS
@@ -49,7 +51,9 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
     evidence = state.get("evidence", {})
     raw_alert = state.get("raw_alert", {})
 
-    has_tracer, has_cloudwatch, has_alert = check_evidence_availability(context, evidence, raw_alert)
+    has_tracer, has_cloudwatch, has_alert = check_evidence_availability(
+        context, evidence, raw_alert
+    )
 
     if _short_circuit_enabled() and is_clearly_healthy(raw_alert, evidence):
         debug_print("Short-circuit: alert is clearly healthy, skipping LLM")
@@ -101,17 +105,13 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
         "validated_claims": masking_ctx.unmask_value(validated_claims_list),
         "non_validated_claims": masking_ctx.unmask_value(non_validated_claims_list),
         "validity_score": validity_score,
-        "investigation_recommendations": [
-            masking_ctx.unmask(rec) for rec in recommendations
-        ],
+        "investigation_recommendations": [masking_ctx.unmask(rec) for rec in recommendations],
         "remediation_steps": [],
         "investigation_loop_count": next_loop_count,
     }
 
 
-def _handle_healthy_finding(
-    state: InvestigationState, tracker, evidence: dict
-) -> dict:
+def _handle_healthy_finding(state: InvestigationState, tracker, evidence: dict) -> dict:
     """Return a deterministic healthy finding, bypassing the LLM.
 
     Called when is_clearly_healthy() confirms the alert is informational and all
@@ -122,7 +122,10 @@ def _handle_healthy_finding(
     loop_count = state.get("investigation_loop_count", 0)
 
     validated_claims = [
-        {"claim": f"{k} data confirmed within normal operating bounds", "validation_status": "validated"}
+        {
+            "claim": f"{k} data confirmed within normal operating bounds",
+            "validation_status": "validated",
+        }
         for k in evidence
         if evidence[k]
     ]
@@ -164,7 +167,11 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
     # If Grafana service names were just discovered but logs haven't been fetched yet,
     # loop back so node_plan_actions can query logs with the correct service name.
     recommendations: list[str] = []
-    if evidence.get("grafana_service_names") and not evidence.get("grafana_logs") and loop_count < MAX_INVESTIGATION_LOOPS:
+    if (
+        evidence.get("grafana_service_names")
+        and not evidence.get("grafana_logs")
+        and loop_count < MAX_INVESTIGATION_LOOPS
+    ):
         recommendations.append("Query Grafana logs using discovered service names")
 
     next_loop_count = loop_count + 1
@@ -172,7 +179,8 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
     tracker.complete(
         "diagnose_root_cause",
         fields_updated=["root_cause"],
-        message="Insufficient evidence" + (f" — retrying ({next_loop_count})" if recommendations else ""),
+        message="Insufficient evidence"
+        + (f" — retrying ({next_loop_count})" if recommendations else ""),
     )
 
     return {
@@ -193,6 +201,8 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
 
 
 @traceable(name="node_diagnose_root_cause")
-def node_diagnose_root_cause(state: InvestigationState) -> dict:
+def node_diagnose_root_cause(
+    state: InvestigationState, config: Optional[RunnableConfig] = None  # noqa: ARG001,UP045
+) -> dict:
     """LangGraph node wrapper with LangSmith tracking."""
     return diagnose_root_cause(state)

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -202,7 +202,8 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
 
 @traceable(name="node_diagnose_root_cause")
 def node_diagnose_root_cause(
-    state: InvestigationState, config: Optional[RunnableConfig] = None  # noqa: ARG001,UP045
+    state: InvestigationState,
+    config: Optional[RunnableConfig] = None,  # noqa: ARG001,UP007,UP045
 ) -> dict:
     """LangGraph node wrapper with LangSmith tracking."""
     return diagnose_root_cause(state)


### PR DESCRIPTION
## Summary

- Standardise all five pipeline node signatures to `Optional[RunnableConfig] = None`
- Fixes the `UserWarning` that fires on every `opensre investigate` run
- Add `# noqa: UP045` to suppress ruff's `X | None` preference since LangGraph's type inspector requires `Optional[RunnableConfig]` specifically

## Root Cause

LangGraph's `RunnableCallable` inspector (`langgraph/_internal/_runnable.py`) only accepts `RunnableConfig`, `Optional[RunnableConfig]`, and their string equivalents as valid config annotations.

Two problems existed:

1. `node_resolve_integrations` used `RunnableConfig | None` (Python's `types.UnionType`) which is not in LangGraph's accepted set
2. Four nodes (`node_extract_alert`, `node_plan_actions`, `node_diagnose_root_cause`, `node_publish_findings`) were missing the `config` parameter entirely

## Verification

- `make lint` ✓
- `make typecheck` ✓
- `python -W error::UserWarning -c "from app.pipeline.graph import build_graph; build_graph()"` ✓ no warnings

Closes #773