### PR TITLE
test(plan-actions): cover extract_keywords behavior

### DIFF
--- a/app/nodes/plan_actions/extract_keywords.py
+++ b/app/nodes/plan_actions/extract_keywords.py
@@ -56,9 +56,9 @@ def extract_keywords(problem_md: str, alert_name: str) -> list[str]:
 
     Examples:
         >>> extract_keywords("Pipeline failed with memory error", "PipelineFailure")
-        ['failure', 'failed', 'error', 'pipeline', 'memory']
+        ['memory', 'failure', 'failed', 'error', 'pipeline']
         >>> extract_keywords("", "BatchJobTimeout")
-        ['batch', 'job', 'timeout']
+        ['timeout', 'batch', 'job']
         >>> extract_keywords("No issues detected", "Success")
         []
     """

--- a/tests/nodes/plan_actions/test_extract_keywords.py
+++ b/tests/nodes/plan_actions/test_extract_keywords.py
@@ -1,0 +1,48 @@
+"""Tests for keyword extraction used by action planning."""
+
+from __future__ import annotations
+
+from app.nodes.plan_actions.extract_keywords import extract_keywords
+
+
+def test_extract_keywords_matches_problem_and_alert_text() -> None:
+    assert extract_keywords(
+        "Pipeline failed with memory error",
+        "PipelineFailure",
+    ) == ["memory", "failure", "failed", "error", "pipeline"]
+
+
+def test_extract_keywords_matches_alert_name_only() -> None:
+    assert extract_keywords("", "BatchJobTimeout") == ["timeout", "batch", "job"]
+
+
+def test_extract_keywords_matches_problem_text_only() -> None:
+    assert extract_keywords("Database timeout with slow queries", "") == [
+        "timeout",
+        "slow",
+        "database",
+    ]
+
+
+def test_extract_keywords_returns_empty_list_when_no_keywords_match() -> None:
+    assert extract_keywords("No issues detected", "Success") == []
+
+
+def test_extract_keywords_returns_empty_list_for_empty_input() -> None:
+    assert extract_keywords("", "") == []
+
+
+def test_extract_keywords_does_not_duplicate_repeated_matches() -> None:
+    assert extract_keywords(
+        "memory memory memory error",
+        "MemoryError",
+    ) == ["memory", "error"]
+
+
+def test_extract_keywords_matches_case_insensitively() -> None:
+    assert extract_keywords("CPU FAILURE", "DiskError") == [
+        "failure",
+        "error",
+        "cpu",
+        "disk",
+    ]


### PR DESCRIPTION
Fixes #837 

#### Describe the changes you have made in this PR -

Aligned the `extract_keywords` docstring output examples with `KEYWORD_PATTERNS` order.

Added test coverage for the documented examples, plus four additional scenarios, for a total of seven tests.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Noticed that the `extract_keywords` docstring examples listed the expected keywords in a different order than the function returns them, so I updated the examples to match `KEYWORD_PATTERNS` order.

Added test coverage for the documented examples, plus the following scenarios:
- empty input
- `problem_md`-only input
- repeated keyword occurrences
- case-insensitive matching

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

**Testing:**

```powershell
uv run --extra dev python -m pytest tests\nodes\plan_actions\test_extract_keywords.py
