### PR TITLE
Add unit tests for availability helpers #830

### DIFF
--- a/tests/tools/test_availability.py
+++ b/tests/tools/test_availability.py
@@ -34,6 +34,10 @@ class TestEksAvailableOrBackend:
         sources = {"eks": {"_backend": None}}
         assert eks_available_or_backend(sources) is False
 
+    def test_eks_backend_overrides_failed_verification(self) -> None:
+        sources = {"eks": {"connection_verified": False, "_backend": object()}}
+        assert eks_available_or_backend(sources) is True
+
 
 class TestDatadogAvailableOrBackend:
     def test_datadog_missing(self) -> None:
@@ -59,6 +63,10 @@ class TestDatadogAvailableOrBackend:
     def test_datadog_backend_none(self) -> None:
         sources = {"datadog": {"_backend": None}}
         assert datadog_available_or_backend(sources) is False
+
+    def test_datadog_backend_overrides_failed_verification(self) -> None:
+        sources = {"datadog": {"connection_verified": False, "_backend": object()}}
+        assert datadog_available_or_backend(sources) is True
 
 
 class TestCloudwatchIsAvailable:

--- a/tests/tools/test_availability.py
+++ b/tests/tools/test_availability.py
@@ -1,0 +1,75 @@
+"""Tests for tool availability helpers."""
+
+from __future__ import annotations
+
+from app.tools.utils.availability import (
+    cloudwatch_is_available,
+    datadog_available_or_backend,
+    eks_available_or_backend,
+)
+
+
+class TestEksAvailableOrBackend:
+    def test_eks_missing(self) -> None:
+        sources: dict[str, dict] = {}
+        assert eks_available_or_backend(sources) is False
+
+    def test_eks_empty(self) -> None:
+        sources = {"eks": {}}
+        assert eks_available_or_backend(sources) is False
+
+    def test_eks_verified(self) -> None:
+        sources = {"eks": {"connection_verified": True}}
+        assert eks_available_or_backend(sources) is True
+
+    def test_eks_backend(self) -> None:
+        sources = {"eks": {"_backend": object()}}
+        assert eks_available_or_backend(sources) is True
+
+    def test_eks_not_available(self) -> None:
+        sources = {"eks": {"connection_verified": False}}
+        assert eks_available_or_backend(sources) is False
+
+    def test_eks_backend_none(self) -> None:
+        sources = {"eks": {"_backend": None}}
+        assert eks_available_or_backend(sources) is False
+
+
+class TestDatadogAvailableOrBackend:
+    def test_datadog_missing(self) -> None:
+        sources: dict[str, dict] = {}
+        assert datadog_available_or_backend(sources) is False
+
+    def test_datadog_empty(self) -> None:
+        sources = {"datadog": {}}
+        assert datadog_available_or_backend(sources) is False
+
+    def test_datadog_verified(self) -> None:
+        sources = {"datadog": {"connection_verified": True}}
+        assert datadog_available_or_backend(sources) is True
+
+    def test_datadog_backend(self) -> None:
+        sources = {"datadog": {"_backend": object()}}
+        assert datadog_available_or_backend(sources) is True
+
+    def test_datadog_not_available(self) -> None:
+        sources = {"datadog": {"connection_verified": False}}
+        assert datadog_available_or_backend(sources) is False
+
+    def test_datadog_backend_none(self) -> None:
+        sources = {"datadog": {"_backend": None}}
+        assert datadog_available_or_backend(sources) is False
+
+
+class TestCloudwatchIsAvailable:
+    def test_cloudwatch_missing(self) -> None:
+        sources: dict[str, dict] = {}
+        assert cloudwatch_is_available(sources) is False
+
+    def test_cloudwatch_present_empty(self) -> None:
+        sources = {"cloudwatch": {}}
+        assert cloudwatch_is_available(sources) is False
+
+    def test_cloudwatch_with_data(self) -> None:
+        sources = {"cloudwatch": {"log_group": "test"}}
+        assert cloudwatch_is_available(sources) is True


### PR DESCRIPTION
Fixes #830 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

I have added a new test file `tests/tools/test_availability.py` that provides direct unit test coverage for the helper functions in `app/tools/utils/availability.py`. This includes:
*   Full coverage for `eks_available_or_backend` and `datadog_available_or_backend`, including edge cases for missing keys, verified credentials, and injected `_backend` objects (both truthy and falsy like `None`).
*   Tests for `cloudwatch_is_available` to verify its truthiness-based availability logic.

### Screenshots of the test cases  -
<img width="1228" height="742" alt="Screenshot 2026-04-24 235406" src="https://github.com/user-attachments/assets/151246eb-f756-4e63-8672-2a6dc540d305" />

<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The goal was to provide unit tests for a small but critical utility module. I chose a class-based structure in `pytest` to group tests by function, which matches the project's existing testing style. 

The implementation focuses on verifying the dictionary-based lookups in the `sources` object. I considered whether to change the CloudWatch logic to "key presence" vs "truthiness" and decided to mirror the existing implementation's truthiness check while adding tests for edge cases like `_backend: None`, which ensures the tools don't accidentally report as "available" when a mock backend is explicitly disabled.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


