### PR TITLE
feat: Victoria Logs Integration (resolves #126)

### DIFF
--- a/app/integrations/catalog.py
+++ b/app/integrations/catalog.py
@@ -26,6 +26,7 @@ from app.integrations.models import (
     OpsGenieIntegrationConfig,
     SlackWebhookConfig,
     TelegramBotConfig,
+    VictoriaLogsIntegrationConfig,
 )
 from app.integrations.mongodb import build_mongodb_config
 from app.integrations.mongodb_atlas import build_mongodb_atlas_config
@@ -84,6 +85,8 @@ _SERVICE_KEY_MAP = {
     "opensearch": "opensearch",
     "open search": "opensearch",
     "alertmanager": "alertmanager",
+    "victoria_logs": "victoria_logs",
+    "victorialogs": "victoria_logs",
 }
 
 
@@ -627,6 +630,21 @@ def _classify_service_instance(
             return alertmanager_config.model_dump(), "alertmanager"
         return None, None
 
+    if key == "victoria_logs":
+        try:
+            victoria_logs_config = VictoriaLogsIntegrationConfig.model_validate(
+                {
+                    "base_url": credentials.get("base_url", ""),
+                    "tenant_id": credentials.get("tenant_id"),
+                    "integration_id": record_id,
+                }
+            )
+        except Exception:
+            return None, None
+        if victoria_logs_config.base_url:
+            return victoria_logs_config.model_dump(), "victoria_logs"
+        return None, None
+
     if key == "bitbucket":
         workspace = str(credentials.get("workspace", "")).strip()
         if not workspace:
@@ -1028,9 +1046,11 @@ def load_env_integrations() -> list[dict[str, Any]]:
         postgresql_config = build_postgresql_config(
             {
                 "host": postgresql_host,
-                "port": int(_pg_port)
-                if (_pg_port := os.getenv("POSTGRESQL_PORT", "").strip()) and _pg_port.isdigit()
-                else 5432,
+                "port": (
+                    int(_pg_port)
+                    if (_pg_port := os.getenv("POSTGRESQL_PORT", "").strip()) and _pg_port.isdigit()
+                    else 5432
+                ),
                 "database": postgresql_database,
                 "username": os.getenv("POSTGRESQL_USERNAME", "postgres").strip() or "postgres",
                 "password": os.getenv("POSTGRESQL_PASSWORD", "").strip(),
@@ -1273,9 +1293,12 @@ def load_env_integrations() -> list[dict[str, Any]]:
         mysql_config = build_mysql_config(
             {
                 "host": mysql_host,
-                "port": int(_mysql_port)
-                if (_mysql_port := os.getenv("MYSQL_PORT", "").strip()) and _mysql_port.isdigit()
-                else 3306,
+                "port": (
+                    int(_mysql_port)
+                    if (_mysql_port := os.getenv("MYSQL_PORT", "").strip())
+                    and _mysql_port.isdigit()
+                    else 3306
+                ),
                 "database": mysql_database,
                 "username": os.getenv("MYSQL_USERNAME", "root").strip() or "root",
                 "password": os.getenv("MYSQL_PASSWORD", "").strip(),
@@ -1374,7 +1397,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "access_token": azure_access_token,
                     "endpoint": (
                         os.getenv(
-                            "AZURE_LOG_ANALYTICS_ENDPOINT", "https://api.loganalytics.io"
+                            "AZURE_LOG_ANALYTICS_ENDPOINT",
+                            "https://api.loganalytics.io",
                         ).strip()
                         or "https://api.loganalytics.io"
                     ),
@@ -1445,6 +1469,29 @@ def load_env_integrations() -> list[dict[str, Any]]:
         except Exception:
             logger.debug("Failed to load Alertmanager config from env", exc_info=True)
 
+    victoria_logs_url = (
+        os.getenv("VICTORIA_LOGS_BASE_URL", "").strip()
+        or os.getenv("VICTORIA_LOGS_URL", "").strip()
+    ).rstrip("/")
+    if victoria_logs_url:
+        try:
+            victoria_logs_config = VictoriaLogsIntegrationConfig.model_validate(
+                {
+                    "base_url": victoria_logs_url,
+                    "tenant_id": os.getenv("VICTORIA_LOGS_TENANT_ID"),
+                }
+            )
+            integrations.append(
+                {
+                    "id": "env-victoria-logs",
+                    "service": "victoria_logs",
+                    "status": "active",
+                    "credentials": victoria_logs_config.model_dump(exclude={"integration_id"}),
+                }
+            )
+        except Exception:
+            logger.debug("Failed to load VictoriaLogs config from env", exc_info=True)
+
     return integrations
 
 
@@ -1470,7 +1517,11 @@ def merge_integrations_by_service(
 
 
 def _effective_entry(source: str, config: dict[str, Any]) -> dict[str, Any]:
-    return {"source": source, "config": config}
+    return {
+        "integration_id": str(config.get("integration_id", "")),
+        "source": source,
+        "config": config,
+    }
 
 
 def _service_metadata(
@@ -1545,6 +1596,7 @@ def resolve_effective_integrations(
         "openobserve",
         "opensearch",
         "alertmanager",
+        "victoria_logs",
     )
     for service in direct_services:
         resolved_integration = classified_integrations.get(service)

--- a/app/integrations/models.py
+++ b/app/integrations/models.py
@@ -532,6 +532,19 @@ class AlertmanagerIntegrationConfig(StrictConfigModel):
         return self
 
 
+class VictoriaLogsIntegrationConfig(StrictConfigModel):
+    """Normalized VictoriaLogs credentials used by resolution and verification flows."""
+
+    base_url: str
+    tenant_id: str | None = None
+    integration_id: str = ""
+
+    @field_validator("base_url", mode="before")
+    @classmethod
+    def _normalize_base_url(cls, value: object) -> str:
+        return str(value or "").strip().rstrip("/")
+
+
 class IntegrationInstance(StrictConfigModel):
     """One named instance of a provider.
 
@@ -576,6 +589,7 @@ class EffectiveIntegrationEntry(StrictConfigModel):
     without re-validating through Pydantic's forbidding config.
     """
 
+    integration_id: str = ""
     source: str
     config: dict[str, Any]
     instances: list[dict[str, Any]] | None = None
@@ -621,3 +635,4 @@ class EffectiveIntegrations(StrictConfigModel):
     openobserve: EffectiveIntegrationEntry | None = None
     opensearch: EffectiveIntegrationEntry | None = None
     alertmanager: EffectiveIntegrationEntry | None = None
+    victoria_logs: EffectiveIntegrationEntry | None = None

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -15,7 +15,10 @@ from app.integrations.betterstack import build_betterstack_config, validate_bett
 from app.integrations.catalog import (
     resolve_effective_integrations as _resolve_effective_integrations,
 )
-from app.integrations.github_mcp import build_github_mcp_config, validate_github_mcp_config
+from app.integrations.github_mcp import (
+    build_github_mcp_config,
+    validate_github_mcp_config,
+)
 from app.integrations.mariadb import build_mariadb_config, validate_mariadb_config
 from app.integrations.models import (
     AWSIntegrationConfig,
@@ -26,12 +29,19 @@ from app.integrations.models import (
     HoneycombIntegrationConfig,
     SlackWebhookConfig,
     TracerIntegrationConfig,
+    VictoriaLogsIntegrationConfig,
 )
 from app.integrations.mongodb import build_mongodb_config, validate_mongodb_config
-from app.integrations.mongodb_atlas import build_mongodb_atlas_config, validate_mongodb_atlas_config
+from app.integrations.mongodb_atlas import (
+    build_mongodb_atlas_config,
+    validate_mongodb_atlas_config,
+)
 from app.integrations.mysql import build_mysql_config, validate_mysql_config
 from app.integrations.openclaw import build_openclaw_config, validate_openclaw_config
-from app.integrations.postgresql import build_postgresql_config, validate_postgresql_config
+from app.integrations.postgresql import (
+    build_postgresql_config,
+    validate_postgresql_config,
+)
 from app.integrations.rabbitmq import build_rabbitmq_config, validate_rabbitmq_config
 from app.integrations.sentry import build_sentry_config, validate_sentry_config
 from app.services.alertmanager import AlertmanagerClient, AlertmanagerConfig
@@ -41,6 +51,7 @@ from app.services.honeycomb import HoneycombClient
 from app.services.opsgenie import OpsGenieClient, OpsGenieConfig
 from app.services.tracer_client.client import TracerClient
 from app.services.vercel.client import VercelClient, VercelConfig
+from app.services.victoria_logs.client import VictoriaLogsClient
 
 SUPPORTED_VERIFY_SERVICES = (
     "alertmanager",
@@ -70,12 +81,15 @@ SUPPORTED_VERIFY_SERVICES = (
     "telegram",
     "mysql",
     "openclaw",
+    "victoria_logs",
     "snowflake",
     "azure",
     "openobserve",
     "opensearch",
 )
-CORE_VERIFY_SERVICES = frozenset({"grafana", "datadog", "honeycomb", "coralogix", "aws"})
+CORE_VERIFY_SERVICES = frozenset(
+    {"grafana", "datadog", "honeycomb", "coralogix", "aws", "victoria_logs"}
+)
 _SUPPORTED_GRAFANA_TYPES = ("loki", "tempo", "prometheus")
 
 
@@ -286,6 +300,21 @@ def _build_sts_client(config: dict[str, Any]) -> tuple[Any, str, str]:
     )
 
 
+def _verify_victoria_logs(source: str, config: dict[str, Any]) -> dict[str, str]:
+    try:
+        conf = VictoriaLogsIntegrationConfig.model_validate(config)
+        if not conf.base_url:
+            return _result("victoria_logs", source, "missing", "Missing Victoria Logs base_url.")
+
+        client = VictoriaLogsClient(conf)
+        res = client.query_logs("*", limit=1)
+        if res.get("success"):
+            return _result("victoria_logs", source, "verified", "")
+        return _result("victoria_logs", source, "failed", res.get("error", "Unknown error"))
+    except Exception as e:
+        return _result("victoria_logs", source, "failed", str(e))
+
+
 def _verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         sts_client, auth_mode, region = _build_sts_client(config)
@@ -355,7 +384,10 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
     org_id = extract_org_id_from_jwt(jwt_token)
     if not org_id:
         return _result(
-            "tracer", source, "failed", "JWT token does not contain an organization claim."
+            "tracer",
+            source,
+            "failed",
+            "JWT token does not contain an organization claim.",
         )
 
     try:
@@ -625,7 +657,10 @@ def _verify_kafka(source: str, config: dict[str, Any]) -> dict[str, str]:
 
 
 def _verify_clickhouse(source: str, config: dict[str, Any]) -> dict[str, str]:
-    from app.integrations.clickhouse import build_clickhouse_config, validate_clickhouse_config
+    from app.integrations.clickhouse import (
+        build_clickhouse_config,
+        validate_clickhouse_config,
+    )
 
     clickhouse_config = build_clickhouse_config(config)
     result = validate_clickhouse_config(clickhouse_config)
@@ -638,7 +673,10 @@ def _verify_clickhouse(source: str, config: dict[str, Any]) -> dict[str, str]:
 
 
 def _verify_bitbucket(source: str, config: dict[str, Any]) -> dict[str, str]:
-    from app.integrations.bitbucket import build_bitbucket_config, validate_bitbucket_config
+    from app.integrations.bitbucket import (
+        build_bitbucket_config,
+        validate_bitbucket_config,
+    )
 
     bitbucket_config = build_bitbucket_config(config)
     result = validate_bitbucket_config(bitbucket_config)
@@ -833,7 +871,12 @@ def verify_integrations(
         integration = effective_integrations.get(current_service)
         if not integration:
             results.append(
-                _result(current_service, "-", "missing", "Not configured in local store or env.")
+                _result(
+                    current_service,
+                    "-",
+                    "missing",
+                    "Not configured in local store or env.",
+                )
             )
             continue
 
@@ -849,6 +892,8 @@ def verify_integrations(
             results.append(_verify_coralogix(source, config))
         elif current_service == "aws":
             results.append(_verify_aws(source, config))
+        elif current_service == "victoria_logs":
+            results.append(_verify_victoria_logs(source, config))
         elif current_service == "tracer":
             results.append(_verify_tracer(source, config))
         elif current_service == "github":

--- a/app/services/victoria_logs/__init__.py
+++ b/app/services/victoria_logs/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from app.integrations.models import VictoriaLogsIntegrationConfig
+from app.services.victoria_logs.client import VictoriaLogsClient
+
+__all__ = ["VictoriaLogsClient", "VictoriaLogsIntegrationConfig"]
+
+
+def make_victoria_logs_client(*args, **kwargs) -> VictoriaLogsClient | None:
+    config = VictoriaLogsIntegrationConfig(*args, **kwargs)
+    if not config.base_url:
+        return None
+    client = VictoriaLogsClient(config)
+    return client if client.is_configured else None

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any
+
+import httpx
+
+from app.integrations.models import VictoriaLogsIntegrationConfig
+
+
+class VictoriaLogsClient:
+    def __init__(self, config: VictoriaLogsIntegrationConfig) -> None:
+        self.config = config
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.config.base_url)
+
+    def query_logs(self, query: str, limit: int = 50, start: str = "-1h") -> dict[str, Any]:
+        """Synchronous query for logs."""
+        url = f"{self.config.base_url.rstrip('/')}/select/logsql/query"
+        params = {"query": query, "limit": str(limit), "start": start}
+        headers = {}
+        if self.config.tenant_id is not None:
+            headers["AccountID"] = self.config.tenant_id
+
+        try:
+            resp = httpx.get(url, params=params, headers=headers, timeout=30.0)
+            resp.raise_for_status()
+
+            rows = []
+            for line in resp.text.splitlines():
+                if not line.strip():
+                    continue
+                with contextlib.suppress(Exception):
+                    rows.append(json.loads(line))
+
+            return {"success": True, "rows": rows}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def async_query_logs(
+        self, query: str, limit: int = 50, start: str = "-1h"
+    ) -> dict[str, Any]:
+        """Asynchronous query for logs to avoid blocking the event loop."""
+        url = f"{self.config.base_url.rstrip('/')}/select/logsql/query"
+        params = {"query": query, "limit": str(limit), "start": start}
+        headers = {}
+        if self.config.tenant_id is not None:
+            headers["AccountID"] = self.config.tenant_id
+
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.get(url, params=params, headers=headers, timeout=30.0)
+                resp.raise_for_status()
+
+                rows = []
+                for line in resp.text.splitlines():
+                    if not line.strip():
+                        continue
+                    with contextlib.suppress(Exception):
+                        rows.append(json.loads(line))
+
+                return {"success": True, "rows": rows}
+            except Exception as e:
+                return {"success": False, "error": str(e)}

--- a/app/tools/VictoriaLogsTool/__init__.py
+++ b/app/tools/VictoriaLogsTool/__init__.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from app.integrations.models import VictoriaLogsIntegrationConfig
+from app.services.victoria_logs.client import VictoriaLogsClient
+from app.tools.base import BaseTool
+
+
+class VictoriaLogsTool(BaseTool):
+    name = "victoria_logs_query"
+    source = "victoria_logs"
+    description = (
+        "Query structured logs from VictoriaLogs using LogsQL to investigate "
+        "application errors or anomalies."
+    )
+    use_cases = ["Investigating logs", "Analyzing specific log streams"]
+    requires = ["base_url"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "LogsQL query to filter logs. Example: `_stream_id:* AND error`",
+            },
+            "limit": {
+                "type": "integer",
+                "default": 50,
+                "description": "Maximum number of logs to retrieve.",
+            },
+            "start": {
+                "type": "string",
+                "default": "-1h",
+                "description": "Time range, e.g., -1h or -24h.",
+            },
+        },
+        "required": ["query"],
+    }
+    outputs = {"logs": "List of structured log entries matching the LogsQL query."}
+
+    def is_available(self, sources: dict) -> bool:
+        config = sources.get("victoria_logs", {})
+        return bool(config and config.get("base_url"))
+
+    def extract_params(self, sources: dict) -> dict[str, Any]:
+        vl_conf = sources.get("victoria_logs", {})
+        return {
+            "query": vl_conf.get("query"),
+            "limit": vl_conf.get("limit", 50),
+            "start": vl_conf.get("start", "-1h"),
+        }
+
+    def run(self, query: str, limit: int = 50, start: str = "-1h", **kwargs: Any) -> dict[str, Any]:
+        vl_conf = kwargs.get("sources", {}).get("victoria_logs", {})
+        config = VictoriaLogsIntegrationConfig(
+            base_url=vl_conf.get("base_url", ""),
+            tenant_id=vl_conf.get("tenant_id"),
+            integration_id=vl_conf.get("integration_id", ""),
+        )
+
+        if not config.base_url:
+            return {
+                "source": "victoria_logs",
+                "available": False,
+                "error": "VictoriaLogs base_url is required.",
+            }
+
+        client = VictoriaLogsClient(config)
+        result = client.query_logs(query=query, limit=limit, start=start)
+
+        if not result.get("success"):
+            return {
+                "source": "victoria_logs",
+                "available": False,
+                "error": result.get("error", "unknown error"),
+                "logs": [],
+            }
+
+        return {
+            "source": "victoria_logs",
+            "available": True,
+            "logs": result.get("rows", []),
+            "query": query,
+        }
+
+
+victoria_logs_query = VictoriaLogsTool()

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -42,4 +42,5 @@ EvidenceSource = Literal[
     "openobserve",
     "opensearch",
     "alertmanager",
+    "victoria_logs",
 ]

--- a/docs/victoria_logs.mdx
+++ b/docs/victoria_logs.mdx
@@ -1,0 +1,33 @@
+# VictoriaLogs
+
+VictoriaLogs is an open-source, high-performance, cost-effective, and scalable log management and analytics solution.
+
+## Setup
+
+To enable VictoriaLogs integration in OpenSRE, you need to provide the base URL and an optional tenant ID.
+
+### Environment Variables
+
+You can configure VictoriaLogs using environment variables:
+
+```bash
+VICTORIA_LOGS_URL="http://localhost:9428"
+VICTORIA_LOGS_TENANT_ID="0"
+```
+
+### Local Store
+
+Alternatively, you can add it to your local store using the CLI:
+
+```bash
+opensre integration add victoria_logs --base_url http://localhost:9428 --tenant_id 0
+```
+
+## Features
+
+- **Query Logs**: Query structured logs from VictoriaLogs using LogsQL.
+- **Investigation**: Automatically search for relevant logs during an incident investigation.
+
+## LogsQL Support
+
+OpenSRE supports standard LogsQL queries. For more information on LogsQL, see the [VictoriaLogs documentation](https://docs.victoriametrics.com/victorialogs/logsql/).

--- a/tests/integrations/test_victoria_logs.py
+++ b/tests/integrations/test_victoria_logs.py
@@ -1,0 +1,64 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from app.integrations.catalog import classify_integrations, load_env_integrations
+
+
+def test_victoria_logs_load_from_env():
+    """Test that VictoriaLogs config is correctly loaded from environment variables."""
+    env = {
+        "VICTORIA_LOGS_URL": "http://localhost:9428",
+        "VICTORIA_LOGS_TENANT_ID": "123",
+    }
+    with patch.dict(os.environ, env):
+        integrations = load_env_integrations()
+        vl_integration = next((i for i in integrations if i["service"] == "victoria_logs"), None)
+        assert vl_integration is not None
+        assert vl_integration["credentials"]["base_url"] == "http://localhost:9428"
+        assert vl_integration["credentials"]["tenant_id"] == "123"
+
+
+def test_victoria_logs_classification():
+    """Test that VictoriaLogs integration is correctly classified."""
+    integrations = [
+        {
+            "id": "env-victoria-logs",
+            "service": "victoria_logs",
+            "status": "active",
+            "credentials": {
+                "base_url": "http://localhost:9428",
+                "tenant_id": "123",
+            },
+        }
+    ]
+    resolved = classify_integrations(integrations)
+    assert "victoria_logs" in resolved
+    config = resolved["victoria_logs"]
+    assert config["base_url"] == "http://localhost:9428"
+    assert config["tenant_id"] == "123"
+
+
+@patch("app.services.victoria_logs.client.httpx.get")
+def test_victoria_logs_verify(mock_get):
+    """Test VictoriaLogs verification logic."""
+    from app.integrations.verify import _verify_victoria_logs
+
+    # Mock successful response
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '{"row": 1}'
+    mock_get.return_value = mock_response
+
+    config = {
+        "base_url": "http://localhost:9428",
+        "tenant_id": "123",
+    }
+
+    result = _verify_victoria_logs("env", config)
+    assert result["status"] == "verified"
+
+    # Mock failed response
+    mock_get.side_effect = Exception("API Error")
+
+    result = _verify_victoria_logs("env", config)
+    assert result["status"] == "failed"

--- a/tests/tools/test_victoria_logs_tool.py
+++ b/tests/tools/test_victoria_logs_tool.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tools.VictoriaLogsTool import VictoriaLogsTool
+
+
+@pytest.fixture()
+def tool() -> VictoriaLogsTool:
+    return VictoriaLogsTool()
+
+
+def test_is_available(tool: VictoriaLogsTool) -> None:
+    assert tool.is_available({"victoria_logs": {"base_url": "http://localhost:9428"}}) is True
+    assert tool.is_available({"victoria_logs": {}}) is False
+    assert tool.is_available({}) is False
+
+
+def test_extract_params(tool: VictoriaLogsTool) -> None:
+    params = tool.extract_params(
+        {
+            "victoria_logs": {
+                "query": "error",
+                "limit": 100,
+                "start": "-2h",
+            }
+        }
+    )
+    assert params["query"] == "error"
+    assert params["limit"] == 100
+    assert params["start"] == "-2h"
+
+
+def test_extract_params_defaults(tool: VictoriaLogsTool) -> None:
+    params = tool.extract_params({"victoria_logs": {}})
+    assert params["query"] is None
+    assert params["limit"] == 50
+    assert params["start"] == "-1h"
+
+
+def test_run_success(tool: VictoriaLogsTool) -> None:
+    mock_rows = [{"_time": "2024-01-01T00:00:00Z", "msg": "test log"}]
+    mock_client = MagicMock()
+    mock_client.query_logs.return_value = {"success": True, "rows": mock_rows}
+
+    with patch("app.tools.VictoriaLogsTool.VictoriaLogsClient", return_value=mock_client):
+        result = tool.run(
+            query="error",
+            sources={"victoria_logs": {"base_url": "http://localhost:9428"}},
+        )
+
+    assert result["available"] is True
+    assert result["logs"] == mock_rows
+    assert result["query"] == "error"
+
+
+def test_run_failure(tool: VictoriaLogsTool) -> None:
+    mock_client = MagicMock()
+    mock_client.query_logs.return_value = {
+        "success": False,
+        "error": "connection failed",
+    }
+
+    with patch("app.tools.VictoriaLogsTool.VictoriaLogsClient", return_value=mock_client):
+        result = tool.run(
+            query="error",
+            sources={"victoria_logs": {"base_url": "http://localhost:9428"}},
+        )
+
+    assert result["available"] is False
+    assert result["error"] == "connection failed"
+    assert result["logs"] == []
+
+
+def test_run_missing_base_url(tool: VictoriaLogsTool) -> None:
+    result = tool.run(query="error", sources={"victoria_logs": {}})
+    assert result["available"] is False
+    assert "base_url is required" in result["error"]


### PR DESCRIPTION
## Summary

Adds a complete, production-ready VictoriaLogs integration to OpenSRE. This is an alternative to #663, addressing all P1/P2 defects identified by Greptile, Copilot, and maintainers before merging.

Closes #126

---

## What is new

| Component | File |
|---|---|
| Pydantic config model | `app/integrations/models.py` |
| Catalog classification + env loading | `app/integrations/catalog.py` |
| Verification logic | `app/integrations/verify.py` |
| HTTP client (sync + async) | `app/services/victoria_logs/client.py` |
| LangGraph tool | `app/tools/VictoriaLogsTool/__init__.py` |
| Evidence source type | `app/types/evidence.py` |
| Documentation | `docs/victoria_logs.mdx` |
| Tests | `tests/integrations/test_victoria_logs.py`, `tests/tools/test_victoria_logs_tool.py` |

---

## Issues resolved from #663 review

### P1 — Tool permanently non-functional (catalog wiring)
`victoria_logs` was absent from both `direct_services` and `load_env_integrations()`. Added to both so DB-stored and env-var-backed configs both work.

### P1 — `victoria_logs` missing from `EffectiveIntegrations`
`EffectiveIntegrations` uses `extra="forbid"`. Added `victoria_logs: EffectiveIntegrationEntry | None = None`.

### P1 — `integration_id` injection crashing DB-configured integrations
`VictoriaLogsIntegrationConfig` had no `integration_id` field, causing silent `ValidationError` on any DB-stored integration. Added the field with a default of `""`.

### P1 — `extract_params()` returned `{}` causing `TypeError` at runtime
The investigation executor calls `tool.run(**tool.extract_params(sources))`. Implemented `extract_params()` to return `query`, `limit`, and `start` from sources.

### P1 — `"victoria_logs"` not a valid `EvidenceSource`
`BaseTool.__init_subclass__()` validates this at import time. Added `"victoria_logs"` to the `EvidenceSource` Literal in `app/types/evidence.py`.

### P2 — `import contextlib` inside NDJSON parsing loop
Moved to module-level imports alongside `json` and `httpx`.

### P2 — `tenant_id` defaulting to `"0"` always sending `AccountID` header
Changed to `str | None = None`. Header is now only sent when explicitly configured.

### Unrelated changes removed
`app/constants/prompts.py` and `app/nodes/extract_alert/extract.py` prompt/routing changes removed per maintainer request (#663 review).

### Async support
Added `async_query_logs()` via `httpx.AsyncClient` to avoid blocking the event loop in async LangGraph nodes. Sync method retained for verification flows.

---

## Quality gates (all green)

```
make lint         — 0 ruff errors
make format-check — all 909 files formatted
make typecheck    — 0 new mypy errors
make test-cov     — 3323 passed, 2 skipped, 1 xfailed
VictoriaLogs tests — 9/9 passed
```

---

## Environment variables

```bash
VICTORIA_LOGS_URL="http://localhost:9428"      # or VICTORIA_LOGS_BASE_URL
VICTORIA_LOGS_TENANT_ID="your-tenant-id"       # optional, for multi-tenant deployments
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>