### PR TITLE
auto-configure PATH in shell profile after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -323,7 +323,7 @@ configure_path() {
   fi
 
   local marker="# Added by opensre installer"
-  if [ -f "$rc_file" ] && grep -qF "$marker" "$rc_file"; then
+  if [ -f "$rc_file" ] && grep -qF "$marker" "$rc_file" && grep -qF "${INSTALL_DIR}" "$rc_file"; then
     return
   fi
 
@@ -331,7 +331,7 @@ configure_path() {
 
   log ""
   log "${BIN_NAME:-opensre} has been added to PATH in ${rc_file}."
-  log "To apply now, run:  source ${rc_file}"
+  log "To apply now, run:  source \"${rc_file}\""
   log "Or open a new terminal."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -274,6 +274,67 @@ verify_binary_version() {
   esac
 }
 
+configure_path() {
+  case ":$PATH:" in
+    *":${INSTALL_DIR}:"*)
+      return
+      ;;
+  esac
+
+  if [ "$platform" = "windows" ]; then
+    warn "'${INSTALL_DIR}' is not in PATH for this shell. Add it to Git Bash or Windows PATH to run ${BIN_NAME:-opensre} from any terminal."
+    return
+  fi
+
+  local rc_file=""
+  local path_line=""
+  local shell_name
+  shell_name="${SHELL##*/}"
+
+  case "$shell_name" in
+    zsh)
+      rc_file="${HOME}/.zshrc"
+      path_line="export PATH=\"\$PATH:${INSTALL_DIR}\""
+      ;;
+    bash)
+      if [ "$platform" = "darwin" ]; then
+        rc_file="${HOME}/.bash_profile"
+      else
+        rc_file="${HOME}/.bashrc"
+      fi
+      path_line="export PATH=\"\$PATH:${INSTALL_DIR}\""
+      ;;
+    fish)
+      rc_file="${HOME}/.config/fish/config.fish"
+      path_line="fish_add_path \"${INSTALL_DIR}\""
+      ;;
+    *)
+      log "Add the following line to your shell profile to use ${BIN_NAME:-opensre}:"
+      log "  export PATH=\"\$PATH:${INSTALL_DIR}\""
+      return
+      ;;
+  esac
+
+  local rc_dir="${rc_file%/*}"
+  [ "$rc_dir" != "$rc_file" ] && [ ! -d "$rc_dir" ] && mkdir -p "$rc_dir"
+
+  if [ -f "$rc_file" ] && grep -qF "${INSTALL_DIR}" "$rc_file"; then
+    return
+  fi
+
+  local marker="# Added by opensre installer"
+  if [ -f "$rc_file" ] && grep -qF "$marker" "$rc_file"; then
+    return
+  fi
+
+  printf '\n%s\n%s\n' "$marker" "$path_line" >> "$rc_file"
+
+  log ""
+  log "${BIN_NAME:-opensre} has been added to PATH in ${rc_file}."
+  log "To apply now, run:  source ${rc_file}"
+  log "Or open a new terminal."
+}
+
 os="$(uname -s)"
 arch="$(uname -m)"
 
@@ -377,15 +438,4 @@ install_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
 
 log "Installed ${BIN_NAME} v${installed_version} to ${INSTALL_DIR}/${BIN_NAME}"
 
-case ":$PATH:" in
-  *":${INSTALL_DIR}:"*)
-    ;;
-  *)
-    if [ "$platform" = "windows" ]; then
-      warn "'${INSTALL_DIR}' is not in PATH for this shell. Add it to Git Bash or Windows PATH to run ${BIN_NAME} from any terminal."
-    else
-      warn "'${INSTALL_DIR}' is not in PATH. Add this line to your shell profile:"
-      warn "  export PATH=\"\$PATH:${INSTALL_DIR}\""
-    fi
-    ;;
-esac
+configure_path

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -1,0 +1,121 @@
+"""Tests for the configure_path() function in install.sh."""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+INSTALL_SH = Path(__file__).parents[2] / "install.sh"
+_LOCAL_BIN = ".local/bin"
+
+
+def _run(
+    tmp_path: Path, shell: str, platform: str = "linux", install_dir: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
+    idir = install_dir if install_dir is not None else str(fake_home / _LOCAL_BIN)
+
+    script = textwrap.dedent(f"""\
+        __fn=$(awk 'p&&/^}}$/{{print;exit}} /^configure_path\\(\\)/{{p=1}} p{{print}}' {INSTALL_SH})
+        if [ -z "$__fn" ]; then
+            echo "configure_path not found in install.sh" >&2
+            exit 1
+        fi
+        log()  {{ printf '%s\\n' "$*"; }}
+        warn() {{ printf 'Warning: %s\\n' "$*" >&2; }}
+        eval "$__fn"
+        INSTALL_DIR="{idir}" platform="{platform}" HOME="{fake_home}" SHELL="{shell}" configure_path
+    """)
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def test_zsh_writes_export_to_zshrc(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/bin/zsh")
+    assert result.returncode == 0, result.stderr
+    zshrc = tmp_path / "home" / ".zshrc"
+    assert zshrc.exists()
+    assert _LOCAL_BIN in zshrc.read_text()
+
+
+def test_bash_linux_writes_to_bashrc(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/bin/bash", platform="linux")
+    assert result.returncode == 0, result.stderr
+    bashrc = tmp_path / "home" / ".bashrc"
+    assert bashrc.exists()
+    assert _LOCAL_BIN in bashrc.read_text()
+
+
+def test_bash_macos_writes_to_bash_profile(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/bin/bash", platform="darwin")
+    assert result.returncode == 0, result.stderr
+    bash_profile = tmp_path / "home" / ".bash_profile"
+    assert bash_profile.exists()
+    assert _LOCAL_BIN in bash_profile.read_text()
+
+
+def test_fish_uses_fish_add_path(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/usr/bin/fish")
+    assert result.returncode == 0, result.stderr
+    fish_config = tmp_path / "home" / ".config" / "fish" / "config.fish"
+    assert fish_config.exists()
+    assert "fish_add_path" in fish_config.read_text()
+
+
+def test_unknown_shell_prints_manual_instructions(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/bin/dash")
+    assert result.returncode == 0, result.stderr
+    home = tmp_path / "home"
+    assert not (home / ".zshrc").exists()
+    assert not (home / ".bashrc").exists()
+    assert not (home / ".bash_profile").exists()
+    assert "export PATH" in result.stdout or "export PATH" in result.stderr
+
+
+def test_idempotent_no_duplicate_on_rerun(tmp_path: Path) -> None:
+    _run(tmp_path, shell="/bin/zsh")
+    _run(tmp_path, shell="/bin/zsh")
+    content = (tmp_path / "home" / ".zshrc").read_text()
+    export_lines = [ln for ln in content.splitlines() if _LOCAL_BIN in ln and "export PATH" in ln]
+    assert len(export_lines) == 1
+
+
+def test_skips_when_install_dir_already_in_rc(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    idir = str(home / _LOCAL_BIN)
+    zshrc = home / ".zshrc"
+    zshrc.write_text(f'export PATH="$PATH:{idir}"\n')
+    original = zshrc.read_text()
+
+    result = _run(tmp_path, shell="/bin/zsh", install_dir=idir)
+    assert result.returncode == 0, result.stderr
+    assert zshrc.read_text() == original
+
+
+def test_creates_rc_file_when_missing(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/bin/zsh")
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "home" / ".zshrc").exists()
+
+
+def test_marker_comment_present(tmp_path: Path) -> None:
+    _run(tmp_path, shell="/bin/zsh")
+    content = (tmp_path / "home" / ".zshrc").read_text()
+    assert "# Added by opensre installer" in content
+
+
+def test_post_install_message_mentions_source(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/bin/zsh")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "source" in combined
+
+
+def test_fish_creates_parent_dirs(tmp_path: Path) -> None:
+    result = _run(tmp_path, shell="/usr/bin/fish")
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "home" / ".config" / "fish" / "config.fish").exists()

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -6,8 +6,6 @@ import subprocess
 import textwrap
 from pathlib import Path
 
-import pytest
-
 INSTALL_SH = Path(__file__).parents[2] / "install.sh"
 _LOCAL_BIN = ".local/bin"
 
@@ -119,3 +117,15 @@ def test_fish_creates_parent_dirs(tmp_path: Path) -> None:
     result = _run(tmp_path, shell="/usr/bin/fish")
     assert result.returncode == 0, result.stderr
     assert (tmp_path / "home" / ".config" / "fish" / "config.fish").exists()
+
+
+def test_readds_export_when_marker_present_but_line_removed(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    zshrc = home / ".zshrc"
+    zshrc.write_text("# Added by opensre installer\n")
+
+    result = _run(tmp_path, shell="/bin/zsh")
+    assert result.returncode == 0, result.stderr
+    content = zshrc.read_text()
+    assert _LOCAL_BIN in content


### PR DESCRIPTION
Fixes #1063

#### Describe the changes you have made in this PR -

After running the one-liner install, `opensre` gave `command not found` because `~/.local/bin` wasn't in `$PATH`. Users had to manually add the export line.

This PR adds a `configure_path()` function to `install.sh` that automatically writes the PATH export to the user's shell profile:

- zsh → `~/.zshrc`
- bash on Linux → `~/.bashrc`
- bash on macOS → `~/.bash_profile`
- fish → `~/.config/fish/config.fish` using `fish_add_path`
- unknown shell → prints manual instructions, no file touched
- Windows → unchanged

Re-running the installer never duplicates the line (idempotent via marker comment). The user is told to `source <profile>` or open a new terminal after install.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1450" height="688" alt="image" src="https://github.com/user-attachments/assets/a2d970c4-7428-4571-bd75-ca37112725f6" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The install script was printing a warning asking users to manually add the PATH export. The fix detects the shell via `$SHELL`, picks the right rc file per shell and OS, then appends an export line guarded by a marker comment so the operation is idempotent. Fish uses `fish_add_path` instead of `export`. Two checks prevent duplicate writes: one for the marker comment (installer-managed) and one for the install dir already appearing in the file (user-managed). The function is placed in the function-definition section of the script so it can be extracted and unit-tested in isolation — 11 tests cover all the above cases.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.