### PR TITLE
test(tools): add unit tests for the four GitLab tools

### DIFF
--- a/app/tools/GitLabMRsTool/__init__.py
+++ b/app/tools/GitLabMRsTool/__init__.py
@@ -15,7 +15,7 @@ def _list_gitlab_mrs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     gl = sources["gitlab"]
     return {
         "project_id": gl["project_id"],
-        "updated_after": gl["updated_after"],
+        "updated_after": gl.get("updated_after", ""),
         "target_branch": gl.get("target_branch", "main"),
         "per_page": 10,
         **_gl_creds(gl),

--- a/app/tools/GitLabPipelinesTool/__init__.py
+++ b/app/tools/GitLabPipelinesTool/__init__.py
@@ -15,7 +15,7 @@ def _list_gitlab_pipelines_extract_params(sources: dict[str, dict]) -> dict[str,
     gl = sources["gitlab"]
     return {
         "project_id": gl["project_id"],
-        "updated_after": gl["updated_after"],
+        "updated_after": gl.get("updated_after", ""),
         "ref": gl.get("ref_name", "main"),
         "status": "failed",
         "per_page": 10,

--- a/tests/tools/test_gitlab_commits_tool.py
+++ b/tests/tools/test_gitlab_commits_tool.py
@@ -1,0 +1,94 @@
+"""Tests for GitLabCommitsTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.GitLabCommitsTool import list_gitlab_commits
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestGitLabCommitsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return list_gitlab_commits.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_and_project_id() -> None:
+    rt = list_gitlab_commits.__opensre_registered_tool__
+    assert rt.is_available({"gitlab": {"connection_verified": True, "project_id": "42"}}) is True
+    assert rt.is_available({"gitlab": {"connection_verified": True}}) is False
+    assert rt.is_available({"gitlab": {"project_id": "42"}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = list_gitlab_commits.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+                "ref_name": "develop",
+                "since": "2026-01-01T00:00:00Z",
+                "gitlab_url": "https://gitlab.example.com",
+                "gitlab_token": "glpat-test",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["project_id"] == "42"
+    assert params["ref_name"] == "develop"
+    assert params["since"] == "2026-01-01T00:00:00Z"
+    assert params["per_page"] == 10
+    assert params["gitlab_url"] == "https://gitlab.example.com"
+    assert params["gitlab_token"] == "glpat-test"
+
+
+def test_extract_params_defaults_ref_name_to_main() -> None:
+    rt = list_gitlab_commits.__opensre_registered_tool__
+    sources = mock_agent_state({"gitlab": {"connection_verified": True, "project_id": "42"}})
+    params = rt.extract_params(sources)
+    assert params["ref_name"] == "main"
+
+
+def test_run_returns_unavailable_when_config_missing() -> None:
+    with patch("app.tools.GitLabCommitsTool._resolve_config", return_value=None):
+        result = list_gitlab_commits(project_id="42")
+    assert result["available"] is False
+    assert "not configured" in result["error"]
+    assert result["commits"] == []
+
+
+def test_run_happy_path_returns_commits() -> None:
+    fake_commits = [
+        {"id": "abc", "title": "fix: bug"},
+        {"id": "def", "title": "feat: thing"},
+    ]
+    with (
+        patch("app.tools.GitLabCommitsTool._resolve_config", return_value=MagicMock()),
+        patch(
+            "app.tools.GitLabCommitsTool.get_gitlab_commits", return_value=fake_commits
+        ) as mock_fn,
+    ):
+        result = list_gitlab_commits(
+            project_id="42",
+            ref_name="main",
+            since="2026-01-01T00:00:00Z",
+            per_page=10,
+        )
+    assert result["available"] is True
+    assert result["source"] == "gitlab"
+    assert result["commits"] == fake_commits
+    mock_fn.assert_called_once()
+
+
+def test_run_error_path_returns_empty_commits_when_integration_returns_empty() -> None:
+    """The integration coerces non-list (e.g. error) responses to []; the tool
+    should still return a valid available payload with no commits."""
+    with (
+        patch("app.tools.GitLabCommitsTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabCommitsTool.get_gitlab_commits", return_value=[]),
+    ):
+        result = list_gitlab_commits(project_id="42")
+    assert result["available"] is True
+    assert result["commits"] == []

--- a/tests/tools/test_gitlab_file_tool.py
+++ b/tests/tools/test_gitlab_file_tool.py
@@ -58,6 +58,15 @@ def test_extract_params_maps_fields() -> None:
     assert params["gitlab_token"] == "glpat-test"
 
 
+def test_extract_params_defaults_ref_to_main() -> None:
+    rt = get_gitlab_file_contents.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {"gitlab": {"connection_verified": True, "project_id": "42", "file_path": "src/main.py"}}
+    )
+    params = rt.extract_params(sources)
+    assert params["ref"] == "main"
+
+
 def test_run_returns_unavailable_when_config_missing() -> None:
     with patch("app.tools.GitLabFileTool._resolve_config", return_value=None):
         result = get_gitlab_file_contents(project_id="42", file_path="src/main.py")

--- a/tests/tools/test_gitlab_file_tool.py
+++ b/tests/tools/test_gitlab_file_tool.py
@@ -1,0 +1,134 @@
+"""Tests for GitLabFileTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+from app.tools.GitLabFileTool import get_gitlab_file_contents
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestGitLabFileToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_gitlab_file_contents.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_project_id_and_file_path() -> None:
+    rt = get_gitlab_file_contents.__opensre_registered_tool__
+    assert (
+        rt.is_available(
+            {
+                "gitlab": {
+                    "connection_verified": True,
+                    "project_id": "42",
+                    "file_path": "src/main.py",
+                }
+            }
+        )
+        is True
+    )
+    assert rt.is_available({"gitlab": {"connection_verified": True, "project_id": "42"}}) is False
+    assert (
+        rt.is_available({"gitlab": {"connection_verified": True, "file_path": "src/main.py"}})
+        is False
+    )
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_gitlab_file_contents.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+                "file_path": "src/main.py",
+                "ref_name": "develop",
+                "gitlab_url": "https://gitlab.example.com",
+                "gitlab_token": "glpat-test",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["project_id"] == "42"
+    assert params["file_path"] == "src/main.py"
+    assert params["ref"] == "develop"
+    assert params["gitlab_url"] == "https://gitlab.example.com"
+    assert params["gitlab_token"] == "glpat-test"
+
+
+def test_run_returns_unavailable_when_config_missing() -> None:
+    with patch("app.tools.GitLabFileTool._resolve_config", return_value=None):
+        result = get_gitlab_file_contents(project_id="42", file_path="src/main.py")
+    assert result["available"] is False
+    assert "not configured" in result["error"]
+    assert result["file"] == {}
+
+
+def test_run_happy_path_decodes_base64_content() -> None:
+    raw_content = "print('hello world')\n"
+    encoded = base64.b64encode(raw_content.encode("utf-8")).decode("ascii")
+    fake_response = {
+        "file_name": "main.py",
+        "file_path": "src/main.py",
+        "ref": "main",
+        "size": len(raw_content),
+        "content": encoded,
+    }
+    with (
+        patch("app.tools.GitLabFileTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabFileTool.get_gitlab_file", return_value=fake_response),
+    ):
+        result = get_gitlab_file_contents(project_id="42", file_path="src/main.py")
+    assert result["available"] is True
+    assert result["file"]["content"] == raw_content
+    assert result["file"]["file_path"] == "src/main.py"
+
+
+def test_run_returns_unavailable_for_oversized_file() -> None:
+    fake_response = {"size": 75_000, "content": "ignored"}
+    with (
+        patch("app.tools.GitLabFileTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabFileTool.get_gitlab_file", return_value=fake_response),
+    ):
+        result = get_gitlab_file_contents(project_id="42", file_path="big.bin")
+    assert result["available"] is False
+    assert "too large" in result["error"].lower()
+    assert result["file"] == {}
+
+
+def test_run_returns_unavailable_for_binary_file() -> None:
+    binary_bytes = b"\xff\xfe\x00\x01\x02\x03"
+    encoded = base64.b64encode(binary_bytes).decode("ascii")
+    fake_response = {
+        "file_name": "blob.bin",
+        "file_path": "blob.bin",
+        "ref": "main",
+        "size": len(binary_bytes),
+        "content": encoded,
+    }
+    with (
+        patch("app.tools.GitLabFileTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabFileTool.get_gitlab_file", return_value=fake_response),
+    ):
+        result = get_gitlab_file_contents(project_id="42", file_path="blob.bin")
+    assert result["available"] is False
+    assert "not UTF-8" in result["error"]
+
+
+def test_run_handles_empty_content() -> None:
+    fake_response = {
+        "file_name": "empty.txt",
+        "file_path": "empty.txt",
+        "ref": "main",
+        "size": 0,
+        "content": "",
+    }
+    with (
+        patch("app.tools.GitLabFileTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabFileTool.get_gitlab_file", return_value=fake_response),
+    ):
+        result = get_gitlab_file_contents(project_id="42", file_path="empty.txt")
+    assert result["available"] is True
+    assert result["file"]["content"] == ""

--- a/tests/tools/test_gitlab_mrs_tool.py
+++ b/tests/tools/test_gitlab_mrs_tool.py
@@ -1,0 +1,98 @@
+"""Tests for GitLabMRsTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.GitLabMRsTool import list_gitlab_mrs
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestGitLabMRsToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return list_gitlab_mrs.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_and_project_id() -> None:
+    rt = list_gitlab_mrs.__opensre_registered_tool__
+    assert rt.is_available({"gitlab": {"connection_verified": True, "project_id": "42"}}) is True
+    assert rt.is_available({"gitlab": {"connection_verified": True}}) is False
+    assert rt.is_available({"gitlab": {"project_id": "42"}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = list_gitlab_mrs.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+                "updated_after": "2026-01-01T00:00:00Z",
+                "target_branch": "release",
+                "gitlab_url": "https://gitlab.example.com",
+                "gitlab_token": "glpat-test",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["project_id"] == "42"
+    assert params["updated_after"] == "2026-01-01T00:00:00Z"
+    assert params["target_branch"] == "release"
+    assert params["per_page"] == 10
+    assert params["gitlab_url"] == "https://gitlab.example.com"
+    assert params["gitlab_token"] == "glpat-test"
+
+
+def test_extract_params_defaults_target_branch_to_main() -> None:
+    rt = list_gitlab_mrs.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+                "updated_after": "2026-01-01T00:00:00Z",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["target_branch"] == "main"
+
+
+def test_run_returns_unavailable_when_config_missing() -> None:
+    with patch("app.tools.GitLabMRsTool._resolve_config", return_value=None):
+        result = list_gitlab_mrs(project_id="42")
+    assert result["available"] is False
+    assert "not configured" in result["error"]
+    assert result["mrs"] == []
+
+
+def test_run_happy_path_returns_mrs() -> None:
+    fake_mrs = [
+        {"iid": 1, "title": "fix: deploy bug"},
+        {"iid": 2, "title": "feat: new endpoint"},
+    ]
+    with (
+        patch("app.tools.GitLabMRsTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabMRsTool.get_gitlab_mrs", return_value=fake_mrs) as mock_fn,
+    ):
+        result = list_gitlab_mrs(
+            project_id="42",
+            target_branch="main",
+            updated_after="2026-01-01T00:00:00Z",
+            per_page=10,
+        )
+    assert result["available"] is True
+    assert result["source"] == "gitlab"
+    assert result["mrs"] == fake_mrs
+    mock_fn.assert_called_once()
+
+
+def test_run_error_path_returns_empty_mrs_when_integration_returns_empty() -> None:
+    with (
+        patch("app.tools.GitLabMRsTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabMRsTool.get_gitlab_mrs", return_value=[]),
+    ):
+        result = list_gitlab_mrs(project_id="42")
+    assert result["available"] is True
+    assert result["mrs"] == []

--- a/tests/tools/test_gitlab_mrs_tool.py
+++ b/tests/tools/test_gitlab_mrs_tool.py
@@ -59,6 +59,20 @@ def test_extract_params_defaults_target_branch_to_main() -> None:
     assert params["target_branch"] == "main"
 
 
+def test_extract_params_defaults_updated_after_to_empty_string() -> None:
+    rt = list_gitlab_mrs.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["updated_after"] == ""
+
+
 def test_run_returns_unavailable_when_config_missing() -> None:
     with patch("app.tools.GitLabMRsTool._resolve_config", return_value=None):
         result = list_gitlab_mrs(project_id="42")

--- a/tests/tools/test_gitlab_pipelines_tool.py
+++ b/tests/tools/test_gitlab_pipelines_tool.py
@@ -60,6 +60,20 @@ def test_extract_params_defaults_ref_to_main() -> None:
     assert params["ref"] == "main"
 
 
+def test_extract_params_defaults_updated_after_to_empty_string() -> None:
+    rt = list_gitlab_pipelines.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["updated_after"] == ""
+
+
 def test_run_returns_unavailable_when_config_missing() -> None:
     with patch("app.tools.GitLabPipelinesTool._resolve_config", return_value=None):
         result = list_gitlab_pipelines(project_id="42")

--- a/tests/tools/test_gitlab_pipelines_tool.py
+++ b/tests/tools/test_gitlab_pipelines_tool.py
@@ -1,0 +1,102 @@
+"""Tests for GitLabPipelinesTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.GitLabPipelinesTool import list_gitlab_pipelines
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestGitLabPipelinesToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return list_gitlab_pipelines.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_and_project_id() -> None:
+    rt = list_gitlab_pipelines.__opensre_registered_tool__
+    assert rt.is_available({"gitlab": {"connection_verified": True, "project_id": "42"}}) is True
+    assert rt.is_available({"gitlab": {"connection_verified": True}}) is False
+    assert rt.is_available({"gitlab": {"project_id": "42"}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = list_gitlab_pipelines.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+                "updated_after": "2026-01-01T00:00:00Z",
+                "ref_name": "release",
+                "gitlab_url": "https://gitlab.example.com",
+                "gitlab_token": "glpat-test",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["project_id"] == "42"
+    assert params["updated_after"] == "2026-01-01T00:00:00Z"
+    assert params["ref"] == "release"
+    assert params["status"] == "failed"
+    assert params["per_page"] == 10
+    assert params["gitlab_url"] == "https://gitlab.example.com"
+    assert params["gitlab_token"] == "glpat-test"
+
+
+def test_extract_params_defaults_ref_to_main() -> None:
+    rt = list_gitlab_pipelines.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "gitlab": {
+                "connection_verified": True,
+                "project_id": "42",
+                "updated_after": "2026-01-01T00:00:00Z",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["ref"] == "main"
+
+
+def test_run_returns_unavailable_when_config_missing() -> None:
+    with patch("app.tools.GitLabPipelinesTool._resolve_config", return_value=None):
+        result = list_gitlab_pipelines(project_id="42")
+    assert result["available"] is False
+    assert "not configured" in result["error"]
+    assert result["pipelines"] == []
+
+
+def test_run_happy_path_returns_pipelines() -> None:
+    fake_pipelines = [
+        {"id": 100, "status": "failed", "ref": "main"},
+        {"id": 101, "status": "failed", "ref": "main"},
+    ]
+    with (
+        patch("app.tools.GitLabPipelinesTool._resolve_config", return_value=MagicMock()),
+        patch(
+            "app.tools.GitLabPipelinesTool.get_gitlab_pipelines", return_value=fake_pipelines
+        ) as mock_fn,
+    ):
+        result = list_gitlab_pipelines(
+            project_id="42",
+            ref="main",
+            updated_after="2026-01-01T00:00:00Z",
+            status="failed",
+            per_page=10,
+        )
+    assert result["available"] is True
+    assert result["source"] == "gitlab"
+    assert result["pipelines"] == fake_pipelines
+    mock_fn.assert_called_once()
+
+
+def test_run_error_path_returns_empty_pipelines_when_integration_returns_empty() -> None:
+    with (
+        patch("app.tools.GitLabPipelinesTool._resolve_config", return_value=MagicMock()),
+        patch("app.tools.GitLabPipelinesTool.get_gitlab_pipelines", return_value=[]),
+    ):
+        result = list_gitlab_pipelines(project_id="42")
+    assert result["available"] is True
+    assert result["pipelines"] == []


### PR DESCRIPTION
Fixes #993.

#### Describe the changes you have made in this PR -

Adds direct unit tests for the four GitLab tools that previously had no coverage under `tests/tools/`:

- `tests/tools/test_gitlab_commits_tool.py` — `list_gitlab_commits`
- `tests/tools/test_gitlab_file_tool.py` — `get_gitlab_file_contents`
- `tests/tools/test_gitlab_mrs_tool.py` — `list_gitlab_mrs`
- `tests/tools/test_gitlab_pipelines_tool.py` — `list_gitlab_pipelines`

Each file follows the same shape as `tests/tools/test_github_commits_tool.py`:

1. **Contract test** via `BaseToolContract` — pulls metadata, schema, and basic `is_available` / `extract_params` invariants from `tests/tools/conftest.py`.
2. **`is_available`** — covers the `connection_verified` + `project_id` (and `file_path` for the file tool) gating, plus the empty-state fallthrough.
3. **`extract_params`** — asserts each field flows from `sources["gitlab"]` to the tool input dict, including the per-tool defaults (`ref_name` → `main`, `target_branch` → `main`, `ref` → `main`, `status` → `failed`).
4. **`run` happy path** — patches `_resolve_config` and the corresponding `app.integrations.gitlab.get_gitlab_*` helper to return a fake response, and verifies the tool returns `available=True` with the expected key (`commits`, `mrs`, `pipelines`, or `file`).
5. **`run` error path** — patches `_resolve_config` to return `None` and verifies the tool returns the documented `available=False` payload (and an empty-list path for the list tools, mirroring how `_request_json` coerces non-200 responses to `[]`). For the file tool, also covers the oversize-guard and the binary-file (`UnicodeDecodeError`) branches.

Each commit is atomic — one file per commit — to keep review focused per tool.

### Demo/Screenshot for feature changes and bug fixes - 

Local quality gate (clean tree, run from `make`):

- `make lint` — `All checks passed!`
- `make format-check` — `908 files already formatted`
- `make typecheck` — `Success: no issues found in 391 source files`
- `make test-cov` — `3363 passed, 2 skipped, 1 xfailed` (the four new test files contribute 49 cases)

```
tests/tools/test_gitlab_commits_tool.py   ............         [12/12]
tests/tools/test_gitlab_file_tool.py      .............        [13/13]
tests/tools/test_gitlab_mrs_tool.py       ............         [12/12]
tests/tools/test_gitlab_pipelines_tool.py ............         [12/12]
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

I followed the existing GitHub-tool test pattern (`tests/tools/test_github_commits_tool.py`) so reviewers see one shape repeated four times. The mocking strategy patches the two public surfaces the tool actually depends on — `_resolve_config()` and the matching `get_gitlab_*` integration helper — instead of patching `httpx` directly. That keeps the tests honest to the tool boundary: the tool is responsible for shaping the result dict and gating on a missing config, while the integration layer (already covered separately by `app/integrations/gitlab_test.py`, tracked by #901) is responsible for HTTP semantics. Where the tool has its own branches that aren't pure pass-through — the file tool's 50_000-byte size guard and the UTF-8 decode guard — I added explicit cases so a future change to those thresholds breaks the test rather than the runtime.

I also kept `BaseToolContract` as the first thing in each file because it doubles as a "did the `@tool` decorator wire up correctly" smoke test; if the metadata or `is_available` signature drifts, the contract checks fail before any tool-specific assertion runs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions