### PR TITLE
docs: clarify audience and purpose of the two integrations overview pages

### DIFF
--- a/docs/integrations-overview.mdx
+++ b/docs/integrations-overview.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Integrations overview"
+description: "Connect your observability stack, infrastructure, and communication tools so OpenSRE can investigate incidents automatically."
 ---
+
+**This page covers enterprise and local integrations for the OpenSRE hosted product.** If you are self-hosting OpenSRE as a library and want to connect workflow tools like Trello, Bash, or Nextflow, see [Integrations (library)](/integrations/overview).
 
 OpenSRE investigates alerts by querying the same tools your engineers use. Connect your stack so OpenSRE can pull logs, check recent deploys, map dependencies, and deliver findings where your team already works.
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -2,7 +2,10 @@
 title: "Integrations / Frameworks"
 sidebarTitle: "Overview"
 description: "Choose the right framework integration for your workflow"
+description: "Workflow and environment integrations for the OpenSRE Python library (self-hosted)."
 ---
+
+> **Scope:** This page covers integrations for the **self-hosted OpenSRE Python library** — workflow tools, compute environments, and pipeline orchestrators. If you are using the hosted OpenSRE product and want to connect Datadog, AWS, or Slack, see [Integrations overview](/integrations-overview).
 
 OpenSRE seamlessly integrates with a wide array of workflow managers, schedulers, and scripting environments.<br/> Choose the integration that best matches your pipeline infrastructure.
 


### PR DESCRIPTION
Closes #826

## Problem

The repo has two integrations overview pages that are easy to confuse:
- `docs/integrations-overview.mdx` — for the **hosted OpenSRE product** (Datadog, AWS, Slack)
- `docs/integrations/overview.mdx` — for the **self-hosted Python library** (Trello, Nextflow, Bash)

First-time contributors and users often land on the wrong page.

## Changes

**`docs/integrations-overview.mdx`:**
- Added `description` frontmatter field for SEO/navigation context
- Added a bold audience statement at the top with a cross-link to the library page

**`docs/integrations/overview.mdx`:**
- Added `description` frontmatter field scoped to the Python library
- Added a callout box clarifying scope with a cross-link back to the hosted product page

No existing product guidance was changed — only titles, descriptions, and intro copy.