### PR TITLE
fix(remote): tighten investigation id validation and add invalid-id endpoint tests

### DIFF
--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -513,7 +513,7 @@ def list_investigations() -> list[InvestigationMeta]:
     return items
 
 
-@app.get("/investigations/{inv_id}")
+@app.get("/investigations/{inv_id:path}")
 def get_investigation(inv_id: str) -> Response:
     """Return the raw ``.md`` content of a single investigation."""
     path = _safe_investigation_path(inv_id)
@@ -527,7 +527,7 @@ def get_investigation(inv_id: str) -> Response:
 # ---------------------------------------------------------------------------
 
 
-_SAFE_INV_ID = re.compile(r"^[\w\-]+\Z")
+_SAFE_INV_ID = re.compile(r"^[\w-]+$")
 
 
 def _safe_investigation_path(inv_id: str) -> Path:

--- a/tests/app/remote/test_server.py
+++ b/tests/app/remote/test_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from urllib.parse import quote
 
 import pytest
 from fastapi import HTTPException
@@ -64,6 +65,33 @@ def test_protected_remote_endpoint_requires_matching_api_key(
     assert wrong_response.status_code == 403
     assert valid_response.status_code == 200
     assert valid_response.json() == []
+
+
+@pytest.mark.parametrize(
+    "invalid_id",
+    [
+        "../x",
+        "x/..",
+        "x.md",
+        "x y",
+        "x$y",
+    ],
+)
+def test_get_investigation_rejects_invalid_id_with_bad_request(
+    monkeypatch: pytest.MonkeyPatch,
+    remote_client: TestClient,
+    invalid_id: str,
+) -> None:
+    monkeypatch.setattr(remote_server, "_AUTH_KEY", "secret-key")
+    encoded_id = quote(invalid_id, safe="")
+
+    response = remote_client.get(
+        f"/investigations/{encoded_id}",
+        headers={"x-api-key": "secret-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid investigation ID"}
 
 
 @pytest.mark.parametrize("path", ["/ok", "/version", "/health/deep"])


### PR DESCRIPTION
Fixes #743

#### Describe the changes you have made in this PR -

This PR tightens the investigation ID validation on the remote server:

1. **Anchored regex pattern:** Updated `_SAFE_INV_ID` to use explicit start/end anchors (`^[\w-]+$`) for clarity and intent, making it unambiguous that only word characters and hyphens are accepted.

2. **Route parameter capture:** Changed the investigation route from `{inv_id}` to `{inv_id:path}` to ensure slash-like invalid IDs reach the validation layer consistently rather than being rejected at the routing level.

3. **Endpoint validation tests:** Added `test_get_investigation_rejects_invalid_id_with_bad_request` covering multiple invalid patterns (`../x`, `x/..`, `x.md`, `x y`, `x$y`) that must return `400 Invalid investigation ID`.

All changes are backward compatible and improve path-traversal protection + test coverage for issue #743 acceptance criteria.

### Demo/Screenshot for feature changes and bug fixes - 
 
<img width="551" height="155" alt="image" src="https://github.com/user-attachments/assets/ba3108d3-3ba8-428c-a65a-6201a3a5df92" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (GitHub Copilot)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue asked for two things: (1) make the regex explicitly anchored for readability, and (2) add tests for invalid IDs returning 400.

I chose a minimal approach:
- Updated the regex from `^[\w\-]+\Z` to `^[\w-]+$` for clarity (explicit start/end anchors instead of Python-specific `\Z` notation).
- Changed the route to capture full path segments so IDs like `../x` reach validation instead of being rejected by the framework.
- Added a parametrized endpoint test for 5 invalid patterns that must consistently return `400 Invalid investigation ID`.
- Kept newline-based validation at the utility test level (already thorough) to avoid relying on HTTP-framework normalization behavior.

The fix is focused, backwards-compatible, and passes all remote-server tests plus broader lint/type checks.

---
