### PR TITLE
fix: emit healthy-short-circuit claims from investigation keys only

### DIFF
--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -38,6 +38,81 @@ INVESTIGATED_EVIDENCE_KEYS = frozenset(
     }
 )
 
+# All evidence keys that represent gathered *data* (lists, dicts with content,
+# compound records) written by the EVIDENCE_MAPPERS in
+# ``app/nodes/investigate/processing/post_process.py``.  Used by the healthy
+# short-circuit to decide which keys should produce a
+# "X data confirmed within normal operating bounds" claim.
+#
+# Maintained as an explicit enumeration so metadata keys — query strings,
+# counts, timings, resource names, trace IDs, source URLs — cannot leak into
+# findings, and so adding a new mapper is a deliberate, reviewable decision
+# (either extend this set, or accept that the new key will not appear in
+# healthy-short-circuit output).
+#
+# A key listed here but not in ``INVESTIGATED_EVIDENCE_KEYS`` produces a claim
+# only when truthy; keys in ``INVESTIGATED_EVIDENCE_KEYS`` produce claims even
+# when empty, since an empty list after a completed investigation is itself
+# the healthy signal.
+CLAIM_EVIDENCE_KEYS = INVESTIGATED_EVIDENCE_KEYS | frozenset(
+    {
+        # Generic telemetry
+        "failed_jobs",
+        "failed_tools",
+        "error_logs",
+        "host_metrics",
+        # CloudWatch extras
+        "cloudwatch_latest_error",
+        # S3 / audit
+        "s3_object",
+        "s3_objects",
+        "s3_marker",
+        "s3_audit_payload",
+        # Lambda
+        "lambda_logs",
+        "lambda_invocations",
+        "lambda_errors",
+        "lambda_function",
+        "lambda_config",
+        # Grafana adjacent
+        "grafana_error_logs",
+        "grafana_traces",
+        "grafana_pipeline_spans",
+        "grafana_service_names",
+        # Datadog adjacent
+        "datadog_error_logs",
+        "datadog_events",
+        "datadog_failed_pods",
+        # Other observability stacks
+        "honeycomb_traces",
+        "coralogix_logs",
+        "coralogix_error_logs",
+        # Diagnostic code sandbox
+        "diagnostic_executions",
+        # Vercel
+        "vercel_deployments",
+        "vercel_failed_deployments",
+        "vercel_deployment",
+        "vercel_events",
+        "vercel_error_events",
+        "vercel_runtime_logs",
+        # GitHub / Git
+        "github_code_matches",
+        "github_file",
+        "github_commits",
+        "git_deploy_timeline",
+        # Alertmanager
+        "alertmanager_alerts",
+        "alertmanager_firing_alerts",
+        "alertmanager_silences",
+        "alertmanager_active_silences",
+        # EKS adjacent
+        "eks_failing_pods",
+        "eks_high_restart_pods",
+        "eks_degraded_deployments",
+    }
+)
+
 
 def check_evidence_availability(
     context: dict[str, Any], evidence: dict[str, Any], raw_alert: dict | str

--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -13,7 +13,7 @@ _ERROR_ANNOTATION_KEYS = ("error", "error_message", "log_excerpt", "failed_steps
 
 # Evidence keys whose presence (even with empty values) confirms investigation was attempted.
 # An empty grafana_logs list is itself a healthy signal: no errors found during investigation.
-_INVESTIGATED_EVIDENCE_KEYS = frozenset(
+INVESTIGATED_EVIDENCE_KEYS = frozenset(
     {
         "grafana_logs",
         "grafana_metrics",
@@ -155,7 +155,7 @@ def is_clearly_healthy(raw_alert: dict[str, Any] | str, evidence: dict[str, Any]
     # An empty grafana_logs / grafana_metrics / etc. after a completed investigation is itself
     # a health signal — it means no errors were found. We only require that the key is present
     # (investigation was attempted), not that it contains data.
-    return any(k in evidence for k in _INVESTIGATED_EVIDENCE_KEYS)
+    return any(k in evidence for k in INVESTIGATED_EVIDENCE_KEYS)
 
 
 def check_vendor_evidence_missing(evidence: dict[str, Any]) -> bool:

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -14,6 +14,7 @@ from app.state import InvestigationState
 
 from .claim_validator import calculate_validity_score, validate_and_categorize_claims
 from .evidence_checker import (
+    _INVESTIGATED_EVIDENCE_KEYS,
     check_evidence_availability,
     check_vendor_evidence_missing,
     is_clearly_healthy,
@@ -121,13 +122,18 @@ def _handle_healthy_finding(state: InvestigationState, tracker, evidence: dict) 
     alert_name = state.get("alert_name", "Health check")
     loop_count = state.get("investigation_loop_count", 0)
 
+    # Mirror is_clearly_healthy's gating: a present investigation key (even with an
+    # empty list) is itself the healthy signal. Iterating evidence.keys() filtered
+    # by truthiness instead emits claims for query-string metadata like
+    # grafana_logs_query and drops the empty-list evidence keys that actually
+    # triggered the short-circuit.
     validated_claims = [
         {
             "claim": f"{k} data confirmed within normal operating bounds",
             "validation_status": "validated",
         }
-        for k in evidence
-        if evidence[k]
+        for k in sorted(_INVESTIGATED_EVIDENCE_KEYS)
+        if k in evidence
     ]
 
     tracker.complete(

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -14,29 +14,13 @@ from app.state import InvestigationState
 
 from .claim_validator import calculate_validity_score, validate_and_categorize_claims
 from .evidence_checker import (
+    CLAIM_EVIDENCE_KEYS,
     INVESTIGATED_EVIDENCE_KEYS,
     check_evidence_availability,
     check_vendor_evidence_missing,
     is_clearly_healthy,
 )
 from .prompt_builder import build_diagnosis_prompt
-
-# Evidence-dict entries whose key matches one of these patterns are metadata —
-# query strings, counts, timings, resource names, totals — not data. Surfacing
-# them as "X data confirmed within normal operating bounds" produces incoherent
-# findings, so they are excluded from healthy-short-circuit claims. Suffixes
-# are matched with ``str.endswith`` (not substring) so e.g. ``grafana_service_names``
-# (plural, a list of names — real data) is not mistaken for metadata.
-_METADATA_KEY_SUFFIXES = (
-    "_query",
-    "_count",
-    "_ms",
-    "_source",
-    "_name",
-    "_namespace",
-    "_total",
-    "_by_pipeline",
-)
 
 
 def _is_healthy_claim_key(key: str, value: object) -> bool:
@@ -45,16 +29,15 @@ def _is_healthy_claim_key(key: str, value: object) -> bool:
     - Investigation keys (``INVESTIGATED_EVIDENCE_KEYS``) always qualify, even
       with an empty value — an empty list after a completed investigation is
       itself the healthy signal (mirrors ``is_clearly_healthy`` condition 4).
-    - Other keys qualify only when they carry data (truthy) and are not
-      obvious metadata (counts, queries, timing, resource names, totals).
+    - Other entries in ``CLAIM_EVIDENCE_KEYS`` qualify only when truthy.
+    - Every other evidence entry (query strings, counts, timings, resource
+      names, trace IDs, etc.) is ignored — the whitelist is authoritative.
     """
     if key in INVESTIGATED_EVIDENCE_KEYS:
         return True
-    if not value:
-        return False
-    if key.startswith("total_") or "_total_" in key:
-        return False
-    return not key.endswith(_METADATA_KEY_SUFFIXES)
+    if key in CLAIM_EVIDENCE_KEYS:
+        return bool(value)
+    return False
 
 
 def _short_circuit_enabled() -> bool:
@@ -157,12 +140,13 @@ def _handle_healthy_finding(state: InvestigationState, tracker, evidence: dict) 
     alert_name = state.get("alert_name", "Health check")
     loop_count = state.get("investigation_loop_count", 0)
 
-    # Emit one validated claim per evidence source that either was investigated
-    # (present in INVESTIGATED_EVIDENCE_KEYS — even empty lists count, per
-    # is_clearly_healthy's condition 4) or carries non-metadata data content.
-    # The previous ``for k in evidence if evidence[k]`` pattern dropped
-    # empty-list investigation keys (the real healthy signal) and leaked
-    # metadata entries like grafana_logs_query / eks_total_pods as findings.
+    # Emit one claim per evidence source drawn from the CLAIM_EVIDENCE_KEYS
+    # whitelist. Investigation keys produce a claim even when empty (per
+    # is_clearly_healthy's condition 4: an empty grafana_logs after a completed
+    # investigation is the healthy signal). Other whitelisted data keys produce
+    # a claim only when non-empty. The previous ``for k in evidence if evidence[k]``
+    # pattern dropped empty investigation keys and leaked metadata entries
+    # (grafana_logs_query, eks_total_pods, datadog_fetch_ms, ...) as findings.
     validated_claims = [
         {
             "claim": f"{k} data confirmed within normal operating bounds",

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -14,12 +14,47 @@ from app.state import InvestigationState
 
 from .claim_validator import calculate_validity_score, validate_and_categorize_claims
 from .evidence_checker import (
-    _INVESTIGATED_EVIDENCE_KEYS,
+    INVESTIGATED_EVIDENCE_KEYS,
     check_evidence_availability,
     check_vendor_evidence_missing,
     is_clearly_healthy,
 )
 from .prompt_builder import build_diagnosis_prompt
+
+# Evidence-dict entries whose key matches one of these patterns are metadata —
+# query strings, counts, timings, resource names, totals — not data. Surfacing
+# them as "X data confirmed within normal operating bounds" produces incoherent
+# findings, so they are excluded from healthy-short-circuit claims. Suffixes
+# are matched with ``str.endswith`` (not substring) so e.g. ``grafana_service_names``
+# (plural, a list of names — real data) is not mistaken for metadata.
+_METADATA_KEY_SUFFIXES = (
+    "_query",
+    "_count",
+    "_ms",
+    "_source",
+    "_name",
+    "_namespace",
+    "_total",
+    "_by_pipeline",
+)
+
+
+def _is_healthy_claim_key(key: str, value: object) -> bool:
+    """Return True iff a key should produce a healthy-short-circuit claim.
+
+    - Investigation keys (``INVESTIGATED_EVIDENCE_KEYS``) always qualify, even
+      with an empty value — an empty list after a completed investigation is
+      itself the healthy signal (mirrors ``is_clearly_healthy`` condition 4).
+    - Other keys qualify only when they carry data (truthy) and are not
+      obvious metadata (counts, queries, timing, resource names, totals).
+    """
+    if key in INVESTIGATED_EVIDENCE_KEYS:
+        return True
+    if not value:
+        return False
+    if key.startswith("total_") or "_total_" in key:
+        return False
+    return not key.endswith(_METADATA_KEY_SUFFIXES)
 
 
 def _short_circuit_enabled() -> bool:
@@ -122,18 +157,19 @@ def _handle_healthy_finding(state: InvestigationState, tracker, evidence: dict) 
     alert_name = state.get("alert_name", "Health check")
     loop_count = state.get("investigation_loop_count", 0)
 
-    # Mirror is_clearly_healthy's gating: a present investigation key (even with an
-    # empty list) is itself the healthy signal. Iterating evidence.keys() filtered
-    # by truthiness instead emits claims for query-string metadata like
-    # grafana_logs_query and drops the empty-list evidence keys that actually
-    # triggered the short-circuit.
+    # Emit one validated claim per evidence source that either was investigated
+    # (present in INVESTIGATED_EVIDENCE_KEYS — even empty lists count, per
+    # is_clearly_healthy's condition 4) or carries non-metadata data content.
+    # The previous ``for k in evidence if evidence[k]`` pattern dropped
+    # empty-list investigation keys (the real healthy signal) and leaked
+    # metadata entries like grafana_logs_query / eks_total_pods as findings.
     validated_claims = [
         {
             "claim": f"{k} data confirmed within normal operating bounds",
             "validation_status": "validated",
         }
-        for k in sorted(_INVESTIGATED_EVIDENCE_KEYS)
-        if k in evidence
+        for k in sorted(evidence)
+        if _is_healthy_claim_key(k, evidence[k])
     ]
 
     tracker.complete(

--- a/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
+++ b/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
@@ -2,7 +2,7 @@
 
 Focuses on the ``is_clearly_healthy`` helper that gates the healthy
 short-circuit in ``diagnose_root_cause``.  In particular, these tests verify
-that the recently-added ``eks_*`` entries in ``_INVESTIGATED_EVIDENCE_KEYS``
+that the recently-added ``eks_*`` entries in ``INVESTIGATED_EVIDENCE_KEYS``
 make pure-Kubernetes healthy investigations fast-path out of the reasoning
 LLM the same way Grafana-only and Datadog-only healthy states already do.
 """
@@ -128,7 +128,7 @@ class TestIsClearlyHealthyRejectsUnhealthyStates:
         assert is_clearly_healthy(alert, evidence) is False
 
     def test_unknown_evidence_key_does_not_trigger_short_circuit(self) -> None:
-        """A key outside _INVESTIGATED_EVIDENCE_KEYS alone is not enough."""
+        """A key outside INVESTIGATED_EVIDENCE_KEYS alone is not enough."""
         evidence = {"random_custom_key": "some value"}
         assert is_clearly_healthy(_healthy_alert(), evidence) is False
 

--- a/tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py
+++ b/tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py
@@ -1,10 +1,12 @@
 """Tests for the healthy-short-circuit claim generation in diagnose_root_cause.
 
 Covers the ``_handle_healthy_finding`` path: when ``is_clearly_healthy`` trips,
-we must emit one validated claim per investigated evidence key that is present
-in evidence — empty list values included, since an empty ``grafana_logs`` after
-a completed investigation is itself a healthy signal. Non-investigation keys
-like ``grafana_logs_query`` (a query string, not data) must not produce claims.
+we must emit one validated claim per evidence source that was either
+investigated (present in ``INVESTIGATED_EVIDENCE_KEYS`` — empty list counts,
+since an empty ``grafana_logs`` after a completed investigation is itself a
+healthy signal) or carries non-metadata data content. Metadata entries such
+as ``grafana_logs_query`` (a query string), ``eks_total_pods`` (a count), or
+``datadog_fetch_ms`` (a timing) must not produce claims.
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.nodes.root_cause_diagnosis import node as diag_node
-from app.nodes.root_cause_diagnosis.evidence_checker import _INVESTIGATED_EVIDENCE_KEYS
+from app.nodes.root_cause_diagnosis.evidence_checker import INVESTIGATED_EVIDENCE_KEYS
 
 
 def _run_handle_healthy_finding(evidence: dict) -> dict:
@@ -30,12 +32,12 @@ def _claim_keys(result: dict) -> list[str]:
     return [c["claim"].split(" ", 1)[0] for c in claims]
 
 
-class TestHealthyClaimsCoverage:
-    """The healthy short-circuit output must cover the investigation keys that
-    triggered it — no more, no less."""
+class TestInvestigationKeyClaims:
+    """Investigation keys must always produce a claim when present — empty
+    values included, because an empty list is the healthy signal that
+    triggered the short-circuit."""
 
-    def test_empty_list_evidence_produces_a_claim(self) -> None:
-        """An empty ``grafana_logs`` list is the healthy signal, not a reason to drop the claim."""
+    def test_empty_list_investigation_key_produces_a_claim(self) -> None:
         result = _run_handle_healthy_finding({"grafana_logs": []})
         assert _claim_keys(result) == ["grafana_logs"]
 
@@ -51,28 +53,114 @@ class TestHealthyClaimsCoverage:
             "datadog_logs",
         }
 
-    def test_non_investigation_keys_do_not_produce_claims(self) -> None:
-        """Query-string metadata like ``grafana_logs_query`` must not be reported as 'data'."""
-        evidence = {
-            "grafana_logs": [],
-            "grafana_logs_query": 'severity:"error"',
-            "datadog_logs_query": "status:error",
-            "total_logs": 0,
-        }
-        assert _claim_keys(_run_handle_healthy_finding(evidence)) == ["grafana_logs"]
-
-    def test_claim_order_is_deterministic(self) -> None:
-        """Claim order must not depend on dict insertion order of ``evidence``."""
-        e1 = {"eks_pods": [], "grafana_logs": []}
-        e2 = {"grafana_logs": [], "eks_pods": []}
-        assert _claim_keys(_run_handle_healthy_finding(e1)) == _claim_keys(
-            _run_handle_healthy_finding(e2)
-        )
-
-    @pytest.mark.parametrize("key", sorted(_INVESTIGATED_EVIDENCE_KEYS))
+    @pytest.mark.parametrize("key", sorted(INVESTIGATED_EVIDENCE_KEYS))
     def test_every_investigation_key_is_recognised(self, key: str) -> None:
         """No investigation key should be silently dropped when empty."""
         assert _claim_keys(_run_handle_healthy_finding({key: []})) == [key]
+
+
+class TestMetadataKeyFiltering:
+    """Query strings, counts, totals, timings, and resource-name metadata keys
+    produce incoherent findings (\"X query data confirmed\") and must never
+    appear in the claim list — even when the adjacent investigation key is
+    also present."""
+
+    @pytest.mark.parametrize(
+        "metadata_key, value",
+        [
+            ("grafana_logs_query", 'severity:"error"'),
+            ("datadog_logs_query", "status:error"),
+            ("datadog_monitors_count", 2),
+            ("datadog_events_count", 5),
+            ("eks_total_pods", 3),
+            ("eks_total_deployments", 1),
+            ("eks_total_warning_count", 0),
+            ("eks_total_nodes", 2),
+            ("eks_not_ready_count", 0),
+            ("datadog_fetch_ms", {"logs": 42}),
+            ("datadog_pod_name", "payments-api-xkp2q"),
+            ("datadog_container_name", "payments-api"),
+            ("datadog_kube_namespace", "payments"),
+            ("betterstack_source", "heroku"),
+            ("grafana_log_count", 11),
+            ("grafana_trace_count", 20),
+            ("honeycomb_trace_count", 5),
+            ("alertmanager_alerts_total", 3),
+            ("alertmanager_silences_total", 1),
+            ("total_logs", 100),
+            ("total_failed_jobs_count", 0),
+            ("cloudwatch_logs_count", 5),
+        ],
+    )
+    def test_metadata_key_in_isolation_produces_no_claim(
+        self, metadata_key: str, value: object
+    ) -> None:
+        assert _claim_keys(_run_handle_healthy_finding({metadata_key: value})) == []
+
+    def test_metadata_keys_alongside_investigation_keys_are_filtered(self) -> None:
+        evidence = {
+            "grafana_logs": [],
+            "grafana_logs_query": 'severity:"error"',
+            "grafana_log_count": 0,
+            "datadog_logs": [],
+            "datadog_logs_query": "status:error",
+            "datadog_monitors_count": 2,
+            "datadog_fetch_ms": {"logs": 42},
+            "eks_pods": [{"name": "x"}],
+            "eks_total_pods": 3,
+            "eks_total_deployments": 1,
+        }
+        assert _claim_keys(_run_handle_healthy_finding(evidence)) == [
+            "datadog_logs",
+            "eks_pods",
+            "grafana_logs",
+        ]
+
+
+class TestTruthyNonInvestigationDataClaims:
+    """Truthy evidence keys that are not investigation-keys but also not
+    metadata represent real gathered data (e.g. ``datadog_events``,
+    ``datadog_error_logs``, ``grafana_traces``, ``honeycomb_traces``,
+    ``eks_failing_pods``) and should still produce a claim — matching the
+    pre-fix observable behavior on those keys."""
+
+    @pytest.mark.parametrize(
+        "key, value",
+        [
+            ("datadog_events", [{"id": "e1"}]),
+            ("datadog_error_logs", [{"message": "err"}]),
+            ("grafana_traces", [{"trace_id": "t1"}]),
+            ("grafana_error_logs", [{"line": "err"}]),
+            ("grafana_service_names", ["api", "db"]),
+            ("honeycomb_traces", [{"trace_id": "h1"}]),
+            ("coralogix_logs", [{"text": "info"}]),
+            ("coralogix_error_logs", [{"text": "err"}]),
+            ("alertmanager_alerts", [{"status": "resolved"}]),
+            ("alertmanager_silences", [{"id": "s1"}]),
+            ("eks_failing_pods", [{"name": "p"}]),
+            ("eks_high_restart_pods", [{"name": "p", "restarts": 3}]),
+            ("eks_degraded_deployments", [{"name": "d"}]),
+            ("failed_tools", [{"name": "query_x"}]),
+            ("error_logs", [{"message": "err"}]),
+            ("host_metrics", {"data": {"cpu": 42}}),
+            ("s3_object", {"found": True}),
+            ("lambda_logs", [{"line": "info"}]),
+            ("lambda_function", {"name": "fn"}),
+        ],
+    )
+    def test_truthy_non_metadata_key_produces_claim(self, key: str, value: object) -> None:
+        assert _claim_keys(_run_handle_healthy_finding({key: value})) == [key]
+
+    def test_empty_non_investigation_key_does_not_produce_claim(self) -> None:
+        """Unlike investigation keys, empty non-investigation keys don't count."""
+        assert _claim_keys(_run_handle_healthy_finding({"datadog_events": []})) == []
+
+    def test_random_custom_truthy_key_is_claimed(self) -> None:
+        """Forward-compat: new data keys from future mappers produce claims
+        without a code change, as long as they aren't metadata-shaped."""
+        assert _claim_keys(_run_handle_healthy_finding({"my_new_source_data": [1]})) == [
+            "my_new_source_data"
+        ]
 
 
 class TestHealthyFindingShape:
@@ -100,6 +188,14 @@ class TestHealthyFindingShape:
         tracker.complete.assert_called_once()
         assert tracker.complete.call_args.kwargs["message"] == "healthy_short_circuit=true"
 
+    def test_claim_order_is_deterministic(self) -> None:
+        """Claim order must not depend on dict insertion order of ``evidence``."""
+        e1 = {"eks_pods": [], "grafana_logs": [], "datadog_events": [{"id": "e1"}]}
+        e2 = {"datadog_events": [{"id": "e1"}], "grafana_logs": [], "eks_pods": []}
+        assert _claim_keys(_run_handle_healthy_finding(e1)) == _claim_keys(
+            _run_handle_healthy_finding(e2)
+        )
+
 
 def test_diagnose_root_cause_short_circuits_through_healthy_finding(monkeypatch) -> None:
     """End-to-end: the diagnose entry point routes a clearly-healthy state through
@@ -117,6 +213,7 @@ def test_diagnose_root_cause_short_circuits_through_healthy_finding(monkeypatch)
         "evidence": {
             "grafana_logs": [],
             "grafana_logs_query": 'severity:"error"',
+            "grafana_log_count": 0,
         },
         "context": {},
         "investigation_loop_count": 0,

--- a/tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py
+++ b/tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py
@@ -1,0 +1,131 @@
+"""Tests for the healthy-short-circuit claim generation in diagnose_root_cause.
+
+Covers the ``_handle_healthy_finding`` path: when ``is_clearly_healthy`` trips,
+we must emit one validated claim per investigated evidence key that is present
+in evidence — empty list values included, since an empty ``grafana_logs`` after
+a completed investigation is itself a healthy signal. Non-investigation keys
+like ``grafana_logs_query`` (a query string, not data) must not produce claims.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.nodes.root_cause_diagnosis import node as diag_node
+from app.nodes.root_cause_diagnosis.evidence_checker import _INVESTIGATED_EVIDENCE_KEYS
+
+
+def _run_handle_healthy_finding(evidence: dict) -> dict:
+    """Invoke ``_handle_healthy_finding`` with a minimal state and fake tracker."""
+    state = {"alert_name": "etl health check", "investigation_loop_count": 0}
+    tracker = MagicMock()
+    return diag_node._handle_healthy_finding(state, tracker, evidence)  # type: ignore[arg-type]
+
+
+def _claim_keys(result: dict) -> list[str]:
+    """Extract the leading evidence-key token from each validated claim."""
+    claims = result["validated_claims"]
+    return [c["claim"].split(" ", 1)[0] for c in claims]
+
+
+class TestHealthyClaimsCoverage:
+    """The healthy short-circuit output must cover the investigation keys that
+    triggered it — no more, no less."""
+
+    def test_empty_list_evidence_produces_a_claim(self) -> None:
+        """An empty ``grafana_logs`` list is the healthy signal, not a reason to drop the claim."""
+        result = _run_handle_healthy_finding({"grafana_logs": []})
+        assert _claim_keys(result) == ["grafana_logs"]
+
+    def test_claim_emitted_for_every_present_investigation_key(self) -> None:
+        evidence = {
+            "grafana_logs": [],
+            "eks_pods": [{"name": "api-worker"}],
+            "datadog_logs": [],
+        }
+        assert set(_claim_keys(_run_handle_healthy_finding(evidence))) == {
+            "grafana_logs",
+            "eks_pods",
+            "datadog_logs",
+        }
+
+    def test_non_investigation_keys_do_not_produce_claims(self) -> None:
+        """Query-string metadata like ``grafana_logs_query`` must not be reported as 'data'."""
+        evidence = {
+            "grafana_logs": [],
+            "grafana_logs_query": 'severity:"error"',
+            "datadog_logs_query": "status:error",
+            "total_logs": 0,
+        }
+        assert _claim_keys(_run_handle_healthy_finding(evidence)) == ["grafana_logs"]
+
+    def test_claim_order_is_deterministic(self) -> None:
+        """Claim order must not depend on dict insertion order of ``evidence``."""
+        e1 = {"eks_pods": [], "grafana_logs": []}
+        e2 = {"grafana_logs": [], "eks_pods": []}
+        assert _claim_keys(_run_handle_healthy_finding(e1)) == _claim_keys(
+            _run_handle_healthy_finding(e2)
+        )
+
+    @pytest.mark.parametrize("key", sorted(_INVESTIGATED_EVIDENCE_KEYS))
+    def test_every_investigation_key_is_recognised(self, key: str) -> None:
+        """No investigation key should be silently dropped when empty."""
+        assert _claim_keys(_run_handle_healthy_finding({key: []})) == [key]
+
+
+class TestHealthyFindingShape:
+    def test_returns_healthy_category_and_deterministic_fields(self) -> None:
+        result = _run_handle_healthy_finding({"grafana_logs": []})
+        assert result["root_cause_category"] == "healthy"
+        assert result["validity_score"] == 1.0
+        assert result["non_validated_claims"] == []
+        assert result["remediation_steps"] == []
+        assert "All monitored metrics are within normal bounds" in result["root_cause"]
+
+    def test_preserves_investigation_loop_count(self) -> None:
+        state = {"alert_name": "x", "investigation_loop_count": 7}
+        tracker = MagicMock()
+        result = diag_node._handle_healthy_finding(state, tracker, {"grafana_logs": []})  # type: ignore[arg-type]
+        assert result["investigation_loop_count"] == 7
+
+    def test_tracker_completion_recorded(self) -> None:
+        tracker = MagicMock()
+        diag_node._handle_healthy_finding(
+            {"alert_name": "x", "investigation_loop_count": 0},
+            tracker,
+            {"grafana_logs": []},
+        )  # type: ignore[arg-type]
+        tracker.complete.assert_called_once()
+        assert tracker.complete.call_args.kwargs["message"] == "healthy_short_circuit=true"
+
+
+def test_diagnose_root_cause_short_circuits_through_healthy_finding(monkeypatch) -> None:
+    """End-to-end: the diagnose entry point routes a clearly-healthy state through
+    ``_handle_healthy_finding`` without invoking the LLM, and the resulting
+    validated claims come from investigation keys, not query metadata."""
+    monkeypatch.setenv("HEALTHY_SHORT_CIRCUIT", "true")
+
+    state = {
+        "alert_name": "synthetic health check",
+        "raw_alert": {
+            "state": "resolved",
+            "commonLabels": {"severity": "info"},
+            "commonAnnotations": {},
+        },
+        "evidence": {
+            "grafana_logs": [],
+            "grafana_logs_query": 'severity:"error"',
+        },
+        "context": {},
+        "investigation_loop_count": 0,
+    }
+
+    with patch.object(diag_node, "get_llm_for_reasoning") as mock_llm_factory:
+        result = diag_node.diagnose_root_cause(state)  # type: ignore[arg-type]
+        mock_llm_factory.assert_not_called()
+
+    assert result["root_cause_category"] == "healthy"
+    claim_keys = [c["claim"].split(" ", 1)[0] for c in result["validated_claims"]]
+    assert claim_keys == ["grafana_logs"]

--- a/tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py
+++ b/tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py
@@ -1,12 +1,13 @@
 """Tests for the healthy-short-circuit claim generation in diagnose_root_cause.
 
-Covers the ``_handle_healthy_finding`` path: when ``is_clearly_healthy`` trips,
-we must emit one validated claim per evidence source that was either
-investigated (present in ``INVESTIGATED_EVIDENCE_KEYS`` — empty list counts,
-since an empty ``grafana_logs`` after a completed investigation is itself a
-healthy signal) or carries non-metadata data content. Metadata entries such
-as ``grafana_logs_query`` (a query string), ``eks_total_pods`` (a count), or
-``datadog_fetch_ms`` (a timing) must not produce claims.
+Covers ``_handle_healthy_finding``: when ``is_clearly_healthy`` trips, we
+must emit one validated claim per evidence source present in the explicit
+``CLAIM_EVIDENCE_KEYS`` whitelist. Investigation keys from
+``INVESTIGATED_EVIDENCE_KEYS`` always qualify (empty lists included — an
+empty ``grafana_logs`` after a completed investigation is the healthy
+signal). Other whitelisted data keys qualify only when non-empty. Everything
+else — query strings, counts, timings, resource names, trace IDs — is
+ignored even when truthy.
 """
 
 from __future__ import annotations
@@ -16,7 +17,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.nodes.root_cause_diagnosis import node as diag_node
-from app.nodes.root_cause_diagnosis.evidence_checker import INVESTIGATED_EVIDENCE_KEYS
+from app.nodes.root_cause_diagnosis.evidence_checker import (
+    CLAIM_EVIDENCE_KEYS,
+    INVESTIGATED_EVIDENCE_KEYS,
+)
 
 
 def _run_handle_healthy_finding(evidence: dict) -> dict:
@@ -59,38 +63,102 @@ class TestInvestigationKeyClaims:
         assert _claim_keys(_run_handle_healthy_finding({key: []})) == [key]
 
 
-class TestMetadataKeyFiltering:
-    """Query strings, counts, totals, timings, and resource-name metadata keys
-    produce incoherent findings (\"X query data confirmed\") and must never
-    appear in the claim list — even when the adjacent investigation key is
-    also present."""
+class TestAdjacentDataKeys:
+    """Non-investigation whitelist entries produce claims only when non-empty."""
+
+    _ADJACENT = sorted(CLAIM_EVIDENCE_KEYS - INVESTIGATED_EVIDENCE_KEYS)
+
+    @pytest.mark.parametrize("key", _ADJACENT)
+    def test_truthy_adjacent_key_produces_claim(self, key: str) -> None:
+        # A non-empty list value is enough to trigger the truthiness gate.
+        assert _claim_keys(_run_handle_healthy_finding({key: [{"stub": 1}]})) == [key]
+
+    @pytest.mark.parametrize("key", _ADJACENT)
+    def test_empty_adjacent_key_produces_no_claim(self, key: str) -> None:
+        # Unlike investigation keys, empty adjacent keys are not claimed —
+        # they signal the tool did not return data, not that the system is healthy.
+        assert _claim_keys(_run_handle_healthy_finding({key: []})) == []
+
+
+class TestNonWhitelistedKeysFiltered:
+    """Every metadata shape that the mappers emit alongside primary data keys
+    must be filtered out — query strings, counts, totals, timings, resource
+    names, trace IDs, source URLs, limits, service names, windows, etc."""
+
+    # Exhaustive set of metadata / non-data keys enumerated by auditing every
+    # mapper in app/nodes/investigate/processing/post_process.py.
+    _METADATA_KEYS: tuple[tuple[str, object], ...] = (
+        # Counts
+        ("total_jobs", 3),
+        ("total_tools", 5),
+        ("total_logs", 42),
+        ("cloudwatch_event_count", 12),
+        ("lambda_invocation_count", 7),
+        ("lambda_error_count", 2),
+        ("grafana_alert_rules_count", 4),
+        ("datadog_monitors_count", 8),
+        ("datadog_events_count", 11),
+        ("honeycomb_trace_count", 6),
+        ("coralogix_logs_count", 15),
+        ("betterstack_logs_count", 22),
+        ("git_deploy_timeline_count", 9),
+        ("eks_total_warning_count", 0),
+        ("eks_not_ready_count", 0),
+        ("s3_object_count", 14),
+        # Totals / aggregates
+        ("alertmanager_alerts_total", 4),
+        ("alertmanager_silences_total", 1),
+        ("vercel_deployments_total", 5),
+        ("vercel_total_events", 20),
+        ("vercel_total_runtime_logs", 33),
+        ("eks_total_pods", 3),
+        ("eks_total_deployments", 1),
+        ("eks_total_nodes", 2),
+        # Query strings
+        ("grafana_logs_query", 'severity:"error"'),
+        ("datadog_logs_query", "status:error"),
+        ("coralogix_logs_query", 'service:"api"'),
+        ("github_code_query", "repo:x query:y"),
+        # Timings
+        ("datadog_fetch_ms", {"logs": 42}),
+        # Service names / identifiers / URLs / text summaries / misc
+        ("grafana_logs_service", "api"),
+        ("grafana_traces_service", "api"),
+        ("grafana_metric_name", "CPUUtilization"),
+        ("grafana_metrics_service", "api"),
+        ("datadog_pod_name", "payments-api-x"),
+        ("datadog_container_name", "payments-api"),
+        ("datadog_kube_namespace", "payments"),
+        ("honeycomb_dataset", "api"),
+        ("honeycomb_service_name", "api"),
+        ("honeycomb_trace_id", "abc123"),
+        ("honeycomb_query_url", "https://ui.honeycomb.io/..."),
+        ("coralogix_application_name", "payments"),
+        ("coralogix_subsystem_name", "api"),
+        ("coralogix_trace_id", "xyz789"),
+        ("betterstack_source", "heroku"),
+        ("betterstack_logs_limit", 1000),
+        ("vercel_project_id", "prj_123"),
+        ("vercel_deployment_id", "dep_456"),
+        ("github_code_text", "summary text"),
+        ("github_file_text", "file text"),
+        ("github_commits_text", "commits text"),
+        ("git_deploy_timeline_window", {"from": "t0", "to": "t1"}),
+        ("eks_pod_logs_pod_name", "payments-api-x"),
+        ("eks_pod_logs_namespace", "payments"),
+        # Summary-of-sample fields
+        (
+            "cloudwatch_latest_error",
+            "OutOfMemory",
+        ),  # intentionally: claimed via the whitelist entry above, not here
+    )
 
     @pytest.mark.parametrize(
         "metadata_key, value",
-        [
-            ("grafana_logs_query", 'severity:"error"'),
-            ("datadog_logs_query", "status:error"),
-            ("datadog_monitors_count", 2),
-            ("datadog_events_count", 5),
-            ("eks_total_pods", 3),
-            ("eks_total_deployments", 1),
-            ("eks_total_warning_count", 0),
-            ("eks_total_nodes", 2),
-            ("eks_not_ready_count", 0),
-            ("datadog_fetch_ms", {"logs": 42}),
-            ("datadog_pod_name", "payments-api-xkp2q"),
-            ("datadog_container_name", "payments-api"),
-            ("datadog_kube_namespace", "payments"),
-            ("betterstack_source", "heroku"),
-            ("grafana_log_count", 11),
-            ("grafana_trace_count", 20),
-            ("honeycomb_trace_count", 5),
-            ("alertmanager_alerts_total", 3),
-            ("alertmanager_silences_total", 1),
-            ("total_logs", 100),
-            ("total_failed_jobs_count", 0),
-            ("cloudwatch_logs_count", 5),
-        ],
+        # Filter out any key that is actually claim-worthy so the test stays
+        # honest — cloudwatch_latest_error is both listed above (as a
+        # reminder) and in the whitelist; drop it from the metadata sweep.
+        [(k, v) for (k, v) in _METADATA_KEYS if k not in CLAIM_EVIDENCE_KEYS],
     )
     def test_metadata_key_in_isolation_produces_no_claim(
         self, metadata_key: str, value: object
@@ -101,14 +169,17 @@ class TestMetadataKeyFiltering:
         evidence = {
             "grafana_logs": [],
             "grafana_logs_query": 'severity:"error"',
-            "grafana_log_count": 0,
+            "grafana_logs_service": "api",
             "datadog_logs": [],
             "datadog_logs_query": "status:error",
             "datadog_monitors_count": 2,
             "datadog_fetch_ms": {"logs": 42},
+            "datadog_pod_name": "payments-api-x",
             "eks_pods": [{"name": "x"}],
             "eks_total_pods": 3,
             "eks_total_deployments": 1,
+            "honeycomb_trace_id": "abc",
+            "honeycomb_query_url": "https://...",
         }
         assert _claim_keys(_run_handle_healthy_finding(evidence)) == [
             "datadog_logs",
@@ -116,51 +187,9 @@ class TestMetadataKeyFiltering:
             "grafana_logs",
         ]
 
-
-class TestTruthyNonInvestigationDataClaims:
-    """Truthy evidence keys that are not investigation-keys but also not
-    metadata represent real gathered data (e.g. ``datadog_events``,
-    ``datadog_error_logs``, ``grafana_traces``, ``honeycomb_traces``,
-    ``eks_failing_pods``) and should still produce a claim — matching the
-    pre-fix observable behavior on those keys."""
-
-    @pytest.mark.parametrize(
-        "key, value",
-        [
-            ("datadog_events", [{"id": "e1"}]),
-            ("datadog_error_logs", [{"message": "err"}]),
-            ("grafana_traces", [{"trace_id": "t1"}]),
-            ("grafana_error_logs", [{"line": "err"}]),
-            ("grafana_service_names", ["api", "db"]),
-            ("honeycomb_traces", [{"trace_id": "h1"}]),
-            ("coralogix_logs", [{"text": "info"}]),
-            ("coralogix_error_logs", [{"text": "err"}]),
-            ("alertmanager_alerts", [{"status": "resolved"}]),
-            ("alertmanager_silences", [{"id": "s1"}]),
-            ("eks_failing_pods", [{"name": "p"}]),
-            ("eks_high_restart_pods", [{"name": "p", "restarts": 3}]),
-            ("eks_degraded_deployments", [{"name": "d"}]),
-            ("failed_tools", [{"name": "query_x"}]),
-            ("error_logs", [{"message": "err"}]),
-            ("host_metrics", {"data": {"cpu": 42}}),
-            ("s3_object", {"found": True}),
-            ("lambda_logs", [{"line": "info"}]),
-            ("lambda_function", {"name": "fn"}),
-        ],
-    )
-    def test_truthy_non_metadata_key_produces_claim(self, key: str, value: object) -> None:
-        assert _claim_keys(_run_handle_healthy_finding({key: value})) == [key]
-
-    def test_empty_non_investigation_key_does_not_produce_claim(self) -> None:
-        """Unlike investigation keys, empty non-investigation keys don't count."""
-        assert _claim_keys(_run_handle_healthy_finding({"datadog_events": []})) == []
-
-    def test_random_custom_truthy_key_is_claimed(self) -> None:
-        """Forward-compat: new data keys from future mappers produce claims
-        without a code change, as long as they aren't metadata-shaped."""
-        assert _claim_keys(_run_handle_healthy_finding({"my_new_source_data": [1]})) == [
-            "my_new_source_data"
-        ]
+    def test_random_custom_key_is_not_claimed(self) -> None:
+        """Whitelist is authoritative: a truthy key not in the set stays out."""
+        assert _claim_keys(_run_handle_healthy_finding({"my_new_custom_thing": [1]})) == []
 
 
 class TestHealthyFindingShape:
@@ -197,10 +226,36 @@ class TestHealthyFindingShape:
         )
 
 
+class TestWhitelistIntegrity:
+    """Guardrails on the ``CLAIM_EVIDENCE_KEYS`` whitelist itself."""
+
+    def test_investigated_is_subset_of_claim_set(self) -> None:
+        assert INVESTIGATED_EVIDENCE_KEYS <= CLAIM_EVIDENCE_KEYS
+
+    def test_no_obvious_metadata_shapes_in_whitelist(self) -> None:
+        """Sanity check: no whitelist entry looks like metadata."""
+        obvious_metadata_suffixes = (
+            "_query",
+            "_count",
+            "_ms",
+            "_total",
+            "_id",
+            "_url",
+            "_text",
+            "_limit",
+            "_window",
+            "_by_pipeline",
+        )
+        offenders = [k for k in CLAIM_EVIDENCE_KEYS if k.endswith(obvious_metadata_suffixes)] + [
+            k for k in CLAIM_EVIDENCE_KEYS if k.startswith("total_")
+        ]
+        assert not offenders, f"metadata-looking keys in whitelist: {offenders}"
+
+
 def test_diagnose_root_cause_short_circuits_through_healthy_finding(monkeypatch) -> None:
     """End-to-end: the diagnose entry point routes a clearly-healthy state through
     ``_handle_healthy_finding`` without invoking the LLM, and the resulting
-    validated claims come from investigation keys, not query metadata."""
+    validated claims come only from whitelisted evidence keys."""
     monkeypatch.setenv("HEALTHY_SHORT_CIRCUIT", "true")
 
     state = {
@@ -213,7 +268,8 @@ def test_diagnose_root_cause_short_circuits_through_healthy_finding(monkeypatch)
         "evidence": {
             "grafana_logs": [],
             "grafana_logs_query": 'severity:"error"',
-            "grafana_log_count": 0,
+            "grafana_logs_service": "api",
+            "grafana_alert_rules_count": 0,
         },
         "context": {},
         "investigation_loop_count": 0,


### PR DESCRIPTION
## Summary

`_handle_healthy_finding` built the `validated_claims` list by iterating every evidence key and filtering by truthiness. Two problems fall out of that:

1. **Metadata leaks into findings.** `grafana_logs_query`, `datadog_logs_query`, counts (`datadog_monitors_count`, `eks_total_pods`), timings (`datadog_fetch_ms`), service names (`grafana_logs_service`), trace IDs (`honeycomb_trace_id`), URLs (`honeycomb_query_url`) — all truthy, all surfaced as e.g.
   > _\"datadog_logs_query data confirmed within normal operating bounds\"_

2. **Empty-list evidence is silently dropped.** An empty `grafana_logs` / `eks_events` after a completed investigation is itself the healthy signal (per `is_clearly_healthy`'s condition 4 and docstring). Empty lists are falsy, so the claim that actually triggered the short-circuit never appears.

## Fix

Introduce an explicit `CLAIM_EVIDENCE_KEYS` whitelist in `evidence_checker.py`, populated by auditing every mapper in `app/nodes/investigate/processing/post_process.py`. Replace the old truthy-filter with:

```python
def _is_healthy_claim_key(key, value):
    if key in INVESTIGATED_EVIDENCE_KEYS:
        return True           # empty lists count — the healthy signal
    if key in CLAIM_EVIDENCE_KEYS:
        return bool(value)    # adjacent data keys claim when non-empty
    return False              # metadata / unknown keys never claim
```

`CLAIM_EVIDENCE_KEYS` (58 entries) is a superset of `INVESTIGATED_EVIDENCE_KEYS` (16 entries) listing every primary data key across the 39 mappers. Metadata keys — queries, counts, timings, names, IDs, URLs, text summaries — are authoritatively excluded by omission. Also renames `_INVESTIGATED_EVIDENCE_KEYS` → `INVESTIGATED_EVIDENCE_KEYS` (cross-module import, leading underscore was misleading).

**Deliberate trade-off:** a future mapper whose primary data key is not added to `CLAIM_EVIDENCE_KEYS` will not produce a healthy-short-circuit claim for that key until someone updates the whitelist. That's the safe default — silent inclusion is what produced the metadata-leak bug this PR fixes.

## E2E validation — full synthetic suites, real Anthropic LLM

`HEALTHY_SHORT_CIRCUIT=true`, mocked EKS/Grafana/Datadog backends, real `claude-sonnet-4-6` reasoning + `claude-haiku-4-5` toolcall for the upstream graph.

### `tests/synthetic/eks/000-healthy` (short-circuit path — this PR's scope)

**Before (`main`)** — 8 claims, 4 metadata noise, `eks_events` silently dropped:
```
eks_pods, eks_total_pods (count), eks_deployments, eks_total_deployments (count),
datadog_monitors, datadog_monitors_count (count), datadog_logs, datadog_logs_query (query)
```

**After (this PR)** — 5 clean claims, `eks_events: []` now surfaced:
```
datadog_logs, datadog_monitors, eks_deployments, eks_events, eks_pods
```

Passed, `actual_category: healthy`, `matched_keywords: [normal, no failure]`. Diagnose at `0ms`, `healthy_short_circuit=true`, LLM not invoked.

### Full EKS suite — 14 scenarios, all mocked backends

| Result | Count | Details |
|---|---|---|
| PASS | 10 | 000-healthy (short-circuit), 001-005, 007-010 (all non-short-circuit LLM path) |
| FAIL | 4 | 006, 011, 012, 013 — all `state: alerting` ⇒ `is_clearly_healthy=False` ⇒ short-circuit never fires, LLM categorization drift (e.g. `got 'infrastructure', expected 'healthy'`) |

### Full RDS suite — 15 scenarios, `--mock-grafana`

| Result | Count | Details |
|---|---|---|
| PASS | 11 | 000-healthy (short-circuit), 001, 003-006, 008-011, 014 |
| FAIL | 4 | 002, 007, 012, 013 — all `state: alerting` ⇒ short-circuit never fires, LLM categorization / keyword-match drift |

**Confirmed every failure is in `state: alerting` where `_handle_healthy_finding` is unreachable** (grepped via `json.load(alert.json)['state']` for each). Both `000-healthy` scenarios — the only short-circuit exercises in the suites — PASS with clean output.

### Non-healthy regression check

`tests/synthetic/eks/001-oomkilled-crashloop`: full LLM investigation (2× diagnose, 192s), produced OOM/SIGKILL root cause, `category=resource_exhaustion`. Confirms the change is confined to the healthy branch.

## Unit coverage — 188 tests in `tests/nodes/root_cause_diagnosis/`

- **`TestInvestigationKeyClaims`** — parametrised over every member of `INVESTIGATED_EVIDENCE_KEYS`; empty list produces a claim.
- **`TestAdjacentDataKeys`** — parametrised twice over `CLAIM_EVIDENCE_KEYS - INVESTIGATED_EVIDENCE_KEYS`: truthy produces a claim, empty does not.
- **`TestNonWhitelistedKeysFiltered`** — 51 exhaustive metadata shapes from the mapper audit (counts, totals, queries, timings, names, IDs, URLs, limits, windows, text summaries); none leak in isolation or alongside adjacent investigation keys.
- **`TestWhitelistIntegrity`** — `INVESTIGATED_EVIDENCE_KEYS ⊆ CLAIM_EVIDENCE_KEYS`; no whitelist entry ends in an obvious-metadata suffix.
- **`TestHealthyFindingShape`** — shape, validity score, loop-count preservation, tracker completion, deterministic claim order.
- **End-to-end** — `diagnose_root_cause` short-circuits on a mixed evidence dict, asserts `mock_llm_factory.assert_not_called()`.

## Verification

- **CI (Python 3.13)**: `test (ubuntu-latest)` PASS, `typecheck` PASS, `quality` PASS, `CodeQL` PASS, `Analyze (python)` PASS
- **Local `pytest tests/`** (Python 3.14, no coverage): **2931 pass**, 1 skipped, 0 failures (was 2767 on `main`; **+164 new**)
- `ruff check app/ tests/`: clean
- `ruff format --check`: clean
- `mypy app/`: same 3 pre-existing `types-PyMySQL` stub warnings, nothing new

## Scope

Two `app/` files (`evidence_checker.py`, `node.py`), one test file. No public API changes aside from renaming the already-exported-by-behavior constant. No state-shape changes. No behavior change for the non-healthy branch. Orthogonal to open PR #672 (which extends `INVESTIGATED_EVIDENCE_KEYS` itself for alertmanager/coralogix/honeycomb) — this PR composes cleanly regardless of which keys that set contains.