### PR TITLE
fix: remove redundant NewGenericSyntax from mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 python_version = 3.13
-enable_incomplete_feature = NewGenericSyntax
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = False


### PR DESCRIPTION
Fixes the `Warning: NewGenericSyntax is already enabled by default` warning emitted on every `make typecheck` run.

Root cause: `python_version = 3.13` was raised in PR #727 but the `enable_incomplete_feature = NewGenericSyntax` line was left behind. Since mypy 1.12+, this feature is enabled by default for Python 3.12+, making the flag redundant.

Fix: remove the redundant line from `mypy.ini`. Type-checking still passes on all 385 source files.

Closes #797