### PR TITLE
test(tracer): add unit tests for get_logs parameter construction

### DIFF
--- a/tests/services/tracer_client/test_tracer_logs.py
+++ b/tests/services/tracer_client/test_tracer_logs.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+from app.services.tracer_client.tracer_logs import TracerLogsMixin
+
+
+class DummyTracerClient(TracerLogsMixin):
+    """Dummy client to isolate and test the TracerLogsMixin."""
+
+    def __init__(self):
+        self.org_id = "test_org_123"
+        self._get = MagicMock(return_value={"success": True, "data": []})
+
+
+def test_get_logs_default_size():
+    """Cover default size."""
+    client = DummyTracerClient()
+    client.get_logs()
+
+    client._get.assert_called_once_with(
+        "/api/opensearch/logs",
+        {"orgId": "test_org_123", "size": 100}
+    )
+
+
+def test_get_logs_trace_id_precedence():
+    """Cover trace_id precedence."""
+    client = DummyTracerClient()
+    client.get_logs(trace_id="trace_abc", run_id="run_xyz")
+
+    client._get.assert_called_once_with(
+        "/api/opensearch/logs",
+        {"orgId": "test_org_123", "size": 100, "runId": "trace_abc"}
+    )
+
+
+def test_get_logs_run_id_fallback():
+    """Cover run_id fallback."""
+    client = DummyTracerClient()
+    client.get_logs(run_id="run_xyz")
+
+    client._get.assert_called_once_with(
+        "/api/opensearch/logs",
+        {"orgId": "test_org_123", "size": 100, "runId": "run_xyz"}
+    )


### PR DESCRIPTION
Introduces a `DummyTracerClient` with a mocked `_get` method to isolate and test the `TracerLogsMixin` without making real HTTP requests. Coverage includes default parameter construction (size=100), `trace_id` precedence, and `run_id` fallback behavior.

Fixes #890

#### Describe the changes you have made in this PR -
- Added `tests/services/tracer_client/test_tracer_logs.py`
- Created a `DummyTracerClient` class to attach the mixin and mock the internal `_get` network call using `MagicMock`.
- Added 3 focused unit tests to verify:
  1. Default parameter construction (`size=100`, `orgId`).
  2. Precedence logic (ensuring `trace_id` overrides `run_id` when both are passed).
  3. Fallback logic (ensuring `run_id` is used when `trace_id` is missing).
- Ensured code passes all local `ruff` linting and `pytest` coverage requirements.

### Demo/Screenshot for feature changes and bug fixes - 

<img width="1388" height="721" alt="Screenshot 2026-04-26 230203" src="https://github.com/user-attachments/assets/3bf0e836-4384-4eb6-bcc5-420d397e0efb" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **What problem does your code solve?** It allows us to safely test the parameter-building logic of `TracerLogsMixin` without triggering real HTTP requests to an OpenSearch database, which would make the tests flaky and dependent on network status.
- **Alternative approaches:** The alternative would be an integration test hitting a real database or a mocked local server, which is too heavy for testing simple dictionary construction.
- **Why this implementation?** Using Python's `MagicMock` acts as a spy, allowing us to intercept the `_get` call and assert exactly what parameters were passed. Creating a `DummyTracerClient` is the cleanest way to test a standalone mixin.
- **Key functions:** `DummyTracerClient` initializes the spy. The three test functions handle the empty state, the collision state (both IDs), and the fallback state.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---