### PR TITLE
test(llm-cli): fix Windows CI codex path assertions

### DIFF
--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -11,6 +11,11 @@ from app.integrations.llm_cli.codex import CodexAdapter, _fallback_codex_paths
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 
 
+def _posix_path_set(paths: list[str]) -> set[str]:
+    """Normalize paths for assertions when simulating POSIX platforms on Windows CI."""
+    return {Path(p).as_posix() for p in paths}
+
+
 def test_flatten_messages_joins_roles() -> None:
     text = flatten_messages_to_prompt(
         [
@@ -296,9 +301,10 @@ def test_fallback_paths_include_env_and_npm_prefix() -> None:
     ):
         paths = _fallback_codex_paths()
 
-    assert "/pnpm/home/codex" in paths
-    assert "/xdg/data/pnpm/codex" in paths
-    assert "/custom/npm/bin/codex" in paths
+    normalized = _posix_path_set(paths)
+    assert "/pnpm/home/codex" in normalized
+    assert "/xdg/data/pnpm/codex" in normalized
+    assert "/custom/npm/bin/codex" in normalized
 
 
 def test_fallback_paths_include_macos_defaults() -> None:
@@ -309,11 +315,12 @@ def test_fallback_paths_include_macos_defaults() -> None:
     ):
         paths = _fallback_codex_paths()
 
-    assert "/opt/homebrew/bin/codex" in paths
-    assert "/usr/local/bin/codex" in paths
-    assert str(Path.home() / ".local/bin/codex") in paths
-    assert str(Path.home() / ".npm-global/bin/codex") in paths
-    assert str(Path.home() / ".volta/bin/codex") in paths
+    normalized = _posix_path_set(paths)
+    assert "/opt/homebrew/bin/codex" in normalized
+    assert "/usr/local/bin/codex" in normalized
+    assert (Path.home() / ".local/bin/codex").as_posix() in normalized
+    assert (Path.home() / ".npm-global/bin/codex").as_posix() in normalized
+    assert (Path.home() / ".volta/bin/codex").as_posix() in normalized
 
 
 def test_fallback_paths_include_windows_defaults() -> None:
@@ -356,7 +363,7 @@ def test_npm_prefix_bin_dirs_unix_uses_prefix_bin() -> None:
         patch.dict(os.environ, {"NPM_CONFIG_PREFIX": "/opt/npm"}, clear=False),
     ):
         dirs = npm_prefix_bin_dirs()
-    assert dirs == ("/opt/npm/bin",)
+    assert tuple(Path(d).as_posix() for d in dirs) == ("/opt/npm/bin",)
 
 
 @patch("app.integrations.llm_cli.codex.shutil.which", return_value="/usr/bin/codex")


### PR DESCRIPTION
Errors in windows due to #781 

#### Describe the changes you have made in this PR -

Windows CI runs `test (windows-latest)` with `sys.platform` patched to `linux`/`darwin` in a few Codex fallback-path tests, but `pathlib.Path` still uses Windows separators on the runner. Assertions expected POSIX strings (`/opt/...`), so pytest failed on the Windows matrix (the workflow stays green only because that job uses `continue-on-error`).

This PR normalizes paths with `Path(...).as_posix()` in those tests so they stay valid on Windows hosts while still checking the intended locations.

### Demo/Screenshot for feature changes and bug fixes - 

N/A (test-only change). Local verification: `uv run pytest tests/integrations/llm_cli/test_codex_adapter.py` — 16 passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The production resolver already returns host-native path strings; the bug was test expectations that mixed “simulated OS” (`sys.platform` patch) with real `Path` flavor (still Windows on CI). Normalizing with `as_posix()` in assertions matches the existing pattern in `test_fallback_paths_include_windows_defaults` and avoids changing runtime behavior.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
