### PR TITLE
test: add unit tests for TracerPipelinesMixin (#888)

### DIFF
--- a/tests/services/tracer_client/test_tracer_pipelines.py
+++ b/tests/services/tracer_client/test_tracer_pipelines.py
@@ -5,25 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-import pytest
-
 from app.services.tracer_client.tracer_pipelines import (
     PipelineRunSummary,
     PipelineSummary,
     TracerPipelinesMixin,
     TracerRunResult,
 )
-
-
-class _FakeResponse:
-    def __init__(self, payload: dict[str, Any]):
-        self._payload = payload
-
-    def raise_for_status(self) -> None:
-        return None
-
-    def json(self) -> dict[str, Any]:
-        return self._payload
 
 
 class _FakePipelinesClient(TracerPipelinesMixin):
@@ -37,6 +24,21 @@ class _FakePipelinesClient(TracerPipelinesMixin):
     def _get(self, _endpoint: str, _params: Mapping[str, Any] | None = None) -> dict[str, Any]:
         """Stub _get to return the configured response."""
         return self._response
+
+
+class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
+    """Fake subclass that captures params passed to _get()."""
+
+    def __init__(self) -> None:
+        self.org_id = "test-org-123"
+        self.base_url = "https://test.tracer.com"
+        self.last_params: Mapping[str, Any] | None = None
+        self.last_endpoint: str | None = None
+
+    def _get(self, endpoint: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        self.last_endpoint = endpoint
+        self.last_params = params
+        return {"success": True, "data": []}
 
 
 class TestGetPipelines:
@@ -141,19 +143,13 @@ class TestGetPipelines:
         assert result[0].n_active_runs == 0
         assert result[0].n_completed_runs == 0
 
+    def test_get_pipelines_calls_correct_endpoint(self) -> None:
+        client = _FakePipelinesClientWithCapture()
+        client.get_pipelines()
+
+        assert client.last_endpoint == "/api/pipelines"
+
     def test_get_pipelines_with_pagination_params(self) -> None:
-        class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
-            def __init__(self) -> None:
-                self.org_id = "test-org-123"
-                self.base_url = "https://test.tracer.com"
-                self.last_params: Mapping[str, Any] | None = None
-
-            def _get(
-                self, _endpoint: str, params: Mapping[str, Any] | None = None
-            ) -> dict[str, Any]:
-                self.last_params = params
-                return {"success": True, "data": []}
-
         client = _FakePipelinesClientWithCapture()
         client.get_pipelines(page=2, size=25)
 
@@ -276,6 +272,18 @@ class TestGetPipelineRuns:
 
         assert len(result) == 1
         assert result[0].pipeline_name == "my-pipeline"
+
+    def test_get_pipeline_runs_calls_correct_endpoint(self) -> None:
+        client = _FakePipelinesClientWithCapture()
+        client.get_pipeline_runs("my-pipeline")
+
+        assert client.last_endpoint == "/api/batch-runs"
+        assert client.last_params == {
+            "orgId": "test-org-123",
+            "page": 1,
+            "size": 50,
+            "pipelineName": "my-pipeline",
+        }
 
 
 class TestGetLatestRun:
@@ -411,22 +419,11 @@ class TestGetLatestRun:
         result_2gb = client_2gb.get_latest_run("my-pipeline")
         assert result_2gb.max_ram_gb == 2.0
 
-    def test_get_latest_run_with_pipeline_name_filter(self) -> None:
-        class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
-            def __init__(self) -> None:
-                self.org_id = "test-org-123"
-                self.base_url = "https://test.tracer.com"
-                self.last_params: Mapping[str, Any] | None = None
-
-            def _get(
-                self, _endpoint: str, params: Mapping[str, Any] | None = None
-            ) -> dict[str, Any]:
-                self.last_params = params
-                return {"success": True, "data": []}
-
+    def test_get_latest_run_calls_correct_endpoint_with_pipeline(self) -> None:
         client = _FakePipelinesClientWithCapture()
         client.get_latest_run("my-pipeline")
 
+        assert client.last_endpoint == "/api/batch-runs"
         assert client.last_params == {
             "page": 1,
             "size": 1,
@@ -434,22 +431,11 @@ class TestGetLatestRun:
             "pipelineName": "my-pipeline",
         }
 
-    def test_get_latest_run_without_pipeline_name(self) -> None:
-        class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
-            def __init__(self) -> None:
-                self.org_id = "test-org-123"
-                self.base_url = "https://test.tracer.com"
-                self.last_params: Mapping[str, Any] | None = None
-
-            def _get(
-                self, _endpoint: str, params: Mapping[str, Any] | None = None
-            ) -> dict[str, Any]:
-                self.last_params = params
-                return {"success": True, "data": []}
-
+    def test_get_latest_run_calls_correct_endpoint_without_pipeline(self) -> None:
         client = _FakePipelinesClientWithCapture()
         client.get_latest_run()
 
+        assert client.last_endpoint == "/api/batch-runs"
         assert client.last_params == {"page": 1, "size": 1, "orgId": "test-org-123"}
         assert "pipelineName" not in client.last_params
 

--- a/tests/services/tracer_client/test_tracer_pipelines.py
+++ b/tests/services/tracer_client/test_tracer_pipelines.py
@@ -1,0 +1,477 @@
+"""Tests for TracerPipelinesMixin pipeline and run methods."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from app.services.tracer_client.tracer_pipelines import (
+    PipelineRunSummary,
+    PipelineSummary,
+    TracerPipelinesMixin,
+    TracerRunResult,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakePipelinesClient(TracerPipelinesMixin):
+    """Fake subclass for testing; stubs _get() method."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+        self.org_id = "test-org-123"
+        self.base_url = "https://test.tracer.com"
+
+    def _get(self, _endpoint: str, _params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        """Stub _get to return the configured response."""
+        return self._response
+
+
+class TestGetPipelines:
+    """Tests for the get_pipelines() method."""
+
+    def test_get_pipelines_success_with_data(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "pipeline_name": "pipeline-1",
+                    "health_status": "healthy",
+                    "last_run_start_time": "2026-04-25T10:00:00Z",
+                    "n_runs": 100,
+                    "n_active_runs": 2,
+                    "n_completed_runs": 98,
+                },
+                {
+                    "pipeline_name": "pipeline-2",
+                    "health_status": "unhealthy",
+                    "last_run_start_time": "2026-04-25T08:00:00Z",
+                    "n_runs": 50,
+                    "n_active_runs": 0,
+                    "n_completed_runs": 50,
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipelines()
+
+        assert len(result) == 2
+        assert result[0] == PipelineSummary(
+            pipeline_name="pipeline-1",
+            health_status="healthy",
+            last_run_start_time="2026-04-25T10:00:00Z",
+            n_runs=100,
+            n_active_runs=2,
+            n_completed_runs=98,
+        )
+        assert result[1] == PipelineSummary(
+            pipeline_name="pipeline-2",
+            health_status="unhealthy",
+            last_run_start_time="2026-04-25T08:00:00Z",
+            n_runs=50,
+            n_active_runs=0,
+            n_completed_runs=50,
+        )
+
+    def test_get_pipelines_empty_data(self) -> None:
+        response = {"success": True, "data": []}
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipelines()
+
+        assert result == []
+
+    def test_get_pipelines_unsuccessful_response(self) -> None:
+        response = {"success": False, "error": "Unauthorized"}
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipelines()
+
+        assert result == []
+
+    def test_get_pipelines_missing_optional_fields(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "pipeline_name": "pipeline-1",
+                    "n_runs": 10,
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipelines()
+
+        assert len(result) == 1
+        assert result[0].health_status is None
+        assert result[0].last_run_start_time is None
+
+    def test_get_pipelines_zero_counts(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "pipeline_name": "new-pipeline",
+                    "n_runs": 0,
+                    "n_active_runs": 0,
+                    "n_completed_runs": 0,
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipelines()
+
+        assert len(result) == 1
+        assert result[0].n_runs == 0
+        assert result[0].n_active_runs == 0
+        assert result[0].n_completed_runs == 0
+
+    def test_get_pipelines_with_pagination_params(self) -> None:
+        class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
+            def __init__(self) -> None:
+                self.org_id = "test-org-123"
+                self.base_url = "https://test.tracer.com"
+                self.last_params: Mapping[str, Any] | None = None
+
+            def _get(
+                self, _endpoint: str, params: Mapping[str, Any] | None = None
+            ) -> dict[str, Any]:
+                self.last_params = params
+                return {"success": True, "data": []}
+
+        client = _FakePipelinesClientWithCapture()
+        client.get_pipelines(page=2, size=25)
+
+        assert client.last_params == {"orgId": "test-org-123", "page": 2, "size": 25}
+
+
+class TestGetPipelineRuns:
+    """Tests for get_pipeline_runs() method."""
+
+    def test_get_pipeline_runs_success_with_data(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "pipeline_name": "pipeline-1",
+                    "run_id": "run-123",
+                    "run_name": "test-run-1",
+                    "trace_id": "trace-abc",
+                    "status": "completed",
+                    "start_time": "2026-04-25T10:00:00Z",
+                    "end_time": "2026-04-25T11:00:00Z",
+                    "run_cost": 1.5,
+                    "tool_count": 5,
+                    "user_email": "user@example.com",
+                    "instance_type": "ml.m5.large",
+                    "region": "us-east-1",
+                    "log_file_count": 3,
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipeline_runs("pipeline-1")
+
+        assert len(result) == 1
+        assert result[0] == PipelineRunSummary(
+            pipeline_name="pipeline-1",
+            run_id="run-123",
+            run_name="test-run-1",
+            trace_id="trace-abc",
+            status="completed",
+            start_time="2026-04-25T10:00:00Z",
+            end_time="2026-04-25T11:00:00Z",
+            run_cost=1.5,
+            tool_count=5,
+            user_email="user@example.com",
+            instance_type="ml.m5.large",
+            region="us-east-1",
+            log_file_count=3,
+        )
+
+    def test_get_pipeline_runs_empty_data(self) -> None:
+        response = {"success": True, "data": []}
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipeline_runs("pipeline-1")
+
+        assert result == []
+
+    def test_get_pipeline_runs_unsuccessful_response(self) -> None:
+        response = {"success": False, "error": "Not found"}
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipeline_runs("pipeline-1")
+
+        assert result == []
+
+    def test_get_pipeline_runs_null_values(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "pipeline_name": "pipeline-1",
+                    "run_id": None,
+                    "run_name": None,
+                    "trace_id": None,
+                    "status": None,
+                    "start_time": None,
+                    "end_time": None,
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipeline_runs("pipeline-1")
+
+        assert len(result) == 1
+        assert result[0].run_id is None
+        assert result[0].trace_id is None
+        assert result[0].status is None
+
+    def test_get_pipeline_runs_numeric_defaults(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {"pipeline_name": "pipeline-1"},
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipeline_runs("pipeline-1")
+
+        assert len(result) == 1
+        assert result[0].run_cost == 0.0
+        assert result[0].tool_count == 0
+        assert result[0].log_file_count == 0
+
+    def test_get_pipeline_runs_pipeline_name_fallback(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "run_id": "run-456",
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_pipeline_runs("my-pipeline")
+
+        assert len(result) == 1
+        assert result[0].pipeline_name == "my-pipeline"
+
+
+class TestGetLatestRun:
+    """Tests for get_latest_run() method."""
+
+    def test_get_latest_run_success_with_tags(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "run_id": "run-789",
+                    "pipeline_name": "my-pipeline",
+                    "run_name": "latest-run",
+                    "status": "running",
+                    "start_time": "2026-04-25T12:00:00Z",
+                    "end_time": None,
+                    "run_time_seconds": 3600,
+                    "run_cost": 2.5,
+                    "max_ram": 2147483648,
+                    "tool_count": 10,
+                    "region": "us-west-2",
+                    "tags": {
+                        "email": "user@example.com",
+                        "team": "data-science",
+                        "department": "analytics",
+                        "instance_type": "ml.m5.xlarge",
+                        "environment": "production",
+                    },
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_latest_run("my-pipeline")
+
+        assert result.found is True
+        assert result.run_id == "run-789"
+        assert result.pipeline_name == "my-pipeline"
+        assert result.run_name == "latest-run"
+        assert result.status == "running"
+        assert result.start_time == "2026-04-25T12:00:00Z"
+        assert result.end_time is None
+        assert result.run_time_seconds == 3600
+        assert result.run_cost == 2.5
+        assert result.max_ram_gb == 2.0
+        assert result.user_email == "user@example.com"
+        assert result.team == "data-science"
+        assert result.department == "analytics"
+        assert result.instance_type == "ml.m5.xlarge"
+        assert result.environment == "production"
+        assert result.region == "us-west-2"
+        assert result.tool_count == 10
+
+    def test_get_latest_run_tags_fallback_to_direct_fields(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "run_id": "run-999",
+                    "pipeline_name": "my-pipeline",
+                    "run_name": "fallback-run",
+                    "status": "completed",
+                    "start_time": "2026-04-25T10:00:00Z",
+                    "end_time": "2026-04-25T11:00:00Z",
+                    "run_time_seconds": 1800,
+                    "run_cost": 1.0,
+                    "max_ram": 1073741824,
+                    "tool_count": 5,
+                    "user_email": "direct@example.com",
+                    "instance_type": "ml.m5.large",
+                    "environment": "staging",
+                    "region": "eu-west-1",
+                    "tags": {},
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_latest_run("my-pipeline")
+
+        assert result.found is True
+        assert result.user_email == "direct@example.com"
+        assert result.instance_type == "ml.m5.large"
+        assert result.environment == "staging"
+        assert result.team == ""
+        assert result.department == ""
+
+    def test_get_latest_run_empty_data(self) -> None:
+        response = {"success": True, "data": []}
+        client = _FakePipelinesClient(response)
+
+        result = client.get_latest_run("my-pipeline")
+
+        assert result == TracerRunResult(found=False)
+
+    def test_get_latest_run_unsuccessful_response(self) -> None:
+        response = {"success": False, "error": "Server error"}
+        client = _FakePipelinesClient(response)
+
+        result = client.get_latest_run("my-pipeline")
+
+        assert result == TracerRunResult(found=False)
+
+    def test_get_latest_run_max_ram_conversion(self) -> None:
+        class _FakePipelinesClientRam(TracerPipelinesMixin):
+            def __init__(self, max_ram_bytes: int) -> None:
+                self.org_id = "test-org-123"
+                self.base_url = "https://test.tracer.com"
+                self._max_ram = max_ram_bytes
+
+            def _get(
+                self, _endpoint: str, _params: Mapping[str, Any] | None = None
+            ) -> dict[str, Any]:
+                return {
+                    "success": True,
+                    "data": [
+                        {
+                            "run_id": "run-ram",
+                            "pipeline_name": "my-pipeline",
+                            "run_name": "ram-test",
+                            "status": "running",
+                            "max_ram": self._max_ram,
+                            "tags": {},
+                        },
+                    ],
+                }
+
+        client = _FakePipelinesClientRam(1073741824)
+        result = client.get_latest_run("my-pipeline")
+        assert result.max_ram_gb == 1.0
+
+        client_2gb = _FakePipelinesClientRam(2147483648)
+        result_2gb = client_2gb.get_latest_run("my-pipeline")
+        assert result_2gb.max_ram_gb == 2.0
+
+    def test_get_latest_run_with_pipeline_name_filter(self) -> None:
+        class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
+            def __init__(self) -> None:
+                self.org_id = "test-org-123"
+                self.base_url = "https://test.tracer.com"
+                self.last_params: Mapping[str, Any] | None = None
+
+            def _get(
+                self, _endpoint: str, params: Mapping[str, Any] | None = None
+            ) -> dict[str, Any]:
+                self.last_params = params
+                return {"success": True, "data": []}
+
+        client = _FakePipelinesClientWithCapture()
+        client.get_latest_run("my-pipeline")
+
+        assert client.last_params == {
+            "page": 1,
+            "size": 1,
+            "orgId": "test-org-123",
+            "pipelineName": "my-pipeline",
+        }
+
+    def test_get_latest_run_without_pipeline_name(self) -> None:
+        class _FakePipelinesClientWithCapture(TracerPipelinesMixin):
+            def __init__(self) -> None:
+                self.org_id = "test-org-123"
+                self.base_url = "https://test.tracer.com"
+                self.last_params: Mapping[str, Any] | None = None
+
+            def _get(
+                self, _endpoint: str, params: Mapping[str, Any] | None = None
+            ) -> dict[str, Any]:
+                self.last_params = params
+                return {"success": True, "data": []}
+
+        client = _FakePipelinesClientWithCapture()
+        client.get_latest_run()
+
+        assert client.last_params == {"page": 1, "size": 1, "orgId": "test-org-123"}
+        assert "pipelineName" not in client.last_params
+
+    def test_get_latest_run_numeric_defaults(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "run_id": "run-empty",
+                    "pipeline_name": "my-pipeline",
+                    "run_name": "empty-numeric",
+                    "status": "pending",
+                    "tags": {},
+                },
+            ],
+        }
+        client = _FakePipelinesClient(response)
+
+        result = client.get_latest_run("my-pipeline")
+
+        assert result.found is True
+        assert result.run_time_seconds == 0
+        assert result.run_cost == 0.0
+        assert result.max_ram_gb == 0.0
+        assert result.tool_count == 0


### PR DESCRIPTION
Fixes #888 

#### Describe the changes you have made in this PR -
Added direct unit tests for the `TracerPipelinesMixin` class in `app/services/tracer_client/tracer_pipelines.py`. This PR adds 20 focused unit tests that cover:

- **`get_pipelines()`** (6 tests): Success with data, empty data, unsuccessful responses, missing optional fields, zero counts, and pagination parameters
- **`get_pipeline_runs()`** (6 tests): Success with data, empty data, unsuccessful responses, null values, numeric defaults, and pipeline name fallback
- **`get_latest_run()`** (8 tests): Success with tags, tags fallback to direct fields, empty data, unsuccessful responses, max_ram conversion (bytes to GB), with/without pipeline name filter, and numeric defaults

The tests use a fake subclass (`_FakePipelinesClient`) that stubs the `_get()` method, following the existing pattern from `test_tracer_client_base.py`. No real HTTP calls are made.

**Coverage:** 88% of `tracer_pipelines.py`.


### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```bash
$ python -m pytest tests/services/tracer_client/test_tracer_pipelines.py -v
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0 -- /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, langsmith-0.7.36, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 20 items                                                                                                                                                                                   

tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_success_with_data PASSED                                                                           [  5%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_empty_data PASSED                                                                                  [ 10%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_unsuccessful_response PASSED                                                                       [ 15%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_missing_optional_fields PASSED                                                                     [ 20%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_zero_counts PASSED                                                                                 [ 25%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_with_pagination_params PASSED                                                                      [ 30%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_success_with_data PASSED                                                                    [ 35%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_empty_data PASSED                                                                           [ 40%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_unsuccessful_response PASSED                                                                [ 45%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_null_values PASSED                                                                          [ 50%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_numeric_defaults PASSED                                                                     [ 55%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_pipeline_name_fallback PASSED                                                               [ 60%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_success_with_tags PASSED                                                                          [ 65%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_tags_fallback_to_direct_fields PASSED                                                             [ 70%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_empty_data PASSED                                                                                 [ 75%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_unsuccessful_response PASSED                                                                      [ 80%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_max_ram_conversion PASSED                                                                         [ 85%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_with_pipeline_name_filter PASSED                                                                  [ 90%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_without_pipeline_name PASSED                                                                      [ 95%]
tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_numeric_defaults PASSED                                                                           [100%]

=========================================================================================== tests coverage ===========================================================================================
__________________________________________________________________________ coverage: platform darwin, python 3.14.3-final-0 __________________________________________________________________________

Name                                             Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------
app/services/tracer_client/tracer_pipelines.py      65      8    88%   128-130, 134-135, 139-141
------------------------------------------------------------------------------
TOTAL                                               65      8    88%
======================================================================================== slowest 20 durations ========================================================================================
0.00s call     tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_success_with_tags
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_success_with_data
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_tags_fallback_to_direct_fields
0.00s call     tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_success_with_data
0.00s call     tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_success_with_data
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_empty_data
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_missing_optional_fields
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_empty_data
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_numeric_defaults
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_zero_counts
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_unsuccessful_response
0.00s teardown tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_success_with_data
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_success_with_tags
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_unsuccessful_response
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_success_with_data
0.00s call     tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_max_ram_conversion
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelineRuns::test_get_pipeline_runs_unsuccessful_response
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_without_pipeline_name
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetLatestRun::test_get_latest_run_max_ram_conversion
0.00s setup    tests/services/tracer_client/test_tracer_pipelines.py::TestGetPipelines::test_get_pipelines_with_pagination_params
========================================================================================= 20 passed in 0.76s =========================================================================================

$ make lint && make format-check && make typecheck
ruff check app/ tests/
All checks passed!
ruff format --check app/ tests/
903 files already formatted
.venv/bin/python -m mypy app/
Success: no issues found in 391 source files
```
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [X] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The problem: `TracerPipelinesMixin` had no direct unit tests, only indirect integration tests. This made it hard to verify the mixin's behavior in isolation and catch regressions quickly.

Chosen implementation: Created a `_FakePipelinesClient`  subclass that overrides `_get()` to return configurable responses. This:
- Matches the existing pattern in the codebase
- Allows testing both success and error scenarios
- Makes tests fast and isolated (no HTTP calls)

Key components:

- `_FakePipelinesClient`: Fake subclass that stubs `_get()` to return mock responses
- `TestGetPipelines`: Tests `get_pipelines()` with various data scenarios
- `TestGetPipelineRuns`: Tests `get_pipeline_runs()` including typed dataclass mapping
- `TestGetLatestRun`: Tests `get_latest_run()` with special focus on the tags fallback behavior (primary: `tags.get("email")`, fallback: `row.get("user_email")`)

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
