### PR TITLE
Fix Makefile Ruff targets to use configured Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else ifeq ($(OS),Windows_NT)
         PYTHON = python
         PIP = python -m pip
     endif
-else ifneq ($(shell python3 -c "import sys" 2>/dev/null),)
+else ifneq ($(shell command -v python3 2>/dev/null),)
     PYTHON = python3
     PIP = python3 -m pip
 else
@@ -405,15 +405,15 @@ clean:
 
 # Lint code
 lint:
-	ruff check app/ tests/
+	$(PYTHON) -m ruff check app/ tests/
 
 # Check formatting (read-only; CI uses this)
 format-check:
-	ruff format --check app/ tests/
+	$(PYTHON) -m ruff format --check app/ tests/
 
 # Format code
 format:
-	ruff format app/ tests/
+	$(PYTHON) -m ruff format app/ tests/
 
 # Type check
 typecheck:


### PR DESCRIPTION
## Summary
- fix Python fallback detection so systems with python3 do not fall through to python
- run Makefile Ruff targets through $(PYTHON) -m ruff
- align local lint and format targets with the CI module invocation

## Why
Part of #176. The Makefile computes a project Python interpreter, but lint/format targets were invoking bare ruff. That can fail after a standard venv install when Ruff is available as a module but not as a shell command.

## Tests
- make -n lint
- make -n format-check
- make -n format
- make lint
- make format-check