### PR TITLE
docs: fix misleading FileNotFoundError example in tests/AGENTS.md

### DIFF
--- a/tests/AGENTS.MD
+++ b/tests/AGENTS.MD
@@ -10,7 +10,7 @@
 # use_case.py - Pure business logic, no test infrastructure
 def extract_and_validate(input_path: str) -> str:
     if not os.path.exists(input_path):
-        raise FileNotFoundError(f"empty file not present: {input_path}")
+        raise FileNotFoundError(f"input file not found: {input_path}")
     return data
 
 # test_orchestrator.py - All test orchestration separate


### PR DESCRIPTION
Fixes #828

example said `empty file not present` but the condition was `not os.path.exists(input_path)`. swapped to `input file not found` so the message matches the missing-file case.

no, i wrote it. one-line copy fix.