### PR TITLE
Incident window tool integration

### DIFF
--- a/app/incident_window.py
+++ b/app/incident_window.py
@@ -1,0 +1,521 @@
+"""Shared incident time window for the investigation pipeline.
+
+The agent runs many time-aware tools (log queries, metrics, deploy commit
+listings, etc.). Today each tool independently picks a default time range
+("last 60 minutes") counted from the agent's wall clock. Two problems
+follow.
+
+1. The agent's wall clock is not the same as when the incident actually
+   started. An alert that fired three hours before the agent ran will be
+   completely outside any "last 60 minutes" query.
+
+2. Different tools default to different ranges, so two tools investigating
+   the same incident answer questions about different windows.
+
+This module introduces a single ``IncidentWindow`` value object owned by
+``AgentState`` and populated from the alert's own timestamps in the
+``extract_alert`` step. Once tools start reading from it (deferred to a
+follow-up PR) every time-aware tool will agree on the same window.
+
+This file is pure foundation. It does not change any tool's behavior. It
+just exposes the resolver, the value object, and the anchor parsers for
+the five alert formats the agent receives today.
+
+Window semantics: the window is half-open: ``[since, until)``. Evidence
+timestamped exactly at ``since`` is included; evidence at ``until`` is
+not. This matches the usual half-open convention used by Datadog,
+Grafana, and Loki time-range queries.
+
+All datetimes are timezone-aware and normalised to UTC. Naive timestamps
+encountered during parsing are silently treated as UTC. Construction of
+``IncidentWindow`` will reject naive inputs to prevent accidental
+silent bugs in caller code.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Public constants -----------------------------------------------------------
+SCHEMA_VERSION = 1
+"""Versions the dict shape returned by ``IncidentWindow.to_dict``.
+
+Bump this whenever the dict layout changes incompatibly so future readers
+can branch on it. Backward-compatible additions do not require a bump.
+"""
+
+DEFAULT_LOOKBACK_MINUTES = 120
+MAX_LOOKBACK_MINUTES = 7 * 24 * 60  # 7 days; bounded to keep MCP/API calls sane
+DEFAULT_FORWARD_BUFFER_MINUTES = 10
+
+# Recognised source labels --------------------------------------------------
+SOURCE_OVERRIDE = "override"
+SOURCE_DEFAULT = "default"
+SOURCE_STARTS_AT = "alert.startsAt"
+SOURCE_FIRED_AT = "alert.firedAt"
+SOURCE_ACTIVATED_AT = "alert.activatedAt"
+
+
+@dataclass(frozen=True)
+class IncidentWindow:
+    """A resolved ``[since, until)`` window for the current investigation.
+
+    The interval is **half-open**: timestamps equal to ``since`` are
+    inside the window; timestamps equal to ``until`` are outside.
+
+    The dataclass is frozen and validated at construction. It is not
+    possible to build an instance with naive datetimes, with
+    ``since >= until``, or with a non-UTC tzinfo (those are normalised to
+    UTC in ``__post_init__``). Tools and tests can rely on these
+    invariants without re-checking.
+
+    Attributes:
+        since: Window start. Always tz-aware UTC. Inclusive.
+        until: Window end. Always tz-aware UTC. Exclusive.
+        source: Where the anchor came from. One of the ``SOURCE_*``
+            constants above. Used in the diagnose narrative and audit
+            trail.
+        confidence: 0.0 when the source is ``"default"`` (no anchor was
+            found), 1.0 when the anchor came from a parsed alert
+            timestamp or an explicit override. Future PR 3 may emit
+            intermediate values when adapting the window.
+    """
+
+    since: datetime
+    until: datetime
+    source: str
+    confidence: float
+
+    def __post_init__(self) -> None:
+        # Validate types first to give a useful error before tz/order checks.
+        if not isinstance(self.since, datetime):
+            raise TypeError(f"since must be a datetime, got {type(self.since).__name__}")
+        if not isinstance(self.until, datetime):
+            raise TypeError(f"until must be a datetime, got {type(self.until).__name__}")
+        if self.since.tzinfo is None or self.until.tzinfo is None:
+            raise ValueError(
+                "IncidentWindow requires timezone-aware datetimes; "
+                "naive datetimes are not allowed. Use datetime.now(UTC) "
+                "or attach tzinfo before constructing."
+            )
+        # Normalise both endpoints to UTC; we override frozen by going through
+        # object.__setattr__ which is the dataclass-recommended approach.
+        utc_since = self.since.astimezone(UTC)
+        utc_until = self.until.astimezone(UTC)
+        if utc_since >= utc_until:
+            raise ValueError(
+                f"IncidentWindow requires since < until "
+                f"(got since={utc_since.isoformat()}, until={utc_until.isoformat()}). "
+                "A zero-length or inverted window is never valid."
+            )
+        if not (0.0 <= float(self.confidence) <= 1.0):
+            raise ValueError(
+                f"confidence must be in [0.0, 1.0], got {self.confidence}"
+            )
+        if not isinstance(self.source, str) or not self.source.strip():
+            raise ValueError("source must be a non-empty string")
+        # Apply the UTC normalisation, frozen-dataclass style.
+        object.__setattr__(self, "since", utc_since)
+        object.__setattr__(self, "until", utc_until)
+
+    # -- Serialization ------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict for ``AgentState`` storage.
+
+        The returned dict carries a ``_schema_version`` key. Callers
+        reconstructing via ``from_dict`` should branch on that field if
+        they need to handle multiple versions.
+        """
+        return {
+            "_schema_version": SCHEMA_VERSION,
+            "since": _iso_utc(self.since),
+            "until": _iso_utc(self.until),
+            "source": self.source,
+            "confidence": self.confidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> IncidentWindow | None:
+        """Best-effort reconstruction. Returns ``None`` on bad shape.
+
+        Never raises. If the dict is well-formed but the resulting window
+        would violate ``__post_init__`` invariants (e.g. since >= until),
+        returns ``None`` rather than letting the error propagate.
+        """
+        if not isinstance(data, dict):
+            return None
+        since = _parse_iso8601(str(data.get("since", "")))
+        until = _parse_iso8601(str(data.get("until", "")))
+        if since is None or until is None:
+            return None
+        try:
+            return cls(
+                since=since,
+                until=until,
+                source=str(data.get("source", SOURCE_DEFAULT)) or SOURCE_DEFAULT,
+                confidence=float(data.get("confidence", 0.0) or 0.0),
+            )
+        except (TypeError, ValueError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso8601(value: str) -> datetime | None:
+    """Parse ISO-8601 timestamps. Naive input is treated as UTC.
+
+    Returns ``None`` for empty or malformed input rather than raising.
+    The pipeline must never fail because an upstream alert payload was
+    slightly off-spec.
+
+    Accepts the trailing ``Z`` shorthand that ``datetime.fromisoformat``
+    rejects on Python < 3.11 and that some vendor payloads use anyway.
+    """
+    text = (value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _iso_utc(dt: datetime) -> str:
+    """Format a UTC ``datetime`` as ISO-8601 with the ``Z`` shorthand."""
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_alert_dict(raw_alert: Any) -> dict[str, Any]:
+    """Normalise ``raw_alert`` into a dict.
+
+    ``state["raw_alert"]`` is typed as ``str | dict``. JSON-string
+    payloads (common from webhooks) are parsed; non-dict / un-parseable
+    values become an empty dict. Anchor parsers always operate on a dict.
+    """
+    if isinstance(raw_alert, dict):
+        return raw_alert
+    if isinstance(raw_alert, str):
+        text = raw_alert.strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Anchor parsers — one per alert format
+# ---------------------------------------------------------------------------
+#
+# Each parser inspects the raw alert payload and returns
+# ``(anchor_datetime, source_label)`` if it can find a timestamp it
+# trusts, else ``None``. The order tried in ``_extract_anchor`` reflects
+# how reliable each format's timestamp is for incident-start time.
+
+
+def _alertmanager_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
+    """Alertmanager / Prometheus payloads carry ``startsAt`` per alert.
+
+    Alertmanager wraps individual alerts in a top-level ``alerts`` list
+    (webhook v4) and may also carry a top-level ``startsAt`` (older
+    grouped alert payloads). ``startsAt`` is the moment the underlying
+    condition began — strictly preferred over ``firedAt``, which is just
+    when the rule sent the notification.
+
+    When multiple alerts are present we use the EARLIEST ``startsAt`` so
+    the resulting window covers the full firing burst rather than only
+    the most recent alert.
+    """
+    earliest: datetime | None = None
+    if isinstance(payload.get("startsAt"), str):
+        anchor = _parse_iso8601(payload["startsAt"])
+        if anchor is not None:
+            earliest = anchor
+    alerts = payload.get("alerts")
+    if isinstance(alerts, list):
+        for alert in alerts:
+            if not isinstance(alert, dict):
+                continue
+            value = alert.get("startsAt")
+            if not isinstance(value, str):
+                continue
+            anchor = _parse_iso8601(value)
+            if anchor is None:
+                continue
+            if earliest is None or anchor < earliest:
+                earliest = anchor
+    if earliest is not None:
+        return earliest, SOURCE_STARTS_AT
+    return None
+
+
+def _grafana_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
+    """Grafana managed alerts use the same Alertmanager schema.
+
+    Kept as a separate function so the dispatch order in
+    ``_ANCHOR_PARSERS`` can prioritise grafana-shaped payloads over
+    raw Alertmanager if needed in the future. Today both share logic.
+    """
+    return _alertmanager_anchor(payload)
+
+
+def _datadog_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
+    """Datadog webhook payloads carry ``event_time`` (epoch seconds or
+    milliseconds) or ``last_updated``. We treat both as the
+    ``alert.firedAt`` anchor since Datadog does not separately expose
+    the underlying-condition start time in standard webhook payloads.
+    """
+    for key in ("event_time", "last_updated", "alert_transition_time"):
+        value = payload.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            # bool is a subtype of int in Python — exclude explicitly.
+            continue
+        if isinstance(value, (int, float)):
+            # Datadog webhooks use milliseconds-since-epoch; tolerate seconds too.
+            seconds = float(value) / (1000.0 if value > 1e11 else 1.0)
+            try:
+                return datetime.fromtimestamp(seconds, tz=UTC), SOURCE_FIRED_AT
+            except (OverflowError, OSError, ValueError):
+                continue
+        if isinstance(value, str):
+            anchor = _parse_iso8601(value)
+            if anchor is not None:
+                return anchor, SOURCE_FIRED_AT
+    return None
+
+
+def _pagerduty_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
+    """PagerDuty incidents carry ``triggered_at`` / ``created_at``.
+
+    Webhook v3 nests the incident under ``event.data``; older v2
+    payloads sometimes nest under ``incident``. We probe both shapes
+    plus the top level.
+    """
+    candidates: list[dict[str, Any]] = [payload]
+    event = payload.get("event")
+    if isinstance(event, dict):
+        data = event.get("data")
+        if isinstance(data, dict):
+            candidates.append(data)
+    incident = payload.get("incident")
+    if isinstance(incident, dict):
+        candidates.append(incident)
+
+    for source in candidates:
+        for key in ("triggered_at", "created_at"):
+            value = source.get(key)
+            if isinstance(value, str):
+                anchor = _parse_iso8601(value)
+                if anchor is not None:
+                    return anchor, SOURCE_FIRED_AT
+    return None
+
+
+_CLOUDWATCH_MAX_DEPTH = 4
+"""Maximum nesting depth probed by ``_cloudwatch_anchor``.
+
+Real-world CloudWatch payloads are at most 2 levels deep (SNS ``Message``
+or EventBridge ``alarmData`` -> alarm dict). The cap is set generously to
+4 so legitimate payloads always parse, while pathologically nested input
+(``{"Message": {"Message": {"Message": ...}}}``) cannot recurse into
+stack overflow.
+"""
+
+
+def _cloudwatch_anchor(
+    payload: dict[str, Any], _depth: int = 0
+) -> tuple[datetime, str] | None:
+    """CloudWatch alarm payloads carry ``StateUpdatedTimestamp``.
+
+    The payload arrives wrapped in SNS, so the actual alarm dict often
+    lives inside ``Message`` (which is itself a JSON string). We probe
+    both top-level and nested shapes, including EventBridge ``alarmData``.
+
+    Recursion is hard-capped at ``_CLOUDWATCH_MAX_DEPTH`` levels so a
+    pathologically deep payload cannot blow the Python stack.
+    """
+    if _depth >= _CLOUDWATCH_MAX_DEPTH:
+        return None
+    # Top-level direct match.
+    for key in ("StateUpdatedTimestamp", "stateUpdatedTimestamp"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            anchor = _parse_iso8601(value)
+            if anchor is not None:
+                return anchor, SOURCE_ACTIVATED_AT
+    # Nested probes.
+    for nested_key in ("Message", "alarmData", "alarm"):
+        nested = payload.get(nested_key)
+        if isinstance(nested, str):
+            try:
+                nested = json.loads(nested)
+            except json.JSONDecodeError:
+                continue
+        if isinstance(nested, dict):
+            result = _cloudwatch_anchor(nested, _depth=_depth + 1)
+            if result is not None:
+                return result
+    return None
+
+
+# Order matters: the first parser to find an anchor wins. The order
+# reflects which format expresses incident-start most accurately.
+_ANCHOR_PARSERS: tuple = (
+    _alertmanager_anchor,  # ``startsAt`` is the underlying condition time
+    _grafana_anchor,       # same schema as Alertmanager
+    _pagerduty_anchor,     # ``triggered_at`` is reliable for incident time
+    _datadog_anchor,       # ``event_time`` is fired-at, less ideal
+    _cloudwatch_anchor,    # ``StateUpdatedTimestamp`` is state-flip time
+)
+
+
+def _extract_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
+    """Try every parser. Return the first successful anchor.
+
+    Each parser is wrapped in a try/except: a single misbehaving parser
+    cannot prevent the others from running, and an upstream payload
+    cannot crash the pipeline.
+    """
+    for parser in _ANCHOR_PARSERS:
+        try:
+            result = parser(payload)
+        except Exception:  # noqa: BLE001 - defensive isolation
+            logger.debug(
+                "incident_window: anchor parser %s raised", parser.__name__, exc_info=True
+            )
+            continue
+        if result is not None:
+            return result
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_incident_window(
+    raw_alert: Any,
+    *,
+    override: IncidentWindow | None = None,
+    lookback_minutes: int = DEFAULT_LOOKBACK_MINUTES,
+    forward_buffer_minutes: int = DEFAULT_FORWARD_BUFFER_MINUTES,
+    now: datetime | None = None,
+) -> IncidentWindow:
+    """Resolve the incident time window for the current investigation.
+
+    Precedence:
+      1. ``override`` always wins. Operators can pin the window and the
+         resolver respects it without inspection.
+      2. The first anchor parser that finds a timestamp in ``raw_alert``
+         determines ``until = anchor + forward_buffer_minutes`` (clamped
+         to ``now`` if the anchor is in the future, e.g. due to clock
+         skew).
+      3. ``since = until - lookback_minutes``.
+      4. If no parser succeeds, ``until = now`` and
+         ``since = until - lookback_minutes``. ``source`` is recorded as
+         ``"default"`` and ``confidence`` is 0.0.
+
+    The resolved window is always clamped to ``MAX_LOOKBACK_MINUTES`` so
+    no caller can accidentally page through months of data.
+
+    Logs at INFO when an anchor is found and at DEBUG when falling back
+    to the default. Operators can grep these to audit which parser
+    matched without attaching a debugger.
+
+    Args:
+        raw_alert: The raw alert payload as a dict, JSON string, or
+            None. Anchor parsing is best-effort.
+        override: A pre-resolved window that should be used as-is.
+        lookback_minutes: How far back from ``until`` to look. Capped at
+            ``MAX_LOOKBACK_MINUTES``. Non-positive values fall back to
+            ``DEFAULT_LOOKBACK_MINUTES``.
+        forward_buffer_minutes: How far past the anchor to extend
+            ``until``. Useful for catching evidence emitted just after
+            the alert condition was detected. Non-positive values use 0.
+        now: Optional injection point for the "current time". Tests pass
+            this; production callers leave it as None.
+
+    Returns:
+        A frozen ``IncidentWindow`` ready to drop into ``AgentState``.
+    """
+    if override is not None:
+        logger.debug(
+            "incident_window: override provided source=%s since=%s until=%s",
+            override.source, _iso_utc(override.since), _iso_utc(override.until),
+        )
+        return override
+
+    lookback_int = int(lookback_minutes) if lookback_minutes else DEFAULT_LOOKBACK_MINUTES
+    if lookback_int <= 0:
+        lookback_int = DEFAULT_LOOKBACK_MINUTES
+    lookback = min(lookback_int, MAX_LOOKBACK_MINUTES)
+    buffer_minutes = max(0, int(forward_buffer_minutes or 0))
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+
+    payload = _coerce_alert_dict(raw_alert)
+    anchor_result = _extract_anchor(payload) if payload else None
+
+    if anchor_result is not None:
+        anchor, label = anchor_result
+        until = anchor + timedelta(minutes=buffer_minutes)
+        # Clock skew protection: the anchor + buffer must not exceed now.
+        if until > current:
+            until = current
+        since = until - timedelta(minutes=lookback)
+        # since < until is guaranteed because lookback is clamped to >= 1.
+        window = IncidentWindow(
+            since=since, until=until, source=label, confidence=1.0,
+        )
+        logger.info(
+            "incident_window: anchored source=%s since=%s until=%s lookback_min=%d",
+            window.source, _iso_utc(window.since), _iso_utc(window.until), lookback,
+        )
+        return window
+
+    # Default fallback.
+    until = current
+    since = until - timedelta(minutes=lookback)
+    window = IncidentWindow(
+        since=since, until=until, source=SOURCE_DEFAULT, confidence=0.0,
+    )
+    logger.debug(
+        "incident_window: no anchor found, using default since=%s until=%s lookback_min=%d",
+        _iso_utc(window.since), _iso_utc(window.until), lookback,
+    )
+    return window
+
+
+__all__ = [
+    "DEFAULT_FORWARD_BUFFER_MINUTES",
+    "DEFAULT_LOOKBACK_MINUTES",
+    "IncidentWindow",
+    "MAX_LOOKBACK_MINUTES",
+    "SCHEMA_VERSION",
+    "SOURCE_ACTIVATED_AT",
+    "SOURCE_DEFAULT",
+    "SOURCE_FIRED_AT",
+    "SOURCE_OVERRIDE",
+    "SOURCE_STARTS_AT",
+    "resolve_incident_window",
+]

--- a/app/incident_window.py
+++ b/app/incident_window.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -115,9 +116,7 @@ class IncidentWindow:
                 "A zero-length or inverted window is never valid."
             )
         if not (0.0 <= float(self.confidence) <= 1.0):
-            raise ValueError(
-                f"confidence must be in [0.0, 1.0], got {self.confidence}"
-            )
+            raise ValueError(f"confidence must be in [0.0, 1.0], got {self.confidence}")
         if not isinstance(self.source, str) or not self.source.strip():
             raise ValueError("source must be a non-empty string")
         # Apply the UTC normalisation, frozen-dataclass style.
@@ -267,14 +266,10 @@ def _alertmanager_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None
     return None
 
 
-def _grafana_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
-    """Grafana managed alerts use the same Alertmanager schema.
-
-    Kept as a separate function so the dispatch order in
-    ``_ANCHOR_PARSERS`` can prioritise grafana-shaped payloads over
-    raw Alertmanager if needed in the future. Today both share logic.
-    """
-    return _alertmanager_anchor(payload)
+# Grafana managed alerts use the Alertmanager webhook schema verbatim, so
+# they are handled by ``_alertmanager_anchor`` above. No separate Grafana
+# parser exists today; if Grafana ever adds a distinct timestamp field, add
+# a dedicated parser here and register it in ``_ANCHOR_PARSERS``.
 
 
 def _datadog_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
@@ -342,9 +337,7 @@ stack overflow.
 """
 
 
-def _cloudwatch_anchor(
-    payload: dict[str, Any], _depth: int = 0
-) -> tuple[datetime, str] | None:
+def _cloudwatch_anchor(payload: dict[str, Any], _depth: int = 0) -> tuple[datetime, str] | None:
     """CloudWatch alarm payloads carry ``StateUpdatedTimestamp``.
 
     The payload arrives wrapped in SNS, so the actual alarm dict often
@@ -380,12 +373,14 @@ def _cloudwatch_anchor(
 
 # Order matters: the first parser to find an anchor wins. The order
 # reflects which format expresses incident-start most accurately.
-_ANCHOR_PARSERS: tuple = (
-    _alertmanager_anchor,  # ``startsAt`` is the underlying condition time
-    _grafana_anchor,       # same schema as Alertmanager
-    _pagerduty_anchor,     # ``triggered_at`` is reliable for incident time
-    _datadog_anchor,       # ``event_time`` is fired-at, less ideal
-    _cloudwatch_anchor,    # ``StateUpdatedTimestamp`` is state-flip time
+# Grafana managed alerts share Alertmanager's schema and are handled by
+# ``_alertmanager_anchor`` — no separate parser is needed.
+_AnchorParser = Callable[[dict[str, Any]], tuple[datetime, str] | None]
+_ANCHOR_PARSERS: tuple[_AnchorParser, ...] = (
+    _alertmanager_anchor,  # ``startsAt`` is the underlying condition time (also covers Grafana)
+    _pagerduty_anchor,  # ``triggered_at`` is reliable for incident time
+    _datadog_anchor,  # ``event_time`` is fired-at, less ideal
+    _cloudwatch_anchor,  # ``StateUpdatedTimestamp`` is state-flip time
 )
 
 
@@ -400,9 +395,7 @@ def _extract_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
         try:
             result = parser(payload)
         except Exception:  # noqa: BLE001 - defensive isolation
-            logger.debug(
-                "incident_window: anchor parser %s raised", parser.__name__, exc_info=True
-            )
+            logger.debug("incident_window: anchor parser %s raised", parser.__name__, exc_info=True)
             continue
         if result is not None:
             return result
@@ -462,7 +455,9 @@ def resolve_incident_window(
     if override is not None:
         logger.debug(
             "incident_window: override provided source=%s since=%s until=%s",
-            override.source, _iso_utc(override.since), _iso_utc(override.until),
+            override.source,
+            _iso_utc(override.since),
+            _iso_utc(override.until),
         )
         return override
 
@@ -485,11 +480,17 @@ def resolve_incident_window(
         since = until - timedelta(minutes=lookback)
         # since < until is guaranteed because lookback is clamped to >= 1.
         window = IncidentWindow(
-            since=since, until=until, source=label, confidence=1.0,
+            since=since,
+            until=until,
+            source=label,
+            confidence=1.0,
         )
         logger.info(
             "incident_window: anchored source=%s since=%s until=%s lookback_min=%d",
-            window.source, _iso_utc(window.since), _iso_utc(window.until), lookback,
+            window.source,
+            _iso_utc(window.since),
+            _iso_utc(window.until),
+            lookback,
         )
         return window
 
@@ -497,11 +498,16 @@ def resolve_incident_window(
     until = current
     since = until - timedelta(minutes=lookback)
     window = IncidentWindow(
-        since=since, until=until, source=SOURCE_DEFAULT, confidence=0.0,
+        since=since,
+        until=until,
+        source=SOURCE_DEFAULT,
+        confidence=0.0,
     )
     logger.debug(
         "incident_window: no anchor found, using default since=%s until=%s lookback_min=%d",
-        _iso_utc(window.since), _iso_utc(window.until), lookback,
+        _iso_utc(window.since),
+        _iso_utc(window.until),
+        lookback,
     )
     return window
 

--- a/app/nodes/extract_alert/extract_node.py
+++ b/app/nodes/extract_alert/extract_node.py
@@ -135,10 +135,16 @@ def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfi
         result["alert_source"] = details.alert_source
     if not state.get("investigation_started_at"):
         result["investigation_started_at"] = time.monotonic()
-    # Resolve a single incident window from the alert's own timestamps. Tools
-    # that opt into the shared window will read this; tools that have not yet
-    # been migrated keep their existing per-tool defaults. Resolution is
-    # best-effort and never raises — falls back to a default window centred
-    # on "now" when no anchor is found in the payload.
-    result["incident_window"] = resolve_incident_window(enriched_alert).to_dict()
+    # Resolve a single incident window from the alert's own timestamps.
+    # IMPORTANT: pass the ORIGINAL ``raw_alert`` (string or dict), NOT the
+    # enriched one. ``_enrich_raw_alert`` discards the content of any
+    # non-dict raw_alert (it returns a fresh dict containing only the
+    # LLM-extracted fields), so a string-form webhook payload would lose
+    # all timestamps before the resolver ever sees it. The resolver's
+    # ``_coerce_alert_dict`` knows how to parse JSON-string payloads.
+    # Tools that opt into the shared window will read this; tools not yet
+    # migrated keep their existing per-tool defaults. Resolution is
+    # best-effort and never raises — falls back to a default window
+    # centred on "now" when no anchor is found.
+    result["incident_window"] = resolve_incident_window(raw_alert).to_dict()
     return result

--- a/app/nodes/extract_alert/extract_node.py
+++ b/app/nodes/extract_alert/extract_node.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
+from app.incident_window import resolve_incident_window
 from app.nodes.extract_alert.extract import _CANONICAL_ALERT_SOURCES, extract_alert_details
 from app.nodes.extract_alert.models import AlertDetails
 from app.output import debug_print, get_tracker, render_investigation_header
@@ -134,4 +135,10 @@ def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfi
         result["alert_source"] = details.alert_source
     if not state.get("investigation_started_at"):
         result["investigation_started_at"] = time.monotonic()
+    # Resolve a single incident window from the alert's own timestamps. Tools
+    # that opt into the shared window will read this; tools that have not yet
+    # been migrated keep their existing per-tool defaults. Resolution is
+    # best-effort and never raises — falls back to a default window centred
+    # on "now" when no anchor is found in the payload.
+    result["incident_window"] = resolve_incident_window(enriched_alert).to_dict()
     return result

--- a/app/nodes/investigate/models.py
+++ b/app/nodes/investigate/models.py
@@ -54,10 +54,21 @@ class InvestigateInput(BaseModel):
     evidence: dict[str, object] = Field(default_factory=dict, description="Current evidence")
     investigation_loop_count: int = Field(default=0, description="Number of investigation loops")
     tool_budget: int = Field(default=10, ge=1, le=50, description="Maximum tools per step")
+    incident_window: dict[str, object] | None = Field(
+        default=None,
+        description=(
+            "Resolved incident time window (from app.incident_window). Threaded "
+            "through plan_actions and exposed to opt-in tools via "
+            "available_sources['_meta']['incident_window']. None when "
+            "extract_alert has not yet populated state.incident_window."
+        ),
+    )
 
     @classmethod
     def from_state(cls, state: InvestigationState | dict[str, object]) -> "InvestigateInput":
         """Create InvestigateInput from investigation state."""
+        raw_window = state.get("incident_window")
+        incident_window = raw_window if isinstance(raw_window, dict) else None
         return cls(
             raw_alert=_raw_alert(state.get("raw_alert", {})),
             context=_object_dict(state.get("context", {})),
@@ -72,6 +83,7 @@ class InvestigateInput(BaseModel):
             evidence=_object_dict(state.get("evidence", {})),
             investigation_loop_count=_int_value(state.get("investigation_loop_count", 0), 0),
             tool_budget=_int_value(state.get("tool_budget", 10), 10),
+            incident_window=incident_window,
         )
 
 

--- a/app/nodes/plan_actions/build_prompt.py
+++ b/app/nodes/plan_actions/build_prompt.py
@@ -145,7 +145,7 @@ def _build_available_sources_hint(available_sources: dict[str, dict]) -> str:
 - Commit SHA: {github.get("sha") or "unknown"}
 - Ref: {github.get("ref") or "unknown"}
 - Code Query: {github.get("query") or "exception OR error"}
-- Prefer get_git_deploy_timeline for deploy correlation (commits in a time window around the alert)
+- Prefer get_git_deploy_timeline for deploy correlation; with no args it auto-uses the shared incident window
 - Use list_github_commits for the N most recent commits regardless of time window
 - Use search_github_code and get_github_file_contents to trace the failure into code"""
         )

--- a/app/nodes/plan_actions/plan_actions.py
+++ b/app/nodes/plan_actions/plan_actions.py
@@ -233,6 +233,15 @@ def plan_actions(
         input_data.raw_alert, input_data.context, resolved_integrations=resolved_integrations
     )
 
+    # Thread shared incident metadata to opt-in tools. The reserved ``_meta``
+    # key holds investigation-level context (today: incident_window) that is
+    # NOT bound to any specific service. Tools that want it read
+    # ``sources["_meta"]["incident_window"]`` in their extract_params; tools
+    # that don't simply ignore the key. Omitted entirely when the state has
+    # no incident_window so the dict shape stays clean.
+    if input_data.incident_window is not None:
+        available_sources["_meta"] = {"incident_window": input_data.incident_window}
+
     # Enhance sources with dynamically discovered information from evidence (e.g., audit_key from S3 metadata)
     s3_object = _evidence_object_dict(input_data.evidence.get("s3_object", {}))
     s3_metadata = _evidence_object_dict(s3_object.get("metadata", {}))

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -84,6 +84,15 @@ class AgentState(TypedDict, total=False):
     executed_hypotheses: list[dict[str, Any]]
     investigation_started_at: float
 
+    # Resolved [since, until) time window for the current incident.
+    # Populated by extract_alert from the alert's own timestamps via
+    # ``app.incident_window.resolve_incident_window``. Time-aware tools will
+    # read from this in a follow-up PR; in this PR the field is wired through
+    # state but not yet consumed. ``None`` means extract_alert has not run yet.
+    # Shape: {"_schema_version": int, "since": iso8601, "until": iso8601,
+    #         "source": str, "confidence": float}.
+    incident_window: dict[str, Any] | None
+
     # Placeholder→original map for reversible infrastructure identifier masking
     masking_map: dict[str, str]
 
@@ -162,6 +171,7 @@ class AgentStateModel(StrictConfigModel):
     hypotheses: list[str] = Field(default_factory=list)
     executed_hypotheses: list[dict[str, Any]] = Field(default_factory=list)
     investigation_started_at: float = 0.0
+    incident_window: dict[str, Any] | None = None
     masking_map: dict[str, str] = Field(default_factory=dict)
     slack_context: dict[str, Any] = Field(default_factory=dict)
     discord_context: dict[str, Any] = Field(default_factory=dict)

--- a/app/tools/GitDeployTimelineTool/__init__.py
+++ b/app/tools/GitDeployTimelineTool/__init__.py
@@ -287,6 +287,21 @@ def get_git_deploy_timeline(
     # narrow the window or raise per_page rather than concluding "nothing
     # else shipped".
     truncated = len(commits) >= effective_per_page
+    # Trace where the window came from for the diagnose narrative.
+    # Three distinct sources, never conflated:
+    #   "shared_incident_window" — tool used state.incident_window because
+    #       no caller-explicit window was provided.
+    #   "caller_explicit"        — caller passed since/until or
+    #       window_minutes_before_alert; the tool honoured it.
+    #   "tool_default"           — no caller input AND no shared window;
+    #       the tool fell back to DEFAULT_WINDOW_MINUTES.
+    if used_shared_window:
+        window_source = "shared_incident_window"
+    elif since or until or window_minutes_before_alert is not None:
+        window_source = "caller_explicit"
+    else:
+        window_source = "tool_default"
+
     payload.update(
         {
             "commits": commits,
@@ -297,10 +312,7 @@ def get_git_deploy_timeline(
                 "branch": branch,
                 "per_page": effective_per_page,
                 "truncated": truncated,
-                # Trace where the window came from for the diagnose narrative.
-                # "shared_incident_window" means the tool used state.incident_window
-                # because no caller-explicit window was provided.
-                "source": "shared_incident_window" if used_shared_window else "tool_default",
+                "source": window_source,
             },
         }
     )

--- a/app/tools/GitDeployTimelineTool/__init__.py
+++ b/app/tools/GitDeployTimelineTool/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from app.incident_window import IncidentWindow
 from app.integrations.github_mcp import call_github_mcp_tool
 from app.tools.GitHubSearchCodeTool import (
     _gh_available,
@@ -127,10 +128,20 @@ def _summarize_commit(raw: dict[str, Any]) -> dict[str, Any]:
 
 def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     gh = sources["github"]
+    # ``_meta`` carries investigation-level context shared across tools
+    # (today: incident_window). Tools that don't care about it ignore the
+    # key. See app.nodes.plan_actions.plan_actions for where this is set.
+    # Defensive isinstance check: if anything ever stuffs a non-dict under
+    # the reserved ``_meta`` key, we degrade to no-shared-window rather
+    # than crashing with AttributeError on the .get below.
+    raw_meta = sources.get("_meta")
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
+    incident_window = meta.get("incident_window")
     return {
         "owner": gh["owner"],
         "repo": gh["repo"],
         "branch": gh.get("branch") or gh.get("default_branch") or "main",
+        "shared_incident_window": incident_window if isinstance(incident_window, dict) else None,
         **_gh_creds(gh),
     }
 
@@ -173,9 +184,10 @@ def _is_available(sources: dict[str, dict]) -> bool:
                 "type": "integer",
                 "description": (
                     "Convenience: minutes back from 'until' (or now) when 'since' is "
-                    f"omitted. Clamped to {MAX_WINDOW_MINUTES} minutes."
+                    f"omitted. Clamped to {MAX_WINDOW_MINUTES} minutes. When omitted, "
+                    "the tool prefers the shared incident window from state if one is "
+                    f"available, otherwise falls back to {DEFAULT_WINDOW_MINUTES} minutes."
                 ),
-                "default": DEFAULT_WINDOW_MINUTES,
             },
             "per_page": {
                 "type": "integer",
@@ -198,8 +210,9 @@ def get_git_deploy_timeline(
     branch: str = "main",
     since: str = "",
     until: str = "",
-    window_minutes_before_alert: int | None = DEFAULT_WINDOW_MINUTES,
+    window_minutes_before_alert: int | None = None,
     per_page: int = DEFAULT_PER_PAGE,
+    shared_incident_window: dict[str, Any] | None = None,
     github_url: str | None = None,
     github_mode: str | None = None,
     github_token: str | None = None,
@@ -207,7 +220,15 @@ def get_git_deploy_timeline(
     github_args: list[str] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
-    """Return commits on ``branch`` between ``since`` and ``until``."""
+    """Return commits on ``branch`` between ``since`` and ``until``.
+
+    Window resolution priority (highest to lowest):
+        1. Explicit ``since`` AND ``until`` from the caller.
+        2. Explicit ``window_minutes_before_alert`` from the caller.
+        3. ``shared_incident_window`` from agent state (when both ``since``
+           and ``until`` are empty AND no explicit window-minutes override).
+        4. ``DEFAULT_WINDOW_MINUTES`` (120 minutes before now).
+    """
     config = _resolve_config(github_url, github_mode, github_token, github_command, github_args)
     if config is None:
         return {
@@ -218,7 +239,28 @@ def get_git_deploy_timeline(
             "window": {},
         }
 
-    resolved_since, resolved_until = _resolve_window(since, until, window_minutes_before_alert)
+    # If neither since/until nor an explicit window-minutes was provided, try
+    # to use the shared incident window from agent state. ``from_dict``
+    # returns None on a malformed payload, which falls back to defaults.
+    effective_since, effective_until = since, until
+    used_shared_window = False
+    if not since and not until and window_minutes_before_alert is None and shared_incident_window:
+        window_obj = IncidentWindow.from_dict(shared_incident_window)
+        if window_obj is not None:
+            effective_since = window_obj.since.isoformat().replace("+00:00", "Z")
+            effective_until = window_obj.until.isoformat().replace("+00:00", "Z")
+            used_shared_window = True
+
+    # Final lookback used by the resolver: caller-explicit if given, else
+    # the tool's traditional default. The resolver clamps + validates.
+    effective_minutes = (
+        window_minutes_before_alert
+        if window_minutes_before_alert is not None
+        else DEFAULT_WINDOW_MINUTES
+    )
+    resolved_since, resolved_until = _resolve_window(
+        effective_since, effective_until, effective_minutes
+    )
     # Clamp per_page to the GitHub REST API maximum of 100. Values above this
     # are silently truncated upstream; we enforce the ceiling explicitly so
     # ``truncated`` below is meaningful.
@@ -255,6 +297,10 @@ def get_git_deploy_timeline(
                 "branch": branch,
                 "per_page": effective_per_page,
                 "truncated": truncated,
+                # Trace where the window came from for the diagnose narrative.
+                # "shared_incident_window" means the tool used state.incident_window
+                # because no caller-explicit window was provided.
+                "source": "shared_incident_window" if used_shared_window else "tool_default",
             },
         }
     )

--- a/tests/app/test_incident_window.py
+++ b/tests/app/test_incident_window.py
@@ -1,0 +1,471 @@
+"""Tests for app.incident_window.
+
+Coverage strategy:
+1. ``IncidentWindow`` value object: construction validation, UTC
+   normalisation, serialisation round-trip.
+2. ``resolve_incident_window`` precedence: override > anchor > default.
+3. One real-world payload shape per supported alert format
+   (Alertmanager v4, Grafana managed alert, PagerDuty v3 webhook,
+   Datadog event_time webhook, CloudWatch SNS-wrapped alarm).
+4. Parser-level unit tests for shape variants (epoch ms vs ISO string,
+   nested SNS Message, multiple Alertmanager alerts → earliest wins).
+5. Edge cases: clock skew, lookback clamp, malformed JSON, naive
+   timestamps, zero/negative lookback, empty payload.
+6. Defensive guarantees: no parser may raise, no payload shape may
+   bring down the resolver.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from app.incident_window import (
+    DEFAULT_LOOKBACK_MINUTES,
+    MAX_LOOKBACK_MINUTES,
+    SCHEMA_VERSION,
+    SOURCE_ACTIVATED_AT,
+    SOURCE_DEFAULT,
+    SOURCE_FIRED_AT,
+    SOURCE_OVERRIDE,
+    SOURCE_STARTS_AT,
+    IncidentWindow,
+    resolve_incident_window,
+)
+
+# Reference "now" used across tests to keep window arithmetic predictable.
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# IncidentWindow construction & invariants
+# ---------------------------------------------------------------------------
+
+
+class TestIncidentWindowConstruction:
+    def test_valid_window_constructs(self) -> None:
+        w = IncidentWindow(
+            since=NOW - timedelta(hours=2),
+            until=NOW,
+            source="test",
+            confidence=1.0,
+        )
+        assert w.since < w.until
+        assert w.confidence == 1.0
+
+    def test_naive_since_rejected(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            IncidentWindow(
+                since=datetime(2026, 4, 20, 10, 0),  # naive
+                until=NOW,
+                source="x",
+                confidence=1.0,
+            )
+
+    def test_naive_until_rejected(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            IncidentWindow(
+                since=NOW - timedelta(hours=2),
+                until=datetime(2026, 4, 20, 12, 0),  # naive
+                source="x",
+                confidence=1.0,
+            )
+
+    def test_inverted_window_rejected(self) -> None:
+        with pytest.raises(ValueError, match="since < until"):
+            IncidentWindow(
+                since=NOW,
+                until=NOW - timedelta(hours=1),
+                source="x",
+                confidence=1.0,
+            )
+
+    def test_zero_length_window_rejected(self) -> None:
+        with pytest.raises(ValueError, match="since < until"):
+            IncidentWindow(since=NOW, until=NOW, source="x", confidence=1.0)
+
+    def test_non_utc_tz_normalised(self) -> None:
+        # Eastern offset; should be converted to UTC internally.
+        eastern = timezone(timedelta(hours=-5))
+        since_local = datetime(2026, 4, 20, 5, 0, tzinfo=eastern)  # = 10:00 UTC
+        until_local = datetime(2026, 4, 20, 7, 0, tzinfo=eastern)  # = 12:00 UTC
+        w = IncidentWindow(since=since_local, until=until_local, source="x", confidence=1.0)
+        assert w.since == datetime(2026, 4, 20, 10, 0, tzinfo=UTC)
+        assert w.until == datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+
+    def test_confidence_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="confidence"):
+            IncidentWindow(since=NOW - timedelta(hours=1), until=NOW, source="x", confidence=1.5)
+        with pytest.raises(ValueError, match="confidence"):
+            IncidentWindow(since=NOW - timedelta(hours=1), until=NOW, source="x", confidence=-0.1)
+
+    def test_empty_source_rejected(self) -> None:
+        with pytest.raises(ValueError, match="source"):
+            IncidentWindow(since=NOW - timedelta(hours=1), until=NOW, source="", confidence=1.0)
+
+    def test_non_datetime_rejected(self) -> None:
+        with pytest.raises(TypeError, match="datetime"):
+            IncidentWindow(since="not-a-date", until=NOW, source="x", confidence=1.0)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerialisation:
+    def test_to_dict_carries_schema_version(self) -> None:
+        w = IncidentWindow(since=NOW - timedelta(hours=2), until=NOW, source="x", confidence=0.5)
+        d = w.to_dict()
+        assert d["_schema_version"] == SCHEMA_VERSION
+        assert d["since"] == "2026-04-20T10:00:00Z"
+        assert d["until"] == "2026-04-20T12:00:00Z"
+
+    def test_round_trip(self) -> None:
+        original = IncidentWindow(
+            since=NOW - timedelta(hours=3), until=NOW, source="alert.startsAt", confidence=1.0
+        )
+        rebuilt = IncidentWindow.from_dict(original.to_dict())
+        assert rebuilt is not None
+        assert rebuilt == original
+
+    def test_from_dict_returns_none_on_bad_shape(self) -> None:
+        assert IncidentWindow.from_dict(None) is None
+        assert IncidentWindow.from_dict("string") is None
+        assert IncidentWindow.from_dict({}) is None
+        assert IncidentWindow.from_dict({"since": "garbage", "until": "x"}) is None
+
+    def test_from_dict_returns_none_when_invariants_violated(self) -> None:
+        # Inverted window in the dict — should not raise, returns None.
+        bad = {
+            "_schema_version": 1,
+            "since": "2026-04-20T12:00:00Z",
+            "until": "2026-04-20T10:00:00Z",
+            "source": "x",
+            "confidence": 1.0,
+        }
+        assert IncidentWindow.from_dict(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# Resolver precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolverPrecedence:
+    def test_override_always_wins(self) -> None:
+        override = IncidentWindow(
+            since=NOW - timedelta(days=3),
+            until=NOW - timedelta(days=2),
+            source=SOURCE_OVERRIDE,
+            confidence=1.0,
+        )
+        result = resolve_incident_window(
+            {"startsAt": "2026-04-20T08:00:00Z"},  # would normally match
+            override=override,
+            now=NOW,
+        )
+        assert result is override
+
+    def test_default_when_no_anchor(self) -> None:
+        result = resolve_incident_window({}, now=NOW)
+        assert result.source == SOURCE_DEFAULT
+        assert result.confidence == 0.0
+        assert result.until == NOW
+        assert result.since == NOW - timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
+
+    def test_default_when_raw_alert_is_none(self) -> None:
+        result = resolve_incident_window(None, now=NOW)
+        assert result.source == SOURCE_DEFAULT
+
+    def test_default_when_raw_alert_is_malformed_json(self) -> None:
+        result = resolve_incident_window("{not valid json", now=NOW)
+        assert result.source == SOURCE_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Real-world payload shapes — one per format
+# ---------------------------------------------------------------------------
+
+
+class TestRealWorldPayloads:
+    """One canonical webhook shape per format, lifted from vendor docs."""
+
+    def test_alertmanager_v4_webhook(self) -> None:
+        # Stripped from https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+        payload = {
+            "version": "4",
+            "groupKey": "{}:{alertname=\"HighCPUUsage\"}",
+            "status": "firing",
+            "receiver": "team-X",
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "HighCPUUsage", "severity": "critical"},
+                    "annotations": {"summary": "CPU 92%"},
+                    "startsAt": "2026-04-20T09:30:00Z",
+                    "endsAt": "0001-01-01T00:00:00Z",
+                }
+            ],
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_STARTS_AT
+        assert result.confidence == 1.0
+        # until = anchor (09:30) + default 10min buffer = 09:40Z
+        assert result.until == datetime(2026, 4, 20, 9, 40, tzinfo=UTC)
+        assert result.since == result.until - timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
+
+    def test_grafana_managed_alert(self) -> None:
+        # Grafana uses the Alertmanager schema but tags the source differently.
+        payload = {
+            "receiver": "grafana-default",
+            "status": "firing",
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"grafana_folder": "Prod"},
+                    "annotations": {"summary": "p95 over budget"},
+                    "startsAt": "2026-04-20T10:15:00Z",
+                    "endsAt": "0001-01-01T00:00:00Z",
+                }
+            ],
+            "groupLabels": {},
+            "commonLabels": {},
+            "commonAnnotations": {},
+            "externalURL": "https://grafana.example.com",
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_STARTS_AT
+        assert result.until == datetime(2026, 4, 20, 10, 25, tzinfo=UTC)
+
+    def test_pagerduty_v3_webhook(self) -> None:
+        # PagerDuty webhook v3 nests incident under event.data.
+        payload = {
+            "event": {
+                "id": "evt-123",
+                "event_type": "incident.triggered",
+                "occurred_at": "2026-04-20T11:00:00Z",
+                "data": {
+                    "type": "incident",
+                    "id": "PINC123",
+                    "title": "Database connection exhausted",
+                    "triggered_at": "2026-04-20T10:55:30Z",
+                    "created_at": "2026-04-20T10:55:30Z",
+                    "status": "triggered",
+                },
+            }
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_FIRED_AT
+        assert result.until == datetime(2026, 4, 20, 11, 5, 30, tzinfo=UTC)
+
+    def test_datadog_event_time_milliseconds(self) -> None:
+        # Datadog webhook payload (representative subset).
+        # event_time in milliseconds since epoch.
+        payload = {
+            "alert_id": "abc-123",
+            "alert_status": "Triggered",
+            "event_msg": "CPU > 80%",
+            "event_time": 1745136000000,  # 2025-04-20T08:00:00Z in ms
+        }
+        result = resolve_incident_window(payload, now=datetime(2025, 4, 20, 12, 0, tzinfo=UTC))
+        assert result.source == SOURCE_FIRED_AT
+        # Anchor is the epoch ms value.
+        assert result.until.year == 2025
+
+    def test_cloudwatch_alarm_sns_wrapped(self) -> None:
+        # SNS wraps the actual alarm message as a JSON-string in the Message field.
+        inner_alarm = {
+            "AlarmName": "HighErrorRate",
+            "NewStateValue": "ALARM",
+            "StateUpdatedTimestamp": "2026-04-20T10:30:00.123+0000",
+            "Region": "us-east-1",
+        }
+        payload = {
+            "Type": "Notification",
+            "MessageId": "abc",
+            "Message": json.dumps(inner_alarm),
+            "Timestamp": "2026-04-20T10:30:01.000Z",
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_ACTIVATED_AT
+        # Anchor 10:30:00.123, plus 10 min buffer = 10:40:00.123
+        assert result.until == datetime(2026, 4, 20, 10, 40, 0, 123000, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Parser shape variants
+# ---------------------------------------------------------------------------
+
+
+class TestParserVariants:
+    def test_alertmanager_multiple_alerts_picks_earliest(self) -> None:
+        payload = {
+            "alerts": [
+                {"startsAt": "2026-04-20T11:00:00Z"},
+                {"startsAt": "2026-04-20T09:30:00Z"},  # earliest
+                {"startsAt": "2026-04-20T10:15:00Z"},
+            ]
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        # until = 09:30 + 10min buffer
+        assert result.until == datetime(2026, 4, 20, 9, 40, tzinfo=UTC)
+
+    def test_alertmanager_top_level_starts_at(self) -> None:
+        # Older grouped payloads can carry startsAt at the top level too.
+        payload = {"startsAt": "2026-04-20T08:00:00Z"}
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_STARTS_AT
+
+    def test_datadog_event_time_seconds(self) -> None:
+        # Some Datadog payloads carry seconds, not ms. We tolerate both.
+        payload = {"event_time": 1745136000}  # seconds
+        result = resolve_incident_window(payload, now=datetime(2025, 4, 20, 12, 0, tzinfo=UTC))
+        assert result.source == SOURCE_FIRED_AT
+
+    def test_datadog_iso_string(self) -> None:
+        payload = {"event_time": "2026-04-20T09:00:00Z"}
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_FIRED_AT
+
+    def test_pagerduty_v2_top_level_incident(self) -> None:
+        # Older shape that doesn't go through event.data.
+        payload = {
+            "incident": {
+                "incident_number": 42,
+                "triggered_at": "2026-04-20T10:00:00Z",
+            }
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_FIRED_AT
+
+    def test_cloudwatch_top_level_state_updated(self) -> None:
+        # When the alarm dict arrives un-SNS-wrapped (e.g. EventBridge → Lambda).
+        payload = {"StateUpdatedTimestamp": "2026-04-20T10:00:00Z"}
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_ACTIVATED_AT
+
+
+# ---------------------------------------------------------------------------
+# Edge cases & defensive guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_clock_skew_anchor_in_future_pinned_to_now(self) -> None:
+        # Anchor 30 minutes in the future → until pinned to now.
+        future_now = NOW
+        payload = {"startsAt": "2026-04-20T12:30:00Z"}  # 30 min after NOW
+        result = resolve_incident_window(payload, now=future_now)
+        assert result.until == future_now
+
+    def test_lookback_clamped_to_max(self) -> None:
+        result = resolve_incident_window(
+            {}, lookback_minutes=10 * MAX_LOOKBACK_MINUTES, now=NOW
+        )
+        assert result.until - result.since == timedelta(minutes=MAX_LOOKBACK_MINUTES)
+
+    def test_lookback_zero_falls_back_to_default(self) -> None:
+        result = resolve_incident_window({}, lookback_minutes=0, now=NOW)
+        assert result.until - result.since == timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
+
+    def test_lookback_negative_falls_back_to_default(self) -> None:
+        result = resolve_incident_window({}, lookback_minutes=-5, now=NOW)
+        assert result.until - result.since == timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
+
+    def test_buffer_negative_treated_as_zero(self) -> None:
+        payload = {"startsAt": "2026-04-20T09:00:00Z"}
+        result = resolve_incident_window(payload, forward_buffer_minutes=-30, now=NOW)
+        # No buffer added.
+        assert result.until == datetime(2026, 4, 20, 9, 0, tzinfo=UTC)
+
+    def test_naive_iso_string_treated_as_utc(self) -> None:
+        # No tz suffix in the alert payload — must not raise, must assume UTC.
+        payload = {"startsAt": "2026-04-20T09:00:00"}
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.until.tzinfo == UTC
+
+    def test_non_dict_non_string_raw_alert(self) -> None:
+        # If the raw_alert is, say, an int (shouldn't happen but might),
+        # the resolver must not crash.
+        result = resolve_incident_window(42, now=NOW)
+        assert result.source == SOURCE_DEFAULT
+
+    def test_alertmanager_alerts_list_with_garbage_entries(self) -> None:
+        payload = {
+            "alerts": [
+                "not-a-dict",
+                {"startsAt": 12345},  # wrong type
+                {"startsAt": "garbage"},  # unparseable
+                {"startsAt": "2026-04-20T09:00:00Z"},  # the real one
+            ]
+        }
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_STARTS_AT
+
+    def test_datadog_bool_event_time_ignored(self) -> None:
+        # bool is a subclass of int in Python — must not be treated as epoch.
+        payload = {"event_time": True}
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_DEFAULT  # parser correctly skipped
+
+    def test_cloudwatch_message_invalid_json_falls_through(self) -> None:
+        payload = {"Message": "not valid json"}
+        result = resolve_incident_window(payload, now=NOW)
+        assert result.source == SOURCE_DEFAULT
+
+    def test_until_pinned_to_now_for_very_recent_anchor(self) -> None:
+        # Anchor exactly at NOW → buffer would push past now → pinned to now.
+        payload = {"startsAt": NOW.isoformat().replace("+00:00", "Z")}
+        result = resolve_incident_window(payload, now=NOW, forward_buffer_minutes=10)
+        assert result.until == NOW
+        assert result.since == NOW - timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
+
+
+# ---------------------------------------------------------------------------
+# Resolver fuzz: arbitrary garbage must never raise
+# ---------------------------------------------------------------------------
+
+
+class TestResolverFuzz:
+    """Property: the resolver returns a valid window for any input."""
+
+    @pytest.mark.parametrize(
+        "garbage",
+        [
+            None,
+            "",
+            "x",
+            "{",
+            "{}",
+            "[]",
+            "null",
+            42,
+            3.14,
+            True,
+            [],
+            {},
+            {"unknown_key": "value"},
+            {"alerts": None},
+            {"alerts": "not-a-list"},
+            {"alerts": [None, None, None]},
+            {"event": None},
+            {"event": {"data": None}},
+            {"Message": None},
+            {"Message": json.dumps({"AlarmName": "x"})},  # no timestamp
+            {"startsAt": ""},
+            {"startsAt": None},
+            {"startsAt": 12345},
+            {"event_time": "not-a-number"},
+            {"triggered_at": ""},
+        ],
+    )
+    def test_never_raises(self, garbage: object) -> None:
+        # The hard property: the resolver must never raise. The window it
+        # returns is always valid because IncidentWindow.__post_init__ enforces
+        # that.
+        result = resolve_incident_window(garbage, now=NOW)
+        assert isinstance(result, IncidentWindow)
+        assert result.since < result.until

--- a/tests/app/test_incident_window.py
+++ b/tests/app/test_incident_window.py
@@ -197,7 +197,7 @@ class TestRealWorldPayloads:
         # Stripped from https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
         payload = {
             "version": "4",
-            "groupKey": "{}:{alertname=\"HighCPUUsage\"}",
+            "groupKey": '{}:{alertname="HighCPUUsage"}',
             "status": "firing",
             "receiver": "team-X",
             "alerts": [
@@ -362,9 +362,7 @@ class TestEdgeCases:
         assert result.until == future_now
 
     def test_lookback_clamped_to_max(self) -> None:
-        result = resolve_incident_window(
-            {}, lookback_minutes=10 * MAX_LOOKBACK_MINUTES, now=NOW
-        )
+        result = resolve_incident_window({}, lookback_minutes=10 * MAX_LOOKBACK_MINUTES, now=NOW)
         assert result.until - result.since == timedelta(minutes=MAX_LOOKBACK_MINUTES)
 
     def test_lookback_zero_falls_back_to_default(self) -> None:

--- a/tests/app/test_incident_window_cloudwatch_depth.py
+++ b/tests/app/test_incident_window_cloudwatch_depth.py
@@ -1,0 +1,42 @@
+"""Targeted regression test for the CloudWatch depth cap.
+
+Pathologically deep ``{"Message": {"Message": ...}}`` payloads must not
+recurse into stack overflow. The cap is enforced inside
+``_cloudwatch_anchor`` and surfaced via the public ``resolve_incident_window``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.incident_window import (
+    SOURCE_ACTIVATED_AT,
+    SOURCE_DEFAULT,
+    resolve_incident_window,
+)
+
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+
+
+def test_cloudwatch_legit_two_level_nesting_resolves() -> None:
+    # SNS -> Message (parsed JSON) -> alarm dict with timestamp.
+    payload = {
+        "Message": {
+            "alarm": {"StateUpdatedTimestamp": "2026-04-20T10:00:00Z"},
+        }
+    }
+    result = resolve_incident_window(payload, now=NOW)
+    assert result.source == SOURCE_ACTIVATED_AT
+
+
+def test_cloudwatch_pathological_deep_nesting_does_not_recurse_forever() -> None:
+    # Build a 200-level deep payload of {"Message": {"Message": ...}}.
+    # Without the depth cap this would blow the Python recursion limit.
+    deep: dict = {}
+    cursor = deep
+    for _ in range(200):
+        cursor["Message"] = {}
+        cursor = cursor["Message"]
+    # No timestamp anywhere; resolver must fall back to default rather than crash.
+    result = resolve_incident_window(deep, now=NOW)
+    assert result.source == SOURCE_DEFAULT

--- a/tests/app/test_incident_window_extract_wiring.py
+++ b/tests/app/test_incident_window_extract_wiring.py
@@ -1,0 +1,73 @@
+"""Regression tests for the extract_alert -> incident_window wiring.
+
+The first test pins the P1 Greptile finding: passing the post-enrichment
+``enriched_alert`` to ``resolve_incident_window`` silently lost timestamps
+for any string-form webhook payload, defeating the whole feature. This
+test confirms a string raw_alert containing ``startsAt`` is still
+correctly anchored after the fix.
+
+The second test confirms Grafana-shaped payloads still resolve to
+``alert.startsAt`` after the dead ``_grafana_anchor`` shim was removed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from app.incident_window import (
+    SOURCE_DEFAULT,
+    SOURCE_STARTS_AT,
+    resolve_incident_window,
+)
+
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+
+
+def test_string_payload_resolves_via_coerce_dict() -> None:
+    """A JSON-string raw_alert must be parsed and anchored correctly.
+
+    extract_alert now passes the original raw_alert (not the LLM-enriched
+    dict that discards string content). resolve_incident_window must be
+    able to coerce the JSON string into a dict and find the timestamp.
+    """
+    payload_str = json.dumps(
+        {
+            "status": "firing",
+            "alerts": [{"startsAt": "2026-04-20T09:00:00Z"}],
+        }
+    )
+    result = resolve_incident_window(payload_str, now=NOW)
+    assert result.source == SOURCE_STARTS_AT
+    # 09:00 + 10min default buffer = 09:10
+    assert result.until == datetime(2026, 4, 20, 9, 10, tzinfo=UTC)
+
+
+def test_string_payload_with_no_timestamp_falls_back_to_default() -> None:
+    """The fallback path is what the bug used to hit for every string
+    payload. Confirm it still works when there is genuinely no anchor."""
+    payload_str = json.dumps({"alertname": "noisy", "severity": "info"})
+    result = resolve_incident_window(payload_str, now=NOW)
+    assert result.source == SOURCE_DEFAULT
+
+
+def test_grafana_payload_still_resolves_after_parser_removal() -> None:
+    """Grafana managed alerts share Alertmanager's schema. The dedicated
+    _grafana_anchor was a dead delegate to _alertmanager_anchor; removing
+    it must not regress Grafana coverage. Today the Alertmanager parser
+    handles both shapes."""
+    payload = {
+        "receiver": "grafana-default",
+        "status": "firing",
+        "alerts": [
+            {
+                "status": "firing",
+                "labels": {"grafana_folder": "Prod"},
+                "startsAt": "2026-04-20T10:15:00Z",
+            }
+        ],
+        "externalURL": "https://grafana.example.com",
+    }
+    result = resolve_incident_window(payload, now=NOW)
+    assert result.source == SOURCE_STARTS_AT
+    assert result.until == datetime(2026, 4, 20, 10, 25, tzinfo=UTC)

--- a/tests/nodes/plan_actions/test_plan_actions_meta.py
+++ b/tests/nodes/plan_actions/test_plan_actions_meta.py
@@ -1,0 +1,80 @@
+"""Tests for the ``_meta`` channel that threads investigation-level
+context (today: incident_window) from state to opt-in tools.
+
+This is the wiring layer for PR 2 of the dynamic incident window work:
+``plan_actions`` attaches ``state.incident_window`` to
+``available_sources["_meta"]`` so tools that opt in can read it via
+their ``extract_params``. Tools that don't opt in see no behavioural
+change.
+"""
+
+from __future__ import annotations
+
+from app.nodes.investigate.models import InvestigateInput
+from app.nodes.plan_actions.detect_sources import detect_sources
+
+# A minimal incident_window dict shaped like ``app.incident_window.IncidentWindow.to_dict``.
+_WINDOW = {
+    "_schema_version": 1,
+    "since": "2026-04-20T08:00:00Z",
+    "until": "2026-04-20T10:00:00Z",
+    "source": "alert.startsAt",
+    "confidence": 1.0,
+}
+
+
+def test_investigate_input_carries_incident_window_from_state() -> None:
+    """``InvestigateInput.from_state`` must surface state.incident_window
+    so plan_actions can thread it onward."""
+    state = {"raw_alert": {}, "incident_window": _WINDOW}
+    input_data = InvestigateInput.from_state(state)
+    assert input_data.incident_window == _WINDOW
+
+
+def test_investigate_input_handles_missing_incident_window() -> None:
+    """Backward compat: states from before PR 1 / extract_alert ran do
+    not carry ``incident_window``. Field defaults to None."""
+    input_data = InvestigateInput.from_state({"raw_alert": {}})
+    assert input_data.incident_window is None
+
+
+def test_investigate_input_rejects_non_dict_incident_window() -> None:
+    """Defensive: a corrupted state with a non-dict incident_window must
+    not propagate garbage downstream."""
+    input_data = InvestigateInput.from_state({"raw_alert": {}, "incident_window": "not-a-dict"})
+    assert input_data.incident_window is None
+
+
+# ---------------------------------------------------------------------------
+# Wiring contract: plan_actions attaches _meta to available_sources
+# ---------------------------------------------------------------------------
+#
+# We verify the contract at the function level rather than running the
+# whole plan_actions pipeline (which would require a configured LLM).
+# detect_sources returns the unchanged sources dict; plan_actions wraps
+# it and adds _meta. Replicate that wrapping here so the test doesn't
+# depend on plan_actions's planning step.
+
+
+def test_meta_channel_attaches_incident_window() -> None:
+    """When state has an incident_window, the _meta key must appear in
+    available_sources after the plan_actions wrapping step. We verify by
+    reproducing the exact lines that wrap detect_sources output."""
+    sources = detect_sources(raw_alert={}, context={})
+    input_data = InvestigateInput(raw_alert={}, incident_window=_WINDOW)
+    if input_data.incident_window is not None:
+        sources["_meta"] = {"incident_window": input_data.incident_window}
+
+    assert "_meta" in sources
+    assert sources["_meta"]["incident_window"] == _WINDOW
+
+
+def test_meta_channel_omitted_when_state_has_no_window() -> None:
+    """When state has no incident_window, the _meta key MUST NOT appear.
+    Tools then see the same available_sources shape as today."""
+    sources = detect_sources(raw_alert={}, context={})
+    input_data = InvestigateInput(raw_alert={})
+    if input_data.incident_window is not None:
+        sources["_meta"] = {"incident_window": input_data.incident_window}
+
+    assert "_meta" not in sources

--- a/tests/tools/test_git_deploy_timeline_tool.py
+++ b/tests/tools/test_git_deploy_timeline_tool.py
@@ -430,7 +430,8 @@ def test_run_uses_shared_window_when_no_caller_override() -> None:
 
 
 def test_run_caller_since_until_overrides_shared_window() -> None:
-    """Explicit since/until from the caller wins over the shared window."""
+    """Explicit since/until from the caller wins over the shared window
+    and is reported as ``caller_explicit`` in the window source."""
     shared = _shared_window_dict("2026-04-20T08:00:00Z", "2026-04-20T10:00:00Z")
     captured, result = _run_with_shared_window(
         shared,
@@ -439,15 +440,15 @@ def test_run_caller_since_until_overrides_shared_window() -> None:
     )
     assert captured["arguments"]["since"] == "2026-04-20T11:00:00Z"
     assert captured["arguments"]["until"] == "2026-04-20T11:30:00Z"
-    assert result["window"]["source"] == "tool_default"
+    assert result["window"]["source"] == "caller_explicit"
 
 
 def test_run_caller_window_minutes_overrides_shared_window() -> None:
-    """Explicit window_minutes_before_alert from the caller also wins."""
+    """Explicit window_minutes_before_alert from the caller also wins
+    and is reported as ``caller_explicit``."""
     shared = _shared_window_dict("2026-04-20T08:00:00Z", "2026-04-20T10:00:00Z")
     _, result = _run_with_shared_window(shared, window_minutes_before_alert=30)
-    # Did NOT use the shared window — used the explicit 30-min lookback.
-    assert result["window"]["source"] == "tool_default"
+    assert result["window"]["source"] == "caller_explicit"
 
 
 def test_run_falls_back_to_default_when_no_shared_window() -> None:

--- a/tests/tools/test_git_deploy_timeline_tool.py
+++ b/tests/tools/test_git_deploy_timeline_tool.py
@@ -331,6 +331,146 @@ def test_run_flags_window_not_truncated_when_fewer_than_page() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shared incident window integration (PR 2)
+# ---------------------------------------------------------------------------
+
+
+def _shared_window_dict(since: str, until: str) -> dict:
+    """Build a shared incident_window dict in the shape extract_alert produces."""
+    return {
+        "_schema_version": 1,
+        "since": since,
+        "until": until,
+        "source": "alert.startsAt",
+        "confidence": 1.0,
+    }
+
+
+def _run_with_shared_window(
+    shared_window: dict | None,
+    *,
+    since: str = "",
+    until: str = "",
+    window_minutes_before_alert: int | None = None,
+) -> tuple[dict, dict]:
+    """Helper: run the tool with a stubbed MCP and return (kwargs_to_mcp, payload)."""
+    captured: dict = {}
+
+    def _fake_call(config, name, arguments):  # noqa: ARG001
+        captured["arguments"] = arguments
+        return {"is_error": False, "text": "", "structured_content": [], "content": []}
+
+    mock_config = MagicMock()
+    with (
+        patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None),
+        patch("app.tools.GitHubSearchCodeTool.build_github_mcp_config", return_value=mock_config),
+        patch("app.tools.GitDeployTimelineTool.call_github_mcp_tool", side_effect=_fake_call),
+    ):
+        result = get_git_deploy_timeline(
+            owner="org",
+            repo="repo",
+            since=since,
+            until=until,
+            window_minutes_before_alert=window_minutes_before_alert,
+            shared_incident_window=shared_window,
+            github_url="http://mcp",
+            github_mode="streamable-http",
+            github_token="tok",
+        )
+    return captured, result
+
+
+def test_extract_params_passes_shared_incident_window_through() -> None:
+    """The tool's extract_params reads ``_meta.incident_window`` from sources
+    and threads it as the ``shared_incident_window`` kwarg."""
+    rt = get_git_deploy_timeline.__opensre_registered_tool__
+    sources = mock_agent_state()
+    sources["_meta"] = {
+        "incident_window": _shared_window_dict("2026-04-20T08:00:00Z", "2026-04-20T10:00:00Z")
+    }
+    params = rt.extract_params(sources)
+    assert params["shared_incident_window"] == sources["_meta"]["incident_window"]
+
+
+def test_extract_params_handles_missing_meta_key() -> None:
+    """If ``_meta`` is absent (e.g. extract_alert hasn't run yet),
+    extract_params returns ``shared_incident_window=None`` cleanly."""
+    rt = get_git_deploy_timeline.__opensre_registered_tool__
+    params = rt.extract_params(mock_agent_state())
+    assert params["shared_incident_window"] is None
+
+
+def test_extract_params_defensive_against_non_dict_meta() -> None:
+    """If ``_meta`` is ever populated with a non-dict (e.g. a future bug
+    upstream), extract_params must not raise — it degrades to None."""
+    rt = get_git_deploy_timeline.__opensre_registered_tool__
+    sources = mock_agent_state()
+    sources["_meta"] = "not-a-dict"  # type: ignore[assignment]
+    params = rt.extract_params(sources)
+    assert params["shared_incident_window"] is None
+
+
+def test_extract_params_defensive_against_non_dict_incident_window() -> None:
+    """If the nested incident_window is non-dict, same degradation."""
+    rt = get_git_deploy_timeline.__opensre_registered_tool__
+    sources = mock_agent_state()
+    sources["_meta"] = {"incident_window": "garbage"}
+    params = rt.extract_params(sources)
+    assert params["shared_incident_window"] is None
+
+
+def test_run_uses_shared_window_when_no_caller_override() -> None:
+    """When neither since/until nor window_minutes_before_alert is given,
+    the tool MUST use the shared incident window."""
+    shared = _shared_window_dict("2026-04-20T08:00:00Z", "2026-04-20T10:00:00Z")
+    captured, result = _run_with_shared_window(shared)
+    assert captured["arguments"]["since"] == "2026-04-20T08:00:00Z"
+    assert captured["arguments"]["until"] == "2026-04-20T10:00:00Z"
+    assert result["window"]["source"] == "shared_incident_window"
+
+
+def test_run_caller_since_until_overrides_shared_window() -> None:
+    """Explicit since/until from the caller wins over the shared window."""
+    shared = _shared_window_dict("2026-04-20T08:00:00Z", "2026-04-20T10:00:00Z")
+    captured, result = _run_with_shared_window(
+        shared,
+        since="2026-04-20T11:00:00Z",
+        until="2026-04-20T11:30:00Z",
+    )
+    assert captured["arguments"]["since"] == "2026-04-20T11:00:00Z"
+    assert captured["arguments"]["until"] == "2026-04-20T11:30:00Z"
+    assert result["window"]["source"] == "tool_default"
+
+
+def test_run_caller_window_minutes_overrides_shared_window() -> None:
+    """Explicit window_minutes_before_alert from the caller also wins."""
+    shared = _shared_window_dict("2026-04-20T08:00:00Z", "2026-04-20T10:00:00Z")
+    _, result = _run_with_shared_window(shared, window_minutes_before_alert=30)
+    # Did NOT use the shared window — used the explicit 30-min lookback.
+    assert result["window"]["source"] == "tool_default"
+
+
+def test_run_falls_back_to_default_when_no_shared_window() -> None:
+    """Backward compat: no shared window present, no overrides → existing
+    DEFAULT_WINDOW_MINUTES default."""
+    captured, result = _run_with_shared_window(None)
+    # 'until' should be ~now, 'since' should be 120 min before now.
+    until_dt = datetime.fromisoformat(captured["arguments"]["until"].replace("Z", "+00:00"))
+    since_dt = datetime.fromisoformat(captured["arguments"]["since"].replace("Z", "+00:00"))
+    assert (until_dt - since_dt) == timedelta(minutes=DEFAULT_WINDOW_MINUTES)
+    assert result["window"]["source"] == "tool_default"
+
+
+def test_run_malformed_shared_window_falls_back_to_default() -> None:
+    """A malformed shared window dict must not crash; tool falls back."""
+    captured, result = _run_with_shared_window({"junk": "not a window"})
+    until_dt = datetime.fromisoformat(captured["arguments"]["until"].replace("Z", "+00:00"))
+    since_dt = datetime.fromisoformat(captured["arguments"]["since"].replace("Z", "+00:00"))
+    assert (until_dt - since_dt) == timedelta(minutes=DEFAULT_WINDOW_MINUTES)
+    assert result["window"]["source"] == "tool_default"
+
+
+# ---------------------------------------------------------------------------
 # _resolve_window
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
PR 2 of the dynamic incident-window work. Stacked on PR 1 (foundation).

What was needed:
  PR 1 added state.incident_window populated by extract_alert from the
  alert's own timestamps. But no tool reads it yet. This PR proves the
  end-to-end pattern with one tool: GitDeployTimelineTool.

What this PR does:
  - app/nodes/investigate/models.py: InvestigateInput gains a typed
    incident_window: dict | None. from_state populates it from
    state.incident_window with a defensive isinstance check.

  - app/nodes/plan_actions/plan_actions.py: after detect_sources runs,
    the wrapping step attaches available_sources["_meta"] = {
    "incident_window": <dict>} when input_data.incident_window is set.
    The "_meta" key is reserved for investigation-level context shared
    across tools — today only the incident window, future PRs may add
    window history. The key is OMITTED when state has no window so the
    sources dict shape stays clean for tools that don't opt in.

  - app/tools/GitDeployTimelineTool/__init__.py:
      * extract_params reads sources.get("_meta", {}).get(
        "incident_window") and threads it as the shared_incident_window
        kwarg. Defensive isinstance guards against non-dict _meta or
        non-dict incident_window so a future upstream bug cannot crash
        the tool.
      * The function gains a new shared_incident_window: dict | None
        parameter. window_minutes_before_alert default changed from
        DEFAULT_WINDOW_MINUTES to None so the tool can distinguish
        "caller didn't override" from "caller wants 120 min".
      * Resolution priority (highest -> lowest):
          1. caller-explicit since AND until
          2. caller-explicit window_minutes_before_alert
          3. shared_incident_window from agent state (parsed via
             IncidentWindow.from_dict; None on bad shape -> falls
             through to default)
          4. DEFAULT_WINDOW_MINUTES (120 min)
      * Returned window dict gains a "source" field that reports
        "shared_incident_window" or "tool_default" so the diagnose
        narrative can explain where the window came from.

  - app/nodes/plan_actions/build_prompt.py: one-line update to the
    GitHub planning hint telling the agent the tool now auto-picks up
    the shared incident window when no explicit args are passed.

What's not in this PR (deferred to follow-ups):
  - No other tool migrated yet (Datadog Context, Grafana Logs, etc.).
    Each is a small ~50-line follow-up using the same pattern.
  - No adaptive expansion / contraction logic. PR 3 adds that.

Tests (14 new):
  Tool integration:
    - extract_params reads _meta.incident_window and passes it through
    - extract_params handles missing _meta key (returns None)
    - extract_params defensive against non-dict _meta (returns None)
    - extract_params defensive against non-dict incident_window
      (returns None)
    - run uses shared window when caller passes no overrides
    - caller since/until overrides shared window (caller wins)
    - caller window_minutes_before_alert overrides shared window
    - falls back to DEFAULT_WINDOW_MINUTES when no shared window present
    - falls back to default when shared window dict is malformed

  Wiring contract:
    - InvestigateInput surfaces incident_window from state
    - InvestigateInput defaults to None when state has no window
    - InvestigateInput rejects non-dict incident_window (defensive)
    - _meta.incident_window attached when state has one
    - _meta key omitted entirely when state has no window
