### PR TITLE
Unit test datadog client

### DIFF
--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -1,0 +1,212 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+import httpx
+
+from app.services.datadog.client import DatadogClient, DatadogConfig
+
+
+@pytest.fixture
+def config():
+    return DatadogConfig(
+        api_key="test-api-key",
+        app_key="test-app-key",
+        site="datadoghq.com",
+    )
+
+
+@pytest.fixture
+def client(config):
+    return DatadogClient(config)
+
+
+@pytest.fixture
+def mock_httpx_client():
+    with patch("app.services.datadog.client.httpx.Client") as mock:
+        yield mock
+
+
+# -------------------------
+# search_logs
+# -------------------------
+
+def test_search_logs_success(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "attributes": {
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": "log message",
+                    "status": "info",
+                    "service": "api",
+                    "host": "host1",
+                    "tags": ["env:prod"],
+                    "attributes": {"pod_name": "pod-1"},
+                }
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_instance.post.return_value = mock_response
+
+    result = client.search_logs("error")
+
+    assert result["success"] is True
+    assert len(result["logs"]) == 1
+    assert result["logs"][0]["message"] == "log message"
+
+
+def test_search_logs_empty_data(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": []}
+    mock_response.raise_for_status.return_value = None
+    mock_instance.post.return_value = mock_response
+
+    result = client.search_logs("error")
+
+    assert result["success"] is True
+    assert result["logs"] == []
+    assert result["total"] == 0
+
+
+def test_search_logs_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "server error"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_instance.post.side_effect = error
+
+    result = client.search_logs("error")
+
+    assert result["success"] is False
+    assert "HTTP 500" in result["error"]
+
+
+# -------------------------
+# list_monitors
+# -------------------------
+
+def test_list_monitors_success(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {
+            "id": 1,
+            "name": "CPU Monitor",
+            "type": "metric alert",
+            "query": "avg:cpu",
+            "message": "alert",
+            "overall_state": "OK",
+            "tags": ["env:prod"],
+        }
+    ]
+    mock_response.raise_for_status.return_value = None
+    mock_instance.get.return_value = mock_response
+
+    result = client.list_monitors()
+
+    assert result["success"] is True
+    assert len(result["monitors"]) == 1
+    assert result["monitors"][0]["name"] == "CPU Monitor"
+
+
+def test_list_monitors_empty(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status.return_value = None
+    mock_instance.get.return_value = mock_response
+
+    result = client.list_monitors()
+
+    assert result["success"] is True
+    assert result["monitors"] == []
+
+
+def test_list_monitors_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.text = "forbidden"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_instance.get.side_effect = error
+
+    result = client.list_monitors()
+
+    assert result["success"] is False
+    assert "HTTP 403" in result["error"]
+
+
+# -------------------------
+# get_events
+# -------------------------
+
+def test_get_events_success(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "attributes": {
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "title": "event title",
+                    "message": "event message",
+                    "tags": ["env:prod"],
+                    "source": "datadog",
+                }
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_instance.post.return_value = mock_response
+
+    result = client.get_events("error")
+
+    assert result["success"] is True
+    assert len(result["events"]) == 1
+    assert result["events"][0]["title"] == "event title"
+
+
+def test_get_events_empty(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": []}
+    mock_response.raise_for_status.return_value = None
+    mock_instance.post.return_value = mock_response
+
+    result = client.get_events()
+
+    assert result["success"] is True
+    assert result["events"] == []

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -25,6 +25,39 @@ def mock_httpx_client():
         yield mock
 
 
+def test_is_configured_true():
+    config = DatadogConfig(api_key="test", app_key="test")
+    client = DatadogClient(config)
+    assert client.is_configured is True
+
+
+def test_is_configured_false():
+    config = DatadogConfig(api_key="", app_key="")
+    client = DatadogClient(config)
+    assert client.is_configured is False
+
+
+def test_is_configured_missing_api_key():
+    config = DatadogConfig(api_key="", app_key="key")
+    client = DatadogClient(config)
+
+    assert client.is_configured is False
+
+
+def test_is_configured_missing_app_key():
+    config = DatadogConfig(api_key="key", app_key="")
+    client = DatadogClient(config)
+
+    assert client.is_configured is False
+
+
+def test_is_configured_both_empty():
+    config = DatadogConfig(api_key="", app_key="")
+    client = DatadogClient(config)
+
+    assert client.is_configured is False
+
+
 # -------------------------
 # search_logs
 # -------------------------
@@ -142,6 +175,7 @@ def test_list_monitors_empty(client, mock_httpx_client):
 
     assert result["success"] is True
     assert result["monitors"] == []
+    assert result["total"] == 0
 
 
 def test_list_monitors_http_error(client, mock_httpx_client):
@@ -212,3 +246,62 @@ def test_get_events_empty(client, mock_httpx_client):
 
     assert result["success"] is True
     assert result["events"] == []
+    assert result["total"] == 0
+
+
+def test_get_events_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "server error"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_instance.post.side_effect = error
+
+    result = client.get_events("error")
+
+    assert result["success"] is False
+    assert "HTTP 500" in result["error"]
+
+
+def test_search_logs_generic_exception(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_instance.post.side_effect = Exception("unexpected error")
+
+    result = client.search_logs("error")
+
+    assert result["success"] is False
+    assert result["error"] == "unexpected error"
+
+
+def test_list_monitors_generic_exception(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_instance.get.side_effect = Exception("boom")
+
+    result = client.list_monitors()
+
+    assert result["success"] is False
+    assert result["error"] == "boom"
+
+
+def test_get_events_generic_exception(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_instance.post.side_effect = Exception("timeout")
+
+    result = client.get_events("error")
+
+    assert result["success"] is False
+    assert result["error"] == "timeout"

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -1,4 +1,3 @@
-
 import pytest
 from unittest.mock import MagicMock, patch
 import httpx
@@ -29,6 +28,7 @@ def mock_httpx_client():
 # -------------------------
 # search_logs
 # -------------------------
+
 
 def test_search_logs_success(client, mock_httpx_client):
     mock_instance = MagicMock()
@@ -102,6 +102,7 @@ def test_search_logs_http_error(client, mock_httpx_client):
 # list_monitors
 # -------------------------
 
+
 def test_list_monitors_success(client, mock_httpx_client):
     mock_instance = MagicMock()
     mock_httpx_client.return_value = mock_instance
@@ -168,6 +169,7 @@ def test_list_monitors_http_error(client, mock_httpx_client):
 # -------------------------
 # get_events
 # -------------------------
+
 
 def test_get_events_success(client, mock_httpx_client):
     mock_instance = MagicMock()


### PR DESCRIPTION
Fixes #878 

<!-- Add issue number above --> 


#### Describe the changes you have made in this PR -

Added a dedicated service-layer test suite for the `DatadogClient` integration to ensure direct coverage of core Datadog API interactions without relying on tool-layer tests.

### Key changes:
- Introduced `tests/services/test_datadog_client.py`
- Added unit tests for:
  - `search_logs()` (success, HTTP failure, empty response)
  - `list_monitors()` (success, HTTP failure, empty response)
  - `get_events()` (success, HTTP failure, empty response)
  - `is_configured` validation
- Mocked `httpx.Client` to ensure no real Datadog API calls are made
- Ensured service-layer isolation so tool tests no longer implicitly validate client logic
- Verified consistent response normalization across logs, monitors, and events APIs

---


### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

## Explain your implementation approach:

This PR introduces service-level testing for the Datadog integration to improve test isolation, reliability, and maintainability.

Previously, Datadog client behavior was only indirectly validated through tool-layer tests. This created tight coupling between layers and made failures harder to trace and debug.

---

## What this solves:
- Ensures Datadog API logic is directly tested at the service layer  
- Removes dependency on tool-layer tests for validating core client behavior  
- Improves test clarity, isolation, and maintainability  
- Makes failures easier to debug by localizing responsibility to the service layer  

---

## Implementation approach:
- Used `httpx.Client` mocking to simulate Datadog API responses without making real network calls  
- Covered both success and failure scenarios for each endpoint:
  - logs (`search_logs`)
  - monitors (`list_monitors`)
  - events (`get_events`)  
- Verified response normalization logic (ensuring consistent structure for logs, monitors, and events)  
- Added coverage for configuration state validation via `is_configured`  

---

## Key design choice:

I chose service-layer mocking instead of integration testing to ensure:

- Deterministic and stable test execution in CI  
- No dependency on external Datadog credentials or network availability  
- Faster test execution and improved developer feedback loop  
- Clear separation between service logic and tool-layer orchestration  

This approach ensures that the Datadog client is independently verifiable and does not rely on higher-level tool tests for correctness.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
