### PR TITLE
chore: spice up post-merge celebration messages

### DIFF
--- a/.github/scripts/merged_pr_celebration_message.py
+++ b/.github/scripts/merged_pr_celebration_message.py
@@ -45,10 +45,6 @@ templates: list[str] = [
         f"⚡ **LGTM → Merged.** @{contributor}, your work is in. "
         "Every commit counts — thank you for this one."
     ),
-    (
-        f"🏆 **PR merged, @{contributor}.** Whether it was a typo fix or a monster feature, "
-        "you shipped and that matters."
-    ),
 ]
 
 # All verified HTTP 200. Weighted toward "" so not every PR gets a GIF (keeps it fresh).

--- a/.github/scripts/merged_pr_celebration_message.py
+++ b/.github/scripts/merged_pr_celebration_message.py
@@ -10,46 +10,67 @@ contributor = os.environ["CONTRIBUTOR_LOGIN"]
 
 templates: list[str] = [
     (
-        f"🎉 **Merged — thanks @{contributor}!** Your change is in; "
-        "appreciate you taking the time to contribute."
+        f"🎉 **MERGED!** @{contributor} just shipped something. "
+        "The diff gods are pleased. 🙌"
     ),
     (
-        f"✨ **Shipped.** Thank you @{contributor} — this PR is merged and "
-        "helps everyone using OpenSRE."
+        f"🚀 **Houston, we have a merge.** @{contributor} your PR is in orbit. "
+        "Thanks for launching this one!"
     ),
     (
-        f"🚀 **Land ho.** @{contributor}, congrats on getting this merged; "
-        "reviews and CI did their job."
+        f"💜 **One more reason the changelog grows.** Thanks @{contributor} — "
+        "your contribution just landed on `main`."
     ),
     (
-        f"💜 **Thank you @{contributor}.** Another contribution landed — "
-        "maintainers and users appreciate it."
+        f"🎊 **Achievement unlocked: PR Merged.** @{contributor} passed code review, "
+        "survived CI, and shipped. Respect. 🤝"
     ),
     (
-        f"🎊 **Merged.** @{contributor}, nice work sticking through review; "
-        "glad this is on main."
+        f"✅ **Merged and deployed to prod^** @{contributor}. "
+        "(*^not actually prod, but your PR is on `main` which is basically the same thing*)"
     ),
     (
-        f"👏 **Thanks @{contributor}!** Your PR merged — documentation, fixes, "
-        "and features all count."
+        f"🔥 **Another one.** @{contributor} said \"here's a PR\" and maintainers said "
+        "\"ship it\". That's how it's done."
     ),
     (
-        f"✅ **On main.** @{contributor}, appreciated — every merged PR moves "
-        "the project forward."
+        f"🧑‍💻 **@{contributor} has entered the contributor hall of fame.** "
+        "Merged. Done. Shipped. Go touch grass (then come back with another PR). 🌱"
+    ),
+    (
+        f"🎯 **Bullseye.** @{contributor} opened a PR, kept the vibes clean, "
+        "and got it merged. Absolute cinema. 🎬"
+    ),
+    (
+        f"⚡ **LGTM → Merged.** @{contributor}, your work is in. "
+        "Every commit counts — thank you for this one."
+    ),
+    (
+        f"🏆 **PR merged, @{contributor}.** Whether it was a typo fix or a monster feature, "
+        "you shipped and that matters."
     ),
 ]
 
+# All verified HTTP 200. Weighted toward "" so not every PR gets a GIF (keeps it fresh).
 gif_blocks: list[str] = [
     "",
+    "",
     "\n\n![](https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif)",
-    "\n\n![](https://media.giphy.com/media/3oz8xAFtuv5nhAfd0I/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/g9582DNuQppxC/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/artj92V8o75VPL7AeQ/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/26u4cqiYI30juCOGY/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/kyLYXonQYYfwYDIeZl/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/xT9IgG50Lg7russbCY/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/zGnnFpOB6s5oNa5VlZ/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/11sBLVxNs7v6WA/giphy.gif)",
+    "\n\n![](https://media.giphy.com/media/Swx36wwSsU49HAnIhC/giphy.gif)",
 ]
 
 head = random.choice(templates) + random.choice(gif_blocks)
 footer = (
     "---\n\n"
-    f"💬 **Community:** [**Discord — OpenSRE**]({discord}) (`#contribute`) — "
-    "questions, coordination, and roadmap chatter welcome anytime."
+    f"💬 **Come hang out:** [**Discord — OpenSRE**]({discord}) — "
+    "`#contribute` for questions, `#general` for vibes. Everyone's welcome."
 )
 body = f"{head}\n\n{footer}"
 

--- a/.github/scripts/merged_pr_celebration_message.py
+++ b/.github/scripts/merged_pr_celebration_message.py
@@ -61,8 +61,8 @@ gif_blocks: list[str] = [
 head = random.choice(templates) + random.choice(gif_blocks)
 footer = (
     "---\n\n"
-    f"💬 **Come hang out:** [**Discord — OpenSRE**]({discord}) — "
-    "`#contribute` for questions, `#general` for vibes. Everyone's welcome."
+    f"👋 **Join us on [Discord — OpenSRE]({discord})** — hang out, contribute, "
+    "or hunt for good first issues. Everyone's welcome."
 )
 body = f"{head}\n\n{footer}"
 

--- a/.github/scripts/merged_pr_celebration_message.py
+++ b/.github/scripts/merged_pr_celebration_message.py
@@ -61,8 +61,8 @@ gif_blocks: list[str] = [
 head = random.choice(templates) + random.choice(gif_blocks)
 footer = (
     "---\n\n"
-    f"👋 **Join us on [Discord — OpenSRE]({discord})** — hang out, contribute, "
-    "or hunt for good first issues. Everyone's welcome."
+    f"👋 **Join us on [Discord - OpenSRE]({discord})** : hang out, contribute, "
+    "or hunt for feature requests and issues. Everyone's welcome."
 )
 body = f"{head}\n\n{footer}"
 

--- a/.github/scripts/merged_pr_celebration_message.py
+++ b/.github/scripts/merged_pr_celebration_message.py
@@ -18,16 +18,12 @@ templates: list[str] = [
         "Thanks for launching this one!"
     ),
     (
-        f"💜 **One more reason the changelog grows.** Thanks @{contributor} — "
-        "your contribution just landed on `main`."
+        f"💜 **One more reason the project grows.** Thanks @{contributor} — "
+        "your contribution just landed!"
     ),
     (
         f"🎊 **Achievement unlocked: PR Merged.** @{contributor} passed code review, "
         "survived CI, and shipped. Respect. 🤝"
-    ),
-    (
-        f"✅ **Merged and deployed to prod^** @{contributor}. "
-        "(*^not actually prod, but your PR is on `main` which is basically the same thing*)"
     ),
     (
         f"🔥 **Another one.** @{contributor} said \"here's a PR\" and maintainers said "

--- a/.github/scripts/merged_pr_celebration_message.py
+++ b/.github/scripts/merged_pr_celebration_message.py
@@ -62,7 +62,7 @@ head = random.choice(templates) + random.choice(gif_blocks)
 footer = (
     "---\n\n"
     f"👋 **Join us on [Discord - OpenSRE]({discord})** : hang out, contribute, "
-    "or hunt for feature requests and issues. Everyone's welcome."
+    "or hunt for features and issues. Everyone's welcome."
 )
 body = f"{head}\n\n{footer}"
 


### PR DESCRIPTION
Improves the post-merge bot comment that was added in #1038.

### Changes
- **Broken/slow GIF dropped** (`3oz8xAFtuv5nhAfd0I`) — replaced with 8 verified HTTP-200 Giphy URLs  
- **10 fun message templates** (up from 7) — more casual, punchy, varied tone  
- **GIF weighting**: 2 of 11 slots are empty so ~18% of merges get emoji-only (keeps it from feeling repetitive)  
- **Friendlier Discord footer**: "Come hang out" copy + `#general` mentioned alongside `#contribute`

### Sample outputs
> 🎯 **Bullseye.** @contributor opened a PR, kept the vibes clean, and got it merged. Absolute cinema. 🎬

> 🧑‍💻 **@contributor has entered the contributor hall of fame.** Merged. Done. Shipped. Go touch grass (then come back with another PR). 🌱

> ✅ **Merged and deployed to prod^** @contributor. (*^not actually prod, but your PR is on `main` which is basically the same thing*)

No logic changes to the workflow itself.


Made with [Cursor](https://cursor.com)