### PR TITLE
fix: anchor investigation ID regex and add invalid ID tests

### DIFF
--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -527,7 +527,7 @@ def get_investigation(inv_id: str) -> Response:
 # ---------------------------------------------------------------------------
 
 
-_SAFE_INV_ID = re.compile(r"[\w\-]+")
+_SAFE_INV_ID = re.compile(r"^[\w\-]+$")
 
 
 def _safe_investigation_path(inv_id: str) -> Path:

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -527,7 +527,7 @@ def get_investigation(inv_id: str) -> Response:
 # ---------------------------------------------------------------------------
 
 
-_SAFE_INV_ID = re.compile(r"^[\w\-]+$")
+_SAFE_INV_ID = re.compile(r"^[\w\-]+\Z")
 
 
 def _safe_investigation_path(inv_id: str) -> Path:

--- a/tests/remote/test_server_utils.py
+++ b/tests/remote/test_server_utils.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from app.remote.server import _make_id, _slugify
+import pytest
+from fastapi import HTTPException
+
+from app.remote.server import _make_id, _safe_investigation_path, _slugify
 
 
 def test_slugify_converts_text_to_url_safe_format() -> None:
@@ -92,13 +95,6 @@ def test_make_id_truncates_long_slugs() -> None:
     assert len(slug) <= 60
 
 
-# ---------------------------------------------------------------------------
-# Tests for _safe_investigation_path
-# ---------------------------------------------------------------------------
-
-from app.remote.server import _safe_investigation_path
-
-
 def test_safe_investigation_path_accepts_valid_id() -> None:
     """Test that valid IDs are accepted and return a Path."""
     result = _safe_investigation_path("abc-123")
@@ -107,49 +103,49 @@ def test_safe_investigation_path_accepts_valid_id() -> None:
 
 def test_safe_investigation_path_rejects_path_traversal_dotdot() -> None:
     """Test that ../x returns 400 Invalid investigation ID."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path("../x")
-    assert exc_info.value.value.status_code == 400
-    assert "Invalid investigation ID" in exc_info.value.value.detail
+    assert exc_info.value.status_code == 400
+    assert "Invalid investigation ID" in exc_info.value.detail
 
 
 def test_safe_investigation_path_rejects_x_dotdot() -> None:
     """Test that x/.. returns 400 Invalid investigation ID."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path("x/..")
-    assert exc_info.value.value.status_code == 400
+    assert exc_info.value.status_code == 400
 
 
 def test_safe_investigation_path_rejects_x_md() -> None:
     """Test that x.md returns 400 Invalid investigation ID."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path("x.md")
-    assert exc_info.value.value.status_code == 400
+    assert exc_info.value.status_code == 400
 
 
 def test_safe_investigation_path_rejects_x_newline() -> None:
     """Test that x\\n returns 400 Invalid investigation ID."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path("x\n")
-    assert exc_info.value.value.status_code == 400
+    assert exc_info.value.status_code == 400
 
 
 def test_safe_investigation_path_rejects_empty() -> None:
     """Test that empty ID returns 400 Invalid investigation ID."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path("")
-    assert exc_info.value.value.status_code == 400
+    assert exc_info.value.status_code == 400
 
 
 def test_safe_investigation_path_rejects_special_chars() -> None:
     """Test that IDs with special characters return 400."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path("x$y")
-    assert exc_info.value.value.status_code == 400
+    assert exc_info.value.status_code == 400
 
 
 def test_safe_investigation_path_rejects_single_dot() -> None:
     """Test that single dot in ID returns 400."""
-    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         _safe_investigation_path(".")
-    assert exc_info.value.value.status_code == 400
+    assert exc_info.value.status_code == 400

--- a/tests/remote/test_server_utils.py
+++ b/tests/remote/test_server_utils.py
@@ -90,3 +90,66 @@ def test_make_id_truncates_long_slugs() -> None:
     slug = parts[2]
     # Slug should be truncated to 60 chars
     assert len(slug) <= 60
+
+
+# ---------------------------------------------------------------------------
+# Tests for _safe_investigation_path
+# ---------------------------------------------------------------------------
+
+from app.remote.server import _safe_investigation_path
+
+
+def test_safe_investigation_path_accepts_valid_id() -> None:
+    """Test that valid IDs are accepted and return a Path."""
+    result = _safe_investigation_path("abc-123")
+    assert result.name == "abc-123.md"
+
+
+def test_safe_investigation_path_rejects_path_traversal_dotdot() -> None:
+    """Test that ../x returns 400 Invalid investigation ID."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path("../x")
+    assert exc_info.value.value.status_code == 400
+    assert "Invalid investigation ID" in exc_info.value.value.detail
+
+
+def test_safe_investigation_path_rejects_x_dotdot() -> None:
+    """Test that x/.. returns 400 Invalid investigation ID."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path("x/..")
+    assert exc_info.value.value.status_code == 400
+
+
+def test_safe_investigation_path_rejects_x_md() -> None:
+    """Test that x.md returns 400 Invalid investigation ID."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path("x.md")
+    assert exc_info.value.value.status_code == 400
+
+
+def test_safe_investigation_path_rejects_x_newline() -> None:
+    """Test that x\\n returns 400 Invalid investigation ID."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path("x\n")
+    assert exc_info.value.value.status_code == 400
+
+
+def test_safe_investigation_path_rejects_empty() -> None:
+    """Test that empty ID returns 400 Invalid investigation ID."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path("")
+    assert exc_info.value.value.status_code == 400
+
+
+def test_safe_investigation_path_rejects_special_chars() -> None:
+    """Test that IDs with special characters return 400."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path("x$y")
+    assert exc_info.value.value.status_code == 400
+
+
+def test_safe_investigation_path_rejects_single_dot() -> None:
+    """Test that single dot in ID returns 400."""
+    with __import__("pytest").raises(__import__("pytest").HTTPException) as exc_info:
+        _safe_investigation_path(".")
+    assert exc_info.value.value.status_code == 400


### PR DESCRIPTION
Good day

This PR addresses issue #743 by:

**The Problem:**
The _SAFE_INV_ID regex was not anchored, making it unclear whether it should match the full string or just a substring of the input.

**The Fix:**
1. Anchored the regex with ^ and $ for explicit start/end matching: r"^[\w\-]+$"
2. Added comprehensive test cases covering:
   - Valid IDs are accepted (baseline)
   - ../x, x/.. (path traversal attempts)
   - x.md (extension suffix)
   - x\n (newline injection)
   - empty string
   - special characters like x$y
   - single dot .

All invalid IDs consistently return 400 "Invalid investigation ID".

**Files Changed:**
- app/remote/server.py: Anchored regex (1 line)
- tests/remote/test_server_utils.py: Added 8 new test cases

The tests follow the existing test patterns in test_server_utils.py.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof