### PR TITLE
fix: stop run_diagnostic_code from crashing every investigation dispatch

### DIFF
--- a/app/tools/run_diagnostic_code.py
+++ b/app/tools/run_diagnostic_code.py
@@ -11,6 +11,7 @@ from app.tools.tool_decorator import tool
 @tool(
     name="run_diagnostic_code",
     source="knowledge",
+    is_available=lambda _: False,
     description=(
         "Execute a Python snippet in a restricted sandbox for targeted diagnostics. "
         "Network access and filesystem writes outside /tmp are blocked. "

--- a/tests/tools/test_run_diagnostic_code_tool.py
+++ b/tests/tools/test_run_diagnostic_code_tool.py
@@ -40,8 +40,11 @@ class TestRunDiagnosticCodeMetadata:
         assert "inputs" not in required
         assert "timeout" not in required
 
-    def test_tool_is_available_without_sources(self) -> None:
-        assert _registered().is_available({}) is True
+    def test_tool_is_not_auto_selected_by_dispatcher(self) -> None:
+        # The dispatcher can't supply the required `code` argument from alert sources,
+        # so this tool must never be auto-selected during an investigation.
+        assert _registered().is_available({}) is False
+        assert _registered().is_available({"knowledge": {"code": "print(1)"}}) is False
 
     def test_registered_on_investigation_surface(self) -> None:
         assert "investigation" in _registered().surfaces


### PR DESCRIPTION
Fixes #956

#### Describe the changes you have made in this PR -

`run_diagnostic_code` was registered with `@tool` but without `is_available` or `extract_params`. The dispatcher's defaults are: always select the tool (`is_available` returns `True`) and call it with empty kwargs (`extract_params` returns `{}`). Since `run_diagnostic_code` requires a `code` argument, this caused a `TypeError` on every investigation - even ones completely unrelated to code execution.

The fix is one line: `is_available=lambda _: False` in the `@tool` decorator. This matches the pattern used in #732, #703, and #704 which fixed the same class of bug for other tools. The tool still works perfectly when called directly with a `code` argument - it just won't be auto-selected by the dispatcher anymore.

Also updated the existing test that was asserting the wrong behaviour (`is_available` returning `True`) and made the intent explicit with a second assertion.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I traced the crash by reading `execute_actions.py` (the dispatcher) and saw it calls `action.extract_params(sources)` then `action.run(**kwargs)`. For tools without a custom `extract_params`, `kwargs` is always `{}`. `run_diagnostic_code` requires `code` as a positional argument, so the call always raises `TypeError`.

I looked at how prior fixes (#732, #703, #704) handled the same problem: they all used `is_available=lambda _: False` to tell the dispatcher "skip me, I can't be auto-called". That's the right fix here too, because there's no way to pull a meaningful `code` string out of an alert's source dict.

The one-line change to the decorator is the entire fix. I also flipped the test that was asserting the wrong thing and added a second assertion that documents why this matters.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.