### PR TITLE
test: move poll_deployment_health tests out of e2e

### DIFF
--- a/tests/test_deployment_health.py
+++ b/tests/test_deployment_health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import requests
 
 from app.deployment.health import poll_deployment_health
@@ -46,7 +47,7 @@ def test_poll_deployment_health_times_out_for_unreachable_endpoint() -> None:
 
     sleep_calls: list[float] = []
 
-    try:
+    with pytest.raises(TimeoutError) as exc_info:
         poll_deployment_health(
             "http://example.test",
             interval_seconds=0.5,
@@ -55,11 +56,9 @@ def test_poll_deployment_health_times_out_for_unreachable_endpoint() -> None:
             http_get=_http_get,
             sleep=lambda seconds: sleep_calls.append(seconds),
         )
-    except TimeoutError as exc:
-        assert "timed out" in str(exc)
-        assert "example.test" in str(exc)
-    else:
-        raise AssertionError("Expected TimeoutError")
+
+    assert "timed out" in str(exc_info.value)
+    assert "example.test" in str(exc_info.value)
 
     assert sleep_calls == [0.5, 0.5]
 

--- a/tests/test_deployment_health.py
+++ b/tests/test_deployment_health.py
@@ -1,3 +1,5 @@
+"""Unit tests for deployment health polling helpers."""
+
 from __future__ import annotations
 
 import requests


### PR DESCRIPTION
Fixes #840

#### Describe the changes you have made in this PR -
Moved the pure mocked `poll_deployment_health` tests out of `tests/e2e/deploy/` and into `tests/test_deployment_health.py`.

This keeps the mocked test behavior unchanged while making the tests discoverable in the default pytest run.

### Screenshots of the UI changes (If any) -
- None

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The issue calls out `tests/e2e/deploy/test_deploy_timing.py` as a pure mocked test module that should be collected by the default suite. I moved it to `tests/test_deployment_health.py` without changing the assertions or retry behavior.

One edge case I considered was the destination path. `pytest.ini` excludes both `tests/e2e` and `tests/deployment` from normal recursion, so moving these tests under `tests/deployment/` would still keep them out of the default run. I placed the file directly under `tests/` so it remains easy to discover and is collected by default.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions

## Verification
- `python -m pytest tests/test_deployment_health.py`
- `python -m pytest --collect-only tests/test_deployment_health.py`

Output summary:
- `3 passed`
- `3 tests collected`
