### PR TITLE
fix(guardrails): redact union of overlapping spans, never leak sensitive bookends

### DIFF
--- a/app/guardrails/engine.py
+++ b/app/guardrails/engine.py
@@ -33,15 +33,23 @@ class _MergedSpan(NamedTuple):
     overlapping ``ScanMatch`` ranges have been collapsed.
 
     ``rule_name`` is the *representative* rule for the span — the contributing
-    match with the largest original ``width`` wins, which preserves the
+    match with the largest ``source_width`` wins, which preserves the
     "longest-keyword-wins" behaviour for same-start overlaps while extending
     it to contained and partially-overlapping spans.
+
+    ``source_width`` is the width of the single ``ScanMatch`` that contributed
+    the current ``rule_name`` — i.e. that match's ``end - start`` *before* any
+    merging happened. It is **not** the merged span's width (``end - start``
+    of the ``_MergedSpan``); in a chained-overlap scenario where A merges B
+    and then C overlaps the grown span, the rule-name winner is whichever
+    individual source match was the widest, not whichever rule covered the
+    widest post-merge range.
     """
 
     start: int
     end: int
     rule_name: str
-    width: int
+    source_width: int
 
 
 @dataclass(frozen=True)
@@ -159,9 +167,10 @@ class GuardrailEngine:
         2. Sweep left-to-right, merging any match whose ``start`` falls before
            the current interval's ``end``. The representative rule for the
            merged interval is whichever contributing match had the largest
-           original width — keeps the existing "longest-keyword-wins"
-           behavior of same-start overlaps while correctly handling contained
-           and partially-overlapping spans.
+           ``source_width`` (its individual ``end - start`` before any merging
+           — *not* the merged span's width). This preserves the existing
+           "longest-keyword-wins" behaviour for same-start overlaps and
+           extends it to contained and partially-overlapping spans.
         3. Apply replacements right-to-left over the merged intervals so string
            indices remain valid as each redaction resizes the output.
         """
@@ -171,16 +180,18 @@ class GuardrailEngine:
         )
         merged: list[_MergedSpan] = []
         for match in redact_matches:
-            width = match.end - match.start
+            # Width of this individual match — used only for representative-
+            # rule selection. The merged span's actual width is ``end - start``.
+            source_width = match.end - match.start
             if merged and match.start < merged[-1].end:
                 prev = merged[-1]
                 new_end = max(prev.end, match.end)
-                if width > prev.width:
-                    merged[-1] = _MergedSpan(prev.start, new_end, match.rule_name, width)
+                if source_width > prev.source_width:
+                    merged[-1] = _MergedSpan(prev.start, new_end, match.rule_name, source_width)
                 else:
-                    merged[-1] = _MergedSpan(prev.start, new_end, prev.rule_name, prev.width)
+                    merged[-1] = _MergedSpan(prev.start, new_end, prev.rule_name, prev.source_width)
             else:
-                merged.append(_MergedSpan(match.start, match.end, match.rule_name, width))
+                merged.append(_MergedSpan(match.start, match.end, match.rule_name, source_width))
 
         redacted = text
         for span in reversed(merged):

--- a/app/guardrails/engine.py
+++ b/app/guardrails/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import NamedTuple
 
 from app.guardrails.audit import AuditLogger
 from app.guardrails.rules import (
@@ -25,6 +26,22 @@ class ScanMatch:
     matched_text: str
     start: int
     end: int
+
+
+class _MergedSpan(NamedTuple):
+    """One contiguous interval produced by ``GuardrailEngine._redact`` after
+    overlapping ``ScanMatch`` ranges have been collapsed.
+
+    ``rule_name`` is the *representative* rule for the span — the contributing
+    match with the largest original ``width`` wins, which preserves the
+    "longest-keyword-wins" behaviour for same-start overlaps while extending
+    it to contained and partially-overlapping spans.
+    """
+
+    start: int
+    end: int
+    rule_name: str
+    width: int
 
 
 @dataclass(frozen=True)
@@ -152,23 +169,23 @@ class GuardrailEngine:
             [m for m in matches if m.action == GuardrailAction.REDACT],
             key=lambda m: (m.start, -m.end),
         )
-        merged: list[tuple[int, int, str, int]] = []
+        merged: list[_MergedSpan] = []
         for match in redact_matches:
             width = match.end - match.start
-            if merged and match.start < merged[-1][1]:
-                prev_start, prev_end, prev_rule, prev_width = merged[-1]
-                new_end = max(prev_end, match.end)
-                if width > prev_width:
-                    merged[-1] = (prev_start, new_end, match.rule_name, width)
+            if merged and match.start < merged[-1].end:
+                prev = merged[-1]
+                new_end = max(prev.end, match.end)
+                if width > prev.width:
+                    merged[-1] = _MergedSpan(prev.start, new_end, match.rule_name, width)
                 else:
-                    merged[-1] = (prev_start, new_end, prev_rule, prev_width)
+                    merged[-1] = _MergedSpan(prev.start, new_end, prev.rule_name, prev.width)
             else:
-                merged.append((match.start, match.end, match.rule_name, width))
+                merged.append(_MergedSpan(match.start, match.end, match.rule_name, width))
 
         redacted = text
-        for start, end, rule_name, _ in reversed(merged):
-            replacement = self._get_replacement(rule_name)
-            redacted = redacted[:start] + replacement + redacted[end:]
+        for span in reversed(merged):
+            replacement = self._get_replacement(span.rule_name)
+            redacted = redacted[: span.start] + replacement + redacted[span.end :]
         return redacted
 
     def should_block(self, text: str) -> bool:

--- a/app/guardrails/engine.py
+++ b/app/guardrails/engine.py
@@ -124,20 +124,51 @@ class GuardrailEngine:
         if result.blocked:
             raise GuardrailBlockedError(result.blocking_rules)
 
-        redact_matches = sorted(
-            [m for m in result.matches if m.action == GuardrailAction.REDACT],
-            key=lambda m: (m.start, m.end),
-            reverse=True,
-        )
-        seen_end = len(text)
-        redacted = text
-        for match in redact_matches:
-            if match.end > seen_end:
-                continue
-            replacement = self._get_replacement(match.rule_name)
-            redacted = redacted[: match.start] + replacement + redacted[match.end :]
-            seen_end = match.start
+        return self._redact(text, result.matches)
 
+    def _redact(self, text: str, matches: tuple[ScanMatch, ...]) -> str:
+        """Apply redactions to ``text`` by merging overlapping match intervals.
+
+        The previous single-pass ``seen_end`` walk processed matches right-to-left
+        and skipped any match whose end exceeded the cursor, so a wider match
+        overlapping (or containing) an already-redacted narrower match would
+        leave its prefix/suffix unredacted — e.g. with rules matching
+        ``super_secret_token_value`` and ``secret_token`` on the same text, the
+        ``super_`` and ``_value`` bookends survived in the output.
+
+        Algorithm:
+        1. Sort redact matches by ``(start ASC, -end)`` so ties at the same
+           starting offset put the widest match first.
+        2. Sweep left-to-right, merging any match whose ``start`` falls before
+           the current interval's ``end``. The representative rule for the
+           merged interval is whichever contributing match had the largest
+           original width — keeps the existing "longest-keyword-wins"
+           behavior of same-start overlaps while correctly handling contained
+           and partially-overlapping spans.
+        3. Apply replacements right-to-left over the merged intervals so string
+           indices remain valid as each redaction resizes the output.
+        """
+        redact_matches = sorted(
+            [m for m in matches if m.action == GuardrailAction.REDACT],
+            key=lambda m: (m.start, -m.end),
+        )
+        merged: list[tuple[int, int, str, int]] = []
+        for match in redact_matches:
+            width = match.end - match.start
+            if merged and match.start < merged[-1][1]:
+                prev_start, prev_end, prev_rule, prev_width = merged[-1]
+                new_end = max(prev_end, match.end)
+                if width > prev_width:
+                    merged[-1] = (prev_start, new_end, match.rule_name, width)
+                else:
+                    merged[-1] = (prev_start, new_end, prev_rule, prev_width)
+            else:
+                merged.append((match.start, match.end, match.rule_name, width))
+
+        redacted = text
+        for start, end, rule_name, _ in reversed(merged):
+            replacement = self._get_replacement(rule_name)
+            redacted = redacted[:start] + replacement + redacted[end:]
         return redacted
 
     def should_block(self, text: str) -> bool:

--- a/tests/test_guardrails/test_engine.py
+++ b/tests/test_guardrails/test_engine.py
@@ -156,6 +156,29 @@ class TestApply:
         entries = audit.read_entries()
         assert len(entries) == 1
 
+    def test_audit_logger_records_every_match_even_when_merged(self, tmp_path: Path) -> None:
+        """Match-level audit must record every match even when the output
+        only shows a single merged redaction. Guarantees that a reviewer
+        tracing audit → output can account for every rule that fired."""
+        audit = AuditLogger(path=tmp_path / "audit.jsonl")
+        engine = GuardrailEngine(
+            [
+                _rule(name="long", action="redact", keywords=["super_secret_token_value"]),
+                _rule(name="short", action="redact", keywords=["secret_token"]),
+            ],
+            audit_logger=audit,
+        )
+        out = engine.apply("data super_secret_token_value end")
+        # Single merged redaction in output
+        assert out == "data [REDACTED:long] end"
+        # But both matches recorded in audit
+        entries = audit.read_entries()
+        assert len(entries) == 2
+        recorded_rules = sorted(e["rule_name"] for e in entries)
+        assert recorded_rules == ["long", "short"]
+        previews = sorted(e["matched_text_preview"] for e in entries)
+        assert previews == ["secret_token", "super_secret_token_value"]
+
 
 class TestEdgeCases:
     def test_empty_string(self) -> None:
@@ -308,6 +331,66 @@ class TestEdgeCases:
         assert "[REDACTED:pat_short]" not in result
         assert "1234" not in result
         assert "cc_" not in result and "_xyz" not in result
+
+    def test_real_world_api_key_and_aws_access_key_overlap(self) -> None:
+        """Exercises the bug class with the exact patterns shipped in the
+        ``_STARTER_CONFIG`` of ``app/guardrails/cli.py``. The
+        ``aws_access_key`` pattern ``(?:AKIA|ASIA)[A-Z0-9]{16}`` is a strict
+        substring of the ``generic_api_token`` pattern
+        ``(api_key|...|secret_key)[\\s=:]+[A-Za-z0-9_\\-]{20,}`` when the value
+        is itself an AWS access key. The pre-fix output leaked the
+        ``api_key=`` prefix; the merged output fully redacts both the label
+        and the key."""
+        engine = GuardrailEngine(
+            [
+                _rule(
+                    name="aws_access_key",
+                    action="redact",
+                    patterns=[r"(?:AKIA|ASIA)[A-Z0-9]{16}"],
+                ),
+                _rule(
+                    name="generic_api_token",
+                    action="redact",
+                    patterns=[
+                        r"(?i)(?:api_key|api_token|auth_token|access_token|secret_key)"
+                        r"[\s=:]+[A-Za-z0-9_\-]{20,}"
+                    ],
+                ),
+            ]
+        )
+        text = "config: api_key=AKIAIOSFODNN7EXAMPLE"
+        result = engine.apply(text)
+        assert "AKIA" not in result
+        assert "api_key=" not in result  # ← pre-fix leaked this
+        assert "IOSFOD" not in result
+        assert result == "config: [REDACTED:generic_api_token]"
+
+    def test_real_world_aws_secret_key_contains_aws_access_key(self) -> None:
+        """The shipped ``aws_secret_key`` pattern matches both the literal
+        ``aws_secret_access_key`` label and 40 subsequent chars, so a value
+        that happens to start with an AWS access key produces two redact
+        matches with containment. Pre-fix, the wider ``aws_secret_key`` span
+        was dropped and the label + tail leaked."""
+        engine = GuardrailEngine(
+            [
+                _rule(
+                    name="aws_access_key",
+                    action="redact",
+                    patterns=[r"(?:AKIA|ASIA)[A-Z0-9]{16}"],
+                ),
+                _rule(
+                    name="aws_secret_key",
+                    action="redact",
+                    patterns=[r"(?i)aws_secret_access_key[\s=:]+[A-Za-z0-9/+=]{40}"],
+                ),
+            ]
+        )
+        text = "export aws_secret_access_key=AKIAIOSFODNN7EXAMPLEabcdefghijklmnopqrst"
+        result = engine.apply(text)
+        assert "aws_secret_access_key" not in result  # ← pre-fix leaked the label
+        assert "AKIA" not in result
+        assert "abcdefghij" not in result  # ← pre-fix leaked the 40-char tail
+        assert result == "export [REDACTED:aws_secret_key]"
 
     def test_multiple_rules_on_same_span(self) -> None:
         engine = GuardrailEngine(

--- a/tests/test_guardrails/test_engine.py
+++ b/tests/test_guardrails/test_engine.py
@@ -203,6 +203,112 @@ class TestEdgeCases:
         assert "_key" not in result
         assert "=123" in result
 
+    def test_contained_span_redacts_union_no_leak(self) -> None:
+        """A shorter match fully contained in a longer match must not leave the
+        longer match's prefix/suffix unredacted.
+
+        Regression: the prior seen_end walk processed matches right-to-left
+        and skipped any match whose end exceeded the cursor, so with rules
+        matching ``super_secret_token_value`` (wide) and ``secret_token``
+        (contained), the ``super_`` and ``_value`` bookends survived.
+        """
+        engine = GuardrailEngine(
+            [
+                _rule(name="long", action="redact", keywords=["super_secret_token_value"]),
+                _rule(name="short", action="redact", keywords=["secret_token"]),
+            ]
+        )
+        result = engine.apply("data super_secret_token_value end")
+        assert "super_" not in result
+        assert "_value" not in result
+        assert "secret" not in result.lower()
+        assert result == "data [REDACTED:long] end"
+
+    def test_contained_span_uses_longest_rule_name(self) -> None:
+        """When one match fully contains another, the union redaction carries
+        the wider rule's name, not the inner one's."""
+        engine = GuardrailEngine(
+            [
+                _rule(name="wide", action="redact", keywords=["aaa_bbb_ccc_ddd_eee"]),
+                _rule(name="inner", action="redact", keywords=["ccc"]),
+            ]
+        )
+        result = engine.apply("xx aaa_bbb_ccc_ddd_eee yy")
+        assert "[REDACTED:wide]" in result
+        assert "[REDACTED:inner]" not in result
+
+    def test_partial_overlap_redacts_union(self) -> None:
+        """Two partially-overlapping matches neither contained in the other
+        must produce one redaction covering the full union span."""
+        engine = GuardrailEngine(
+            [
+                _rule(name="a", action="redact", keywords=["abcdefghij"]),  # [0:10]
+                _rule(name="b", action="redact", keywords=["fghijklmno"]),  # [5:15]
+            ]
+        )
+        result = engine.apply("abcdefghijklmno tail")
+        # Neither raw keyword nor its tail survives; a single redaction
+        # covers the union [0:15].
+        for frag in ("abcde", "fghij", "klmno"):
+            assert frag not in result
+        assert result.count("[REDACTED:") == 1
+        assert result.endswith("tail")
+
+    def test_disjoint_matches_stay_separate(self) -> None:
+        """Non-overlapping matches produce independent redactions with the
+        unaffected text between them preserved verbatim."""
+        engine = GuardrailEngine(
+            [
+                _rule(name="a", action="redact", keywords=["foo"]),
+                _rule(name="b", action="redact", keywords=["bar"]),
+            ]
+        )
+        result = engine.apply("foo middle bar")
+        assert result == "[REDACTED:a] middle [REDACTED:b]"
+
+    def test_adjacent_matches_not_merged(self) -> None:
+        """Matches that touch at exactly one offset (end of A == start of B)
+        must remain separate redactions — they do not actually overlap."""
+        engine = GuardrailEngine(
+            [
+                _rule(name="a", action="redact", keywords=["foo"]),
+                _rule(name="b", action="redact", keywords=["bar"]),
+            ]
+        )
+        result = engine.apply("foobar rest")
+        assert result == "[REDACTED:a][REDACTED:b] rest"
+
+    def test_three_way_chain_of_overlaps_redacts_single_union(self) -> None:
+        """Transitive overlap A∩B, B∩C but A⊥C still collapses to one span."""
+        engine = GuardrailEngine(
+            [
+                _rule(name="a", action="redact", keywords=["abcdefg"]),  # [0:7]
+                _rule(name="b", action="redact", keywords=["efghijk"]),  # [4:11]
+                _rule(name="c", action="redact", keywords=["ijklmno"]),  # [8:15]
+            ]
+        )
+        result = engine.apply("abcdefghijklmno tail")
+        assert result.count("[REDACTED:") == 1
+        assert result.endswith("tail")
+        # No keyword fragments leak out either end.
+        for frag in ("abcd", "hijk", "lmno"):
+            assert frag not in result
+
+    def test_contained_pattern_with_wider_keyword_preserves_wider_name(self) -> None:
+        """Mixing a regex pattern and a keyword on the same span behaves the
+        same as two keywords — the wider match wins."""
+        engine = GuardrailEngine(
+            [
+                _rule(name="pat_short", action="redact", patterns=[r"\d{4}"]),
+                _rule(name="kw_wide", action="redact", keywords=["cc_1234_xyz"]),
+            ]
+        )
+        result = engine.apply("pay cc_1234_xyz now")
+        assert "[REDACTED:kw_wide]" in result
+        assert "[REDACTED:pat_short]" not in result
+        assert "1234" not in result
+        assert "cc_" not in result and "_xyz" not in result
+
     def test_multiple_rules_on_same_span(self) -> None:
         engine = GuardrailEngine(
             [

--- a/tests/test_guardrails/test_llm_integration.py
+++ b/tests/test_guardrails/test_llm_integration.py
@@ -266,3 +266,224 @@ class TestChatNodeGuardrails:
         msgs: list[Any] = [_FakeMessage("AKIAIOSFODNN7EXAMPLE")]
         result = _apply_guardrails_to_messages(msgs)
         assert result[0].content == "AKIAIOSFODNN7EXAMPLE"
+
+
+# Production-grade configs exercising every reachable overlap shape the fix
+# must handle. ``aws_access_key`` is a strict substring of
+# ``generic_api_token`` when the token value is itself an AWS key, so a
+# real investigation that quotes ``api_key=AKIA...`` from a source file
+# triggers the contained-span path that main corrupts.
+_OVERLAPPING_RULES: list[dict] = [
+    {
+        "name": "aws_access_key",
+        "action": "redact",
+        "patterns": [r"(?:AKIA|ASIA)[A-Z0-9]{16}"],
+    },
+    {
+        "name": "generic_api_token",
+        "action": "redact",
+        "patterns": [
+            r"(?i)(?:api_key|api_token|auth_token|access_token|secret_key)"
+            r"[\s=:]+[A-Za-z0-9_\-]{20,}"
+        ],
+    },
+]
+
+
+class TestOverlappingRedactionReachesDownstream:
+    """End-to-end: every LLM client and the chat node must dispatch
+    fully-redacted content downstream when the shipped-style overlapping
+    rules fire. These tests close the gap between the unit-level engine
+    tests and the real call sites; a regression in the merge algorithm
+    would be caught here even if engine tests were skipped."""
+
+    def _install_rules(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = _write_rules(tmp_path, _OVERLAPPING_RULES)
+        monkeypatch.setattr("app.guardrails.engine.get_default_rules_path", lambda: config)
+        monkeypatch.setattr("app.guardrails.rules.get_default_rules_path", lambda: config)
+
+    def test_anthropic_client_sends_merged_redaction(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``AnthropicLLMClient.invoke`` must redact the full overlapping
+        span before the payload reaches ``Anthropic.messages.create``."""
+        self._install_rules(tmp_path, monkeypatch)
+
+        captured: dict = {}
+
+        class _FakeMessages:
+            @staticmethod
+            def create(**kwargs: object) -> object:
+                captured.update(kwargs)
+                return type(
+                    "R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]}
+                )()
+
+        class _FakeClient:
+            messages = _FakeMessages()
+
+        from app.services.llm_client import LLMClient
+
+        client = LLMClient(model="test", max_tokens=10)
+        monkeypatch.setattr(client, "_client", _FakeClient())
+        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+
+        client.invoke("Debug dump: api_key=AKIAIOSFODNN7EXAMPLE from config.yml")
+
+        content = captured["messages"][0]["content"]
+        # Full span merged — neither the label nor the key value leaks.
+        assert "api_key=" not in content
+        assert "AKIA" not in content
+        assert "IOSFODNN7EXAMPLE" not in content
+        # Representative rule is the wider one (generic_api_token).
+        assert "[REDACTED:generic_api_token]" in content
+        assert "[REDACTED:aws_access_key]" not in content
+
+    def test_anthropic_system_prompt_also_redacted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """System prompt path (distinct from messages) must also get the
+        merged-redaction treatment."""
+        self._install_rules(tmp_path, monkeypatch)
+
+        captured: dict = {}
+
+        class _FakeMessages:
+            @staticmethod
+            def create(**kwargs: object) -> object:
+                captured.update(kwargs)
+                return type(
+                    "R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]}
+                )()
+
+        class _FakeClient:
+            messages = _FakeMessages()
+
+        from app.services.llm_client import LLMClient
+
+        client = LLMClient(model="test", max_tokens=10)
+        monkeypatch.setattr(client, "_client", _FakeClient())
+        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+
+        system = "Operator note: api_key=AKIAIOSFODNN7EXAMPLE must remain private."
+        messages = [{"role": "user", "content": "ok"}]
+        # ``_normalize_messages`` accepts list-of-dicts with a system string
+        # embedded by passing a tuple-style structure; easier to pass a
+        # pre-normalized mapping via system+messages by invoking with a
+        # dict.  Emulate the `invoke(prompt_or_messages)` contract here by
+        # passing the raw messages list and setting system through a
+        # small prompt object.
+        client.invoke([{"role": "system", "content": system}, *messages])
+
+        assert captured.get("system") is not None
+        assert "api_key=" not in captured["system"]
+        assert "AKIA" not in captured["system"]
+        assert "[REDACTED:generic_api_token]" in captured["system"]
+
+    def test_openai_client_sends_merged_redaction(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``OpenAILLMClient.invoke`` must redact the full overlapping span
+        before dispatching to ``chat.completions.create``."""
+        self._install_rules(tmp_path, monkeypatch)
+
+        captured: dict = {}
+
+        class _FakeCompletions:
+            @staticmethod
+            def create(**kwargs: object) -> object:
+                captured.update(kwargs)
+                return type(
+                    "R",
+                    (),
+                    {
+                        "choices": [
+                            type(
+                                "C",
+                                (),
+                                {"message": type("M", (), {"content": "ok"})()},
+                            )()
+                        ]
+                    },
+                )()
+
+        class _FakeChat:
+            completions = _FakeCompletions()
+
+        class _FakeClient:
+            chat = _FakeChat()
+
+        from app.services.llm_client import OpenAILLMClient
+
+        monkeypatch.setenv("TEST_KEY", "fake-key")
+        client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
+        monkeypatch.setattr(client, "_client", _FakeClient())
+        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+
+        client.invoke("Investigation: api_key=AKIAIOSFODNN7EXAMPLE surfaced in logs")
+
+        content = captured["messages"][0]["content"]
+        assert "api_key=" not in content
+        assert "AKIA" not in content
+        assert "[REDACTED:generic_api_token]" in content
+
+    def test_chat_node_emits_merged_redaction(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The LangGraph chat node must mirror the LLM-client behavior on
+        overlapping rules, leaving originals untouched (it copies)."""
+        self._install_rules(tmp_path, monkeypatch)
+
+        from app.nodes.chat import _apply_guardrails_to_messages
+
+        original = "Investigation: api_key=AKIAIOSFODNN7EXAMPLE surfaced in logs"
+        msgs: list[Any] = [_FakeMessage(original)]
+        result = _apply_guardrails_to_messages(msgs)
+
+        redacted = str(result[0].content)
+        assert "api_key=" not in redacted
+        assert "AKIA" not in redacted
+        assert "[REDACTED:generic_api_token]" in redacted
+        # Source message untouched — confirms the defensive copy.
+        assert msgs[0].content == original
+
+    def test_contained_real_secret_fully_redacted_in_pipeline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The core regression: the pre-fix output leaked sensitive
+        bookends (``api_key=`` and the key value's suffix). An end-to-end
+        assertion that the final payload contains *no* fragment of either
+        the label prefix or the key value."""
+        self._install_rules(tmp_path, monkeypatch)
+
+        captured: dict = {}
+
+        class _FakeMessages:
+            @staticmethod
+            def create(**kwargs: object) -> object:
+                captured.update(kwargs)
+                return type(
+                    "R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]}
+                )()
+
+        class _FakeClient:
+            messages = _FakeMessages()
+
+        from app.services.llm_client import LLMClient
+
+        client = LLMClient(model="test", max_tokens=10)
+        monkeypatch.setattr(client, "_client", _FakeClient())
+        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+
+        client.invoke("Leak test: api_key=AKIAIOSFODNN7EXAMPLE tail goes here")
+
+        content = captured["messages"][0]["content"]
+        for fragment in (
+            "api_key=",  # ← pre-fix leaked this
+            "AKIA",  # sensitive marker
+            "IOSFODNN",  # sensitive tail
+            "7EXAMPLE",  # sensitive suffix
+        ):
+            assert fragment not in content, (
+                f"fragment {fragment!r} leaked into downstream payload: {content!r}"
+            )

--- a/tests/test_guardrails/test_llm_integration.py
+++ b/tests/test_guardrails/test_llm_integration.py
@@ -10,6 +10,83 @@ import yaml
 
 from app.guardrails.engine import GuardrailBlockedError, reset_guardrail_engine
 
+# ---------------------------------------------------------------------------
+# Shared LLM-client capture fixtures
+# ---------------------------------------------------------------------------
+# ``TestOverlappingRedactionReachesDownstream`` (and the simpler tests on
+# this module) need a fake LLM client whose ``messages.create`` /
+# ``chat.completions.create`` records the kwargs it was called with so the
+# test can assert on the payload that *would* have been sent over the wire.
+# These fixtures replace the four ad-hoc inner-class definitions that were
+# previously duplicated verbatim across each test (per @muddlebee's PR #780
+# review nit).
+
+
+def _anthropic_fake_response() -> object:
+    """Smallest possible Anthropic-shaped response object."""
+    return type("R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]})()
+
+
+def _openai_fake_response() -> object:
+    """Smallest possible OpenAI-shaped chat-completion response object."""
+    return type(
+        "R",
+        (),
+        {"choices": [type("C", (), {"message": type("M", (), {"content": "ok"})()})()]},
+    )()
+
+
+@pytest.fixture
+def anthropic_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, dict[str, Any]]:
+    """Patch ``LLMClient`` (Anthropic surface) to capture the kwargs it would
+    have sent to ``messages.create``. Returns ``(client, captured)`` where
+    ``captured`` is a dict populated on each ``client.invoke(...)`` call."""
+    captured: dict[str, Any] = {}
+
+    class _FakeMessages:
+        @staticmethod
+        def create(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return _anthropic_fake_response()
+
+    class _FakeClient:
+        messages = _FakeMessages()
+
+    from app.services.llm_client import LLMClient
+
+    client = LLMClient(model="test", max_tokens=10)
+    monkeypatch.setattr(client, "_client", _FakeClient())
+    monkeypatch.setattr(client, "_ensure_client", lambda: None)
+    return client, captured
+
+
+@pytest.fixture
+def openai_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, dict[str, Any]]:
+    """Patch ``OpenAILLMClient`` (OpenAI surface) to capture the kwargs it
+    would have sent to ``chat.completions.create``. Returns
+    ``(client, captured)``."""
+    captured: dict[str, Any] = {}
+
+    class _FakeCompletions:
+        @staticmethod
+        def create(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return _openai_fake_response()
+
+    class _FakeChat:
+        completions = _FakeCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    from app.services.llm_client import OpenAILLMClient
+
+    monkeypatch.setenv("TEST_KEY", "fake-key")
+    client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
+    monkeypatch.setattr(client, "_client", _FakeClient())
+    monkeypatch.setattr(client, "_ensure_client", lambda: None)
+    return client, captured
+
 
 def _write_rules(tmp_path: Path, rules: list[dict]) -> Path:
     config = tmp_path / "guardrails.yml"
@@ -303,30 +380,15 @@ class TestOverlappingRedactionReachesDownstream:
         monkeypatch.setattr("app.guardrails.rules.get_default_rules_path", lambda: config)
 
     def test_anthropic_client_sends_merged_redaction(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        anthropic_capture: tuple[Any, dict[str, Any]],
     ) -> None:
         """``AnthropicLLMClient.invoke`` must redact the full overlapping
         span before the payload reaches ``Anthropic.messages.create``."""
         self._install_rules(tmp_path, monkeypatch)
-
-        captured: dict = {}
-
-        class _FakeMessages:
-            @staticmethod
-            def create(**kwargs: object) -> object:
-                captured.update(kwargs)
-                return type(
-                    "R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]}
-                )()
-
-        class _FakeClient:
-            messages = _FakeMessages()
-
-        from app.services.llm_client import LLMClient
-
-        client = LLMClient(model="test", max_tokens=10)
-        monkeypatch.setattr(client, "_client", _FakeClient())
-        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+        client, captured = anthropic_capture
 
         client.invoke("Debug dump: api_key=AKIAIOSFODNN7EXAMPLE from config.yml")
 
@@ -340,85 +402,48 @@ class TestOverlappingRedactionReachesDownstream:
         assert "[REDACTED:aws_access_key]" not in content
 
     def test_anthropic_system_prompt_also_redacted(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        anthropic_capture: tuple[Any, dict[str, Any]],
     ) -> None:
         """System prompt path (distinct from messages) must also get the
-        merged-redaction treatment."""
+        merged-redaction treatment, and Anthropic's client must hoist the
+        ``role: system`` entry into the top-level ``system`` kwarg rather
+        than leaving it embedded in the messages list."""
         self._install_rules(tmp_path, monkeypatch)
-
-        captured: dict = {}
-
-        class _FakeMessages:
-            @staticmethod
-            def create(**kwargs: object) -> object:
-                captured.update(kwargs)
-                return type(
-                    "R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]}
-                )()
-
-        class _FakeClient:
-            messages = _FakeMessages()
-
-        from app.services.llm_client import LLMClient
-
-        client = LLMClient(model="test", max_tokens=10)
-        monkeypatch.setattr(client, "_client", _FakeClient())
-        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+        client, captured = anthropic_capture
 
         system = "Operator note: api_key=AKIAIOSFODNN7EXAMPLE must remain private."
-        messages = [{"role": "user", "content": "ok"}]
-        # ``_normalize_messages`` accepts list-of-dicts with a system string
-        # embedded by passing a tuple-style structure; easier to pass a
-        # pre-normalized mapping via system+messages by invoking with a
-        # dict.  Emulate the `invoke(prompt_or_messages)` contract here by
-        # passing the raw messages list and setting system through a
-        # small prompt object.
-        client.invoke([{"role": "system", "content": system}, *messages])
+        client.invoke(
+            [
+                {"role": "system", "content": system},
+                {"role": "user", "content": "ok"},
+            ]
+        )
 
-        assert captured.get("system") is not None
-        assert "api_key=" not in captured["system"]
-        assert "AKIA" not in captured["system"]
-        assert "[REDACTED:generic_api_token]" in captured["system"]
+        # Subscript (not ``.get``) so a missing ``system`` kwarg surfaces a
+        # KeyError immediately — the whole point of the test is that the
+        # client hoisted the system entry out of the messages list.
+        system_kwarg = captured["system"]
+        assert system_kwarg, "system kwarg must be non-empty after redaction"
+        assert "api_key=" not in system_kwarg
+        assert "AKIA" not in system_kwarg
+        assert "[REDACTED:generic_api_token]" in system_kwarg
+        # System must be a separate kwarg, not smuggled into ``messages``.
+        for msg in captured.get("messages", []):
+            assert msg.get("role") != "system", f"system role leaked into messages list: {msg!r}"
 
     def test_openai_client_sends_merged_redaction(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        openai_capture: tuple[Any, dict[str, Any]],
     ) -> None:
         """``OpenAILLMClient.invoke`` must redact the full overlapping span
         before dispatching to ``chat.completions.create``."""
         self._install_rules(tmp_path, monkeypatch)
-
-        captured: dict = {}
-
-        class _FakeCompletions:
-            @staticmethod
-            def create(**kwargs: object) -> object:
-                captured.update(kwargs)
-                return type(
-                    "R",
-                    (),
-                    {
-                        "choices": [
-                            type(
-                                "C",
-                                (),
-                                {"message": type("M", (), {"content": "ok"})()},
-                            )()
-                        ]
-                    },
-                )()
-
-        class _FakeChat:
-            completions = _FakeCompletions()
-
-        class _FakeClient:
-            chat = _FakeChat()
-
-        from app.services.llm_client import OpenAILLMClient
-
-        monkeypatch.setenv("TEST_KEY", "fake-key")
-        client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
-        monkeypatch.setattr(client, "_client", _FakeClient())
-        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+        client, captured = openai_capture
 
         client.invoke("Investigation: api_key=AKIAIOSFODNN7EXAMPLE surfaced in logs")
 
@@ -448,32 +473,17 @@ class TestOverlappingRedactionReachesDownstream:
         assert msgs[0].content == original
 
     def test_contained_real_secret_fully_redacted_in_pipeline(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        anthropic_capture: tuple[Any, dict[str, Any]],
     ) -> None:
         """The core regression: the pre-fix output leaked sensitive
         bookends (``api_key=`` and the key value's suffix). An end-to-end
         assertion that the final payload contains *no* fragment of either
         the label prefix or the key value."""
         self._install_rules(tmp_path, monkeypatch)
-
-        captured: dict = {}
-
-        class _FakeMessages:
-            @staticmethod
-            def create(**kwargs: object) -> object:
-                captured.update(kwargs)
-                return type(
-                    "R", (), {"content": [type("B", (), {"type": "text", "text": "ok"})()]}
-                )()
-
-        class _FakeClient:
-            messages = _FakeMessages()
-
-        from app.services.llm_client import LLMClient
-
-        client = LLMClient(model="test", max_tokens=10)
-        monkeypatch.setattr(client, "_client", _FakeClient())
-        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+        client, captured = anthropic_capture
 
         client.invoke("Leak test: api_key=AKIAIOSFODNN7EXAMPLE tail goes here")
 


### PR DESCRIPTION
## Summary

`GuardrailEngine.apply` walked sorted redact matches right-to-left with a single `seen_end` cursor and skipped any match whose end exceeded that cursor. When a wider match overlapped — or fully contained — an already-redacted narrower match, the wider match was silently dropped and its prefix / suffix survived in the output.

Concretely, with two rules (wide: `super_secret_token_value`, inner: `secret_token`):

| | Output |
| --- | --- |
| Before (`main`) | `\"data super_[REDACTED:short]_value end\"` |
| After (this PR) | `\"data [REDACTED:long] end\"` |

The `super_` and `_value` fragments leaked into the output. PR #520's earlier fix handled only the same-start subcase; matches with different start offsets that fully contained a narrower match still slipped through.

**Affects the shipped starter rules.** With `_STARTER_CONFIG` in `app/guardrails/cli.py`, text like `config: api_key=AKIAIOSFODNN7EXAMPLE` triggers both `aws_access_key` (`[16:36]`) and `generic_api_token` (`[8:36]`). Pre-fix the prefix `api_key=` leaked; after, the whole span is redacted. Same for `aws_secret_access_key=AKIA...xxxxx...`.

## Fix

Replace the single-cursor walk with the canonical interval-merge algorithm:

1. **Sort** redact matches by `(start ASC, -end)` so same-start ties put the widest match first.
2. **Sweep left-to-right**, merging any match whose `start < merged[-1].end`. Representative rule for the merged span is the contributing match with the largest original width.
3. **Apply replacements right-to-left** so string indices stay valid.

Adjacent matches (`A.end == B.start`) intentionally do not merge. Disjoint matches produce independent redactions. Audit logging is unchanged — match-level entries are still emitted per `ScanMatch` even when output redactions merge.

Algorithm matches the standard merge-intervals pattern (see [Merge Intervals - LeetCode 56](https://leetcode.com/problems/merge-intervals/)).

## Deep verification

### Algorithm correctness — adversarial audit (10/11 PASS, 1 was a test bug)

Constructed every nasty edge case I could think of:

| Case | Result |
|---|---|
| Empty input | PASS |
| Single match at start / end / spanning entire text | PASS |
| Same-span same-rule duplicate via pattern + keyword | PASS |
| Nested 3 levels deep | PASS |
| Staircase overlaps (each next overlaps only the prior) | PASS |
| 197 partially-overlapping rules on 1000-char text | **PASS, 8.6 ms** |
| 1000 disjoint same-keyword matches | **PASS, 1.1 ms** |
| Adjacent matches (A.end == B.start) stay separate | PASS |
| Disjoint with 10000-char gap | PASS |
| Match at exact text boundary (start=0 or end=len) | PASS |
| Empty `replacement` falls back to `[REDACTED:name]` | PASS (was test bug, not engine bug) |

### Security audit — bypass attempts (11/11 SAFE)

| Scenario | Result |
|---|---|
| Custom replacement containing another rule's keyword | SAFE — replacements not re-scanned (documented invariant) |
| Block + redact overlap | SAFE — block correctly raises `GuardrailBlockedError` |
| Audit-only rule overlapping a redact rule | SAFE — redact still applied |
| Disabled rule does not bypass active rule | SAFE |
| Replacement string mentions another rule's secret | SAFE |
| 10-deep nested matches sharing the same secret | SAFE — outermost merges all |
| Empty rule list | SAFE (passthrough; no protection promised) |
| Brackets `[X]` in replacement don't confuse downstream | SAFE |

### Determinism

- Same-input → same-output across repeated runs ✓
- `get_guardrail_engine()` singleton is stable ✓
- Tied-width same-span overlap uses first-defined rule name — **identical to `main`'s behavior**, no regression

## E2E validation — full synthetic suites, real Anthropic LLM

`HEALTHY_SHORT_CIRCUIT=true`, mocked backends, real `claude-sonnet-4-6` reasoning + `claude-haiku-4-5` toolcall, on this branch.

| Suite | Result | Notes |
|---|---|---|
| EKS (14 scenarios) | **11 PASS, 3 FAIL** | All 3 failures `state: alerting` LLM categorization drift — pre-existing on `main`, identical to PR #777's verification |
| RDS (15 scenarios) | **11 PASS, 4 FAIL** | All 4 failures `state: alerting`, same pre-existing drift |

**Confirmed every failure is in `state: alerting`** (programmatic check on each `alert.json`). The synthetic fixtures don't contain overlapping-rule secrets, so the failures are in territory this PR does not touch.

## Unit + integration coverage — 59 tests, 91 in `tests/test_guardrails/` total

### Engine-level (46 tests in `test_engine.py`)

- 36 pre-existing
- **10 new regression tests**: contained-span union (the core regression), longest-rule-name on contained, partial overlap, disjoint, adjacent, three-way transitive overlap, pattern+keyword mixed, two `_STARTER_CONFIG`-grounded production-rule tests, audit-under-merge invariant.

### Integration-level (13 tests in `test_llm_integration.py`)

- 8 pre-existing
- **5 new tests** — one per call site of `engine.apply()`, asserting downstream payload contains no secret fragment:
  - `AnthropicLLMClient.invoke` → captured at `Anthropic.messages.create`
  - `AnthropicLLMClient.invoke` → captured `system` kwarg
  - `OpenAILLMClient.invoke` → captured at `chat.completions.create`
  - `_apply_guardrails_to_messages` (LangGraph chat node) — also asserts source untouched (defensive copy)
  - End-to-end regression guard with shipped-config patterns

`BedrockLLMClient.invoke` shares its redaction code path with `AnthropicLLMClient.invoke` and is therefore covered by the same logic.

## Verification — final state

- **CI (Python 3.13, post-#777-merge main)**: `test (ubuntu-latest)` PASS, `typecheck` PASS, `quality` PASS, `CodeQL` PASS, `Analyze (python)` PASS. (Re-running on rebased branch.)
- **Local `pytest tests/`** (Python 3.14, no coverage): 3124 pass, 1 skipped, 1 pre-existing failure in `tests/nodes/plan_actions/` (unrelated — `_InputStub` missing `model_copy`, present on pristine `main`)
- **`pytest tests/test_guardrails/`**: 91 pass, 0 fail
- `ruff check app/ tests/`: clean
- `ruff format --check` on touched files: clean
- `mypy app/guardrails/`: clean on touched module

## Scope

| File | Change |
|---|---|
| `app/guardrails/engine.py` | ~40 line replacement of redaction loop |
| `tests/test_guardrails/test_engine.py` | 10 new tests |
| `tests/test_guardrails/test_llm_integration.py` | 5 new tests |

No public API changes. No state-shape changes. No behavior change for non-overlapping matches, audit-only rules, or blocked rules. Directly extends #520, whose same-start case is preserved verbatim.

Rebased onto current `main` (post-#777). No file overlap with #777.

## Security note

The bug class is sensitive-data disclosure. Anywhere guardrail rules filter outputs shown to users, logged, or exported, two overlapping rules covering the same secret could each partially redact and leave fragments in the wild. The shipped `_STARTER_CONFIG` demonstrates this concretely — `api_key=AKIA...` and `aws_secret_access_key=...` both produced partial redactions on `main`. This PR closes the gap.