### PR TITLE
refactor(wizard): migrate Slack webhook validation from requests to httpx

### DIFF
--- a/app/cli/wizard/integration_health.py
+++ b/app/cli/wizard/integration_health.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import requests
+import httpx
 
 from app.integrations.betterstack import build_betterstack_config, validate_betterstack_config
 from app.integrations.github_mcp import (
@@ -182,8 +182,12 @@ def validate_slack_webhook(*, webhook_url: str) -> IntegrationHealthResult:
         return IntegrationHealthResult(ok=False, detail=str(err))
 
     try:
-        response = requests.get(slack_config.webhook_url, timeout=10, allow_redirects=False)
-    except requests.RequestException as err:
+        response = httpx.get(
+            slack_config.webhook_url,
+            timeout=10,
+            follow_redirects=False,
+        )
+    except httpx.RequestError as err:
         return IntegrationHealthResult(ok=False, detail=f"Slack webhook validation failed: {err}")
 
     if response.status_code == 404:

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import types
 
+import httpx
 import pytest
 
 from app.cli.wizard.integration_health import (
@@ -123,21 +124,25 @@ def test_validate_coralogix_integration_fails(monkeypatch) -> None:
     assert "http 401" in result.detail.lower()
 
 
-def test_validate_slack_webhook_succeeds_with_non_posting_probe(monkeypatch) -> None:
+@pytest.mark.parametrize("status_code", [200, 400, 403, 405])
+def test_validate_slack_webhook_succeeds_for_allowed_probe_statuses(
+    monkeypatch,
+    status_code: int,
+) -> None:
     monkeypatch.setattr(
-        "app.cli.wizard.integration_health.requests.get",
-        lambda *_args, **_kwargs: types.SimpleNamespace(status_code=405),
+        "app.cli.wizard.integration_health.httpx.get",
+        lambda *_args, **_kwargs: types.SimpleNamespace(status_code=status_code),
     )
 
     result = validate_slack_webhook(webhook_url="https://hooks.slack.com/services/T000/B000/abc")
 
     assert result.ok is True
-    assert "non-posting probe" in result.detail
+    assert f"HTTP {status_code}" in result.detail
 
 
 def test_validate_slack_webhook_fails_for_not_found(monkeypatch) -> None:
     monkeypatch.setattr(
-        "app.cli.wizard.integration_health.requests.get",
+        "app.cli.wizard.integration_health.httpx.get",
         lambda *_args, **_kwargs: types.SimpleNamespace(status_code=404),
     )
 
@@ -145,6 +150,22 @@ def test_validate_slack_webhook_fails_for_not_found(monkeypatch) -> None:
 
     assert result.ok is False
     assert "404" in result.detail
+
+
+def test_validate_slack_webhook_fails_for_httpx_request_error(monkeypatch) -> None:
+    def _raise_request_error(*_args, **_kwargs):
+        raise httpx.RequestError(
+            "connection failed",
+            request=httpx.Request("GET", "https://hooks.slack.com/services/T000/B000/abc"),
+        )
+
+    monkeypatch.setattr("app.cli.wizard.integration_health.httpx.get", _raise_request_error)
+
+    result = validate_slack_webhook(webhook_url="https://hooks.slack.com/services/T000/B000/abc")
+
+    assert result.ok is False
+    assert "slack webhook validation failed" in result.detail.lower()
+    assert "connection failed" in result.detail.lower()
 
 
 def test_validate_slack_webhook_fails_for_invalid_host() -> None:

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -137,6 +137,7 @@ def test_validate_slack_webhook_succeeds_for_allowed_probe_statuses(
     result = validate_slack_webhook(webhook_url="https://hooks.slack.com/services/T000/B000/abc")
 
     assert result.ok is True
+    assert "non-posting probe" in result.detail.lower()
     assert f"HTTP {status_code}" in result.detail
 
 


### PR DESCRIPTION
Fixes #874

#### Describe the changes you have made in this PR -

This PR updates only the Slack webhook validator in the onboarding health checks.

What changed:
1. Switched `validate_slack_webhook()` from `requests.get(...)` to `httpx.get(...)`.
2. Kept existing behavior unchanged for status handling:
   - 404 -> invalid webhook (fail)
   - 200, 400, 403, 405 -> reachable endpoint (pass)
   - all others -> unexpected status (fail)
3. Kept existing success/failure message behavior intact.

Test updates:
1. Added one test for `httpx.RequestError` network failure handling.
2. Added one test to confirm allowed status codes still pass (`200, 400, 403, 405`).
3. Updated Slack-specific mocks to use `httpx.get`.

No other validators were changed.

### Demo/Screenshot for feature changes and bug fixes -

Validation run for this change:
- ✅ `tests/cli/wizard/test_integration_health.py` — 30 passed
- ✅ `ruff check app/cli/wizard/integration_health.py tests/cli/wizard/test_integration_health.py`
- ✅ `ruff format --check app/cli/wizard/integration_health.py tests/cli/wizard/test_integration_health.py`
- ✅ `mypy app/cli/wizard/integration_health.py` (no issues)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (GitHub Copilot)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue asked for a focused migration of only `validate_slack_webhook()` from `requests` to `httpx`, while preserving behavior and extending coverage.

I made the smallest change possible:
- replaced `requests` call + exception handling with equivalent `httpx` call + `httpx.RequestError`
- left status code behavior and messages unchanged
- added the two tests requested in the issue

This keeps the PR scoped, readable, and behaviorally safe.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions