### PR TITLE
test: add unit tests for AWSBatchJobsMixin and fix timezone bug

### DIFF
--- a/app/services/tracer_client/aws_batch_jobs.py
+++ b/app/services/tracer_client/aws_batch_jobs.py
@@ -94,9 +94,9 @@ class AWSBatchJobsMixin(TracerClientBase):
 
             started_at = None
             if row.get("startedAt"):
-                started_at = datetime.fromtimestamp(
-                    row["startedAt"] / 1000, tz=UTC
-                ).strftime("%Y-%m-%d %H:%M:%S")
+                started_at = datetime.fromtimestamp(row["startedAt"] / 1000, tz=UTC).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
 
             jobs.append(
                 {

--- a/app/services/tracer_client/aws_batch_jobs.py
+++ b/app/services/tracer_client/aws_batch_jobs.py
@@ -1,7 +1,7 @@
 """Batch jobs-related API methods and models."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from app.services.tracer_client.tracer_client_base import TracerClientBase
@@ -94,9 +94,9 @@ class AWSBatchJobsMixin(TracerClientBase):
 
             started_at = None
             if row.get("startedAt"):
-                started_at = datetime.fromtimestamp(row["startedAt"] / 1000).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                )
+                started_at = datetime.fromtimestamp(
+                    row["startedAt"] / 1000, tz=UTC
+                ).strftime("%Y-%m-%d %H:%M:%S")
 
             jobs.append(
                 {

--- a/tests/services/tracer_client/test_aws_batch_jobs.py
+++ b/tests/services/tracer_client/test_aws_batch_jobs.py
@@ -1,0 +1,267 @@
+"""Tests for AWSBatchJobsMixin batch job methods."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from app.services.tracer_client.aws_batch_jobs import (
+    AWSBatchJobResult,
+    AWSBatchJobsMixin,
+)
+
+
+class _FakeBatchJobsClient(AWSBatchJobsMixin):
+    """Fake subclass for testing; stubs _get() method."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        super().__init__(
+            base_url="https://opensre.com",
+            org_id="test-org-123",
+            jwt_token="token",
+        )
+        self._response = response
+
+    def _get(self, _endpoint: str, _params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        return self._response
+
+
+class _FakeBatchJobsClientWithCapture(AWSBatchJobsMixin):
+    """Fake subclass that captures params passed to _get()."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            base_url="https://opensre.com",
+            org_id="test-org-123",
+            jwt_token="token",
+        )
+        self.last_params: Mapping[str, Any] | None = None
+        self.last_endpoint: str | None = None
+
+    def _get(self, endpoint: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        self.last_endpoint = endpoint
+        self.last_params = params
+        return {"success": True, "data": []}
+
+
+class TestNoTraceId:
+    """Tests for no trace_id behavior."""
+
+    def test_no_trace_id_returns_typed_result(self) -> None:
+        client = _FakeBatchJobsClient({"success": True, "data": []})
+
+        result = client.get_batch_jobs()
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.found is False
+
+    def test_no_trace_id_returns_raw_dict(self) -> None:
+        client = _FakeBatchJobsClient({"success": True, "data": []})
+
+        result = client.get_batch_jobs(return_dict=True)
+
+        assert result == {"success": False, "data": []}
+
+
+class TestStatusFilter:
+    """Tests for status filter logic."""
+
+    def test_default_statuses_when_none_provided(self) -> None:
+        client = _FakeBatchJobsClientWithCapture()
+        client.get_batch_jobs(trace_id="trace-1")
+
+        assert client.last_params is not None
+        assert client.last_params["status"] == ["SUCCEEDED", "FAILED", "RUNNING"]
+
+    def test_custom_statuses_passed_to_params(self) -> None:
+        client = _FakeBatchJobsClientWithCapture()
+        client.get_batch_jobs(trace_id="trace-1", statuses=["FAILED"])
+
+        assert client.last_params is not None
+        assert client.last_params["status"] == ["FAILED"]
+
+    def test_endpoint_is_correct(self) -> None:
+        client = _FakeBatchJobsClientWithCapture()
+        client.get_batch_jobs(trace_id="trace-1")
+
+        assert client.last_endpoint == "/api/aws/batch/jobs/completed"
+
+
+class TestTypedReturnMode:
+    """Tests for typed AWSBatchJobResult return mode."""
+
+    def test_success_with_jobs_parsed(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "jobName": "job-1",
+                    "status": "SUCCEEDED",
+                    "statusReason": "completed",
+                    "container": {
+                        "reason": "exit",
+                        "exitCode": 0,
+                        "resourceRequirements": [
+                            {"type": "VCPU", "value": "2"},
+                            {"type": "MEMORY", "value": "4096"},
+                            {"type": "GPU", "value": "1"},
+                        ],
+                    },
+                    "startedAt": 1713960000000,
+                },
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.found is True
+        assert result.total_jobs == 1
+        assert result.failed_jobs == 0
+        assert result.succeeded_jobs == 1
+        assert result.jobs is not None
+        assert len(result.jobs) == 1
+        assert result.jobs[0]["job_name"] == "job-1"
+        assert result.jobs[0]["status"] == "SUCCEEDED"
+        assert result.jobs[0]["status_reason"] == "completed"
+        assert result.jobs[0]["failure_reason"] == "exit"
+        assert result.jobs[0]["exit_code"] == 0
+        assert result.jobs[0]["vcpu"] == 2
+        assert result.jobs[0]["memory_mb"] == 4096
+        assert result.jobs[0]["gpu_count"] == 1
+        assert result.jobs[0]["started_at"] == "2024-04-24 12:00:00"
+
+    def test_empty_data_returns_found_false(self) -> None:
+        client = _FakeBatchJobsClient({"success": True, "data": []})
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.found is False
+
+    def test_unsuccessful_response_returns_found_false(self) -> None:
+        client = _FakeBatchJobsClient({"success": False, "error": "Unauthorized"})
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.found is False
+
+    def test_failed_and_succeeded_counts(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {"jobName": "job-1", "status": "FAILED", "container": {}},
+                {"jobName": "job-2", "status": "SUCCEEDED", "container": {}},
+                {"jobName": "job-3", "status": "FAILED", "container": {}},
+                {"jobName": "job-4", "status": "SUCCEEDED", "container": {}},
+                {"jobName": "job-5", "status": "RUNNING", "container": {}},
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.total_jobs == 5
+        assert result.failed_jobs == 2
+        assert result.succeeded_jobs == 2
+
+    def test_failure_reason_from_first_failed(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "jobName": "job-1",
+                    "status": "FAILED",
+                    "container": {"reason": "first-failure-reason"},
+                },
+                {
+                    "jobName": "job-2",
+                    "status": "FAILED",
+                    "container": {"reason": "second-failure-reason"},
+                },
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.failure_reason == "first-failure-reason"
+
+    def test_failure_reason_none_when_all_succeeded(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {"jobName": "job-1", "status": "SUCCEEDED", "container": {}},
+                {"jobName": "job-2", "status": "SUCCEEDED", "container": {}},
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.failure_reason is None
+
+    def test_started_at_timestamp_conversion(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "jobName": "job-1",
+                    "status": "SUCCEEDED",
+                    "startedAt": 1713960000000,
+                    "container": {},
+                },
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.jobs is not None
+        assert result.jobs[0]["started_at"] == "2024-04-24 12:00:00"
+
+    def test_started_at_none_when_missing(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "jobName": "job-1",
+                    "status": "SUCCEEDED",
+                    "container": {},
+                },
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1")
+
+        assert isinstance(result, AWSBatchJobResult)
+        assert result.jobs is not None
+        assert result.jobs[0]["started_at"] is None
+
+
+class TestRawReturnMode:
+    """Tests for raw dict return mode."""
+
+    def test_return_dict_returns_raw_response(self) -> None:
+        response = {
+            "success": True,
+            "data": [
+                {
+                    "jobName": "job-1",
+                    "status": "SUCCEEDED",
+                    "container": {"reason": "exit", "exitCode": 0},
+                },
+            ],
+        }
+        client = _FakeBatchJobsClient(response)
+
+        result = client.get_batch_jobs(trace_id="trace-1", return_dict=True)
+
+        assert result == response


### PR DESCRIPTION
Fixes #892

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

Two changes were made in `app/services/tracer_client/aws_batch_jobs.py`:

1. **Timezone fix**: `datetime.fromtimestamp()` now uses `tz=UTC` explicitly. Without this, AWS Batch timestamp conversion depended on the local timezone, causing tests to fail in CI (which runs with `TZ=UTC`).

2. **14 unit tests** in `tests/services/tracer_client/test_aws_batch_jobs.py`:
   - `TestNoTraceId` (2 tests): behavior when no `trace_id` is passed, both in typed and raw dict modes.
   - `TestStatusFilter` (3 tests): default values (`SUCCEEDED`, `FAILED`, `RUNNING`), custom filters, and endpoint verification.
   - `TestTypedReturnMode` (9 tests): job parsing, extracted fields (vcpu, memory, gpu, exit_code, failure_reason), failed/succeeded counts, failure reason extraction from first failed job, timestamp conversion, and empty data or unsuccessful response cases.
   - `TestRawReturnMode` (1 test): `return_dict=True` returns the raw response without parsing.

Tests use `_FakeBatchJobsClient` and `_FakeBatchJobsClientWithCapture` which stub `_get()`, with no real HTTP calls.

### Demo/Screenshot for feature changes and bug fixes -

```bash
# Local (CEST)
uv run python -m pytest tests/services/tracer_client/test_aws_batch_jobs.py -v
# 14 passed

# CI simulation (UTC)
env TZ=UTC uv run python -m pytest tests/services/tracer_client/test_aws_batch_jobs.py -v
# 14 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **What problem does your code solve?** Adds unit test coverage for `AWSBatchJobsMixin.get_batch_jobs()` which had none, and fixes a timezone bug in timestamp conversion that would cause tests to fail in CI.

- **What alternative approaches did you consider?** I could have used `pytest-mock` or `unittest.mock`, but following the existing pattern in `test_tracer_pipelines.py`, a fake subclass that stubs `_get()` is simpler and more idiomatic.

- **Why did you choose this specific implementation?** The fake subclass pattern is already established in the codebase (see `test_tracer_pipelines.py`). It keeps tests readable and avoids complex mock setup.

- **What are the key functions/components and what do they do?**
  - `_FakeBatchJobsClient` — returns a configurable response from `_get()`, used for testing return value parsing.
  - `_FakeBatchJobsClientWithCapture` — captures the endpoint and params passed to `_get()`, used for verifying API calls.
  - `TestNoTraceId` — verifies early return behavior when no trace_id is provided (both typed and raw modes).
  - `TestStatusFilter` — verifies default and custom status filters are passed correctly to the API params.
  - `TestTypedReturnMode` — verifies `AWSBatchJobResult` parsing: job fields, failure reason extraction, timestamp conversion, counts.
  - `TestRawReturnMode` — verifies `return_dict=True` returns the raw API response unchanged.
  - Timezone fix in `aws_batch_jobs.py` — uses `tz=UTC` in `datetime.fromtimestamp()` so the conversion is deterministic regardless of the local timezone.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.