### PR TITLE
test(cli): add direct unit coverage for args helpers

### DIFF
--- a/tests/cli/test_args.py
+++ b/tests/cli/test_args.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.cli.args import parse_args, write_json
+from app.cli.constants import ALERT_TEMPLATE_CHOICES
+
+
+def test_write_json_prints_to_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    payload = {"status": "ok", "count": 2}
+
+    write_json(payload, None)
+
+    assert capsys.readouterr().out == json.dumps(payload, indent=2) + "\n"
+
+
+def test_write_json_writes_to_file(tmp_path: Path) -> None:
+    payload = {"status": "ok", "count": 2}
+    output_path = tmp_path / "result.json"
+
+    write_json(payload, str(output_path))
+
+    assert output_path.read_text(encoding="utf-8") == json.dumps(payload, indent=2) + "\n"
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_error"),
+    [
+        (["--input", "alert.json", "--input-json", '{"alert":"test"}'], "--input-json"),
+        (["--input", "alert.json", "--interactive"], "--interactive"),
+        (
+            ["--input-json", '{"alert":"test"}', "--print-template", ALERT_TEMPLATE_CHOICES[0]],
+            "--print-template",
+        ),
+    ],
+)
+def test_parse_args_rejects_multiple_input_sources(
+    argv: list[str], expected_error: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(argv)
+
+    assert exc_info.value.code == 2
+    assert expected_error in capsys.readouterr().err
+
+
+def test_parse_args_accepts_output_and_evaluate_flags() -> None:
+    args = parse_args(["--input", "alert.json", "--output", "result.json", "--evaluate"])
+
+    assert args.input == "alert.json"
+    assert args.input_json is None
+    assert args.interactive is False
+    assert args.print_template is None
+    assert args.output == "result.json"
+    assert args.evaluate is True


### PR DESCRIPTION
Fixes #834

#### Describe the changes you have made in this PR -
Added direct unit tests for `app/cli/args.py` in `tests/cli/test_args.py`.

The new coverage verifies `write_json` when writing to stdout and to a file, and it adds parser-level checks for the mutually exclusive input flags without going through end-to-end CLI execution.

### Screenshots of the UI changes (If any) -
- None

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I added a focused unit test module for `parse_args` and `write_json` instead of exercising the full CLI entrypoint. This keeps the tests aligned with the issue's request to validate parser behavior directly.

For edge cases, I covered both `write_json` output paths and multiple invalid combinations of the mutually exclusive input flags. The parser assertions check that these conflicts still fail with argparse's standard exit code and surface the conflicting flag in stderr, which helps guard against regressions in the CLI contract.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] My code follows the project's style guidelines and conventions

## Verification
- `python -m pytest tests/cli/test_args.py`
- `ruff check tests/cli/test_args.py`

Output summary:
- `6 passed`
- `All checks passed!`