### PR TITLE
Refactor: Parallelize Investigation via LangGraph Send()

### DIFF
--- a/app/nodes/__init__.py
+++ b/app/nodes/__init__.py
@@ -1,7 +1,6 @@
 """LangGraph nodes for investigation workflow."""
 
 from app.nodes.extract_alert import node_extract_alert
-from app.nodes.investigate.node import node_investigate
 from app.nodes.plan_actions.node import node_plan_actions
 from app.nodes.publish_findings import node_publish_findings
 from app.nodes.resolve_integrations import node_resolve_integrations
@@ -11,7 +10,6 @@ __all__ = [
     "node_diagnose_root_cause",
     "node_extract_alert",
     "node_plan_actions",
-    "node_investigate",
     "node_publish_findings",
     "node_resolve_integrations",
 ]

--- a/app/nodes/investigate/__init__.py
+++ b/app/nodes/investigate/__init__.py
@@ -1,9 +1,1 @@
 """Investigate node package."""
-
-from app.nodes.investigate.node import node_investigate
-from app.nodes.plan_actions.node import node_plan_actions
-
-__all__ = [
-    "node_plan_actions",
-    "node_investigate",
-]

--- a/app/nodes/investigate/merge.py
+++ b/app/nodes/investigate/merge.py
@@ -1,4 +1,4 @@
-"""Investigate node - execute planned actions and post-process evidence."""
+"""Merge node for parallel hypothesis execution results."""
 
 import logging
 from typing import Any, cast
@@ -6,15 +6,12 @@ from typing import Any, cast
 from langsmith import traceable
 
 from app.masking import MaskingContext
-from app.nodes.investigate.execution import execute_actions
+from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
 from app.nodes.investigate.models import InvestigateInput, InvestigateOutput
-from app.nodes.investigate.processing import (
-    summarize_execution_results,
-)
+from app.nodes.investigate.processing import summarize_execution_results
 from app.nodes.investigate.types import PlanAudit
-from app.output import debug_print, get_tracker
+from app.output import get_tracker
 from app.state import InvestigationState
-from app.tools.investigation_registry import get_available_actions
 
 logger = logging.getLogger(__name__)
 
@@ -39,55 +36,43 @@ def _load_opensre_telemetry_into_evidence(
         logger.exception("OpenSRE telemetry load failed during evidence gathering")
         return prior, None
     ev = seed.get("evidence") or prior
+    from app.output import debug_print
+
     if ev.get("opensre_telemetry_seed"):
         debug_print(f"OpenSRE telemetry loaded from {ev.get('opensre_telemetry_dir', '')}")
     return ev, seed.get("resolved_integrations")
 
 
-@traceable(name="node_investigate")
-def node_investigate(state: InvestigationState) -> dict:
-    """
-    Execute node:
-    1) Loads OpenSRE/OpenRCA CSV telemetry into evidence when applicable
-    2) Executes planned actions and post-processes evidence
-    """
+@traceable(name="node_merge_hypothesis_results")
+def merge_hypothesis_results(state: InvestigationState) -> dict:
+    """Merge results from parallel investigate_hypothesis subgraphs."""
     tracker = get_tracker()
-    tracker.start("investigate", "Gathering evidence")
+    tracker.start("merge_hypotheses", "Merging parallel investigation results")
 
     base_evidence, resolved_from_opensre = _load_opensre_telemetry_into_evidence(state)
     input_data = InvestigateInput.from_state(state).model_copy(update={"evidence": base_evidence})
 
-    planned_actions = state.get("planned_actions", [])
     plan_rationale = state.get("plan_rationale", "")
     available_sources = cast(dict[str, dict[str, object]], state.get("available_sources", {}))
-    available_action_names = state.get("available_action_names", [])
 
-    if not available_action_names or not planned_actions:
-        debug_print("No planned actions to execute. Using existing evidence.")
-        tracker.complete("investigate", fields_updated=["evidence"], message="No new actions")
-        out: dict[str, Any] = {"evidence": input_data.evidence}
-        if resolved_from_opensre is not None:
-            out["resolved_integrations"] = resolved_from_opensre
-        return out
+    hypothesis_results = state.get("hypothesis_results", [])
 
-    all_actions = get_available_actions()
-    actions_by_name = {action.name: action for action in all_actions}
+    execution_results = {}
+    for res in hypothesis_results:
+        action_name = res.get("action_name")
+        if action_name:
+            execution_results[action_name] = ActionExecutionResult(
+                action_name=action_name,
+                success=res.get("success", False),
+                data=res.get("data", {}),
+                error=res.get("error"),
+            )
 
-    # Build available actions dictionary from ALL planned actions (not just available_action_names)
-    # This allows retrying actions that may have been filtered out by select_actions
-    available_actions = {}
-    for name in planned_actions:
-        if name in actions_by_name:
-            available_actions[name] = actions_by_name[name]
-        else:
-            logger.warning("Planned action '%s' not found in action registry", name)
-
-    # Execute actions and summarize results
-    execution_results = execute_actions(planned_actions, available_actions, available_sources)
     raw_plan_audit = state.get("plan_audit")
     plan_audit = cast(
         PlanAudit | None, raw_plan_audit if isinstance(raw_plan_audit, dict) else None
     )
+
     evidence, executed_hypotheses, evidence_summary = summarize_execution_results(
         execution_results=execution_results,
         current_evidence=input_data.evidence,
@@ -111,7 +96,6 @@ def node_investigate(state: InvestigationState) -> dict:
         current_service = str(grafana_source.get("service_name", ""))
         pipeline_name = str(grafana_source.get("pipeline_name", ""))
         no_logs_yet = not evidence.get("grafana_logs")
-        # Only update if the current service_name doesn't match anything in Loki
         if no_logs_yet and current_service not in discovered_services:
             matching_services = [
                 s for s in discovered_services if pipeline_name and pipeline_name in s
@@ -121,14 +105,12 @@ def node_investigate(state: InvestigationState) -> dict:
             elif discovered_services:
                 available_sources["grafana"]["service_name"] = discovered_services[0]
 
-    # Apply reversible masking to evidence before it flows to downstream LLM
-    # nodes. No-op when OPENSRE_MASK_ENABLED is not set.
     masking_ctx = MaskingContext.from_state(cast(dict[str, object], state))
     masked_evidence = masking_ctx.mask_value(evidence)
     masking_map = masking_ctx.to_state()
 
     tracker.complete(
-        "investigate",
+        "merge_hypotheses",
         fields_updated=["evidence", "executed_hypotheses"],
         message=evidence_summary,
     )
@@ -137,7 +119,9 @@ def node_investigate(state: InvestigationState) -> dict:
     result: dict[str, object] = {
         **output.to_dict(),
         "available_sources": available_sources,
+        "hypothesis_results": ["CLEAR"],
     }
+
     if resolved_from_opensre is not None:
         result["resolved_integrations"] = resolved_from_opensre
     if masking_map:

--- a/app/nodes/investigate/merge.py
+++ b/app/nodes/investigate/merge.py
@@ -10,7 +10,7 @@ from app.nodes.investigate.execution.execute_actions import ActionExecutionResul
 from app.nodes.investigate.models import InvestigateInput, InvestigateOutput
 from app.nodes.investigate.processing import summarize_execution_results
 from app.nodes.investigate.types import PlanAudit
-from app.output import get_tracker
+from app.output import debug_print, get_tracker
 from app.state import InvestigationState
 
 logger = logging.getLogger(__name__)
@@ -36,8 +36,6 @@ def _load_opensre_telemetry_into_evidence(
         logger.exception("OpenSRE telemetry load failed during evidence gathering")
         return prior, None
     ev = seed.get("evidence") or prior
-    from app.output import debug_print
-
     if ev.get("opensre_telemetry_seed"):
         debug_print(f"OpenSRE telemetry loaded from {ev.get('opensre_telemetry_dir', '')}")
     return ev, seed.get("resolved_integrations")
@@ -119,7 +117,7 @@ def merge_hypothesis_results(state: InvestigationState) -> dict:
     result: dict[str, object] = {
         **output.to_dict(),
         "available_sources": available_sources,
-        "hypothesis_results": ["CLEAR"],
+        "hypothesis_results": [{"__clear": True}],
     }
 
     if resolved_from_opensre is not None:

--- a/app/nodes/investigate/parallel.py
+++ b/app/nodes/investigate/parallel.py
@@ -31,6 +31,11 @@ def node_investigate_hypothesis(state: InvestigationState) -> dict:
     # Check if action is available
     if action_name not in actions_by_name:
         logger.warning("Planned action '%s' not found in action registry", action_name)
+        tracker.complete(
+            f"investigate_{action_name}",
+            fields_updated=[],
+            message=f"Skipped {action_name}: not in registry",
+        )
         return {"hypothesis_results": []}
 
     available_actions = {action_name: actions_by_name[action_name]}

--- a/app/nodes/investigate/parallel.py
+++ b/app/nodes/investigate/parallel.py
@@ -1,0 +1,58 @@
+"""Parallel execution of investigate actions as hypotheses."""
+
+import logging
+from typing import cast
+
+from langsmith import traceable
+
+from app.nodes.investigate.execution.execute_actions import execute_actions
+from app.output import get_tracker
+from app.state import InvestigationState
+from app.tools.investigation_registry import get_available_actions
+
+logger = logging.getLogger(__name__)
+
+
+@traceable(name="node_investigate_hypothesis")
+def node_investigate_hypothesis(state: InvestigationState) -> dict:
+    """Execute a single investigation action (hypothesis) in its own subgraph."""
+    tracker = get_tracker()
+
+    action_name = state.get("action_to_run")
+    if not action_name:
+        return {"hypothesis_results": []}
+
+    tracker.start(f"investigate_{action_name}", f"Executing {action_name}")
+
+    available_sources = cast(dict[str, dict[str, object]], state.get("available_sources", {}))
+    all_actions = get_available_actions()
+    actions_by_name = {action.name: action for action in all_actions}
+
+    # Check if action is available
+    if action_name not in actions_by_name:
+        logger.warning("Planned action '%s' not found in action registry", action_name)
+        return {"hypothesis_results": []}
+
+    available_actions = {action_name: actions_by_name[action_name]}
+
+    # Execute single action
+    execution_results = execute_actions([action_name], available_actions, available_sources)
+
+    tracker.complete(
+        f"investigate_{action_name}", fields_updated=[], message=f"Completed {action_name}"
+    )
+
+    # Return serialized result to be collected by merge node
+    result = execution_results.get(action_name)
+    if result:
+        return {
+            "hypothesis_results": [
+                {
+                    "action_name": action_name,
+                    "success": result.success,
+                    "data": result.data,
+                    "error": result.error,
+                }
+            ]
+        }
+    return {"hypothesis_results": []}

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -20,8 +20,10 @@ from app.nodes.chat import (
     tool_executor_node,
 )
 from app.nodes.evaluate_opensre import node_opensre_llm_eval
-from app.nodes.investigate.node import node_investigate
+from app.nodes.investigate.merge import merge_hypothesis_results
+from app.nodes.investigate.parallel import node_investigate_hypothesis
 from app.pipeline.routing import (
+    distribute_hypotheses,
     route_after_extract,
     route_by_mode,
     route_chat,
@@ -46,7 +48,8 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     graph.add_node("extract_alert", node_extract_alert)
     graph.add_node("resolve_integrations", node_resolve_integrations)
     graph.add_node("plan_actions", node_plan_actions)
-    graph.add_node("investigate", node_investigate)
+    graph.add_node("investigate_hypothesis", node_investigate_hypothesis)
+    graph.add_node("merge_hypothesis_results", merge_hypothesis_results)
     graph.add_node("diagnose", node_diagnose_root_cause)
     graph.add_node("opensre_eval", node_opensre_llm_eval)
     graph.add_node("publish", node_publish_findings)
@@ -70,8 +73,9 @@ def build_graph(config: None = None) -> CompiledStateGraph:
         "extract_alert", route_after_extract, {"end": END, "investigate": "resolve_integrations"}
     )
     graph.add_edge("resolve_integrations", "plan_actions")
-    graph.add_edge("plan_actions", "investigate")
-    graph.add_edge("investigate", "diagnose")
+    graph.add_conditional_edges("plan_actions", distribute_hypotheses)
+    graph.add_edge("investigate_hypothesis", "merge_hypothesis_results")
+    graph.add_edge("merge_hypothesis_results", "diagnose")
     graph.add_conditional_edges(
         "diagnose",
         route_investigation_loop,

--- a/app/pipeline/routing.py
+++ b/app/pipeline/routing.py
@@ -48,18 +48,13 @@ def should_call_tools(state: AgentState) -> str:
     return "done"
 
 
-def distribute_hypotheses(state: AgentState) -> list[Send]:
+def distribute_hypotheses(state: AgentState) -> list[Send] | list[str]:
     """Distribute planned actions to parallel hypothesis execution nodes."""
     actions = state.get("planned_actions", [])
     available_sources = state.get("available_sources", {})
     if not actions:
         # No actions planned, skip to merge
-        return [
-            Send(
-                "investigate_hypothesis",
-                {"action_to_run": "", "available_sources": available_sources},
-            )
-        ]
+        return ["merge_hypothesis_results"]
 
     return [
         Send(

--- a/app/pipeline/routing.py
+++ b/app/pipeline/routing.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from langgraph.constants import Send
+
 from app.investigation_constants import MAX_INVESTIGATION_LOOPS
 from app.output import debug_print
 from app.state import AgentState, InvestigationState
@@ -44,6 +46,28 @@ def should_call_tools(state: AgentState) -> str:
         if hasattr(last, "tool_calls") and getattr(last, "tool_calls", None):
             return "call_tools"
     return "done"
+
+
+def distribute_hypotheses(state: AgentState) -> list[Send]:
+    """Distribute planned actions to parallel hypothesis execution nodes."""
+    actions = state.get("planned_actions", [])
+    available_sources = state.get("available_sources", {})
+    if not actions:
+        # No actions planned, skip to merge
+        return [
+            Send(
+                "investigate_hypothesis",
+                {"action_to_run": "", "available_sources": available_sources},
+            )
+        ]
+
+    return [
+        Send(
+            "investigate_hypothesis",
+            {"action_to_run": action, "available_sources": available_sources},
+        )
+        for action in actions
+    ]
 
 
 def should_continue_investigation(state: InvestigationState) -> str:

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -19,8 +19,10 @@ from app.strict_config import StrictConfigModel
 from app.types.retrieval import RetrievalControlsMap
 
 
-def merge_results_reducer(existing: list | None, new: list | None) -> list:
-    if new == ["CLEAR"]:
+def merge_results_reducer(
+    existing: list[dict[str, Any]] | None, new: list[dict[str, Any]] | None
+) -> list[dict[str, Any]]:
+    if new and len(new) == 1 and new[0].get("__clear"):
         return []
     if not existing:
         return new or []

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -19,6 +19,16 @@ from app.strict_config import StrictConfigModel
 from app.types.retrieval import RetrievalControlsMap
 
 
+def merge_results_reducer(existing: list | None, new: list | None) -> list:
+    if new == ["CLEAR"]:
+        return []
+    if not existing:
+        return new or []
+    if not new:
+        return existing
+    return existing + new
+
+
 class AgentState(TypedDict, total=False):
     """Unified state for chat and investigation modes.
 
@@ -82,6 +92,8 @@ class AgentState(TypedDict, total=False):
     investigation_loop_count: int
     hypotheses: list[str]
     executed_hypotheses: list[dict[str, Any]]
+    hypothesis_results: Annotated[list[dict[str, Any]], merge_results_reducer]
+    action_to_run: str
     investigation_started_at: float
 
     # Placeholder→original map for reversible infrastructure identifier masking
@@ -161,6 +173,8 @@ class AgentStateModel(StrictConfigModel):
     investigation_loop_count: int = 0
     hypotheses: list[str] = Field(default_factory=list)
     executed_hypotheses: list[dict[str, Any]] = Field(default_factory=list)
+    hypothesis_results: list[dict[str, Any]] = Field(default_factory=list)
+    action_to_run: str = ""
     investigation_started_at: float = 0.0
     masking_map: dict[str, str] = Field(default_factory=dict)
     slack_context: dict[str, Any] = Field(default_factory=dict)

--- a/tests/nodes/test_parallel_investigate.py
+++ b/tests/nodes/test_parallel_investigate.py
@@ -34,14 +34,22 @@ def test_distribute_hypotheses_empty():
     routes = distribute_hypotheses(state)
 
     assert len(routes) == 1
-    assert routes[0].node == "investigate_hypothesis"
-    assert routes[0].arg["action_to_run"] == ""
+    assert routes[0] == "merge_hypothesis_results"
 
 
 def test_node_investigate_hypothesis_empty():
     """Test parallel node with empty action."""
     state = make_initial_state("test", "test", "low")
     state["action_to_run"] = ""
+
+    result = node_investigate_hypothesis(state)
+    assert result == {"hypothesis_results": []}
+
+
+def test_node_investigate_hypothesis_unknown_action():
+    """Test parallel node handles missing registry actions safely."""
+    state = make_initial_state("test", "test", "low")
+    state["action_to_run"] = "non_existent_action_123"
 
     result = node_investigate_hypothesis(state)
     assert result == {"hypothesis_results": []}

--- a/tests/nodes/test_parallel_investigate.py
+++ b/tests/nodes/test_parallel_investigate.py
@@ -1,0 +1,47 @@
+"""Tests for parallel investigate hypothesis routing and merging."""
+
+import pytest
+from langgraph.constants import Send
+
+from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
+from app.nodes.investigate.merge import merge_hypothesis_results
+from app.nodes.investigate.parallel import node_investigate_hypothesis
+from app.pipeline.routing import distribute_hypotheses
+from app.state.factory import make_initial_state
+
+
+def test_distribute_hypotheses_with_actions():
+    """Test that distribute_hypotheses routes to parallel branches."""
+    state = make_initial_state("test", "test", "low")
+    state["planned_actions"] = ["query_grafana_logs", "query_datadog_all"]
+    state["available_sources"] = {"grafana": {"service_name": "test"}}
+
+    routes = distribute_hypotheses(state)
+
+    assert len(routes) == 2
+    for route in routes:
+        assert isinstance(route, Send)
+        assert route.node == "investigate_hypothesis"
+        assert "action_to_run" in route.arg
+        assert "available_sources" in route.arg
+
+
+def test_distribute_hypotheses_empty():
+    """Test routing when no actions are planned."""
+    state = make_initial_state("test", "test", "low")
+    state["planned_actions"] = []
+
+    routes = distribute_hypotheses(state)
+
+    assert len(routes) == 1
+    assert routes[0].node == "investigate_hypothesis"
+    assert routes[0].arg["action_to_run"] == ""
+
+
+def test_node_investigate_hypothesis_empty():
+    """Test parallel node with empty action."""
+    state = make_initial_state("test", "test", "low")
+    state["action_to_run"] = ""
+
+    result = node_investigate_hypothesis(state)
+    assert result == {"hypothesis_results": []}


### PR DESCRIPTION
**Type of Change:**
- [x] Feature
- [ ] Bug Fix
- [x] Improvement (Refactor / Performance)

**Description:**
This PR resolves a significant performance bottleneck in the `investigate` loop by migrating from sequential action execution to a parallelized, native LangGraph Fan-out/Fan-in architecture using `langgraph.constants.Send`.

*Changes:*
- Split the monolithic `node_investigate` into `node_investigate_hypothesis` (executing a single action) and `merge_hypothesis_results`.
- Implemented the `distribute_hypotheses` router to dispatch parallel graph branches based on the `planned_actions` array.
- Updated `AgentState` with a custom `merge_results_reducer` to properly combine isolated subgraph `hypothesis_results` concurrently.
- Re-wired `graph.py` to route through these new parallel nodes natively.

**Testing:**
- [x] Added `tests/nodes/test_parallel_investigate.py` to verify proper sub-graph routing distribution.
- [x] Ran all local checks (`make lint`, `make typecheck`, `make test-cov`); the entire test suite passes.
- [x] Verified graph compilations and state synchronizations remain intact.

**Impact Analysis:**
- *Backward compatible?* Yes. The `AgentState` schema changes are backwards-compatible additions (`action_to_run` and `hypothesis_results`), and the final state mutation behaves identically to the old sequential node.
- *Performance impact:* Highly positive. Actions that depend on external APIs (e.g., Datadog, Prometheus) now execute concurrently in the LangGraph lifecycle.

**AI-Assisted PRs:**
- [x] I reviewed every single line of AI-generated code.
- [x] I understand the logic and can explain it in my own words.
- [x] I tested edge cases (e.g., handling empty `planned_actions`).
- [x] I modified output to match project conventions (Ruff formatting, MyPy types).
- [x] Verified tests pass with the code.
