### PR TITLE
refactor: extract shared SQL tool wrapper helper

### DIFF
--- a/app/tools/utils/sql_wrapper.py
+++ b/app/tools/utils/sql_wrapper.py
@@ -1,7 +1,8 @@
 """Shared SQL tool wrapper helper.
 
 Extracts the repeated ``resolve config → call integration → attach warning``
-pattern that all six SQL tools (AzureSQL, PostgreSQL, MySQL, MariaDB) share.
+pattern shared across all 20 SQL tools (5 per family: AzureSQL, PostgreSQL,
+MySQL, MariaDB).
 
 See: https://github.com/Tracer-Cloud/opensre/issues/894
 """
@@ -25,7 +26,7 @@ def run_sql_tool(
 
     1. Call the integration helper function with the resolved config params
     2. If a *warning* string is provided, inject it into the returned dict
-       under the ``"warning"`` key (only when the call succeeds)
+       under the ``"default_db_warning"`` key (only when the call succeeds)
     3. Return the dict unchanged on failure
 
     Parameters
@@ -38,15 +39,17 @@ def run_sql_tool(
     warning:
         Optional warning message to attach to a successful result.
         Set by tools that need to surface a default-database notice, a
-        deprecated-credentials notice, etc.
+        deprecated-credentials notice, etc.  Written under the
+        ``"default_db_warning"`` key to match the convention used by all
+        existing SQL tools.
     **kwargs:
         Keyword arguments forwarded to *integration_fn*.
 
     Returns
     -------
     dict[str, Any]
-        The result dict from *integration_fn*, with ``"warning"`` added
-        when *warning* is not ``None`` and the call succeeded.
+        The result dict from *integration_fn*, with ``"default_db_warning"``
+        added when *warning* is not ``None`` and the call succeeded.
 
     Example
     -------
@@ -62,5 +65,5 @@ def run_sql_tool(
     """
     result: dict[str, Any] = integration_fn(*args, **kwargs)
     if warning is not None and result.get("available", True):
-        result["warning"] = warning
+        result["default_db_warning"] = warning
     return result

--- a/app/tools/utils/sql_wrapper.py
+++ b/app/tools/utils/sql_wrapper.py
@@ -8,7 +8,8 @@ See: https://github.com/Tracer-Cloud/opensre/issues/894
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 
 def run_sql_tool(

--- a/app/tools/utils/sql_wrapper.py
+++ b/app/tools/utils/sql_wrapper.py
@@ -1,0 +1,65 @@
+"""Shared SQL tool wrapper helper.
+
+Extracts the repeated ``resolve config → call integration → attach warning``
+pattern that all six SQL tools (AzureSQL, PostgreSQL, MySQL, MariaDB) share.
+
+See: https://github.com/Tracer-Cloud/opensre/issues/894
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def run_sql_tool(
+    integration_fn: Callable[..., dict[str, Any]],
+    /,
+    *args: Any,
+    warning: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Call *integration_fn* with *args* / *kwargs* and optionally attach a warning.
+
+    This is the shared pattern used across all SQL tools:
+
+    1. Call the integration helper function with the resolved config params
+    2. If a *warning* string is provided, inject it into the returned dict
+       under the ``"warning"`` key (only when the call succeeds)
+    3. Return the dict unchanged on failure
+
+    Parameters
+    ----------
+    integration_fn:
+        The underlying integration function to call
+        (e.g. ``query_current_queries``, ``query_slow_queries``).
+    *args:
+        Positional arguments forwarded to *integration_fn*.
+    warning:
+        Optional warning message to attach to a successful result.
+        Set by tools that need to surface a default-database notice, a
+        deprecated-credentials notice, etc.
+    **kwargs:
+        Keyword arguments forwarded to *integration_fn*.
+
+    Returns
+    -------
+    dict[str, Any]
+        The result dict from *integration_fn*, with ``"warning"`` added
+        when *warning* is not ``None`` and the call succeeded.
+
+    Example
+    -------
+    >>> result = run_sql_tool(
+    ...     query_current_queries,
+    ...     host=host,
+    ...     port=port,
+    ...     user=user,
+    ...     password=password,
+    ...     database=database,
+    ...     warning="Using default database — set DB_NAME to target a specific DB.",
+    ... )
+    """
+    result: dict[str, Any] = integration_fn(*args, **kwargs)
+    if warning is not None and result.get("available", True):
+        result["warning"] = warning
+    return result

--- a/tests/tools/utils/test_sql_wrapper.py
+++ b/tests/tools/utils/test_sql_wrapper.py
@@ -16,6 +16,10 @@ def _integration_fail(**kwargs) -> dict:
     return {"available": False, "error": "connection refused"}
 
 
+def _integration_positional(*args, **kwargs) -> dict:
+    return {"available": True, "args": list(args), **kwargs}
+
+
 # ── Core wrapper behaviour ────────────────────────────────────────────────────
 
 def test_run_sql_tool_returns_integration_result() -> None:
@@ -30,9 +34,15 @@ def test_run_sql_tool_forwards_kwargs() -> None:
     assert result["port"] == 5432
 
 
+def test_run_sql_tool_forwards_positional_args() -> None:
+    """Positional args must be forwarded to the integration function."""
+    result = run_sql_tool(_integration_positional, "host-arg", 5432)
+    assert result["args"] == ["host-arg", 5432]
+
+
 def test_run_sql_tool_no_warning_by_default() -> None:
     result = run_sql_tool(_integration_ok)
-    assert "warning" not in result
+    assert "default_db_warning" not in result
 
 
 # ── Warning injection ─────────────────────────────────────────────────────────
@@ -42,7 +52,7 @@ def test_run_sql_tool_injects_warning_on_success() -> None:
         _integration_ok,
         warning="Using default database.",
     )
-    assert result["warning"] == "Using default database."
+    assert result["default_db_warning"] == "Using default database."
 
 
 def test_run_sql_tool_does_not_inject_warning_on_failure() -> None:
@@ -51,7 +61,7 @@ def test_run_sql_tool_does_not_inject_warning_on_failure() -> None:
         _integration_fail,
         warning="This should not appear.",
     )
-    assert "warning" not in result
+    assert "default_db_warning" not in result
     assert result["available"] is False
 
 

--- a/tests/tools/utils/test_sql_wrapper.py
+++ b/tests/tools/utils/test_sql_wrapper.py
@@ -1,0 +1,69 @@
+"""Unit tests for the shared SQL tool wrapper helper.
+
+See: https://github.com/Tracer-Cloud/opensre/issues/894
+"""
+
+from __future__ import annotations
+
+from app.tools.utils.sql_wrapper import run_sql_tool
+
+
+def _integration_ok(**kwargs) -> dict:
+    return {"available": True, "rows": [{"query": "SELECT 1"}], **kwargs}
+
+
+def _integration_fail(**kwargs) -> dict:
+    return {"available": False, "error": "connection refused"}
+
+
+# ── Core wrapper behaviour ────────────────────────────────────────────────────
+
+def test_run_sql_tool_returns_integration_result() -> None:
+    result = run_sql_tool(_integration_ok)
+    assert result["available"] is True
+    assert "rows" in result
+
+
+def test_run_sql_tool_forwards_kwargs() -> None:
+    result = run_sql_tool(_integration_ok, host="localhost", port=5432)
+    assert result["host"] == "localhost"
+    assert result["port"] == 5432
+
+
+def test_run_sql_tool_no_warning_by_default() -> None:
+    result = run_sql_tool(_integration_ok)
+    assert "warning" not in result
+
+
+# ── Warning injection ─────────────────────────────────────────────────────────
+
+def test_run_sql_tool_injects_warning_on_success() -> None:
+    result = run_sql_tool(
+        _integration_ok,
+        warning="Using default database.",
+    )
+    assert result["warning"] == "Using default database."
+
+
+def test_run_sql_tool_does_not_inject_warning_on_failure() -> None:
+    """Warning must NOT be added when the integration call fails."""
+    result = run_sql_tool(
+        _integration_fail,
+        warning="This should not appear.",
+    )
+    assert "warning" not in result
+    assert result["available"] is False
+
+
+def test_run_sql_tool_preserves_error_dict_on_failure() -> None:
+    result = run_sql_tool(_integration_fail)
+    assert result["error"] == "connection refused"
+
+
+# ── Regression: output keys unchanged ────────────────────────────────────────
+
+def test_run_sql_tool_output_keys_unchanged() -> None:
+    """Tool output keys must not be renamed or removed by the wrapper."""
+    result = run_sql_tool(_integration_ok)
+    expected_keys = {"available", "rows"}
+    assert expected_keys.issubset(result.keys())


### PR DESCRIPTION
Closes #894

Adds `app/tools/utils/sql_wrapper.py` — a single `run_sql_tool()` helper that encapsulates the repeated `resolve config → call integration → attach warning → return dict` pattern shared across all six SQL tools.

**Files:**
- `app/tools/utils/sql_wrapper.py` — helper with full docstring + example
- `tests/tools/utils/test_sql_wrapper.py` — 7 tests: happy path, kwargs forwarding, warning injection, warning suppressed on failure, error dict preserved, output keys regression

Migration of the six SQL tools is left for a follow-up PR per the issue scope.