### PR TITLE
test(plan_actions): repair _InputStub after model_copy/model_dump usage

### DIFF
--- a/tests/nodes/plan_actions/test_node_plan_actions.py
+++ b/tests/nodes/plan_actions/test_node_plan_actions.py
@@ -27,7 +27,21 @@ def test_node_plan_actions_emits_retrieval_controls(monkeypatch: Any) -> None:
     )
 
     class _InputStub:
+        # Production ``node_plan_actions`` calls ``input_data.model_copy(update=...)``
+        # after a ``input_data.model_dump()`` round-trip to mask sensitive
+        # identifiers before the LLM sees them. Mirror those two pydantic
+        # surfaces here so the stub stays a drop-in for ``InvestigateInput``
+        # without dragging in a full Pydantic model definition.
         tool_budget = 10
+
+        def model_dump(self) -> dict[str, Any]:
+            return {"tool_budget": self.tool_budget}
+
+        def model_copy(self, *, update: dict[str, Any]) -> _InputStub:
+            copy = _InputStub()
+            for key, value in update.items():
+                setattr(copy, key, value)
+            return copy
 
     monkeypatch.setattr(node_module.InvestigateInput, "from_state", lambda _state: _InputStub())
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

PR #807 added a masking round-trip in `node_plan_actions`:

\`\`\`python
input_data = input_data.model_copy(
    update={k: masking_ctx.mask_value(v) for k, v in input_data.model_dump().items()}
)
\`\`\`

The matching test (\`test_node_plan_actions_emits_retrieval_controls\`) was not updated, so its \`_InputStub\` — which only defines \`tool_budget = 10\` — raises on every CI run since #807 landed:

\`\`\`
E   AttributeError: '_InputStub' object has no attribute 'model_copy'
app/nodes/plan_actions/node.py:55: AttributeError
\`\`\`

This breaks the \`test (ubuntu-latest)\` CI job for **every PR currently in flight** against \`main\` and blocks merges.

## Fix

Add the two pydantic-surface methods the production code path uses, keeping \`_InputStub\` a thin stub rather than dragging in a full \`BaseModel\`:

- \`model_dump()\` returns a dict carrying \`tool_budget\`.
- \`model_copy(update=...)\` returns a new \`_InputStub\` with the update applied via \`setattr\`.

## Verification

- \`pytest tests/nodes/plan_actions/test_node_plan_actions.py\`: 1 passed.
- \`ruff check\` and \`ruff format --check\`: clean.

## Scope

One file (the test), 14 inserted lines, 0 production-code change.