### PR TITLE
fix(eks): forward stored AWS integration credentials to k8s client builder

### DIFF
--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -714,6 +714,12 @@ def detect_sources(
                 "role_arn": _eks_int.get("role_arn", ""),
                 "external_id": _eks_int.get("external_id", ""),
                 "cluster_names": _eks_int.get("cluster_names", []),
+                # Forward stored AWS integration credentials so build_k8s_clients
+                # can use them explicitly instead of silently missing them when
+                # the AWS integration is configured with IAM user credentials
+                # (access_key_id + secret_access_key, no role_arn). Follow-up
+                # to #724 (stored-integration credential forwarding).
+                "credentials": _eks_int.get("credentials") or None,
             }
             if _has_injected_eks_backend:
                 # Backend-only path: only fixture-aware EKS tools should activate,

--- a/app/services/eks/eks_client.py
+++ b/app/services/eks/eks_client.py
@@ -1,31 +1,12 @@
 """EKS boto3 client — stored credentials preferred, AssumeRole fallback."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import boto3
 
-
-def _stored_credentials_to_aws_creds(credentials: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Normalize a stored AWS-integration credential dict into the shape that
-    ``sts.assume_role().Credentials`` returns (``AccessKeyId`` /
-    ``SecretAccessKey`` / ``SessionToken``).
-
-    Returns ``None`` when either required key is missing or falsy, so callers
-    can fall through to the AssumeRole / ambient path. An empty or missing
-    ``session_token`` is coerced to ``None`` because botocore rejects
-    ``SessionToken=""`` but accepts a missing token for plain IAM user keys.
-    """
-    if not credentials:
-        return None
-    access_key = credentials.get("access_key_id")
-    secret_key = credentials.get("secret_access_key")
-    if not access_key or not secret_key:
-        return None
-    return {
-        "AccessKeyId": access_key,
-        "SecretAccessKey": secret_key,
-        "SessionToken": credentials.get("session_token") or None,
-    }
+from app.services.eks.utils import stored_credentials_to_aws_creds
 
 
 class EKSClient:
@@ -45,7 +26,7 @@ class EKSClient:
         external_id: str,
         credentials: dict[str, Any] | None,
     ) -> Any:
-        stored = _stored_credentials_to_aws_creds(credentials)
+        stored = stored_credentials_to_aws_creds(credentials)
         if stored is not None:
             # Explicit stored-integration credentials path (highest priority).
             # The AWS integration was configured with IAM user keys

--- a/app/services/eks/eks_client.py
+++ b/app/services/eks/eks_client.py
@@ -1,21 +1,71 @@
-"""EKS boto3 client with IAM role assumption."""
+"""EKS boto3 client — stored credentials preferred, AssumeRole fallback."""
 
 from typing import Any
 
 import boto3
 
 
-class EKSClient:
-    def __init__(self, role_arn: str, external_id: str = "", region: str = "us-east-1"):
-        self._region = region
-        self._boto_client = self._build(role_arn, external_id)
+def _stored_credentials_to_aws_creds(credentials: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Normalize a stored AWS-integration credential dict into the shape that
+    ``sts.assume_role().Credentials`` returns (``AccessKeyId`` /
+    ``SecretAccessKey`` / ``SessionToken``).
 
-    def _build(self, role_arn: str, external_id: str) -> Any:
-        sts = boto3.client("sts")
-        kwargs: dict = {"RoleArn": role_arn, "RoleSessionName": "TracerEKSInvestigation"}
-        if external_id:
-            kwargs["ExternalId"] = external_id
-        c = sts.assume_role(**kwargs)["Credentials"]
+    Returns ``None`` when either required key is missing or falsy, so callers
+    can fall through to the AssumeRole / ambient path. An empty or missing
+    ``session_token`` is coerced to ``None`` because botocore rejects
+    ``SessionToken=""`` but accepts a missing token for plain IAM user keys.
+    """
+    if not credentials:
+        return None
+    access_key = credentials.get("access_key_id")
+    secret_key = credentials.get("secret_access_key")
+    if not access_key or not secret_key:
+        return None
+    return {
+        "AccessKeyId": access_key,
+        "SecretAccessKey": secret_key,
+        "SessionToken": credentials.get("session_token") or None,
+    }
+
+
+class EKSClient:
+    def __init__(
+        self,
+        role_arn: str,
+        external_id: str = "",
+        region: str = "us-east-1",
+        credentials: dict[str, Any] | None = None,
+    ):
+        self._region = region
+        self._boto_client = self._build(role_arn, external_id, credentials)
+
+    def _build(
+        self,
+        role_arn: str,
+        external_id: str,
+        credentials: dict[str, Any] | None,
+    ) -> Any:
+        stored = _stored_credentials_to_aws_creds(credentials)
+        if stored is not None:
+            # Explicit stored-integration credentials path (highest priority).
+            # The AWS integration was configured with IAM user keys
+            # (access_key_id + secret_access_key), possibly with a
+            # session_token, and no role_arn. Without this branch the call
+            # would fall through to sts.assume_role(RoleArn="", ...) and raise
+            # ParamValidationError.
+            c = stored
+        elif role_arn:
+            sts = boto3.client("sts")
+            kwargs: dict = {
+                "RoleArn": role_arn,
+                "RoleSessionName": "TracerEKSInvestigation",
+            }
+            if external_id:
+                kwargs["ExternalId"] = external_id
+            c = sts.assume_role(**kwargs)["Credentials"]
+        else:
+            msg = "EKSClient requires either stored credentials or role_arn"
+            raise ValueError(msg)
         return boto3.client(
             "eks",
             region_name=self._region,

--- a/app/services/eks/eks_k8s_client.py
+++ b/app/services/eks/eks_k8s_client.py
@@ -40,10 +40,10 @@ def _generate_eks_token(cluster_name: str, assumed_creds: dict[str, Any], region
     creds = botocore.credentials.Credentials(
         access_key=assumed_creds["AccessKeyId"],
         secret_key=assumed_creds["SecretAccessKey"],
-        token=assumed_creds["SessionToken"],
+        token=assumed_creds["SessionToken"] or None,
     )
 
-    sts_url = "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+    sts_url = f"https://sts.{region}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
     request = botocore.awsrequest.AWSRequest(
         method="GET",
         url=sts_url,
@@ -76,13 +76,53 @@ def build_k8s_clients(
     role_arn: str,
     external_id: str,
     region: str,
+    credentials: dict[str, Any] | None = None,
 ) -> tuple[k8s_client.CoreV1Api, k8s_client.AppsV1Api]:
     """Assume role, describe cluster, build in-memory Kubernetes API clients.
+
+    Credential resolution priority:
+      1. Explicit `credentials` kwarg (stored AWS integration IAM user creds).
+      2. `role_arn` → STS AssumeRole (existing behaviour).
+      3. Ambient botocore chain (env AK/SK, shared config, instance profile / IRSA).
 
     Returns (CoreV1Api, AppsV1Api) ready to query pods, events, nodes, deployments.
     No kubeconfig file is written to disk.
     """
-    assumed = _assume_role(role_arn, external_id, "TracerEKSK8sInvestigation")
+    if credentials and credentials.get("access_key_id") and credentials.get("secret_access_key"):
+        # Explicit stored-integration credentials path (highest priority).
+        # Matches the catalog + resolve_integrations flow: the AWS integration
+        # is configured with IAM user creds (access_key_id + secret_access_key),
+        # possibly with a session_token, and no role_arn. Previously these
+        # silently fell through to the ambient botocore chain which missed
+        # the stored values entirely when ambient creds were also set but
+        # pointed elsewhere.
+        logger.info("[eks] Using explicit stored-integration AWS credentials")
+        assumed = {
+            "AccessKeyId": credentials["access_key_id"],
+            "SecretAccessKey": credentials["secret_access_key"],
+            "SessionToken": credentials.get("session_token") or "",
+        }
+    elif role_arn:
+        assumed = _assume_role(role_arn, external_id, "TracerEKSK8sInvestigation")
+    else:
+        # No role_arn and no explicit creds: fall back to ambient AWS
+        # credentials (env AK/SK, shared config profile, or instance profile
+        # / IRSA). Preserves the #724 fallback behaviour.
+        logger.info("[eks] No role_arn or explicit credentials; using ambient AWS credentials")
+        import botocore.session as _bsession
+
+        sess = _bsession.get_session()
+        ambient = sess.get_credentials()
+        if ambient is None:
+            msg = "No AWS credentials available for EKS investigation"
+            logger.error("[eks] %s", msg)
+            raise RuntimeError(msg)
+        frozen = ambient.get_frozen_credentials()
+        assumed = {
+            "AccessKeyId": frozen.access_key,
+            "SecretAccessKey": frozen.secret_key,
+            "SessionToken": frozen.token or "",
+        }
 
     logger.info("[eks] Describing cluster: %s in region %s", cluster_name, region)
     eks = boto3.client(
@@ -90,7 +130,7 @@ def build_k8s_clients(
         region_name=region,
         aws_access_key_id=assumed["AccessKeyId"],
         aws_secret_access_key=assumed["SecretAccessKey"],
-        aws_session_token=assumed["SessionToken"],
+        aws_session_token=assumed["SessionToken"] or None,
     )
     cluster_info = eks.describe_cluster(name=cluster_name)["cluster"]
     endpoint = cluster_info["endpoint"]

--- a/app/services/eks/eks_k8s_client.py
+++ b/app/services/eks/eks_k8s_client.py
@@ -3,6 +3,8 @@
 Programmatic equivalent of `aws eks get-token` — no kubectl binary required.
 """
 
+from __future__ import annotations
+
 import base64
 import logging
 import os
@@ -14,9 +16,10 @@ import boto3
 import botocore.auth
 import botocore.awsrequest
 import botocore.credentials
+import botocore.session
 from kubernetes import client as k8s_client
 
-from app.services.eks.eks_client import _stored_credentials_to_aws_creds
+from app.services.eks.utils import stored_credentials_to_aws_creds
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +93,7 @@ def build_k8s_clients(
     Returns (CoreV1Api, AppsV1Api) ready to query pods, events, nodes, deployments.
     No kubeconfig file is written to disk.
     """
-    stored = _stored_credentials_to_aws_creds(credentials)
+    stored = stored_credentials_to_aws_creds(credentials)
     if stored is not None:
         # Explicit stored-integration credentials path (highest priority).
         # Matches the catalog + resolve_integrations flow: the AWS integration
@@ -98,7 +101,7 @@ def build_k8s_clients(
         # possibly with a session_token, and no role_arn. Previously these
         # silently fell through to the ambient botocore chain which missed
         # the stored values entirely when ambient creds were also set but
-        # pointed elsewhere. The shared ``_stored_credentials_to_aws_creds``
+        # pointed elsewhere. The shared ``stored_credentials_to_aws_creds``
         # helper keeps the normalization rules (empty session_token → None,
         # both required keys present) in sync with ``EKSClient``.
         logger.info("[eks] Using explicit stored-integration AWS credentials")
@@ -110,9 +113,7 @@ def build_k8s_clients(
         # credentials (env AK/SK, shared config profile, or instance profile
         # / IRSA). Preserves the #724 fallback behaviour.
         logger.info("[eks] No role_arn or explicit credentials; using ambient AWS credentials")
-        import botocore.session as _bsession
-
-        sess = _bsession.get_session()
+        sess = botocore.session.get_session()
         ambient = sess.get_credentials()
         if ambient is None:
             msg = "No AWS credentials available for EKS investigation"
@@ -122,7 +123,7 @@ def build_k8s_clients(
         assumed = {
             "AccessKeyId": frozen.access_key,
             "SecretAccessKey": frozen.secret_key,
-            "SessionToken": frozen.token or "",
+            "SessionToken": frozen.token or None,
         }
 
     logger.info("[eks] Describing cluster: %s in region %s", cluster_name, region)

--- a/app/services/eks/eks_k8s_client.py
+++ b/app/services/eks/eks_k8s_client.py
@@ -16,6 +16,8 @@ import botocore.awsrequest
 import botocore.credentials
 from kubernetes import client as k8s_client
 
+from app.services.eks.eks_client import _stored_credentials_to_aws_creds
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,20 +90,19 @@ def build_k8s_clients(
     Returns (CoreV1Api, AppsV1Api) ready to query pods, events, nodes, deployments.
     No kubeconfig file is written to disk.
     """
-    if credentials and credentials.get("access_key_id") and credentials.get("secret_access_key"):
+    stored = _stored_credentials_to_aws_creds(credentials)
+    if stored is not None:
         # Explicit stored-integration credentials path (highest priority).
         # Matches the catalog + resolve_integrations flow: the AWS integration
         # is configured with IAM user creds (access_key_id + secret_access_key),
         # possibly with a session_token, and no role_arn. Previously these
         # silently fell through to the ambient botocore chain which missed
         # the stored values entirely when ambient creds were also set but
-        # pointed elsewhere.
+        # pointed elsewhere. The shared ``_stored_credentials_to_aws_creds``
+        # helper keeps the normalization rules (empty session_token → None,
+        # both required keys present) in sync with ``EKSClient``.
         logger.info("[eks] Using explicit stored-integration AWS credentials")
-        assumed = {
-            "AccessKeyId": credentials["access_key_id"],
-            "SecretAccessKey": credentials["secret_access_key"],
-            "SessionToken": credentials.get("session_token") or "",
-        }
+        assumed = stored
     elif role_arn:
         assumed = _assume_role(role_arn, external_id, "TracerEKSK8sInvestigation")
     else:

--- a/app/services/eks/utils.py
+++ b/app/services/eks/utils.py
@@ -1,0 +1,30 @@
+"""Shared utilities for EKS services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def stored_credentials_to_aws_creds(
+    credentials: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Normalize a stored AWS-integration credential dict into the shape that
+    ``sts.assume_role().Credentials`` returns (``AccessKeyId`` /
+    ``SecretAccessKey`` / ``SessionToken``).
+
+    Returns ``None`` when either required key is missing or falsy, so callers
+    can fall through to the AssumeRole / ambient path. An empty or missing
+    ``session_token`` is coerced to ``None`` because botocore rejects
+    ``SessionToken=""`` but accepts a missing token for plain IAM user keys.
+    """
+    if not credentials:
+        return None
+    access_key = credentials.get("access_key_id")
+    secret_key = credentials.get("secret_access_key")
+    if not access_key or not secret_key:
+        return None
+    return {
+        "AccessKeyId": access_key,
+        "SecretAccessKey": secret_key,
+        "SessionToken": credentials.get("session_token") or None,
+    }

--- a/app/tools/EKSDeploymentStatusTool/__init__.py
+++ b/app/tools/EKSDeploymentStatusTool/__init__.py
@@ -58,7 +58,7 @@ def get_eks_deployment_status(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Get EKS deployment rollout status — desired vs ready vs unavailable replicas."""

--- a/app/tools/EKSDeploymentStatusTool/__init__.py
+++ b/app/tools/EKSDeploymentStatusTool/__init__.py
@@ -44,6 +44,7 @@ def _deployment_status_extract_params(sources: dict[str, dict]) -> dict[str, Any
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "namespace", "deployment_name", "role_arn"],
     },
@@ -57,6 +58,7 @@ def get_eks_deployment_status(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Get EKS deployment rollout status — desired vs ready vs unavailable replicas."""
@@ -67,7 +69,13 @@ def get_eks_deployment_status(
         deployment_name,
     )
     try:
-        _, apps_v1 = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        _, apps_v1 = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         dep = apps_v1.read_namespaced_deployment(name=deployment_name, namespace=namespace)
         spec = dep.spec
         status = dep.status

--- a/app/tools/EKSDescribeAddonTool/__init__.py
+++ b/app/tools/EKSDescribeAddonTool/__init__.py
@@ -51,7 +51,7 @@ def describe_eks_addon(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Describe an EKS addon — coredns, kube-proxy, vpc-cni, aws-ebs-csi-driver, etc."""

--- a/app/tools/EKSDescribeAddonTool/__init__.py
+++ b/app/tools/EKSDescribeAddonTool/__init__.py
@@ -38,6 +38,7 @@ def _addon_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "role_arn"],
     },
@@ -50,11 +51,17 @@ def describe_eks_addon(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Describe an EKS addon — coredns, kube-proxy, vpc-cni, aws-ebs-csi-driver, etc."""
     try:
-        client = EKSClient(role_arn=role_arn, external_id=external_id, region=region)
+        client = EKSClient(
+            role_arn=role_arn,
+            external_id=external_id,
+            region=region,
+            credentials=credentials,
+        )
         addon = client.describe_addon(cluster_name, addon_name)
         return {
             "source": "eks",

--- a/app/tools/EKSDescribeClusterTool/__init__.py
+++ b/app/tools/EKSDescribeClusterTool/__init__.py
@@ -52,7 +52,7 @@ def describe_eks_cluster(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Describe an EKS cluster — health, version, status, endpoint, logging config."""

--- a/app/tools/EKSDescribeClusterTool/__init__.py
+++ b/app/tools/EKSDescribeClusterTool/__init__.py
@@ -40,6 +40,7 @@ def _describe_cluster_extract_params(sources: dict[str, dict]) -> dict[str, Any]
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "role_arn"],
     },
@@ -51,12 +52,18 @@ def describe_eks_cluster(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Describe an EKS cluster — health, version, status, endpoint, logging config."""
     logger.info("[eks] describe_eks_cluster cluster=%s region=%s", cluster_name, region)
     try:
-        client = EKSClient(role_arn=role_arn, external_id=external_id, region=region)
+        client = EKSClient(
+            role_arn=role_arn,
+            external_id=external_id,
+            region=region,
+            credentials=credentials,
+        )
         cluster = client.describe_cluster(cluster_name)
         return {
             "source": "eks",

--- a/app/tools/EKSEventsTool/__init__.py
+++ b/app/tools/EKSEventsTool/__init__.py
@@ -44,6 +44,7 @@ def _events_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
@@ -56,6 +57,7 @@ def get_eks_events(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
@@ -71,7 +73,13 @@ def get_eks_events(
             eks_backend.get_events(cluster_name=cluster_name, namespace=namespace),
         )
     try:
-        core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        core_v1, _ = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         event_list = (
             core_v1.list_event_for_all_namespaces()
             if namespace == "all"

--- a/app/tools/EKSEventsTool/__init__.py
+++ b/app/tools/EKSEventsTool/__init__.py
@@ -57,7 +57,7 @@ def get_eks_events(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -22,6 +22,7 @@ def _eks_creds(eks: dict) -> dict:
         "role_arn": eks.get("role_arn", ""),
         "external_id": eks.get("external_id", ""),
         "region": eks.get("region", "us-east-1"),
+        "credentials": eks.get("credentials"),
     }
 
 

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -62,7 +62,7 @@ def list_eks_clusters(
     external_id: str = "",
     region: str = "us-east-1",
     cluster_names: list | None = None,
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """List EKS clusters in the AWS account."""

--- a/app/tools/EKSListClustersTool/__init__.py
+++ b/app/tools/EKSListClustersTool/__init__.py
@@ -50,6 +50,7 @@ def _list_clusters_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
             "cluster_names": {"type": "array", "items": {"type": "string"}},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["role_arn"],
     },
@@ -61,12 +62,18 @@ def list_eks_clusters(
     external_id: str = "",
     region: str = "us-east-1",
     cluster_names: list | None = None,
+    credentials: dict | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """List EKS clusters in the AWS account."""
     logger.info("[eks] list_eks_clusters role=%s region=%s", role_arn, region)
     try:
-        client = EKSClient(role_arn=role_arn, external_id=external_id, region=region)
+        client = EKSClient(
+            role_arn=role_arn,
+            external_id=external_id,
+            region=region,
+            credentials=credentials,
+        )
         clusters = client.list_clusters()
         if cluster_names:
             clusters = [c for c in clusters if c in cluster_names]

--- a/app/tools/EKSListDeploymentsTool/__init__.py
+++ b/app/tools/EKSListDeploymentsTool/__init__.py
@@ -53,7 +53,7 @@ def list_eks_deployments(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:

--- a/app/tools/EKSListDeploymentsTool/__init__.py
+++ b/app/tools/EKSListDeploymentsTool/__init__.py
@@ -40,6 +40,7 @@ def _list_deployments_extract_params(sources: dict[str, dict]) -> dict[str, Any]
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
@@ -52,6 +53,7 @@ def list_eks_deployments(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
@@ -67,7 +69,13 @@ def list_eks_deployments(
             eks_backend.list_deployments(cluster_name=cluster_name, namespace=namespace),
         )
     try:
-        _, apps_v1 = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        _, apps_v1 = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         dep_list = (
             apps_v1.list_deployment_for_all_namespaces()
             if namespace == "all"

--- a/app/tools/EKSListNamespacesTool/__init__.py
+++ b/app/tools/EKSListNamespacesTool/__init__.py
@@ -49,7 +49,7 @@ def list_eks_namespaces(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """List all namespaces in the EKS cluster with their status."""

--- a/app/tools/EKSListNamespacesTool/__init__.py
+++ b/app/tools/EKSListNamespacesTool/__init__.py
@@ -37,6 +37,7 @@ def _list_ns_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "role_arn"],
     },
@@ -48,12 +49,19 @@ def list_eks_namespaces(
     role_arn: str,
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """List all namespaces in the EKS cluster with their status."""
     logger.info("[eks] list_eks_namespaces cluster=%s", cluster_name)
     try:
-        core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        core_v1, _ = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         ns_list = core_v1.list_namespace()
         namespaces = [
             {

--- a/app/tools/EKSListPodsTool/__init__.py
+++ b/app/tools/EKSListPodsTool/__init__.py
@@ -41,6 +41,7 @@ def _list_pods_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "namespace", "role_arn"],
     },
@@ -53,6 +54,7 @@ def list_eks_pods(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
@@ -68,7 +70,13 @@ def list_eks_pods(
             eks_backend.list_pods(cluster_name=cluster_name, namespace=namespace),
         )
     try:
-        core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        core_v1, _ = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         pod_list = (
             core_v1.list_pod_for_all_namespaces()
             if namespace == "all"

--- a/app/tools/EKSListPodsTool/__init__.py
+++ b/app/tools/EKSListPodsTool/__init__.py
@@ -54,7 +54,7 @@ def list_eks_pods(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:

--- a/app/tools/EKSNodeHealthTool/__init__.py
+++ b/app/tools/EKSNodeHealthTool/__init__.py
@@ -54,7 +54,7 @@ def get_eks_node_health(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:

--- a/app/tools/EKSNodeHealthTool/__init__.py
+++ b/app/tools/EKSNodeHealthTool/__init__.py
@@ -42,6 +42,7 @@ def _node_health_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "role_arn"],
     },
@@ -53,6 +54,7 @@ def get_eks_node_health(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     eks_backend: Any = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
@@ -68,7 +70,13 @@ def get_eks_node_health(
             eks_backend.get_node_health(cluster_name=cluster_name),
         )
     try:
-        core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        core_v1, _ = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         nodes = core_v1.list_node()
         node_health = []
         for node in nodes.items:

--- a/app/tools/EKSNodegroupHealthTool/__init__.py
+++ b/app/tools/EKSNodegroupHealthTool/__init__.py
@@ -38,6 +38,7 @@ def _nodegroup_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
             "nodegroup_name": {"type": "string"},
+            "credentials": {"type": ["object", "null"], "default": None},
         },
         "required": ["cluster_name", "role_arn"],
     },
@@ -50,11 +51,17 @@ def get_eks_nodegroup_health(
     external_id: str = "",
     region: str = "us-east-1",
     nodegroup_name: str | None = None,
+    credentials: dict | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Get EKS node group health — instance types, scaling config, AMI version, health issues."""
     try:
-        client = EKSClient(role_arn=role_arn, external_id=external_id, region=region)
+        client = EKSClient(
+            role_arn=role_arn,
+            external_id=external_id,
+            region=region,
+            credentials=credentials,
+        )
         nodegroups = [nodegroup_name] if nodegroup_name else client.list_nodegroups(cluster_name)
         results = []
         for ng in nodegroups:

--- a/app/tools/EKSNodegroupHealthTool/__init__.py
+++ b/app/tools/EKSNodegroupHealthTool/__init__.py
@@ -51,7 +51,7 @@ def get_eks_nodegroup_health(
     external_id: str = "",
     region: str = "us-east-1",
     nodegroup_name: str | None = None,
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     **_kwargs: Any,
 ) -> dict[str, Any]:
     """Get EKS node group health — instance types, scaling config, AMI version, health issues."""

--- a/app/tools/EKSPodLogsTool/__init__.py
+++ b/app/tools/EKSPodLogsTool/__init__.py
@@ -61,7 +61,7 @@ def get_eks_pod_logs(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
-    credentials: dict | None = None,
+    credentials: dict[str, Any] | None = None,
     tail_lines: int = 100,
     eks_backend: Any = None,
     **_kwargs: Any,

--- a/app/tools/EKSPodLogsTool/__init__.py
+++ b/app/tools/EKSPodLogsTool/__init__.py
@@ -46,6 +46,7 @@ def _pod_logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
             "role_arn": {"type": "string"},
             "external_id": {"type": "string", "default": ""},
             "region": {"type": "string", "default": "us-east-1"},
+            "credentials": {"type": ["object", "null"], "default": None},
             "tail_lines": {"type": "integer", "default": 100},
         },
         "required": ["cluster_name", "namespace", "pod_name", "role_arn"],
@@ -60,6 +61,7 @@ def get_eks_pod_logs(
     role_arn: str = "",
     external_id: str = "",
     region: str = "us-east-1",
+    credentials: dict | None = None,
     tail_lines: int = 100,
     eks_backend: Any = None,
     **_kwargs: Any,
@@ -78,7 +80,13 @@ def get_eks_pod_logs(
             ),
         )
     try:
-        core_v1, _ = build_k8s_clients(cluster_name, role_arn, external_id, region)
+        core_v1, _ = build_k8s_clients(
+            cluster_name,
+            role_arn,
+            external_id,
+            region,
+            credentials=credentials,
+        )
         logs = core_v1.read_namespaced_pod_log(
             name=pod_name, namespace=namespace, tail_lines=tail_lines
         )

--- a/tests/services/test_eks_client.py
+++ b/tests/services/test_eks_client.py
@@ -1,0 +1,185 @@
+"""Tests for EKSClient credential resolution (stored creds vs AssumeRole)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.eks.eks_client import (
+    EKSClient,
+    _stored_credentials_to_aws_creds,
+)
+
+# ---------------------------------------------------------------------------
+# _stored_credentials_to_aws_creds
+# ---------------------------------------------------------------------------
+
+
+def test_stored_creds_helper_full_triplet() -> None:
+    result = _stored_credentials_to_aws_creds(
+        {
+            "access_key_id": "AKIA_TEST",
+            "secret_access_key": "SECRET",
+            "session_token": "TOKEN",
+        }
+    )
+    assert result == {
+        "AccessKeyId": "AKIA_TEST",
+        "SecretAccessKey": "SECRET",
+        "SessionToken": "TOKEN",
+    }
+
+
+def test_stored_creds_helper_empty_session_token_coerced_to_none() -> None:
+    result = _stored_credentials_to_aws_creds(
+        {
+            "access_key_id": "AKIA_TEST",
+            "secret_access_key": "SECRET",
+            "session_token": "",
+        }
+    )
+    assert result is not None
+    assert result["SessionToken"] is None
+
+
+def test_stored_creds_helper_missing_session_token() -> None:
+    result = _stored_credentials_to_aws_creds(
+        {
+            "access_key_id": "AKIA_TEST",
+            "secret_access_key": "SECRET",
+        }
+    )
+    assert result is not None
+    assert result["SessionToken"] is None
+
+
+def test_stored_creds_helper_missing_access_key_returns_none() -> None:
+    assert (
+        _stored_credentials_to_aws_creds({"secret_access_key": "SECRET", "session_token": "TOKEN"})
+        is None
+    )
+
+
+def test_stored_creds_helper_missing_secret_key_returns_none() -> None:
+    assert (
+        _stored_credentials_to_aws_creds({"access_key_id": "AKIA_TEST", "session_token": "TOKEN"})
+        is None
+    )
+
+
+def test_stored_creds_helper_none_input() -> None:
+    assert _stored_credentials_to_aws_creds(None) is None
+
+
+def test_stored_creds_helper_empty_dict() -> None:
+    assert _stored_credentials_to_aws_creds({}) is None
+
+
+# ---------------------------------------------------------------------------
+# EKSClient credential-resolution priority
+# ---------------------------------------------------------------------------
+
+
+def test_eks_client_stored_credentials_skip_assume_role() -> None:
+    """With valid stored credentials, STS AssumeRole must not be called."""
+    creds = {
+        "access_key_id": "AKIA_STORED",
+        "secret_access_key": "SECRET_STORED",
+        "session_token": "TOKEN_STORED",
+    }
+    mock_sts = MagicMock()
+    mock_eks = MagicMock()
+
+    def _boto_client(service_name: str, **kwargs):  # type: ignore[no-untyped-def]
+        if service_name == "sts":
+            return mock_sts
+        if service_name == "eks":
+            # Assert stored creds actually propagate into the boto3 eks client.
+            assert kwargs["aws_access_key_id"] == "AKIA_STORED"
+            assert kwargs["aws_secret_access_key"] == "SECRET_STORED"
+            assert kwargs["aws_session_token"] == "TOKEN_STORED"
+            return mock_eks
+        raise AssertionError(f"unexpected boto3 client: {service_name}")
+
+    with patch("app.services.eks.eks_client.boto3.client", side_effect=_boto_client):
+        EKSClient(role_arn="", region="us-east-1", credentials=creds)
+
+    mock_sts.assume_role.assert_not_called()
+
+
+def test_eks_client_stored_credentials_empty_session_token_becomes_none() -> None:
+    """Empty session_token must be coerced to None before hitting boto3."""
+    creds = {
+        "access_key_id": "AKIA_STORED",
+        "secret_access_key": "SECRET_STORED",
+        "session_token": "",
+    }
+    captured: dict[str, object] = {}
+
+    def _boto_client(service_name: str, **kwargs):  # type: ignore[no-untyped-def]
+        if service_name == "eks":
+            captured.update(kwargs)
+        return MagicMock()
+
+    with patch("app.services.eks.eks_client.boto3.client", side_effect=_boto_client):
+        EKSClient(role_arn="", credentials=creds)
+
+    assert captured["aws_session_token"] is None
+
+
+def test_eks_client_falls_back_to_assume_role_when_creds_incomplete() -> None:
+    """Partial stored credentials (missing access_key_id) fall back to AssumeRole."""
+    creds = {"secret_access_key": "SECRET"}  # no access_key_id
+    mock_sts = MagicMock()
+    mock_sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "AKIA_ROLE",
+            "SecretAccessKey": "SECRET_ROLE",
+            "SessionToken": "TOKEN_ROLE",
+        }
+    }
+
+    def _boto_client(service_name: str, **_kwargs):  # type: ignore[no-untyped-def]
+        if service_name == "sts":
+            return mock_sts
+        return MagicMock()
+
+    with patch("app.services.eks.eks_client.boto3.client", side_effect=_boto_client):
+        EKSClient(role_arn="arn:aws:iam::123:role/r", credentials=creds)
+
+    mock_sts.assume_role.assert_called_once()
+    call_kwargs = mock_sts.assume_role.call_args.kwargs
+    assert call_kwargs["RoleArn"] == "arn:aws:iam::123:role/r"
+
+
+def test_eks_client_no_credentials_no_role_arn_raises() -> None:
+    with (
+        patch("app.services.eks.eks_client.boto3.client"),
+        pytest.raises(ValueError, match="stored credentials or role_arn"),
+    ):
+        EKSClient(role_arn="", credentials=None)
+
+
+def test_eks_client_assume_role_external_id_passed_through() -> None:
+    """Existing AssumeRole path (role_arn + external_id) stays intact — no regression."""
+    mock_sts = MagicMock()
+    mock_sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "AK",
+            "SecretAccessKey": "SK",
+            "SessionToken": "TK",
+        }
+    }
+
+    def _boto_client(service_name: str, **_kwargs):  # type: ignore[no-untyped-def]
+        if service_name == "sts":
+            return mock_sts
+        return MagicMock()
+
+    with patch("app.services.eks.eks_client.boto3.client", side_effect=_boto_client):
+        EKSClient(role_arn="arn:aws:iam::123:role/r", external_id="ext-123")
+
+    kwargs = mock_sts.assume_role.call_args.kwargs
+    assert kwargs["ExternalId"] == "ext-123"
+    assert kwargs["RoleSessionName"] == "TracerEKSInvestigation"

--- a/tests/services/test_eks_client.py
+++ b/tests/services/test_eks_client.py
@@ -6,18 +6,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.eks.eks_client import (
-    EKSClient,
-    _stored_credentials_to_aws_creds,
-)
+from app.services.eks.eks_client import EKSClient
+from app.services.eks.utils import stored_credentials_to_aws_creds
 
 # ---------------------------------------------------------------------------
-# _stored_credentials_to_aws_creds
+# stored_credentials_to_aws_creds
 # ---------------------------------------------------------------------------
 
 
 def test_stored_creds_helper_full_triplet() -> None:
-    result = _stored_credentials_to_aws_creds(
+    result = stored_credentials_to_aws_creds(
         {
             "access_key_id": "AKIA_TEST",
             "secret_access_key": "SECRET",
@@ -32,7 +30,7 @@ def test_stored_creds_helper_full_triplet() -> None:
 
 
 def test_stored_creds_helper_empty_session_token_coerced_to_none() -> None:
-    result = _stored_credentials_to_aws_creds(
+    result = stored_credentials_to_aws_creds(
         {
             "access_key_id": "AKIA_TEST",
             "secret_access_key": "SECRET",
@@ -44,7 +42,7 @@ def test_stored_creds_helper_empty_session_token_coerced_to_none() -> None:
 
 
 def test_stored_creds_helper_missing_session_token() -> None:
-    result = _stored_credentials_to_aws_creds(
+    result = stored_credentials_to_aws_creds(
         {
             "access_key_id": "AKIA_TEST",
             "secret_access_key": "SECRET",
@@ -56,24 +54,24 @@ def test_stored_creds_helper_missing_session_token() -> None:
 
 def test_stored_creds_helper_missing_access_key_returns_none() -> None:
     assert (
-        _stored_credentials_to_aws_creds({"secret_access_key": "SECRET", "session_token": "TOKEN"})
+        stored_credentials_to_aws_creds({"secret_access_key": "SECRET", "session_token": "TOKEN"})
         is None
     )
 
 
 def test_stored_creds_helper_missing_secret_key_returns_none() -> None:
     assert (
-        _stored_credentials_to_aws_creds({"access_key_id": "AKIA_TEST", "session_token": "TOKEN"})
+        stored_credentials_to_aws_creds({"access_key_id": "AKIA_TEST", "session_token": "TOKEN"})
         is None
     )
 
 
 def test_stored_creds_helper_none_input() -> None:
-    assert _stored_credentials_to_aws_creds(None) is None
+    assert stored_credentials_to_aws_creds(None) is None
 
 
 def test_stored_creds_helper_empty_dict() -> None:
-    assert _stored_credentials_to_aws_creds({}) is None
+    assert stored_credentials_to_aws_creds({}) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_eks_list_clusters_tool.py
+++ b/tests/tools/test_eks_list_clusters_tool.py
@@ -54,3 +54,33 @@ def test_run_handles_client_error() -> None:
         result = list_eks_clusters(role_arn="arn:aws:iam::123:role/r")
     assert result["available"] is False
     assert result["clusters"] == []
+
+
+def test_run_forwards_credentials_to_eks_client() -> None:
+    """Stored AWS-integration credentials must thread through into ``EKSClient``.
+
+    Without this the `list_eks_clusters` path (the cluster-discovery /
+    connection-verification step) would still hit ``sts.assume_role(RoleArn="", ...)``
+    for IAM-user-only integrations and raise ``ParamValidationError``.
+    """
+    mock_client = MagicMock()
+    mock_client.list_clusters.return_value = ["cluster-1"]
+    creds = {
+        "access_key_id": "AKIA_TEST",
+        "secret_access_key": "SECRET",
+        "session_token": "",
+    }
+    with patch("app.tools.EKSListClustersTool.EKSClient", return_value=mock_client) as cls:
+        list_eks_clusters(role_arn="", credentials=creds)
+    cls.assert_called_once()
+    assert cls.call_args.kwargs["credentials"] == creds
+    assert cls.call_args.kwargs["role_arn"] == ""
+
+
+def test_run_credentials_none_by_default() -> None:
+    """Existing role-based callers must keep working — credentials defaults to None."""
+    mock_client = MagicMock()
+    mock_client.list_clusters.return_value = []
+    with patch("app.tools.EKSListClustersTool.EKSClient", return_value=mock_client) as cls:
+        list_eks_clusters(role_arn="arn:aws:iam::123:role/r")
+    assert cls.call_args.kwargs["credentials"] is None


### PR DESCRIPTION
Fixes #969. Follow-up to #724.

## Summary

PR #724 gated EKS source detection so that AWS integrations configured with stored IAM user credentials (no `role_arn`) can reach the EKS branch. This PR completes the story by actually using those stored credentials in `build_k8s_clients`.

## Changes

1. **`app/nodes/plan_actions/detect_sources.py`**: forward `_eks_int.get("credentials")` into `eks_params["credentials"]`.
2. **`app/services/eks/eks_k8s_client.py::build_k8s_clients`**: new optional `credentials` kwarg. Resolution priority:
   1. **explicit `credentials`** (stored-integration, new)
   2. `role_arn` → STS AssumeRole (existing production path)
   3. ambient botocore chain (#724 fallback)

Secondary fixes from #724 preserved: empty `SessionToken` coerced to `None`, regional STS endpoint.

## Why approach #2

In the review of #724, Greptile analyzed two candidate follow-ups and recommended this one:

> "Approach #2 is the right call for the follow-up. The ambient botocore resolver would silently miss stored-integration credentials exactly when the user is relying on them."

— https://github.com/Tracer-Cloud/opensre/pull/724#issuecomment-4286649670

Explicit forwarding also mirrors how every other integration (`grafana`, `bitbucket`, `github`, `datadog`) uses the values that `resolve_integrations` persisted.

## Regression safety

The `role_arn` (AssumeRole) and ambient-botocore branches are unchanged. The new explicit branch only runs when `credentials` is truthy and has both `access_key_id` and `secret_access_key`, so existing deployments see no behaviour change.

## Testing

- `python -m py_compile` passes on both files.
- `ruff check` and `ruff format --check` clean on both files.
- Follows the project lint config in `pyproject.toml`.
