### PR TITLE
fix(CI): lazy-load GitHub MCP in CLI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        # Run Windows on PRs and pushes so cross-platform issues surface before merge.
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -74,7 +75,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        # Run Windows on PRs and pushes so cross-platform issues surface before merge.
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -110,7 +112,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        # Run Windows on PRs and pushes so cross-platform issues surface before merge.
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run Windows on PRs and pushes so cross-platform issues surface before merge.
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -75,8 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run Windows on PRs and pushes so cross-platform issues surface before merge.
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -112,8 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run Windows on PRs and pushes so cross-platform issues surface before merge.
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -14,19 +14,10 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, NoReturn, cast
+from typing import Any, Literal, NoReturn, cast
 
 import questionary
 
-from app.integrations.github_mcp import (
-    GitHubMcpDisplayDetailLevel,
-    GitHubMcpRepoView,
-    GitHubMcpRepoVisibilityFilter,
-    build_github_mcp_config,
-    format_github_mcp_validation_cli_report,
-    print_github_mcp_validation_report,
-    validate_github_mcp_config,
-)
 from app.integrations.gitlab import DEFAULT_GITLAB_BASE_URL
 from app.integrations.store import (
     STORE_PATH,
@@ -44,6 +35,9 @@ from app.integrations.verify import (
 
 _B = "\033[1m"
 _R = "\033[0m"
+GitHubMcpDisplayDetailLevel = Literal["summary", "standard", "full"]
+GitHubMcpRepoView = Literal["auto", "user", "accessible", "starred", "search_user"]
+GitHubMcpRepoVisibilityFilter = Literal["any", "public", "private"]
 
 
 def _json_echo(data: Any) -> None:
@@ -326,6 +320,13 @@ def _setup_betterstack() -> None:
 
 
 def _setup_github() -> None:
+    from app.integrations.github_mcp import (
+        build_github_mcp_config,
+        format_github_mcp_validation_cli_report,
+        print_github_mcp_validation_report,
+        validate_github_mcp_config,
+    )
+
     print("  1) SSE  2) Streamable HTTP  3) stdio")
     choice = _p("Choice", default="2")
     mode = {"1": "sse", "2": "streamable-http", "3": "stdio"}.get(choice, "streamable-http")

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import questionary
+
+if TYPE_CHECKING:
+    from app.integrations.github_mcp import GitHubMcpDisplayDetailLevel
 
 from app.integrations.gitlab import DEFAULT_GITLAB_BASE_URL
 from app.integrations.store import (
@@ -35,9 +38,6 @@ from app.integrations.verify import (
 
 _B = "\033[1m"
 _R = "\033[0m"
-GitHubMcpDisplayDetailLevel = Literal["summary", "standard", "full"]
-GitHubMcpRepoView = Literal["auto", "user", "accessible", "starred", "search_user"]
-GitHubMcpRepoVisibilityFilter = Literal["any", "public", "private"]
 
 
 def _json_echo(data: Any) -> None:
@@ -102,7 +102,9 @@ def _prompt_github_repo_report_level() -> GitHubMcpDisplayDetailLevel:
     if sel is None:
         return "summary"
     if sel in ("summary", "standard", "full"):
-        return cast(GitHubMcpDisplayDetailLevel, sel)
+        from app.integrations.github_mcp import GitHubMcpDisplayDetailLevel as _Detail
+
+        return cast(_Detail, sel)
     return "summary"
 
 
@@ -321,6 +323,8 @@ def _setup_betterstack() -> None:
 
 def _setup_github() -> None:
     from app.integrations.github_mcp import (
+        GitHubMcpRepoView,
+        GitHubMcpRepoVisibilityFilter,
         build_github_mcp_config,
         format_github_mcp_validation_cli_report,
         print_github_mcp_validation_report,

--- a/tests/cli/test_integrations_setup_github.py
+++ b/tests/cli/test_integrations_setup_github.py
@@ -35,7 +35,7 @@ def test_setup_github_prints_connected_and_saves_on_validation_success(
     )
 
     monkeypatch.setattr(
-        "app.integrations.cli.validate_github_mcp_config",
+        "app.integrations.github_mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
             ok=True,
             detail=(
@@ -93,7 +93,7 @@ def test_setup_github_exits_without_save_on_validation_failure(
         lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
     )
     monkeypatch.setattr(
-        "app.integrations.cli.validate_github_mcp_config",
+        "app.integrations.github_mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
             ok=False,
             detail="GitHub MCP connected, but authentication failed: bad token",
@@ -129,7 +129,7 @@ def test_cmd_setup_github_skips_saved_line_on_validation_failure(
         lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
     )
     monkeypatch.setattr(
-        "app.integrations.cli.validate_github_mcp_config",
+        "app.integrations.github_mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
             ok=False,
             detail="validation failed for test",
@@ -164,7 +164,7 @@ def test_cmd_setup_github_prints_saved_after_success(
         lambda *_a, **_k: type("X", (), {"ask": lambda *_aa, **_kk: "auto"})(),
     )
     monkeypatch.setattr(
-        "app.integrations.cli.validate_github_mcp_config",
+        "app.integrations.github_mcp.validate_github_mcp_config",
         lambda _c, **_kwargs: GitHubMCPValidationResult(
             ok=True,
             detail="OK @u; repos=0; owners=-; examples=-; mcp_tools=5",


### PR DESCRIPTION
Relates to CI discussion (optional); no open issue

#### Describe the changes you have made in this PR -

`app/integrations/cli.py` imported `app.integrations.github_mcp` at module load, which pulls in `mcp` → `anyio`. That made lightweight commands like `opensre integrations list` / `show` fail if those transitive imports misbehaved on a runner.

`github_mcp` helpers are now imported only inside `_setup_github()`, after the user starts GitHub setup. Local `Literal` aliases replace the re-exported type names for annotations.

### Demo/Screenshot for feature changes and bug fixes - 

`uv run pytest tests/cli_smoke_test.py::test_integrations_list_and_show_smoke -q --no-cov` — passed  
`make lint` — passed  
`make typecheck` — passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Lazy import keeps the default integrations CLI path free of GitHub MCP and MCP client dependencies. The alternative was a larger refactor of `github_mcp` (split transport vs. CLI) or pre-import guards; lazy import is minimal and matches “pay for import only when needed.”

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
