### PR TITLE
test(cli): add direct unit tests for ollama lifecycle helpers

### DIFF
--- a/tests/cli/test_local_llm_ollama_lifecycle.py
+++ b/tests/cli/test_local_llm_ollama_lifecycle.py
@@ -1,0 +1,199 @@
+"""Direct unit tests for Ollama lifecycle helpers: is_installed, start_server, wait_for_server, install."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+from app.cli.local_llm.ollama import (
+    install,
+    is_installed,
+    start_server,
+    wait_for_server,
+)
+
+# ---------------------------------------------------------------------------
+# is_installed
+# ---------------------------------------------------------------------------
+
+
+def test_is_installed_returns_true_when_ollama_on_path(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: "/usr/local/bin/ollama")
+    assert is_installed() is True
+
+
+def test_is_installed_returns_false_when_ollama_not_on_path(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: None)
+    assert is_installed() is False
+
+
+# ---------------------------------------------------------------------------
+# start_server
+# ---------------------------------------------------------------------------
+
+
+def test_start_server_opens_popen_with_ollama_serve(monkeypatch) -> None:
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    popen_calls: list[tuple[list[str], dict]] = []
+
+    def fake_popen(args, **kwargs):  # type: ignore[no-untyped-def]
+        popen_calls.append((args, kwargs))
+        return fake_proc
+
+    monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.Popen", fake_popen)
+    result = start_server()
+
+    assert result is fake_proc
+    assert len(popen_calls) == 1
+    args, kwargs = popen_calls[0]
+    assert args == ["ollama", "serve"]
+    assert kwargs.get("stdout") == subprocess.DEVNULL
+    assert kwargs.get("stderr") == subprocess.DEVNULL
+
+
+# ---------------------------------------------------------------------------
+# wait_for_server
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_server_returns_true_on_first_attempt(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.is_server_running", lambda _: True)
+    monkeypatch.setattr("app.cli.local_llm.ollama.time.sleep", lambda _: None)
+    assert wait_for_server("http://localhost:11434") is True
+
+
+def test_wait_for_server_returns_true_after_retries(monkeypatch) -> None:
+    attempt: dict[str, int] = {"count": 0}
+
+    def flaky_check(_host: str) -> bool:
+        attempt["count"] += 1
+        return attempt["count"] >= 3  # fails twice, then succeeds
+
+    monkeypatch.setattr("app.cli.local_llm.ollama.is_server_running", flaky_check)
+    monkeypatch.setattr("app.cli.local_llm.ollama.time.sleep", lambda _: None)
+
+    assert wait_for_server("http://localhost:11434", timeout_s=5) is True
+    assert attempt["count"] == 3
+
+
+def test_wait_for_server_returns_false_on_timeout(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.is_server_running", lambda _: False)
+    sleep_calls: list[int] = []
+    monkeypatch.setattr("app.cli.local_llm.ollama.time.sleep", lambda s: sleep_calls.append(s))
+
+    assert wait_for_server("http://localhost:11434", timeout_s=3) is False
+    assert len(sleep_calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# install — macOS with Homebrew present
+# ---------------------------------------------------------------------------
+
+
+def test_install_macos_brew_present_user_confirms_succeeds(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "darwin")
+    monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: "/usr/local/bin/brew")
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
+
+    import questionary
+
+    monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
+
+    console = MagicMock()
+    assert install(console) is True
+
+
+def test_install_macos_brew_present_user_declines_returns_false(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "darwin")
+    monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: "/usr/local/bin/brew")
+
+    import questionary
+
+    monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: False))
+
+    console = MagicMock()
+    assert install(console) is False
+
+
+def test_install_macos_brew_absent_returns_false_and_prints_link(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "darwin")
+    monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: None)
+
+    console = MagicMock()
+    assert install(console) is False
+    # Should print both the "no homebrew" warning and the download URL
+    assert console.print.call_count >= 2
+
+
+def test_install_macos_brew_present_subprocess_fails_returns_false(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "darwin")
+    monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: "/usr/local/bin/brew")
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
+
+    import questionary
+
+    monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
+
+    console = MagicMock()
+    assert install(console) is False
+
+
+# ---------------------------------------------------------------------------
+# install — Linux
+# ---------------------------------------------------------------------------
+
+
+def test_install_linux_user_confirms_succeeds(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "linux")
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
+
+    import questionary
+
+    monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
+
+    console = MagicMock()
+    assert install(console) is True
+
+
+def test_install_linux_user_declines_returns_false(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "linux")
+
+    import questionary
+
+    monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: False))
+
+    console = MagicMock()
+    assert install(console) is False
+
+
+def test_install_linux_subprocess_fails_returns_false(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "linux")
+    fake_result = MagicMock()
+    fake_result.returncode = 2
+    monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
+
+    import questionary
+
+    monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
+
+    console = MagicMock()
+    assert install(console) is False
+
+
+# ---------------------------------------------------------------------------
+# install — Windows (unsupported)
+# ---------------------------------------------------------------------------
+
+
+def test_install_windows_returns_false(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "win32")
+
+    console = MagicMock()
+    assert install(console) is False
+    console.print.assert_called()

--- a/tests/cli/test_local_llm_ollama_lifecycle.py
+++ b/tests/cli/test_local_llm_ollama_lifecycle.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock
 
+import questionary
+
 from app.cli.local_llm.ollama import (
     install,
     is_installed,
@@ -78,7 +80,7 @@ def test_wait_for_server_returns_true_after_retries(monkeypatch) -> None:
 
 def test_wait_for_server_returns_false_on_timeout(monkeypatch) -> None:
     monkeypatch.setattr("app.cli.local_llm.ollama.is_server_running", lambda _: False)
-    sleep_calls: list[int] = []
+    sleep_calls: list[float] = []
     monkeypatch.setattr("app.cli.local_llm.ollama.time.sleep", lambda s: sleep_calls.append(s))
 
     assert wait_for_server("http://localhost:11434", timeout_s=3) is False
@@ -96,9 +98,6 @@ def test_install_macos_brew_present_user_confirms_succeeds(monkeypatch) -> None:
     fake_result = MagicMock()
     fake_result.returncode = 0
     monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
-
-    import questionary
-
     monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
 
     console = MagicMock()
@@ -108,9 +107,6 @@ def test_install_macos_brew_present_user_confirms_succeeds(monkeypatch) -> None:
 def test_install_macos_brew_present_user_declines_returns_false(monkeypatch) -> None:
     monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "darwin")
     monkeypatch.setattr("app.cli.local_llm.ollama.shutil.which", lambda _: "/usr/local/bin/brew")
-
-    import questionary
-
     monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: False))
 
     console = MagicMock()
@@ -133,9 +129,6 @@ def test_install_macos_brew_present_subprocess_fails_returns_false(monkeypatch) 
     fake_result = MagicMock()
     fake_result.returncode = 1
     monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
-
-    import questionary
-
     monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
 
     console = MagicMock()
@@ -152,9 +145,6 @@ def test_install_linux_user_confirms_succeeds(monkeypatch) -> None:
     fake_result = MagicMock()
     fake_result.returncode = 0
     monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
-
-    import questionary
-
     monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
 
     console = MagicMock()
@@ -163,9 +153,6 @@ def test_install_linux_user_confirms_succeeds(monkeypatch) -> None:
 
 def test_install_linux_user_declines_returns_false(monkeypatch) -> None:
     monkeypatch.setattr("app.cli.local_llm.ollama.sys.platform", "linux")
-
-    import questionary
-
     monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: False))
 
     console = MagicMock()
@@ -177,9 +164,6 @@ def test_install_linux_subprocess_fails_returns_false(monkeypatch) -> None:
     fake_result = MagicMock()
     fake_result.returncode = 2
     monkeypatch.setattr("app.cli.local_llm.ollama.subprocess.run", lambda *_a, **_kw: fake_result)
-
-    import questionary
-
     monkeypatch.setattr(questionary, "confirm", lambda *_a, **_kw: MagicMock(ask=lambda: True))
 
     console = MagicMock()


### PR DESCRIPTION
Fixes #906

#### Describe the changes you have made in this PR

Added tests/cli/test_local_llm_ollama_lifecycle.py with 14 direct unit tests covering the lifecycle helpers in app/cli/local_llm/ollama.py:

- is_installed() — ollama found on PATH / not found
- start_server() — correct Popen args and DEVNULL stdio wiring
- wait_for_server() — succeeds on first try, succeeds after retries, times out correctly
- install() macOS — brew present + user confirms, user declines, no brew (prints manual link), subprocess failure
- install() Linux — user confirms, user declines, subprocess failure
- install() Windows — returns False (unsupported)

No real package managers or ollama processes are invoked. All external calls (shutil.which, subprocess.Popen, subprocess.run, time.sleep, httpx, questionary) are monkeypatched.

### Demo/Screenshot
<img width="1512" height="982" alt="Screenshot 2026-04-28 at 02 49 16" src="https://github.com/user-attachments/assets/f6c4e9b6-06af-432f-a337-1692db45e273" />



All 14 tests pass:

python3 -m pytest tests/cli/test_local_llm_ollama_lifecycle.py -v

PASSED test_is_installed_returns_true_when_ollama_on_path
PASSED test_is_installed_returns_false_when_ollama_not_on_path
PASSED test_start_server_opens_popen_with_ollama_serve
PASSED test_wait_for_server_returns_true_on_first_attempt
PASSED test_wait_for_server_returns_true_after_retries
PASSED test_wait_for_server_returns_false_on_timeout
PASSED test_install_macos_brew_present_user_confirms_succeeds
PASSED test_install_macos_brew_present_user_declines_returns_false
PASSED test_install_macos_brew_absent_returns_false_and_prints_link
PASSED test_install_macos_brew_present_subprocess_fails_returns_false
PASSED test_install_linux_user_confirms_succeeds
PASSED test_install_linux_user_declines_returns_false
PASSED test_install_linux_subprocess_fails_returns_false
PASSED test_install_windows_returns_false
14 passed in 0.13s
