### PR TITLE
eval: harden OpenSRE LLM judge JSON extraction

### DIFF
--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -51,7 +51,7 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     if fence:
         text = fence.group(1).strip()
 
-    if text.startswith("["):
+    if text.lstrip().startswith("["):
         msg = "Judge response JSON must be an object"
         raise ValueError(msg)
 

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -50,11 +50,17 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     fence = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
     if fence:
         text = fence.group(1)
+
+    if text.startswith("["):
+        msg = "Judge response JSON must be an object"
+        raise ValueError(msg)
+
     start = text.find("{")
     end = text.rfind("}")
     if start == -1 or end == -1 or end <= start:
         msg = "Judge response did not contain a JSON object"
         raise ValueError(msg)
+
     raw = json.loads(text[start : end + 1])
     if not isinstance(raw, dict):
         msg = "Judge response JSON must be an object"

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -47,9 +47,9 @@ def _claims_lines(claims: list[Any], key: str = "claim") -> str:
 
 def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     text = text.strip()
-    fence = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
+    fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.DOTALL)
     if fence:
-        text = fence.group(1)
+        text = fence.group(1).strip()
 
     if text.startswith("["):
         msg = "Judge response JSON must be an object"

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -75,6 +75,23 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     if isinstance(raw, list):
         msg = "Judge response JSON must be an object"
         raise ValueError(msg)
+    
+    array_start = text.find("[")
+    array_end = text.rfind("]")
+
+    if array_start != -1 and array_end != -1 and array_end > array_start:
+        object_start = text.find("{")
+
+        if object_start == -1 or array_start < object_start:
+            try:
+                candidate = text[array_start : array_end + 1]
+                parsed = json.loads(candidate)
+            except json.JSONDecodeError:
+                parsed = None
+
+            if isinstance(parsed, list):
+                msg = "Judge response JSON must be an object"
+                raise ValueError(msg)
 
     start = text.find("{")
     end = text.rfind("}")

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -50,8 +50,6 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
 
     fences = re.findall(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.DOTALL)
     if fences:
-        saw_array_fence = False
-
         for fence_candidate in reversed(fences):
             fence_candidate = fence_candidate.strip()
             try:
@@ -63,12 +61,7 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
                 return cast(dict[str, Any], parsed_fence)
 
             if isinstance(parsed_fence, list):
-                saw_array_fence = True
                 continue
-
-        if saw_array_fence:
-            msg = "Judge response JSON must be an object"
-            raise ValueError(msg)
 
     try:
         raw = json.loads(text)

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -75,7 +75,7 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     if isinstance(raw, list):
         msg = "Judge response JSON must be an object"
         raise ValueError(msg)
-    
+
     array_start = text.find("[")
     array_end = text.rfind("]")
 

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -83,15 +83,17 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
         object_start = text.find("{")
 
         if object_start == -1 or array_start < object_start:
-            try:
-                candidate = text[array_start : array_end + 1]
-                parsed = json.loads(candidate)
-            except json.JSONDecodeError:
-                parsed = None
+            for i in range(array_start, array_end + 1):
+                if text[i] == "[":
+                    candidate = text[i : array_end + 1]
+                    try:
+                        parsed = json.loads(candidate)
+                    except json.JSONDecodeError:
+                        continue
 
-            if isinstance(parsed, list):
-                msg = "Judge response JSON must be an object"
-                raise ValueError(msg)
+                    if isinstance(parsed, list):
+                        msg = "Judge response JSON must be an object"
+                        raise ValueError(msg)
 
     start = text.find("{")
     end = text.rfind("}")

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -57,9 +57,23 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
             except json.JSONDecodeError:
                 continue
 
-            if isinstance(raw, dict):
-                return cast(dict[str, Any], raw)
-            if isinstance(raw, list):
+            saw_array_fence = False
+
+            for candidate in reversed(fences):
+                candidate = candidate.strip()
+                try:
+                    raw = json.loads(candidate)
+                except json.JSONDecodeError:
+                    continue
+
+                if isinstance(raw, dict):
+                    return cast(dict[str, Any], raw)
+
+                if isinstance(raw, list):
+                    saw_array_fence = True
+                    continue
+
+            if saw_array_fence:
                 msg = "Judge response JSON must be an object"
                 raise ValueError(msg)
 
@@ -85,8 +99,28 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     # If an array span exists and fully contains the object span,
     # the top-level value is an array — reject it.
     if has_arr and has_obj and arr_start < obj_start and arr_end > obj_end:
-        msg = "Judge response JSON must be an object"
-        raise ValueError(msg)
+        try:
+            arr_candidate = json.loads(text[arr_start : arr_end + 1])
+        except json.JSONDecodeError:
+            arr_candidate = None
+
+        if isinstance(arr_candidate, list):
+            msg = "Judge response JSON must be an object"
+            raise ValueError(msg)
+
+        if arr_candidate is None:
+            for i, ch in enumerate(text):
+                if ch == "[" and i < obj_start:
+                    inner_arr_end = text.rfind("]", obj_end)
+                    if inner_arr_end == -1:
+                        continue
+                    try:
+                        inner = json.loads(text[i : inner_arr_end + 1])
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(inner, list):
+                        msg = "Judge response JSON must be an object"
+                        raise ValueError(msg)
 
     if not has_obj:
         msg = "Judge response did not contain a JSON object"

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -65,8 +65,6 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
                 msg = "Judge response JSON must be an object"
                 raise ValueError(msg)
 
-    # 🔥 burada artık startswith("[") yok
-    # önce parse etmeye çalışıyoruz
     try:
         raw = json.loads(text)
         if isinstance(raw, dict):
@@ -77,7 +75,6 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     except json.JSONDecodeError:
         pass
 
-    # salvage path (prose + {...})
     start = text.find("{")
     end = text.rfind("}")
     if start == -1 or end == -1 or end <= start:

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -52,7 +52,6 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     if fences:
         for candidate in reversed(fences):
             candidate = candidate.strip()
-
             try:
                 raw = json.loads(candidate)
             except json.JSONDecodeError:
@@ -60,7 +59,6 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
 
             if isinstance(raw, dict):
                 return cast(dict[str, Any], raw)
-
             if isinstance(raw, list):
                 msg = "Judge response JSON must be an object"
                 raise ValueError(msg)
@@ -76,32 +74,25 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
         msg = "Judge response JSON must be an object"
         raise ValueError(msg)
 
-    array_start = text.find("[")
-    array_end = text.rfind("]")
+    obj_start = text.find("{")
+    obj_end = text.rfind("}")
+    arr_start = text.find("[")
+    arr_end = text.rfind("]")
 
-    if array_start != -1 and array_end != -1 and array_end > array_start:
-        object_start = text.find("{")
+    has_obj = obj_start != -1 and obj_end != -1 and obj_end > obj_start
+    has_arr = arr_start != -1 and arr_end != -1 and arr_end > arr_start
 
-        if object_start == -1 or array_start < object_start:
-            for i in range(array_start, array_end + 1):
-                if text[i] == "[":
-                    candidate = text[i : array_end + 1]
-                    try:
-                        parsed = json.loads(candidate)
-                    except json.JSONDecodeError:
-                        continue
+    # If an array span exists and fully contains the object span,
+    # the top-level value is an array — reject it.
+    if has_arr and has_obj and arr_start < obj_start and arr_end > obj_end:
+        msg = "Judge response JSON must be an object"
+        raise ValueError(msg)
 
-                    if isinstance(parsed, list):
-                        msg = "Judge response JSON must be an object"
-                        raise ValueError(msg)
-
-    start = text.find("{")
-    end = text.rfind("}")
-    if start == -1 or end == -1 or end <= start:
+    if not has_obj:
         msg = "Judge response did not contain a JSON object"
         raise ValueError(msg)
 
-    raw = json.loads(text[start : end + 1])
+    raw = json.loads(text[obj_start : obj_end + 1])
     if not isinstance(raw, dict):
         msg = "Judge response JSON must be an object"
         raise ValueError(msg)

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -50,32 +50,25 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
 
     fences = re.findall(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.DOTALL)
     if fences:
-        for candidate in reversed(fences):
-            candidate = candidate.strip()
+        saw_array_fence = False
+
+        for fence_candidate in reversed(fences):
+            fence_candidate = fence_candidate.strip()
             try:
-                raw = json.loads(candidate)
+                parsed_fence = json.loads(fence_candidate)
             except json.JSONDecodeError:
                 continue
 
-            saw_array_fence = False
+            if isinstance(parsed_fence, dict):
+                return cast(dict[str, Any], parsed_fence)
 
-            for candidate in reversed(fences):
-                candidate = candidate.strip()
-                try:
-                    raw = json.loads(candidate)
-                except json.JSONDecodeError:
-                    continue
+            if isinstance(parsed_fence, list):
+                saw_array_fence = True
+                continue
 
-                if isinstance(raw, dict):
-                    return cast(dict[str, Any], raw)
-
-                if isinstance(raw, list):
-                    saw_array_fence = True
-                    continue
-
-            if saw_array_fence:
-                msg = "Judge response JSON must be an object"
-                raise ValueError(msg)
+        if saw_array_fence:
+            msg = "Judge response JSON must be an object"
+            raise ValueError(msg)
 
     try:
         raw = json.loads(text)

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -67,13 +67,14 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
 
     try:
         raw = json.loads(text)
-        if isinstance(raw, dict):
-            return cast(dict[str, Any], raw)
-        if isinstance(raw, list):
-            msg = "Judge response JSON must be an object"
-            raise ValueError(msg)
     except json.JSONDecodeError:
-        pass
+        raw = None
+
+    if isinstance(raw, dict):
+        return cast(dict[str, Any], raw)
+    if isinstance(raw, list):
+        msg = "Judge response JSON must be an object"
+        raise ValueError(msg)
 
     start = text.find("{")
     end = text.rfind("}")

--- a/app/integrations/opensre/llm_eval_judge.py
+++ b/app/integrations/opensre/llm_eval_judge.py
@@ -47,14 +47,37 @@ def _claims_lines(claims: list[Any], key: str = "claim") -> str:
 
 def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     text = text.strip()
-    fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.DOTALL)
-    if fence:
-        text = fence.group(1).strip()
 
-    if text.lstrip().startswith("["):
-        msg = "Judge response JSON must be an object"
-        raise ValueError(msg)
+    fences = re.findall(r"```(?:json)?\s*([\s\S]*?)\s*```", text, re.DOTALL)
+    if fences:
+        for candidate in reversed(fences):
+            candidate = candidate.strip()
 
+            try:
+                raw = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+
+            if isinstance(raw, dict):
+                return cast(dict[str, Any], raw)
+
+            if isinstance(raw, list):
+                msg = "Judge response JSON must be an object"
+                raise ValueError(msg)
+
+    # 🔥 burada artık startswith("[") yok
+    # önce parse etmeye çalışıyoruz
+    try:
+        raw = json.loads(text)
+        if isinstance(raw, dict):
+            return cast(dict[str, Any], raw)
+        if isinstance(raw, list):
+            msg = "Judge response JSON must be an object"
+            raise ValueError(msg)
+    except json.JSONDecodeError:
+        pass
+
+    # salvage path (prose + {...})
     start = text.find("{")
     end = text.rfind("}")
     if start == -1 or end == -1 or end <= start:
@@ -65,6 +88,7 @@ def extract_judge_json_from_response(text: str) -> dict[str, Any]:
     if not isinstance(raw, dict):
         msg = "Judge response JSON must be an object"
         raise ValueError(msg)
+
     return cast(dict[str, Any], raw)
 
 

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -51,3 +51,12 @@ def test_extract_judge_json_raises_for_json_array() -> None:
 def test_extract_judge_json_raises_for_invalid_json() -> None:
     with pytest.raises(ValueError):
         extract_judge_json_from_response('{"overall_pass": true, "score_0_100": 90,')
+
+
+def test_extract_judge_json_raises_for_fenced_json_array() -> None:
+    with pytest.raises(ValueError, match="JSON must be an object"):
+        extract_judge_json_from_response(
+            """```json
+[{"overall_pass": true}]
+```"""
+        )

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -44,7 +44,7 @@ def test_extract_judge_json_raises_when_no_json_object() -> None:
 
 
 def test_extract_judge_json_raises_for_json_array() -> None:
-    with pytest.raises(ValueError, match="JSON must be an object|did not contain a JSON object"):
+    with pytest.raises(ValueError, match="JSON must be an object"):
         extract_judge_json_from_response('[{"overall_pass": true}]')
 
 
@@ -60,3 +60,8 @@ def test_extract_judge_json_raises_for_fenced_json_array() -> None:
 [{"overall_pass": true}]
 ```"""
         )
+
+
+def test_extract_judge_json_raises_for_whitespace_json_array() -> None:
+    with pytest.raises(ValueError, match="JSON must be an object"):
+        extract_judge_json_from_response('   \n  [{"overall_pass": true}]')

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from app.integrations.opensre.llm_eval_judge import extract_judge_json_from_response
+
+
+def test_extract_judge_json_from_clean_json() -> None:
+    out = extract_judge_json_from_response(
+        '{"overall_pass": true, "score_0_100": 95, "rubric_items": [], "summary": "ok"}'
+    )
+
+    assert out["overall_pass"] is True
+    assert out["score_0_100"] == 95
+
+
+def test_extract_judge_json_from_markdown_fence() -> None:
+    out = extract_judge_json_from_response(
+        """```json
+{"overall_pass": false, "score_0_100": 40, "rubric_items": [], "summary": "missed rubric"}
+```"""
+    )
+
+    assert out["overall_pass"] is False
+    assert out["score_0_100"] == 40
+
+
+def test_extract_judge_json_with_extra_text() -> None:
+    out = extract_judge_json_from_response(
+        """Here is the evaluation result:
+
+{"overall_pass": true, "score_0_100": 88, "rubric_items": [{"id": "rca", "satisfied": true, "explanation": "matches"}], "summary": "good"}
+
+Thanks."""
+    )
+
+    assert out["overall_pass"] is True
+    assert out["rubric_items"][0]["id"] == "rca"
+
+
+def test_extract_judge_json_raises_when_no_json_object() -> None:
+    with pytest.raises(ValueError, match="did not contain a JSON object"):
+        extract_judge_json_from_response("The investigation looks good overall.")
+
+
+def test_extract_judge_json_raises_for_json_array() -> None:
+    with pytest.raises(ValueError, match="JSON must be an object|did not contain a JSON object"):
+        extract_judge_json_from_response('[{"overall_pass": true}]')
+
+
+def test_extract_judge_json_raises_for_invalid_json() -> None:
+    with pytest.raises(ValueError):
+        extract_judge_json_from_response(
+            '{"overall_pass": true, "score_0_100": 90,'
+        )

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -50,6 +50,4 @@ def test_extract_judge_json_raises_for_json_array() -> None:
 
 def test_extract_judge_json_raises_for_invalid_json() -> None:
     with pytest.raises(ValueError):
-        extract_judge_json_from_response(
-            '{"overall_pass": true, "score_0_100": 90,'
-        )
+        extract_judge_json_from_response('{"overall_pass": true, "score_0_100": 90,')

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -81,3 +81,10 @@ def test_extract_judge_json_picks_last_valid_fence_with_multiple_fences() -> Non
 
     assert out["overall_pass"] is True
     assert out["score_0_100"] == 90
+
+
+def test_extract_judge_json_raises_for_prose_wrapped_array() -> None:
+    with pytest.raises(ValueError, match="JSON must be an object"):
+        extract_judge_json_from_response(
+            'Here is the result: [{"overall_pass": true}] Thanks'
+        )

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -90,6 +90,4 @@ def test_extract_judge_json_raises_for_prose_wrapped_array() -> None:
 
 def test_extract_judge_json_raises_for_info_prefixed_array() -> None:
     with pytest.raises(ValueError, match="JSON must be an object"):
-        extract_judge_json_from_response(
-            '[INFO] result: [{"overall_pass": true}]'
-        )
+        extract_judge_json_from_response('[INFO] result: [{"overall_pass": true}]')

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -101,3 +101,26 @@ def test_extract_judge_json_allows_log_prefix_with_nested_array() -> None:
     assert out["overall_pass"] is True
     assert out["score_0_100"] == 90
     assert out["rubric_items"] == []
+
+
+def test_extract_judge_json_skips_array_fence_and_returns_earlier_dict() -> None:
+    out = extract_judge_json_from_response(
+        "Result:\n"
+        "```json\n"
+        '{"overall_pass": true, "score_0_100": 90, "rubric_items": [], "summary": "ok"}\n'
+        "```\n\n"
+        "Examples:\n"
+        "```json\n"
+        '["item1", "item2"]\n'
+        "```"
+    )
+    assert out["overall_pass"] is True
+    assert out["score_0_100"] == 90
+
+
+def test_extract_judge_json_allows_bracketed_prose_around_object() -> None:
+    out = extract_judge_json_from_response(
+        '[INFO] here is the result: {"overall_pass": true, "score_0_100": 90, "rubric_items": [], "summary": "ok"} [end]'
+    )
+    assert out["overall_pass"] is True
+    assert out["score_0_100"] == 90

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -124,3 +124,17 @@ def test_extract_judge_json_allows_bracketed_prose_around_object() -> None:
     )
     assert out["overall_pass"] is True
     assert out["score_0_100"] == 90
+
+
+def test_extract_judge_json_prefers_inline_dict_over_array_fence() -> None:
+    out = extract_judge_json_from_response(
+        "For reference:\n"
+        "```json\n"
+        '["item1", "item2"]\n'
+        "```\n\n"
+        "Actual result:\n"
+        '{"overall_pass": true, "score_0_100": 90, "rubric_items": [], "summary": "ok"}'
+    )
+
+    assert out["overall_pass"] is True
+    assert out["score_0_100"] == 90

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -86,3 +86,10 @@ def test_extract_judge_json_picks_last_valid_fence_with_multiple_fences() -> Non
 def test_extract_judge_json_raises_for_prose_wrapped_array() -> None:
     with pytest.raises(ValueError, match="JSON must be an object"):
         extract_judge_json_from_response('Here is the result: [{"overall_pass": true}] Thanks')
+
+
+def test_extract_judge_json_raises_for_info_prefixed_array() -> None:
+    with pytest.raises(ValueError, match="JSON must be an object"):
+        extract_judge_json_from_response(
+            '[INFO] result: [{"overall_pass": true}]'
+        )

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -65,3 +65,19 @@ def test_extract_judge_json_raises_for_fenced_json_array() -> None:
 def test_extract_judge_json_raises_for_whitespace_json_array() -> None:
     with pytest.raises(ValueError, match="JSON must be an object"):
         extract_judge_json_from_response('   \n  [{"overall_pass": true}]')
+
+
+def test_extract_judge_json_picks_last_valid_fence_with_multiple_fences() -> None:
+    out = extract_judge_json_from_response(
+        "Example shape:\n"
+        "```json\n"
+        '{"old": 1}\n'
+        "```\n\n"
+        "Actual answer:\n"
+        "```json\n"
+        '{"overall_pass": true, "score_0_100": 90, "rubric_items": [], "summary": "ok"}\n'
+        "```"
+    )
+
+    assert out["overall_pass"] is True
+    assert out["score_0_100"] == 90

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -85,6 +85,4 @@ def test_extract_judge_json_picks_last_valid_fence_with_multiple_fences() -> Non
 
 def test_extract_judge_json_raises_for_prose_wrapped_array() -> None:
     with pytest.raises(ValueError, match="JSON must be an object"):
-        extract_judge_json_from_response(
-            'Here is the result: [{"overall_pass": true}] Thanks'
-        )
+        extract_judge_json_from_response('Here is the result: [{"overall_pass": true}] Thanks')

--- a/tests/integrations/opensre/test_llm_eval_judge.py
+++ b/tests/integrations/opensre/test_llm_eval_judge.py
@@ -91,3 +91,13 @@ def test_extract_judge_json_raises_for_prose_wrapped_array() -> None:
 def test_extract_judge_json_raises_for_info_prefixed_array() -> None:
     with pytest.raises(ValueError, match="JSON must be an object"):
         extract_judge_json_from_response('[INFO] result: [{"overall_pass": true}]')
+
+
+def test_extract_judge_json_allows_log_prefix_with_nested_array() -> None:
+    out = extract_judge_json_from_response(
+        '[INFO] result: {"overall_pass": true, "score_0_100": 90, "rubric_items": [], "summary": "ok"}'
+    )
+
+    assert out["overall_pass"] is True
+    assert out["score_0_100"] == 90
+    assert out["rubric_items"] == []


### PR DESCRIPTION
## Summary

This PR improves the robustness of the OpenSRE evaluation pipeline by hardening how LLM judge responses are parsed and validated.

The current evaluation flow relies on extracting a JSON object from LLM outputs. However, real LLM responses are often not strictly well-formed and may include additional text, markdown fences, or malformed structures. This can lead to unstable or incorrect benchmark results.

## Problem

The existing `extract_judge_json_from_response` implementation:

- assumes a clean JSON object in the response
- does not explicitly reject JSON arrays
- can incorrectly extract partial JSON from mixed outputs
- is not tested against real-world LLM response patterns

As a result, evaluation can silently succeed with incorrect parsing or fail unpredictably depending on LLM formatting.

## Changes

- Hardened JSON extraction logic:
  - captures full fenced content (not just `{...}`) to avoid partial extraction
  - explicitly rejects JSON arrays (`[...]`), including fenced cases
  - improves detection of valid JSON object boundaries
  - ensures only dictionary outputs are accepted

- Added dedicated test coverage for judge parsing:
  - clean JSON responses
  - markdown fenced JSON (```json)
  - mixed prose + JSON outputs
  - missing JSON cases
  - JSON arrays (invalid)
  - malformed JSON
  - fenced JSON arrays (invalid, now explicitly rejected)

## Why this matters

OpenSRE evaluation depends on LLM judge outputs for scoring (`overall_pass`, `score_0_100`, etc.).

This change improves:

- evaluation stability
- reproducibility of benchmark results
- robustness to real LLM output variability
- prevents silent mis-scoring due to partial JSON extraction 

## Result:
8 passed

## Validation

```bash
pytest tests/integrations/opensre/test_llm_eval_judge.py