### PR TITLE
docs(dev): align local checks with CI ruff format

### DIFF
--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -30,10 +30,12 @@ alwaysApply: true
 ## Quality Commands
 
 ```bash
-make lint        # ruff check app/ tests/
-make typecheck   # mypy app/
-make test-cov    # pytest with coverage
-make format      # ruff format
+make lint            # ruff check app/ tests/
+make format-check    # ruff format --check app/ tests/ (read-only; CI enforces this)
+make format          # ruff format app/ tests/ (write fixes locally)
+make typecheck       # mypy app/
+make test-cov        # pytest with coverage
+make check           # lint + format-check + typecheck + test-full
 ```
 
-All three checks (lint, typecheck, test-cov) must pass before submitting a PR.
+CI runs `ruff check` and `ruff format --check` (see `.github/workflows/ci.yml`). `make lint` alone is not enough—run `make format-check` (or `make check`) before submitting a PR. Lint, format-check, and typecheck must pass; `test-cov` (or the test suite you use) must pass before merge.

--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -38,4 +38,4 @@ make test-cov        # pytest with coverage
 make check           # lint + format-check + typecheck + test-full
 ```
 
-CI runs `ruff check` and `ruff format --check` (see `.github/workflows/ci.yml`). `make lint` alone is not enough—run `make format-check` (or `make check`) before submitting a PR. Lint, format-check, and typecheck must pass; `test-cov` (or the test suite you use) must pass before merge.
+Before opening a PR, run `make format-check` (or `make check`) in addition to `make lint`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,11 @@
 
 ## Lint & Format
 
-CI runs **both** ruff lint and ruff format in read-only mode (see `.github/workflows/ci.yml`). `make lint` is only the lint step—run formatting separately.
-
 - Lint: `make lint` (or fix: `ruff check app/ tests/ --fix`)
-- **Format (matches CI):** `make format-check` — must pass before opening a PR
-- Auto-format locally: `make format` (then re-run `make format-check` to confirm)
+- Format check: `make format-check`
+- Auto-format locally: `make format`
 - Type check: `make typecheck`
-- One-shot quality gate (lint + format check + typecheck + full tests): `make check`
+- One-shot quality gate: `make check`
 
 ## Testing
 
@@ -28,9 +26,9 @@ CI runs **both** ruff lint and ruff format in read-only mode (see `.github/workf
 ### Before Push
 
 1. Clean working tree
-2. `make test-cov` (or `make test-full` for the widest run)
+2. `make test-cov` (or `make test-full`)
 3. `make lint`
-4. `make format-check` (same as CI; use `make format` first if it fails)
+4. `make format-check` (run `make format` if it fails)
 5. `make typecheck`
 
 ## 1. Repo Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,13 @@
 
 ## Lint & Format
 
-- Lint all: `make lint`
-- Fix linting: `ruff check app/ tests/ --fix`
+CI runs **both** ruff lint and ruff format in read-only mode (see `.github/workflows/ci.yml`). `make lint` is only the lint step—run formatting separately.
+
+- Lint: `make lint` (or fix: `ruff check app/ tests/ --fix`)
+- **Format (matches CI):** `make format-check` — must pass before opening a PR
+- Auto-format locally: `make format` (then re-run `make format-check` to confirm)
 - Type check: `make typecheck`
+- One-shot quality gate (lint + format check + typecheck + full tests): `make check`
 
 ## Testing
 
@@ -24,9 +28,10 @@
 ### Before Push
 
 1. Clean working tree
-2. `make test-cov`
+2. `make test-cov` (or `make test-full` for the widest run)
 3. `make lint`
-4. `make typecheck`
+4. `make format-check` (same as CI; use `make format` first if it fails)
+5. `make typecheck`
 
 ## 1. Repo Map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ See **[SETUP.md](SETUP.md)** for detailed setup instructions including Windows-s
 
 1. Clone the repo and create a virtual environment
 2. Install dependencies: `pip install -e ".[dev]"`
-3. Run checks: `make lint && make typecheck && make test-cov`
+3. Run checks: `make lint && make format-check && make typecheck && make test-cov`
 4. Build release artifacts when needed: `make build`
 
 If you prefer VS Code, you can use the repo's devcontainer at [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) instead of setting up Python manually.
@@ -153,7 +153,7 @@ Use the **[PR template](.github/PULL_REQUEST_TEMPLATE.md)** (automatically provi
 ### PR Checklist Before Submitting
 
 - [ ] Linked to the relevant issue
-- [ ] All local checks pass: `make lint && make typecheck && make test-cov`
+- [ ] All local checks pass: `make lint && make format-check && make typecheck && make test-cov`
 - [ ] Added tests for bug fixes or new features
 - [ ] Updated documentation if behavior changed
 - [ ] Code follows project style (see **Code Quality** section below)

--- a/Makefile
+++ b/Makefile
@@ -381,8 +381,8 @@ format:
 typecheck:
 	$(PYTHON) -m mypy app/
 
-# Run all checks
-check: lint typecheck test-full
+# Run all checks (lint + format read-only check + types + full tests; mirrors CI quality gates)
+check: lint format-check typecheck test-full
 
 # ─── Deployment Tests (LangSmith) ────────────────────────────────────────────
 deploy-langsmith:


### PR DESCRIPTION
Fixes #788

#### Describe the changes you have made in this PR -

- **AGENTS.md** — Clarify that CI runs both `ruff check` and `ruff format --check`; document `make format-check`, `make format`, and that `make check` includes format + lint + typecheck + full tests; extend the before-push list with `format-check`.
- **CONTRIBUTING.md** — Add `make format-check` to the quick-start check command and the PR checklist one-liner so it matches the existing “Run Local Checks” section.
- **`.cursor/rules/code-style.mdc`** — Document the same commands and state that `make lint` alone does not satisfy the format step CI runs.
- **Makefile** — `make check` now runs `lint`, `format-check`, `typecheck`, and `test-full` so one target is closer to CI’s ruff gates (plus full local tests).

### Screenshots of the UI changes (If any) -

N/A (documentation and Makefile only)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

CI already enforces formatting with `ruff format --check`; this change only makes local docs and `make check` reflect that so fewer PRs fail the format job after passing `make lint`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
