### PR TITLE
Adaptive incident window: expand-on-empty-deploy-timeline

### DIFF
--- a/app/incident_window.py
+++ b/app/incident_window.py
@@ -164,6 +164,40 @@ class IncidentWindow:
         except (TypeError, ValueError):
             return None
 
+    # -- Adaptation ---------------------------------------------------------
+
+    def expanded(self, factor: float = 2.0) -> IncidentWindow:
+        """Return a NEW window with the lookback widened by ``factor``.
+
+        ``until`` is preserved (the anchor edge does not move). Only
+        ``since`` moves earlier. The widened lookback is clamped to
+        ``MAX_LOOKBACK_MINUTES`` so callers cannot accidentally page
+        through months of data.
+
+        ``source`` and ``confidence`` are preserved: the underlying anchor
+        is still trusted; the expansion only admits the original lookback
+        guess was too narrow. The fact of expansion is recorded
+        separately in ``state.incident_window_history`` by the caller.
+
+        Raises:
+            ValueError: when ``factor <= 1.0``. This method is for
+                expansion only; contraction is a separate, deferred
+                operation with different semantics.
+        """
+        if factor <= 1.0:
+            raise ValueError(
+                f"expanded() requires factor > 1.0 to widen the window (got {factor!r}); "
+                "use a separate contraction method to narrow."
+            )
+        current_lookback_min = (self.until - self.since).total_seconds() / 60.0
+        new_lookback_min = min(current_lookback_min * factor, float(MAX_LOOKBACK_MINUTES))
+        return IncidentWindow(
+            since=self.until - timedelta(minutes=new_lookback_min),
+            until=self.until,
+            source=self.source,
+            confidence=self.confidence,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers

--- a/app/investigation_constants.py
+++ b/app/investigation_constants.py
@@ -8,3 +8,12 @@ would otherwise create.
 from __future__ import annotations
 
 MAX_INVESTIGATION_LOOPS = 4
+
+# Maximum number of times ``adapt_window`` may replace ``state.incident_window``
+# during a single investigation. Each replacement records the previous window
+# in ``state.incident_window_history``; once the history reaches this length
+# the rule layer no-ops. With ``MAX_INVESTIGATION_LOOPS = 4`` and
+# ``MAX_EXPANSIONS = 2`` the worst case is two expansions inside the four-loop
+# budget, which is enough to widen 120m → 240m → 480m before deferring to the
+# diagnose narrative.
+MAX_EXPANSIONS = 2

--- a/app/nodes/__init__.py
+++ b/app/nodes/__init__.py
@@ -1,5 +1,6 @@
 """LangGraph nodes for investigation workflow."""
 
+from app.nodes.adapt_window import node_adapt_window
 from app.nodes.extract_alert import node_extract_alert
 from app.nodes.plan_actions.node import node_plan_actions
 from app.nodes.publish_findings import node_publish_findings
@@ -7,6 +8,7 @@ from app.nodes.resolve_integrations import node_resolve_integrations
 from app.nodes.root_cause_diagnosis import node_diagnose_root_cause
 
 __all__ = [
+    "node_adapt_window",
     "node_diagnose_root_cause",
     "node_extract_alert",
     "node_plan_actions",

--- a/app/nodes/adapt_window/__init__.py
+++ b/app/nodes/adapt_window/__init__.py
@@ -7,9 +7,9 @@ The package is split into two modules:
   dicts so tests can drive it without spinning up LangGraph. Today it
   contains a single rule: expand-on-empty-deploy-timeline.
 
-- ``node.py`` — the LangGraph entry point ``node_adapt_window`` (added in
-  the next commit). Wraps the rule in ``@traceable`` and adapts the
-  state-delta to LangGraph's reducer.
+- ``node.py`` — the LangGraph entry point ``node_adapt_window``. Wraps
+  the rule in ``@traceable`` and adapts the state-delta to LangGraph's
+  reducer.
 """
 
 from app.nodes.adapt_window.node import node_adapt_window

--- a/app/nodes/adapt_window/__init__.py
+++ b/app/nodes/adapt_window/__init__.py
@@ -1,0 +1,17 @@
+"""Adaptive-window node — widens the incident window between investigation
+iterations when prior tool calls came back empty.
+
+The package is split into two modules:
+
+- ``rules.py`` — pure, side-effect-free decision logic. Operates on plain
+  dicts so tests can drive it without spinning up LangGraph. Today it
+  contains a single rule: expand-on-empty-deploy-timeline.
+
+- ``node.py`` — the LangGraph entry point ``node_adapt_window`` (added in
+  the next commit). Wraps the rule in ``@traceable`` and adapts the
+  state-delta to LangGraph's reducer.
+"""
+
+from app.nodes.adapt_window.rules import adapt_incident_window
+
+__all__ = ["adapt_incident_window"]

--- a/app/nodes/adapt_window/__init__.py
+++ b/app/nodes/adapt_window/__init__.py
@@ -12,6 +12,7 @@ The package is split into two modules:
   state-delta to LangGraph's reducer.
 """
 
+from app.nodes.adapt_window.node import node_adapt_window
 from app.nodes.adapt_window.rules import adapt_incident_window
 
-__all__ = ["adapt_incident_window"]
+__all__ = ["adapt_incident_window", "node_adapt_window"]

--- a/app/nodes/adapt_window/node.py
+++ b/app/nodes/adapt_window/node.py
@@ -1,0 +1,57 @@
+"""LangGraph entry point for the adaptive-window node.
+
+The node sits between ``diagnose`` and ``plan_actions`` on the
+loop-back edge of the investigation pipeline. It runs ONLY when the
+loop is continuing — terminal paths bypass it.
+
+The actual decision logic lives in ``app.nodes.adapt_window.rules`` and
+is imported here. Keeping the LangGraph wrapper thin means the rule can
+be tested in isolation against plain dicts.
+"""
+
+import logging
+from typing import Optional
+
+from langchain_core.runnables import RunnableConfig
+from langsmith import traceable
+
+from app.nodes.adapt_window.rules import adapt_incident_window
+from app.output import debug_print
+from app.state import InvestigationState
+
+logger = logging.getLogger(__name__)
+
+
+@traceable(name="node_adapt_window")
+def node_adapt_window(
+    state: InvestigationState,
+    config: Optional[RunnableConfig] = None,  # noqa: ARG001,UP007,UP045
+) -> dict:
+    """Apply the adaptive-window rules and return a state delta.
+
+    Returns an empty dict (LangGraph's "no state change" signal) when no
+    rule fires. Otherwise returns a dict with ``incident_window`` (new
+    window) and ``incident_window_history`` (old window appended).
+
+    Pure wrapper around ``adapt_incident_window`` — no I/O, no LLM. The
+    only side effect is a debug log line so operators can audit when an
+    expansion happened during a run.
+    """
+    delta = adapt_incident_window(dict(state))
+    if delta:
+        new_window = delta.get("incident_window") or {}
+        history = delta.get("incident_window_history") or []
+        last_entry = history[-1] if history else {}
+        reason = last_entry.get("replaced_reason", "") if isinstance(last_entry, dict) else ""
+        debug_print(
+            "adapt_window: widened incident window "
+            f"since={new_window.get('since')} until={new_window.get('until')} "
+            f"reason={reason}"
+        )
+        logger.info(
+            "adapt_window: widened incident window since=%s until=%s reason=%s",
+            new_window.get("since"),
+            new_window.get("until"),
+            reason,
+        )
+    return delta

--- a/app/nodes/adapt_window/rules.py
+++ b/app/nodes/adapt_window/rules.py
@@ -1,0 +1,173 @@
+"""Pure adaptive-window rule logic.
+
+This module is intentionally free of LangChain / LangGraph imports so the
+rules can be tested in isolation against plain dicts. The node entry point
+in ``app.nodes.adapt_window.node`` wraps these functions in the ``@traceable``
+decorator.
+
+Today there is exactly one rule: **expand the window when the deploy
+timeline came back empty for a shared-window query**. The rule is
+deliberately conservative — it only widens when:
+
+- the GitDeployTimelineTool actually ran in the most recent investigation
+  iteration (defended by reading ``state.executed_hypotheses[-1].actions``);
+- its returned window's ``source`` was ``"shared_incident_window"``
+  (caller-explicit windows are NEVER overridden);
+- its ``commits_count`` was zero;
+- the existing ``state.incident_window_history`` has fewer than
+  ``MAX_EXPANSIONS`` entries (worst-case bound on expansion);
+- expanding would actually widen the window — i.e. we are not already at
+  ``MAX_LOOKBACK_MINUTES``.
+
+When all guards pass, the rule emits a state delta containing the new
+window plus the OLD window appended to history with ``replaced_at`` and
+``replaced_reason``. When any guard fails the rule returns an empty dict
+and nothing in state changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from app.incident_window import IncidentWindow
+from app.investigation_constants import MAX_EXPANSIONS
+
+DEPLOY_TIMELINE_ACTION = "get_git_deploy_timeline"
+SHARED_WINDOW_SOURCE = "shared_incident_window"
+EXPANSION_FACTOR = 2.0
+EXPAND_REASON_EMPTY_DEPLOY_TIMELINE = "expanded:empty_deploy_timeline"
+
+
+def _strictly_wider(new: IncidentWindow, old: IncidentWindow) -> bool:
+    """Return True when ``new`` covers MORE time than ``old``.
+
+    Used to detect "expanded() returned the same width" — happens when the
+    current window is already at MAX_LOOKBACK_MINUTES. A no-op expansion
+    must not be recorded in history because nothing actually changed.
+    """
+    return (new.until - new.since) > (old.until - old.since)
+
+
+def _last_iteration_actions(state: dict[str, Any]) -> list[str]:
+    """Return the action names executed in the most recent investigation
+    loop, or an empty list if there are none / the shape is malformed.
+
+    Reads ``state.executed_hypotheses[-1].actions``. Each entry in
+    ``executed_hypotheses`` is a dict with an ``actions: list[str]``
+    sub-field. Defensive: any wrong shape downgrades to an empty list,
+    which the caller treats as "no recent tool activity, no-op".
+    """
+    history = state.get("executed_hypotheses")
+    if not isinstance(history, list) or not history:
+        return []
+    last = history[-1]
+    if not isinstance(last, dict):
+        return []
+    actions = last.get("actions")
+    if not isinstance(actions, list):
+        return []
+    return [item for item in actions if isinstance(item, str)]
+
+
+def _now_iso(now_fn: Callable[[], datetime]) -> str:
+    """Render ``now_fn()`` as ISO-8601 with the trailing ``Z`` shorthand."""
+    current = now_fn()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    return current.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def adapt_incident_window(
+    state: dict[str, Any],
+    *,
+    now_fn: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> dict[str, Any]:
+    """Decide whether to widen ``state.incident_window`` for the next
+    investigation iteration. Returns a state-delta dict (the keys
+    LangGraph should merge into state) or an empty dict for "no change".
+
+    The function is pure: it never raises, never mutates ``state``, never
+    performs I/O. ``now_fn`` is injected so tests can pin the
+    ``replaced_at`` timestamp deterministically; production callers leave
+    the default.
+
+    See module docstring for the full guard chain.
+    """
+    # 1. Window must be present and well-formed.
+    current_dict = state.get("incident_window")
+    if not isinstance(current_dict, dict):
+        return {}
+    current = IncidentWindow.from_dict(current_dict)
+    if current is None:
+        return {}
+
+    # 2. History must be within cap. Treat malformed history as "no entries"
+    # so a single corrupted record cannot strand adaptation forever.
+    raw_history = state.get("incident_window_history")
+    history: list[dict[str, Any]] = (
+        [entry for entry in raw_history if isinstance(entry, dict)]
+        if isinstance(raw_history, list)
+        else []
+    )
+    if len(history) >= MAX_EXPANSIONS:
+        return {}
+
+    # 3. Stale-signal guard: the deploy timeline tool must have run in the
+    # most recent iteration. Without this check, a 0-commit result from
+    # iteration 1 would re-fire the rule at the end of iteration 2 even
+    # when iteration 2 ran completely different tools.
+    if DEPLOY_TIMELINE_ACTION not in _last_iteration_actions(state):
+        return {}
+
+    # 4. Read the tool's evidence. The mapper in
+    # ``investigate.processing.post_process._map_git_deploy_timeline``
+    # publishes the full ``window`` dict under this key.
+    evidence = state.get("evidence")
+    if not isinstance(evidence, dict):
+        return {}
+    window_info = evidence.get("git_deploy_timeline_window")
+    if not isinstance(window_info, dict):
+        return {}
+
+    # 5. Only expand when the tool used the shared window. caller_explicit
+    # / tool_default / unset (== {}) all fall through.
+    if window_info.get("source") != SHARED_WINDOW_SOURCE:
+        return {}
+
+    # 6. Empty result is the trigger. A None / missing count is treated as
+    # zero so a partial response cannot misfire the rule the other way.
+    try:
+        commits_count = int(evidence.get("git_deploy_timeline_count") or 0)
+    except (TypeError, ValueError):
+        commits_count = 0
+    if commits_count > 0:
+        return {}
+
+    # 7. Compute the expansion. If we are already at MAX_LOOKBACK_MINUTES,
+    # ``expanded`` returns a window of the same width — nothing to record.
+    new_window = current.expanded(factor=EXPANSION_FACTOR)
+    if not _strictly_wider(new_window, current):
+        return {}
+
+    # 8. Build the audit entry for the OLD window.
+    old_entry: dict[str, Any] = {
+        **current_dict,
+        "replaced_at": _now_iso(now_fn),
+        "replaced_reason": EXPAND_REASON_EMPTY_DEPLOY_TIMELINE,
+    }
+
+    return {
+        "incident_window": new_window.to_dict(),
+        "incident_window_history": [*history, old_entry],
+    }
+
+
+__all__ = [
+    "DEPLOY_TIMELINE_ACTION",
+    "EXPAND_REASON_EMPTY_DEPLOY_TIMELINE",
+    "EXPANSION_FACTOR",
+    "SHARED_WINDOW_SOURCE",
+    "adapt_incident_window",
+]

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -6,6 +6,7 @@ from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
 from app.nodes import (
+    node_adapt_window,
     node_diagnose_root_cause,
     node_extract_alert,
     node_plan_actions,
@@ -51,6 +52,7 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     graph.add_node("investigate_hypothesis", node_investigate_hypothesis)
     graph.add_node("merge_hypothesis_results", merge_hypothesis_results)
     graph.add_node("diagnose", node_diagnose_root_cause)
+    graph.add_node("adapt_window", node_adapt_window)
     graph.add_node("opensre_eval", node_opensre_llm_eval)
     graph.add_node("publish", node_publish_findings)
 
@@ -76,11 +78,16 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     graph.add_conditional_edges("plan_actions", distribute_hypotheses)
     graph.add_edge("investigate_hypothesis", "merge_hypothesis_results")
     graph.add_edge("merge_hypothesis_results", "diagnose")
+    # When the routing function returns "investigate" (loop again), the path
+    # goes through ``adapt_window`` first so the window can be widened
+    # before the next plan_actions iteration. Terminal paths
+    # ("opensre_eval", "publish") bypass adapt_window entirely.
     graph.add_conditional_edges(
         "diagnose",
         route_investigation_loop,
-        {"investigate": "plan_actions", "opensre_eval": "opensre_eval", "publish": "publish"},
+        {"investigate": "adapt_window", "opensre_eval": "opensre_eval", "publish": "publish"},
     )
+    graph.add_edge("adapt_window", "plan_actions")
     graph.add_edge("opensre_eval", "publish")
     graph.add_edge("publish", END)
 

--- a/app/state/agent_state.py
+++ b/app/state/agent_state.py
@@ -107,6 +107,15 @@ class AgentState(TypedDict, total=False):
     #         "source": str, "confidence": float}.
     incident_window: dict[str, Any] | None
 
+    # Append-only audit trail of windows replaced by ``adapt_window``. Each
+    # entry is the OLD window dict at the moment of replacement, plus
+    # ``replaced_at`` (ISO-8601) and ``replaced_reason`` (e.g.
+    # "expanded:empty_deploy_timeline"). Bounded by ``MAX_EXPANSIONS`` in
+    # the adapt_window rule layer; the field itself imposes no cap.
+    # ``None`` until the first expansion. Diagnose narratives may cite
+    # this to explain "we tried 120m, found no deploys, widened to 240m".
+    incident_window_history: list[dict[str, Any]] | None
+
     # Placeholder→original map for reversible infrastructure identifier masking
     masking_map: dict[str, str]
 
@@ -188,6 +197,7 @@ class AgentStateModel(StrictConfigModel):
     action_to_run: str = ""
     investigation_started_at: float = 0.0
     incident_window: dict[str, Any] | None = None
+    incident_window_history: list[dict[str, Any]] | None = None
     masking_map: dict[str, str] = Field(default_factory=dict)
     slack_context: dict[str, Any] = Field(default_factory=dict)
     discord_context: dict[str, Any] = Field(default_factory=dict)

--- a/tests/app/test_incident_window.py
+++ b/tests/app/test_incident_window.py
@@ -150,6 +150,96 @@ class TestSerialisation:
 
 
 # ---------------------------------------------------------------------------
+# Adaptation: expanded()
+# ---------------------------------------------------------------------------
+
+
+class TestExpanded:
+    """``IncidentWindow.expanded()`` — used by the adapt_window node when
+    the deploy timeline came back empty for a shared-window query. The
+    method is deliberately tiny: it widens the lookback, clamps to
+    MAX_LOOKBACK_MINUTES, and preserves every other field. The history of
+    expansions is tracked separately in ``state.incident_window_history``.
+    """
+
+    def _two_hour_window(self) -> IncidentWindow:
+        return IncidentWindow(
+            since=NOW - timedelta(hours=2),
+            until=NOW,
+            source=SOURCE_STARTS_AT,
+            confidence=1.0,
+        )
+
+    def test_doubles_lookback_with_default_factor(self) -> None:
+        original = self._two_hour_window()
+        widened = original.expanded()
+        assert (widened.until - widened.since) == timedelta(hours=4)
+        assert widened.until == original.until  # anchor preserved
+
+    def test_custom_factor_scales_lookback(self) -> None:
+        original = self._two_hour_window()
+        widened = original.expanded(factor=3.0)
+        assert (widened.until - widened.since) == timedelta(hours=6)
+
+    def test_clamps_to_max_lookback_minutes(self) -> None:
+        # Start at 5 days, doubling would be 10 days; cap is 7 days.
+        original = IncidentWindow(
+            since=NOW - timedelta(days=5),
+            until=NOW,
+            source=SOURCE_STARTS_AT,
+            confidence=1.0,
+        )
+        widened = original.expanded(factor=2.0)
+        actual_lookback_min = (widened.until - widened.since).total_seconds() / 60.0
+        assert actual_lookback_min == float(MAX_LOOKBACK_MINUTES)
+
+    def test_already_at_cap_returns_same_width(self) -> None:
+        # When we're already at the cap, expansion is a no-op for width.
+        # The rule layer detects this via a strictly-wider check.
+        original = IncidentWindow(
+            since=NOW - timedelta(minutes=MAX_LOOKBACK_MINUTES),
+            until=NOW,
+            source=SOURCE_STARTS_AT,
+            confidence=1.0,
+        )
+        widened = original.expanded(factor=2.0)
+        assert (widened.until - widened.since) == (original.until - original.since)
+
+    def test_returns_new_instance_not_mutation(self) -> None:
+        # Frozen dataclass; identity must differ even if values match.
+        original = self._two_hour_window()
+        widened = original.expanded(factor=2.0)
+        assert widened is not original
+        assert original.since == NOW - timedelta(hours=2)  # unchanged
+
+    def test_preserves_until_anchor(self) -> None:
+        original = self._two_hour_window()
+        widened = original.expanded(factor=4.0)
+        assert widened.until == original.until
+
+    def test_preserves_source_and_confidence(self) -> None:
+        original = IncidentWindow(
+            since=NOW - timedelta(hours=2),
+            until=NOW,
+            source=SOURCE_FIRED_AT,
+            confidence=1.0,
+        )
+        widened = original.expanded(factor=2.0)
+        assert widened.source == SOURCE_FIRED_AT
+        assert widened.confidence == 1.0
+
+    def test_factor_one_is_rejected(self) -> None:
+        # factor=1.0 is a no-op width but the API contract is "expansion
+        # only" so we reject it explicitly rather than silently no-op.
+        with pytest.raises(ValueError, match="factor > 1.0"):
+            self._two_hour_window().expanded(factor=1.0)
+
+    def test_factor_below_one_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="factor > 1.0"):
+            self._two_hour_window().expanded(factor=0.5)
+
+
+# ---------------------------------------------------------------------------
 # Resolver precedence
 # ---------------------------------------------------------------------------
 

--- a/tests/nodes/adapt_window/test_node.py
+++ b/tests/nodes/adapt_window/test_node.py
@@ -1,0 +1,118 @@
+"""Tests for the LangGraph wrapper ``node_adapt_window``.
+
+The pure rule logic is exhaustively covered in ``test_rules.py``. These
+tests focus on the wrapper's contract:
+
+- it returns the rule's output unchanged when the rule emits a delta;
+- it returns ``{}`` (LangGraph's "no state change") when the rule no-ops;
+- it accepts a real ``InvestigationState`` shape (the TypedDict from
+  ``app.state``) — not just bare dicts;
+- it logs at INFO when an expansion happens, but never raises;
+- the wrapper does not mutate the state passed in.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.incident_window import SOURCE_STARTS_AT, IncidentWindow
+from app.nodes.adapt_window import node_adapt_window
+from app.nodes.adapt_window.rules import (
+    DEPLOY_TIMELINE_ACTION,
+    EXPAND_REASON_EMPTY_DEPLOY_TIMELINE,
+    SHARED_WINDOW_SOURCE,
+)
+
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+
+
+def _two_hour_window_dict() -> dict[str, Any]:
+    return IncidentWindow(
+        since=NOW - timedelta(hours=2),
+        until=NOW,
+        source=SOURCE_STARTS_AT,
+        confidence=1.0,
+    ).to_dict()
+
+
+def _firing_state() -> dict[str, Any]:
+    """A state dict that should fire the rule."""
+    return {
+        "incident_window": _two_hour_window_dict(),
+        "incident_window_history": None,
+        "executed_hypotheses": [{"actions": [DEPLOY_TIMELINE_ACTION]}],
+        "evidence": {
+            "git_deploy_timeline_count": 0,
+            "git_deploy_timeline_window": {"source": SHARED_WINDOW_SOURCE},
+        },
+    }
+
+
+def _no_op_state() -> dict[str, Any]:
+    """A state dict that should NOT fire the rule (deploy didn't run)."""
+    return {
+        "incident_window": _two_hour_window_dict(),
+        "incident_window_history": None,
+        "executed_hypotheses": [{"actions": ["query_grafana_logs"]}],
+        "evidence": {
+            "git_deploy_timeline_count": 0,
+            "git_deploy_timeline_window": {"source": SHARED_WINDOW_SOURCE},
+        },
+    }
+
+
+def test_node_returns_state_delta_when_rule_fires() -> None:
+    delta = node_adapt_window(_firing_state())  # type: ignore[arg-type]
+    assert "incident_window" in delta
+    assert "incident_window_history" in delta
+    assert len(delta["incident_window_history"]) == 1
+
+
+def test_node_returns_empty_dict_on_no_op() -> None:
+    delta = node_adapt_window(_no_op_state())  # type: ignore[arg-type]
+    assert delta == {}
+
+
+def test_node_handles_completely_empty_state() -> None:
+    # No fields populated yet — early in the pipeline, before extract_alert.
+    delta = node_adapt_window({})  # type: ignore[arg-type]
+    assert delta == {}
+
+
+def test_node_does_not_mutate_input_state() -> None:
+    state = _firing_state()
+    snapshot_window = dict(state["incident_window"])
+    snapshot_evidence = {
+        k: dict(v) if isinstance(v, dict) else v for k, v in state["evidence"].items()
+    }
+    node_adapt_window(state)  # type: ignore[arg-type]
+    assert state["incident_window"] == snapshot_window
+    assert (
+        state["evidence"]["git_deploy_timeline_window"]
+        == snapshot_evidence["git_deploy_timeline_window"]
+    )
+
+
+def test_node_logs_at_info_when_expansion_happens(caplog: Any) -> None:
+    with caplog.at_level(logging.INFO, logger="app.nodes.adapt_window.node"):
+        node_adapt_window(_firing_state())  # type: ignore[arg-type]
+    assert any(
+        "widened incident window" in rec.message
+        and EXPAND_REASON_EMPTY_DEPLOY_TIMELINE in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_node_does_not_log_at_info_on_no_op(caplog: Any) -> None:
+    with caplog.at_level(logging.INFO, logger="app.nodes.adapt_window.node"):
+        node_adapt_window(_no_op_state())  # type: ignore[arg-type]
+    info_records = [rec for rec in caplog.records if rec.levelno >= logging.INFO]
+    assert not any("widened incident window" in rec.message for rec in info_records)
+
+
+def test_node_accepts_config_kwarg() -> None:
+    # LangGraph passes a RunnableConfig; the node must accept and ignore it.
+    delta = node_adapt_window(_firing_state(), config={"configurable": {}})  # type: ignore[arg-type]
+    assert "incident_window" in delta

--- a/tests/nodes/adapt_window/test_rules.py
+++ b/tests/nodes/adapt_window/test_rules.py
@@ -1,0 +1,335 @@
+"""Tests for ``app.nodes.adapt_window.rules.adapt_incident_window``.
+
+The rule is a pure function over a state dict, so these tests build minimal
+state dicts and assert the returned delta. We never spin up LangGraph here —
+the node-layer wrapper is tested separately in ``test_node.py``.
+
+Coverage strategy:
+  1. Happy path: every guard passes, state delta returned correctly.
+  2. Each individual guard short-circuiting (one test per guard).
+  3. The stale-signal guard specifically: this is the bug-class fix
+     called out in the design (without it, evidence from iteration 1
+     would re-fire the rule at the end of iteration 2).
+  4. History accumulation across consecutive expansions.
+  5. The MAX_EXPANSIONS cap blocks the third expansion.
+  6. Defensive: malformed evidence / history / executed_hypotheses must
+     never raise.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from app.incident_window import (
+    MAX_LOOKBACK_MINUTES,
+    SOURCE_STARTS_AT,
+    IncidentWindow,
+)
+from app.investigation_constants import MAX_EXPANSIONS
+from app.nodes.adapt_window.rules import (
+    DEPLOY_TIMELINE_ACTION,
+    EXPAND_REASON_EMPTY_DEPLOY_TIMELINE,
+    SHARED_WINDOW_SOURCE,
+    adapt_incident_window,
+)
+
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+FROZEN_NOW = datetime(2026, 4, 20, 12, 1, 23, 456789, tzinfo=UTC)
+
+
+def _frozen_now() -> datetime:
+    return FROZEN_NOW
+
+
+def _two_hour_window_dict() -> dict[str, Any]:
+    """A 120-minute window anchored at NOW, source ``alert.startsAt``."""
+    return IncidentWindow(
+        since=NOW - timedelta(hours=2),
+        until=NOW,
+        source=SOURCE_STARTS_AT,
+        confidence=1.0,
+    ).to_dict()
+
+
+def _state_with_empty_timeline_signal(
+    *,
+    window_source: str = SHARED_WINDOW_SOURCE,
+    commits_count: int = 0,
+    last_actions: list[str] | None = None,
+    history: list[dict[str, Any]] | None = None,
+    incident_window: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Minimal state shape that should, by default, fire the rule.
+
+    Each kwarg lets a single test toggle one guard off.
+    """
+    actions = last_actions if last_actions is not None else [DEPLOY_TIMELINE_ACTION]
+    return {
+        "incident_window": (
+            incident_window if incident_window is not None else _two_hour_window_dict()
+        ),
+        "incident_window_history": history if history is not None else None,
+        "executed_hypotheses": [{"actions": actions}],
+        "evidence": {
+            "git_deploy_timeline_count": commits_count,
+            "git_deploy_timeline_window": {
+                "source": window_source,
+                "since": "2026-04-20T10:00:00Z",
+                "until": "2026-04-20T12:00:00Z",
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_expands_when_all_guards_pass(self) -> None:
+        delta = adapt_incident_window(_state_with_empty_timeline_signal(), now_fn=_frozen_now)
+        assert "incident_window" in delta
+        assert "incident_window_history" in delta
+
+    def test_doubled_lookback(self) -> None:
+        delta = adapt_incident_window(_state_with_empty_timeline_signal(), now_fn=_frozen_now)
+        new = IncidentWindow.from_dict(delta["incident_window"])
+        assert new is not None
+        # 120 min × 2 = 240 min = 4 hours.
+        assert (new.until - new.since) == timedelta(hours=4)
+
+    def test_history_records_old_window(self) -> None:
+        original = _two_hour_window_dict()
+        delta = adapt_incident_window(
+            _state_with_empty_timeline_signal(incident_window=original),
+            now_fn=_frozen_now,
+        )
+        history = delta["incident_window_history"]
+        assert len(history) == 1
+        recorded = history[0]
+        # Old window's full shape is preserved...
+        for key in ("since", "until", "source", "confidence", "_schema_version"):
+            assert recorded[key] == original[key]
+        # ...plus the audit fields.
+        assert recorded["replaced_reason"] == EXPAND_REASON_EMPTY_DEPLOY_TIMELINE
+        assert recorded["replaced_at"] == "2026-04-20T12:01:23.456789Z"
+
+    def test_until_anchor_preserved(self) -> None:
+        delta = adapt_incident_window(_state_with_empty_timeline_signal(), now_fn=_frozen_now)
+        new = IncidentWindow.from_dict(delta["incident_window"])
+        assert new is not None
+        assert new.until == NOW
+
+
+# ---------------------------------------------------------------------------
+# Guards: each one short-circuits independently
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpGuards:
+    def test_no_op_when_no_incident_window(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["incident_window"] = None
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_incident_window_malformed(self) -> None:
+        state = _state_with_empty_timeline_signal(incident_window={"junk": "value"})
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_history_at_cap(self) -> None:
+        # MAX_EXPANSIONS is 2, so any history with 2+ entries blocks.
+        state = _state_with_empty_timeline_signal(
+            history=[{"any": "entry"}] * MAX_EXPANSIONS,
+        )
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_evidence_missing(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["evidence"] = None
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_deploy_timeline_window_missing(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        del state["evidence"]["git_deploy_timeline_window"]
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_window_source_is_caller_explicit(self) -> None:
+        state = _state_with_empty_timeline_signal(window_source="caller_explicit")
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_window_source_is_tool_default(self) -> None:
+        state = _state_with_empty_timeline_signal(window_source="tool_default")
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_window_source_missing(self) -> None:
+        # Tool-failure path: GitHub MCP not configured → window=={}.
+        state = _state_with_empty_timeline_signal()
+        state["evidence"]["git_deploy_timeline_window"] = {}
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_commits_count_positive(self) -> None:
+        state = _state_with_empty_timeline_signal(commits_count=3)
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_already_at_max_lookback(self) -> None:
+        already_max = IncidentWindow(
+            since=NOW - timedelta(minutes=MAX_LOOKBACK_MINUTES),
+            until=NOW,
+            source=SOURCE_STARTS_AT,
+            confidence=1.0,
+        ).to_dict()
+        state = _state_with_empty_timeline_signal(incident_window=already_max)
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+
+# ---------------------------------------------------------------------------
+# Stale-signal guard
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSignalGuard:
+    """Without this guard, the rule would re-fire at the end of every
+    iteration after a 0-commit deploy timeline result, even when the tool
+    didn't actually run again. This was a bug found during plan review.
+    """
+
+    def test_no_op_when_executed_hypotheses_empty(self) -> None:
+        state = _state_with_empty_timeline_signal(last_actions=[])
+        # last_actions=[] means the most recent iteration's actions list
+        # is empty — the deploy timeline did NOT run.
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_deploy_timeline_not_in_last_iteration(self) -> None:
+        # Iteration 2 ran a different tool. Stale signal from iteration 1
+        # remains in evidence but must not re-fire the rule.
+        state = _state_with_empty_timeline_signal(
+            last_actions=["query_grafana_logs"],
+        )
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_executed_hypotheses_missing(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        del state["executed_hypotheses"]
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_executed_hypotheses_malformed(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["executed_hypotheses"] = "not a list"
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_no_op_when_last_iteration_actions_not_a_list(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["executed_hypotheses"] = [{"actions": "not a list"}]
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+
+# ---------------------------------------------------------------------------
+# Multi-iteration expansion behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRepeatedExpansion:
+    def test_second_expansion_doubles_again(self) -> None:
+        # Simulate iteration 2: history already has one entry, current
+        # window is now 4h (post-expansion). Expanding again gives 8h.
+        first_window = IncidentWindow(
+            since=NOW - timedelta(hours=4),
+            until=NOW,
+            source=SOURCE_STARTS_AT,
+            confidence=1.0,
+        ).to_dict()
+        state = _state_with_empty_timeline_signal(incident_window=first_window)
+        # One prior entry in history (the 2h window that got expanded).
+        state["incident_window_history"] = [_two_hour_window_dict()]
+
+        delta = adapt_incident_window(state, now_fn=_frozen_now)
+
+        assert delta != {}
+        new = IncidentWindow.from_dict(delta["incident_window"])
+        assert new is not None
+        assert (new.until - new.since) == timedelta(hours=8)
+        assert len(delta["incident_window_history"]) == 2
+
+    def test_third_expansion_blocked_by_history_cap(self) -> None:
+        # MAX_EXPANSIONS=2 means once history has 2 entries, no more.
+        state = _state_with_empty_timeline_signal()
+        state["incident_window_history"] = [
+            _two_hour_window_dict(),
+            _two_hour_window_dict(),
+        ]
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+
+# ---------------------------------------------------------------------------
+# Defensive shape handling
+# ---------------------------------------------------------------------------
+
+
+class TestDefensive:
+    def test_history_with_non_dict_entries_treated_as_no_entries(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["incident_window_history"] = ["str", 42, None]
+        # Filtered to empty → rule fires normally, history starts fresh.
+        delta = adapt_incident_window(state, now_fn=_frozen_now)
+        assert len(delta["incident_window_history"]) == 1
+
+    def test_evidence_count_is_string_treats_as_zero(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["evidence"]["git_deploy_timeline_count"] = "garbage"
+        # Coerces to 0 → rule fires.
+        delta = adapt_incident_window(state, now_fn=_frozen_now)
+        assert delta != {}
+
+    def test_evidence_window_is_not_a_dict(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        state["evidence"]["git_deploy_timeline_window"] = "not a dict"
+        assert adapt_incident_window(state, now_fn=_frozen_now) == {}
+
+    def test_default_now_fn_does_not_raise(self) -> None:
+        # When no now_fn is injected, the default uses datetime.now(UTC)
+        # — must not raise and must produce a valid ISO string.
+        state = _state_with_empty_timeline_signal()
+        delta = adapt_incident_window(state)
+        recorded_at = delta["incident_window_history"][0]["replaced_at"]
+        assert recorded_at.endswith("Z")
+        # Sanity check: parses back as ISO-8601.
+        parsed = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
+
+    def test_state_is_not_mutated(self) -> None:
+        state = _state_with_empty_timeline_signal()
+        snapshot_window = dict(state["incident_window"])
+        snapshot_evidence = dict(state["evidence"])
+        adapt_incident_window(state, now_fn=_frozen_now)
+        assert state["incident_window"] == snapshot_window
+        assert state["evidence"] == snapshot_evidence
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the state shape used by the helper matches our assumptions
+# ---------------------------------------------------------------------------
+
+
+def test_max_expansions_constant_is_two() -> None:
+    """If MAX_EXPANSIONS ever changes, several tests above need to be updated.
+    Pin the constant here so that's caught immediately."""
+    assert MAX_EXPANSIONS == 2
+
+
+@pytest.mark.parametrize(
+    "factor,expected_hours",
+    [(2.0, 4), (3.0, 6), (4.0, 8)],
+)
+def test_documented_factor_is_used(factor: float, expected_hours: int) -> None:
+    """The rule applies a fixed expansion factor (2.0). This test is a
+    sanity check that the imported constant is in fact 2.0; if someone
+    later parameterizes the rule, they should remove or adapt this."""
+    from app.nodes.adapt_window.rules import EXPANSION_FACTOR
+
+    if factor == EXPANSION_FACTOR:
+        # 120 min * 2.0 = 240 min = 4h
+        assert expected_hours == 4

--- a/tests/pipeline/test_graph_adapt_window_wiring.py
+++ b/tests/pipeline/test_graph_adapt_window_wiring.py
@@ -1,0 +1,107 @@
+"""Graph-level smoke tests for the adapt_window node wiring.
+
+The adapt_window node sits on the loop-back edge of the investigation
+pipeline: ``diagnose → adapt_window → plan_actions``. Terminal paths
+(``opensre_eval``, ``publish``) bypass it. These tests assert that
+contract by inspecting the compiled LangGraph rather than running it.
+
+Per-node behaviour is tested elsewhere (``tests/nodes/adapt_window/``),
+and the routing function itself is tested in
+``test_route_investigation_eval.py``. This file only verifies the
+WIRING.
+
+Implementation note: LangGraph's public ``get_graph().edges`` cannot
+statically traverse past an ``add_conditional_edges`` call that uses
+dynamic ``Send`` fan-out (``distribute_hypotheses``) — every edge after
+that point is dropped from the introspection view. We therefore read
+``builder.branches`` (conditional edges with their path maps) and
+``builder.edges`` (unconditional edges) directly. Both are stable,
+documented attributes of LangGraph's StateGraph.
+"""
+
+from __future__ import annotations
+
+from app.pipeline.graph import build_graph
+
+
+def _builder():  # noqa: ANN202 - internal LangGraph type, type-stub varies
+    return build_graph().builder
+
+
+def _branch_ends(source: str, branch_name: str) -> dict[str, str] | None:
+    """Return the path-map dict for ``add_conditional_edges(source, fn)``
+    where the function name is ``branch_name``, or None if not present."""
+    branches = _builder().branches.get(source, {})
+    branch = branches.get(branch_name)
+    return getattr(branch, "ends", None) if branch is not None else None
+
+
+def _unconditional_edges() -> set[tuple[str, str]]:
+    return {(src, dst) for src, dst in _builder().edges}
+
+
+def _nodes() -> set[str]:
+    # ``builder.nodes`` includes only user-added nodes (no __start__/__end__).
+    return set(_builder().nodes.keys())
+
+
+def test_adapt_window_node_is_registered() -> None:
+    assert "adapt_window" in _nodes()
+
+
+def test_loop_path_goes_through_adapt_window() -> None:
+    """When ``route_investigation_loop`` returns ``"investigate"``, the
+    graph must enter ``adapt_window`` BEFORE re-entering ``plan_actions``.
+    Without this edge the loop would skip adaptation entirely."""
+    ends = _branch_ends("diagnose", "route_investigation_loop")
+    assert ends is not None, "diagnose must have a conditional edge via route_investigation_loop"
+    assert ends.get("investigate") == "adapt_window"
+
+
+def test_adapt_window_unconditionally_returns_to_plan_actions() -> None:
+    """``adapt_window`` is a pass-through: whether or not it widens the
+    window, the next node is always ``plan_actions``."""
+    assert ("adapt_window", "plan_actions") in _unconditional_edges()
+
+
+def test_terminate_paths_bypass_adapt_window() -> None:
+    """Terminal routing decisions go straight from ``diagnose`` to
+    ``opensre_eval`` or ``publish`` — adaptation is never run on a
+    terminating iteration."""
+    ends = _branch_ends("diagnose", "route_investigation_loop")
+    assert ends is not None
+    assert ends.get("opensre_eval") == "opensre_eval"
+    assert ends.get("publish") == "publish"
+    # And nothing else feeds adapt_window:
+    incoming_to_adapt = [(src, dst) for src, dst in _builder().edges if dst == "adapt_window"]
+    incoming_branches_to_adapt = [
+        (src, branch_fn, key)
+        for src, branches in _builder().branches.items()
+        for branch_fn, branch in branches.items()
+        for key, target in (getattr(branch, "ends", None) or {}).items()
+        if target == "adapt_window"
+    ]
+    assert incoming_to_adapt == []  # no unconditional edges feed adapt_window
+    assert incoming_branches_to_adapt == [("diagnose", "route_investigation_loop", "investigate")]
+
+
+def test_no_direct_diagnose_to_plan_actions_edge() -> None:
+    """Regression guard: before this PR, ``diagnose → plan_actions`` was
+    a direct conditional edge. After the wiring change it must route
+    through ``adapt_window``. A direct edge here would mean the rule is
+    being silently skipped."""
+    ends = _branch_ends("diagnose", "route_investigation_loop")
+    assert ends is not None
+    assert ends.get("investigate") != "plan_actions"
+    assert ("diagnose", "plan_actions") not in _unconditional_edges()
+
+
+def test_pre_loop_path_unchanged() -> None:
+    """Pre-loop edges (resolve_integrations → plan_actions → ... → diagnose)
+    are untouched by this wiring change. The middle of that chain is the
+    parallel-hypotheses fan-out introduced by an earlier PR — the
+    adapt_window wiring change only affects the diagnose loop-back."""
+    edges = _unconditional_edges()
+    assert ("resolve_integrations", "plan_actions") in edges
+    assert ("investigate_hypothesis", "merge_hypothesis_results") in edges
+    assert ("merge_hypothesis_results", "diagnose") in edges


### PR DESCRIPTION
PR 3 of the dynamic incident-window work. Builds on #951 and #954 (both merged).

## What it does

Inserts a new `adapt_window` node on the `diagnose → plan_actions` loop-back edge. When the loop continues, one rule runs:

**Widen the incident window when the deploy timeline came back empty for a shared-window query.**

Specifically: if `get_git_deploy_timeline` ran this iteration with `window.source == "shared_incident_window"` and returned 0 commits, double the lookback (clamped at 7 days) and record the old window in `state.incident_window_history`. Next iteration sees the wider window.

Capped at 2 expansions per investigation (e.g. 120m → 240m → 480m, then stops). Caller-explicit windows are never overridden. Terminal routing bypasses the node entirely.

## Files

**New:**
- `app/nodes/adapt_window/{rules.py, node.py, __init__.py}`
- `tests/nodes/adapt_window/{test_rules.py, test_node.py}`
- `tests/pipeline/test_graph_adapt_window_wiring.py`

**Modified:**
- `app/incident_window.py` — `IncidentWindow.expanded()` helper
- `app/state/agent_state.py` — `incident_window_history` field (drift test green)
- `app/investigation_constants.py` — `MAX_EXPANSIONS = 2`
- `app/nodes/__init__.py`, `app/pipeline/graph.py` — wiring

## Tests

52 new tests, 1993 passing in the broad sweep, 0 regressions.

## Not in this PR

Window contraction on deploy anchor (PR 4), LLM-driven adaptation, migrating other tools to the shared window, diagnose narrative changes.
