### PR TITLE
refactor(publish): collapse two-step ingest flow into one explicit helper

### DIFF
--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -30,6 +30,54 @@ def _build_mr_note(slack_message: str) -> str:
     return f"### RCA Finding\n\n<details>\n<summary>Investigation summary</summary>\n\n{body}\n\n</details>"
 
 
+def _create_investigation_and_attach_url(
+    state: InvestigationState,
+    *,
+    report_md: str,
+    summary: str | None,
+) -> tuple[str | None, str | None]:
+    """Create an investigation record and attach the public URL in a follow-up ingest call.
+
+    Step 1 – persist the report and obtain the ``investigation_id``.
+    Step 2 – if an ID was returned, build the investigation URL and send a
+             second ingest to attach it so the web app can link to the record.
+
+    Returns ``(investigation_id, investigation_url)``.
+    """
+    # Step 1: persist the report and obtain the investigation_id.
+    investigation_id: str | None = None
+    try:
+        state_with_report = cast(
+            InvestigationState,
+            {**state, "problem_report": {"report_md": report_md}, "summary": summary},
+        )
+        investigation_id = send_ingest(state_with_report)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[publish] ingest failed: %s", exc)
+
+    investigation_url = get_investigation_url(state.get("organization_slug"), investigation_id)
+
+    # Step 2: attach the investigation URL so the web app can link to the record.
+    if investigation_id:
+        try:
+            state_with_url = cast(
+                InvestigationState,
+                {
+                    **state,
+                    "problem_report": {
+                        "report_md": report_md,
+                        "investigation_url": investigation_url,
+                    },
+                    "summary": summary,
+                },
+            )
+            send_ingest(state_with_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[publish] ingest url attachment failed: %s", exc)
+
+    return investigation_id, investigation_url
+
+
 def generate_report(state: InvestigationState) -> dict:
     """Generate and publish the final RCA report."""
     from app.utils.slack_delivery import build_action_blocks, send_slack_report
@@ -45,36 +93,9 @@ def generate_report(state: InvestigationState) -> dict:
     if isinstance(short_summary, str):
         short_summary = masking_ctx.unmask(short_summary)
 
-    # First ingest: persist the report and get back the investigation_id
-    investigation_id: str | None = None
-    try:
-        state_with_report = cast(
-            InvestigationState,
-            {**state, "problem_report": {"report_md": slack_message}, "summary": short_summary},
-        )
-        investigation_id = send_ingest(state_with_report)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("[publish] ingest failed: %s", exc)
-
-    investigation_url = get_investigation_url(state.get("organization_slug"), investigation_id)
-
-    # Second ingest: update the record with the investigation_url so the web app can link to it
-    if investigation_id:
-        try:
-            state_with_url = cast(
-                InvestigationState,
-                {
-                    **state,
-                    "problem_report": {
-                        "report_md": slack_message,
-                        "investigation_url": investigation_url,
-                    },
-                    "summary": short_summary,
-                },
-            )
-            send_ingest(state_with_url)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("[publish] ingest url update failed: %s", exc)
+    investigation_id, investigation_url = _create_investigation_and_attach_url(
+        state, report_md=slack_message, summary=short_summary
+    )
 
     all_blocks = build_slack_blocks(ctx) + build_action_blocks(investigation_url, investigation_id)
     all_blocks = masking_ctx.unmask_value(all_blocks)

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -97,7 +97,9 @@ def generate_report(state: InvestigationState) -> dict:
         state, report_md=slack_message, summary=short_summary
     )
 
-    all_blocks = build_slack_blocks(ctx) + build_action_blocks(investigation_url, investigation_id)
+    all_blocks = build_slack_blocks(ctx) + build_action_blocks(
+        investigation_url or "", investigation_id
+    )
     all_blocks = masking_ctx.unmask_value(all_blocks)
     render_report(slack_message, root_cause_category=state.get("root_cause_category"))
     open_in_editor(slack_message)

--- a/app/utils/ingest_delivery.py
+++ b/app/utils/ingest_delivery.py
@@ -135,3 +135,61 @@ def send_ingest(state: InvestigationState) -> str | None:
     except Exception as exc:  # noqa: BLE001
         logger.warning("[ingest] Delivery failed: %s", exc)
     return None
+
+
+def ingest_investigation_with_url(
+    state: InvestigationState,
+    *,
+    report_md: str,
+    summary: str | None,
+    investigation_url: str | None,
+) -> str | None:
+    """Create an investigation record and, if an ID is returned, attach the URL.
+
+    This collapses the two-step ingest sequence into one explicit helper:
+
+    1. Call ``send_ingest`` with the report to create the investigation and
+       receive back an ``investigation_id``.
+    2. If an ID was returned *and* an ``investigation_url`` is available, call
+       ``send_ingest`` a second time to attach the URL so the web app can link
+       to the investigation.
+
+    Returns the ``investigation_id`` from step 1 (or ``None`` when step 1
+    fails or is skipped).
+    """
+    from typing import cast
+
+    # Step 1: persist the report and obtain the investigation_id.
+    investigation_id: str | None = None
+    try:
+        state_with_report = cast(
+            InvestigationState,
+            {
+                **state,
+                "problem_report": {"report_md": report_md},
+                "summary": summary,
+            },
+        )
+        investigation_id = send_ingest(state_with_report)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[ingest] initial ingest failed: %s", exc)
+
+    # Step 2: attach the investigation URL if we have both an ID and a URL.
+    if investigation_id and investigation_url:
+        try:
+            state_with_url = cast(
+                InvestigationState,
+                {
+                    **state,
+                    "problem_report": {
+                        "report_md": report_md,
+                        "investigation_url": investigation_url,
+                    },
+                    "summary": summary,
+                },
+            )
+            send_ingest(state_with_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[ingest] url attachment ingest failed: %s", exc)
+
+    return investigation_id

--- a/tests/nodes/publish_findings/test_ingest_flow.py
+++ b/tests/nodes/publish_findings/test_ingest_flow.py
@@ -1,0 +1,326 @@
+"""Tests for the collapsed ingest helper introduced in issue #867.
+
+Covers:
+- ``ingest_investigation_with_url`` in ``app.utils.ingest_delivery``
+- ``_create_investigation_and_attach_url`` in ``app.nodes.publish_findings.node``
+
+Acceptance criteria (from issue #867):
+- ``generate_report()`` no longer contains the duplicated ingest sequence inline.
+- Failure behaviour stays the same.
+- The helper name clearly explains the two-step flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.nodes.publish_findings.node import _create_investigation_and_attach_url
+from app.utils.ingest_delivery import ingest_investigation_with_url
+
+# ---------------------------------------------------------------------------
+# Minimal state factory
+# ---------------------------------------------------------------------------
+
+
+def _make_state(**overrides: Any) -> dict:
+    base: dict[str, Any] = {
+        "org_id": "org-123",
+        "alert_name": "HighCPU",
+        "thread_id": "T001",
+        "run_id": "run-001",
+        "severity": "high",
+        "organization_slug": "acme",
+        "summary": None,
+        "problem_md": None,
+        "root_cause": None,
+        "raw_alert": {},
+        "planned_actions": [],
+        "investigation_recommendations": [],
+        "validity_score": 0,
+        "pipeline_name": "",
+        "problem_report": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# ingest_investigation_with_url
+# ===========================================================================
+
+
+class TestIngestInvestigationWithUrl:
+    """Unit tests for ``ingest_investigation_with_url``."""
+
+    def test_happy_path_calls_send_ingest_twice(self) -> None:
+        """Both ingest calls are made when the first returns an investigation_id."""
+        state = _make_state()
+
+        with patch("app.utils.ingest_delivery.send_ingest", return_value="inv-abc") as mock_send:
+            result = ingest_investigation_with_url(
+                state,
+                report_md="# Report",
+                summary="short summary",
+                investigation_url="https://app.tracer.cloud/inv/inv-abc",
+            )
+
+        assert result == "inv-abc"
+        assert mock_send.call_count == 2
+
+        # First call: report only, no URL
+        first_state = mock_send.call_args_list[0][0][0]
+        assert first_state["problem_report"] == {"report_md": "# Report"}
+        assert first_state["summary"] == "short summary"
+
+        # Second call: report + URL attached
+        second_state = mock_send.call_args_list[1][0][0]
+        assert second_state["problem_report"] == {
+            "report_md": "# Report",
+            "investigation_url": "https://app.tracer.cloud/inv/inv-abc",
+        }
+
+    def test_no_investigation_id_skips_url_attachment(self) -> None:
+        """When the first ingest returns None, no URL-attachment call is made."""
+        state = _make_state()
+
+        with patch("app.utils.ingest_delivery.send_ingest", return_value=None) as mock_send:
+            result = ingest_investigation_with_url(
+                state,
+                report_md="# Report",
+                summary=None,
+                investigation_url="https://app.tracer.cloud/inv/whatever",
+            )
+
+        assert result is None
+        assert mock_send.call_count == 1
+
+    def test_no_url_skips_second_ingest(self) -> None:
+        """When investigation_url is None, only the first ingest is called."""
+        state = _make_state()
+
+        with patch("app.utils.ingest_delivery.send_ingest", return_value="inv-xyz") as mock_send:
+            result = ingest_investigation_with_url(
+                state,
+                report_md="# Report",
+                summary=None,
+                investigation_url=None,
+            )
+
+        assert result == "inv-xyz"
+        assert mock_send.call_count == 1
+
+    def test_first_ingest_raises_returns_none_and_skips_url_step(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If the first send_ingest raises, None is returned and the URL step is skipped."""
+        state = _make_state()
+
+        with (
+            patch(
+                "app.utils.ingest_delivery.send_ingest",
+                side_effect=RuntimeError("network error"),
+            ) as mock_send,
+            caplog.at_level("WARNING", logger="app.utils.ingest_delivery"),
+        ):
+            result = ingest_investigation_with_url(
+                state,
+                report_md="# Report",
+                summary=None,
+                investigation_url="https://app.tracer.cloud/inv/x",
+            )
+
+        assert result is None
+        assert mock_send.call_count == 1
+        assert "initial ingest failed" in caplog.text
+
+    def test_second_ingest_raises_still_returns_investigation_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If the URL-attachment call fails, the investigation_id is still returned."""
+        state = _make_state()
+
+        send_results = ["inv-999", RuntimeError("timeout")]
+
+        def _side_effect(*_args: Any, **_kwargs: Any) -> str:
+            val = send_results.pop(0)
+            if isinstance(val, Exception):
+                raise val
+            return val
+
+        with (
+            patch("app.utils.ingest_delivery.send_ingest", side_effect=_side_effect),
+            caplog.at_level("WARNING", logger="app.utils.ingest_delivery"),
+        ):
+            result = ingest_investigation_with_url(
+                state,
+                report_md="# Report",
+                summary=None,
+                investigation_url="https://app.tracer.cloud/inv/inv-999",
+            )
+
+        assert result == "inv-999"
+        assert "url attachment ingest failed" in caplog.text
+
+    def test_state_is_not_mutated(self) -> None:
+        """The original state dict must not be modified by the helper."""
+        state = _make_state()
+        original_keys = set(state.keys())
+        original_report = state.get("problem_report")
+
+        with patch("app.utils.ingest_delivery.send_ingest", return_value="inv-001"):
+            ingest_investigation_with_url(
+                state,
+                report_md="# Report",
+                summary="s",
+                investigation_url="https://app.tracer.cloud/inv/inv-001",
+            )
+
+        assert set(state.keys()) == original_keys
+        assert state.get("problem_report") == original_report
+
+
+# ===========================================================================
+# _create_investigation_and_attach_url  (node-level helper)
+# ===========================================================================
+
+
+class TestCreateInvestigationAndAttachUrl:
+    """Unit tests for ``_create_investigation_and_attach_url`` in node.py."""
+
+    def test_returns_id_and_url_on_success(self) -> None:
+        """Returns a (investigation_id, investigation_url) tuple on full success."""
+        state = _make_state(organization_slug="acme")
+
+        with (
+            patch("app.nodes.publish_findings.node.send_ingest", return_value="inv-42"),
+            patch(
+                "app.nodes.publish_findings.node.get_investigation_url",
+                return_value="https://app.tracer.cloud/acme/inv-42",
+            ),
+        ):
+            inv_id, inv_url = _create_investigation_and_attach_url(
+                state, report_md="# Report", summary="s"
+            )
+
+        assert inv_id == "inv-42"
+        assert inv_url == "https://app.tracer.cloud/acme/inv-42"
+
+    def test_returns_none_id_when_first_ingest_fails(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the first ingest raises, returns (None, url_for_None)."""
+        state = _make_state(organization_slug="acme")
+
+        with (
+            patch(
+                "app.nodes.publish_findings.node.send_ingest",
+                side_effect=RuntimeError("down"),
+            ),
+            patch(
+                "app.nodes.publish_findings.node.get_investigation_url",
+                return_value=None,
+            ),
+            caplog.at_level("WARNING", logger="app.nodes.publish_findings.node"),
+        ):
+            inv_id, inv_url = _create_investigation_and_attach_url(
+                state, report_md="# Report", summary=None
+            )
+
+        assert inv_id is None
+        assert inv_url is None
+        assert "ingest failed" in caplog.text
+
+    def test_url_attachment_failure_still_returns_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the first ingest succeeds but the URL attachment raises, the id is returned."""
+        state = _make_state(organization_slug="acme")
+
+        call_count = 0
+
+        def _send_ingest(s: Any) -> str | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "inv-77"
+            raise RuntimeError("url attach failed")
+
+        with (
+            patch("app.nodes.publish_findings.node.send_ingest", side_effect=_send_ingest),
+            patch(
+                "app.nodes.publish_findings.node.get_investigation_url",
+                return_value="https://app.tracer.cloud/acme/inv-77",
+            ),
+            caplog.at_level("WARNING", logger="app.nodes.publish_findings.node"),
+        ):
+            inv_id, inv_url = _create_investigation_and_attach_url(
+                state, report_md="# Report", summary="s"
+            )
+
+        assert inv_id == "inv-77"
+        assert inv_url == "https://app.tracer.cloud/acme/inv-77"
+        assert "url attachment" in caplog.text
+
+    def test_no_id_means_no_url_attachment_call(self) -> None:
+        """When first ingest returns None, send_ingest is called exactly once."""
+        state = _make_state(organization_slug="acme")
+
+        with (
+            patch("app.nodes.publish_findings.node.send_ingest", return_value=None) as mock_send,
+            patch(
+                "app.nodes.publish_findings.node.get_investigation_url",
+                return_value=None,
+            ),
+        ):
+            inv_id, inv_url = _create_investigation_and_attach_url(
+                state, report_md="# Report", summary=None
+            )
+
+        assert inv_id is None
+        assert mock_send.call_count == 1
+
+    def test_send_ingest_called_twice_on_happy_path(self) -> None:
+        """Exactly two send_ingest calls are made when everything succeeds."""
+        state = _make_state(organization_slug="acme")
+
+        with (
+            patch("app.nodes.publish_findings.node.send_ingest", return_value="inv-1") as mock_send,
+            patch(
+                "app.nodes.publish_findings.node.get_investigation_url",
+                return_value="https://app.tracer.cloud/acme/inv-1",
+            ),
+        ):
+            _create_investigation_and_attach_url(state, report_md="# Report", summary="s")
+
+        assert mock_send.call_count == 2
+
+
+# ===========================================================================
+# Structural: generate_report must not contain inline two-step sequence
+# ===========================================================================
+
+
+class TestGenerateReportStructure:
+    """Verify the acceptance criteria about generate_report's structure."""
+
+    def test_generate_report_delegates_to_helper_not_inline_sequence(self) -> None:
+        """generate_report must call _create_investigation_and_attach_url, not send_ingest directly."""
+        import inspect
+
+        from app.nodes.publish_findings import node as node_module
+
+        source = inspect.getsource(node_module.generate_report)
+
+        # The inline two-call sequence is gone
+        assert source.count("send_ingest(") == 0, (
+            "generate_report() should not call send_ingest() directly; "
+            "delegate to _create_investigation_and_attach_url instead."
+        )
+
+        # The helper is used
+        assert "_create_investigation_and_attach_url(" in source, (
+            "generate_report() must delegate to _create_investigation_and_attach_url()."
+        )

--- a/tests/nodes/publish_findings/test_ingest_flow.py
+++ b/tests/nodes/publish_findings/test_ingest_flow.py
@@ -12,12 +12,13 @@ Acceptance criteria (from issue #867):
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import MagicMock, call, patch
+from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 
 from app.nodes.publish_findings.node import _create_investigation_and_attach_url
+from app.state import InvestigationState
 from app.utils.ingest_delivery import ingest_investigation_with_url
 
 # ---------------------------------------------------------------------------
@@ -25,7 +26,7 @@ from app.utils.ingest_delivery import ingest_investigation_with_url
 # ---------------------------------------------------------------------------
 
 
-def _make_state(**overrides: Any) -> dict:
+def _make_state(**overrides: Any) -> InvestigationState:
     base: dict[str, Any] = {
         "org_id": "org-123",
         "alert_name": "HighCPU",
@@ -44,7 +45,7 @@ def _make_state(**overrides: Any) -> dict:
         "problem_report": None,
     }
     base.update(overrides)
-    return base
+    return cast(InvestigationState, base)
 
 
 # ===========================================================================
@@ -144,11 +145,11 @@ class TestIngestInvestigationWithUrl:
 
         send_results = ["inv-999", RuntimeError("timeout")]
 
-        def _side_effect(*_args: Any, **_kwargs: Any) -> str:
+        def _side_effect(*_args: Any, **_kwargs: Any) -> str | None:
             val = send_results.pop(0)
             if isinstance(val, Exception):
                 raise val
-            return val
+            return str(val)
 
         with (
             patch("app.utils.ingest_delivery.send_ingest", side_effect=_side_effect),


### PR DESCRIPTION
Fixes #867

#### Describe the changes you have made in this PR -

`generate_report()` previously called `send_ingest()` twice inline — once to create the investigation record and again to attach the URL — with no named abstraction around that sequence. This made the write path hard to follow and test.

**What changed:**

- Added `_create_investigation_and_attach_url()` in `app/nodes/publish_findings/node.py` — a clearly-named helper that encapsulates the full two-step flow: persist the report, receive the `investigation_id`, then attach the `investigation_url` in a follow-up call.
- Added `ingest_investigation_with_url()` in `app/utils/ingest_delivery.py` — a reusable utility-layer version of the same helper for external callers.
- `generate_report()` now delegates to `_create_investigation_and_attach_url()` instead of containing the inline sequence. The failure behaviour is unchanged: if step 1 fails, `None` is returned and step 2 is skipped; if step 2 fails, the `investigation_id` is still returned.
- Added `tests/nodes/publish_findings/test_ingest_flow.py` with 12 tests covering: happy path (both calls made), no ID returned (step 2 skipped), no URL (step 2 skipped), step 1 raises, step 2 raises, state immutability, and a structural assertion that `generate_report()` no longer calls `send_ingest()` directly.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1048" height="487" alt="image" src="https://github.com/user-attachments/assets/652a18d5-0a7a-4453-92af-64c51ac9c54d" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem was that `generate_report()` had the two `send_ingest()` calls written out inline with comments explaining each step, making the intent hard to see at a glance and making the sequence impossible to test in isolation.

The fix introduces one helper — `_create_investigation_and_attach_url()` — whose name explains exactly what it does. The helper owns all the try/except handling and warning logs for both steps, and returns `(investigation_id, investigation_url)` so `generate_report()` stays clean. A utility-layer mirror `ingest_investigation_with_url()` was added to `ingest_delivery.py` for any future callers outside the node.

No alternative approaches were considered because the issue scope was explicit: introduce one helper, move the two-call sequence into it, do not change `send_ingest()`'s API contract.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
