### PR TITLE
fix: add Windows fallback when .venv not yet created (closes #803)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,26 @@ export
 
 .PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert verify-integrations check-docker check-langgraph check-langsmith-api-key grafana-local-up grafana-local-down grafana-local-seed langgraph-build langgraph-deploy clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-langsmith destroy-langsmith test-langsmith deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock
 
+
 ifneq ($(wildcard .venv/bin/python),)
-PYTHON = .venv/bin/python
-PIP = .venv/bin/python -m pip
+    PYTHON = .venv/bin/python
+    PIP = .venv/bin/python -m pip
 else ifeq ($(OS),Windows_NT)
-ifneq ($(wildcard .venv/Scripts/python.exe),)
-PYTHON = .venv\\Scripts\\python.exe
-PIP = .venv\\Scripts\\python.exe -m pip
-endif
-else ifneq ($(shell python3 -c "import sys" 2>$(if $(filter Windows_NT,$(OS)),NUL,/dev/null)),)
-PYTHON = python3
-PIP = python3 -m pip
+    ifneq ($(wildcard .venv/Scripts/python.exe),)
+        PYTHON = .venv\\Scripts\\python.exe
+        PIP = .venv\\Scripts\\python.exe -m pip
+    else
+        PYTHON = python
+        PIP = python -m pip
+    endif
+else ifneq ($(shell python3 -c "import sys" 2>/dev/null),)
+    PYTHON = python3
+    PIP = python3 -m pip
 else
-PYTHON = python
-PIP = python -m pip
+    PYTHON = python
+    PIP = python -m pip
 endif
+
 # PIP_INSTALL_FLAGS = --user --break-system-packages
 USER_BASE := $(shell $(PYTHON) -m site --user-base)
 USER_BIN := $(if $(filter Windows_NT,$(OS)),$(USER_BASE)/Scripts,$(USER_BASE)/bin)


### PR DESCRIPTION


Fixes #803

#### Describe the changes you have made in this PR -

Two changes were made to the Python detection block in the `Makefile`:

**1. Added a Windows fallback**

The original Windows block only handled the case where `.venv/Scripts/python.exe` already exists, but had no `else` — so if you ran `make install` on a fresh Windows clone (before the venv is created), `PYTHON` and `PIP` would be undefined and everything would fail silently.

The fix adds an `else` clause inside the Windows block so it falls back to the system `python` when the venv doesn't exist yet.

**2. Simplified the stderr redirect on the python3 check**

Replaced `2>$(if $(filter Windows_NT,$(OS)),NUL,/dev/null)` with `2>/dev/null`. That line is inside an `else` branch that only runs when `OS` is **not** `Windows_NT`, so the Windows-specific `NUL` redirect was unnecessary.

### Screenshots of the UI changes (If any) -
N/A — Makefile change only.

---

## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [] I have reviewed every single line of the AI-generated code
- [] I can explain the purpose and logic of each function/component I added
- [] I have tested edge cases and understand how the code handles them
- [] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue was that the Windows branch of the `PYTHON` detection block had no fallback for when `.venv` doesn't exist yet. On a fresh clone, running any `make` target on Windows would leave `PYTHON` undefined and fail silently. The fix adds a simple `else` clause pointing to the system `python`, matching the pattern already used in the non-Windows branch. The stderr redirect simplification is a minor cleanup that removes dead code.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.