### PR TITLE
test(cli): add regression test for command/help sync, fix missing guardrails entry

### DIFF
--- a/app/cli/layout.py
+++ b/app/cli/layout.py
@@ -22,6 +22,7 @@ _HELP_COMMANDS: tuple[tuple[str, str], ...] = (
     ("remote", "Connect to remote agents and hosted service ops."),
     ("tests", "Browse and run inventoried tests from the terminal."),
     ("integrations", "Manage local integration credentials."),
+    ("guardrails", "Manage sensitive information guardrail rules."),
     ("health", "Check integration and agent setup status."),
     ("doctor", "Run a full environment diagnostic."),
     ("update", "Check for a newer version and update if one is available."),

--- a/tests/cli/test_command_help_sync.py
+++ b/tests/cli/test_command_help_sync.py
@@ -12,6 +12,10 @@ from app.cli.layout import _HELP_COMMANDS
 
 def test_registered_commands_match_help_table() -> None:
     registered = {cmd.name for cmd in _COMMANDS}
+    assert None not in registered, (
+        "A command in _COMMANDS has no name set. "
+        "Ensure every click.Command is decorated with an explicit name."
+    )
     documented = {name for name, _ in _HELP_COMMANDS}
 
     missing_from_help = registered - documented

--- a/tests/cli/test_command_help_sync.py
+++ b/tests/cli/test_command_help_sync.py
@@ -1,0 +1,27 @@
+"""Regression test: CLI command registration must stay in sync with help copy.
+
+If a command is added to _COMMANDS but forgotten in _HELP_COMMANDS (or vice
+versa) this test will fail and name exactly which command is out of sync.
+"""
+
+from __future__ import annotations
+
+from app.cli.commands import _COMMANDS
+from app.cli.layout import _HELP_COMMANDS
+
+
+def test_registered_commands_match_help_table() -> None:
+    registered = {cmd.name for cmd in _COMMANDS}
+    documented = {name for name, _ in _HELP_COMMANDS}
+
+    missing_from_help = registered - documented
+    missing_from_registry = documented - registered
+
+    assert not missing_from_help, (
+        f"Commands registered in _COMMANDS but missing from _HELP_COMMANDS: {missing_from_help}. "
+        "Add an entry to _HELP_COMMANDS in app/cli/layout.py."
+    )
+    assert not missing_from_registry, (
+        f"Commands in _HELP_COMMANDS but not registered in _COMMANDS: {missing_from_registry}. "
+        "Add the command to _COMMANDS in app/cli/commands/__init__.py."
+    )


### PR DESCRIPTION
Fixes #835

#### Describe the changes you have made in this PR -

Added `tests/cli/test_command_help_sync.py` — a regression test that compares the set of registered command names in `_COMMANDS` (`app/cli/commands/__init__.py`) against the set of keys in `_HELP_COMMANDS` (`app/cli/layout.py`). The test fails with a clear message naming the exact out-of-sync command if either list drifts from the other.

While writing the test, it immediately caught an existing drift: `guardrails` was registered in `_COMMANDS` but missing from `_HELP_COMMANDS`. This has been fixed in `app/cli/layout.py`.

### Demo/Screenshot for feature changes and bug fixes -
<img width="1512" height="982" alt="Screenshot 2026-04-24 at 16 01 13" src="https://github.com/user-attachments/assets/50d1384a-e9e4-4526-80ae-d8d1618a6180" />



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `_COMMANDS` and `_HELP_COMMANDS` are two separate tuples that must stay in sync but have no enforced relationship — a developer can add a command to one and forget the other.

The fix is a set-comparison test. It extracts `cmd.name` from each `click.Command` in `_COMMANDS` (all commands use explicit `name=` in their decorator so `.name` is reliable), and the first element of each tuple in `_HELP_COMMANDS`. It then diffs the two sets and fails with a targeted message if anything is missing on either side. No formatting details are checked — only the names — so cosmetic changes to the help copy won't break it.

Alternative considered: checking the Click group's registered commands at runtime via `cli.commands`. Rejected because that requires booting the full CLI, while this test touches only the two data structures directly.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
