### PR TITLE
fix Makefile: use wildcard detection for cross-platform venv paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,18 @@ export
 
 .PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert verify-integrations check-docker check-langgraph check-langsmith-api-key grafana-local-up grafana-local-down grafana-local-seed langgraph-build langgraph-deploy clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-langsmith destroy-langsmith test-langsmith deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock
 
-ifneq ($(wildcard .venv/bin/python),)
-PYTHON = .venv/bin/python
-PIP = .venv/bin/python -m pip
-else ifeq ($(OS),Windows_NT)
-ifneq ($(wildcard .venv/Scripts/python.exe),)
-PYTHON = .venv\\Scripts\\python.exe
-PIP = .venv\\Scripts\\python.exe -m pip
-endif
-else ifneq ($(shell python3 -c "import sys" 2>$(if $(filter Windows_NT,$(OS)),NUL,/dev/null)),)
-PYTHON = python3
-PIP = python3 -m pip
+PYTHON_WIN := $(wildcard .venv/Scripts/python.exe)
+PYTHON_UNIX := $(wildcard .venv/bin/python3)
+
+ifneq ($(PYTHON_WIN),)
+PYTHON = .venv/Scripts/python
+PIP = .venv/Scripts/python -m pip
+else ifneq ($(PYTHON_UNIX),)
+PYTHON = .venv/bin/python3
+PIP = .venv/bin/python3 -m pip
 else
-PYTHON = python
-PIP = python -m pip
+PYTHON := $(shell python -c 'import sys; print(sys.executable)' 2>/dev/null || python3 -c 'import sys; print(sys.executable)' 2>/dev/null || echo python3)
+PIP := $(PYTHON) -m pip
 endif
 # PIP_INSTALL_FLAGS = --user --break-system-packages
 USER_BASE := $(shell $(PYTHON) -m site --user-base)


### PR DESCRIPTION
## Summary
Fix cross-platform venv path detection in Makefile for Windows/Unix compatibility.

## Problem
The current Makefile has brittle platform detection using `$(OS),Windows_NT` and shell commands. Windows users with `.venv/Scripts/python.exe` are not properly detected.

## Solution
Use Make wildcard to detect platform and venv structure:

- **Windows**: Check for `.venv/Scripts/python.exe` → use `.venv/Scripts/python`
- **Unix**: Check for `.venv/bin/python3` → use `.venv/bin/python3`  
- **Fallback**: Try `python` first (Windows), then `python3`

## Changes
- Added `PYTHON_WIN := $(wildcard .venv/Scripts/python.exe)`
- Added `PYTHON_UNIX := $(wildcard .venv/bin/python3)`
- Replaced complex $(OS) checks with simple wildcard detection
- `install:` target already uses $(PYTHON) correctly

## Related
Original PR: #809 (superseded)