### PR TITLE
refactor(utils): extract shared HTTP-post helper for delivery modules

### DIFF
--- a/app/utils/delivery_transport.py
+++ b/app/utils/delivery_transport.py
@@ -21,7 +21,9 @@ for Telegram).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any
 
 import httpx
@@ -38,19 +40,34 @@ class DeliveryResponse:
         status_code: HTTP status code from the response, or ``0`` when the
             request itself raised before a response was received.
         data: Parsed JSON body when the response was a JSON object,
-            otherwise an empty dict. Never ``None``, so callers can chain
-            ``.get(...)`` safely without a None-check.
+            otherwise an empty mapping. Never ``None``, so callers can
+            chain ``.get(...)`` safely without a None-check. The mapping
+            is read-only (``MappingProxyType``) so the frozen dataclass
+            stays fully immutable end-to-end.
         text: Raw response body, useful for fallback error extraction
             when the body is not valid JSON or is empty.
         error: String form of the exception that aborted the request.
             Empty when ``ok`` is True.
+        error_type: Class name of the exception that aborted the request
+            (e.g. ``"TimeoutError"``, ``"ConnectError"``). Empty when
+            ``ok`` is True. Surfaced separately so callers can include
+            the exception shape in triage logs without parsing ``error``.
     """
 
     ok: bool
     status_code: int = 0
-    data: dict[str, Any] = field(default_factory=dict)
+    data: Mapping[str, Any] = field(default_factory=dict)
     text: str = ""
     error: str = ""
+    error_type: str = ""
+
+    def __post_init__(self) -> None:
+        # Wrap ``data`` in a read-only view so callers cannot mutate the
+        # response after the fact and break the frozen-dataclass contract.
+        # ``object.__setattr__`` is required because ``frozen=True`` blocks
+        # normal attribute assignment.
+        if not isinstance(self.data, MappingProxyType):
+            object.__setattr__(self, "data", MappingProxyType(dict(self.data)))
 
 
 def post_json(
@@ -95,7 +112,7 @@ def post_json(
             follow_redirects=follow_redirects,
         )
     except Exception as exc:  # noqa: BLE001 — transport never re-raises
-        return DeliveryResponse(ok=False, error=str(exc))
+        return DeliveryResponse(ok=False, error=str(exc), error_type=type(exc).__name__)
 
     text = response.text
     data: dict[str, Any] = {}

--- a/app/utils/delivery_transport.py
+++ b/app/utils/delivery_transport.py
@@ -1,0 +1,114 @@
+"""Shared HTTP-post transport for outbound message-delivery helpers.
+
+Slack, Discord, and Telegram delivery modules each issue a JSON ``POST``
+to a provider endpoint, parse the response body, and return a
+``(success, error, ...)`` tuple. The transport pieces of that flow —
+making the request, applying a timeout, catching network exceptions, and
+attempting JSON decode — are identical; only the success criteria,
+authentication scheme, and error-message extraction differ per provider.
+
+This module hosts the shared transport so each delivery module can keep
+its provider-specific payload building and result interpretation while
+sharing one well-tested HTTP code path.
+
+The helper deliberately does **not** decide whether the call succeeded
+at the provider level. It returns ``ok=True`` whenever the request
+completed without raising; callers then inspect ``status_code`` and
+``data``/``text`` to apply provider semantics (e.g. ``data["ok"]`` for
+Slack, ``status_code in (200, 201)`` for Discord, ``status_code == 200``
+for Telegram).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class DeliveryResponse:
+    """Normalized result of a delivery POST.
+
+    Attributes:
+        ok: ``True`` iff the request completed without raising. This is a
+            transport-level signal only; provider-level success requires
+            inspecting ``status_code`` / ``data`` per provider semantics.
+        status_code: HTTP status code from the response, or ``0`` when the
+            request itself raised before a response was received.
+        data: Parsed JSON body when the response was a JSON object,
+            otherwise an empty dict. Never ``None``, so callers can chain
+            ``.get(...)`` safely without a None-check.
+        text: Raw response body, useful for fallback error extraction
+            when the body is not valid JSON or is empty.
+        error: String form of the exception that aborted the request.
+            Empty when ``ok`` is True.
+    """
+
+    ok: bool
+    status_code: int = 0
+    data: dict[str, Any] = field(default_factory=dict)
+    text: str = ""
+    error: str = ""
+
+
+def post_json(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float = 15.0,
+    follow_redirects: bool = False,
+) -> DeliveryResponse:
+    """POST ``payload`` as JSON to ``url`` and return a normalized result.
+
+    On request exceptions the result carries ``ok=False`` and ``error``
+    set to the exception message — callers are not expected to handle
+    raised errors. The transport never re-raises.
+
+    Args:
+        url: Absolute URL to post to.
+        payload: JSON-serializable dict body.
+        headers: Optional headers (e.g. ``Authorization``). Defaults to
+            an empty dict; httpx will still set ``Content-Type`` and the
+            standard headers it manages.
+        timeout: Request timeout in seconds. Defaults to 15s, matching
+            the pre-existing per-provider timeouts.
+        follow_redirects: Whether to follow 3xx redirects. Disabled by
+            default to match Slack/Discord/Telegram REST APIs (which never
+            redirect on success). Slack incoming webhooks and the NextJS
+            ``/api/slack`` proxy enable it.
+
+    Returns:
+        ``DeliveryResponse`` with ``ok``, ``status_code``, ``data``,
+        ``text``, and ``error`` populated. JSON decode failures are
+        non-fatal: ``data`` falls back to ``{}`` and ``text`` always
+        carries the raw body.
+    """
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=headers or {},
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+        )
+    except Exception as exc:  # noqa: BLE001 — transport never re-raises
+        return DeliveryResponse(ok=False, error=str(exc))
+
+    text = response.text
+    data: dict[str, Any] = {}
+    try:
+        parsed = response.json()
+        if isinstance(parsed, dict):
+            data = parsed
+    except Exception:  # noqa: BLE001 — non-JSON body is permitted
+        pass
+
+    return DeliveryResponse(
+        ok=True,
+        status_code=response.status_code,
+        data=data,
+        text=text,
+    )

--- a/app/utils/delivery_transport.py
+++ b/app/utils/delivery_transport.py
@@ -48,10 +48,12 @@ class DeliveryResponse:
             when the body is not valid JSON or is empty.
         error: String form of the exception that aborted the request.
             Empty when ``ok`` is True.
-        error_type: Class name of the exception that aborted the request
+        exc_type: Class name of the exception that aborted the request
             (e.g. ``"TimeoutError"``, ``"ConnectError"``). Empty when
             ``ok`` is True. Surfaced separately so callers can include
             the exception shape in triage logs without parsing ``error``.
+            Named ``exc_type`` rather than ``type`` because ``type`` is
+            a Python builtin.
     """
 
     ok: bool
@@ -59,7 +61,7 @@ class DeliveryResponse:
     data: Mapping[str, Any] = field(default_factory=dict)
     text: str = ""
     error: str = ""
-    error_type: str = ""
+    exc_type: str = ""
 
     def __post_init__(self) -> None:
         # Wrap ``data`` in a read-only view so callers cannot mutate the
@@ -112,7 +114,7 @@ def post_json(
             follow_redirects=follow_redirects,
         )
     except Exception as exc:  # noqa: BLE001 — transport never re-raises
-        return DeliveryResponse(ok=False, error=str(exc), error_type=type(exc).__name__)
+        return DeliveryResponse(ok=False, error=str(exc), exc_type=type(exc).__name__)
 
     text = response.text
     data: dict[str, Any] = {}

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from app.utils.delivery_transport import post_json
@@ -17,7 +18,7 @@ def _discord_auth_headers(bot_token: str) -> dict[str, str]:
     }
 
 
-def _discord_error_from_data(data: dict[str, Any]) -> str:
+def _discord_error_from_data(data: Mapping[str, Any]) -> str:
     return str(data.get("message", data.get("error", "unknown")))
 
 

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -12,10 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def _discord_auth_headers(bot_token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bot {bot_token}",
-        "Content-Type": "application/json; charset=utf-8",
-    }
+    # ``Content-Type: application/json`` is set automatically by httpx when
+    # the request uses the ``json=`` kwarg, so we only need to add auth.
+    return {"Authorization": f"Bot {bot_token}"}
 
 
 def _discord_error_from_data(data: Mapping[str, Any]) -> str:

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import httpx
+from app.utils.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
+
+
+def _discord_auth_headers(bot_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bot {bot_token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+
+def _discord_error_from_data(data: dict[str, Any]) -> str:
+    return str(data.get("message", data.get("error", "unknown")))
 
 
 def post_discord_message(
@@ -21,29 +32,22 @@ def post_discord_message(
     Returns True on success, False on expected failures.
     """
     logger.debug("[discord] post message params channel_id: %s", channel_id)
-    try:
-        resp = httpx.post(
-            url=f"https://discord.com/api/v10/channels/{channel_id}/messages",
-            json={"content": content, "embeds": embeds},
-            headers={
-                "Authorization": f"Bot {bot_token}",
-                "Content-Type": "application/json; charset=utf-8",
-            },
-            timeout=15.0,
-        )
-        data = resp.json()
-        error_message = ""
-        if resp.status_code not in (200, 201):
-            logger.warning("[discord] post message failed: %s", resp.status_code)
-            logger.warning("[discord] api response %s", data)
-            error_message = data.get("message", data.get("error", "unknown"))
-            logger.warning("[discord] post message failed: %s", error_message)
-            return False, error_message, ""
-        message_id: str = str(data.get("id") or "")
-        return True, error_message, message_id
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("[discord] post message exception: %s", exc)
-        return False, str(exc), ""
+    response = post_json(
+        url=f"https://discord.com/api/v10/channels/{channel_id}/messages",
+        payload={"content": content, "embeds": embeds},
+        headers=_discord_auth_headers(bot_token),
+    )
+    if not response.ok:
+        logger.warning("[discord] post message exception: %s", response.error)
+        return False, response.error, ""
+    if response.status_code not in (200, 201):
+        logger.warning("[discord] post message failed: %s", response.status_code)
+        logger.warning("[discord] api response %s", response.data)
+        error_message = _discord_error_from_data(response.data)
+        logger.warning("[discord] post message failed: %s", error_message)
+        return False, error_message, ""
+    message_id = str(response.data.get("id") or "")
+    return True, "", message_id
 
 
 def create_discord_thread(
@@ -56,29 +60,20 @@ def create_discord_thread(
 
     Returns True on success, False on expected failures.
     """
-    try:
-        resp = httpx.post(
-            url=(
-                f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}/threads"
-            ),
-            json={"name": name, "auto_archive_duration": 1440},
-            headers={
-                "Authorization": f"Bot {bot_token}",
-                "Content-Type": "application/json; charset=utf-8",
-            },
-            timeout=15.0,
-        )
-        data = resp.json()
-        error_message = ""
-        if resp.status_code not in (200, 201):
-            error_message = data.get("message", data.get("error", "unknown"))
-            logger.warning("[discord] create thread failed: %s", error_message)
-            return False, error_message, ""
-        thread_id: str = str(data.get("id") or "")
-        return True, error_message, thread_id
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("[discord] create thread exception: %s", exc)
-        return False, str(exc), ""
+    response = post_json(
+        url=f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}/threads",
+        payload={"name": name, "auto_archive_duration": 1440},
+        headers=_discord_auth_headers(bot_token),
+    )
+    if not response.ok:
+        logger.warning("[discord] create thread exception: %s", response.error)
+        return False, response.error, ""
+    if response.status_code not in (200, 201):
+        error_message = _discord_error_from_data(response.data)
+        logger.warning("[discord] create thread failed: %s", error_message)
+        return False, error_message, ""
+    thread_id = str(response.data.get("id") or "")
+    return True, "", thread_id
 
 
 _EMBED_TITLE_LIMIT = 256

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -217,10 +217,11 @@ def _post_direct(
     )
     if not response.ok:
         logger.error(
-            "[slack] Direct post exception channel=%s thread_ts=%s detail=%s "
-            "(caller may attempt fallback)",
+            "[slack] Direct post exception channel=%s thread_ts=%s "
+            "exc_type=%s detail=%s (caller may attempt fallback)",
             channel,
             thread_ts,
+            response.error_type or "Exception",
             response.error,
         )
         return False, f"exception={response.error}"

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -14,9 +14,16 @@ logger = logging.getLogger(__name__)
 
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
-    # ``Content-Type: application/json`` is set automatically by httpx when
-    # the request uses the ``json=`` kwarg, so we only need to add auth.
-    return {"Authorization": f"Bearer {token}"}
+    # Slack explicitly recommends ``charset=utf-8`` on JSON POSTs — without
+    # it the API replies with a ``missing_charset`` warning in
+    # ``response_metadata.warnings``. httpx only auto-sets the bare
+    # ``application/json`` (no charset) for ``json=`` kwargs, so we keep
+    # the explicit charset header here.
+    # See https://api.slack.com/web#posting_json
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
 
 
 def _call_reactions_api(method: str, token: str, channel: str, timestamp: str, emoji: str) -> bool:

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -14,10 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json; charset=utf-8",
-    }
+    # ``Content-Type: application/json`` is set automatically by httpx when
+    # the request uses the ``json=`` kwarg, so we only need to add auth.
+    return {"Authorization": f"Bearer {token}"}
 
 
 def _call_reactions_api(method: str, token: str, channel: str, timestamp: str, emoji: str) -> bool:
@@ -217,11 +216,11 @@ def _post_direct(
     )
     if not response.ok:
         logger.error(
-            "[slack] Direct post exception channel=%s thread_ts=%s "
-            "exc_type=%s detail=%s (caller may attempt fallback)",
+            "[slack] Direct post exception type=%s channel=%s thread_ts=%s detail=%s "
+            "(caller may attempt fallback)",
+            response.exc_type or "Exception",
             channel,
             thread_ts,
-            response.error_type or "Exception",
             response.error,
         )
         return False, f"exception={response.error}"

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -6,12 +6,18 @@ import logging
 import os
 from typing import Any
 
-import httpx
-
 from app.config import SLACK_CHANNEL
 from app.output import debug_print
+from app.utils.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
+
+
+def _slack_bearer_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
 
 
 def _call_reactions_api(method: str, token: str, channel: str, timestamp: str, emoji: str) -> bool:
@@ -19,25 +25,20 @@ def _call_reactions_api(method: str, token: str, channel: str, timestamp: str, e
 
     Returns True on success, False on expected failures (already_reacted, no_reaction, etc.).
     """
-    try:
-        resp = httpx.post(
-            f"https://slack.com/api/{method}",
-            json={"channel": channel, "timestamp": timestamp, "name": emoji},
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json; charset=utf-8",
-            },
-            timeout=8.0,
-        )
-        data = resp.json()
-        if not data.get("ok"):
-            error = data.get("error", "unknown")
-            if error not in ("already_reacted", "no_reaction", "message_not_found"):
-                logger.warning("[slack] %s(%s) failed: %s", method, emoji, error)
-        return bool(data.get("ok", False))
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("[slack] %s(%s) exception: %s", method, emoji, exc)
+    response = post_json(
+        url=f"https://slack.com/api/{method}",
+        payload={"channel": channel, "timestamp": timestamp, "name": emoji},
+        headers=_slack_bearer_headers(token),
+        timeout=8.0,
+    )
+    if not response.ok:
+        logger.warning("[slack] %s(%s) exception: %s", method, emoji, response.error)
         return False
+    if not response.data.get("ok"):
+        error = response.data.get("error", "unknown")
+        if error not in ("already_reacted", "no_reaction", "message_not_found"):
+            logger.warning("[slack] %s(%s) failed: %s", method, emoji, error)
+    return bool(response.data.get("ok", False))
 
 
 def add_reaction(
@@ -209,46 +210,40 @@ def _post_direct(
     Returns (success, error_detail) where error_detail is empty on success.
     """
     payload = _merge_payload(channel, text, thread_ts, blocks=blocks, **extra)
-
-    try:
-        resp = httpx.post(
-            "https://slack.com/api/chat.postMessage",
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json; charset=utf-8",
-            },
-            timeout=15.0,
-        )
-        data = resp.json()
-        if not data.get("ok"):
-            error = data.get("error", "unknown")
-            response_meta = data.get("response_metadata", {})
-            logger.error(
-                "[slack] Direct post FAILED: error=%s, metadata=%s (channel=%s, thread_ts=%s)",
-                error,
-                response_meta,
-                channel,
-                thread_ts,
-            )
-            return False, f"slack_error={error}"
-        warnings = data.get("response_metadata", {}).get("warnings", [])
-        if warnings:
-            logger.warning("[slack] Reply posted with warnings: %s", warnings)
-        logger.info(
-            "[slack] Reply posted successfully (thread_ts=%s, ts=%s)", thread_ts, data.get("ts")
-        )
-        return True, ""
-    except Exception as exc:  # noqa: BLE001
+    response = post_json(
+        url="https://slack.com/api/chat.postMessage",
+        payload=payload,
+        headers=_slack_bearer_headers(token),
+    )
+    if not response.ok:
         logger.error(
-            "[slack] Direct post exception type=%s channel=%s thread_ts=%s detail=%s "
+            "[slack] Direct post exception channel=%s thread_ts=%s detail=%s "
             "(caller may attempt fallback)",
-            type(exc).__name__,
             channel,
             thread_ts,
-            exc,
+            response.error,
         )
-        return False, f"exception={exc}"
+        return False, f"exception={response.error}"
+    if not response.data.get("ok"):
+        error = response.data.get("error", "unknown")
+        response_meta = response.data.get("response_metadata", {})
+        logger.error(
+            "[slack] Direct post FAILED: error=%s, metadata=%s (channel=%s, thread_ts=%s)",
+            error,
+            response_meta,
+            channel,
+            thread_ts,
+        )
+        return False, f"slack_error={error}"
+    warnings = response.data.get("response_metadata", {}).get("warnings", [])
+    if warnings:
+        logger.warning("[slack] Reply posted with warnings: %s", warnings)
+    logger.info(
+        "[slack] Reply posted successfully (thread_ts=%s, ts=%s)",
+        thread_ts,
+        response.data.get("ts"),
+    )
+    return True, ""
 
 
 def _post_via_webapp(
@@ -272,22 +267,15 @@ def _post_via_webapp(
 
     api_url = f"{base_url.rstrip('/')}/api/slack"
     payload = _merge_payload(target_channel, text, thread_ts, blocks=blocks, **extra)
-
-    try:
-        response = httpx.post(api_url, json=payload, timeout=10.0, follow_redirects=True)
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        detail = exc.response.text if exc.response is not None else str(exc)
-        debug_print(
-            f"Slack delivery failed: HTTP {exc.response.status_code if exc.response else 'unknown'}: {detail[:200]}"
-        )
+    response = post_json(url=api_url, payload=payload, timeout=10.0, follow_redirects=True)
+    if not response.ok:
+        debug_print(f"Slack delivery failed: {response.error}")
         return False
-    except Exception as exc:  # noqa: BLE001
-        debug_print(f"Slack delivery failed: {exc}")
+    if not 200 <= response.status_code < 300:
+        debug_print(f"Slack delivery failed: HTTP {response.status_code}: {response.text[:200]}")
         return False
-    else:
-        debug_print(f"Slack delivery triggered via NextJS /api/slack (thread_ts={thread_ts}).")
-        return True
+    debug_print(f"Slack delivery triggered via NextJS /api/slack (thread_ts={thread_ts}).")
+    return True
 
 
 def _post_via_incoming_webhook(
@@ -304,18 +292,14 @@ def _post_via_incoming_webhook(
     if extra:
         payload.update(extra)
 
-    try:
-        response = httpx.post(webhook_url, json=payload, timeout=10.0, follow_redirects=True)
-        response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        detail = exc.response.text if exc.response is not None else str(exc)
+    response = post_json(url=webhook_url, payload=payload, timeout=10.0, follow_redirects=True)
+    if not response.ok:
+        debug_print(f"Slack incoming webhook failed: {response.error}")
+        return False
+    if not 200 <= response.status_code < 300:
         debug_print(
-            f"Slack incoming webhook failed: HTTP {exc.response.status_code if exc.response else 'unknown'}: {detail[:200]}"
+            f"Slack incoming webhook failed: HTTP {response.status_code}: {response.text[:200]}"
         )
         return False
-    except Exception as exc:  # noqa: BLE001
-        debug_print(f"Slack incoming webhook failed: {exc}")
-        return False
-    else:
-        debug_print("Slack report posted via incoming webhook.")
-        return True
+    debug_print("Slack report posted via incoming webhook.")
+    return True

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -7,7 +7,7 @@ import logging
 import re
 from typing import Any
 
-import httpx
+from app.utils.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
 
@@ -73,29 +73,27 @@ def post_telegram_message(
     if reply_to_message_id and reply_to_message_id != "0":
         with contextlib.suppress(ValueError, TypeError):
             payload["reply_to_message_id"] = int(reply_to_message_id)
-    try:
-        resp = httpx.post(
-            url=f"https://api.telegram.org/bot{bot_token}/sendMessage",
-            json=payload,
-            timeout=15.0,
-        )
-        if resp.status_code != 200:
-            logger.warning("[telegram] post message failed: %s", resp.status_code)
-            try:
-                data = resp.json()
-                error_message = str(data.get("description", data.get("error", "unknown")))
-            except Exception:  # noqa: BLE001
-                error_message = resp.text or f"HTTP {resp.status_code}"
-            logger.warning("[telegram] post message failed: %s", error_message)
-            return False, error_message, ""
-        data = resp.json()
-        result = data.get("result", {})
-        message_id: str = str(result.get("message_id") or "")
-        return True, "", message_id
-    except Exception as exc:  # noqa: BLE001
-        error = _redact_token(str(exc), bot_token)
+    response = post_json(
+        url=f"https://api.telegram.org/bot{bot_token}/sendMessage",
+        payload=payload,
+    )
+    if not response.ok:
+        error = _redact_token(response.error, bot_token)
         logger.warning("[telegram] post message exception: %s", error)
         return False, error, ""
+    if response.status_code != 200:
+        logger.warning("[telegram] post message failed: %s", response.status_code)
+        if response.data:
+            error_message = str(
+                response.data.get("description", response.data.get("error", "unknown"))
+            )
+        else:
+            error_message = response.text or f"HTTP {response.status_code}"
+        logger.warning("[telegram] post message failed: %s", error_message)
+        return False, error_message, ""
+    result = response.data.get("result", {})
+    message_id = str(result.get("message_id") or "") if isinstance(result, dict) else ""
+    return True, "", message_id
 
 
 def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[bool, str]:

--- a/tests/utils/test_delivery_transport.py
+++ b/tests/utils/test_delivery_transport.py
@@ -188,7 +188,7 @@ class TestDeliveryResponseShape:
         assert result.data == {}
         assert result.text == ""
         assert result.error == ""
-        assert result.error_type == ""
+        assert result.exc_type == ""
 
     def test_response_is_frozen(self) -> None:
         """``DeliveryResponse`` is a frozen dataclass — callers cannot mutate
@@ -235,7 +235,7 @@ class TestPostJsonErrorType:
     """The transport surfaces the exception class name on failure so callers
     can include it in triage logs without parsing the error string."""
 
-    def test_error_type_populated_on_transport_exception(
+    def test_exc_type_populated_on_transport_exception(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def _raise(*_a: Any, **_kw: Any) -> Any:
@@ -244,7 +244,7 @@ class TestPostJsonErrorType:
         monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
         result = post_json("https://example.test", {})
         assert result.ok is False
-        assert result.error_type == "TimeoutError"
+        assert result.exc_type == "TimeoutError"
         assert "read timeout" in result.error
 
     @pytest.mark.parametrize(
@@ -256,7 +256,7 @@ class TestPostJsonErrorType:
             (RuntimeError("oops"), "RuntimeError"),
         ],
     )
-    def test_error_type_matches_exception_class(
+    def test_exc_type_matches_exception_class(
         self, exc: Exception, expected_name: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def _raise(*_a: Any, **_kw: Any) -> Any:
@@ -264,13 +264,13 @@ class TestPostJsonErrorType:
 
         monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
         result = post_json("https://example.test", {})
-        assert result.error_type == expected_name
+        assert result.exc_type == expected_name
 
-    def test_error_type_empty_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_exc_type_empty_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             "app.utils.delivery_transport.httpx.post",
             lambda *_a, **_kw: _mock_response(200, {"ok": True}),
         )
         result = post_json("https://example.test", {})
         assert result.ok is True
-        assert result.error_type == ""
+        assert result.exc_type == ""

--- a/tests/utils/test_delivery_transport.py
+++ b/tests/utils/test_delivery_transport.py
@@ -1,0 +1,199 @@
+"""Tests for ``app/utils/delivery_transport.py``.
+
+The transport is the shared HTTP-POST plumbing used by the Slack, Discord,
+and Telegram delivery helpers. These tests pin down the contract:
+
+- It never re-raises; every transport-level failure becomes ``ok=False``.
+- Status code and parsed JSON body are surfaced unchanged on success.
+- Non-JSON / empty / non-dict response bodies degrade gracefully — ``data``
+  always falls back to ``{}`` so callers can chain ``.get(...)``.
+- Optional ``headers``, ``timeout``, and ``follow_redirects`` arguments
+  reach ``httpx.post`` correctly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from app.utils.delivery_transport import DeliveryResponse, post_json
+
+
+def _mock_response(status_code: int, json_body: Any = None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if isinstance(json_body, Exception):
+
+        def _raise() -> Any:
+            raise json_body
+
+        resp.json.side_effect = _raise
+    else:
+        resp.json.return_value = json_body
+    return resp
+
+
+class TestPostJsonHappyPath:
+    def test_returns_ok_with_status_data_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        body = {"ok": True, "id": "msg-1"}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, body, '{"ok":true,"id":"msg-1"}'),
+        )
+        result = post_json("https://example.test/api", {"hello": "world"})
+        assert result.ok is True
+        assert result.status_code == 200
+        assert result.data == body
+        assert result.text == '{"ok":true,"id":"msg-1"}'
+        assert result.error == ""
+
+    def test_returns_status_for_4xx_5xx_without_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Provider-level errors return ``ok=True`` (the request succeeded
+        at the transport layer); callers interpret status_code/data."""
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(403, {"error": "forbidden"}, "forbidden"),
+        )
+        result = post_json("https://example.test", {})
+        assert result.ok is True
+        assert result.status_code == 403
+        assert result.data == {"error": "forbidden"}
+        assert result.error == ""
+
+    def test_passes_headers_and_timeout_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def _capture(url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured.update(kwargs)
+            return _mock_response(200, {})
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _capture)
+        post_json(
+            "https://example.test/api",
+            {"k": "v"},
+            headers={"Authorization": "Bearer abc"},
+            timeout=4.5,
+        )
+        assert captured["url"] == "https://example.test/api"
+        assert captured["json"] == {"k": "v"}
+        assert captured["headers"] == {"Authorization": "Bearer abc"}
+        assert captured["timeout"] == 4.5
+        assert captured["follow_redirects"] is False
+
+    def test_default_headers_are_empty_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **kw: captured.update(kw) or _mock_response(200, {}),
+        )
+        post_json("https://example.test", {})
+        assert captured["headers"] == {}
+
+    def test_follow_redirects_can_be_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **kw: captured.update(kw) or _mock_response(200, {}),
+        )
+        post_json("https://example.test", {}, follow_redirects=True)
+        assert captured["follow_redirects"] is True
+
+
+class TestPostJsonTransportFailures:
+    """The helper must catch every transport-level error and never re-raise."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("connection refused"),
+            httpx.ReadTimeout("timed out"),
+            httpx.RequestError("generic transport error"),
+            OSError("network down"),
+            RuntimeError("unexpected"),
+        ],
+    )
+    def test_request_exceptions_become_ok_false(
+        self, exc: Exception, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise exc
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        result = post_json("https://example.test", {})
+        assert result.ok is False
+        assert result.status_code == 0
+        assert result.data == {}
+        assert result.text == ""
+        assert str(exc).split(":")[0] in result.error or str(exc) in result.error
+
+
+class TestPostJsonResponseDecoding:
+    """Non-JSON / non-dict / empty bodies must degrade gracefully."""
+
+    def test_non_json_body_yields_empty_data_and_keeps_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(
+                200, ValueError("not json"), text="<html>oops</html>"
+            ),
+        )
+        result = post_json("https://example.test", {})
+        assert result.ok is True
+        assert result.status_code == 200
+        assert result.data == {}  # callers can still .get(...) safely
+        assert result.text == "<html>oops</html>"
+
+    def test_json_array_response_is_treated_as_no_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A JSON list at the top level isn't a provider-style envelope; we
+        fall back to ``data={}`` so callers don't accidentally subscript a list."""
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, [1, 2, 3], text="[1,2,3]"),
+        )
+        result = post_json("https://example.test", {})
+        assert result.ok is True
+        assert result.data == {}
+        assert result.text == "[1,2,3]"
+
+    def test_empty_body_yields_empty_data_and_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(204, ValueError("empty"), text=""),
+        )
+        result = post_json("https://example.test", {})
+        assert result.ok is True
+        assert result.status_code == 204
+        assert result.data == {}
+        assert result.text == ""
+
+
+class TestDeliveryResponseShape:
+    def test_default_construction_is_safe(self) -> None:
+        """Defaults must allow callers to chain ``.data.get(...)`` and
+        access ``.status_code`` even when the helper hasn't populated them."""
+        result = DeliveryResponse(ok=False)
+        assert result.ok is False
+        assert result.status_code == 0
+        assert result.data == {}
+        assert result.text == ""
+        assert result.error == ""
+
+    def test_response_is_frozen(self) -> None:
+        """``DeliveryResponse`` is a frozen dataclass — callers cannot mutate
+        the result after the fact."""
+        from dataclasses import FrozenInstanceError
+
+        result = DeliveryResponse(ok=True)
+        with pytest.raises(FrozenInstanceError):
+            result.ok = False  # type: ignore[misc]

--- a/tests/utils/test_delivery_transport.py
+++ b/tests/utils/test_delivery_transport.py
@@ -188,6 +188,7 @@ class TestDeliveryResponseShape:
         assert result.data == {}
         assert result.text == ""
         assert result.error == ""
+        assert result.error_type == ""
 
     def test_response_is_frozen(self) -> None:
         """``DeliveryResponse`` is a frozen dataclass — callers cannot mutate
@@ -197,3 +198,79 @@ class TestDeliveryResponseShape:
         result = DeliveryResponse(ok=True)
         with pytest.raises(FrozenInstanceError):
             result.ok = False  # type: ignore[misc]
+
+    def test_data_is_read_only(self) -> None:
+        """``data`` is wrapped in ``MappingProxyType`` so the frozen
+        dataclass stays fully immutable end-to-end. Mutating it must
+        raise ``TypeError`` rather than silently succeeding."""
+        result = DeliveryResponse(ok=True, data={"a": 1})
+        with pytest.raises(TypeError):
+            result.data["b"] = 2  # type: ignore[index]
+
+    def test_data_is_isolated_from_caller_dict(self) -> None:
+        """Mutating the dict the caller passed in must not bleed through
+        to the response — the proxy must wrap a copy, not the original."""
+        original: dict[str, Any] = {"a": 1}
+        result = DeliveryResponse(ok=True, data=original)
+        original["a"] = 999
+        original["b"] = "leaked"
+        assert dict(result.data) == {"a": 1}
+
+    def test_data_compares_equal_to_plain_dict(self) -> None:
+        """``MappingProxyType`` must still compare equal to a regular dict
+        so existing assertions in delivery test files keep working."""
+        body = {"ok": True, "id": "msg-1"}
+        result = DeliveryResponse(ok=True, status_code=200, data=body)
+        assert result.data == body
+
+    def test_default_data_instances_are_independent(self) -> None:
+        """Each default ``data`` must be its own mapping — no shared state
+        between instances (a classic mutable-default-argument bug)."""
+        a = DeliveryResponse(ok=True)
+        b = DeliveryResponse(ok=True)
+        assert a.data is not b.data
+
+
+class TestPostJsonErrorType:
+    """The transport surfaces the exception class name on failure so callers
+    can include it in triage logs without parsing the error string."""
+
+    def test_error_type_populated_on_transport_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise TimeoutError("read timeout")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        result = post_json("https://example.test", {})
+        assert result.ok is False
+        assert result.error_type == "TimeoutError"
+        assert "read timeout" in result.error
+
+    @pytest.mark.parametrize(
+        ("exc", "expected_name"),
+        [
+            (httpx.ConnectError("refused"), "ConnectError"),
+            (httpx.ReadTimeout("timed out"), "ReadTimeout"),
+            (OSError("network down"), "OSError"),
+            (RuntimeError("oops"), "RuntimeError"),
+        ],
+    )
+    def test_error_type_matches_exception_class(
+        self, exc: Exception, expected_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise exc
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        result = post_json("https://example.test", {})
+        assert result.error_type == expected_name
+
+    def test_error_type_empty_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, {"ok": True}),
+        )
+        result = post_json("https://example.test", {})
+        assert result.ok is True
+        assert result.error_type == ""

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -32,7 +32,7 @@ def _mock_response(status_code: int, body: dict[str, Any]) -> MagicMock:
 
 def test_post_discord_message_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(200, {"id": "msg-123"}),
     )
     ok, error, message_id = post_discord_message("chan-1", [{"title": "Alert"}], "bot-token")
@@ -43,7 +43,7 @@ def test_post_discord_message_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_post_discord_message_201_also_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(201, {"id": "msg-456"}),
     )
     ok, _, message_id = post_discord_message("chan-1", [], "bot-token")
@@ -62,7 +62,7 @@ def test_post_discord_message_sends_correct_payload(monkeypatch: pytest.MonkeyPa
         captured["headers"] = headers
         return _mock_response(200, {"id": "x"})
 
-    monkeypatch.setattr("app.utils.discord_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     embeds = [{"title": "Test"}]
     post_discord_message("chan-42", embeds, "my-token", content="hello")
 
@@ -74,7 +74,7 @@ def test_post_discord_message_sends_correct_payload(monkeypatch: pytest.MonkeyPa
 
 def test_post_discord_message_failure_returns_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(403, {"message": "Missing Permissions"}),
     )
     ok, error, message_id = post_discord_message("chan-1", [], "bot-token")
@@ -87,7 +87,7 @@ def test_post_discord_message_failure_falls_back_to_error_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(400, {"error": "Bad Request"}),
     )
     ok, error, _ = post_discord_message("chan-1", [], "bot-token")
@@ -99,7 +99,7 @@ def test_post_discord_message_exception_returns_false(monkeypatch: pytest.Monkey
     def _raise(*_a: Any, **_kw: Any) -> None:
         raise ConnectionError("network down")
 
-    monkeypatch.setattr("app.utils.discord_delivery.httpx.post", _raise)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
     ok, error, message_id = post_discord_message("chan-1", [], "bot-token")
     assert ok is False
     assert "network down" in error
@@ -113,7 +113,7 @@ def test_post_discord_message_exception_returns_false(monkeypatch: pytest.Monkey
 
 def test_create_discord_thread_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(201, {"id": "thread-99"}),
     )
     ok, error, thread_id = create_discord_thread("chan-1", "msg-1", "My Thread", "bot-token")
@@ -129,7 +129,7 @@ def test_create_discord_thread_sends_correct_url(monkeypatch: pytest.MonkeyPatch
         captured["url"] = url
         return _mock_response(200, {"id": "t-1"})
 
-    monkeypatch.setattr("app.utils.discord_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     create_discord_thread("chan-5", "msg-5", "Thread Name", "bot-token")
     assert "chan-5" in captured["url"]
     assert "msg-5" in captured["url"]
@@ -138,7 +138,7 @@ def test_create_discord_thread_sends_correct_url(monkeypatch: pytest.MonkeyPatch
 
 def test_create_discord_thread_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(403, {"message": "Forbidden"}),
     )
     ok, error, thread_id = create_discord_thread("chan-1", "msg-1", "name", "bot-token")
@@ -151,7 +151,7 @@ def test_create_discord_thread_exception(monkeypatch: pytest.MonkeyPatch) -> Non
     def _raise(*_a: Any, **_kw: Any) -> None:
         raise TimeoutError("timed out")
 
-    monkeypatch.setattr("app.utils.discord_delivery.httpx.post", _raise)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
     ok, error, thread_id = create_discord_thread("chan-1", "msg-1", "name", "bot-token")
     assert ok is False
     assert "timed out" in error
@@ -171,7 +171,7 @@ def test_send_discord_report_posts_to_channel(monkeypatch: pytest.MonkeyPatch) -
         captured["embeds"] = json.get("embeds", [])
         return _mock_response(200, {"id": "m-1"})
 
-    monkeypatch.setattr("app.utils.discord_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     ok, error = send_discord_report("Report text", {"channel_id": "chan-1", "bot_token": "tok"})
 
     assert ok is True
@@ -191,7 +191,7 @@ def test_send_discord_report_prefers_thread_over_channel(monkeypatch: pytest.Mon
         captured["url"] = url
         return _mock_response(200, {"id": "m-1"})
 
-    monkeypatch.setattr("app.utils.discord_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     send_discord_report(
         "Report",
         {"channel_id": "chan-1", "thread_id": "thread-99", "bot_token": "tok"},
@@ -202,7 +202,7 @@ def test_send_discord_report_prefers_thread_over_channel(monkeypatch: pytest.Mon
 
 def test_send_discord_report_returns_false_on_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(403, {"message": "Forbidden"}),
     )
     ok, error = send_discord_report("Report", {"channel_id": "chan-1", "bot_token": "tok"})
@@ -214,7 +214,7 @@ def test_send_discord_report_truncates_description_to_4096(monkeypatch: pytest.M
     captured: dict[str, Any] = {}
 
     monkeypatch.setattr(
-        "app.utils.discord_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **kw: (
             captured.update({"embeds": kw["json"].get("embeds", [])})
             or _mock_response(200, {"id": "m-1"})
@@ -225,3 +225,57 @@ def test_send_discord_report_truncates_description_to_4096(monkeypatch: pytest.M
     description = captured["embeds"][0]["description"]
     assert len(description) == 4096
     assert description.endswith("…")
+
+
+# ---------------------------------------------------------------------------
+# Shared-transport delegation (regression coverage for the #864 refactor)
+# ---------------------------------------------------------------------------
+
+
+class TestDelegatesToSharedTransport:
+    """After #864 the discord helper uses ``delivery_transport.post_json``
+    rather than calling httpx directly. These tests pin that contract so a
+    future regression that re-imports httpx into ``discord_delivery`` is
+    caught immediately."""
+
+    def test_module_does_not_import_httpx(self) -> None:
+        import app.utils.discord_delivery as mod
+
+        assert not hasattr(mod, "httpx"), (
+            "discord_delivery should not import httpx directly — "
+            "it must go through delivery_transport.post_json"
+        )
+
+    def test_post_message_uses_post_json_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        calls: list[dict[str, Any]] = []
+
+        def _stub_post_json(url: str, payload: dict, **kw: Any) -> DeliveryResponse:
+            calls.append({"url": url, "payload": payload, **kw})
+            return DeliveryResponse(ok=True, status_code=200, data={"id": "m-via-helper"})
+
+        monkeypatch.setattr("app.utils.discord_delivery.post_json", _stub_post_json)
+        ok, _err, mid = post_discord_message("c1", [], "tok", content="hi")
+        assert ok is True
+        assert mid == "m-via-helper"
+        assert calls and calls[0]["url"].endswith("/channels/c1/messages")
+        assert calls[0]["headers"]["Authorization"] == "Bot tok"
+
+    def test_create_thread_uses_post_json_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        captured: dict[str, Any] = {}
+
+        def _stub_post_json(url: str, payload: dict, **kw: Any) -> DeliveryResponse:
+            captured["url"] = url
+            captured["payload"] = payload
+            return DeliveryResponse(ok=True, status_code=201, data={"id": "thread-9"})
+
+        monkeypatch.setattr("app.utils.discord_delivery.post_json", _stub_post_json)
+        ok, _err, tid = create_discord_thread("c1", "m1", "Investigation", "tok")
+        assert ok is True
+        assert tid == "thread-9"
+        assert "/messages/m1/threads" in captured["url"]
+        assert captured["payload"]["name"] == "Investigation"
+        assert captured["payload"]["auto_archive_duration"] == 1440

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.utils import discord_delivery
 from app.utils.discord_delivery import (
     create_discord_thread,
     post_discord_message,
@@ -239,9 +240,10 @@ class TestDelegatesToSharedTransport:
     caught immediately."""
 
     def test_module_does_not_import_httpx(self) -> None:
-        import app.utils.discord_delivery as mod
-
-        assert not hasattr(mod, "httpx"), (
+        # Reuse the module-level ``from app.utils import discord_delivery``
+        # to avoid importing the same module via both ``import`` and
+        # ``from import`` styles (CodeQL py/import-and-import-from).
+        assert not hasattr(discord_delivery, "httpx"), (
             "discord_delivery should not import httpx directly — "
             "it must go through delivery_transport.post_json"
         )

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -311,9 +311,11 @@ class TestSendSlackReport:
 
 class TestPostDirectExceptionLog:
     """The original ``_post_direct`` log embedded ``type(exc).__name__``
-    so on-call could distinguish ``TimeoutError`` from ``ConnectionError``
-    at a glance. The shared transport now exposes ``error_type`` and the
-    Slack helper threads it back into the log line."""
+    as ``type=…`` so on-call could distinguish ``TimeoutError`` from
+    ``ConnectionError`` at a glance. The shared transport now exposes
+    ``exc_type`` on ``DeliveryResponse`` and the Slack helper threads it
+    back into the log line under the original ``type=`` key for
+    log-parser compatibility with the pre-refactor format."""
 
     def test_log_includes_exception_class_name(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -326,7 +328,7 @@ class TestPostDirectExceptionLog:
             slack_delivery._post_direct("hi", "C1", "1.0", "tok")
 
         joined = " ".join(rec.getMessage() for rec in caplog.records)
-        assert "exc_type=TimeoutError" in joined
+        assert "type=TimeoutError" in joined
         assert "read timeout" in joined
 
     def test_log_distinguishes_connection_from_timeout(
@@ -340,7 +342,7 @@ class TestPostDirectExceptionLog:
             slack_delivery._post_direct("hi", "C1", "1.0", "tok")
 
         joined = " ".join(rec.getMessage() for rec in caplog.records)
-        assert "exc_type=ConnectionError" in joined
+        assert "type=ConnectionError" in joined
 
 
 # ---------------------------------------------------------------------------
@@ -357,9 +359,10 @@ class TestDelegatesToSharedTransport:
     and Telegram test files."""
 
     def test_module_does_not_import_httpx(self) -> None:
-        import app.utils.slack_delivery as mod
-
-        assert not hasattr(mod, "httpx"), (
+        # Reuse the top-level ``from app.utils import slack_delivery`` to
+        # avoid importing the same module via both ``import`` and
+        # ``from import`` styles (CodeQL py/import-and-import-from).
+        assert not hasattr(slack_delivery, "httpx"), (
             "slack_delivery should not import httpx directly — "
             "it must go through delivery_transport.post_json"
         )

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -96,6 +96,11 @@ class TestCallReactionsApi:
         )
         assert captured["url"] == "https://slack.com/api/reactions.remove"
         assert captured["headers"]["Authorization"] == "Bearer my-token"
+        # Slack emits a `missing_charset` warning without the explicit
+        # ``charset=utf-8`` suffix on JSON POSTs (httpx alone only sets
+        # the bare ``application/json``). Pin the header to match Slack's
+        # documented recommendation: https://api.slack.com/web#posting_json
+        assert captured["headers"]["Content-Type"] == "application/json; charset=utf-8"
         assert captured["json"] == {"channel": "C9", "timestamp": "1.5", "name": "thinking_face"}
         assert captured["timeout"] == 8.0
 
@@ -148,6 +153,8 @@ class TestPostDirect:
         slack_delivery._post_direct("the body", "C42", "9.876", "secret-tok", blocks=[{"x": 1}])
         assert captured["url"] == "https://slack.com/api/chat.postMessage"
         assert captured["headers"]["Authorization"] == "Bearer secret-tok"
+        # Pin the charset header — Slack emits ``missing_charset`` without it.
+        assert captured["headers"]["Content-Type"] == "application/json; charset=utf-8"
         assert captured["json"]["channel"] == "C42"
         assert captured["json"]["thread_ts"] == "9.876"
         assert captured["json"]["text"] == "the body"

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -1,0 +1,303 @@
+"""Tests for ``app/utils/slack_delivery.py``.
+
+Covers the four ``slack.com`` / NextJS-proxy / incoming-webhook code paths
+after the refactor onto the shared ``delivery_transport.post_json`` helper:
+
+- ``_call_reactions_api`` / ``add_reaction`` / ``remove_reaction``
+- ``_post_direct`` (chat.postMessage as thread reply)
+- ``_post_via_webapp`` (NextJS ``/api/slack`` fallback)
+- ``_post_via_incoming_webhook`` (standalone ``SLACK_WEBHOOK_URL``)
+- ``send_slack_report`` orchestration across direct / webapp / webhook
+
+All tests stub ``app.utils.delivery_transport.httpx.post`` so the real
+network is never touched. Provider-specific success criteria
+(``data["ok"]``, status codes, etc.) are exercised explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.utils import slack_delivery
+
+
+def _mock_response(status_code: int, json_body: Any = None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if isinstance(json_body, Exception):
+
+        def _raise() -> Any:
+            raise json_body
+
+        resp.json.side_effect = _raise
+    else:
+        resp.json.return_value = json_body if json_body is not None else {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Reactions API
+# ---------------------------------------------------------------------------
+
+
+class TestCallReactionsApi:
+    def test_add_reaction_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, {"ok": True}),
+        )
+        ok = slack_delivery._call_reactions_api(
+            "reactions.add", "tok", "C123", "1.0", "white_check_mark"
+        )
+        assert ok is True
+
+    @pytest.mark.parametrize("err", ["already_reacted", "no_reaction", "message_not_found"])
+    def test_known_idempotent_failures_swallowed(
+        self, err: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``already_reacted`` and ``no_reaction`` are not real errors —
+        they happen during normal swap_reaction flows and must not log."""
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, {"ok": False, "error": err}),
+        )
+        assert slack_delivery._call_reactions_api("reactions.add", "tok", "C", "1.0", "x") is False
+
+    def test_unexpected_error_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, {"ok": False, "error": "channel_not_found"}),
+        )
+        assert slack_delivery._call_reactions_api("reactions.add", "tok", "C", "1.0", "x") is False
+
+    def test_transport_exception_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise ConnectionError("dns failure")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        assert slack_delivery._call_reactions_api("reactions.add", "tok", "C", "1.0", "x") is False
+
+    def test_sends_correct_url_and_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def _capture(url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured.update(kwargs)
+            return _mock_response(200, {"ok": True})
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _capture)
+        slack_delivery._call_reactions_api(
+            "reactions.remove", "my-token", "C9", "1.5", "thinking_face"
+        )
+        assert captured["url"] == "https://slack.com/api/reactions.remove"
+        assert captured["headers"]["Authorization"] == "Bearer my-token"
+        assert captured["json"] == {"channel": "C9", "timestamp": "1.5", "name": "thinking_face"}
+        assert captured["timeout"] == 8.0
+
+
+# ---------------------------------------------------------------------------
+# _post_direct (chat.postMessage)
+# ---------------------------------------------------------------------------
+
+
+class TestPostDirect:
+    def test_success_returns_true_empty_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, {"ok": True, "ts": "1.234"}),
+        )
+        ok, err = slack_delivery._post_direct("hello", "C1", "1.000", "tok")
+        assert ok is True
+        assert err == ""
+
+    def test_slack_error_returned_with_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, {"ok": False, "error": "channel_not_found"}),
+        )
+        ok, err = slack_delivery._post_direct("hello", "C1", "1.000", "tok")
+        assert ok is False
+        assert err == "slack_error=channel_not_found"
+
+    def test_transport_exception_returns_exception_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise TimeoutError("read timeout")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        ok, err = slack_delivery._post_direct("hello", "C1", "1.000", "tok")
+        assert ok is False
+        assert err.startswith("exception=")
+        assert "read timeout" in err
+
+    def test_sends_thread_reply_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def _capture(url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured.update(kwargs)
+            return _mock_response(200, {"ok": True})
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _capture)
+        slack_delivery._post_direct("the body", "C42", "9.876", "secret-tok", blocks=[{"x": 1}])
+        assert captured["url"] == "https://slack.com/api/chat.postMessage"
+        assert captured["headers"]["Authorization"] == "Bearer secret-tok"
+        assert captured["json"]["channel"] == "C42"
+        assert captured["json"]["thread_ts"] == "9.876"
+        assert captured["json"]["text"] == "the body"
+        assert captured["json"]["blocks"] == [{"x": 1}]
+
+
+# ---------------------------------------------------------------------------
+# _post_via_incoming_webhook
+# ---------------------------------------------------------------------------
+
+
+class TestIncomingWebhook:
+    def test_success_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(200, None, "ok"),
+        )
+        assert (
+            slack_delivery._post_via_incoming_webhook("hi", "https://hooks.slack.test/abc") is True
+        )
+
+    @pytest.mark.parametrize("status", [400, 403, 404, 500, 502])
+    def test_non_2xx_status_returns_false(
+        self, status: int, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(status, None, f"err {status}"),
+        )
+        assert (
+            slack_delivery._post_via_incoming_webhook("hi", "https://hooks.slack.test/abc") is False
+        )
+
+    def test_transport_exception_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise ConnectionError("refused")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        assert (
+            slack_delivery._post_via_incoming_webhook("hi", "https://hooks.slack.test/abc") is False
+        )
+
+    def test_blocks_and_extra_merged_into_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **kw: captured.update(kw) or _mock_response(200, None, ""),
+        )
+        slack_delivery._post_via_incoming_webhook(
+            "hi", "https://hooks.slack.test/abc", blocks=[{"b": 1}], unfurl_links=False
+        )
+        body = captured["json"]
+        assert body["text"] == "hi"
+        assert body["blocks"] == [{"b": 1}]
+        assert body["unfurl_links"] is False
+        assert captured["follow_redirects"] is True
+
+
+# ---------------------------------------------------------------------------
+# _post_via_webapp
+# ---------------------------------------------------------------------------
+
+
+class TestPostViaWebapp:
+    def test_skips_when_tracer_api_url_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TRACER_API_URL", raising=False)
+        # httpx.post must NOT be called
+        called = {"n": 0}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: (called.update(n=called["n"] + 1), _mock_response(200, None, ""))[1],
+        )
+        assert slack_delivery._post_via_webapp("hi", "C1", "1.0") is False
+        assert called["n"] == 0
+
+    def test_success_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TRACER_API_URL", "https://api.tracer.test")
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda url, **kw: captured.update({"url": url}, **kw) or _mock_response(200, None, ""),
+        )
+        assert slack_delivery._post_via_webapp("hi", "C1", "1.0") is True
+        assert captured["url"] == "https://api.tracer.test/api/slack"
+        assert captured["follow_redirects"] is True
+
+    def test_5xx_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TRACER_API_URL", "https://api.tracer.test")
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda *_a, **_kw: _mock_response(500, None, "boom"),
+        )
+        assert slack_delivery._post_via_webapp("hi", "C1", "1.0") is False
+
+
+# ---------------------------------------------------------------------------
+# send_slack_report orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestSendSlackReport:
+    def test_no_thread_ts_no_webhook_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        ok, err = slack_delivery.send_slack_report("hi", channel="C1", thread_ts=None)
+        assert ok is False
+        assert err == "no_thread_ts"
+
+    def test_no_thread_ts_with_webhook_uses_webhook(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/abc")
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda url, **kw: captured.update({"url": url}, **kw) or _mock_response(200, None, ""),
+        )
+        ok, err = slack_delivery.send_slack_report("hi", channel="C1", thread_ts=None)
+        assert ok is True
+        assert err == ""
+        assert captured["url"] == "https://hooks.slack.test/abc"
+
+    def test_direct_post_used_when_token_and_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[str] = []
+
+        def _capture(url: str, **_kw: Any) -> MagicMock:
+            captured.append(url)
+            return _mock_response(200, {"ok": True, "ts": "x"})
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _capture)
+        ok, err = slack_delivery.send_slack_report(
+            "hi", channel="C1", thread_ts="1.0", access_token="tok"
+        )
+        assert ok is True
+        assert err == ""
+        assert captured == ["https://slack.com/api/chat.postMessage"]
+
+    def test_direct_failure_falls_back_to_webapp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TRACER_API_URL", "https://api.tracer.test")
+        urls: list[str] = []
+
+        def _capture(url: str, **kw: Any) -> MagicMock:
+            urls.append(url)
+            if "chat.postMessage" in url:
+                return _mock_response(200, {"ok": False, "error": "channel_not_found"})
+            return _mock_response(200, None, "")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _capture)
+        ok, err = slack_delivery.send_slack_report(
+            "hi", channel="C1", thread_ts="1.0", access_token="tok"
+        )
+        assert ok is True
+        assert err == ""
+        assert urls == [
+            "https://slack.com/api/chat.postMessage",
+            "https://api.tracer.test/api/slack",
+        ]

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -16,6 +16,7 @@ network is never touched. Provider-specific success criteria
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -301,3 +302,150 @@ class TestSendSlackReport:
             "https://slack.com/api/chat.postMessage",
             "https://api.tracer.test/api/slack",
         ]
+
+
+# ---------------------------------------------------------------------------
+# Exception-type triage log line (regression for the #864 refactor)
+# ---------------------------------------------------------------------------
+
+
+class TestPostDirectExceptionLog:
+    """The original ``_post_direct`` log embedded ``type(exc).__name__``
+    so on-call could distinguish ``TimeoutError`` from ``ConnectionError``
+    at a glance. The shared transport now exposes ``error_type`` and the
+    Slack helper threads it back into the log line."""
+
+    def test_log_includes_exception_class_name(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise TimeoutError("read timeout")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        with caplog.at_level(logging.ERROR, logger="app.utils.slack_delivery"):
+            slack_delivery._post_direct("hi", "C1", "1.0", "tok")
+
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "exc_type=TimeoutError" in joined
+        assert "read timeout" in joined
+
+    def test_log_distinguishes_connection_from_timeout(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def _raise(*_a: Any, **_kw: Any) -> Any:
+            raise ConnectionError("dns failure")
+
+        monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
+        with caplog.at_level(logging.ERROR, logger="app.utils.slack_delivery"):
+            slack_delivery._post_direct("hi", "C1", "1.0", "tok")
+
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "exc_type=ConnectionError" in joined
+
+
+# ---------------------------------------------------------------------------
+# Shared-transport delegation (regression coverage for the #864 refactor)
+# ---------------------------------------------------------------------------
+
+
+class TestDelegatesToSharedTransport:
+    """After #864 the slack helper uses ``delivery_transport.post_json``
+    rather than calling httpx directly. These tests pin that contract so
+    a future regression that re-imports httpx into ``slack_delivery`` —
+    or that bypasses ``post_json`` from any of the four code paths — is
+    caught immediately. Mirrors the same regression class on the Discord
+    and Telegram test files."""
+
+    def test_module_does_not_import_httpx(self) -> None:
+        import app.utils.slack_delivery as mod
+
+        assert not hasattr(mod, "httpx"), (
+            "slack_delivery should not import httpx directly — "
+            "it must go through delivery_transport.post_json"
+        )
+
+    def test_call_reactions_api_uses_post_json_helper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        captured: dict[str, Any] = {}
+
+        def _stub_post_json(url: str, payload: dict[str, Any], **kw: Any) -> DeliveryResponse:
+            captured["url"] = url
+            captured["payload"] = payload
+            captured["headers"] = kw.get("headers")
+            captured["timeout"] = kw.get("timeout")
+            return DeliveryResponse(ok=True, status_code=200, data={"ok": True})
+
+        monkeypatch.setattr("app.utils.slack_delivery.post_json", _stub_post_json)
+        ok = slack_delivery._call_reactions_api(
+            "reactions.add", "tok", "C9", "1.5", "thinking_face"
+        )
+        assert ok is True
+        assert captured["url"] == "https://slack.com/api/reactions.add"
+        assert captured["headers"]["Authorization"] == "Bearer tok"
+        # Reactions API uses a tighter 8s timeout than the default 15s.
+        assert captured["timeout"] == 8.0
+
+    def test_post_direct_uses_post_json_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        captured: dict[str, Any] = {}
+
+        def _stub_post_json(url: str, payload: dict[str, Any], **kw: Any) -> DeliveryResponse:
+            captured["url"] = url
+            captured["payload"] = payload
+            captured["headers"] = kw.get("headers")
+            return DeliveryResponse(ok=True, status_code=200, data={"ok": True, "ts": "1.234"})
+
+        monkeypatch.setattr("app.utils.slack_delivery.post_json", _stub_post_json)
+        ok, err = slack_delivery._post_direct(
+            "hello", "C1", "1.000", "secret-tok", blocks=[{"x": 1}]
+        )
+        assert ok is True
+        assert err == ""
+        assert captured["url"] == "https://slack.com/api/chat.postMessage"
+        assert captured["headers"]["Authorization"] == "Bearer secret-tok"
+        assert captured["payload"]["blocks"] == [{"x": 1}]
+
+    def test_post_via_webapp_uses_post_json_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        monkeypatch.setenv("TRACER_API_URL", "https://api.tracer.test")
+        captured: dict[str, Any] = {}
+
+        def _stub_post_json(url: str, payload: dict[str, Any], **kw: Any) -> DeliveryResponse:
+            captured["url"] = url
+            captured["payload"] = payload
+            captured["follow_redirects"] = kw.get("follow_redirects")
+            return DeliveryResponse(ok=True, status_code=200, data={}, text="")
+
+        monkeypatch.setattr("app.utils.slack_delivery.post_json", _stub_post_json)
+        ok = slack_delivery._post_via_webapp("hi", "C1", "1.0")
+        assert ok is True
+        assert captured["url"] == "https://api.tracer.test/api/slack"
+        assert captured["follow_redirects"] is True
+
+    def test_post_via_incoming_webhook_uses_post_json_helper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        captured: dict[str, Any] = {}
+
+        def _stub_post_json(url: str, payload: dict[str, Any], **kw: Any) -> DeliveryResponse:
+            captured["url"] = url
+            captured["payload"] = payload
+            captured["follow_redirects"] = kw.get("follow_redirects")
+            return DeliveryResponse(ok=True, status_code=200, data={}, text="ok")
+
+        monkeypatch.setattr("app.utils.slack_delivery.post_json", _stub_post_json)
+        ok = slack_delivery._post_via_incoming_webhook(
+            "hi", "https://hooks.slack.test/abc", blocks=[{"b": 1}]
+        )
+        assert ok is True
+        assert captured["url"] == "https://hooks.slack.test/abc"
+        assert captured["payload"]["text"] == "hi"
+        assert captured["payload"]["blocks"] == [{"b": 1}]
+        assert captured["follow_redirects"] is True

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -33,7 +33,7 @@ def _mock_response(status_code: int, body: dict[str, Any]) -> MagicMock:
 
 def test_post_telegram_message_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.telegram_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(200, {"ok": True, "result": {"message_id": 42}}),
     )
     ok, error, message_id = post_telegram_message("chat-1", "hello", "bot-token")
@@ -50,7 +50,7 @@ def test_post_telegram_message_sends_correct_payload(monkeypatch: pytest.MonkeyP
         captured["json"] = json
         return _mock_response(200, {"ok": True, "result": {"message_id": 1}})
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     post_telegram_message("chat-42", "test text", "my-token")
 
     assert "my-token" in captured["url"]
@@ -66,14 +66,14 @@ def test_post_telegram_message_with_reply_to(monkeypatch: pytest.MonkeyPatch) ->
         captured["json"] = json
         return _mock_response(200, {"ok": True, "result": {"message_id": 2}})
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     post_telegram_message("chat-1", "text", "token", reply_to_message_id="99")
     assert captured["json"]["reply_to_message_id"] == 99
 
 
 def test_post_telegram_message_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.telegram_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(
             400, {"ok": False, "description": "Bad Request: chat not found"}
         ),
@@ -88,7 +88,7 @@ def test_post_telegram_message_exception_returns_false(monkeypatch: pytest.Monke
     def _raise(*_a: Any, **_kw: Any) -> None:
         raise ConnectionError("network down")
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _raise)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
     ok, error, message_id = post_telegram_message("chat-1", "text", "bot-token")
     assert ok is False
     assert "network down" in error
@@ -101,7 +101,7 @@ def test_post_telegram_message_exception_redacts_token(monkeypatch: pytest.Monke
     def _raise(*_a: Any, **_kw: Any) -> None:
         raise ConnectionError(f"failed to connect to api.telegram.org/bot{secret}/sendMessage")
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _raise)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _raise)
     ok, error, _ = post_telegram_message("chat-1", "text", secret)
     assert ok is False
     assert secret not in error
@@ -121,7 +121,7 @@ def test_send_telegram_report_posts_to_chat(monkeypatch: pytest.MonkeyPatch) -> 
         captured["json"] = json
         return _mock_response(200, {"ok": True, "result": {"message_id": 5}})
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     ok, error = send_telegram_report("Report text", {"bot_token": "tok", "chat_id": "chat-1"})
 
     assert ok is True
@@ -138,7 +138,7 @@ def test_send_telegram_report_uses_reply_to_message_id(monkeypatch: pytest.Monke
         captured["json"] = json
         return _mock_response(200, {"ok": True, "result": {"message_id": 6}})
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     send_telegram_report(
         "Report",
         {"bot_token": "tok", "chat_id": "chat-1", "reply_to_message_id": "77"},
@@ -148,7 +148,7 @@ def test_send_telegram_report_uses_reply_to_message_id(monkeypatch: pytest.Monke
 
 def test_send_telegram_report_returns_false_on_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.utils.telegram_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **_kw: _mock_response(403, {"ok": False, "description": "Forbidden"}),
     )
     ok, error = send_telegram_report("Report", {"bot_token": "tok", "chat_id": "chat-1"})
@@ -251,7 +251,7 @@ def test_post_telegram_message_non_json_error_body(monkeypatch: pytest.MonkeyPat
     resp.json.side_effect = ValueError("not JSON")
     resp.text = "Bad Gateway"
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", lambda *_a, **_kw: resp)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", lambda *_a, **_kw: resp)
     ok, error, message_id = post_telegram_message("chat-1", "text", "tok")
 
     assert ok is False
@@ -273,7 +273,7 @@ def test_post_telegram_message_reply_to_zero_string_not_sent(
         captured["json"] = json
         return _mock_response(200, {"ok": True, "result": {"message_id": 1}})
 
-    monkeypatch.setattr("app.utils.telegram_delivery.httpx.post", _fake_post)
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
     post_telegram_message("chat-1", "text", "tok", reply_to_message_id="0")
     assert "reply_to_message_id" not in captured["json"]
 
@@ -282,7 +282,7 @@ def test_send_telegram_report_truncates_to_4096(monkeypatch: pytest.MonkeyPatch)
     captured: dict[str, Any] = {}
 
     monkeypatch.setattr(
-        "app.utils.telegram_delivery.httpx.post",
+        "app.utils.delivery_transport.httpx.post",
         lambda *_a, **kw: (
             captured.update({"text": kw["json"].get("text", "")})
             or _mock_response(200, {"ok": True, "result": {"message_id": 7}})
@@ -292,3 +292,63 @@ def test_send_telegram_report_truncates_to_4096(monkeypatch: pytest.MonkeyPatch)
     send_telegram_report(long_report, {"bot_token": "tok", "chat_id": "chat-1"})
     assert len(captured["text"]) == 4096
     assert captured["text"].endswith("…")
+
+
+# ---------------------------------------------------------------------------
+# Shared-transport delegation (regression coverage for the #864 refactor)
+# ---------------------------------------------------------------------------
+
+
+class TestDelegatesToSharedTransport:
+    """After #864 the telegram helper uses ``delivery_transport.post_json``
+    rather than calling httpx directly. Pins the contract so re-importing
+    httpx into ``telegram_delivery`` regresses loudly."""
+
+    def test_module_does_not_import_httpx(self) -> None:
+        import app.utils.telegram_delivery as mod
+
+        assert not hasattr(mod, "httpx"), (
+            "telegram_delivery should not import httpx directly — "
+            "it must go through delivery_transport.post_json"
+        )
+
+    def test_post_message_uses_post_json_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        captured: dict[str, Any] = {}
+
+        def _stub_post_json(url: str, payload: dict, **kw: Any) -> DeliveryResponse:
+            captured["url"] = url
+            captured["payload"] = payload
+            return DeliveryResponse(
+                ok=True, status_code=200, data={"ok": True, "result": {"message_id": 42}}
+            )
+
+        monkeypatch.setattr("app.utils.telegram_delivery.post_json", _stub_post_json)
+        ok, err, mid = post_telegram_message("chat-1", "hello", "secret-bot-tok")
+        assert ok is True
+        assert err == ""
+        assert mid == "42"
+        assert "/bot" in captured["url"]
+        assert captured["payload"]["chat_id"] == "chat-1"
+        assert captured["payload"]["text"] == "hello"
+
+    def test_transport_failure_redacts_token_in_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the shared helper returns ``ok=False`` because the transport
+        raised, telegram must still scrub the bot token out of the error
+        string before propagating it."""
+        from app.utils.delivery_transport import DeliveryResponse
+
+        bot_token = "1234567890:ABCDEFverysecretvalue"
+        leak_msg = f"connect failed for url=https://api.telegram.org/bot{bot_token}/sendMessage"
+
+        monkeypatch.setattr(
+            "app.utils.telegram_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
+        )
+        ok, err, _ = post_telegram_message("chat-1", "hi", bot_token)
+        assert ok is False
+        assert bot_token not in err
+        assert "<redacted>" in err

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.utils import telegram_delivery
 from app.utils.telegram_delivery import (
     _TelegramTokenFilter,
     post_telegram_message,
@@ -305,9 +306,10 @@ class TestDelegatesToSharedTransport:
     httpx into ``telegram_delivery`` regresses loudly."""
 
     def test_module_does_not_import_httpx(self) -> None:
-        import app.utils.telegram_delivery as mod
-
-        assert not hasattr(mod, "httpx"), (
+        # Reuse the module-level ``from app.utils import telegram_delivery``
+        # to avoid importing the same module via both ``import`` and
+        # ``from import`` styles (CodeQL py/import-and-import-from).
+        assert not hasattr(telegram_delivery, "httpx"), (
             "telegram_delivery should not import httpx directly — "
             "it must go through delivery_transport.post_json"
         )


### PR DESCRIPTION
Closes #864.

## Summary

\`app/utils/slack_delivery.py\`, \`app/utils/discord_delivery.py\`, and \`app/utils/telegram_delivery.py\` each reimplemented the same \"POST JSON + parse response + return \`(ok, error, id)\` style result\" pattern. The transport pieces (HTTP POST, timeout, exception suppression, JSON decode) were identical; only the success criteria, auth scheme, and error-extraction differed.

This PR adds \`app/utils/delivery_transport.py\` and migrates all three modules onto it, per the issue's acceptance criteria.

## Design

\`\`\`python
@dataclass(frozen=True)
class DeliveryResponse:
    ok: bool                 # request did not raise
    status_code: int = 0     # HTTP status (0 if request raised)
    data: dict = {}          # parsed JSON object body, or {} on non-JSON / non-dict / decode error
    text: str = \"\"           # raw response body
    error: str = \"\"          # exception message when ok=False

def post_json(url, payload, *, headers=None, timeout=15.0, follow_redirects=False) -> DeliveryResponse:
    ...
\`\`\`

The helper **deliberately does not decide provider-level success.** \`ok=True\` means the HTTP request completed without raising; callers inspect \`status_code\` and \`data\` per their own provider semantics:

| Provider | Success check |
|---|---|
| Slack ``chat.postMessage`` / reactions | \`data[\"ok\"]\` |
| Slack incoming webhook / NextJS proxy | \`200 ≤ status_code < 300\` |
| Discord channels API | \`status_code in (200, 201)\` |
| Telegram bot API | \`status_code == 200\` |

## Refactored call sites

- **Slack** — all 4 code paths (\`_call_reactions_api\`, \`_post_direct\`, \`_post_via_webapp\`, \`_post_via_incoming_webhook\`) now go through \`post_json\`. \`send_slack_report\` orchestration is unchanged. Bearer-header construction factored into \`_slack_bearer_headers\`.
- **Discord** — \`post_discord_message\` and \`create_discord_thread\` go through \`post_json\`. \`Bot <token>\` header construction factored into \`_discord_auth_headers\`. Error extraction factored into \`_discord_error_from_data\`.
- **Telegram** — \`post_telegram_message\` goes through \`post_json\`. The bot-token redaction in error strings is preserved (the shared transport never sees the bot token in the URL after the request raises, but \`_redact_token\` still runs over \`response.error\` defensively).

Public function signatures unchanged. Provider-specific payload building stays in the calling modules per the issue's scope.

## Test coverage

| File | Tests | Status |
|---|---|---|
| \`tests/utils/test_delivery_transport.py\` | **15 (new)** | happy path, 5 transport-failure exception shapes, JSON decode fallbacks (non-JSON / JSON array / empty body), header/timeout/follow_redirects pass-through, DeliveryResponse frozen-dataclass invariants |
| \`tests/utils/test_slack_delivery.py\` | **24 (new)** | reactions API (success / known-idempotent failure / unexpected error / transport exception / payload assertions), \`_post_direct\` (success, slack_error, exception, payload), incoming webhook (success / 5 status codes / transport exception / blocks+extra merge), \`_post_via_webapp\` (skipped without TRACER_API_URL / success / 5xx), \`send_slack_report\` orchestration (no thread_ts / webhook fallback / direct path / direct→webapp fallback chain) |
| \`tests/utils/test_discord_delivery.py\` | 32 existing + **3 new** | pre-existing tests updated to patch new transport boundary; new \`TestDelegatesToSharedTransport\` class pins the contract: module no longer imports \`httpx\`, both Discord helpers go through \`post_json\` |
| \`tests/utils/test_telegram_delivery.py\` | 26 existing + **3 new** | same delegation pins, plus a regression test that bot-token is redacted in error strings even when the failure originates in the shared transport |

## Verification

- **\`pytest tests/\`** (excluding e2e/deployment/chaos/synthetic): **3191 pass**, 2 skipped, 1 xfailed, 0 failures.
- **\`pytest tests/utils/\`**: 105 pass, 1 skipped.
- **\`ruff check app/ tests/\`** and **\`ruff format --check\`**: clean.
- **\`mypy app/utils/\`**: clean on the new and refactored modules. (The 5 errors mypy reports are pre-existing missing-stub warnings for \`pymysql\`, \`datasets\`, and \`huggingface_hub\` in \`app/integrations/\` — unrelated to this PR.)

## Acceptance criteria audit

- [x] Slack, Discord, and Telegram helpers all use the shared transport helper
- [x] Provider-specific response shapes stay unchanged
- [x] Existing public helper names stay unchanged (\`post_discord_message\`, \`create_discord_thread\`, \`post_telegram_message\`, \`send_slack_report\`, etc.)
- [x] \`tests/utils/test_slack_delivery.py\` added
- [x] \`tests/utils/test_discord_delivery.py\` extended
- [x] \`tests/utils/test_telegram_delivery.py\` extended
- [x] Focused test module for the new shared helper added (\`tests/utils/test_delivery_transport.py\`)

## Scope

| Files | Change |
|---|---|
| \`app/utils/delivery_transport.py\` | new (97 lines) |
| \`app/utils/slack_delivery.py\` | refactored — all 4 \`httpx.post\` call sites replaced |
| \`app/utils/discord_delivery.py\` | refactored — both call sites replaced |
| \`app/utils/telegram_delivery.py\` | refactored — single call site replaced |
| \`tests/utils/test_delivery_transport.py\` | new |
| \`tests/utils/test_slack_delivery.py\` | new |
| \`tests/utils/test_discord_delivery.py\` | 3 new tests + patch-path updates on pre-existing tests |
| \`tests/utils/test_telegram_delivery.py\` | 3 new tests + patch-path updates on pre-existing tests |