### PR TITLE
refactor(tools): centralize code-host unavailable payload for code-host tools

### DIFF
--- a/app/tools/BitbucketSearchCodeTool/__init__.py
+++ b/app/tools/BitbucketSearchCodeTool/__init__.py
@@ -11,6 +11,7 @@ from app.integrations.bitbucket import (
     search_code,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
 
 
 def _resolve_config(
@@ -116,10 +117,10 @@ def search_bitbucket_code(
         integration_id,
     )
     if config is None:
-        return {
-            "source": "bitbucket",
-            "available": False,
-            "error": "Bitbucket integration is not configured.",
-            "results": [],
-        }
+        return code_host_unavailable_payload(
+            source="bitbucket",
+            integration_name="Bitbucket",
+            empty_key="results",
+            empty_value=[],
+        )
     return search_code(config, query=query, repo_slug=repo_slug, limit=limit)

--- a/app/tools/GitHubFileContentsTool/__init__.py
+++ b/app/tools/GitHubFileContentsTool/__init__.py
@@ -12,6 +12,7 @@ from app.tools.GitHubSearchCodeTool import (
     _resolve_config,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
 
 
 def _get_github_file_contents_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -75,12 +76,12 @@ def get_github_file_contents(
     """Fetch a file or directory from GitHub through the MCP server."""
     config = _resolve_config(github_url, github_mode, github_token, github_command, github_args)
     if config is None:
-        return {
-            "source": "github",
-            "available": False,
-            "error": "GitHub MCP integration is not configured.",
-            "file": {},
-        }
+        return code_host_unavailable_payload(
+            source="github",
+            integration_name="GitHub MCP",
+            empty_key="file",
+            empty_value={},
+        )
 
     arguments = {"owner": owner, "repo": repo, "path": path}
     if ref:

--- a/app/tools/GitHubSearchCodeTool/__init__.py
+++ b/app/tools/GitHubSearchCodeTool/__init__.py
@@ -12,6 +12,7 @@ from app.integrations.github_mcp import (
     github_mcp_config_from_env,
 )
 from app.tools.tool_decorator import tool
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
 
 
 def _resolve_config(
@@ -126,12 +127,12 @@ def search_github_code(
     """Search GitHub repository code through the configured GitHub MCP server."""
     config = _resolve_config(github_url, github_mode, github_token, github_command, github_args)
     if config is None:
-        return {
-            "source": "github",
-            "available": False,
-            "error": "GitHub MCP integration is not configured.",
-            "matches": [],
-        }
+        return code_host_unavailable_payload(
+            source="github",
+            integration_name="GitHub MCP",
+            empty_key="matches",
+            empty_value=[],
+        )
 
     final_query = build_github_code_search_query(owner, repo, query)
     result = call_github_mcp_tool(config, "search_code", {"query": final_query})

--- a/app/tools/GitLabFileTool/__init__.py
+++ b/app/tools/GitLabFileTool/__init__.py
@@ -10,6 +10,7 @@ from app.integrations.gitlab import (
 )
 from app.tools.GitLabCommitsTool import _gitlab_available, _gl_creds, _resolve_config
 from app.tools.tool_decorator import tool
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
 
 
 def _get_gitlab_file_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -63,12 +64,12 @@ def get_gitlab_file_contents(
     """Read the contents of a specific file from a GitLab repository."""
     config = _resolve_config(gitlab_url, gitlab_token)
     if config is None:
-        return {
-            "source": "gitlab",
-            "available": False,
-            "error": "gitlab integration is not configured.",
-            "file": {},
-        }
+        return code_host_unavailable_payload(
+            source="gitlab",
+            integration_name="GitLab",
+            empty_key="file",
+            empty_value={},
+        )
 
     result = get_gitlab_file(
         config=config,

--- a/app/tools/GitLabFileTool/__init__.py
+++ b/app/tools/GitLabFileTool/__init__.py
@@ -66,7 +66,7 @@ def get_gitlab_file_contents(
     if config is None:
         return code_host_unavailable_payload(
             source="gitlab",
-            integration_name="GitLab",
+            integration_name="gitlab",
             empty_key="file",
             empty_value={},
         )

--- a/app/tools/utils/__init__.py
+++ b/app/tools/utils/__init__.py
@@ -29,6 +29,7 @@ from app.tools.utils.log_compaction import (
 __all__ = [
     # Database warnings
     "default_db_warning",
+    # Code-host utilities
     "code_host_unavailable_payload",
     # Data validation
     "validate_host_metrics",

--- a/app/tools/utils/__init__.py
+++ b/app/tools/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Tool utilities - data validation, evidence compaction, and log deduplication."""
+"""Tool utilities - code-host helpers, data validation, evidence compaction, and log deduplication."""
 
 from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
 from app.tools.utils.compaction import (

--- a/app/tools/utils/__init__.py
+++ b/app/tools/utils/__init__.py
@@ -1,5 +1,6 @@
 """Tool utilities - data validation, evidence compaction, and log deduplication."""
 
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
 from app.tools.utils.compaction import (
     DEFAULT_ERROR_LOG_LIMIT,
     DEFAULT_LOG_LIMIT,
@@ -28,6 +29,7 @@ from app.tools.utils.log_compaction import (
 __all__ = [
     # Database warnings
     "default_db_warning",
+    "code_host_unavailable_payload",
     # Data validation
     "validate_host_metrics",
     # Compaction utilities

--- a/app/tools/utils/code_host_unavailable.py
+++ b/app/tools/utils/code_host_unavailable.py
@@ -1,0 +1,21 @@
+"""Shared unavailable payload helper for code-host investigation tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def code_host_unavailable_payload(
+    *,
+    source: str,
+    integration_name: str,
+    empty_key: str,
+    empty_value: Any,
+) -> dict[str, Any]:
+    """Return a standardized unavailable payload for code-host tools."""
+    return {
+        "source": source,
+        "available": False,
+        "error": f"{integration_name} integration is not configured.",
+        empty_key: empty_value,
+    }

--- a/tests/tools/test_bitbucket_search_code_tool.py
+++ b/tests/tools/test_bitbucket_search_code_tool.py
@@ -1,0 +1,84 @@
+"""Tests for BitbucketSearchCodeTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from app.tools.BitbucketSearchCodeTool import search_bitbucket_code
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestBitbucketSearchCodeToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return search_bitbucket_code.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_verified() -> None:
+    rt = search_bitbucket_code.__opensre_registered_tool__
+    assert rt.is_available({"bitbucket": {"connection_verified": True}}) is True
+    assert rt.is_available({"bitbucket": {}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = search_bitbucket_code.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "bitbucket": {
+                "connection_verified": True,
+                "query": "panic",
+                "repo_slug": "backend-service",
+                "workspace": "acme",
+                "username": "bb-user",
+                "app_password": "bb-pass",
+                "base_url": "https://api.bitbucket.org/2.0",
+                "max_results": 50,
+                "integration_id": "bb-main",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["query"] == "panic"
+    assert params["repo_slug"] == "backend-service"
+    assert params["workspace"] == "acme"
+    assert params["username"] == "bb-user"
+    assert params["app_password"] == "bb-pass"
+    assert params["base_url"] == "https://api.bitbucket.org/2.0"
+    assert params["max_results"] == 50
+    assert params["integration_id"] == "bb-main"
+
+
+def test_run_returns_unavailable_when_no_config() -> None:
+    with patch("app.tools.BitbucketSearchCodeTool.bitbucket_config_from_env", return_value=None):
+        result = search_bitbucket_code(query="error OR exception")
+
+    assert result == {
+        "source": "bitbucket",
+        "available": False,
+        "error": "Bitbucket integration is not configured.",
+        "results": [],
+    }
+
+
+def test_run_happy_path() -> None:
+    mock_result: dict[str, Any] = {
+        "source": "bitbucket",
+        "available": True,
+        "query": "panic",
+        "results": [{"file_path": "src/main.py", "line": 13, "snippet": "panic(err)"}],
+    }
+
+    with (
+        patch("app.tools.BitbucketSearchCodeTool.bitbucket_config_from_env", return_value=None),
+        patch("app.tools.BitbucketSearchCodeTool.build_bitbucket_config", return_value=object()),
+        patch("app.tools.BitbucketSearchCodeTool.search_code", return_value=mock_result),
+    ):
+        result = search_bitbucket_code(
+            query="panic",
+            workspace="acme",
+            username="bb-user",
+            app_password="bb-pass",
+        )
+
+    assert result == mock_result

--- a/tests/tools/test_code_host_unavailable.py
+++ b/tests/tools/test_code_host_unavailable.py
@@ -1,0 +1,21 @@
+"""Tests for shared code-host unavailable payload helper."""
+
+from __future__ import annotations
+
+from app.tools.utils.code_host_unavailable import code_host_unavailable_payload
+
+
+def test_code_host_unavailable_payload_shape() -> None:
+    payload = code_host_unavailable_payload(
+        source="github",
+        integration_name="GitHub MCP",
+        empty_key="matches",
+        empty_value=[],
+    )
+
+    assert payload == {
+        "source": "github",
+        "available": False,
+        "error": "GitHub MCP integration is not configured.",
+        "matches": [],
+    }

--- a/tests/tools/test_github_file_contents_tool.py
+++ b/tests/tools/test_github_file_contents_tool.py
@@ -45,7 +45,12 @@ def test_extract_params_maps_fields() -> None:
 def test_run_returns_unavailable_when_no_config() -> None:
     with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
         result = get_github_file_contents(owner="org", repo="repo", path="README.md")
-    assert result["available"] is False
+    assert result == {
+        "source": "github",
+        "available": False,
+        "error": "GitHub MCP integration is not configured.",
+        "file": {},
+    }
 
 
 def test_run_happy_path() -> None:

--- a/tests/tools/test_github_search_code_tool.py
+++ b/tests/tools/test_github_search_code_tool.py
@@ -34,8 +34,12 @@ def test_extract_params_maps_fields() -> None:
 def test_run_returns_unavailable_when_no_config() -> None:
     with patch("app.tools.GitHubSearchCodeTool.github_mcp_config_from_env", return_value=None):
         result = search_github_code(owner="org", repo="repo", query="error")
-    assert result["available"] is False
-    assert result["matches"] is None or result.get("matches") == [] or "error" in result
+    assert result == {
+        "source": "github",
+        "available": False,
+        "error": "GitHub MCP integration is not configured.",
+        "matches": [],
+    }
 
 
 def test_run_happy_path() -> None:

--- a/tests/tools/test_gitlab_file_tool.py
+++ b/tests/tools/test_gitlab_file_tool.py
@@ -70,9 +70,12 @@ def test_extract_params_defaults_ref_to_main() -> None:
 def test_run_returns_unavailable_when_config_missing() -> None:
     with patch("app.tools.GitLabFileTool._resolve_config", return_value=None):
         result = get_gitlab_file_contents(project_id="42", file_path="src/main.py")
-    assert result["available"] is False
-    assert "not configured" in result["error"]
-    assert result["file"] == {}
+    assert result == {
+        "source": "gitlab",
+        "available": False,
+        "error": "GitLab integration is not configured.",
+        "file": {},
+    }
 
 
 def test_run_happy_path_decodes_base64_content() -> None:

--- a/tests/tools/test_gitlab_file_tool.py
+++ b/tests/tools/test_gitlab_file_tool.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 import base64
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from app.tools.GitLabFileTool import get_gitlab_file_contents
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
+def _registered_tool() -> Any:
+    return cast(Any, get_gitlab_file_contents).__opensre_registered_tool__
+
+
 class TestGitLabFileToolContract(BaseToolContract):
     def get_tool_under_test(self):
-        return get_gitlab_file_contents.__opensre_registered_tool__
+        return _registered_tool()
 
 
 def test_is_available_requires_connection_project_id_and_file_path() -> None:
-    rt = get_gitlab_file_contents.__opensre_registered_tool__
+    rt = _registered_tool()
     assert (
         rt.is_available(
             {
@@ -37,7 +42,7 @@ def test_is_available_requires_connection_project_id_and_file_path() -> None:
 
 
 def test_extract_params_maps_fields() -> None:
-    rt = get_gitlab_file_contents.__opensre_registered_tool__
+    rt = _registered_tool()
     sources = mock_agent_state(
         {
             "gitlab": {
@@ -59,7 +64,7 @@ def test_extract_params_maps_fields() -> None:
 
 
 def test_extract_params_defaults_ref_to_main() -> None:
-    rt = get_gitlab_file_contents.__opensre_registered_tool__
+    rt = _registered_tool()
     sources = mock_agent_state(
         {"gitlab": {"connection_verified": True, "project_id": "42", "file_path": "src/main.py"}}
     )
@@ -73,7 +78,7 @@ def test_run_returns_unavailable_when_config_missing() -> None:
     assert result == {
         "source": "gitlab",
         "available": False,
-        "error": "GitLab integration is not configured.",
+        "error": "gitlab integration is not configured.",
         "file": {},
     }
 


### PR DESCRIPTION
Fixes #896

Added a shared helper for the integration-not-configured response used by code-host tools, and migrated only the scoped tools from the issue.

**This PR covers:**

- Added shared helper: `code_host_unavailable.py`
- Migrated these tools to use it:
  - `GitHubSearchCodeTool`
  - `GitHubFileContentsTool`
  - `BitbucketSearchCodeTool`
  - `GitLabFileTool`
- Kept provider-specific success responses unchanged
- Preserved tool-specific empty-result keys:
  - `matches` for GitHub search
  - `file` for GitHub file contents
  - `results` for Bitbucket search
  - `file` for GitLab file contents

**Test updates:**
- Extended:
  - `test_github_search_code_tool.py`
  - `test_github_file_contents_tool.py`
  - `test_gitlab_file_tool.py`
- Added:
  - `test_bitbucket_search_code_tool.py`
  - `test_code_host_unavailable.py` (locks exact helper payload shape)

---

### Demo/Screenshot for feature changes and bug fixes -

**Validation output:**

- Focused tool tests passed
- Ruff check passed
- Ruff format check passed
- Mypy passed
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I extracted a single helper to remove duplicated unavailable payload logic across code-host tools while keeping behavior stable and scoped. I intentionally migrated only the four tools listed in the issue and did not touch provider-specific API behavior. I then added tests to verify exact unavailable payload shape and to guard each tool's required empty-result key to prevent regressions.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions