### PR TITLE
test(tools): add unit tests for ClickHouseQueryActivity and ClickHous…

### DIFF
--- a/tests/tools/test_clickhouse_query_activity_tool.py
+++ b/tests/tools/test_clickhouse_query_activity_tool.py
@@ -1,0 +1,93 @@
+"""Tests for ClickHouseQueryActivityTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.ClickHouseQueryActivityTool import get_clickhouse_query_activity
+from tests.tools.conftest import BaseToolContract
+
+
+class TestClickHouseQueryActivityToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_clickhouse_query_activity.__opensre_registered_tool__
+
+
+def test_is_available_true_when_connection_verified() -> None:
+    rt = get_clickhouse_query_activity.__opensre_registered_tool__
+    assert rt.is_available({"clickhouse": {"host": "ch.example.com", "connection_verified": True}}) is True
+
+
+def test_is_available_false_without_connection_verified() -> None:
+    rt = get_clickhouse_query_activity.__opensre_registered_tool__
+    assert rt.is_available({"clickhouse": {"host": "ch.example.com"}}) is False
+
+
+def test_is_available_false_when_no_clickhouse_source() -> None:
+    rt = get_clickhouse_query_activity.__opensre_registered_tool__
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_clickhouse_query_activity.__opensre_registered_tool__
+    sources = {
+        "clickhouse": {
+            "host": "ch.example.com",
+            "port": 9000,
+            "database": "analytics",
+            "username": "admin",
+            "password": "secret",
+            "secure": True,
+            "connection_verified": True,
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["host"] == "ch.example.com"
+    assert params["port"] == 9000
+    assert params["database"] == "analytics"
+    assert params["username"] == "admin"
+    assert params["password"] == "secret"
+    assert params["secure"] is True
+
+
+def test_extract_params_uses_defaults_for_missing_fields() -> None:
+    rt = get_clickhouse_query_activity.__opensre_registered_tool__
+    params = rt.extract_params({"clickhouse": {"host": "ch.example.com"}})
+    assert params["port"] == 8123
+    assert params["database"] == "default"
+    assert params["username"] == "default"
+    assert params["password"] == ""
+    assert params["secure"] is False
+
+
+def test_run_happy_path() -> None:
+    mock_result = {
+        "source": "clickhouse",
+        "available": True,
+        "total_returned": 2,
+        "queries": [
+            {"query_id": "q1", "query": "SELECT 1", "duration_ms": 10},
+            {"query_id": "q2", "query": "SELECT sleep(1)", "duration_ms": 1000},
+        ],
+    }
+    with patch(
+        "app.tools.ClickHouseQueryActivityTool.get_query_activity", return_value=mock_result
+    ):
+        result = get_clickhouse_query_activity(host="ch.example.com", limit=20)
+    assert result["available"] is True
+    assert result["total_returned"] == 2
+    assert len(result["queries"]) == 2
+
+
+def test_run_error_path() -> None:
+    error_result = {
+        "source": "clickhouse",
+        "available": False,
+        "error": "connection refused",
+    }
+    with patch(
+        "app.tools.ClickHouseQueryActivityTool.get_query_activity", return_value=error_result
+    ):
+        result = get_clickhouse_query_activity(host="ch.example.com")
+    assert result["available"] is False
+    assert "error" in result

--- a/tests/tools/test_clickhouse_query_activity_tool.py
+++ b/tests/tools/test_clickhouse_query_activity_tool.py
@@ -15,7 +15,10 @@ class TestClickHouseQueryActivityToolContract(BaseToolContract):
 
 def test_is_available_true_when_connection_verified() -> None:
     rt = get_clickhouse_query_activity.__opensre_registered_tool__
-    assert rt.is_available({"clickhouse": {"host": "ch.example.com", "connection_verified": True}}) is True
+    assert (
+        rt.is_available({"clickhouse": {"host": "ch.example.com", "connection_verified": True}})
+        is True
+    )
 
 
 def test_is_available_false_without_connection_verified() -> None:

--- a/tests/tools/test_clickhouse_system_health_tool.py
+++ b/tests/tools/test_clickhouse_system_health_tool.py
@@ -1,0 +1,138 @@
+"""Tests for ClickHouseSystemHealthTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.ClickHouseSystemHealthTool import get_clickhouse_system_health
+from tests.tools.conftest import BaseToolContract
+
+
+class TestClickHouseSystemHealthToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_clickhouse_system_health.__opensre_registered_tool__
+
+
+def test_is_available_true_when_connection_verified() -> None:
+    rt = get_clickhouse_system_health.__opensre_registered_tool__
+    assert rt.is_available({"clickhouse": {"host": "ch.example.com", "connection_verified": True}}) is True
+
+
+def test_is_available_false_without_connection_verified() -> None:
+    rt = get_clickhouse_system_health.__opensre_registered_tool__
+    assert rt.is_available({"clickhouse": {"host": "ch.example.com"}}) is False
+
+
+def test_is_available_false_when_no_clickhouse_source() -> None:
+    rt = get_clickhouse_system_health.__opensre_registered_tool__
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_clickhouse_system_health.__opensre_registered_tool__
+    sources = {
+        "clickhouse": {
+            "host": "ch.example.com",
+            "port": 9000,
+            "database": "analytics",
+            "username": "admin",
+            "password": "secret",
+            "secure": False,
+            "connection_verified": True,
+        }
+    }
+    params = rt.extract_params(sources)
+    assert params["host"] == "ch.example.com"
+    assert params["port"] == 9000
+    assert params["database"] == "analytics"
+    assert params["username"] == "admin"
+    assert params["password"] == "secret"
+    assert params["secure"] is False
+
+
+def test_extract_params_uses_defaults_for_missing_fields() -> None:
+    rt = get_clickhouse_system_health.__opensre_registered_tool__
+    params = rt.extract_params({"clickhouse": {"host": "ch.example.com"}})
+    assert params["port"] == 8123
+    assert params["database"] == "default"
+    assert params["username"] == "default"
+    assert params["password"] == ""
+    assert params["secure"] is False
+
+
+def test_run_happy_path_with_table_stats() -> None:
+    health_result = {
+        "source": "clickhouse",
+        "available": True,
+        "version": "23.8.1",
+        "uptime_seconds": 3600,
+        "metrics": {"Query": 5, "TCPConnection": 10},
+    }
+    table_result = {
+        "source": "clickhouse",
+        "available": True,
+        "tables": [
+            {"table": "events", "total_rows": 1000, "total_bytes": 512000},
+        ],
+    }
+    with (
+        patch(
+            "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result
+        ),
+        patch(
+            "app.tools.ClickHouseSystemHealthTool.get_table_stats", return_value=table_result
+        ),
+    ):
+        result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=True)
+    assert result["available"] is True
+    assert result["version"] == "23.8.1"
+    assert result["table_stats"] == table_result["tables"]
+
+
+def test_run_happy_path_without_table_stats() -> None:
+    health_result = {
+        "source": "clickhouse",
+        "available": True,
+        "version": "23.8.1",
+        "uptime_seconds": 3600,
+        "metrics": {},
+    }
+    with patch(
+        "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result
+    ):
+        result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=False)
+    assert result["available"] is True
+    assert "table_stats" not in result
+
+
+def test_run_skips_table_stats_when_health_unavailable() -> None:
+    health_result = {
+        "source": "clickhouse",
+        "available": False,
+        "error": "connection refused",
+    }
+    with (
+        patch(
+            "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result
+        ),
+        patch(
+            "app.tools.ClickHouseSystemHealthTool.get_table_stats"
+        ) as mock_table_stats,
+    ):
+        result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=True)
+    assert result["available"] is False
+    mock_table_stats.assert_not_called()
+
+
+def test_run_error_path() -> None:
+    error_result = {
+        "source": "clickhouse",
+        "available": False,
+        "error": "connection refused",
+    }
+    with patch(
+        "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=error_result
+    ):
+        result = get_clickhouse_system_health(host="ch.example.com")
+    assert result["available"] is False
+    assert "error" in result

--- a/tests/tools/test_clickhouse_system_health_tool.py
+++ b/tests/tools/test_clickhouse_system_health_tool.py
@@ -96,12 +96,34 @@ def test_run_happy_path_without_table_stats() -> None:
         "uptime_seconds": 3600,
         "metrics": {},
     }
-    with patch(
-        "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result
+    with (
+        patch("app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result),
+        patch("app.tools.ClickHouseSystemHealthTool.get_table_stats") as mock_table_stats,
     ):
         result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=False)
     assert result["available"] is True
     assert "table_stats" not in result
+    mock_table_stats.assert_not_called()
+
+
+def test_run_table_stats_error_falls_back_to_empty_list() -> None:
+    health_result = {
+        "source": "clickhouse",
+        "available": True,
+        "version": "23.8.1",
+        "uptime_seconds": 3600,
+        "metrics": {},
+    }
+    table_error_result = {"source": "clickhouse", "available": False, "error": "timeout"}
+    with (
+        patch("app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result),
+        patch(
+            "app.tools.ClickHouseSystemHealthTool.get_table_stats", return_value=table_error_result
+        ),
+    ):
+        result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=True)
+    assert result["available"] is True
+    assert result["table_stats"] == []
 
 
 def test_run_skips_table_stats_when_health_unavailable() -> None:

--- a/tests/tools/test_clickhouse_system_health_tool.py
+++ b/tests/tools/test_clickhouse_system_health_tool.py
@@ -15,7 +15,10 @@ class TestClickHouseSystemHealthToolContract(BaseToolContract):
 
 def test_is_available_true_when_connection_verified() -> None:
     rt = get_clickhouse_system_health.__opensre_registered_tool__
-    assert rt.is_available({"clickhouse": {"host": "ch.example.com", "connection_verified": True}}) is True
+    assert (
+        rt.is_available({"clickhouse": {"host": "ch.example.com", "connection_verified": True}})
+        is True
+    )
 
 
 def test_is_available_false_without_connection_verified() -> None:
@@ -76,12 +79,8 @@ def test_run_happy_path_with_table_stats() -> None:
         ],
     }
     with (
-        patch(
-            "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result
-        ),
-        patch(
-            "app.tools.ClickHouseSystemHealthTool.get_table_stats", return_value=table_result
-        ),
+        patch("app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result),
+        patch("app.tools.ClickHouseSystemHealthTool.get_table_stats", return_value=table_result),
     ):
         result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=True)
     assert result["available"] is True
@@ -112,12 +111,8 @@ def test_run_skips_table_stats_when_health_unavailable() -> None:
         "error": "connection refused",
     }
     with (
-        patch(
-            "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result
-        ),
-        patch(
-            "app.tools.ClickHouseSystemHealthTool.get_table_stats"
-        ) as mock_table_stats,
+        patch("app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=health_result),
+        patch("app.tools.ClickHouseSystemHealthTool.get_table_stats") as mock_table_stats,
     ):
         result = get_clickhouse_system_health(host="ch.example.com", include_table_stats=True)
     assert result["available"] is False
@@ -130,9 +125,7 @@ def test_run_error_path() -> None:
         "available": False,
         "error": "connection refused",
     }
-    with patch(
-        "app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=error_result
-    ):
+    with patch("app.tools.ClickHouseSystemHealthTool.get_system_health", return_value=error_result):
         result = get_clickhouse_system_health(host="ch.example.com")
     assert result["available"] is False
     assert "error" in result


### PR DESCRIPTION
Closes #995

#### Describe the changes you have made in this PR -
Added unit tests for `ClickHouseQueryActivityTool` and `ClickHouseSystemHealthTool`, which previously had no test coverage. Created two new test files:
- `tests/tools/test_clickhouse_query_activity_tool.py` — 13 tests
- `tests/tools/test_clickhouse_system_health_tool.py` — 15 tests

Each file covers contract validation, `is_available`, `extract_params`, run happy path, and run error path. No live ClickHouse instance needed — integration calls are patched.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1512" height="982" alt="Screenshot 2026-04-28 at 00 11 19" src="https://github.com/user-attachments/assets/089ae70c-0dc8-4a88-849f-d1946278556f" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Both tools are function-based `@tool` decorated functions that delegate to `app/integrations/clickhouse.py`. The tests follow the same pattern used in similar tool tests in this repo (e.g. `test_cloudwatch_logs_tool.py`) — accessing `__opensre_registered_tool__` for contract checks and patching the integration functions at the tool module level so no real database connection is needed. The system health test also covers the `include_table_stats` branching logic and verifies `get_table_stats` is never called when health returns unavailable.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
