### PR TITLE
feat: add Argo CD deployment investigation integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,22 @@ GRAFANA_TEMPO_DATASOURCE_UID=
 # ]'
 GRAFANA_INSTANCES=
 
+# Argo CD (read-only REST API integration)
+# Use exactly one auth method: ARGOCD_AUTH_TOKEN/ARGOCD_TOKEN or username/password.
+ARGOCD_BASE_URL=
+ARGOCD_AUTH_TOKEN=
+ARGOCD_TOKEN=
+ARGOCD_USERNAME=
+ARGOCD_PASSWORD=
+ARGOCD_PROJECT=
+ARGOCD_APP_NAMESPACE=
+ARGOCD_VERIFY_SSL=true
+
+# Multi-instance Argo CD (optional). When set, takes precedence over the
+# single-instance ARGOCD_* vars above. See docs/multi-instance-integrations.mdx.
+# ARGOCD_INSTANCES='[{"name":"prod","base_url":"https://argocd.example.com","bearer_token":"***","project":"default"}]'
+ARGOCD_INSTANCES=
+
 # Datadog
 DD_API_KEY=
 DD_APP_KEY=

--- a/app/cli/constants.py
+++ b/app/cli/constants.py
@@ -53,6 +53,7 @@ SETUP_SERVICES: tuple[str, ...] = (
 
 VERIFY_SERVICES: tuple[str, ...] = (
     "alertmanager",
+    "argocd",
     "aws",
     "betterstack",
     "bitbucket",

--- a/app/integrations/catalog.py
+++ b/app/integrations/catalog.py
@@ -20,6 +20,7 @@ from app.integrations.gitlab import DEFAULT_GITLAB_BASE_URL, build_gitlab_config
 from app.integrations.mariadb import build_mariadb_config
 from app.integrations.models import (
     AlertmanagerIntegrationConfig,
+    ArgoCDIntegrationConfig,
     AWSIntegrationConfig,
     CoralogixIntegrationConfig,
     DatadogIntegrationConfig,
@@ -92,6 +93,7 @@ _SERVICE_KEY_MAP = {
     "alertmanager": "alertmanager",
     "airflow": "airflow",
     "apache airflow": "airflow",
+    "argocd": "argocd",
 }
 
 
@@ -645,6 +647,30 @@ def _classify_service_instance(
             return alertmanager_config.model_dump(), "alertmanager"
         return None, None
 
+    if key == "argocd":
+        try:
+            argocd_config = ArgoCDIntegrationConfig.model_validate(
+                {
+                    "base_url": credentials.get("base_url", ""),
+                    "bearer_token": credentials.get("bearer_token", "")
+                    or credentials.get("auth_token", "")
+                    or credentials.get("token", ""),
+                    "username": credentials.get("username", ""),
+                    "password": credentials.get("password", ""),
+                    "project": credentials.get("project", ""),
+                    "app_namespace": credentials.get("app_namespace", ""),
+                    "verify_ssl": credentials.get("verify_ssl", True),
+                    "integration_id": record_id,
+                }
+            )
+        except Exception:
+            return None, None
+        if argocd_config.base_url and (
+            argocd_config.bearer_token or (argocd_config.username and argocd_config.password)
+        ):
+            return argocd_config.model_dump(), "argocd"
+        return None, None
+
     if key == "bitbucket":
         workspace = str(credentials.get("workspace", "")).strip()
         if not workspace:
@@ -1063,6 +1089,43 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 "credentials": postgresql_config.model_dump(exclude={"integration_id"}),
             }
         )
+
+    argocd_multi = _parse_instances_env("ARGOCD_INSTANCES", "argocd")
+    if argocd_multi is not None:
+        integrations.append(argocd_multi)
+        argocd_base_url = ""
+        argocd_auth_token = ""
+        argocd_username = ""
+        argocd_password = ""
+    else:
+        argocd_base_url = os.getenv("ARGOCD_BASE_URL", "").strip()
+        argocd_auth_token = os.getenv("ARGOCD_AUTH_TOKEN", os.getenv("ARGOCD_TOKEN", "")).strip()
+        argocd_username = os.getenv("ARGOCD_USERNAME", "").strip()
+        argocd_password = os.getenv("ARGOCD_PASSWORD", "").strip()
+    if argocd_base_url and (argocd_auth_token or (argocd_username and argocd_password)):
+        try:
+            argocd_config = ArgoCDIntegrationConfig.model_validate(
+                {
+                    "base_url": argocd_base_url,
+                    "bearer_token": argocd_auth_token,
+                    "username": argocd_username,
+                    "password": argocd_password,
+                    "project": os.getenv("ARGOCD_PROJECT", "").strip(),
+                    "app_namespace": os.getenv("ARGOCD_APP_NAMESPACE", "").strip(),
+                    "verify_ssl": os.getenv("ARGOCD_VERIFY_SSL", "true").strip(),
+                }
+            )
+        except Exception:
+            pass
+        else:
+            integrations.append(
+                {
+                    "id": "env-argocd",
+                    "service": "argocd",
+                    "status": "active",
+                    "credentials": argocd_config.model_dump(exclude={"integration_id"}),
+                }
+            )
 
     vercel_api_token = os.getenv("VERCEL_API_TOKEN", "").strip()
     if vercel_api_token:
@@ -1575,6 +1638,7 @@ def resolve_effective_integrations(
         "opensearch",
         "alertmanager",
         "airflow",
+        "argocd",
     )
     for service in direct_services:
         resolved_integration = classified_integrations.get(service)

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from ipaddress import ip_address
 from typing import Any
 from urllib.parse import urlparse
 
@@ -11,33 +10,12 @@ from pydantic import Field, field_validator, model_validator
 
 from app.config import get_tracer_base_url
 from app.strict_config import StrictConfigModel
+from app.utils.url_validation import validate_https_or_loopback_http_url
 
 _LOCAL_GRAFANA_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0"}
 DEFAULT_HONEYCOMB_BASE_URL = "https://api.honeycomb.io"
 DEFAULT_HONEYCOMB_DATASET = "__all__"
 DEFAULT_CORALOGIX_BASE_URL = "https://api.coralogix.com"
-
-
-def _is_loopback_host(host: str) -> bool:
-    normalized = host.strip().strip("[]").lower()
-    if normalized == "localhost":
-        return True
-    try:
-        return ip_address(normalized).is_loopback
-    except ValueError:
-        return False
-
-
-def _validate_argocd_base_url(value: str) -> str:
-    if not value:
-        return ""
-    parsed = urlparse(value)
-    scheme = parsed.scheme.lower()
-    if scheme == "https" and parsed.netloc:
-        return value
-    if scheme == "http" and parsed.netloc and _is_loopback_host(parsed.hostname or ""):
-        return value
-    raise ValueError("Argo CD base_url must use https:// unless targeting localhost/loopback.")
 
 
 class GrafanaIntegrationConfig(StrictConfigModel):
@@ -571,7 +549,7 @@ class ArgoCDIntegrationConfig(StrictConfigModel):
     @classmethod
     def _normalize_base_url(cls, value: object) -> str:
         normalized = str(value or "").strip().rstrip("/")
-        return _validate_argocd_base_url(normalized)
+        return validate_https_or_loopback_http_url(normalized, service_name="Argo CD")
 
     @field_validator("bearer_token", mode="before")
     @classmethod

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -573,21 +573,20 @@ class ArgoCDIntegrationConfig(StrictConfigModel):
         normalized = str(value or "").strip().rstrip("/")
         return _validate_argocd_base_url(normalized)
 
-    @field_validator(
-        "bearer_token",
-        "username",
-        "password",
-        "project",
-        "app_namespace",
-        "integration_id",
-        mode="before",
-    )
+    @field_validator("bearer_token", mode="before")
     @classmethod
-    def _normalize_str(cls, value: object) -> str:
+    def _normalize_bearer_token(cls, value: object) -> str:
         text = str(value or "").strip()
         if text.lower().startswith("bearer "):
             text = text.split(None, 1)[1].strip()
         return text
+
+    @field_validator(
+        "username", "password", "project", "app_namespace", "integration_id", mode="before"
+    )
+    @classmethod
+    def _normalize_str(cls, value: object) -> str:
+        return str(value or "").strip()
 
     @field_validator("verify_ssl", mode="before")
     @classmethod

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from ipaddress import ip_address
 from typing import Any
 from urllib.parse import urlparse
 
@@ -15,6 +16,28 @@ _LOCAL_GRAFANA_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0"}
 DEFAULT_HONEYCOMB_BASE_URL = "https://api.honeycomb.io"
 DEFAULT_HONEYCOMB_DATASET = "__all__"
 DEFAULT_CORALOGIX_BASE_URL = "https://api.coralogix.com"
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().strip("[]").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _validate_argocd_base_url(value: str) -> str:
+    if not value:
+        return ""
+    parsed = urlparse(value)
+    scheme = parsed.scheme.lower()
+    if scheme == "https" and parsed.netloc:
+        return value
+    if scheme == "http" and parsed.netloc and _is_loopback_host(parsed.hostname or ""):
+        return value
+    raise ValueError("Argo CD base_url must use https:// unless targeting localhost/loopback.")
 
 
 class GrafanaIntegrationConfig(StrictConfigModel):
@@ -532,6 +555,64 @@ class AlertmanagerIntegrationConfig(StrictConfigModel):
         return self
 
 
+class ArgoCDIntegrationConfig(StrictConfigModel):
+    """Normalized Argo CD credentials used by resolution and verification flows."""
+
+    base_url: str
+    bearer_token: str = ""
+    username: str = ""
+    password: str = ""
+    project: str = ""
+    app_namespace: str = ""
+    verify_ssl: bool = True
+    integration_id: str = ""
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _normalize_base_url(cls, value: object) -> str:
+        normalized = str(value or "").strip().rstrip("/")
+        return _validate_argocd_base_url(normalized)
+
+    @field_validator(
+        "bearer_token",
+        "username",
+        "password",
+        "project",
+        "app_namespace",
+        "integration_id",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_str(cls, value: object) -> str:
+        text = str(value or "").strip()
+        if text.lower().startswith("bearer "):
+            text = text.split(None, 1)[1].strip()
+        return text
+
+    @field_validator("verify_ssl", mode="before")
+    @classmethod
+    def _normalize_bool(cls, value: object) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return True
+        text = str(value).strip().lower()
+        if text in {"0", "false", "no", "off"}:
+            return False
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        return bool(value)
+
+    @model_validator(mode="after")
+    def _no_dual_auth(self) -> ArgoCDIntegrationConfig:
+        if self.bearer_token and (self.username or self.password):
+            raise ValueError(
+                "Argo CD config has both bearer_token and username/password set; "
+                "use one auth method only."
+            )
+        return self
+
+
 class IntegrationInstance(StrictConfigModel):
     """One named instance of a provider.
 
@@ -622,3 +703,4 @@ class EffectiveIntegrations(StrictConfigModel):
     opensearch: EffectiveIntegrationEntry | None = None
     alertmanager: EffectiveIntegrationEntry | None = None
     airflow: dict[str, Any] | None = None
+    argocd: EffectiveIntegrationEntry | None = None

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -35,6 +35,7 @@ from app.integrations.postgresql import build_postgresql_config, validate_postgr
 from app.integrations.rabbitmq import build_rabbitmq_config, validate_rabbitmq_config
 from app.integrations.sentry import build_sentry_config, validate_sentry_config
 from app.services.alertmanager import AlertmanagerClient, AlertmanagerConfig
+from app.services.argocd import ArgoCDClient, ArgoCDConfig
 from app.services.coralogix import CoralogixClient
 from app.services.datadog.client import DatadogClient, DatadogConfig
 from app.services.honeycomb import HoneycombClient
@@ -44,6 +45,7 @@ from app.services.vercel.client import VercelClient, VercelConfig
 
 SUPPORTED_VERIFY_SERVICES = (
     "alertmanager",
+    "argocd",
     "grafana",
     "datadog",
     "honeycomb",
@@ -578,6 +580,53 @@ def _verify_alertmanager(source: str, config: dict[str, Any]) -> dict[str, str]:
     )
 
 
+def _verify_argocd(source: str, config: dict[str, Any]) -> dict[str, str]:
+    base_url = str(config.get("base_url", "")).strip()
+    bearer_token = str(config.get("bearer_token", "")).strip()
+    username = str(config.get("username", "")).strip()
+    password = str(config.get("password", "")).strip()
+    if not base_url:
+        return _result("argocd", source, "missing", "Missing base_url.")
+    if not (bearer_token or (username and password)):
+        return _result(
+            "argocd",
+            source,
+            "missing",
+            "Missing bearer token or username/password credentials.",
+        )
+
+    try:
+        argocd_config = ArgoCDConfig.model_validate(
+            {
+                "base_url": base_url,
+                "bearer_token": bearer_token,
+                "username": username,
+                "password": password,
+                "project": config.get("project", ""),
+                "app_namespace": config.get("app_namespace", ""),
+                "verify_ssl": config.get("verify_ssl", True),
+            }
+        )
+    except Exception as err:
+        return _result("argocd", source, "missing", str(err))
+
+    with ArgoCDClient(argocd_config) as client:
+        projects = [argocd_config.project] if argocd_config.project else None
+        result = client.list_applications(projects=projects)
+
+    if not result.get("success"):
+        return _result(
+            "argocd",
+            source,
+            "failed",
+            f"Application list failed: {result.get('error', 'unknown error')}",
+        )
+
+    total = int(result.get("total", 0) or 0)
+    suffix = "application" if total == 1 else "applications"
+    return _result("argocd", source, "passed", f"Connected to Argo CD and listed {total} {suffix}.")
+
+
 def _verify_opsgenie(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         opsgenie_config = OpsGenieConfig.model_validate(
@@ -891,6 +940,8 @@ def verify_integrations(
             results.append(_verify_mysql(source, config))
         elif current_service == "alertmanager":
             results.append(_verify_alertmanager(source, config))
+        elif current_service == "argocd":
+            results.append(_verify_argocd(source, config))
         elif current_service == "snowflake":
             results.append(_verify_snowflake(source, config))
         elif current_service == "azure":

--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -398,8 +398,13 @@ def _map_git_deploy_timeline(data: dict) -> dict:
 
 
 def _map_argocd_application_status(data: dict) -> dict:
+    applications = data.get("applications", [])
+    if not isinstance(applications, list):
+        applications = []
     return {
         "argocd_application": data.get("application", {}) or {},
+        "argocd_applications": applications,
+        "argocd_applications_total": data.get("total", len(applications)) or 0,
         "argocd_revision_history": data.get("recent_history", []) or [],
     }
 
@@ -720,6 +725,11 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
                 if count:
                     summary_parts.append(f"github:{count} commits in deploy window")
             elif action_name == "argocd_application_status":
+                applications = data.get("applications")
+                if isinstance(applications, list) and not data.get("application"):
+                    total = int(data.get("total", len(applications)) or 0)
+                    summary_parts.append(f"argocd:{total} applications")
+                    continue
                 app = (
                     data.get("application", {})
                     if isinstance(data.get("application", {}), dict)

--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -397,6 +397,20 @@ def _map_git_deploy_timeline(data: dict) -> dict:
     }
 
 
+def _map_argocd_application_status(data: dict) -> dict:
+    return {
+        "argocd_application": data.get("application", {}) or {},
+        "argocd_revision_history": data.get("recent_history", []) or [],
+    }
+
+
+def _map_argocd_application_diff(data: dict) -> dict:
+    return {
+        "argocd_drift_detected": bool(data.get("drift_detected", False)),
+        "argocd_diff": data.get("diffs", []) or [],
+    }
+
+
 def _map_alertmanager_alerts(data: dict) -> dict:
     return {
         "alertmanager_alerts": data.get("alerts") or [],
@@ -497,6 +511,8 @@ EVIDENCE_MAPPERS: dict[str, Callable[[dict], dict]] = {
     "get_github_file_contents": _map_github_file_contents,
     "list_github_commits": _map_github_commits,
     "get_git_deploy_timeline": _map_git_deploy_timeline,
+    "argocd_application_status": _map_argocd_application_status,
+    "argocd_application_diff": _map_argocd_application_diff,
     "alertmanager_alerts": _map_alertmanager_alerts,
     "alertmanager_silences": _map_alertmanager_silences,
     "list_eks_pods": _map_eks_pods,
@@ -703,6 +719,19 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
                 count = data.get("commits_count") or len(data.get("commits") or [])
                 if count:
                     summary_parts.append(f"github:{count} commits in deploy window")
+            elif action_name == "argocd_application_status":
+                app = (
+                    data.get("application", {})
+                    if isinstance(data.get("application", {}), dict)
+                    else {}
+                )
+                app_name = str(app.get("name", "")).strip() or "?"
+                sync_status = str(app.get("sync_status", "")).strip() or "unknown"
+                summary_parts.append(f"argocd:{app_name} status {sync_status}")
+            elif action_name == "argocd_application_diff":
+                app_name = str(data.get("application_name", "")).strip() or "?"
+                drift = str(bool(data.get("drift_detected", False))).lower()
+                summary_parts.append(f"argocd:{app_name} drift {drift}")
             elif action_name == "alertmanager_alerts":
                 firing_count = len(data.get("firing_alerts") or [])
                 total = data.get("total", 0)

--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -1272,7 +1272,14 @@ def detect_sources(
         ).lower()
         has_gitops_hint = any(
             marker in argocd_hint_text
-            for marker in ("argocd", "argo cd", "gitops", "drift", "deploy")
+            for marker in (
+                "argocd",
+                "argo cd",
+                "argo-cd",
+                "gitops",
+                "outofsync",
+                "outofsynced",
+            )
         )
         if application_name or revision or has_gitops_hint:
             sources["argocd"] = {

--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -1235,6 +1235,60 @@ def detect_sources(
             "connection_verified": True,
         }
 
+    argocd_int = (resolved_integrations or {}).get("argocd")
+    if argocd_int and str(argocd_int.get("base_url", "")).strip():
+        application_name = str(
+            annotations.get("argocd_application")
+            or annotations.get("argocd_app")
+            or annotations.get("application_name")
+            or raw_alert.get("argocd_application", "")
+            or raw_alert.get("argocd_app", "")
+        ).strip()
+        revision = str(
+            annotations.get("argocd_revision")
+            or annotations.get("revision")
+            or raw_alert.get("argocd_revision", "")
+        ).strip()
+        project = str(
+            annotations.get("argocd_project")
+            or raw_alert.get("argocd_project", "")
+            or argocd_int.get("project", "")
+        ).strip()
+        app_namespace = str(
+            annotations.get("argocd_app_namespace")
+            or raw_alert.get("argocd_app_namespace", "")
+            or argocd_int.get("app_namespace", "")
+        ).strip()
+        argocd_hint_text = " ".join(
+            str(value)
+            for value in (
+                raw_alert.get("alert_name", ""),
+                raw_alert.get("error_message", ""),
+                annotations.get("summary", ""),
+                annotations.get("description", ""),
+                annotations.get("message", ""),
+            )
+            if value
+        ).lower()
+        has_gitops_hint = any(
+            marker in argocd_hint_text
+            for marker in ("argocd", "argo cd", "gitops", "drift", "deploy")
+        )
+        if application_name or revision or has_gitops_hint:
+            sources["argocd"] = {
+                "base_url": str(argocd_int.get("base_url", "")).strip().rstrip("/"),
+                "bearer_token": str(argocd_int.get("bearer_token", "")).strip(),
+                "username": str(argocd_int.get("username", "")).strip(),
+                "password": str(argocd_int.get("password", "")).strip(),
+                "application_name": application_name,
+                "revision": revision,
+                "project": project,
+                "app_namespace": app_namespace,
+                "verify_ssl": argocd_int.get("verify_ssl", True),
+                "integration_id": str(argocd_int.get("integration_id", "")).strip(),
+                "connection_verified": True,
+            }
+
     alertmanager_int = (resolved_integrations or {}).get("alertmanager")
     if alertmanager_int and str(alertmanager_int.get("base_url", "")).strip():
         # Carry label filters from the alert when present so tools can pre-scope the query

--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -35,7 +35,9 @@ INVESTIGATED_EVIDENCE_KEYS = frozenset(
         "eks_node_health",
         "eks_pod_logs",
         "eks_deployment_status",
+        # Argo CD status can be collected for one app or in list mode.
         "argocd_application",
+        "argocd_applications",
     }
 )
 

--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -35,6 +35,7 @@ INVESTIGATED_EVIDENCE_KEYS = frozenset(
         "eks_node_health",
         "eks_pod_logs",
         "eks_deployment_status",
+        "argocd_application",
     }
 )
 

--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -35,9 +35,10 @@ INVESTIGATED_EVIDENCE_KEYS = frozenset(
         "eks_node_health",
         "eks_pod_logs",
         "eks_deployment_status",
-        # Argo CD status can be collected for one app or in list mode.
+        # Argo CD status can be collected for one app, in list mode, or as diff/drift data.
         "argocd_application",
         "argocd_applications",
+        "argocd_diff",
     }
 )
 
@@ -159,6 +160,9 @@ def check_evidence_availability(
         or evidence.get("eks_deployments") is not None
         or evidence.get("eks_pod_logs") is not None
         or evidence.get("eks_deployment_status") is not None
+        or evidence.get("argocd_application") is not None
+        or evidence.get("argocd_applications") is not None
+        or evidence.get("argocd_diff") is not None
     )
 
     # Check for evidence in alert annotations or raw text

--- a/app/services/argocd/__init__.py
+++ b/app/services/argocd/__init__.py
@@ -1,0 +1,5 @@
+"""Argo CD API client module."""
+
+from app.services.argocd.client import ArgoCDClient, ArgoCDConfig, make_argocd_client
+
+__all__ = ["ArgoCDClient", "ArgoCDConfig", "make_argocd_client"]

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -90,21 +90,20 @@ class ArgoCDConfig(StrictConfigModel):
         normalized = str(value or "").strip().rstrip("/")
         return _validate_base_url(normalized)
 
-    @field_validator(
-        "bearer_token",
-        "username",
-        "password",
-        "project",
-        "app_namespace",
-        "integration_id",
-        mode="before",
-    )
+    @field_validator("bearer_token", mode="before")
     @classmethod
-    def _normalize_str(cls, value: object) -> str:
+    def _normalize_bearer_token(cls, value: object) -> str:
         text = str(value or "").strip()
         if text.lower().startswith("bearer "):
             text = text.split(None, 1)[1].strip()
         return text
+
+    @field_validator(
+        "username", "password", "project", "app_namespace", "integration_id", mode="before"
+    )
+    @classmethod
+    def _normalize_str(cls, value: object) -> str:
+        return str(value or "").strip()
 
     @field_validator("verify_ssl", mode="before")
     @classmethod

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -7,6 +7,8 @@ from environment variables resolved by ``app.integrations.catalog``.
 
 from __future__ import annotations
 
+import difflib
+import json
 import logging
 import re
 from typing import Any
@@ -34,6 +36,10 @@ _GENERIC_SECRET_VALUE_RE = re.compile(
     r"|AKIA[0-9A-Z]{16}"
     r"|-----BEGIN [A-Z ]*PRIVATE KEY-----"
     r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"
+)
+_SENSITIVE_FIELD_RE = re.compile(
+    r"(?i)(password|passwd|secret|token|api[_-]?key|authorization|auth|private[_-]?key|"
+    r"client[_-]?secret|connection[_-]?string|credential)"
 )
 
 
@@ -288,7 +294,7 @@ class ArgoCDClient:
         project: str = "",
         app_namespace: str = "",
     ) -> dict[str, Any]:
-        """Fetch Argo CD server-side diff data for one application."""
+        """Fetch Argo CD diff data for one application."""
         name = str(application_name or "").strip()
         if not name:
             return {"success": False, "error": "application_name is required"}
@@ -302,12 +308,24 @@ class ArgoCDClient:
                 params=params,
             )
             payload = response.json()
-            raw_diffs = payload.get("diffs", []) if isinstance(payload, dict) else []
-            diffs = [_normalize_diff(diff) for diff in raw_diffs if isinstance(diff, dict)]
+            raw_diffs: list[Any] = []
+            payload_modified = False
+            if isinstance(payload, dict):
+                # Argo CD v3.3 exposes this response as {items, modified}; keep
+                # accepting the older/tested {diffs} shape for compatibility.
+                raw_diffs = payload.get("diffs") or payload.get("items") or []
+                payload_modified = bool(payload.get("modified"))
+            diffs = [
+                _normalize_diff(diff)
+                for diff in raw_diffs
+                if isinstance(diff, dict) and _resource_diff_is_modified(diff)
+            ]
+            if not diffs:
+                diffs = self._get_managed_resource_diffs(name, params=params)
             return {
                 "success": True,
                 "application_name": name,
-                "drift_detected": bool(diffs),
+                "drift_detected": bool(diffs) or payload_modified,
                 "diffs": diffs,
                 "diff_count": len(diffs),
             }
@@ -318,6 +336,29 @@ class ArgoCDClient:
                 name,
             )
             return self._error_result("get application diff failed", exc)
+
+    def _get_managed_resource_diffs(
+        self,
+        application_name: str,
+        *,
+        params: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Derive drift from Argo CD managed resource target/live states."""
+        response = self._request(
+            "GET",
+            f"/api/v1/applications/{quote(application_name, safe='')}/managed-resources",
+            params=params,
+        )
+        payload = response.json()
+        raw_items = payload.get("items", []) if isinstance(payload, dict) else []
+        diffs: list[dict[str, Any]] = []
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            diff = _managed_resource_diff(item)
+            if diff:
+                diffs.append(_normalize_diff(diff))
+        return diffs
 
 
 def _application_params(project: str = "", app_namespace: str = "") -> dict[str, str]:
@@ -385,6 +426,86 @@ def _recent_history(payload: dict[str, Any], limit: int = 5) -> list[dict[str, A
     history = status.get("history", []) if isinstance(status.get("history"), list) else []
     recent = [item for item in reversed(history) if isinstance(item, dict)]
     return recent[:limit]
+
+
+def _resource_diff_is_modified(payload: dict[str, Any]) -> bool:
+    if "modified" in payload:
+        return bool(payload.get("modified"))
+    return bool(
+        payload.get("diff")
+        or payload.get("liveState")
+        or payload.get("normalizedLiveState")
+        or payload.get("targetState")
+        or payload.get("predictedLiveState")
+    )
+
+
+def _managed_resource_diff(payload: dict[str, Any]) -> dict[str, Any] | None:
+    desired = str(payload.get("predictedLiveState") or payload.get("targetState") or "")
+    live = str(payload.get("normalizedLiveState") or payload.get("liveState") or "")
+    desired_state = _parse_json_state(desired)
+    live_state = _parse_json_state(live)
+    if desired_state is None or live_state is None:
+        # Argo CD managed resource states are expected to be JSON. Avoid
+        # synthesizing diffs from plain text/YAML where formatting alone can
+        # look like drift.
+        return None
+    desired_lines = _json_state_lines(desired_state)
+    live_lines = _json_state_lines(live_state)
+    if desired_lines == live_lines:
+        return None
+    if _json_contains_sensitive_data(desired_state) or _json_contains_sensitive_data(live_state):
+        rendered_diff = "[REDACTED secret-bearing resource diff]"
+    else:
+        rendered_diff = _render_state_diff(desired_lines, live_lines)
+    return {
+        "group": payload.get("group", ""),
+        "kind": payload.get("kind", ""),
+        "name": payload.get("name", ""),
+        "namespace": payload.get("namespace", ""),
+        "diff": rendered_diff,
+    }
+
+
+def _parse_json_state(value: str) -> Any | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _json_state_lines(value: Any) -> list[str]:
+    return json.dumps(value, indent=2, sort_keys=True).splitlines()
+
+
+def _json_contains_sensitive_data(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if _SENSITIVE_FIELD_RE.search(str(key)):
+                return True
+            if _json_contains_sensitive_data(nested):
+                return True
+        return False
+    if isinstance(value, list):
+        return any(_json_contains_sensitive_data(item) for item in value)
+    if isinstance(value, str):
+        return bool(_GENERIC_SECRET_VALUE_RE.search(value))
+    return False
+
+
+def _render_state_diff(desired_lines: list[str], live_lines: list[str]) -> str:
+    return "\n".join(
+        difflib.unified_diff(
+            desired_lines,
+            live_lines,
+            fromfile="desired",
+            tofile="live",
+            lineterm="",
+        )
+    )
 
 
 def _sanitize_diff(value: object, *, resource_kind: str = "") -> str:

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -1,0 +1,452 @@
+"""Argo CD REST API client.
+
+Wraps the read-only Argo CD API endpoints used by investigation tools and
+integration verification. Credentials come from the local integration store or
+from environment variables resolved by ``app.integrations.catalog``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from ipaddress import ip_address
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import httpx
+from pydantic import field_validator, model_validator
+
+from app.strict_config import StrictConfigModel
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 10.0
+_MAX_DIFF_CHARS = 10_000
+_SECRET_LINE_RE = re.compile(
+    r"(?i)(password|passwd|secret|token|api[_-]?key|authorization|bearer)\s*[:=]"
+)
+
+_GENERIC_SECRET_VALUE_RE = re.compile(
+    r"(?i)(bearer\s+[A-Za-z0-9._~+/=-]{6,}"
+    r"|authorization\s*[:=]\s*\S+"
+    r"|xox[baprs]-[A-Za-z0-9-]{8,}"
+    r"|gh[pousr]_[A-Za-z0-9_]{20,}"
+    r"|AKIA[0-9A-Z]{16}"
+    r"|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+    r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"
+)
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().strip("[]").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _validate_base_url(value: str) -> str:
+    if not value:
+        return ""
+    parsed = urlparse(value)
+    scheme = parsed.scheme.lower()
+    if scheme == "https" and parsed.netloc:
+        return value
+    if scheme == "http" and parsed.netloc and _is_loopback_host(parsed.hostname or ""):
+        return value
+    raise ValueError("Argo CD base_url must use https:// unless targeting localhost/loopback.")
+
+
+def _normalize_verify_ssl(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return True
+    text = str(value).strip().lower()
+    if text in {"0", "false", "no", "off"}:
+        return False
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    return bool(value)
+
+
+class ArgoCDConfig(StrictConfigModel):
+    """Normalized Argo CD connection settings."""
+
+    base_url: str
+    bearer_token: str = ""
+    username: str = ""
+    password: str = ""
+    project: str = ""
+    app_namespace: str = ""
+    verify_ssl: bool = True
+    integration_id: str = ""
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _normalize_base_url(cls, value: object) -> str:
+        normalized = str(value or "").strip().rstrip("/")
+        return _validate_base_url(normalized)
+
+    @field_validator(
+        "bearer_token",
+        "username",
+        "password",
+        "project",
+        "app_namespace",
+        "integration_id",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_str(cls, value: object) -> str:
+        text = str(value or "").strip()
+        if text.lower().startswith("bearer "):
+            text = text.split(None, 1)[1].strip()
+        return text
+
+    @field_validator("verify_ssl", mode="before")
+    @classmethod
+    def _normalize_bool(cls, value: object) -> bool:
+        return _normalize_verify_ssl(value)
+
+    @model_validator(mode="after")
+    def _no_dual_auth(self) -> ArgoCDConfig:
+        if self.bearer_token and (self.username or self.password):
+            raise ValueError(
+                "Argo CD config has both bearer_token and username/password set; "
+                "use one auth method only."
+            )
+        return self
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.base_url and (self.bearer_token or (self.username and self.password)))
+
+
+class ArgoCDClient:
+    """Synchronous read-only client for Argo CD's REST API."""
+
+    def __init__(
+        self,
+        config: ArgoCDConfig,
+        *,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.config = config
+        self._transport = transport
+        self._client: httpx.Client | None = None
+        self._session_token = ""
+
+    def _get_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self.config.base_url,
+                timeout=_DEFAULT_TIMEOUT,
+                verify=self.config.verify_ssl,
+                transport=self._transport,
+            )
+        return self._client
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> ArgoCDClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    @property
+    def is_configured(self) -> bool:
+        return self.config.is_configured
+
+    def _redact(self, value: object) -> str:
+        text = str(value)
+        for secret in (
+            self.config.bearer_token,
+            self.config.password,
+            self._session_token,
+        ):
+            if secret:
+                text = text.replace(secret, "[REDACTED]")
+        text = _GENERIC_SECRET_VALUE_RE.sub("[REDACTED]", text)
+        return re.sub(
+            r"(?i)\b(password|passwd|secret|token|api[_-]?key)\b\s+([A-Za-z0-9._~+/=-]{6,})",
+            r"\1 [REDACTED]",
+            text,
+        )
+
+    def _error_result(self, prefix: str, exc: Exception) -> dict[str, Any]:
+        if isinstance(exc, httpx.HTTPStatusError):
+            response_text = self._redact(exc.response.text[:2000])
+            return {
+                "success": False,
+                "error": f"HTTP {exc.response.status_code}: {response_text}",
+            }
+        return {"success": False, "error": self._redact(f"{prefix}: {exc}")}
+
+    def _ensure_session_token(self) -> str:
+        if self.config.bearer_token:
+            return self.config.bearer_token
+        if self._session_token:
+            return self._session_token
+        if not (self.config.username and self.config.password):
+            return ""
+
+        # Investigation tools issue short-lived read-only calls; if Argo CD expires
+        # this session token mid-run, the next request will surface the 401/403
+        # without leaking the token so callers can retry with fresh credentials.
+        response = self._get_client().post(
+            "/api/v1/session",
+            json={"username": self.config.username, "password": self.config.password},
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        token = str(payload.get("token", "")).strip() if isinstance(payload, dict) else ""
+        self._session_token = token
+        return token
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        token = self._ensure_session_token()
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        headers.update(kwargs.pop("headers", {}) or {})
+        response = self._get_client().request(method, path, headers=headers, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def list_applications(
+        self,
+        *,
+        projects: list[str] | None = None,
+        selector: str = "",
+    ) -> dict[str, Any]:
+        """List Argo CD applications, optionally filtered by projects or selector."""
+        params: dict[str, Any] = {}
+        cleaned_projects = [
+            str(project).strip() for project in (projects or []) if str(project).strip()
+        ]
+        if cleaned_projects:
+            params["projects"] = ",".join(cleaned_projects)
+        cleaned_selector = str(selector or "").strip()
+        if cleaned_selector:
+            params["selector"] = cleaned_selector
+        try:
+            response = self._request("GET", "/api/v1/applications", params=params)
+            payload = response.json()
+            items = payload.get("items", []) if isinstance(payload, dict) else []
+            applications = [
+                _normalize_application(item) for item in items if isinstance(item, dict)
+            ]
+            return {"success": True, "applications": applications, "total": len(applications)}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[argocd] list_applications failed type=%s", type(exc).__name__)
+            return self._error_result("list applications failed", exc)
+
+    def get_application_summary(
+        self,
+        application_name: str,
+        *,
+        project: str = "",
+        app_namespace: str = "",
+    ) -> dict[str, Any]:
+        """Fetch one Argo CD application and return a compact status summary."""
+        name = str(application_name or "").strip()
+        if not name:
+            return {"success": False, "error": "application_name is required"}
+        params = _application_params(
+            project or self.config.project, app_namespace or self.config.app_namespace
+        )
+        try:
+            response = self._request(
+                "GET",
+                f"/api/v1/applications/{quote(name, safe='')}",
+                params=params,
+            )
+            payload = response.json()
+            if not isinstance(payload, dict):
+                return {"success": False, "error": "unexpected application response"}
+            app = _normalize_application(payload)
+            return {
+                "success": True,
+                "application": app,
+                "recent_history": _recent_history(payload),
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[argocd] get_application_summary failed type=%s app=%r",
+                type(exc).__name__,
+                name,
+            )
+            return self._error_result("get application summary failed", exc)
+
+    def get_application_diff(
+        self,
+        application_name: str,
+        *,
+        project: str = "",
+        app_namespace: str = "",
+    ) -> dict[str, Any]:
+        """Fetch Argo CD server-side diff data for one application."""
+        name = str(application_name or "").strip()
+        if not name:
+            return {"success": False, "error": "application_name is required"}
+        params = _application_params(
+            project or self.config.project, app_namespace or self.config.app_namespace
+        )
+        try:
+            response = self._request(
+                "GET",
+                f"/api/v1/applications/{quote(name, safe='')}/server-side-diff",
+                params=params,
+            )
+            payload = response.json()
+            raw_diffs = payload.get("diffs", []) if isinstance(payload, dict) else []
+            diffs = [_normalize_diff(diff) for diff in raw_diffs if isinstance(diff, dict)]
+            return {
+                "success": True,
+                "application_name": name,
+                "drift_detected": bool(diffs),
+                "diffs": diffs,
+                "diff_count": len(diffs),
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[argocd] get_application_diff failed type=%s app=%r",
+                type(exc).__name__,
+                name,
+            )
+            return self._error_result("get application diff failed", exc)
+
+
+def _application_params(project: str = "", app_namespace: str = "") -> dict[str, str]:
+    params: dict[str, str] = {}
+    if project:
+        params["project"] = project
+    if app_namespace:
+        params["appNamespace"] = app_namespace
+    return params
+
+
+def _normalize_application(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata = payload.get("metadata", {}) if isinstance(payload.get("metadata"), dict) else {}
+    spec = payload.get("spec", {}) if isinstance(payload.get("spec"), dict) else {}
+    source = spec.get("source", {}) if isinstance(spec.get("source"), dict) else {}
+    destination = spec.get("destination", {}) if isinstance(spec.get("destination"), dict) else {}
+    status = payload.get("status", {}) if isinstance(payload.get("status"), dict) else {}
+    sync = status.get("sync", {}) if isinstance(status.get("sync"), dict) else {}
+    health = status.get("health", {}) if isinstance(status.get("health"), dict) else {}
+    operation_state = (
+        status.get("operationState", {}) if isinstance(status.get("operationState"), dict) else {}
+    )
+    sync_result = (
+        operation_state.get("syncResult", {})
+        if isinstance(operation_state.get("syncResult"), dict)
+        else {}
+    )
+    history = status.get("history", []) if isinstance(status.get("history"), list) else []
+    summary = status.get("summary", {}) if isinstance(status.get("summary"), dict) else {}
+    revision = (
+        str(sync.get("revision") or "").strip()
+        or str(sync_result.get("revision") or "").strip()
+        or _history_revision(history)
+    )
+    return {
+        "name": str(metadata.get("name", "")).strip(),
+        "namespace": str(metadata.get("namespace", "")).strip(),
+        "project": str(spec.get("project", "")).strip(),
+        "repo_url": str(source.get("repoURL", "")).strip(),
+        "target_revision": str(source.get("targetRevision", "")).strip(),
+        "destination_server": str(destination.get("server", "")).strip(),
+        "destination_namespace": str(destination.get("namespace", "")).strip(),
+        "sync_status": str(sync.get("status", "")).strip(),
+        "health_status": str(health.get("status", "")).strip(),
+        "health_message": str(health.get("message", "")).strip(),
+        "revision": revision,
+        "operation_phase": str(operation_state.get("phase", "")).strip(),
+        "operation_message": str(operation_state.get("message", "")).strip(),
+        "images": list(summary.get("images", []) or [])
+        if isinstance(summary.get("images", []), list)
+        else [],
+        "history_count": len(history),
+    }
+
+
+def _history_revision(history: list[Any]) -> str:
+    for item in reversed(history):
+        if isinstance(item, dict) and item.get("revision"):
+            return str(item["revision"]).strip()
+    return ""
+
+
+def _recent_history(payload: dict[str, Any], limit: int = 5) -> list[dict[str, Any]]:
+    status = payload.get("status", {}) if isinstance(payload.get("status"), dict) else {}
+    history = status.get("history", []) if isinstance(status.get("history"), list) else []
+    recent = [item for item in reversed(history) if isinstance(item, dict)]
+    return recent[:limit]
+
+
+def _sanitize_diff(value: object, *, resource_kind: str = "") -> str:
+    if str(resource_kind or "").strip().lower() == "secret":
+        return "[REDACTED Kubernetes Secret diff]"
+
+    lines: list[str] = []
+    for line in str(value or "").splitlines():
+        if _SECRET_LINE_RE.search(line) or _GENERIC_SECRET_VALUE_RE.search(line):
+            lines.append("[REDACTED secret-bearing diff line]")
+        else:
+            lines.append(line)
+    text = "\n".join(lines)
+    if len(text) > _MAX_DIFF_CHARS:
+        return f"{text[:_MAX_DIFF_CHARS]}\n[truncated after {_MAX_DIFF_CHARS} chars]"
+    return text
+
+
+def _normalize_diff(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "group": str(payload.get("group", "")).strip(),
+        "kind": str(payload.get("kind", "")).strip(),
+        "name": str(payload.get("name", "")).strip(),
+        "namespace": str(payload.get("namespace", "")).strip(),
+        "diff": _sanitize_diff(payload.get("diff", ""), resource_kind=payload.get("kind", "")),
+    }
+
+
+def make_argocd_client(
+    base_url: str | None,
+    bearer_token: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    *,
+    project: str | None = None,
+    app_namespace: str | None = None,
+    verify_ssl: bool | str = True,
+) -> ArgoCDClient | None:
+    """Create an ArgoCDClient when a URL and auth method are available."""
+    url = (base_url or "").strip().rstrip("/")
+    token = (bearer_token or "").strip()
+    user = (username or "").strip()
+    pw = (password or "").strip()
+    if not url or not (token or (user and pw)):
+        return None
+    try:
+        return ArgoCDClient(
+            ArgoCDConfig(
+                base_url=url,
+                bearer_token=token,
+                username=user,
+                password=pw,
+                project=project or "",
+                app_namespace=app_namespace or "",
+                verify_ssl=_normalize_verify_ssl(verify_ssl),
+            )
+        )
+    except Exception:
+        return None

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import logging
 import re
-from ipaddress import ip_address
 from typing import Any
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 import httpx
 from pydantic import field_validator, model_validator
 
 from app.strict_config import StrictConfigModel
+from app.utils.url_validation import validate_https_or_loopback_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -35,28 +35,6 @@ _GENERIC_SECRET_VALUE_RE = re.compile(
     r"|-----BEGIN [A-Z ]*PRIVATE KEY-----"
     r"|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})"
 )
-
-
-def _is_loopback_host(host: str) -> bool:
-    normalized = host.strip().strip("[]").lower()
-    if normalized == "localhost":
-        return True
-    try:
-        return ip_address(normalized).is_loopback
-    except ValueError:
-        return False
-
-
-def _validate_base_url(value: str) -> str:
-    if not value:
-        return ""
-    parsed = urlparse(value)
-    scheme = parsed.scheme.lower()
-    if scheme == "https" and parsed.netloc:
-        return value
-    if scheme == "http" and parsed.netloc and _is_loopback_host(parsed.hostname or ""):
-        return value
-    raise ValueError("Argo CD base_url must use https:// unless targeting localhost/loopback.")
 
 
 def _normalize_verify_ssl(value: object) -> bool:
@@ -88,7 +66,7 @@ class ArgoCDConfig(StrictConfigModel):
     @classmethod
     def _normalize_base_url(cls, value: object) -> str:
         normalized = str(value or "").strip().rstrip("/")
-        return _validate_base_url(normalized)
+        return validate_https_or_loopback_http_url(normalized, service_name="Argo CD")
 
     @field_validator("bearer_token", mode="before")
     @classmethod
@@ -137,6 +115,7 @@ class ArgoCDClient:
         self._transport = transport
         self._client: httpx.Client | None = None
         self._session_token = ""
+        self._retired_session_tokens: set[str] = set()
 
     def _get_client(self) -> httpx.Client:
         if self._client is None:
@@ -170,6 +149,7 @@ class ArgoCDClient:
             self.config.bearer_token,
             self.config.password,
             self._session_token,
+            *self._retired_session_tokens,
         ):
             if secret:
                 text = text.replace(secret, "[REDACTED]")
@@ -197,9 +177,9 @@ class ArgoCDClient:
         if not (self.config.username and self.config.password):
             return ""
 
-        # Investigation tools issue short-lived read-only calls; if Argo CD expires
-        # this session token mid-run, the next request will surface the 401/403
-        # without leaking the token so callers can retry with fresh credentials.
+        # Investigation tools issue short-lived read-only calls. If Argo CD expires
+        # a session token mid-run, _request clears the cached token, retries once,
+        # and redacts both active and retired tokens in any surfaced error.
         response = self._get_client().post(
             "/api/v1/session",
             json={"username": self.config.username, "password": self.config.password},
@@ -212,14 +192,29 @@ class ArgoCDClient:
         return token
 
     def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        token = self._ensure_session_token()
-        headers = {"Content-Type": "application/json"}
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        headers.update(kwargs.pop("headers", {}) or {})
-        response = self._get_client().request(method, path, headers=headers, **kwargs)
-        response.raise_for_status()
-        return response
+        for attempt in range(2):
+            request_kwargs = dict(kwargs)
+            token = self._ensure_session_token()
+            headers = {"Content-Type": "application/json"}
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            headers.update(request_kwargs.pop("headers", {}) or {})
+            response = self._get_client().request(method, path, headers=headers, **request_kwargs)
+            try:
+                response.raise_for_status()
+                return response
+            except httpx.HTTPStatusError as exc:
+                if (
+                    exc.response.status_code == 401
+                    and self._session_token
+                    and not self.config.bearer_token
+                ):
+                    self._retired_session_tokens.add(self._session_token)
+                    self._session_token = ""
+                    if attempt == 0:
+                        continue
+                raise
+        raise RuntimeError("Argo CD request retry exhausted")
 
     def list_applications(
         self,

--- a/app/tools/ArgoCDApplicationDiffTool/__init__.py
+++ b/app/tools/ArgoCDApplicationDiffTool/__init__.py
@@ -1,0 +1,133 @@
+"""Argo CD application diff/drift investigation tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.argocd import make_argocd_client
+from app.tools.base import BaseTool
+
+
+class ArgoCDApplicationDiffTool(BaseTool):
+    """Fetch Argo CD server-side diff data for an application."""
+
+    name = "argocd_application_diff"
+    source = "argocd"
+    description = (
+        "Fetch Argo CD server-side diff output and report whether live cluster state "
+        "has drifted from the desired GitOps state."
+    )
+    use_cases = [
+        "Detecting GitOps drift during an incident",
+        "Checking whether an OutOfSync application has Kubernetes object diffs",
+        "Correlating deployment drift with application health degradation",
+    ]
+    requires = ["base_url", "application_name"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "base_url": {"type": "string", "description": "Argo CD base URL"},
+            "bearer_token": {"type": "string", "default": "", "description": "Argo CD API token"},
+            "username": {"type": "string", "default": "", "description": "Argo CD username"},
+            "password": {"type": "string", "default": "", "description": "Argo CD password"},
+            "application_name": {"type": "string", "description": "Application name"},
+            "project": {"type": "string", "default": "", "description": "Optional Argo CD project"},
+            "app_namespace": {
+                "type": "string",
+                "default": "",
+                "description": "Optional app namespace",
+            },
+            "verify_ssl": {
+                "type": "boolean",
+                "default": True,
+                "description": "Verify TLS certificates",
+            },
+        },
+        "required": ["base_url", "application_name"],
+    }
+    outputs = {
+        "drift_detected": "True when Argo CD reports one or more object diffs",
+        "diffs": "Sanitized server-side diff records",
+        "diff_count": "Number of diff records returned",
+    }
+
+    def is_available(self, sources: dict) -> bool:
+        argocd = sources.get("argocd", {})
+        return bool(
+            argocd.get("connection_verified")
+            and argocd.get("base_url")
+            and argocd.get("application_name")
+            and (argocd.get("bearer_token") or (argocd.get("username") and argocd.get("password")))
+        )
+
+    def extract_params(self, sources: dict) -> dict[str, Any]:
+        argocd = sources["argocd"]
+        return {
+            "base_url": argocd.get("base_url", ""),
+            "bearer_token": argocd.get("bearer_token", ""),
+            "username": argocd.get("username", ""),
+            "password": argocd.get("password", ""),
+            "application_name": argocd.get("application_name", ""),
+            "project": argocd.get("project", ""),
+            "app_namespace": argocd.get("app_namespace", ""),
+            "verify_ssl": argocd.get("verify_ssl", True),
+        }
+
+    def run(
+        self,
+        base_url: str,
+        application_name: str,
+        bearer_token: str = "",
+        username: str = "",
+        password: str = "",
+        project: str = "",
+        app_namespace: str = "",
+        verify_ssl: bool = True,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        client = make_argocd_client(
+            base_url,
+            bearer_token,
+            username,
+            password,
+            project=project,
+            app_namespace=app_namespace,
+            verify_ssl=verify_ssl,
+        )
+        if client is None:
+            return {
+                "source": "argocd",
+                "available": False,
+                "error": "Argo CD integration is not configured (missing base_url or auth).",
+                "application_name": application_name,
+                "drift_detected": False,
+                "diffs": [],
+                "diff_count": 0,
+            }
+
+        with client:
+            result = client.get_application_diff(
+                application_name,
+                project=project,
+                app_namespace=app_namespace,
+            )
+
+        if not result.get("success"):
+            return {
+                "source": "argocd",
+                "available": False,
+                "error": result.get("error", "unknown error"),
+                "application_name": application_name,
+                "drift_detected": False,
+                "diffs": [],
+                "diff_count": 0,
+            }
+
+        return {
+            "source": "argocd",
+            "available": True,
+            **result,
+        }
+
+
+argocd_application_diff = ArgoCDApplicationDiffTool()

--- a/app/tools/ArgoCDApplicationStatusTool/__init__.py
+++ b/app/tools/ArgoCDApplicationStatusTool/__init__.py
@@ -1,0 +1,137 @@
+"""Argo CD application status investigation tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.argocd import make_argocd_client
+from app.tools.base import BaseTool
+
+
+class ArgoCDApplicationStatusTool(BaseTool):
+    """Fetch Argo CD application sync and health status."""
+
+    name = "argocd_application_status"
+    source = "argocd"
+    description = (
+        "Fetch Argo CD application sync status, health status, current revision, "
+        "and recent deployment history."
+    )
+    use_cases = [
+        "Checking whether a GitOps application is OutOfSync or Degraded",
+        "Correlating an incident with a recent Argo CD deployment revision",
+        "Listing visible Argo CD applications when an alert omits the application name",
+    ]
+    requires = ["base_url"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "base_url": {"type": "string", "description": "Argo CD base URL"},
+            "bearer_token": {"type": "string", "default": "", "description": "Argo CD API token"},
+            "username": {"type": "string", "default": "", "description": "Argo CD username"},
+            "password": {"type": "string", "default": "", "description": "Argo CD password"},
+            "application_name": {
+                "type": "string",
+                "default": "",
+                "description": "Application name",
+            },
+            "project": {"type": "string", "default": "", "description": "Optional Argo CD project"},
+            "app_namespace": {
+                "type": "string",
+                "default": "",
+                "description": "Optional app namespace",
+            },
+            "verify_ssl": {
+                "type": "boolean",
+                "default": True,
+                "description": "Verify TLS certificates",
+            },
+        },
+        "required": ["base_url"],
+    }
+    outputs = {
+        "application": "Application status summary when application_name is provided",
+        "applications": "Application list when application_name is omitted",
+        "recent_history": "Recent Argo CD deployment history entries",
+    }
+
+    def is_available(self, sources: dict) -> bool:
+        argocd = sources.get("argocd", {})
+        return bool(
+            argocd.get("connection_verified")
+            and argocd.get("base_url")
+            and (argocd.get("bearer_token") or (argocd.get("username") and argocd.get("password")))
+        )
+
+    def extract_params(self, sources: dict) -> dict[str, Any]:
+        argocd = sources["argocd"]
+        return {
+            "base_url": argocd.get("base_url", ""),
+            "bearer_token": argocd.get("bearer_token", ""),
+            "username": argocd.get("username", ""),
+            "password": argocd.get("password", ""),
+            "application_name": argocd.get("application_name", ""),
+            "project": argocd.get("project", ""),
+            "app_namespace": argocd.get("app_namespace", ""),
+            "verify_ssl": argocd.get("verify_ssl", True),
+        }
+
+    def run(
+        self,
+        base_url: str,
+        bearer_token: str = "",
+        username: str = "",
+        password: str = "",
+        application_name: str = "",
+        project: str = "",
+        app_namespace: str = "",
+        verify_ssl: bool = True,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        client = make_argocd_client(
+            base_url,
+            bearer_token,
+            username,
+            password,
+            project=project,
+            app_namespace=app_namespace,
+            verify_ssl=verify_ssl,
+        )
+        if client is None:
+            return {
+                "source": "argocd",
+                "available": False,
+                "error": "Argo CD integration is not configured (missing base_url or auth).",
+                "application": {},
+                "applications": [],
+                "recent_history": [],
+            }
+
+        with client:
+            if application_name:
+                result = client.get_application_summary(
+                    application_name,
+                    project=project,
+                    app_namespace=app_namespace,
+                )
+            else:
+                result = client.list_applications(projects=[project] if project else None)
+
+        if not result.get("success"):
+            return {
+                "source": "argocd",
+                "available": False,
+                "error": result.get("error", "unknown error"),
+                "application": {},
+                "applications": [],
+                "recent_history": [],
+            }
+
+        return {
+            "source": "argocd",
+            "available": True,
+            **result,
+        }
+
+
+argocd_application_status = ArgoCDApplicationStatusTool()

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -43,4 +43,5 @@ EvidenceSource = Literal[
     "opensearch",
     "alertmanager",
     "airflow",
+    "argocd",
 ]

--- a/app/utils/url_validation.py
+++ b/app/utils/url_validation.py
@@ -1,0 +1,38 @@
+"""Shared URL validation helpers."""
+
+from __future__ import annotations
+
+from ipaddress import ip_address
+from urllib.parse import urlparse
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return True when ``host`` identifies localhost or a loopback IP."""
+    normalized = host.strip().strip("[]").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_https_or_loopback_http_url(
+    value: str,
+    *,
+    service_name: str,
+    field_name: str = "base_url",
+) -> str:
+    """Allow HTTPS URLs, plus plaintext HTTP only for loopback targets."""
+    if not value:
+        return ""
+
+    parsed = urlparse(value)
+    scheme = parsed.scheme.lower()
+    if scheme == "https" and parsed.netloc:
+        return value
+    if scheme == "http" and parsed.netloc and is_loopback_host(parsed.hostname or ""):
+        return value
+    raise ValueError(
+        f"{service_name} {field_name} must use https:// unless targeting localhost/loopback."
+    )

--- a/docs/argocd.mdx
+++ b/docs/argocd.mdx
@@ -1,0 +1,199 @@
+---
+title: "Argo CD"
+description: "Connect Argo CD so OpenSRE can inspect GitOps application health, sync state, revisions, and drift during investigations"
+---
+
+OpenSRE queries the Argo CD REST API as a read-only evidence source during GitOps incident investigations. It can list visible applications, inspect one application's sync and health status, and fetch sanitized server-side diff output to show deployment drift.
+
+## Prerequisites
+
+- Argo CD API server reachable from the machine running OpenSRE
+- A dedicated Argo CD account or API token with read access to the applications you want OpenSRE to inspect
+- The Argo CD base URL, for example `https://argocd.example.com`
+- Optional alert annotations that identify the affected Argo CD application, project, namespace, or revision
+
+## Setup
+
+Argo CD is configured through environment variables or the persistent integration store.
+
+### Option 1: Environment variables
+
+Add one authentication method to your `.env`:
+
+```bash
+ARGOCD_BASE_URL=https://argocd.example.com
+
+# Option A: API token auth. The token may be set with or without a "Bearer " prefix.
+ARGOCD_AUTH_TOKEN=***
+# ARGOCD_TOKEN=***   # alias also supported
+
+# Option B: username/password auth. Use instead of ARGOCD_AUTH_TOKEN.
+# ARGOCD_USERNAME=opensre-readonly
+# ARGOCD_PASSWORD=***
+
+# Optional scoping and TLS settings
+ARGOCD_PROJECT=default
+ARGOCD_APP_NAMESPACE=argocd
+ARGOCD_VERIFY_SSL=true
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ARGOCD_BASE_URL` | — | **Required.** Argo CD API base URL. Remote URLs must use `https://`; plain `http://` is accepted only for loopback or localhost development URLs. |
+| `ARGOCD_AUTH_TOKEN` | — | Argo CD bearer/API token. Use this or username/password, not both. |
+| `ARGOCD_TOKEN` | — | Alias for `ARGOCD_AUTH_TOKEN`. |
+| `ARGOCD_USERNAME` | — | Username for Argo CD session login. Use together with `ARGOCD_PASSWORD`. |
+| `ARGOCD_PASSWORD` | — | Password for Argo CD session login. Use together with `ARGOCD_USERNAME`. |
+| `ARGOCD_PROJECT` | — | Optional Argo CD project filter for listing and application-specific requests. |
+| `ARGOCD_APP_NAMESPACE` | — | Optional application namespace passed as `appNamespace` for application-specific requests. |
+| `ARGOCD_VERIFY_SSL` | `true` | Whether to verify TLS certificates. Set to `false` only for trusted local or lab environments. |
+
+OpenSRE rejects ambiguous auth configuration. Do not set a bearer token and username/password at the same time.
+
+### Option 2: Persistent store
+
+You can also add Argo CD to `~/.tracer/integrations.json`:
+
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "argocd-prod",
+      "service": "argocd",
+      "status": "active",
+      "credentials": {
+        "base_url": "https://argocd.example.com",
+        "bearer_token": "***",
+        "project": "default",
+        "app_namespace": "argocd",
+        "verify_ssl": true
+      }
+    }
+  ]
+}
+```
+
+The store also accepts `auth_token` or `token` as aliases for `bearer_token`. For username/password auth, omit `bearer_token` and set `username` and `password` instead.
+
+### Option 3: Multiple Argo CD instances
+
+For multiple Argo CD instances, set `ARGOCD_INSTANCES` to a JSON array. The first valid instance is used as the default integration for investigations.
+
+```bash
+export ARGOCD_INSTANCES='[
+  {
+    "name": "prod",
+    "tags": {"env": "prod"},
+    "credentials": {
+      "base_url": "https://argocd.prod.example.com",
+      "bearer_token": "***",
+      "project": "default"
+    }
+  },
+  {
+    "name": "staging",
+    "tags": {"env": "staging"},
+    "base_url": "https://argocd.staging.example.com",
+    "username": "opensre-readonly",
+    "password": "***"
+  }
+]'
+```
+
+When `ARGOCD_INSTANCES` is set, the single-instance `ARGOCD_BASE_URL` and auth variables are ignored for this service. `opensre integrations verify argocd` validates the resolved default instance.
+
+## Verify
+
+Run:
+
+```bash
+opensre integrations verify argocd
+```
+
+Expected output:
+
+```text
+Service: argocd
+Status:  passed
+Detail:  Connected to Argo CD and listed 3 applications.
+```
+
+Verification performs a read-only application list call. It proves OpenSRE can reach Argo CD and list visible applications with the configured credentials; it does not write to Argo CD or sync applications.
+
+## Usage in investigations
+
+When Argo CD is configured and an incoming alert contains GitOps context, OpenSRE can add Argo CD evidence to the investigation plan.
+
+OpenSRE recognizes these explicit alert fields:
+
+| Field | Location | Purpose |
+| --- | --- | --- |
+| `argocd_application` or `argocd_app` | Top-level alert payload or `annotations` | Name of the affected Argo CD application. |
+| `application_name` | `annotations` | Generic application name fallback. |
+| `argocd_revision` | Top-level alert payload or `annotations` | Revision mentioned by the alert. |
+| `revision` | `annotations` | Generic revision fallback. |
+| `argocd_project` | Top-level alert payload or `annotations` | Argo CD project for scoped application requests. |
+| `argocd_app_namespace` | Top-level alert payload or `annotations` | Argo CD application namespace for scoped requests. |
+
+OpenSRE also looks for GitOps hints in alert text such as `argocd`, `argo cd`, `argo-cd`, `gitops`, `outofsync`, or `outofsynced`.
+
+Example alert:
+
+```json
+{
+  "alert_name": "checkout-api OutOfSync",
+  "annotations": {
+    "summary": "Argo CD reports checkout-api is OutOfSync",
+    "argocd_application": "checkout-api",
+    "argocd_project": "default",
+    "argocd_revision": "abc123"
+  }
+}
+```
+
+Then run OpenSRE with the alert payload:
+
+```bash
+opensre investigate -i alert.json
+```
+
+## Evidence collected
+
+### `argocd_application_status`
+
+Fetches application status from Argo CD.
+
+- With `application_name`, it returns a compact summary for that application: sync status, health status, current revision, operation phase/message, destination, images, and recent deployment history.
+- Without `application_name`, it lists visible applications, optionally scoped by `ARGOCD_PROJECT`.
+
+The investigation agent uses this evidence to determine whether a deployment is `OutOfSync`, `Degraded`, on an unexpected revision, or correlated with a recent rollout.
+
+### `argocd_application_diff`
+
+Fetches Argo CD server-side diff output for one application.
+
+- Requires `application_name`.
+- Returns `drift_detected`, `diff_count`, and sanitized diff records.
+- Helps identify Kubernetes objects whose live state differs from the desired GitOps state.
+
+## Security best practices
+
+- Use a dedicated read-only Argo CD account or token for OpenSRE.
+- Store credentials in `.env` or `~/.tracer/integrations.json`, not in source code.
+- Use `https://` for remote Argo CD URLs. Plain `http://` is accepted only for loopback or localhost development URLs.
+- Do not disable `ARGOCD_VERIFY_SSL` for production instances.
+- OpenSRE redacts bearer tokens, passwords, token-like strings, and Kubernetes `Secret` diffs before surfacing Argo CD errors or diff evidence.
+- The integration is read-only: it lists applications, reads application summaries, and reads server-side diff data. It does not sync, modify, or delete Argo CD resources.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **Status: missing** | Set `ARGOCD_BASE_URL` and exactly one auth method, or add an active `argocd` store entry. |
+| **Remote `http://` URL rejected** | Use `https://` for remote Argo CD. Use plain HTTP only for `localhost`, `127.0.0.1`, or `::1` development endpoints. |
+| **401 Unauthorized** | Check the token, or verify that username/password login can create an Argo CD session. |
+| **403 Forbidden** | Ensure the account can list applications and read the target application. |
+| **SSL error** | Fix the certificate chain or, for a trusted lab only, set `ARGOCD_VERIFY_SSL=false`. |
+| **No diff evidence** | Confirm the alert provides `argocd_application` or `argocd_app`; the diff tool requires an application name. |
+| **Application list succeeds but a named app fails** | Check `ARGOCD_PROJECT` and `ARGOCD_APP_NAMESPACE`, and confirm the account has access to that application. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,6 +57,7 @@
               "honeycomb",
               "coralogix",
               "sentry",
+              "argocd",
               "github",
               "gitlab",
               "bitbucket",

--- a/docs/multi-instance-integrations.mdx
+++ b/docs/multi-instance-integrations.mdx
@@ -22,7 +22,7 @@ export GRAFANA_INSTANCES='[
 ]'
 ```
 
-Supported env vars: `GRAFANA_INSTANCES`, `DD_INSTANCES`, `HONEYCOMB_INSTANCES`, `CORALOGIX_INSTANCES`, `AWS_INSTANCES`.
+Supported env vars: `GRAFANA_INSTANCES`, `DD_INSTANCES`, `HONEYCOMB_INSTANCES`, `CORALOGIX_INSTANCES`, `AWS_INSTANCES`, `ARGOCD_INSTANCES`.
 
 When `<SERVICE>_INSTANCES` is set, the legacy single-instance vars for that service (e.g. `GRAFANA_INSTANCE_URL`, `GRAFANA_READ_TOKEN`) are ignored. If the JSON is invalid the loader logs a warning and falls back to the legacy vars.
 
@@ -106,6 +106,7 @@ picked = select_instance(resolved_integrations, "grafana", tags={"env": "staging
 | AWS | ✅ | ✅ | Default instance only |
 | Honeycomb | ✅ | ✅ | Default instance only |
 | Coralogix | ✅ | ✅ | Default instance only |
+| Argo CD | ✅ | ✅ | Default instance only |
 | Others | — | Default instance only | Default instance only |
 
 Providers without end-to-end selection fall back to the default (first) instance — identical behavior to before this feature.

--- a/tests/cli/test_integrations.py
+++ b/tests/cli/test_integrations.py
@@ -140,3 +140,20 @@ def test_integrations_verify_accepts_openclaw() -> None:
         send_slack_test=False,
     )
     mock_capture.assert_called_once_with("openclaw")
+
+
+def test_integrations_verify_accepts_argocd() -> None:
+    runner = CliRunner()
+
+    with (
+        patch("app.cli.commands.integrations.capture_integration_verified") as mock_capture,
+        patch("app.integrations.cli.cmd_verify", return_value=0) as mock_verify,
+    ):
+        result = runner.invoke(cli, ["integrations", "verify", "argocd"])
+
+    assert result.exit_code == 0
+    mock_verify.assert_called_once_with(
+        "argocd",
+        send_slack_test=False,
+    )
+    mock_capture.assert_called_once_with("argocd")

--- a/tests/integrations/test_argocd_catalog_verify.py
+++ b/tests/integrations/test_argocd_catalog_verify.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from app.integrations.catalog import classify_integrations, resolve_effective_integrations
+from app.integrations.models import ArgoCDIntegrationConfig
 from app.integrations.verify import _verify_argocd, verify_integrations
 
 
@@ -86,6 +87,21 @@ def test_classify_argocd_rejects_ambiguous_auth_methods() -> None:
     )
 
     assert "argocd" not in resolved
+
+
+def test_argocd_integration_config_only_strips_bearer_prefix_from_token() -> None:
+    config = ArgoCDIntegrationConfig(
+        base_url="https://argocd.example.com",
+        bearer_token="Bearer tok_store",
+        project="bearer platform",
+        app_namespace="bearer namespace",
+        integration_id="bearer integration",
+    )
+
+    assert config.bearer_token == "tok_store"
+    assert config.project == "bearer platform"
+    assert config.app_namespace == "bearer namespace"
+    assert config.integration_id == "bearer integration"
 
 
 def test_resolve_effective_integrations_includes_argocd_from_env(

--- a/tests/integrations/test_argocd_catalog_verify.py
+++ b/tests/integrations/test_argocd_catalog_verify.py
@@ -1,0 +1,211 @@
+"""Catalog and verification coverage for the Argo CD integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.integrations.catalog import classify_integrations, resolve_effective_integrations
+from app.integrations.verify import _verify_argocd, verify_integrations
+
+
+@pytest.fixture(autouse=True)
+def _clear_argocd_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "ARGOCD_INSTANCES",
+        "ARGOCD_BASE_URL",
+        "ARGOCD_AUTH_TOKEN",
+        "ARGOCD_TOKEN",
+        "ARGOCD_USERNAME",
+        "ARGOCD_PASSWORD",
+        "ARGOCD_PROJECT",
+        "ARGOCD_APP_NAMESPACE",
+        "ARGOCD_VERIFY_SSL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_classify_argocd_store_record() -> None:
+    resolved = classify_integrations(
+        [
+            {
+                "id": "argocd-store-1",
+                "service": "argocd",
+                "status": "active",
+                "credentials": {
+                    "base_url": "https://argocd.example.com/",
+                    "bearer_token": "Bearer tok_store",
+                    "project": "default",
+                    "app_namespace": "argocd",
+                },
+            }
+        ]
+    )
+
+    assert resolved["argocd"]["base_url"] == "https://argocd.example.com"
+    assert resolved["argocd"]["bearer_token"] == "tok_store"
+    assert resolved["argocd"]["project"] == "default"
+    assert resolved["argocd"]["app_namespace"] == "argocd"
+    assert resolved["argocd"]["integration_id"] == "argocd-store-1"
+
+
+def test_classify_argocd_rejects_plain_http_remote() -> None:
+    resolved = classify_integrations(
+        [
+            {
+                "id": "argocd-store-plain-http",
+                "service": "argocd",
+                "status": "active",
+                "credentials": {
+                    "base_url": "http://argocd.example.com",
+                    "bearer_token": "tok_store",
+                },
+            }
+        ]
+    )
+
+    assert "argocd" not in resolved
+
+
+def test_classify_argocd_rejects_ambiguous_auth_methods() -> None:
+    resolved = classify_integrations(
+        [
+            {
+                "id": "argocd-store-dual-auth",
+                "service": "argocd",
+                "status": "active",
+                "credentials": {
+                    "base_url": "https://argocd.example.com",
+                    "bearer_token": "tok_store",
+                    "username": "admin",
+                    "password": "pw",
+                },
+            }
+        ]
+    )
+
+    assert "argocd" not in resolved
+
+
+def test_resolve_effective_integrations_includes_argocd_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.integrations.catalog.load_integrations", lambda: [])
+    monkeypatch.setenv("ARGOCD_BASE_URL", "https://argocd.example.com/")
+    monkeypatch.setenv("ARGOCD_AUTH_TOKEN", "Bearer tok_env")
+    monkeypatch.setenv("ARGOCD_PROJECT", "payments")
+    monkeypatch.setenv("ARGOCD_APP_NAMESPACE", "argocd")
+    monkeypatch.setenv("ARGOCD_VERIFY_SSL", "false")
+
+    effective = resolve_effective_integrations()
+
+    argocd = effective.get("argocd")
+    assert argocd is not None
+    assert argocd["source"] == "local env"
+    assert argocd["config"]["base_url"] == "https://argocd.example.com"
+    assert argocd["config"]["bearer_token"] == "tok_env"
+    assert argocd["config"]["project"] == "payments"
+    assert argocd["config"]["app_namespace"] == "argocd"
+    assert argocd["config"]["verify_ssl"] is False
+
+
+def test_resolve_effective_integrations_ignores_invalid_argocd_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.integrations.catalog.load_integrations", lambda: [])
+    monkeypatch.setenv("ARGOCD_BASE_URL", "https://argocd.example.com")
+    monkeypatch.setenv("ARGOCD_AUTH_TOKEN", "tok_env")
+    monkeypatch.setenv("ARGOCD_USERNAME", "admin")
+    monkeypatch.setenv("ARGOCD_PASSWORD", "pw")
+
+    assert "argocd" not in resolve_effective_integrations()
+
+
+def test_argocd_multi_instance_env_is_propagated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.integrations.catalog.load_integrations", lambda: [])
+    monkeypatch.setenv(
+        "ARGOCD_INSTANCES",
+        """
+        [
+          {"name":"prod","tags":{"env":"prod"},"base_url":"https://prod.argocd.example.com","bearer_token":"prod-token"},
+          {"name":"stage","tags":{"env":"stage"},"credentials":{"base_url":"https://stage.argocd.example.com","bearer_token":"stage-token"}}
+        ]
+        """,
+    )
+
+    effective = resolve_effective_integrations()
+
+    assert effective["argocd"]["config"]["base_url"] == "https://prod.argocd.example.com"
+    assert [i["name"] for i in effective["argocd"]["instances"]] == ["prod", "stage"]
+    assert effective["argocd"]["instances"][1]["config"]["bearer_token"] == "stage-token"
+
+
+def test_verify_argocd_passes_with_reachable_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeArgoCDClient:
+        def __init__(self, config: Any) -> None:
+            assert config.base_url == "https://argocd.example.com"
+            assert config.bearer_token == "tok_test"
+
+        def __enter__(self) -> _FakeArgoCDClient:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def list_applications(self, **_: Any) -> dict[str, Any]:
+            return {"success": True, "applications": [{"name": "payments"}], "total": 1}
+
+    monkeypatch.setattr("app.integrations.verify.ArgoCDClient", _FakeArgoCDClient)
+
+    result = _verify_argocd(
+        "local env",
+        {"base_url": "https://argocd.example.com", "bearer_token": "tok_test"},
+    )
+
+    assert result["status"] == "passed"
+    assert "1 application" in result["detail"]
+
+
+def test_verify_argocd_reports_missing_auth() -> None:
+    result = _verify_argocd("local env", {"base_url": "https://argocd.example.com"})
+
+    assert result["status"] == "missing"
+    assert "bearer token or username/password" in result["detail"]
+
+
+def test_verify_integrations_dispatches_to_argocd(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeArgoCDClient:
+        def __init__(self, config: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeArgoCDClient:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def list_applications(self, **_: Any) -> dict[str, Any]:
+            return {"success": True, "applications": [], "total": 0}
+
+    monkeypatch.setattr("app.integrations.verify.ArgoCDClient", _FakeArgoCDClient)
+    monkeypatch.setattr(
+        "app.integrations.catalog.load_integrations",
+        lambda: [
+            {
+                "id": "argocd-1",
+                "service": "argocd",
+                "status": "active",
+                "credentials": {
+                    "base_url": "https://argocd.example.com",
+                    "bearer_token": "tok_test",
+                },
+            }
+        ],
+    )
+
+    results = verify_integrations("argocd")
+
+    assert len(results) == 1
+    assert results[0]["service"] == "argocd"
+    assert results[0]["status"] == "passed"

--- a/tests/nodes/plan_actions/test_detect_sources_argocd.py
+++ b/tests/nodes/plan_actions/test_detect_sources_argocd.py
@@ -48,6 +48,22 @@ def test_argocd_source_created_when_configured_even_without_app_hint() -> None:
     assert argocd["project"] == "default"
 
 
+def test_argocd_source_detected_from_argocd_specific_hint() -> None:
+    alert = {"annotations": {"summary": "Argo-CD application is OutOfSync"}}
+
+    sources = detect_sources(alert, {}, {"argocd": _ARGOCD_INT})
+
+    assert "argocd" in sources
+
+
+def test_argocd_source_not_created_for_generic_deployment_alert() -> None:
+    alert = {"annotations": {"summary": "EKS pod deployment failed during rollout"}}
+
+    sources = detect_sources(alert, {}, {"argocd": _ARGOCD_INT})
+
+    assert "argocd" not in sources
+
+
 def test_argocd_source_not_created_without_integration() -> None:
     alert = {"annotations": {"argocd_application": "payments-api"}}
 

--- a/tests/nodes/plan_actions/test_detect_sources_argocd.py
+++ b/tests/nodes/plan_actions/test_detect_sources_argocd.py
@@ -1,0 +1,70 @@
+"""Tests for Argo CD source detection in detect_sources."""
+
+from __future__ import annotations
+
+from app.nodes.plan_actions.detect_sources import detect_sources
+
+_ARGOCD_INT = {
+    "base_url": "https://argocd.example.com",
+    "bearer_token": "tok_test",
+    "username": "",
+    "password": "",
+    "project": "default",
+    "app_namespace": "argocd",
+    "verify_ssl": True,
+    "integration_id": "argocd-1",
+}
+
+
+def test_argocd_source_detected_from_prefixed_annotations() -> None:
+    alert = {
+        "annotations": {
+            "argocd_application": "payments-api",
+            "argocd_project": "payments",
+            "argocd_app_namespace": "argocd-system",
+        }
+    }
+
+    sources = detect_sources(alert, {}, {"argocd": _ARGOCD_INT})
+
+    argocd = sources.get("argocd")
+    assert argocd is not None
+    assert argocd["base_url"] == "https://argocd.example.com"
+    assert argocd["bearer_token"] == "tok_test"
+    assert argocd["application_name"] == "payments-api"
+    assert argocd["project"] == "payments"
+    assert argocd["app_namespace"] == "argocd-system"
+    assert argocd["connection_verified"] is True
+
+
+def test_argocd_source_created_when_configured_even_without_app_hint() -> None:
+    alert = {"annotations": {"summary": "deployment drift detected in GitOps control plane"}}
+
+    sources = detect_sources(alert, {}, {"argocd": _ARGOCD_INT})
+
+    argocd = sources.get("argocd")
+    assert argocd is not None
+    assert argocd["application_name"] == ""
+    assert argocd["project"] == "default"
+
+
+def test_argocd_source_not_created_without_integration() -> None:
+    alert = {"annotations": {"argocd_application": "payments-api"}}
+
+    sources = detect_sources(alert, {}, {})
+
+    assert "argocd" not in sources
+
+
+def test_argocd_source_supports_top_level_application_fields() -> None:
+    alert = {
+        "argocd_app": "checkout-api",
+        "argocd_revision": "abc123",
+        "annotations": {},
+    }
+
+    sources = detect_sources(alert, {}, {"argocd": _ARGOCD_INT})
+
+    argocd = sources["argocd"]
+    assert argocd["application_name"] == "checkout-api"
+    assert argocd["revision"] == "abc123"

--- a/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
+++ b/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import pytest
 
-from app.nodes.root_cause_diagnosis.evidence_checker import is_clearly_healthy
+from app.nodes.root_cause_diagnosis.evidence_checker import (
+    check_evidence_availability,
+    is_clearly_healthy,
+)
 
 
 def _healthy_alert() -> dict:
@@ -132,6 +135,23 @@ class TestIsClearlyHealthyRejectsUnhealthyStates:
         evidence = {"random_custom_key": "some value"}
         assert is_clearly_healthy(_healthy_alert(), evidence) is False
 
+    def test_argocd_diff_evidence_triggers_short_circuit(self) -> None:
+        evidence = {"argocd_diff": []}
+        assert is_clearly_healthy(_healthy_alert(), evidence) is True
+
     def test_non_dict_alert_returns_false(self) -> None:
         evidence = {"eks_pods": [{"name": "x"}]}
         assert is_clearly_healthy("raw text alert", evidence) is False
+
+
+class TestEvidenceAvailabilityArgoCD:
+    @pytest.mark.parametrize(
+        "evidence_key",
+        ["argocd_application", "argocd_applications", "argocd_diff"],
+    )
+    def test_argocd_evidence_counts_as_vendor_evidence(self, evidence_key: str) -> None:
+        has_tracer, has_vendor, has_alert = check_evidence_availability({}, {evidence_key: []}, {})
+
+        assert has_tracer is None
+        assert has_vendor is True
+        assert has_alert is False

--- a/tests/services/argocd/test_client.py
+++ b/tests/services/argocd/test_client.py
@@ -87,6 +87,28 @@ def test_config_rejects_ambiguous_auth_methods() -> None:
     )
 
 
+def test_config_only_strips_bearer_prefix_from_bearer_token() -> None:
+    token_config = ArgoCDConfig(
+        base_url="https://argocd.example.com",
+        bearer_token="Bearer tok_prefixed",
+        project="bearer platform",
+        app_namespace="bearer namespace",
+        integration_id="bearer integration",
+    )
+    assert token_config.bearer_token == "tok_prefixed"
+    assert token_config.project == "bearer platform"
+    assert token_config.app_namespace == "bearer namespace"
+    assert token_config.integration_id == "bearer integration"
+
+    login_config = ArgoCDConfig(
+        base_url="https://argocd.example.com",
+        username="bearer admin",
+        password="bearer password",
+    )
+    assert login_config.username == "bearer admin"
+    assert login_config.password == "bearer password"
+
+
 def test_list_applications_uses_bearer_auth_and_normalizes_status() -> None:
     seen_requests: list[httpx.Request] = []
 

--- a/tests/services/argocd/test_client.py
+++ b/tests/services/argocd/test_client.py
@@ -1,0 +1,369 @@
+"""Tests for the Argo CD API client."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from app.services.argocd import ArgoCDClient, ArgoCDConfig, make_argocd_client
+
+
+def _application_payload(name: str = "payments-api") -> dict[str, Any]:
+    return {
+        "metadata": {"name": name, "namespace": "argocd"},
+        "spec": {
+            "project": "default",
+            "source": {"repoURL": "https://github.com/example/payments", "targetRevision": "main"},
+            "destination": {"server": "https://kubernetes.default.svc", "namespace": "payments"},
+        },
+        "status": {
+            "sync": {"status": "OutOfSync", "revision": "abc123"},
+            "health": {"status": "Degraded", "message": "Deployment unavailable"},
+            "history": [
+                {"revision": "old111", "deployedAt": "2026-04-01T00:00:00Z", "id": 1},
+                {"revision": "abc123", "deployedAt": "2026-04-02T00:00:00Z", "id": 2},
+            ],
+            "operationState": {"phase": "Succeeded", "syncResult": {"revision": "abc123"}},
+            "summary": {"images": ["registry.example.com/payments:abc123"]},
+        },
+    }
+
+
+def test_config_normalizes_base_url_bearer_prefix_and_verify_ssl() -> None:
+    config = ArgoCDConfig(base_url="https://argocd.example.com/", bearer_token="Bearer tok_test")
+    insecure_config = ArgoCDConfig(
+        base_url="https://argocd.example.com/", bearer_token="tok_test", verify_ssl="false"
+    )
+
+    assert config.base_url == "https://argocd.example.com"
+    assert config.bearer_token == "tok_test"
+    assert config.verify_ssl is True
+    assert insecure_config.verify_ssl is False
+
+
+def test_make_argocd_client_requires_base_url_and_auth() -> None:
+    assert make_argocd_client("", bearer_token="tok") is None
+    assert make_argocd_client("https://argocd.example.com") is None
+    assert make_argocd_client("https://argocd.example.com", bearer_token="tok") is not None
+    assert (
+        make_argocd_client("https://argocd.example.com", username="admin", password="pw")
+        is not None
+    )
+
+
+def test_config_rejects_plain_http_except_loopback() -> None:
+    with pytest.raises(ValidationError):
+        ArgoCDConfig(base_url="http://argocd.example.com", bearer_token="tok")
+
+    local = ArgoCDConfig(base_url="http://127.0.0.1:8080", bearer_token="tok")
+    assert local.base_url == "http://127.0.0.1:8080"
+
+    ipv6_local = ArgoCDConfig(base_url="http://[::1]:8080", bearer_token="tok")
+    assert ipv6_local.base_url == "http://[::1]:8080"
+    assert make_argocd_client("http://argocd.example.com", bearer_token="tok") is None
+
+
+def test_config_rejects_ambiguous_auth_methods() -> None:
+    with pytest.raises(ValidationError, match="one auth method"):
+        ArgoCDConfig(
+            base_url="https://argocd.example.com",
+            bearer_token="tok_test",
+            username="admin",
+            password="pw",
+        )
+
+    assert (
+        make_argocd_client(
+            "https://argocd.example.com",
+            bearer_token="tok_test",
+            username="admin",
+            password="pw",
+        )
+        is None
+    )
+
+
+def test_list_applications_uses_bearer_auth_and_normalizes_status() -> None:
+    seen_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        assert request.headers["authorization"] == "Bearer tok_test"
+        assert request.url.path == "/api/v1/applications"
+        return httpx.Response(200, json={"items": [_application_payload()]}, request=request)
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.list_applications(projects=["default"], selector="app=payments")
+
+    assert result["success"] is True
+    assert result["total"] == 1
+    app = result["applications"][0]
+    assert app["name"] == "payments-api"
+    assert app["sync_status"] == "OutOfSync"
+    assert app["health_status"] == "Degraded"
+    assert app["revision"] == "abc123"
+    assert app["history_count"] == 2
+    assert "projects=default" in str(seen_requests[0].url)
+    assert "selector=app%3Dpayments" in str(seen_requests[0].url)
+
+
+def test_username_password_login_fetches_session_token_lazily() -> None:
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        auth = request.headers.get("authorization", "")
+        seen.append((request.method, request.url.path, auth))
+        if request.method == "POST" and request.url.path == "/api/v1/session":
+            assert json.loads(request.content.decode()) == {"username": "admin", "password": "pw"}
+            return httpx.Response(200, json={"token": "session-token"}, request=request)
+        assert auth == "Bearer session-token"
+        return httpx.Response(200, json={"items": [_application_payload()]}, request=request)
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", username="admin", password="pw"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert client.list_applications()["success"] is True
+    assert seen[0] == ("POST", "/api/v1/session", "")
+    assert seen[1][0:2] == ("GET", "/api/v1/applications")
+    assert seen[1][2] == "Bearer session-token"
+
+
+def test_expired_session_token_surfaces_401_without_relogin() -> None:
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        auth = request.headers.get("authorization", "")
+        seen.append((request.method, request.url.path, auth))
+        if request.method == "POST" and request.url.path == "/api/v1/session":
+            return httpx.Response(200, json={"token": "expired-session-token"}, request=request)
+        assert auth == "Bearer expired-session-token"
+        return httpx.Response(
+            401,
+            text="session expired for bearer expired-session-token password leaked-password",
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", username="admin", password="pw"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_summary("payments-api")
+
+    assert result["success"] is False
+    assert "401" in result["error"]
+    assert "expired-session-token" not in result["error"]
+    assert "leaked-password" not in result["error"]
+    assert "[REDACTED]" in result["error"]
+    assert [call[0] for call in seen] == ["POST", "GET"]
+
+
+def test_get_application_summary_includes_revision_history_and_operation_state() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/applications/payments-api"
+        return httpx.Response(200, json=_application_payload(), request=request)
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_summary(
+        "payments-api", project="default", app_namespace="argocd"
+    )
+
+    assert result["success"] is True
+    assert result["application"]["name"] == "payments-api"
+    assert result["application"]["project"] == "default"
+    assert result["application"]["operation_phase"] == "Succeeded"
+    assert [h["revision"] for h in result["recent_history"]] == ["abc123", "old111"]
+
+
+def test_get_application_diff_reports_drift_from_server_side_diff() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/applications/payments-api/server-side-diff"
+        return httpx.Response(
+            200,
+            json={
+                "diffs": [
+                    {
+                        "group": "apps",
+                        "kind": "Deployment",
+                        "name": "payments-api",
+                        "namespace": "payments",
+                        "diff": "- replicas: 3\n+ replicas: 2",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-api", project="default", app_namespace="argocd")
+
+    assert result["success"] is True
+    assert result["drift_detected"] is True
+    assert result["diff_count"] == 1
+    assert result["diffs"][0]["kind"] == "Deployment"
+
+
+def test_get_application_diff_redacts_secret_resources_and_token_like_values() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "diffs": [
+                    {
+                        "group": "",
+                        "kind": "Secret",
+                        "name": "payments-secret",
+                        "namespace": "payments",
+                        "diff": "+ opaque: dummy-sensitive-value",
+                    },
+                    {
+                        "group": "",
+                        "kind": "ConfigMap",
+                        "name": "payments-config",
+                        "namespace": "payments",
+                        "diff": "+ auth: Bearer dummy-sensitive-value",
+                    },
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-api")
+
+    assert result["success"] is True
+    rendered = "\n".join(diff["diff"] for diff in result["diffs"])
+    assert "dummy-sensitive-value" not in rendered
+    assert "[REDACTED" in rendered
+
+
+def test_http_errors_are_returned_without_leaking_tokens() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="forbidden for token tok_secret", request=request)
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_secret"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_summary("payments-api")
+
+    assert result["success"] is False
+    assert "403" in result["error"]
+    assert "tok_secret" not in result["error"]
+    assert "[REDACTED]" in result["error"]
+
+
+def test_unauthorized_errors_are_returned_without_leaking_tokens() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            text="unauthorized for bearer tok_secret password leaked-password",
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_secret"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_summary("payments-api")
+
+    assert result["success"] is False
+    assert "401" in result["error"]
+    assert "tok_secret" not in result["error"]
+    assert "leaked-password" not in result["error"]
+    assert "[REDACTED]" in result["error"]
+
+
+def test_large_diffs_are_truncated_after_redaction() -> None:
+    large_diff = "+ replicas: 3\n" + ("+ safe-config: value\n" * 700)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "diffs": [
+                    {
+                        "group": "apps",
+                        "kind": "Deployment",
+                        "name": "payments-api",
+                        "namespace": "payments",
+                        "diff": large_diff,
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-api")
+
+    assert result["success"] is True
+    rendered = result["diffs"][0]["diff"]
+    assert len(rendered) < len(large_diff)
+    assert "[truncated after 10000 chars]" in rendered
+
+
+def test_list_applications_omits_empty_project_and_selector_params() -> None:
+    seen_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(200, json={"items": []}, request=request)
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.list_applications(projects=["", "   "], selector="   ")
+
+    assert result["success"] is True
+    assert seen_requests[0].url.query == b""
+
+
+def test_verify_ssl_false_is_passed_to_http_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("app.services.argocd.client.httpx.Client", FakeClient)
+    client = ArgoCDClient(
+        ArgoCDConfig(
+            base_url="https://argocd.example.com",
+            bearer_token="tok_test",
+            verify_ssl=False,
+        )
+    )
+
+    assert client._get_client() is not None
+    assert captured["verify"] is False

--- a/tests/services/argocd/test_client.py
+++ b/tests/services/argocd/test_client.py
@@ -275,6 +275,237 @@ def test_get_application_diff_reports_drift_from_server_side_diff() -> None:
     assert result["diffs"][0]["kind"] == "Deployment"
 
 
+def test_get_application_diff_accepts_argocd_items_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/applications/payments-api/server-side-diff"
+        return httpx.Response(
+            200,
+            json={
+                "modified": True,
+                "items": [
+                    {
+                        "group": "apps",
+                        "kind": "Deployment",
+                        "name": "payments-api",
+                        "namespace": "payments",
+                        "modified": True,
+                        "diff": "- replicas: 3\n+ replicas: 2",
+                    }
+                ],
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-api")
+
+    assert result["success"] is True
+    assert result["drift_detected"] is True
+    assert result["diff_count"] == 1
+    assert result["diffs"][0]["kind"] == "Deployment"
+
+
+def test_get_application_diff_falls_back_to_managed_resources_when_server_side_diff_empty() -> None:
+    seen_paths: list[str] = []
+    target_state = json.dumps(
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "payments-api", "namespace": "payments"},
+            "spec": {"replicas": 1},
+        },
+        sort_keys=True,
+    )
+    live_state = json.dumps(
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "payments-api", "namespace": "payments"},
+            "spec": {"replicas": 2},
+        },
+        sort_keys=True,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path.endswith("/server-side-diff"):
+            return httpx.Response(200, json={"modified": False}, request=request)
+        assert request.url.path.endswith("/managed-resources")
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "group": "apps",
+                        "kind": "Deployment",
+                        "name": "payments-api",
+                        "namespace": "payments",
+                        "targetState": target_state,
+                        "normalizedLiveState": live_state,
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-api")
+
+    assert result["success"] is True
+    assert result["drift_detected"] is True
+    assert result["diff_count"] == 1
+    assert result["diffs"][0]["kind"] == "Deployment"
+    assert "replicas" in result["diffs"][0]["diff"]
+    assert seen_paths == [
+        "/api/v1/applications/payments-api/server-side-diff",
+        "/api/v1/applications/payments-api/managed-resources",
+    ]
+
+
+def test_get_application_diff_fallback_ignores_equal_managed_resource_states() -> None:
+    state = json.dumps(
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": "payments-api", "namespace": "payments"},
+            "spec": {"replicas": 1},
+        },
+        sort_keys=True,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/server-side-diff"):
+            return httpx.Response(200, json={"modified": False}, request=request)
+        assert request.url.path.endswith("/managed-resources")
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "group": "apps",
+                        "kind": "Deployment",
+                        "name": "payments-api",
+                        "namespace": "payments",
+                        "targetState": state,
+                        "normalizedLiveState": state,
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-api")
+
+    assert result["success"] is True
+    assert result["drift_detected"] is False
+    assert result["diff_count"] == 0
+    assert result["diffs"] == []
+
+
+def test_get_application_diff_fallback_skips_non_json_managed_resource_states() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/server-side-diff"):
+            return httpx.Response(200, json={"modified": False}, request=request)
+        assert request.url.path.endswith("/managed-resources")
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "group": "",
+                        "kind": "ConfigMap",
+                        "name": "payments-config",
+                        "namespace": "payments",
+                        "targetState": "kind: ConfigMap\nmetadata:\n  name: payments-config\n",
+                        "normalizedLiveState": "kind: ConfigMap\nmetadata: {name: payments-config}\n",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-config")
+
+    assert result["success"] is True
+    assert result["drift_detected"] is False
+    assert result["diff_count"] == 0
+
+
+def test_get_application_diff_fallback_redacts_sensitive_non_secret_json_state() -> None:
+    target_state = json.dumps(
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "payments-config", "namespace": "payments"},
+            "data": {"clientSecret": "old-super-secret-value"},
+        },
+        sort_keys=True,
+    )
+    live_state = json.dumps(
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "payments-config", "namespace": "payments"},
+            "data": {"clientSecret": "new-super-secret-value"},
+        },
+        sort_keys=True,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/server-side-diff"):
+            return httpx.Response(200, json={"modified": False}, request=request)
+        assert request.url.path.endswith("/managed-resources")
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "group": "",
+                        "kind": "ConfigMap",
+                        "name": "payments-config",
+                        "namespace": "payments",
+                        "targetState": target_state,
+                        "normalizedLiveState": live_state,
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", bearer_token="tok_test"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_diff("payments-config")
+
+    assert result["success"] is True
+    assert result["drift_detected"] is True
+    assert result["diff_count"] == 1
+    rendered = result["diffs"][0]["diff"]
+    assert "old-super-secret-value" not in rendered
+    assert "new-super-secret-value" not in rendered
+    assert rendered == "[REDACTED secret-bearing resource diff]"
+
+
 def test_get_application_diff_redacts_secret_resources_and_token_like_values() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/tests/services/argocd/test_client.py
+++ b/tests/services/argocd/test_client.py
@@ -160,18 +160,49 @@ def test_username_password_login_fetches_session_token_lazily() -> None:
     assert seen[1][2] == "Bearer session-token"
 
 
-def test_expired_session_token_surfaces_401_without_relogin() -> None:
+def test_expired_session_token_is_cleared_and_retried_once() -> None:
     seen: list[tuple[str, str, str]] = []
+    issued_tokens = iter(["expired-session-token", "fresh-session-token"])
 
     def handler(request: httpx.Request) -> httpx.Response:
         auth = request.headers.get("authorization", "")
         seen.append((request.method, request.url.path, auth))
         if request.method == "POST" and request.url.path == "/api/v1/session":
-            return httpx.Response(200, json={"token": "expired-session-token"}, request=request)
-        assert auth == "Bearer expired-session-token"
+            return httpx.Response(200, json={"token": next(issued_tokens)}, request=request)
+        if auth == "Bearer expired-session-token":
+            return httpx.Response(401, text="session expired", request=request)
+        assert auth == "Bearer fresh-session-token"
+        return httpx.Response(200, json=_application_payload(), request=request)
+
+    client = ArgoCDClient(
+        ArgoCDConfig(base_url="https://argocd.example.com", username="admin", password="pw"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.get_application_summary("payments-api")
+
+    assert result["success"] is True
+    assert result["application"]["name"] == "payments-api"
+    assert seen == [
+        ("POST", "/api/v1/session", ""),
+        ("GET", "/api/v1/applications/payments-api", "Bearer expired-session-token"),
+        ("POST", "/api/v1/session", ""),
+        ("GET", "/api/v1/applications/payments-api", "Bearer fresh-session-token"),
+    ]
+
+
+def test_expired_session_token_final_401_redacts_retired_tokens() -> None:
+    seen: list[tuple[str, str, str]] = []
+    issued_tokens = iter(["expired-session-token", "second-expired-session-token"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        auth = request.headers.get("authorization", "")
+        seen.append((request.method, request.url.path, auth))
+        if request.method == "POST" and request.url.path == "/api/v1/session":
+            return httpx.Response(200, json={"token": next(issued_tokens)}, request=request)
         return httpx.Response(
             401,
-            text="session expired for bearer expired-session-token password leaked-password",
+            text=f"session expired for {auth} password leaked-password",
             request=request,
         )
 
@@ -185,9 +216,10 @@ def test_expired_session_token_surfaces_401_without_relogin() -> None:
     assert result["success"] is False
     assert "401" in result["error"]
     assert "expired-session-token" not in result["error"]
+    assert "second-expired-session-token" not in result["error"]
     assert "leaked-password" not in result["error"]
     assert "[REDACTED]" in result["error"]
-    assert [call[0] for call in seen] == ["POST", "GET"]
+    assert [call[0] for call in seen] == ["POST", "GET", "POST", "GET"]
 
 
 def test_get_application_summary_includes_revision_history_and_operation_state() -> None:

--- a/tests/tools/test_argocd_tools.py
+++ b/tests/tools/test_argocd_tools.py
@@ -156,3 +156,4 @@ def test_argocd_evidence_counts_as_investigated_for_healthy_short_circuit() -> N
 
     assert is_clearly_healthy(alert, {"argocd_application": {"name": "payments-api"}}) is True
     assert is_clearly_healthy(alert, {"argocd_applications": []}) is True
+    assert is_clearly_healthy(alert, {"argocd_diff": []}) is True

--- a/tests/tools/test_argocd_tools.py
+++ b/tests/tools/test_argocd_tools.py
@@ -1,0 +1,129 @@
+"""Tests for Argo CD investigation tools and evidence mapping."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
+from app.nodes.investigate.processing.post_process import build_evidence_summary, merge_evidence
+from app.nodes.root_cause_diagnosis.evidence_checker import is_clearly_healthy
+from app.tools.ArgoCDApplicationDiffTool import ArgoCDApplicationDiffTool
+from app.tools.ArgoCDApplicationStatusTool import ArgoCDApplicationStatusTool
+
+
+class _FakeArgoCDClient:
+    def __enter__(self) -> _FakeArgoCDClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def get_application_summary(self, application_name: str, **_: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "application": {
+                "name": application_name,
+                "sync_status": "OutOfSync",
+                "health_status": "Degraded",
+                "revision": "abc123",
+            },
+            "recent_history": [{"revision": "abc123", "deployedAt": "2026-04-02T00:00:00Z"}],
+        }
+
+    def list_applications(self, **_: Any) -> dict[str, Any]:
+        return {"success": True, "applications": [{"name": "payments-api"}], "total": 1}
+
+    def get_application_diff(self, application_name: str, **_: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "application_name": application_name,
+            "drift_detected": True,
+            "diffs": [{"kind": "Deployment", "name": application_name, "diff": "replicas changed"}],
+            "diff_count": 1,
+        }
+
+
+_ARGOCD_SOURCE = {
+    "base_url": "https://argocd.example.com",
+    "bearer_token": "tok_test",
+    "username": "",
+    "password": "",
+    "project": "default",
+    "app_namespace": "argocd",
+    "application_name": "payments-api",
+    "verify_ssl": True,
+    "connection_verified": True,
+}
+
+
+def test_argocd_status_tool_extracts_params_and_returns_application(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        "app.tools.ArgoCDApplicationStatusTool.make_argocd_client",
+        lambda *_args, **_kwargs: _FakeArgoCDClient(),
+    )
+    tool = ArgoCDApplicationStatusTool()
+
+    assert tool.is_available({"argocd": _ARGOCD_SOURCE}) is True
+    params = tool.extract_params({"argocd": _ARGOCD_SOURCE})
+    result = tool.run(**params)
+
+    assert result["available"] is True
+    assert result["application"]["name"] == "payments-api"
+    assert result["application"]["sync_status"] == "OutOfSync"
+    assert result["recent_history"][0]["revision"] == "abc123"
+
+
+def test_argocd_diff_tool_reports_drift(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        "app.tools.ArgoCDApplicationDiffTool.make_argocd_client",
+        lambda *_args, **_kwargs: _FakeArgoCDClient(),
+    )
+    tool = ArgoCDApplicationDiffTool()
+
+    result = tool.run(**tool.extract_params({"argocd": _ARGOCD_SOURCE}))
+
+    assert result["available"] is True
+    assert result["drift_detected"] is True
+    assert result["diffs"][0]["kind"] == "Deployment"
+
+
+def test_argocd_tools_require_configured_source() -> None:
+    assert ArgoCDApplicationStatusTool().is_available({}) is False
+    assert (
+        ArgoCDApplicationDiffTool().is_available({"argocd": {"connection_verified": False}})
+        is False
+    )
+
+
+def test_argocd_tool_results_merge_into_evidence_and_summary() -> None:
+    results = {
+        "argocd_application_status": ActionExecutionResult(
+            action_name="argocd_application_status",
+            success=True,
+            data={
+                "application": {"name": "payments-api", "sync_status": "Synced"},
+                "recent_history": [{"revision": "abc123"}],
+            },
+        ),
+        "argocd_application_diff": ActionExecutionResult(
+            action_name="argocd_application_diff",
+            success=True,
+            data={"application_name": "payments-api", "drift_detected": False, "diffs": []},
+        ),
+    }
+
+    evidence = merge_evidence({}, results)
+    summary = build_evidence_summary(results)
+
+    assert evidence["argocd_application"]["name"] == "payments-api"
+    assert evidence["argocd_revision_history"][0]["revision"] == "abc123"
+    assert evidence["argocd_drift_detected"] is False
+    assert evidence["argocd_diff"] == []
+    assert "argocd:payments-api status Synced" in summary
+    assert "argocd:payments-api drift false" in summary
+
+
+def test_argocd_evidence_counts_as_investigated_for_healthy_short_circuit() -> None:
+    alert = {"state": "resolved", "commonLabels": {"severity": "info"}, "commonAnnotations": {}}
+
+    assert is_clearly_healthy(alert, {"argocd_application": {"name": "payments-api"}}) is True

--- a/tests/tools/test_argocd_tools.py
+++ b/tests/tools/test_argocd_tools.py
@@ -73,6 +73,34 @@ def test_argocd_status_tool_extracts_params_and_returns_application(monkeypatch)
     assert result["recent_history"][0]["revision"] == "abc123"
 
 
+def test_argocd_status_list_mode_preserves_applications_in_evidence(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        "app.tools.ArgoCDApplicationStatusTool.make_argocd_client",
+        lambda *_args, **_kwargs: _FakeArgoCDClient(),
+    )
+    tool = ArgoCDApplicationStatusTool()
+    source = {**_ARGOCD_SOURCE, "application_name": ""}
+
+    result = tool.run(**tool.extract_params({"argocd": source}))
+    execution_results = {
+        "argocd_application_status": ActionExecutionResult(
+            action_name="argocd_application_status",
+            success=True,
+            data=result,
+        )
+    }
+    evidence = merge_evidence({}, execution_results)
+    summary = build_evidence_summary(execution_results)
+
+    assert result["available"] is True
+    assert result["applications"] == [{"name": "payments-api"}]
+    assert evidence["argocd_application"] == {}
+    assert evidence["argocd_applications"] == [{"name": "payments-api"}]
+    assert evidence["argocd_applications_total"] == 1
+    assert "argocd:1 applications" in summary
+    assert "argocd:? status unknown" not in summary
+
+
 def test_argocd_diff_tool_reports_drift(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.setattr(
         "app.tools.ArgoCDApplicationDiffTool.make_argocd_client",

--- a/tests/tools/test_argocd_tools.py
+++ b/tests/tools/test_argocd_tools.py
@@ -155,3 +155,4 @@ def test_argocd_evidence_counts_as_investigated_for_healthy_short_circuit() -> N
     alert = {"state": "resolved", "commonLabels": {"severity": "info"}, "commonAnnotations": {}}
 
     assert is_clearly_healthy(alert, {"argocd_application": {"name": "payments-api"}}) is True
+    assert is_clearly_healthy(alert, {"argocd_applications": []}) is True


### PR DESCRIPTION
Fixes #320

#### Describe changes -

This PR adds a first-class, read-only Argo CD integration for deployment and drift investigation.

What changed:
- Added a dedicated `app/services/argocd` client for application listing, application status/summary, managed resources, and server-side diff retrieval.
- Added Argo CD integration config, catalog/env resolution, and local verification support.
- Added read-only investigation tools:
  - `ArgoCDApplicationStatusTool`
  - `ArgoCDApplicationDiffTool`
- Wired Argo CD into source detection, evidence typing, investigation post-processing, and RCA evidence summaries.
- Added regression coverage for client behavior, catalog/verify resolution, source detection, and tools.

Security and safety hardening:
- Remote Argo CD URLs must use `https://`; plain `http://` is accepted only for localhost/loopback development endpoints, including IPv6 loopback.
- Bearer token auth and username/password session auth are supported, but ambiguous dual-auth configuration is rejected.
- Credentials, session tokens, bearer/JWT-like values, Kubernetes Secret diffs, private-key-like content, and password/token-like fields are redacted before surfacing errors, diffs, tool output, or evidence.
- Argo CD API usage remains read-only except for `POST /api/v1/session`, which is used only to obtain a session token when username/password auth is configured.
- HTTP 401 handling avoids unsafe retry loops and redacts sensitive response content.

### Screenshots (if UI) -

N/A — backend integration and investigation tooling only.

### Demo video -

https://github.com/MestreY0d4-Uninter/opensre/releases/download/pr-948-argocd-real-demo/opensre-pr948-argocd-real-walkthrough.mp4

Release artifact page: https://github.com/MestreY0d4-Uninter/opensre/releases/tag/pr-948-argocd-real-demo

What it shows:
- A real local Argo CD instance running on kind for the PR branch validation.
- The documented CLI path: `opensre integrations verify argocd`.
- Read-only Argo CD application status and list-mode evidence collection.
- A live GitOps drift scenario: the demo app is synced, the Kubernetes Deployment is scaled outside Git, Argo CD reports `OutOfSync`, and `ArgoCDApplicationDiffTool` returns `drift_detected=true` with a replica diff.
- Credentials are hidden/redacted; no raw token, password, JWT, or Kubernetes Secret value is shown.

Transparency note: this is a real terminal-session recording with commands entered into a live shell by automation for repeatability. The commands run against a local kind-hosted Argo CD instance and exercise the real OpenSRE code paths.

---

## Code Understanding and AI Usage

**Used AI?**
- [ ] No
- [x] Yes → confirmed:
  - [x] I reviewed every line of the AI-generated code
  - [x] I can explain the logic
  - [x] I tested edge cases
  - [x] I adapted it to the project's conventions

**Approach:**
- The implementation follows existing OpenSRE integration patterns: `app/services/*/client.py`, integration catalog/verify wiring, `BaseTool` investigation tools, source detection, and evidence/post-processing hooks.
- The first slice is intentionally read-only to keep the blast radius bounded while still supporting the issue's deployment/drift investigation use case.
- The main security focus was avoiding accidental credential exposure through configurable URLs, HTTP errors, Argo CD diffs, Kubernetes Secret manifests, and tool/evidence output.
- Edge cases covered include invalid/remote plaintext URLs, localhost/IPv6 loopback URLs, dual-auth rejection, whitespace-only list filters, auth failures, session-token 401 behavior, diff truncation, and env isolation.

---

## Validation

Follow-up validation after maintainer review:

- Addressed the `.env.example` request by adding the documented Argo CD environment variables.
- Verified the documented command against a real local Argo CD instance:
  - `uv run opensre integrations verify argocd`
  - Result: `argocd    local env    passed      Connected to Argo CD and listed 1 application.`
- Verified the real read-only status/list/diff tool paths against the same Argo CD instance.
- Verified drift detection with live Kubernetes drift:
  - `sync_status: OutOfSync`
  - `drift_detected: true`
  - `diff_count: 1`
  - replica drift shown for the `guestbook-ui` Deployment.
- Verified the negative path after restoring desired replicas:
  - `drift_detected: false`
  - `diff_count: 0`
- Focused regression suite after follow-up changes:
  - `245 passed`
- Quality gates after follow-up changes:
  - `make lint`: passed
  - `make format-check`: passed
  - `make typecheck`: passed
  - `git diff --check`: passed
- Demo video validation:
  - Duration: `42.93s`
  - Resolution: `1280x720`
  - SHA-256: `515c60b1e8a25c12302f5a6f48a5fb5ea697ed501b2c4ab8140ca898c2c9c5a7`
  - OCR/secret scan found no raw Argo CD password, bearer token, JWT, GitHub token, AWS key, or private key.

Local validation completed before opening the PR:

- Focused Argo CD tests:
  - `uv run pytest -q tests/services/argocd/test_client.py tests/integrations/test_argocd_catalog_verify.py tests/nodes/plan_actions/test_detect_sources_argocd.py tests/tools/test_argocd_tools.py`
  - Result: `33 passed`

- Expanded related tests:
  - `uv run pytest -q tests/integrations/test_argocd_catalog_verify.py tests/integrations/test_catalog_multi_instance.py tests/integrations/test_verify.py tests/nodes/plan_actions/test_detect_sources_argocd.py tests/tools/test_argocd_tools.py tests/tools/test_registry.py`
  - Result: `60 passed`

- Parallel focused run:
  - Argo CD focused suite under xdist with 4 workers
  - Result: `33 passed`

- Type checking:
  - `make typecheck`
  - Result: `Success: no issues found in 396 source files`

- Lint:
  - `make lint`
  - Result: `All checks passed!`

- Formatting:
  - `make format-check`
  - Result: `910 files already formatted`

- Whitespace/diff validation:
  - `git diff --check --cached`
  - Result: passed

- Coverage/full non-synthetic local suite:
  - `make test-cov`
  - Result: `3294 passed, 2 skipped, 1 xfailed, 1 warning`

- Local Argo CD scenario simulator:
  - Simulated Argo CD endpoints with a local `ThreadingHTTPServer`
  - Validated remote HTTP rejection, loopback HTTP allowance, dual-auth rejection, bearer list/status/diff flow, diff redaction, HTTP error redaction, lazy session login, verify surface, tools, and env catalog resolution.

---

## Checklist

- [x] Linked issue
- [x] Self-review completed
- [x] Purpose of each new function/class is clear from names, structure, and docstrings/comments where useful
- [x] Tests added for edge cases and regressions
- [x] Code style validated


