### PR TITLE
test: add unit tests for Bitbucket tools (Commits, FileContents, SearchCode)

### DIFF
--- a/tests/tools/test_bitbucket_commits_tool.py
+++ b/tests/tools/test_bitbucket_commits_tool.py
@@ -1,0 +1,100 @@
+"""Unit tests for BitbucketCommitsTool (list_bitbucket_commits)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.BitbucketCommitsTool import list_bitbucket_commits
+from tests.tools.conftest import BaseToolContract
+
+
+class TestBitbucketCommitsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return list_bitbucket_commits.__opensre_registered_tool__
+
+
+# ── is_available ────────────────────────────────────────────────────
+
+def test_is_available_true_with_full_creds() -> None:
+    rt = list_bitbucket_commits.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+            "repo_slug": "my-repo",
+        }
+    }
+    assert rt.is_available(sources) is True
+
+
+def test_is_available_false_missing_repo_slug() -> None:
+    rt = list_bitbucket_commits.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+        }
+    }
+    assert rt.is_available(sources) is False
+
+
+def test_is_available_false_missing_bitbucket_key() -> None:
+    rt = list_bitbucket_commits.__opensre_registered_tool__
+    assert rt.is_available({}) is False
+
+
+# ── extract_params ──────────────────────────────────────────────────
+
+def test_extract_params_maps_fields() -> None:
+    rt = list_bitbucket_commits.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+            "repo_slug": "my-repo",
+            "path": "src/main.py",
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["repo_slug"] == "my-repo"
+    assert params["path"] == "src/main.py"
+    assert params["workspace"] == "my-workspace"
+    assert params["username"] == "user"
+    assert params["app_password"] == "secret"
+
+
+# ── run ─────────────────────────────────────────────────────────────
+
+def test_run_returns_commits_on_success() -> None:
+    mock_commits = [
+        {"hash": "abc123", "message": "fix: resolve crash", "author": "dev"},
+        {"hash": "def456", "message": "feat: add feature", "author": "dev"},
+    ]
+    with patch("app.tools.BitbucketCommitsTool.list_commits", return_value=mock_commits):
+        result = list_bitbucket_commits(
+            repo_slug="my-repo",
+            workspace="my-workspace",
+            username="user",
+            app_password="secret",
+        )
+    assert result["available"] is True
+    assert len(result["commits"]) == 2
+    assert result["commits"][0]["hash"] == "abc123"
+
+
+def test_run_returns_unavailable_on_exception() -> None:
+    with patch(
+        "app.tools.BitbucketCommitsTool.list_commits",
+        side_effect=Exception("connection refused"),
+    ):
+        result = list_bitbucket_commits(
+            repo_slug="my-repo",
+            workspace="my-workspace",
+            username="user",
+            app_password="secret",
+        )
+    assert result["available"] is False
+    assert "error" in result

--- a/tests/tools/test_bitbucket_file_contents_tool.py
+++ b/tests/tools/test_bitbucket_file_contents_tool.py
@@ -1,0 +1,100 @@
+"""Unit tests for BitbucketFileContentsTool (get_bitbucket_file_contents)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.BitbucketFileContentsTool import get_bitbucket_file_contents
+from tests.tools.conftest import BaseToolContract
+
+
+class TestBitbucketFileContentsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_bitbucket_file_contents.__opensre_registered_tool__
+
+
+# ── is_available ────────────────────────────────────────────────────
+
+def test_is_available_true_with_full_creds() -> None:
+    rt = get_bitbucket_file_contents.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+            "repo_slug": "my-repo",
+            "path": "config/settings.yaml",
+        }
+    }
+    assert rt.is_available(sources) is True
+
+
+def test_is_available_false_missing_path() -> None:
+    rt = get_bitbucket_file_contents.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+            "repo_slug": "my-repo",
+        }
+    }
+    assert rt.is_available(sources) is False
+
+
+def test_is_available_false_missing_bitbucket_key() -> None:
+    rt = get_bitbucket_file_contents.__opensre_registered_tool__
+    assert rt.is_available({}) is False
+
+
+# ── extract_params ──────────────────────────────────────────────────
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_bitbucket_file_contents.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+            "repo_slug": "my-repo",
+            "path": "config/settings.yaml",
+            "ref": "main",
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["repo_slug"] == "my-repo"
+    assert params["path"] == "config/settings.yaml"
+    assert params["ref"] == "main"
+    assert params["workspace"] == "my-workspace"
+
+
+# ── run ─────────────────────────────────────────────────────────────
+
+def test_run_returns_file_contents_on_success() -> None:
+    mock_contents = {"content": "key: value\nother: data", "size": 22}
+    with patch("app.tools.BitbucketFileContentsTool.get_file_contents", return_value=mock_contents):
+        result = get_bitbucket_file_contents(
+            repo_slug="my-repo",
+            path="config/settings.yaml",
+            workspace="my-workspace",
+            username="user",
+            app_password="secret",
+        )
+    assert result["available"] is True
+    assert "content" in result
+
+
+def test_run_returns_unavailable_on_exception() -> None:
+    with patch(
+        "app.tools.BitbucketFileContentsTool.get_file_contents",
+        side_effect=Exception("404 not found"),
+    ):
+        result = get_bitbucket_file_contents(
+            repo_slug="my-repo",
+            path="missing.yaml",
+            workspace="my-workspace",
+            username="user",
+            app_password="secret",
+        )
+    assert result["available"] is False
+    assert "error" in result

--- a/tests/tools/test_bitbucket_search_code_tool.py
+++ b/tests/tools/test_bitbucket_search_code_tool.py
@@ -1,0 +1,89 @@
+"""Unit tests for BitbucketSearchCodeTool (search_bitbucket_code)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.BitbucketSearchCodeTool import search_bitbucket_code
+from tests.tools.conftest import BaseToolContract
+
+
+class TestBitbucketSearchCodeToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return search_bitbucket_code.__opensre_registered_tool__
+
+
+# ── is_available ────────────────────────────────────────────────────
+
+def test_is_available_true_with_full_creds() -> None:
+    rt = search_bitbucket_code.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+        }
+    }
+    assert rt.is_available(sources) is True
+
+
+def test_is_available_false_missing_creds() -> None:
+    rt = search_bitbucket_code.__opensre_registered_tool__
+    assert rt.is_available({"bitbucket": {}}) is False
+
+
+def test_is_available_false_missing_bitbucket_key() -> None:
+    rt = search_bitbucket_code.__opensre_registered_tool__
+    assert rt.is_available({}) is False
+
+
+# ── extract_params ──────────────────────────────────────────────────
+
+def test_extract_params_maps_fields() -> None:
+    rt = search_bitbucket_code.__opensre_registered_tool__
+    sources = {
+        "bitbucket": {
+            "workspace": "my-workspace",
+            "username": "user",
+            "app_password": "secret",
+            "query": "def connect",
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["workspace"] == "my-workspace"
+    assert params["username"] == "user"
+    assert params["app_password"] == "secret"
+
+
+# ── run ─────────────────────────────────────────────────────────────
+
+def test_run_returns_results_on_success() -> None:
+    mock_results = {
+        "values": [
+            {"file": {"path": "app/db.py"}, "lines": [{"line": "def connect():"}]},
+        ]
+    }
+    with patch("app.tools.BitbucketSearchCodeTool.search_code", return_value=mock_results):
+        result = search_bitbucket_code(
+            query="def connect",
+            workspace="my-workspace",
+            username="user",
+            app_password="secret",
+        )
+    assert result["available"] is True
+    assert len(result["results"]) >= 1
+
+
+def test_run_returns_unavailable_on_exception() -> None:
+    with patch(
+        "app.tools.BitbucketSearchCodeTool.search_code",
+        side_effect=Exception("auth error"),
+    ):
+        result = search_bitbucket_code(
+            query="def connect",
+            workspace="my-workspace",
+            username="user",
+            app_password="secret",
+        )
+    assert result["available"] is False
+    assert "error" in result


### PR DESCRIPTION
Closes #992

## What

Adds unit tests for all three Bitbucket tools as specified in the issue:

- `tests/tools/test_bitbucket_commits_tool.py`
- `tests/tools/test_bitbucket_file_contents_tool.py`
- `tests/tools/test_bitbucket_search_code_tool.py`

## Coverage per file

Each test file covers:
1. **Contract test** — inherits `BaseToolContract`, implements `get_tool_under_test()`
2. **`is_available`** — `True` with full creds + required fields; `False` when creds missing or key absent
3. **`extract_params`** — asserts `repo_slug`, `workspace`, `username`, `app_password` map correctly
4. **`run` happy path** — patches the underlying integration function (`list_commits`, `get_file_contents`, `search_code`) with `MagicMock` and asserts expected output shape
5. **`run` error path** — patches with `side_effect=Exception(...)` and asserts `available=False` + `error` key present

## Pattern followed

Matches `tests/tools/test_grafana_logs_tool.py` exactly — same import style, same structure, same mock approach.