### PR TITLE
Revert "fix: use relative provisioning path in local Grafana compose"

### DIFF
--- a/app/cli/wizard/local_grafana_stack/docker-compose.yml
+++ b/app/cli/wizard/local_grafana_stack/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
     volumes:
-      - ./provisioning:/etc/grafana/provisioning
+      - ${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/local_grafana_stack/provisioning:/etc/grafana/provisioning

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -39,11 +39,7 @@ def test_devcontainer_config_matches_local_dev_workflow() -> None:
     )
 
 
-def test_local_grafana_compose_uses_relative_provisioning_path() -> None:
-    # Relative path resolves from the compose file's own directory, so it works
-    # on the host (opensre onboard), via make grafana-local-up, and in devcontainer —
-    # without requiring LOCAL_WORKSPACE_FOLDER to be set.
+def test_local_grafana_compose_uses_workspace_override_for_devcontainers() -> None:
     compose = (REPO_ROOT / "app/cli/wizard/local_grafana_stack/docker-compose.yml").read_text()
 
-    assert "./provisioning:/etc/grafana/provisioning" in compose
-    assert "${LOCAL_WORKSPACE_FOLDER" not in compose
+    assert "${LOCAL_WORKSPACE_FOLDER:-}/app/cli/wizard/local_grafana_stack/provisioning" in compose


### PR DESCRIPTION
Reverts Tracer-Cloud/opensre#786