### PR TITLE
test: add unit tests for app/cli/context.py

### DIFF
--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.cli.context import is_debug, is_json_output, is_verbose, is_yes
+
+
+def test_is_json_output_true() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"json": True}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_json_output() is True
+
+
+def test_is_json_output_false() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"json": False}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_json_output() is False
+
+
+def test_is_verbose_true() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"verbose": True}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_verbose() is True
+
+
+def test_is_verbose_false() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"verbose": False}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_verbose() is False
+
+
+def test_is_debug_true() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"debug": True}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_debug() is True
+
+
+def test_is_debug_false() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"debug": False}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_debug() is False
+
+
+def test_is_yes_true() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"yes": True}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_yes() is True
+
+
+def test_is_yes_false() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = {"yes": False}
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_yes() is False
+
+
+def test_no_context() -> None:
+    with patch("click.get_current_context", return_value=None):
+        assert is_json_output() is False
+        assert is_verbose() is False
+        assert is_debug() is False
+        assert is_yes() is False
+
+
+def test_root_traversal() -> None:
+    root_ctx = MagicMock()
+    root_ctx.parent = None
+    root_ctx.obj = {"json": True}
+
+    child_ctx = MagicMock()
+    child_ctx.parent = root_ctx
+    child_ctx.obj = {"json": False}  # Should be ignored
+
+    with patch("click.get_current_context", return_value=child_ctx):
+        assert is_json_output() is True
+
+
+def test_none_obj() -> None:
+    mock_ctx = MagicMock()
+    mock_ctx.parent = None
+    mock_ctx.obj = None
+    with patch("click.get_current_context", return_value=mock_ctx):
+        assert is_json_output() is False
+        assert is_verbose() is False
+        assert is_debug() is False
+        assert is_yes() is False

--- a/tests/cli/test_context.py
+++ b/tests/cli/test_context.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import click
+
 from app.cli.context import is_debug, is_json_output, is_verbose, is_yes
 
 
 def test_is_json_output_true() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"json": True}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -14,7 +16,7 @@ def test_is_json_output_true() -> None:
 
 
 def test_is_json_output_false() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"json": False}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -22,7 +24,7 @@ def test_is_json_output_false() -> None:
 
 
 def test_is_verbose_true() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"verbose": True}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -30,7 +32,7 @@ def test_is_verbose_true() -> None:
 
 
 def test_is_verbose_false() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"verbose": False}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -38,7 +40,7 @@ def test_is_verbose_false() -> None:
 
 
 def test_is_debug_true() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"debug": True}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -46,7 +48,7 @@ def test_is_debug_true() -> None:
 
 
 def test_is_debug_false() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"debug": False}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -54,7 +56,7 @@ def test_is_debug_false() -> None:
 
 
 def test_is_yes_true() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"yes": True}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -62,7 +64,7 @@ def test_is_yes_true() -> None:
 
 
 def test_is_yes_false() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = {"yes": False}
     with patch("click.get_current_context", return_value=mock_ctx):
@@ -70,19 +72,21 @@ def test_is_yes_false() -> None:
 
 
 def test_no_context() -> None:
-    with patch("click.get_current_context", return_value=None):
+    with patch("click.get_current_context", return_value=None) as mock_get_ctx:
         assert is_json_output() is False
         assert is_verbose() is False
         assert is_debug() is False
         assert is_yes() is False
+        # Verify that we call it with silent=True so it doesn't raise RuntimeError
+        mock_get_ctx.assert_called_with(silent=True)
 
 
 def test_root_traversal() -> None:
-    root_ctx = MagicMock()
+    root_ctx = MagicMock(spec=click.Context)
     root_ctx.parent = None
     root_ctx.obj = {"json": True}
 
-    child_ctx = MagicMock()
+    child_ctx = MagicMock(spec=click.Context)
     child_ctx.parent = root_ctx
     child_ctx.obj = {"json": False}  # Should be ignored
 
@@ -91,7 +95,7 @@ def test_root_traversal() -> None:
 
 
 def test_none_obj() -> None:
-    mock_ctx = MagicMock()
+    mock_ctx = MagicMock(spec=click.Context)
     mock_ctx.parent = None
     mock_ctx.obj = None
     with patch("click.get_current_context", return_value=mock_ctx):


### PR DESCRIPTION
**PR Description**:
Fixes #836

#### Describe the changes you have made in this PR -
Added direct unit tests for `app/cli/context.py` to ensure reliable access to global CLI flags from any command depth. These tests verify the helper functions `is_json_output`, `is_verbose`, `is_debug`, and `is_yes` by mocking the Click context hierarchy.

### Demo/Screenshot for feature changes and bug fixes - 
```text
tests/cli/test_context.py::test_is_json_output_true PASSED               [  9%]
tests/cli/test_context.py::test_is_json_output_false PASSED              [ 18%]
tests/cli/test_context.py::test_is_verbose_true PASSED                   [ 27%]
tests/cli/test_context.py::test_is_verbose_false PASSED                  [ 36%]
tests/cli/test_context.py::test_is_debug_true PASSED                     [ 45%]
tests/cli/test_context.py::test_is_debug_false PASSED                    [ 54%]
tests/cli/test_context.py::test_is_yes_true PASSED                       [ 63%]
tests/cli/test_context.py::test_is_yes_false PASSED                      [ 72%]
tests/cli/test_context.py::test_no_context PASSED                        [ 81%]
tests/cli/test_context.py::test_root_traversal PASSED                    [ 90%]
tests/cli/test_context.py::test_none_obj PASSED                          [100%]

============================= 11 passed in 0.13s ==============================
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (Antigravity)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The tests utilize `unittest.mock.patch` to mock `click.get_current_context()`. This allows us to simulate the internal Click state (parent contexts and the `obj` dictionary) without needing to execute the full CLI runner for simple logic checks. 

Following feedback from Greptile, I have:
1. **Added `spec=click.Context` to all mocks**: This ensures that any typos in attribute access (like `ctx.parent`) are caught during testing.
2. **Verified `silent=True` in `test_no_context`**: Added an assertion to ensure `click.get_current_context` is called with `silent=True`, which is critical for preventing `RuntimeError` when called outside of a Click command.

I focused on three main scenarios:
1. **Direct Access**: When the current context is the root.
2. **Traversal**: When the current context is a sub-command, ensuring it traverses up to the root to find the flags.
3. **Safety**: Handling cases where no context exists (e.g., when imported/called as a library) or when `ctx.obj` is unexpectedly `None`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
