### PR TITLE
feat(config): add optional EnigmAgent LLM credential override

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -145,6 +145,8 @@ def _resolve_enigmagent_api_key_overrides(provider: str, enigm_agent_url: str) -
     parsed = urlparse(enigm_agent_url)
     if parsed.scheme != "http" or not parsed.hostname:
         raise ValueError("ENIGM_AGENT_URL must be a valid http://host[:port] URL.")
+    if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+        raise ValueError("ENIGM_AGENT_URL only supports plain HTTP for localhost/127.0.0.1/::1.")
 
     try:
         from enigmagent import VaultClient  # type: ignore[import-not-found]

--- a/app/config.py
+++ b/app/config.py
@@ -143,6 +143,8 @@ def _resolve_enigmagent_api_key_overrides(provider: str, enigm_agent_url: str) -
         return {}
 
     parsed = urlparse(enigm_agent_url)
+    # EnigmAgent's current local agent flow is intentionally limited to plain HTTP on loopback.
+    # If the SDK adds TLS support later, this validator can be relaxed to allow HTTPS hosts.
     if parsed.scheme != "http" or not parsed.hostname:
         raise ValueError("ENIGM_AGENT_URL must be a valid http://host[:port] URL.")
     if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ import os
 from difflib import get_close_matches
 from enum import Enum
 from typing import Literal
+from urllib.parse import urlparse
 
 from pydantic import Field, field_validator, model_validator
 
@@ -124,6 +125,53 @@ LLMProvider = Literal[
     "codex",
 ]
 
+_ENIGMAGENT_IGNORED_ERROR_CODES = frozenset({"not_found", "no_domain_binding", "domain_mismatch"})
+_PROVIDER_API_KEY_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "nvidia": "NVIDIA_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
+}
+
+
+def _resolve_enigmagent_api_key_overrides(provider: str, enigm_agent_url: str) -> dict[str, str]:
+    """Resolve provider-scoped LLM API key overrides from EnigmAgent when configured."""
+    env_var = _PROVIDER_API_KEY_ENV_VARS.get(provider)
+    if not env_var:
+        return {}
+
+    parsed = urlparse(enigm_agent_url)
+    if parsed.scheme != "http" or not parsed.hostname:
+        raise ValueError("ENIGM_AGENT_URL must be a valid http://host[:port] URL.")
+
+    try:
+        from enigmagent import VaultClient  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "ENIGM_AGENT_URL is set but the optional dependency 'enigmagent' is not installed. "
+            "Install OpenSRE with the 'enigmagent' extra."
+        ) from exc
+
+    client = VaultClient(
+        host=parsed.hostname,
+        port=parsed.port or 3737,
+        timeout=5.0,
+        origin="http://localhost",
+    )
+
+    try:
+        value = client.resolve(env_var, origin="http://localhost").strip()
+    except Exception as exc:
+        if getattr(exc, "code", None) in _ENIGMAGENT_IGNORED_ERROR_CODES:
+            return {}
+        raise RuntimeError(f"Failed to resolve {env_var} from ENIGM_AGENT_URL: {exc}") from exc
+
+    if not value:
+        return {}
+    return {env_var: value}
+
 
 class LLMSettings(StrictConfigModel):
     """Strict runtime configuration for selecting and authenticating an LLM provider."""
@@ -207,15 +255,24 @@ class LLMSettings(StrictConfigModel):
     @classmethod
     def from_env(cls) -> "LLMSettings":
         """Build validated LLM settings from environment variables."""
+        provider = os.getenv("LLM_PROVIDER", "anthropic").strip().lower() or "anthropic"
+        enigm_agent_url = os.getenv("ENIGM_AGENT_URL", "").strip()
+        enigm_overrides = (
+            _resolve_enigmagent_api_key_overrides(provider, enigm_agent_url) if enigm_agent_url else {}
+        )
+
+        def resolve_api_key(env_var: str) -> str:
+            return enigm_overrides.get(env_var) or resolve_llm_api_key(env_var)
+
         return cls.model_validate(
             {
-                "provider": os.getenv("LLM_PROVIDER", "anthropic").strip().lower() or "anthropic",
-                "anthropic_api_key": resolve_llm_api_key("ANTHROPIC_API_KEY"),
-                "openai_api_key": resolve_llm_api_key("OPENAI_API_KEY"),
-                "openrouter_api_key": resolve_llm_api_key("OPENROUTER_API_KEY"),
-                "gemini_api_key": resolve_llm_api_key("GEMINI_API_KEY"),
-                "nvidia_api_key": resolve_llm_api_key("NVIDIA_API_KEY"),
-                "minimax_api_key": resolve_llm_api_key("MINIMAX_API_KEY"),
+                "provider": provider,
+                "anthropic_api_key": resolve_api_key("ANTHROPIC_API_KEY"),
+                "openai_api_key": resolve_api_key("OPENAI_API_KEY"),
+                "openrouter_api_key": resolve_api_key("OPENROUTER_API_KEY"),
+                "gemini_api_key": resolve_api_key("GEMINI_API_KEY"),
+                "nvidia_api_key": resolve_api_key("NVIDIA_API_KEY"),
+                "minimax_api_key": resolve_api_key("MINIMAX_API_KEY"),
                 "anthropic_reasoning_model": os.getenv(
                     "ANTHROPIC_REASONING_MODEL", ANTHROPIC_REASONING_MODEL
                 ).strip()

--- a/app/config.py
+++ b/app/config.py
@@ -258,7 +258,9 @@ class LLMSettings(StrictConfigModel):
         provider = os.getenv("LLM_PROVIDER", "anthropic").strip().lower() or "anthropic"
         enigm_agent_url = os.getenv("ENIGM_AGENT_URL", "").strip()
         enigm_overrides = (
-            _resolve_enigmagent_api_key_overrides(provider, enigm_agent_url) if enigm_agent_url else {}
+            _resolve_enigmagent_api_key_overrides(provider, enigm_agent_url)
+            if enigm_agent_url
+            else {}
         )
 
         def resolve_api_key(env_var: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ postgresql = [
 azure_sql = [
     "pyodbc>=5.1.0,<6.0.0",
 ]
+enigmagent = [
+    "enigmagent>=1.0.0",
+]
 
 [tool.setuptools.packages.find]
 include = ["app*", "tests*"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,7 +62,9 @@ def test_llm_settings_from_env_uses_enigmagent_override(monkeypatch) -> None:
             }
             return "vault-openai-key"
 
-    monkeypatch.setitem(sys.modules, "enigmagent", types.SimpleNamespace(VaultClient=FakeVaultClient))
+    monkeypatch.setitem(
+        sys.modules, "enigmagent", types.SimpleNamespace(VaultClient=FakeVaultClient)
+    )
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("ENIGM_AGENT_URL", "http://127.0.0.1:3737")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+import types
+
 import pytest
 from pydantic import ValidationError
 
@@ -23,7 +26,12 @@ def test_llm_settings_require_api_key_for_selected_provider() -> None:
 
 def test_llm_settings_from_env_uses_secure_local_api_key(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.delenv("ENIGM_AGENT_URL", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "app.config._resolve_enigmagent_api_key_overrides",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
     monkeypatch.setattr(
         "app.config.resolve_llm_api_key",
         lambda env_var: "stored-secret" if env_var == "OPENAI_API_KEY" else "",
@@ -33,6 +41,49 @@ def test_llm_settings_from_env_uses_secure_local_api_key(monkeypatch) -> None:
 
     assert settings.provider == "openai"
     assert settings.openai_api_key == "stored-secret"
+
+
+def test_llm_settings_from_env_uses_enigmagent_override(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeVaultClient:
+        def __init__(self, host: str, port: int, timeout: float, origin: str) -> None:
+            seen["init"] = {
+                "host": host,
+                "port": port,
+                "timeout": timeout,
+                "origin": origin,
+            }
+
+        def resolve(self, placeholder: str, origin: str | None = None) -> str:
+            seen["resolve"] = {
+                "placeholder": placeholder,
+                "origin": origin,
+            }
+            return "vault-openai-key"
+
+    monkeypatch.setitem(sys.modules, "enigmagent", types.SimpleNamespace(VaultClient=FakeVaultClient))
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("ENIGM_AGENT_URL", "http://127.0.0.1:3737")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "stored-secret" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.openai_api_key == "vault-openai-key"
+    assert seen["init"] == {
+        "host": "127.0.0.1",
+        "port": 3737,
+        "timeout": 5.0,
+        "origin": "http://localhost",
+    }
+    assert seen["resolve"] == {
+        "placeholder": "OPENAI_API_KEY",
+        "origin": "http://localhost",
+    }
 
 
 def test_llm_settings_require_minimax_api_key() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,11 @@ from pydantic import ValidationError
 from app.config import LLMSettings
 
 
+@pytest.fixture(autouse=True)
+def _clear_enigm_agent_url(monkeypatch) -> None:
+    monkeypatch.delenv("ENIGM_AGENT_URL", raising=False)
+
+
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
     with pytest.raises(ValidationError, match="Did you mean 'openai'"):
         LLMSettings.model_validate(
@@ -26,12 +31,7 @@ def test_llm_settings_require_api_key_for_selected_provider() -> None:
 
 def test_llm_settings_from_env_uses_secure_local_api_key(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "openai")
-    monkeypatch.delenv("ENIGM_AGENT_URL", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setattr(
-        "app.config._resolve_enigmagent_api_key_overrides",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not be called")),
-    )
     monkeypatch.setattr(
         "app.config.resolve_llm_api_key",
         lambda env_var: "stored-secret" if env_var == "OPENAI_API_KEY" else "",
@@ -86,6 +86,22 @@ def test_llm_settings_from_env_uses_enigmagent_override(monkeypatch) -> None:
         "placeholder": "OPENAI_API_KEY",
         "origin": "http://localhost",
     }
+
+
+def test_llm_settings_from_env_rejects_non_local_plain_http_enigmagent_url(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("ENIGM_AGENT_URL", "http://vault.example.internal:3737")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "stored-secret" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="ENIGM_AGENT_URL only supports plain HTTP for localhost/127.0.0.1/::1",
+    ):
+        LLMSettings.from_env()
 
 
 def test_llm_settings_require_minimax_api_key() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,6 +88,36 @@ def test_llm_settings_from_env_uses_enigmagent_override(monkeypatch) -> None:
     }
 
 
+def test_llm_settings_from_env_enigmagent_ignored_errors_fallback(monkeypatch) -> None:
+    class MissingVaultSecretError(Exception):
+        code = "not_found"
+
+    class FakeVaultClient:
+        def __init__(self, host: str, port: int, timeout: float, origin: str) -> None:
+            pass
+
+        def resolve(self, placeholder: str, origin: str | None = None) -> str:
+            assert placeholder == "OPENAI_API_KEY"
+            assert origin == "http://localhost"
+            raise MissingVaultSecretError("secret is not available in EnigmAgent")
+
+    monkeypatch.setitem(
+        sys.modules, "enigmagent", types.SimpleNamespace(VaultClient=FakeVaultClient)
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("ENIGM_AGENT_URL", "http://127.0.0.1:3737")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "stored-secret" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    settings = LLMSettings.from_env()
+
+    assert settings.provider == "openai"
+    assert settings.openai_api_key == "stored-secret"
+
+
 def test_llm_settings_from_env_rejects_non_local_plain_http_enigmagent_url(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("ENIGM_AGENT_URL", "http://vault.example.internal:3737")


### PR DESCRIPTION
Fixes #769

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs

## What Changed
This PR implements the minimal first slice discussed in issue #769: an optional EnigmAgent-backed credential override for `LLMSettings.from_env()`.

Scope intentionally kept small and reviewable:
- add optional `ENIGM_AGENT_URL` handling inside `LLMSettings.from_env()`
- keep the path a complete no-op when `ENIGM_AGENT_URL` is unset
- add `enigmagent` as an optional dependency in `pyproject.toml`
- add two focused tests in `tests/test_config.py`

### Implementation details
- Added a small helper in `app/config.py` that:
  - parses `ENIGM_AGENT_URL`
  - lazily imports the optional `enigmagent` dependency
  - uses EnigmAgent's Python SDK client to resolve the selected provider API key
- The resolved value is merged into the config payload passed to `LLMSettings.model_validate()`.
- This does **not** mutate `os.environ`; the override is local to config construction.
- If `ENIGM_AGENT_URL` is absent, existing behavior is unchanged.

### SDK note
The issue body used pseudocode with `EnigmClient(...).resolve(scope=...)`, but the current Python SDK exposes `VaultClient` / `resolve(...)`. This PR follows the current SDK surface while preserving the requested minimal integration shape.

## Testing
Ran local validation in the worktree:
- ✅ `uv run pytest tests/test_config.py -q`
- ✅ `uv run make lint`
- ✅ `uv run make typecheck`
- ✅ `uv run make test-cov`

### Test coverage added
- no-op when `ENIGM_AGENT_URL` is absent
- override path when `ENIGM_AGENT_URL` is present and EnigmAgent returns a provider API key

## Impact Analysis
- **Backward compatible:** Yes
- **Default behavior changed when `ENIGM_AGENT_URL` is unset:** No
- **Environment mutation:** None
- **Scope:** limited to config construction + tests + optional dependency entry

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I intentionally kept this first PR limited to the smallest integration surface suggested in the issue discussion.

I considered two implementation styles:
1. mutate `os.environ` before normal resolution
2. resolve EnigmAgent values and merge them only into the `model_validate()` input

I chose option 2 because it keeps `LLMSettings.from_env()` free of global side effects and makes the behavior easier to test.

The change only affects the selected provider API-key resolution path when `ENIGM_AGENT_URL` is configured. Otherwise, `resolve_llm_api_key()` continues to behave exactly as before.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added corresponding tests
- [x] My code follows the project's style guidelines and conventions
