### PR TITLE
test: add direct unit tests for data validation (#831)

### DIFF
--- a/tests/tools/utils/test_data_validation.py
+++ b/tests/tools/utils/test_data_validation.py
@@ -24,6 +24,7 @@ def test_impossible_percentages():
     assert issues[0]["issue"] == "impossible_percentage"
     assert issues[0]["severity"] == "error"
 
+
 def test_cpu_suspicious_percentage():
     """Test that CPU > 1000% is flagged as suspicious but not strictly impossible."""
     validator = MetricsValidator()
@@ -33,6 +34,7 @@ def test_cpu_suspicious_percentage():
     assert result["cpu"]["percent_raw"] == 1500
     assert result["data_quality_issues"][0]["issue"] == "suspicious_value"
     assert result["data_quality_issues"][0]["severity"] == "warning"
+
 
 def test_byte_to_gb_and_mb_inference():
     """Test memory unit inference for bytes masquerading as percentages."""
@@ -56,6 +58,7 @@ def test_byte_to_gb_and_mb_inference():
     assert interpretation_mb["likely_unit"] == "bytes"
     assert interpretation_mb["likely_value_mb"] == 500.0
 
+
 def test_class_flat_metric_payload():
     """Test class validation on flat API response structures."""
     payload = {"cpu": 95, "ram": 8589934592, "disk": 50}
@@ -71,6 +74,7 @@ def test_class_flat_metric_payload():
     assert "data_quality_issues" in result
     assert result["data_quality_issues"][0]["field"] == "ram"
 
+
 def test_wrapper_flat_metric_payload():
     """Test wrapper validation on flat API response structures."""
     payload = {"cpu": 95, "ram": 8589934592, "disk": 50}
@@ -85,12 +89,10 @@ def test_wrapper_flat_metric_payload():
     assert "data_quality_issues" in result
     assert result["data_quality_issues"][0]["field"] == "ram"
 
+
 def test_nested_metric_payload():
     """Test validation on deeply nested API response structures."""
-    payload = {
-        "memory": {"percent": 8589934592},
-        "cpu": {"percent": 95}
-    }
+    payload = {"memory": {"percent": 8589934592}, "cpu": {"percent": 95}}
     validator = MetricsValidator()
     result = validator.validate_metrics(payload)
 
@@ -98,14 +100,15 @@ def test_nested_metric_payload():
     assert "percent_interpretation" in result["memory"]
     assert result["data_quality_issues"][0]["field"] == "memory.percent"
 
+
 def test_class_list_structure_payload():
     """Test class validation on list-based API response structures."""
     payload = {
         "success": True,
         "data": [
             {"cpu": 95, "ram": 8589934592, "disk": 50},
-            {"cpu": 10, "ram": 45, "disk": 20} # Valid payload
-        ]
+            {"cpu": 10, "ram": 45, "disk": 20},  # Valid payload
+        ],
     }
     validator = MetricsValidator()
     result = validator.validate_metrics(payload)
@@ -122,20 +125,19 @@ def test_class_list_structure_payload():
     assert len(result["data_quality_issues"]) == 1
     assert result["data_quality_issues"][0]["field"] == "ram"
 
+
 @pytest.mark.xfail(reason="Known bug: wrapper fails to attach data_quality_issues for lists")
 def test_wrapper_list_structure_payload():
     """Test wrapper validation on lists (Currently expected to fail due to bug)."""
     payload = {
         "success": True,
-        "data": [
-            {"cpu": 95, "ram": 8589934592, "disk": 50},
-            {"cpu": 10, "ram": 45, "disk": 20}
-        ]
+        "data": [{"cpu": 95, "ram": 8589934592, "disk": 50}, {"cpu": 10, "ram": 45, "disk": 20}],
     }
     result = validate_host_metrics(payload)
 
     # This assertion WILL fail because of the bug, but xfail tells pytest we expect it to!
     assert "data_quality_issues" in result
+
 
 def test_invalid_format():
     """Test fallback when metrics is not a dictionary."""

--- a/tests/tools/utils/test_data_validation.py
+++ b/tests/tools/utils/test_data_validation.py
@@ -1,0 +1,127 @@
+"""Unit tests for the data_validation utilities."""
+
+from app.tools.utils.data_validation import MetricsValidator, validate_host_metrics
+
+def test_impossible_percentages():
+    """Test that percentages over 100 are flagged as impossible."""
+    validator = MetricsValidator()
+
+    # Disk percent > 100
+    payload = {"disk": {"percent": 150}}
+    result = validator.validate_metrics(payload)
+
+    assert result["disk"]["percent_invalid"] is True
+    assert result["disk"]["percent_raw"] == 150
+    assert result["disk"]["percent"] is None
+
+    # Check that data quality issues are attached
+    issues = result["data_quality_issues"]
+    assert len(issues) == 1
+    assert issues[0]["field"] == "disk.percent"
+    assert issues[0]["issue"] == "impossible_percentage"
+    assert issues[0]["severity"] == "error"
+
+def test_cpu_suspicious_percentage():
+    """Test that CPU > 1000% is flagged as suspicious but not strictly impossible."""
+    validator = MetricsValidator()
+    result = validator.validate_metrics({"cpu": {"percent": 1500}})
+
+    assert result["cpu"]["percent_suspicious"] is True
+    assert result["cpu"]["percent_raw"] == 1500
+    assert result["data_quality_issues"][0]["issue"] == "suspicious_value"
+    assert result["data_quality_issues"][0]["severity"] == "warning"
+
+def test_byte_to_gb_and_mb_inference():
+    """Test memory unit inference for bytes masquerading as percentages."""
+    validator = MetricsValidator()
+
+    # 8 GB in bytes
+    gb_bytes = 8 * (1024**3)
+    result_gb = validator.validate_metrics({"memory": {"percent": gb_bytes}})
+
+    assert result_gb["memory"]["percent_invalid"] is True
+    interpretation_gb = result_gb["memory"]["percent_interpretation"]
+    assert interpretation_gb["likely_unit"] == "bytes"
+    assert interpretation_gb["likely_value_gb"] == 8.0
+
+    # 500 MB in bytes
+    mb_bytes = 500 * (1024**2)
+    result_mb = validator.validate_metrics({"memory": {"percent": mb_bytes}})
+
+    assert result_mb["memory"]["percent_invalid"] is True
+    interpretation_mb = result_mb["memory"]["percent_interpretation"]
+    assert interpretation_mb["likely_unit"] == "bytes"
+    assert interpretation_mb["likely_value_mb"] == 500.0
+
+def test_flat_metric_payload():
+    """Test validation on flat API response structures."""
+    payload = {"cpu": 95, "ram": 8589934592, "disk": 50}
+    result = validate_host_metrics(payload)
+
+    # Ram should be flagged as invalid and inferred as 8 GB
+    assert result["ram_invalid"] is True
+    assert result["ram_interpretation"]["likely_unit"] == "bytes"
+    assert result["ram_interpretation"]["likely_value_gb"] == 8.0
+
+    # Issues should be attached at the root level
+    assert "data_quality_issues" in result
+    assert result["data_quality_issues"][0]["field"] == "ram"
+
+def test_flat_metric_payload():
+    """Test validation on flat API response structures."""
+    payload = {"cpu": 95, "ram": 8589934592, "disk": 50}
+    validator = MetricsValidator()
+    result = validator.validate_metrics(payload)
+
+    # Ram should be flagged as invalid and inferred as 8 GB
+    assert result["ram_invalid"] is True
+    assert result["ram_interpretation"]["likely_unit"] == "bytes"
+    assert result["ram_interpretation"]["likely_value_gb"] == 8.0
+
+    # Issues should be attached at the root level
+    assert "data_quality_issues" in result
+    assert result["data_quality_issues"][0]["field"] == "ram"
+
+def test_nested_metric_payload():
+    """Test validation on deeply nested API response structures."""
+    payload = {
+        "memory": {"percent": 8589934592},
+        "cpu": {"percent": 95}
+    }
+    validator = MetricsValidator()
+    result = validator.validate_metrics(payload)
+
+    assert result["memory"]["percent_invalid"] is True
+    assert "percent_interpretation" in result["memory"]
+    assert result["data_quality_issues"][0]["field"] == "memory.percent"
+
+def test_list_structure_payload():
+    """Test validation on list-based API response structures."""
+    payload = {
+        "success": True,
+        "data": [
+            {"cpu": 95, "ram": 8589934592, "disk": 50},
+            {"cpu": 10, "ram": 45, "disk": 20} # Valid payload
+        ]
+    }
+    validator = MetricsValidator()
+    result = validator.validate_metrics(payload)
+
+    # First item in data array should have validation flags
+    assert result["data"][0]["ram_invalid"] is True
+    assert result["data"][0]["ram_interpretation"]["likely_unit"] == "bytes"
+
+    # Second item should remain untouched
+    assert "ram_invalid" not in result["data"][1]
+
+    # Root level should aggregate the data_quality_issues
+    assert "data_quality_issues" in result
+    assert len(result["data_quality_issues"]) == 1
+    assert result["data_quality_issues"][0]["field"] == "ram"
+
+def test_invalid_format():
+    """Test fallback when metrics is not a dictionary."""
+    from app.tools.utils.data_validation import validate_host_metrics
+    result = validate_host_metrics("this is just a string, not a dict")
+    assert result["validated"] is False
+    assert result["data_quality_issues"][0]["issue"] == "invalid_format"

--- a/tests/tools/utils/test_data_validation.py
+++ b/tests/tools/utils/test_data_validation.py
@@ -1,7 +1,9 @@
 """Unit tests for the data_validation utilities."""
 
 import pytest
+
 from app.tools.utils.data_validation import MetricsValidator, validate_host_metrics
+
 
 def test_impossible_percentages():
     """Test that percentages over 100 are flagged as impossible."""

--- a/tests/tools/utils/test_data_validation.py
+++ b/tests/tools/utils/test_data_validation.py
@@ -1,5 +1,6 @@
 """Unit tests for the data_validation utilities."""
 
+import pytest
 from app.tools.utils.data_validation import MetricsValidator, validate_host_metrics
 
 def test_impossible_percentages():
@@ -53,10 +54,11 @@ def test_byte_to_gb_and_mb_inference():
     assert interpretation_mb["likely_unit"] == "bytes"
     assert interpretation_mb["likely_value_mb"] == 500.0
 
-def test_flat_metric_payload():
-    """Test validation on flat API response structures."""
+def test_class_flat_metric_payload():
+    """Test class validation on flat API response structures."""
     payload = {"cpu": 95, "ram": 8589934592, "disk": 50}
-    result = validate_host_metrics(payload)
+    validator = MetricsValidator()
+    result = validator.validate_metrics(payload)
 
     # Ram should be flagged as invalid and inferred as 8 GB
     assert result["ram_invalid"] is True
@@ -67,11 +69,10 @@ def test_flat_metric_payload():
     assert "data_quality_issues" in result
     assert result["data_quality_issues"][0]["field"] == "ram"
 
-def test_flat_metric_payload():
-    """Test validation on flat API response structures."""
+def test_wrapper_flat_metric_payload():
+    """Test wrapper validation on flat API response structures."""
     payload = {"cpu": 95, "ram": 8589934592, "disk": 50}
-    validator = MetricsValidator()
-    result = validator.validate_metrics(payload)
+    result = validate_host_metrics(payload)
 
     # Ram should be flagged as invalid and inferred as 8 GB
     assert result["ram_invalid"] is True
@@ -95,8 +96,8 @@ def test_nested_metric_payload():
     assert "percent_interpretation" in result["memory"]
     assert result["data_quality_issues"][0]["field"] == "memory.percent"
 
-def test_list_structure_payload():
-    """Test validation on list-based API response structures."""
+def test_class_list_structure_payload():
+    """Test class validation on list-based API response structures."""
     payload = {
         "success": True,
         "data": [
@@ -119,9 +120,23 @@ def test_list_structure_payload():
     assert len(result["data_quality_issues"]) == 1
     assert result["data_quality_issues"][0]["field"] == "ram"
 
+@pytest.mark.xfail(reason="Known bug: wrapper fails to attach data_quality_issues for lists")
+def test_wrapper_list_structure_payload():
+    """Test wrapper validation on lists (Currently expected to fail due to bug)."""
+    payload = {
+        "success": True,
+        "data": [
+            {"cpu": 95, "ram": 8589934592, "disk": 50},
+            {"cpu": 10, "ram": 45, "disk": 20}
+        ]
+    }
+    result = validate_host_metrics(payload)
+
+    # This assertion WILL fail because of the bug, but xfail tells pytest we expect it to!
+    assert "data_quality_issues" in result
+
 def test_invalid_format():
     """Test fallback when metrics is not a dictionary."""
-    from app.tools.utils.data_validation import validate_host_metrics
     result = validate_host_metrics("this is just a string, not a dict")
     assert result["validated"] is False
     assert result["data_quality_issues"][0]["issue"] == "invalid_format"


### PR DESCRIPTION
Fixes #831

#### Describe the changes you have made in this PR -

This PR adds comprehensive unit testing for `app/tools/utils/data_validation.py`. It satisfies all acceptance criteria outlined in the issue by testing pure Python logic against impossible percentages, byte-to-GB/MB inferences, and various payload structures (flat, nested, and lists). 

**🐛 Bug Discovery & Implementation Note:**
While writing the tests for list-based payloads, I discovered a bug in the `validate_host_metrics()` wrapper function. When it processes lists, it loops through and calls `validator._validate_flat_metrics()`, but it fails to extract and attach the `data_quality_issues` to the root result. 

To handle this cleanly:
1. I tested the `MetricsValidator` class directly to ensure the core logic is properly covered without being blocked by the wrapper bug.
2. I added a specific test for the wrapper (`test_wrapper_list_structure_payload`) and explicitly marked it with `@pytest.mark.xfail` to formally document the known bug. 
*(I am happy to open a separate issue/PR to fix the wrapper function!)*

### Screenshots of the UI changes (If any) -
N/A - backend unit tests only.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
* **What problem does your code solve?** It fulfills Issue #831 by providing direct unit test coverage for the metric data validation utilities, ensuring we catch impossible metrics and correctly infer unit conversions (like bytes to GB).
* **What alternative approaches did you consider?** I initially tried testing everything through the `validate_host_metrics()` wrapper function.
* **Why did you choose this specific implementation?** I pivoted to testing the `MetricsValidator` class directly for list payloads because I discovered a bug in how the wrapper handles list structures (it drops the `data_quality_issues` list). Using `@pytest.mark.xfail` on the wrapper test allows me to document the bug, while testing the class directly isolates the pure-Python validation logic as requested by the issue.
* **What are the key functions/components and what do they do?** * `test_impossible_percentages` & `test_cpu_suspicious_percentage`: Verify threshold limits and severity warnings.
    * `test_byte_to_gb_and_mb_inference`: Validates the mathematical inference engine.
    * `test_class_flat_metric_payload`, `test_nested_metric_payload`, `test_class_list_structure_payload`: Ensure the core validator can handle different JSON dictionary shapes.
    * `test_wrapper_list_structure_payload`: Explicitly documents the known list bug in the wrapper function using `xfail`.
    * *(Note: I used **Gemini 3.1 Pro** to help scaffold the test logic, debug Git states, and write the test functions based on the provided source code and acceptance criteria).*

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---