### PR TITLE
fix(mypy): remove stale NewGenericSyntax enable flag

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 python_version = 3.13
-enable_incomplete_feature = NewGenericSyntax
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = False


### PR DESCRIPTION
## Summary

The project's `mypy.ini` explicitly enabled `NewGenericSyntax`, which is already the default in modern mypy under `python_version = 3.13`. As a result, every `make typecheck` run (locally and in CI) emitted a misleading warning:

```
Warning: NewGenericSyntax is already enabled by default
Success: no issues found in 385 source files
```

The warning is purely cosmetic — the project still passes typecheck — but it's a constant paper-cut in the developer experience and an unnecessary line in every CI log.

## Root cause

`NewGenericSyntax` became the default in mypy once the project's baseline was raised to Python 3.13 (PR #727, "align Python baseline on 3.13 across mypy and ruff"). The `enable_incomplete_feature` line was left behind in `mypy.ini`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

Removed a single line from `mypy.ini`:

```diff
 [mypy]
 python_version = 3.13
-enable_incomplete_feature = NewGenericSyntax
 warn_return_any = True
 warn_unused_configs = True
```

## Testing

Ran the full local check suite per CONTRIBUTING.md before and after the change:

| Check | Before | After |
|---|---|---|
| `make lint` | ✅ `All checks passed!` | ✅ `All checks passed!` |
| `make format-check` | ✅ `886 files already formatted` | ✅ `886 files already formatted` |
| `make typecheck` | ⚠️ Warning + `Success: no issues found in 385 source files` | ✅ `Success: no issues found in 385 source files` (warning gone) |
| `make test-cov` | ✅ `3156 passed, 2 skipped` | ✅ `3156 passed, 2 skipped` |

The only output difference is that the spurious mypy warning no longer appears. No behavioral change, no test impact, no coverage delta.

## Impact Analysis

- **Backward compatible:** Yes.
- **Breaking changes:** None.
- **Performance impact:** None (static config change only).
- **Runtime impact:** None — this only affects what mypy prints during typecheck.

## Checklist

- [x] Linked to the relevant issue (Fixes #797)
- [x] All local checks pass: `make lint && make format-check && make typecheck && make test-cov`
- [x] No tests added — this is a config-only change with no behavioral impact (existing tests continue to cover the typechecked code)
- [x] No documentation updates needed
- [x] Code follows project style
- [x] Self-reviewed the change
- [x] Considered edge cases (verified that mypy still resolves all 385 source files correctly)

## AI-Assisted PR Disclosure

- [x] I reviewed every line of the change
- [x] I understand the logic and can explain it in my own words
- [x] I tested the change locally
- [x] Verified existing tests pass

Fixes #797
