### PR TITLE
refactor(publish): extract GitLab MR write-back into dedicated helper module

### DIFF
--- a/app/nodes/publish_findings/gitlab_writeback.py
+++ b/app/nodes/publish_findings/gitlab_writeback.py
@@ -1,0 +1,52 @@
+"""GitLab MR write-back helper for the publish_findings node."""
+
+import logging
+import os
+
+from app.integrations.gitlab import build_gitlab_config, post_gitlab_mr_note
+from app.state import InvestigationState
+
+logger = logging.getLogger(__name__)
+
+
+def _build_mr_note(slack_message: str) -> str:
+    body = slack_message.strip()
+    if len(body) > 4000:
+        body = body[:3997] + "..."
+    return f"### RCA Finding\n\n<details>\n<summary>Investigation summary</summary>\n\n{body}\n\n</details>"
+
+
+def post_gitlab_mr_writeback(state: InvestigationState, slack_message: str) -> None:
+    """Post an RCA summary as a GitLab MR note if write-back is enabled.
+
+    No-ops when:
+    - GITLAB_MR_WRITEBACK env var is not set to a truthy value
+    - merge_request_iid or project_id are absent from state
+    Failures are logged as warnings and never propagate to the caller.
+    """
+    if os.getenv("GITLAB_MR_WRITEBACK", "").lower() not in ("true", "1", "yes"):
+        return
+
+    _gl = (state.get("available_sources") or {}).get("gitlab", {})
+    _mr_iid = _gl.get("merge_request_iid", "")
+    _project_id = _gl.get("project_id", "")
+
+    if not _mr_iid or not _project_id:
+        return
+
+    try:
+        _gl_config = build_gitlab_config(
+            {
+                "base_url": _gl.get("gitlab_url", ""),
+                "auth_token": _gl.get("gitlab_token", ""),
+            }
+        )
+        post_gitlab_mr_note(
+            config=_gl_config,
+            project_id=_project_id,
+            mr_iid=_mr_iid,
+            body=_build_mr_note(slack_message),
+        )
+        logger.info("[publish] GitLab MR note posted: project=%s mr_iid=%s", _project_id, _mr_iid)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[publish] GitLab MR write-back failed: %s", exc)

--- a/app/nodes/publish_findings/gitlab_writeback.py
+++ b/app/nodes/publish_findings/gitlab_writeback.py
@@ -9,14 +9,14 @@ from app.state import InvestigationState
 logger = logging.getLogger(__name__)
 
 
-def _build_mr_note(slack_message: str) -> str:
-    body = slack_message.strip()
+def _build_mr_note(report: str) -> str:
+    body = report.strip()
     if len(body) > 4000:
         body = body[:3997] + "..."
     return f"### RCA Finding\n\n<details>\n<summary>Investigation summary</summary>\n\n{body}\n\n</details>"
 
 
-def post_gitlab_mr_writeback(state: InvestigationState, slack_message: str) -> None:
+def post_gitlab_mr_writeback(state: InvestigationState, report: str) -> None:
     """Post an RCA summary as a GitLab MR note if write-back is enabled.
 
     No-ops when:
@@ -27,26 +27,26 @@ def post_gitlab_mr_writeback(state: InvestigationState, slack_message: str) -> N
     if os.getenv("GITLAB_MR_WRITEBACK", "").lower() not in ("true", "1", "yes"):
         return
 
-    _gl = (state.get("available_sources") or {}).get("gitlab", {})
-    _mr_iid = _gl.get("merge_request_iid", "")
-    _project_id = _gl.get("project_id", "")
+    gl = (state.get("available_sources") or {}).get("gitlab", {})
+    mr_iid = gl.get("merge_request_iid", "")
+    project_id = gl.get("project_id", "")
 
-    if not _mr_iid or not _project_id:
+    if not mr_iid or not project_id:
         return
 
     try:
-        _gl_config = build_gitlab_config(
+        gl_config = build_gitlab_config(
             {
-                "base_url": _gl.get("gitlab_url", ""),
-                "auth_token": _gl.get("gitlab_token", ""),
+                "base_url": gl.get("gitlab_url", ""),
+                "auth_token": gl.get("gitlab_token", ""),
             }
         )
         post_gitlab_mr_note(
-            config=_gl_config,
-            project_id=_project_id,
-            mr_iid=_mr_iid,
-            body=_build_mr_note(slack_message),
+            config=gl_config,
+            project_id=project_id,
+            mr_iid=mr_iid,
+            body=_build_mr_note(report),
         )
-        logger.info("[publish] GitLab MR note posted: project=%s mr_iid=%s", _project_id, _mr_iid)
+        logger.info("[publish] GitLab MR note posted: project=%s mr_iid=%s", project_id, mr_iid)
     except Exception as exc:  # noqa: BLE001
         logger.warning("[publish] GitLab MR write-back failed: %s", exc)

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -1,7 +1,6 @@
 """Main orchestration node for report generation and publishing."""
 
 import logging
-import os
 from typing import Optional, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -13,6 +12,7 @@ from app.nodes.publish_findings.formatters.report import (
     format_slack_message,
     get_investigation_url,
 )
+from app.nodes.publish_findings.gitlab_writeback import post_gitlab_mr_writeback
 from app.nodes.publish_findings.renderers.editor import open_in_editor
 from app.nodes.publish_findings.renderers.terminal import render_report
 from app.nodes.publish_findings.report_context import build_report_context
@@ -20,14 +20,6 @@ from app.state import InvestigationState
 from app.utils.ingest_delivery import send_ingest
 
 logger = logging.getLogger(__name__)
-
-
-def _build_mr_note(slack_message: str) -> str:
-    body = slack_message.strip()
-    if len(body) > 4000:
-        body = body[:3997] + "..."
-
-    return f"### RCA Finding\n\n<details>\n<summary>Investigation summary</summary>\n\n{body}\n\n</details>"
 
 
 def generate_report(state: InvestigationState) -> dict:
@@ -193,32 +185,7 @@ def generate_report(state: InvestigationState) -> dict:
     else:
         logger.debug("[publish] telegram delivery: no telegram integration configured")
 
-    # GitLab MR write-back (opt-in via GITLAB_MR_WRITEBACK env var)
-    if os.getenv("GITLAB_MR_WRITEBACK", "").lower() in ("true", "1", "yes"):
-        _gl = (state.get("available_sources") or {}).get("gitlab", {})
-        _mr_iid = _gl.get("merge_request_iid", "")
-        _project_id = _gl.get("project_id", "")
-        if _mr_iid and _project_id:
-            try:
-                from app.integrations.gitlab import build_gitlab_config, post_gitlab_mr_note
-
-                _gl_config = build_gitlab_config(
-                    {
-                        "base_url": _gl.get("gitlab_url", ""),
-                        "auth_token": _gl.get("gitlab_token", ""),
-                    }
-                )
-                post_gitlab_mr_note(
-                    config=_gl_config,
-                    project_id=_project_id,
-                    mr_iid=_mr_iid,
-                    body=_build_mr_note(slack_message),
-                )
-                logger.info(
-                    "[publish] GitLab MR note posted: project=%s mr_iid=%s", _project_id, _mr_iid
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("[publish] GitLab MR write-back failed: %s", exc)
+    post_gitlab_mr_writeback(state, slack_message)
 
     return {"slack_message": slack_message, "report": slack_message}
 

--- a/tests/nodes/publish_findings/test_gitlab_writeback.py
+++ b/tests/nodes/publish_findings/test_gitlab_writeback.py
@@ -1,0 +1,100 @@
+"""Tests for the GitLab MR write-back helper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.nodes.publish_findings.gitlab_writeback import _build_mr_note, post_gitlab_mr_writeback
+
+
+@pytest.fixture()
+def state_with_gitlab():
+    return {
+        "available_sources": {
+            "gitlab": {
+                "merge_request_iid": "42",
+                "project_id": "99",
+                "gitlab_url": "https://gitlab.example.com",
+                "gitlab_token": "glpat-test",
+            }
+        }
+    }
+
+
+def test_build_mr_note_short_message():
+    note = _build_mr_note("Hello world")
+    assert "Hello world" in note
+    assert "<details>" in note
+
+
+def test_build_mr_note_truncates_long_message():
+    long_msg = "x" * 5000
+    note = _build_mr_note(long_msg)
+    assert "x" * 3997 + "..." in note
+    assert "x" * 3998 not in note
+
+
+def test_no_op_when_env_flag_off(state_with_gitlab):
+    with (
+        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="false"),
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
+    ):
+        post_gitlab_mr_writeback(state_with_gitlab, "report")
+        mock_post.assert_not_called()
+
+
+def test_no_op_when_mr_iid_missing():
+    state = {"available_sources": {"gitlab": {"project_id": "99"}}}
+    with (
+        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
+    ):
+        post_gitlab_mr_writeback(state, "report")
+        mock_post.assert_not_called()
+
+
+def test_no_op_when_project_id_missing():
+    state = {"available_sources": {"gitlab": {"merge_request_iid": "42"}}}
+    with (
+        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
+    ):
+        post_gitlab_mr_writeback(state, "report")
+        mock_post.assert_not_called()
+
+
+def test_failure_does_not_propagate(state_with_gitlab):
+    with (
+        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch(
+            "app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note",
+            side_effect=RuntimeError("network error"),
+        ),
+        patch(
+            "app.nodes.publish_findings.gitlab_writeback.build_gitlab_config",
+            return_value=MagicMock(),
+        ),
+    ):
+        post_gitlab_mr_writeback(state_with_gitlab, "report")
+
+
+def test_happy_path_calls_post_mr_note(state_with_gitlab):
+    mock_config = MagicMock()
+    with (
+        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch(
+            "app.nodes.publish_findings.gitlab_writeback.build_gitlab_config",
+            return_value=mock_config,
+        ) as mock_build,
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
+    ):
+        post_gitlab_mr_writeback(state_with_gitlab, "the report")
+
+        mock_build.assert_called_once_with(
+            {"base_url": "https://gitlab.example.com", "auth_token": "glpat-test"}
+        )
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["project_id"] == "99"
+        assert call_kwargs["mr_iid"] == "42"
+        assert "the report" in call_kwargs["body"]

--- a/tests/nodes/publish_findings/test_gitlab_writeback.py
+++ b/tests/nodes/publish_findings/test_gitlab_writeback.py
@@ -1,5 +1,6 @@
 """Tests for the GitLab MR write-back helper."""
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,7 +37,7 @@ def test_build_mr_note_truncates_long_message():
 
 def test_no_op_when_env_flag_off(state_with_gitlab):
     with (
-        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="false"),
+        patch.dict(os.environ, {"GITLAB_MR_WRITEBACK": "false"}),
         patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
     ):
         post_gitlab_mr_writeback(state_with_gitlab, "report")
@@ -46,7 +47,7 @@ def test_no_op_when_env_flag_off(state_with_gitlab):
 def test_no_op_when_mr_iid_missing():
     state = {"available_sources": {"gitlab": {"project_id": "99"}}}
     with (
-        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch.dict(os.environ, {"GITLAB_MR_WRITEBACK": "true"}),
         patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
     ):
         post_gitlab_mr_writeback(state, "report")
@@ -56,7 +57,7 @@ def test_no_op_when_mr_iid_missing():
 def test_no_op_when_project_id_missing():
     state = {"available_sources": {"gitlab": {"merge_request_iid": "42"}}}
     with (
-        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch.dict(os.environ, {"GITLAB_MR_WRITEBACK": "true"}),
         patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note") as mock_post,
     ):
         post_gitlab_mr_writeback(state, "report")
@@ -65,7 +66,7 @@ def test_no_op_when_project_id_missing():
 
 def test_failure_does_not_propagate(state_with_gitlab):
     with (
-        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch.dict(os.environ, {"GITLAB_MR_WRITEBACK": "true"}),
         patch(
             "app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note",
             side_effect=RuntimeError("network error"),
@@ -74,14 +75,16 @@ def test_failure_does_not_propagate(state_with_gitlab):
             "app.nodes.publish_findings.gitlab_writeback.build_gitlab_config",
             return_value=MagicMock(),
         ),
+        patch("app.nodes.publish_findings.gitlab_writeback.logger") as mock_logger,
     ):
         post_gitlab_mr_writeback(state_with_gitlab, "report")
+        mock_logger.warning.assert_called_once()
 
 
 def test_happy_path_calls_post_mr_note(state_with_gitlab):
     mock_config = MagicMock()
     with (
-        patch("app.nodes.publish_findings.gitlab_writeback.os.getenv", return_value="true"),
+        patch.dict(os.environ, {"GITLAB_MR_WRITEBACK": "true"}),
         patch(
             "app.nodes.publish_findings.gitlab_writeback.build_gitlab_config",
             return_value=mock_config,

--- a/tests/nodes/publish_findings/test_node.py
+++ b/tests/nodes/publish_findings/test_node.py
@@ -111,7 +111,10 @@ def test_gitlab_writeback_calls_post_when_enabled(monkeypatch: pytest.MonkeyPatc
         patch("app.utils.slack_delivery.send_slack_report", mock_send_slack),
         patch("app.utils.slack_delivery.build_action_blocks", mock_build_action_blocks),
         patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note", mock_post_note),
-        patch("app.nodes.publish_findings.gitlab_writeback.build_gitlab_config", return_value=MagicMock()),
+        patch(
+            "app.nodes.publish_findings.gitlab_writeback.build_gitlab_config",
+            return_value=MagicMock(),
+        ),
     ):
         from app.nodes.publish_findings.node import generate_report
 
@@ -177,9 +180,13 @@ def test_gitlab_writeback_failure_does_not_raise(monkeypatch: pytest.MonkeyPatch
         patch("app.utils.slack_delivery.send_slack_report", mock_send_slack),
         patch("app.utils.slack_delivery.build_action_blocks", mock_build_action_blocks),
         patch(
-            "app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note", side_effect=RuntimeError("network error")
+            "app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note",
+            side_effect=RuntimeError("network error"),
         ),
-        patch("app.nodes.publish_findings.gitlab_writeback.build_gitlab_config", return_value=MagicMock()),
+        patch(
+            "app.nodes.publish_findings.gitlab_writeback.build_gitlab_config",
+            return_value=MagicMock(),
+        ),
     ):
         from app.nodes.publish_findings.node import generate_report
 

--- a/tests/nodes/publish_findings/test_node.py
+++ b/tests/nodes/publish_findings/test_node.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.nodes.publish_findings.node import _build_mr_note
+from app.nodes.publish_findings.gitlab_writeback import _build_mr_note
 
 # ---------------------------------------------------------------------------
 # _build_mr_note
@@ -110,8 +110,8 @@ def test_gitlab_writeback_calls_post_when_enabled(monkeypatch: pytest.MonkeyPatc
     with (
         patch("app.utils.slack_delivery.send_slack_report", mock_send_slack),
         patch("app.utils.slack_delivery.build_action_blocks", mock_build_action_blocks),
-        patch("app.integrations.gitlab.post_gitlab_mr_note", mock_post_note),
-        patch("app.integrations.gitlab.build_gitlab_config", return_value=MagicMock()),
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note", mock_post_note),
+        patch("app.nodes.publish_findings.gitlab_writeback.build_gitlab_config", return_value=MagicMock()),
     ):
         from app.nodes.publish_findings.node import generate_report
 
@@ -134,7 +134,7 @@ def test_gitlab_writeback_skipped_when_env_var_not_set(monkeypatch: pytest.Monke
     with (
         patch("app.utils.slack_delivery.send_slack_report", mock_send_slack),
         patch("app.utils.slack_delivery.build_action_blocks", mock_build_action_blocks),
-        patch("app.integrations.gitlab.post_gitlab_mr_note", mock_post_note),
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note", mock_post_note),
     ):
         from app.nodes.publish_findings.node import generate_report
 
@@ -157,7 +157,7 @@ def test_gitlab_writeback_skipped_when_mr_iid_missing(monkeypatch: pytest.Monkey
     with (
         patch("app.utils.slack_delivery.send_slack_report", mock_send_slack),
         patch("app.utils.slack_delivery.build_action_blocks", mock_build_action_blocks),
-        patch("app.integrations.gitlab.post_gitlab_mr_note", mock_post_note),
+        patch("app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note", mock_post_note),
     ):
         from app.nodes.publish_findings.node import generate_report
 
@@ -177,9 +177,9 @@ def test_gitlab_writeback_failure_does_not_raise(monkeypatch: pytest.MonkeyPatch
         patch("app.utils.slack_delivery.send_slack_report", mock_send_slack),
         patch("app.utils.slack_delivery.build_action_blocks", mock_build_action_blocks),
         patch(
-            "app.integrations.gitlab.post_gitlab_mr_note", side_effect=RuntimeError("network error")
+            "app.nodes.publish_findings.gitlab_writeback.post_gitlab_mr_note", side_effect=RuntimeError("network error")
         ),
-        patch("app.integrations.gitlab.build_gitlab_config", return_value=MagicMock()),
+        patch("app.nodes.publish_findings.gitlab_writeback.build_gitlab_config", return_value=MagicMock()),
     ):
         from app.nodes.publish_findings.node import generate_report
 


### PR DESCRIPTION
## Problem

`app/nodes/publish_findings/node.py` was doing too many things in one file — rendering, ingest, Slack, Discord, Telegram, and GitLab MR write-back all inline. The GitLab branch was 20+ lines including a `_build_mr_note()` helper, making the node hard to test and maintain.

## Solution

Extracted `_build_mr_note()` and the entire GitLab write-back branch into `app/nodes/publish_findings/gitlab_writeback.py` behind a single `post_gitlab_mr_writeback()` function. The publish node now calls that one function instead of inlining the logic. `GITLAB_MR_WRITEBACK` env-flag behavior and failure handling are unchanged.

## Tests

Added `tests/nodes/publish_findings/test_gitlab_writeback.py` covering:
- env flag off → no-op
- missing MR IID → no-op
- missing project ID → no-op
- write-back failure → does not propagate
- happy path → `post_gitlab_mr_note` called with correct args

Closes #869