### PR TITLE
fix(wizard): bind Grafana provisioning relative to compose file

### DIFF
--- a/app/cli/wizard/local_grafana_stack/docker-compose.yml
+++ b/app/cli/wizard/local_grafana_stack/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
     volumes:
-      - ${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/local_grafana_stack/provisioning:/etc/grafana/provisioning
+      - ./provisioning:/etc/grafana/provisioning

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -39,7 +39,7 @@ def test_devcontainer_config_matches_local_dev_workflow() -> None:
     )
 
 
-def test_local_grafana_compose_uses_workspace_override_for_devcontainers() -> None:
+def test_local_grafana_compose_binds_provisioning_relative_to_compose_file() -> None:
     compose = (REPO_ROOT / "app/cli/wizard/local_grafana_stack/docker-compose.yml").read_text()
 
-    assert "${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/local_grafana_stack/provisioning" in compose
+    assert "./provisioning:/etc/grafana/provisioning" in compose


### PR DESCRIPTION
Fixes #784

#### Describe the changes you have made in this PR -

- Restored the Grafana bind mount to `./provisioning:/etc/grafana/provisioning` (path is relative to the compose file).
- When `LOCAL_WORKSPACE_FOLDER` is unset, the previous `${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/...` value collapsed to `/app/cli/...` on the host and Docker rejected the mount — this broke `opensre onboard` → Grafana Local and `make grafana-local-up`.
- Updated `tests/test_devcontainer.py` to assert the relative bind; devcontainer still sets `LOCAL_WORKSPACE_FOLDER` for the shell but the stack no longer depends on it for this volume.

### Screenshots of the UI changes (If any) -

<img width="874" height="930" alt="image" src="https://github.com/user-attachments/assets/ccab5e64-1bb7-4c6a-90e8-8e992b7b5b83" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Compose resolves `./provisioning` next to `local_grafana_stack/docker-compose.yml`, so the bind source is always under the repo without requiring `LOCAL_WORKSPACE_FOLDER`. Alternative was to inject the repo root in `flow.py` when calling `docker compose`; the relative volume is simpler and matches the pre-#693 behavior. Verified with `docker compose ... up -d` and HTTP 200 on Grafana.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
