### PR TITLE
docs: add redirects for common post-signup URL patterns

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -204,6 +204,14 @@
       }
     ]
   },
+  "redirects": [
+    { "source": "/getting-started", "destination": "/quickstart" },
+    { "source": "/onboarding",      "destination": "/quickstart" },
+    { "source": "/welcome",         "destination": "/quickstart" },
+    { "source": "/start",           "destination": "/quickstart" },
+    { "source": "/setup",           "destination": "/quickstart" },
+    { "source": "/docs",            "destination": "/quickstart" }
+  ],
   "navbar": {
     "links": [
       {


### PR DESCRIPTION
## Summary

After signing up at `app.tracer.cloud`, users are redirected to a documentation page. If that redirect targets a URL like `/getting-started`, `/onboarding`, `/welcome`, `/start`, `/setup`, or bare `/docs`, Mintlify returns a 404 because none of those routes exist in the current navigation.

This PR adds a `redirects` block to `docs.json` so all common post-signup entry-point aliases route to `/quickstart` instead of a blank 404 page.

**Redirects added:**
- `/getting-started` → `/quickstart`
- `/onboarding` → `/quickstart`
- `/welcome` → `/quickstart`
- `/start` → `/quickstart`
- `/setup` → `/quickstart`
- `/docs` → `/quickstart`

## Test plan

- [ ] `docs/docs.json` is valid JSON (verified locally)
- [ ] Visiting any of the redirect sources on the deployed docs site routes to `/quickstart` with no 404

Closes #947