### PR TITLE
Add tracer integration service tests

### DIFF
--- a/tests/services/tracer_client/test_tracer_integrations.py
+++ b/tests/services/tracer_client/test_tracer_integrations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from collections.abc import Mapping
 from typing import Any
@@ -28,7 +29,7 @@ class DummyTracerClient(TracerIntegrationsMixin):
     ) -> dict[str, Any]:
         self.last_endpoint = endpoint
         self.last_params = dict(params or {})
-        return self._payload
+        return copy.deepcopy(self._payload)
 
 
 def test_get_integration_credentials_uses_service_filter() -> None:
@@ -99,7 +100,10 @@ def test_get_all_integrations_falls_back_to_empty_credentials_on_malformed_json(
     }
     client = DummyTracerClient(payload)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(
+        logging.WARNING,
+        logger="app.services.tracer_client.tracer_integrations",
+    ):
         result = client.get_all_integrations()
 
     assert result[0]["credentials"] == {}
@@ -138,6 +142,51 @@ def test_get_grafana_credentials_prefers_active_integration() -> None:
         api_key="active-token",
         integration_id="grafana-active",
         status="active",
+    )
+
+
+def test_get_grafana_credentials_returns_not_found_when_no_integrations() -> None:
+    """Return found=False when no Grafana integrations exist."""
+    client = DummyTracerClient({"success": True, "data": []})
+
+    result = client.get_grafana_credentials()
+
+    assert result == GrafanaIntegrationCredentials(found=False)
+
+
+def test_get_grafana_credentials_falls_back_to_first_inactive_integration() -> None:
+    """Use the first integration when no Grafana records are active."""
+    payload = {
+        "success": True,
+        "data": [
+            {
+                "id": "grafana-inactive-1",
+                "status": "inactive",
+                "credentials": {
+                    "endpoint": "https://inactive-one.grafana.example.com",
+                    "api_key": "inactive-one-token",
+                },
+            },
+            {
+                "id": "grafana-inactive-2",
+                "status": "pending",
+                "credentials": {
+                    "endpoint": "https://inactive-two.grafana.example.com",
+                    "api_key": "inactive-two-token",
+                },
+            },
+        ],
+    }
+    client = DummyTracerClient(payload)
+
+    result = client.get_grafana_credentials()
+
+    assert result == GrafanaIntegrationCredentials(
+        found=True,
+        endpoint="https://inactive-one.grafana.example.com",
+        api_key="inactive-one-token",
+        integration_id="grafana-inactive-1",
+        status="inactive",
     )
 
 

--- a/tests/services/tracer_client/test_tracer_integrations.py
+++ b/tests/services/tracer_client/test_tracer_integrations.py
@@ -17,7 +17,11 @@ class DummyTracerClient(TracerIntegrationsMixin):
     """Dummy client to isolate and test the TracerIntegrationsMixin."""
 
     def __init__(self, payload: dict[str, Any]) -> None:
-        self.org_id = "test_org_123"
+        super().__init__(
+            base_url="https://tracer.example.com",
+            org_id="test_org_123",
+            jwt_token="invalid-test-token",
+        )
         self._payload = payload
         self.last_endpoint = ""
         self.last_params: dict[str, Any] = {}

--- a/tests/services/tracer_client/test_tracer_integrations.py
+++ b/tests/services/tracer_client/test_tracer_integrations.py
@@ -122,7 +122,9 @@ def test_get_grafana_credentials_prefers_active_integration() -> None:
             {
                 "id": "grafana-active",
                 "status": "active",
-                "credentials": '{"endpoint":"https://active.grafana.example.com","api_key":"active-token"}',
+                "credentials": (
+                    '{"endpoint":"https://active.grafana.example.com","api_key":"active-token"}'
+                ),
             },
         ],
     }

--- a/tests/services/tracer_client/test_tracer_integrations.py
+++ b/tests/services/tracer_client/test_tracer_integrations.py
@@ -1,0 +1,165 @@
+"""Tests for Tracer integration credential helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from app.services.tracer_client.tracer_integrations import (
+    GrafanaIntegrationCredentials,
+    TracerIntegrationsMixin,
+)
+
+
+class DummyTracerClient(TracerIntegrationsMixin):
+    """Dummy client to isolate and test the TracerIntegrationsMixin."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.org_id = "test_org_123"
+        self._payload = payload
+        self.last_endpoint = ""
+        self.last_params: dict[str, Any] = {}
+
+    def _get(
+        self,
+        endpoint: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.last_endpoint = endpoint
+        self.last_params = dict(params or {})
+        return self._payload
+
+
+def test_get_integration_credentials_uses_service_filter() -> None:
+    """Fetch credentials for one service using org and service filters."""
+    payload = {
+        "success": True,
+        "data": [{"id": "grafana-1", "credentials": {"endpoint": "https://grafana.example.com"}}],
+    }
+    client = DummyTracerClient(payload)
+
+    result = client.get_integration_credentials("Grafana")
+
+    assert result == payload["data"]
+    assert client.last_endpoint == "/api/integrations"
+    assert client.last_params == {"orgId": "test_org_123", "service": "Grafana"}
+
+
+def test_get_integration_credentials_returns_empty_when_request_fails() -> None:
+    """Return an empty list when the integrations API has no usable data."""
+    client = DummyTracerClient({"success": False, "data": []})
+
+    assert client.get_integration_credentials("Grafana") == []
+
+
+def test_get_all_integrations_parses_string_credentials_and_preserves_dicts() -> None:
+    """Parse JSON string credentials while keeping dict credentials unchanged."""
+    payload = {
+        "success": True,
+        "data": [
+            {
+                "id": "grafana-1",
+                "service": "Grafana",
+                "credentials": '{"endpoint":"https://grafana.example.com","api_key":"token-123"}',
+            },
+            {
+                "id": "slack-1",
+                "service": "Slack",
+                "credentials": {"channel": "#alerts"},
+            },
+        ],
+    }
+    client = DummyTracerClient(payload)
+
+    result = client.get_all_integrations()
+
+    assert result[0]["credentials"] == {
+        "endpoint": "https://grafana.example.com",
+        "api_key": "token-123",
+    }
+    assert result[1]["credentials"] == {"channel": "#alerts"}
+    assert client.last_endpoint == "/api/integrations"
+    assert client.last_params == {"orgId": "test_org_123"}
+
+
+def test_get_all_integrations_falls_back_to_empty_credentials_on_malformed_json(
+    caplog,
+) -> None:
+    """Replace malformed credential JSON with an empty dict and warn."""
+    payload = {
+        "success": True,
+        "data": [
+            {
+                "id": "grafana-1",
+                "service": "Grafana",
+                "credentials": '{"endpoint": "https://grafana.example.com"',
+            }
+        ],
+    }
+    client = DummyTracerClient(payload)
+
+    with caplog.at_level(logging.WARNING):
+        result = client.get_all_integrations()
+
+    assert result[0]["credentials"] == {}
+    assert "Malformed credentials JSON for integration grafana-1" in caplog.text
+
+
+def test_get_grafana_credentials_prefers_active_integration() -> None:
+    """Prefer the active Grafana integration over an earlier inactive record."""
+    payload = {
+        "success": True,
+        "data": [
+            {
+                "id": "grafana-inactive",
+                "status": "inactive",
+                "credentials": {
+                    "endpoint": "https://inactive.grafana.example.com",
+                    "api_key": "inactive-token",
+                },
+            },
+            {
+                "id": "grafana-active",
+                "status": "active",
+                "credentials": '{"endpoint":"https://active.grafana.example.com","api_key":"active-token"}',
+            },
+        ],
+    }
+    client = DummyTracerClient(payload)
+
+    result = client.get_grafana_credentials()
+
+    assert result == GrafanaIntegrationCredentials(
+        found=True,
+        endpoint="https://active.grafana.example.com",
+        api_key="active-token",
+        integration_id="grafana-active",
+        status="active",
+    )
+
+
+def test_get_grafana_credentials_handles_malformed_json() -> None:
+    """Return found credentials with empty fields when Grafana JSON is malformed."""
+    payload = {
+        "success": True,
+        "data": [
+            {
+                "id": "grafana-1",
+                "status": "active",
+                "credentials": '{"endpoint":"https://grafana.example.com"',
+            }
+        ],
+    }
+    client = DummyTracerClient(payload)
+
+    result = client.get_grafana_credentials()
+
+    assert result == GrafanaIntegrationCredentials(
+        found=True,
+        endpoint="",
+        api_key="",
+        integration_id="grafana-1",
+        status="active",
+    )
+    assert result.is_configured is False


### PR DESCRIPTION
Fixes #891

#### Describe the changes you have made in this PR -
Added direct unit tests for `app/services/tracer_client/tracer_integrations.py` in:

- `tests/services/tracer_client/test_tracer_integrations.py`

The new coverage includes:
- a fake `DummyTracerClient` subclass that stubs `_get()`
- direct tests for `get_integration_credentials()`
- direct tests for `get_all_integrations()`
- direct tests for `get_grafana_credentials()`

The tests specifically cover:
- JSON credential parsing when credentials are stored as a string
- preserving credentials when they are already a dict
- malformed JSON fallback to an empty dict
- active Grafana integration preference over inactive records
- request parameter construction for integration fetches

### Demo/Screenshot for feature changes and bug fixes -
Terminal proof:
- `ruff check tests/services/tracer_client/test_tracer_integrations.py` passed
- branch pushed successfully: `issue/891-tracer-integrations-tests`

Note: full local project validation was limited in this environment because the available machine runtime is Python 3.9, while this repository targets Python 3.11+.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
This PR adds direct unit coverage for `TracerIntegrationsMixin`, which contains JSON parsing and integration selection logic that should not regress.

I followed the existing service test style used under `tests/services/tracer_client/` and created a minimal fake client that stubs `_get()` while recording the endpoint and params passed to it. This keeps the tests focused on the mixin behavior rather than HTTP details.

The implementation covers the three methods requested in the issue:
- `get_integration_credentials()` verifies service filtering and empty-result behavior
- `get_all_integrations()` verifies JSON string parsing, dict preservation, and malformed JSON fallback
- `get_grafana_credentials()` verifies active-record preference and malformed JSON handling for Grafana credentials

The tests are intentionally narrow and direct so they document the service contract clearly and protect the parsing/selection logic from regressions.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
