### PR TITLE
refactor(tools): extract shared default_db_warning helper for SQL too…

### DIFF
--- a/app/tools/AzureSQLCurrentQueriesTool/__init__.py
+++ b/app/tools/AzureSQLCurrentQueriesTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.azure_sql import (
     resolve_azure_sql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.db_warnings import default_db_warning
 
 
 @tool(
@@ -37,7 +38,5 @@ def get_azure_sql_current_queries(
     config = resolve_azure_sql_config(server=server, database=database, port=port)
     result = get_current_queries(config, threshold_seconds=threshold_seconds)
     if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'master'. Results may not reflect application data."
-        )
+        result["default_db_warning"] = default_db_warning("master")
     return result

--- a/app/tools/AzureSQLSlowQueriesTool/__init__.py
+++ b/app/tools/AzureSQLSlowQueriesTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.azure_sql import (
     resolve_azure_sql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.db_warnings import default_db_warning
 
 
 @tool(
@@ -37,7 +38,5 @@ def get_azure_sql_slow_queries(
     config = resolve_azure_sql_config(server=server, database=database, port=port)
     result = get_slow_queries(config, threshold_ms=threshold_ms)
     if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'master'. Results may not reflect application data."
-        )
+        result["default_db_warning"] = default_db_warning("master")
     return result

--- a/app/tools/MariaDBProcessListTool/__init__.py
+++ b/app/tools/MariaDBProcessListTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.mariadb import (
     mariadb_is_available,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.db_warnings import default_db_warning
 
 
 @tool(
@@ -43,7 +44,5 @@ def get_mariadb_process_list(
     )
     result = get_process_list(config)
     if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'mysql'. Results may not reflect application data."
-        )
+        result["default_db_warning"] = default_db_warning("mysql")
     return result

--- a/app/tools/MySQLCurrentProcessesTool/__init__.py
+++ b/app/tools/MySQLCurrentProcessesTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.mysql import (
     resolve_mysql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.db_warnings import default_db_warning
 
 
 @tool(
@@ -37,7 +38,5 @@ def get_mysql_current_processes(
     config = resolve_mysql_config(host=host, database=database, port=port)
     result = get_current_processes(config, threshold_seconds=threshold_seconds)
     if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'mysql'. Results may not reflect application data."
-        )
+        result["default_db_warning"] = default_db_warning("mysql")
     return result

--- a/app/tools/PostgreSQLCurrentQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLCurrentQueriesTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.postgresql import (
     resolve_postgresql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.db_warnings import default_db_warning
 
 
 @tool(
@@ -37,7 +38,5 @@ def get_postgresql_current_queries(
     config = resolve_postgresql_config(host=host, database=database, port=port)
     result = get_current_queries(config, threshold_seconds=threshold_seconds)
     if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'postgres'. Results may not reflect application data."
-        )
+        result["default_db_warning"] = default_db_warning("postgres")
     return result

--- a/app/tools/PostgreSQLSlowQueriesTool/__init__.py
+++ b/app/tools/PostgreSQLSlowQueriesTool/__init__.py
@@ -9,6 +9,7 @@ from app.integrations.postgresql import (
     resolve_postgresql_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.db_warnings import default_db_warning
 
 
 @tool(
@@ -37,7 +38,5 @@ def get_postgresql_slow_queries(
     config = resolve_postgresql_config(host=host, database=database, port=port)
     result = get_slow_queries(config, threshold_ms=threshold_ms)
     if _db_defaulted:
-        result["default_db_warning"] = (
-            "WARNING: No database was specified; defaulted to 'postgres'. Results may not reflect application data."
-        )
+        result["default_db_warning"] = default_db_warning("postgres")
     return result

--- a/app/tools/utils/__init__.py
+++ b/app/tools/utils/__init__.py
@@ -1,5 +1,6 @@
 """Tool utilities - data validation, evidence compaction, and log deduplication."""
 
+from app.tools.utils.db_warnings import default_db_warning
 from app.tools.utils.compaction import (
     DEFAULT_ERROR_LOG_LIMIT,
     DEFAULT_LOG_LIMIT,
@@ -25,6 +26,8 @@ from app.tools.utils.log_compaction import (
 )
 
 __all__ = [
+    # Database warnings
+    "default_db_warning",
     # Data validation
     "validate_host_metrics",
     # Compaction utilities

--- a/app/tools/utils/__init__.py
+++ b/app/tools/utils/__init__.py
@@ -1,6 +1,5 @@
 """Tool utilities - data validation, evidence compaction, and log deduplication."""
 
-from app.tools.utils.db_warnings import default_db_warning
 from app.tools.utils.compaction import (
     DEFAULT_ERROR_LOG_LIMIT,
     DEFAULT_LOG_LIMIT,
@@ -17,6 +16,7 @@ from app.tools.utils.compaction import (
     truncate_message,
 )
 from app.tools.utils.data_validation import validate_host_metrics
+from app.tools.utils.db_warnings import default_db_warning
 from app.tools.utils.log_compaction import (
     build_error_taxonomy,
     deduplicate_logs,

--- a/app/tools/utils/db_warnings.py
+++ b/app/tools/utils/db_warnings.py
@@ -1,5 +1,7 @@
 """Shared warning helper for SQL tools that default to a system database."""
 
+from __future__ import annotations
+
 
 def default_db_warning(db_name: str) -> str:
     return (

--- a/app/tools/utils/db_warnings.py
+++ b/app/tools/utils/db_warnings.py
@@ -1,0 +1,8 @@
+"""Shared warning helper for SQL tools that default to a system database."""
+
+
+def default_db_warning(db_name: str) -> str:
+    return (
+        f"WARNING: No database was specified; defaulted to '{db_name}'. "
+        "Results may not reflect application data."
+    )

--- a/tests/tools/test_azure_sql_current_queries_tool.py
+++ b/tests/tools/test_azure_sql_current_queries_tool.py
@@ -53,3 +53,24 @@ def test_run_error_propagated() -> None:
     ):
         result = get_azure_sql_current_queries(server="invalid", database="testdb")
     assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.AzureSQLCurrentQueriesTool.get_current_queries",
+        return_value={"source": "azure_sql", "available": True, "queries": []},
+    ):
+        result = get_azure_sql_current_queries(server="myserver.database.windows.net")
+    assert "default_db_warning" in result
+    assert "master" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.AzureSQLCurrentQueriesTool.get_current_queries",
+        return_value={"source": "azure_sql", "available": True, "queries": []},
+    ):
+        result = get_azure_sql_current_queries(
+            server="myserver.database.windows.net", database="mydb"
+        )
+    assert "default_db_warning" not in result

--- a/tests/tools/test_azure_sql_slow_queries_tool.py
+++ b/tests/tools/test_azure_sql_slow_queries_tool.py
@@ -52,3 +52,24 @@ def test_run_error_propagated() -> None:
     ):
         result = get_azure_sql_slow_queries(server="invalid", database="testdb")
     assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.AzureSQLSlowQueriesTool.get_slow_queries",
+        return_value={"source": "azure_sql", "available": True, "queries": []},
+    ):
+        result = get_azure_sql_slow_queries(server="myserver.database.windows.net")
+    assert "default_db_warning" in result
+    assert "master" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.AzureSQLSlowQueriesTool.get_slow_queries",
+        return_value={"source": "azure_sql", "available": True, "queries": []},
+    ):
+        result = get_azure_sql_slow_queries(
+            server="myserver.database.windows.net", database="mydb"
+        )
+    assert "default_db_warning" not in result

--- a/tests/tools/test_azure_sql_slow_queries_tool.py
+++ b/tests/tools/test_azure_sql_slow_queries_tool.py
@@ -69,7 +69,5 @@ def test_no_default_db_warning_when_database_provided() -> None:
         "app.tools.AzureSQLSlowQueriesTool.get_slow_queries",
         return_value={"source": "azure_sql", "available": True, "queries": []},
     ):
-        result = get_azure_sql_slow_queries(
-            server="myserver.database.windows.net", database="mydb"
-        )
+        result = get_azure_sql_slow_queries(server="myserver.database.windows.net", database="mydb")
     assert "default_db_warning" not in result

--- a/tests/tools/test_db_warnings.py
+++ b/tests/tools/test_db_warnings.py
@@ -1,0 +1,25 @@
+"""Direct unit tests for the default_db_warning helper."""
+
+from __future__ import annotations
+
+from app.tools.utils.db_warnings import default_db_warning
+
+
+def test_contains_db_name() -> None:
+    warning = default_db_warning("postgres")
+    assert "postgres" in warning
+
+
+def test_contains_warning_prefix() -> None:
+    assert default_db_warning("master").startswith("WARNING:")
+
+
+def test_consistent_template() -> None:
+    for db in ("master", "postgres", "mysql"):
+        w = default_db_warning(db)
+        assert f"defaulted to '{db}'" in w
+        assert "Results may not reflect application data." in w
+
+
+def test_different_db_names_differ() -> None:
+    assert default_db_warning("master") != default_db_warning("postgres")

--- a/tests/tools/test_mariadb_process_list_tool.py
+++ b/tests/tools/test_mariadb_process_list_tool.py
@@ -39,3 +39,22 @@ def test_run_error_propagated() -> None:
     ):
         result = get_mariadb_process_list(host="invalid", database="test", username="user")
     assert "error" in result
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.MariaDBProcessListTool.get_process_list",
+        return_value={"source": "mariadb", "available": True, "processes": []},
+    ):
+        result = get_mariadb_process_list(host="localhost", username="user")
+    assert "default_db_warning" in result
+    assert "mysql" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.MariaDBProcessListTool.get_process_list",
+        return_value={"source": "mariadb", "available": True, "processes": []},
+    ):
+        result = get_mariadb_process_list(host="localhost", username="user", database="mydb")
+    assert "default_db_warning" not in result

--- a/tests/tools/test_mysql_current_processes_tool.py
+++ b/tests/tools/test_mysql_current_processes_tool.py
@@ -69,3 +69,22 @@ def test_run_error_propagated() -> None:
         result = get_mysql_current_processes(host="invalid", database="testdb")
     assert "error" in result
     assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.MySQLCurrentProcessesTool.get_current_processes",
+        return_value={"source": "mysql", "available": True, "processes": []},
+    ):
+        result = get_mysql_current_processes(host="localhost")
+    assert "default_db_warning" in result
+    assert "mysql" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.MySQLCurrentProcessesTool.get_current_processes",
+        return_value={"source": "mysql", "available": True, "processes": []},
+    ):
+        result = get_mysql_current_processes(host="localhost", database="mydb")
+    assert "default_db_warning" not in result

--- a/tests/tools/test_postgresql_current_queries_tool.py
+++ b/tests/tools/test_postgresql_current_queries_tool.py
@@ -72,3 +72,22 @@ def test_run_error_propagated() -> None:
         result = get_postgresql_current_queries(host="invalid", database="testdb")
     assert "error" in result
     assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.PostgreSQLCurrentQueriesTool.get_current_queries",
+        return_value={"source": "postgresql", "available": True, "queries": []},
+    ):
+        result = get_postgresql_current_queries(host="localhost")
+    assert "default_db_warning" in result
+    assert "postgres" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.PostgreSQLCurrentQueriesTool.get_current_queries",
+        return_value={"source": "postgresql", "available": True, "queries": []},
+    ):
+        result = get_postgresql_current_queries(host="localhost", database="mydb")
+    assert "default_db_warning" not in result

--- a/tests/tools/test_postgresql_slow_queries_tool.py
+++ b/tests/tools/test_postgresql_slow_queries_tool.py
@@ -94,3 +94,22 @@ def test_run_error_propagated() -> None:
         result = get_postgresql_slow_queries(host="localhost", database="invalid_db")
     assert "error" in result
     assert result["available"] is False
+
+
+def test_default_db_warning_present_when_database_omitted() -> None:
+    with patch(
+        "app.tools.PostgreSQLSlowQueriesTool.get_slow_queries",
+        return_value={"source": "postgresql", "available": True, "queries": []},
+    ):
+        result = get_postgresql_slow_queries(host="localhost")
+    assert "default_db_warning" in result
+    assert "postgres" in result["default_db_warning"]
+
+
+def test_no_default_db_warning_when_database_provided() -> None:
+    with patch(
+        "app.tools.PostgreSQLSlowQueriesTool.get_slow_queries",
+        return_value={"source": "postgresql", "available": True, "queries": []},
+    ):
+        result = get_postgresql_slow_queries(host="localhost", database="mydb")
+    assert "default_db_warning" not in result


### PR DESCRIPTION
Fixes #893

#### Describe the changes you have made in this PR -

Added a shared `default_db_warning(db_name)` helper under `app/tools/utils/db_warnings.py` and migrated six SQL tools that were each repeating the same inline warning string to use it instead. The warning key (`default_db_warning`) and warning text are unchanged — only the source of truth moved to one place.

Tools migrated:
- `AzureSQLCurrentQueriesTool`
- `AzureSQLSlowQueriesTool`
- `PostgreSQLCurrentQueriesTool`
- `PostgreSQLSlowQueriesTool`
- `MySQLCurrentProcessesTool`
- `MariaDBProcessListTool`

Also added:
- `tests/tools/test_db_warnings.py` — direct unit tests for the helper
- Two warning behavior tests per tool (warning present when `database` omitted, absent when provided)

### Demo/Screenshot for feature changes and bug fixes -
<img width="1512" height="982" alt="Screenshot 2026-04-28 at 01 39 45" src="https://github.com/user-attachments/assets/ee794b2c-8860-4908-8999-b8e1fe30073a" />




**Did you use AI assistance?**
- [x] Yes, I used AI assistance

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The six SQL tools each had an identical block: check if `database` was `None`, set a default, then attach a warning string to the result dict. The only variation was the default DB name (`master`, `postgres`, or `mysql`). The fix is a one-line function `default_db_warning(db_name: str) -> str` in `app/tools/utils/db_warnings.py` that returns the formatted warning. Each tool now calls that instead of hardcoding the string. No logic changed — the response key and warning text are identical to before.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
