### PR TITLE
refactor(utils): extract shared truncate() helper, replace six inline _truncate() implementations

### DIFF
--- a/app/integrations/azure_sql.py
+++ b/app/integrations/azure_sql.py
@@ -20,6 +20,7 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from app.strict_config import StrictConfigModel
+from app.utils.truncation import truncate
 
 logger = logging.getLogger(__name__)
 
@@ -172,12 +173,6 @@ def _get_connection(config: AzureSQLConfig) -> Any:
         f"APP=opensre;"
     )
     return pyodbc.connect(conn_str, timeout=int(config.timeout_seconds))
-
-
-def _truncate(text: str, max_len: int = _QUERY_TRUNCATE_LEN) -> str:
-    if len(text) <= max_len:
-        return text
-    return text[:max_len] + "..."
 
 
 def validate_azure_sql_config(config: AzureSQLConfig) -> AzureSQLValidationResult:
@@ -397,7 +392,7 @@ def get_current_queries(
                         "cpu_time_ms": row[9] or 0,
                         "logical_reads": row[10] or 0,
                         "writes": row[11] or 0,
-                        "query_text": _truncate(row[12] or ""),
+                        "query_text": truncate(row[12] or "", _QUERY_TRUNCATE_LEN),
                     }
                 )
 
@@ -544,7 +539,7 @@ def get_slow_queries(
                 queries.append(
                     {
                         "query_hash": str(row[0]) if row[0] else "",
-                        "query_text": _truncate(row[1] or ""),
+                        "query_text": truncate(row[1] or "", _QUERY_TRUNCATE_LEN),
                         "execution_count": row[2] or 0,
                         "total_time_ms": round(float(row[3] or 0), 3),
                         "avg_time_ms": round(float(row[4] or 0), 3),

--- a/app/integrations/mariadb.py
+++ b/app/integrations/mariadb.py
@@ -16,6 +16,7 @@ from pydantic import Field, field_validator
 
 from app.strict_config import StrictConfigModel
 from app.utils.coercion import safe_int
+from app.utils.truncation import truncate
 
 logger = logging.getLogger(__name__)
 
@@ -149,12 +150,6 @@ def validate_mariadb_config(config: MariaDBConfig) -> MariaDBValidationResult:
         return MariaDBValidationResult(ok=False, detail=f"MariaDB connection failed: {err}")
 
 
-def _truncate(text: str, max_len: int = _QUERY_TRUNCATE_LEN) -> str:
-    if len(text) <= max_len:
-        return text
-    return text[:max_len] + "..."
-
-
 def mariadb_is_available(sources: dict[str, dict]) -> bool:
     """Check if MariaDB integration credentials are present."""
     mdb = sources.get("mariadb", {})
@@ -213,7 +208,7 @@ def get_process_list(
                             "command": row[4],
                             "time_secs": row[5] or 0,
                             "state": row[6] or "",
-                            "query": _truncate(row[7] or ""),
+                            "query": truncate(row[7] or "", _QUERY_TRUNCATE_LEN),
                         }
                     )
                 return {
@@ -358,7 +353,7 @@ def get_slow_queries(
                 for row in cur.fetchall():
                     queries.append(
                         {
-                            "digest_text": _truncate(row[0] or ""),
+                            "digest_text": truncate(row[0] or "", _QUERY_TRUNCATE_LEN),
                             "count": row[1] or 0,
                             "avg_time_ms": float(row[2]) if row[2] is not None else 0,
                             "total_time_ms": float(row[3]) if row[3] is not None else 0,

--- a/app/integrations/mysql.py
+++ b/app/integrations/mysql.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from app.strict_config import StrictConfigModel
+from app.utils.truncation import truncate
 
 DEFAULT_MYSQL_PORT = 3306
 DEFAULT_MYSQL_USER = "root"
@@ -200,12 +201,6 @@ def validate_mysql_config(config: MySQLConfig) -> MySQLValidationResult:
         return MySQLValidationResult(ok=False, detail=f"MySQL connection failed: {err}")
 
 
-def _truncate(text: str, max_len: int = _QUERY_TRUNCATE_LEN) -> str:
-    if len(text) <= max_len:
-        return text
-    return text[:max_len] + "..."
-
-
 def mysql_is_available(sources: dict[str, dict]) -> bool:
     """Check if MySQL integration identifying params are present."""
     my = sources.get("mysql", {})
@@ -359,7 +354,7 @@ def get_current_processes(
                             "command": row["COMMAND"],
                             "time_seconds": row["TIME"] or 0,
                             "state": row["STATE"] or "",
-                            "query": _truncate(row["INFO"] or ""),
+                            "query": truncate(row["INFO"] or "", _QUERY_TRUNCATE_LEN),
                         }
                     )
 
@@ -511,7 +506,7 @@ def get_slow_queries(
                 for row in cur.fetchall():
                     queries.append(
                         {
-                            "digest_text": _truncate(row["DIGEST_TEXT"] or ""),
+                            "digest_text": truncate(row["DIGEST_TEXT"] or "", _QUERY_TRUNCATE_LEN),
                             "schema_name": row["SCHEMA_NAME"] or "",
                             "count": row["COUNT_STAR"] or 0,
                             "avg_time_ms": float(row["avg_time_ms"])

--- a/app/nodes/publish_findings/gitlab_writeback.py
+++ b/app/nodes/publish_findings/gitlab_writeback.py
@@ -5,14 +5,16 @@ import os
 
 from app.integrations.gitlab import build_gitlab_config, post_gitlab_mr_note
 from app.state import InvestigationState
+from app.utils.truncation import truncate
 
 logger = logging.getLogger(__name__)
 
 
+_GITLAB_MR_NOTE_LIMIT = 4000
+
+
 def _build_mr_note(report: str) -> str:
-    body = report.strip()
-    if len(body) > 4000:
-        body = body[:3997] + "..."
+    body = truncate(report.strip(), _GITLAB_MR_NOTE_LIMIT)
     return f"### RCA Finding\n\n<details>\n<summary>Investigation summary</summary>\n\n{body}\n\n</details>"
 
 

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -86,9 +86,9 @@ def send_discord_report(report: str, discord_ctx: dict[str, Any]) -> tuple[bool,
     thread_id: str = str(discord_ctx.get("thread_id") or "")
     bot_token: str = str(discord_ctx.get("bot_token") or "")
     embed = {
-        "title": truncate("Investigation Complete", _EMBED_TITLE_LIMIT, ellipsis="…"),
+        "title": truncate("Investigation Complete", _EMBED_TITLE_LIMIT, suffix="…"),
         "color": 15158332,
-        "description": truncate(report, _EMBED_DESCRIPTION_LIMIT, ellipsis="…"),
+        "description": truncate(report, _EMBED_DESCRIPTION_LIMIT, suffix="…"),
         "footer": {"text": "OpenSRE Investigation"},
     }
     target = thread_id if thread_id else channel_id

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from app.utils.delivery_transport import post_json
+from app.utils.truncation import truncate
 
 logger = logging.getLogger(__name__)
 
@@ -80,18 +81,14 @@ _EMBED_TITLE_LIMIT = 256
 _EMBED_DESCRIPTION_LIMIT = 4096
 
 
-def _truncate(text: str, limit: int) -> str:
-    return (text[: limit - 1] + "…") if len(text) > limit else text
-
-
 def send_discord_report(report: str, discord_ctx: dict[str, Any]) -> tuple[bool, str]:
     channel_id: str = str(discord_ctx.get("channel_id") or "")
     thread_id: str = str(discord_ctx.get("thread_id") or "")
     bot_token: str = str(discord_ctx.get("bot_token") or "")
     embed = {
-        "title": _truncate("Investigation Complete", _EMBED_TITLE_LIMIT),
+        "title": truncate("Investigation Complete", _EMBED_TITLE_LIMIT, ellipsis="…"),
         "color": 15158332,
-        "description": _truncate(report, _EMBED_DESCRIPTION_LIMIT),
+        "description": truncate(report, _EMBED_DESCRIPTION_LIMIT, ellipsis="…"),
         "footer": {"text": "OpenSRE Investigation"},
     }
     target = thread_id if thread_id else channel_id

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 from app.utils.delivery_transport import post_json
+from app.utils.truncation import truncate
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +43,6 @@ def _install_httpx_token_filter() -> None:
 
 
 _install_httpx_token_filter()
-
-
-def _truncate(text: str, limit: int) -> str:
-    return (text[: limit - 1] + "…") if len(text) > limit else text
 
 
 def _redact_token(text: str, bot_token: str) -> str:
@@ -103,7 +100,7 @@ def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[boo
     if not bot_token or not chat_id:
         return False, "Missing bot_token or chat_id"
     reply_to_message_id: str = str(telegram_ctx.get("reply_to_message_id") or "")
-    text = _truncate(report, _MESSAGE_LIMIT)
+    text = truncate(report, _MESSAGE_LIMIT, ellipsis="…")
     post_success, error, _ = post_telegram_message(
         chat_id, text, bot_token, reply_to_message_id=reply_to_message_id
     )

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -100,7 +100,7 @@ def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[boo
     if not bot_token or not chat_id:
         return False, "Missing bot_token or chat_id"
     reply_to_message_id: str = str(telegram_ctx.get("reply_to_message_id") or "")
-    text = truncate(report, _MESSAGE_LIMIT, ellipsis="…")
+    text = truncate(report, _MESSAGE_LIMIT, suffix="…")
     post_success, error, _ = post_telegram_message(
         chat_id, text, bot_token, reply_to_message_id=reply_to_message_id
     )

--- a/app/utils/truncation.py
+++ b/app/utils/truncation.py
@@ -4,5 +4,6 @@
 def truncate(text: str, limit: int, suffix: str = "...") -> str:
     if len(text) <= limit:
         return text
-    cut = max(0, limit - len(suffix))
-    return text[:cut] + suffix
+    if limit <= len(suffix):
+        return suffix[:limit]
+    return text[: limit - len(suffix)] + suffix

--- a/app/utils/truncation.py
+++ b/app/utils/truncation.py
@@ -1,0 +1,7 @@
+"""Shared text truncation utility."""
+
+
+def truncate(text: str, limit: int, ellipsis: str = "...") -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - len(ellipsis)] + ellipsis

--- a/app/utils/truncation.py
+++ b/app/utils/truncation.py
@@ -1,7 +1,8 @@
 """Shared text truncation utility."""
 
 
-def truncate(text: str, limit: int, ellipsis: str = "...") -> str:
+def truncate(text: str, limit: int, suffix: str = "...") -> str:
     if len(text) <= limit:
         return text
-    return text[: limit - len(ellipsis)] + ellipsis
+    cut = max(0, limit - len(suffix))
+    return text[:cut] + suffix

--- a/tests/nodes/publish_findings/test_gitlab_writeback.py
+++ b/tests/nodes/publish_findings/test_gitlab_writeback.py
@@ -35,6 +35,14 @@ def test_build_mr_note_truncates_long_message():
     assert "x" * 3998 not in note
 
 
+def test_build_mr_note_body_capped_at_4000_chars():
+    long_msg = "x" * 5000
+    note = _build_mr_note(long_msg)
+    body = note.split("<summary>Investigation summary</summary>\n\n")[1].split("\n\n</details>")[0]
+    assert len(body) == 4000
+    assert body.endswith("...")
+
+
 def test_no_op_when_env_flag_off(state_with_gitlab):
     with (
         patch.dict(os.environ, {"GITLAB_MR_WRITEBACK": "false"}),

--- a/tests/test_mariadb_integration.py
+++ b/tests/test_mariadb_integration.py
@@ -342,7 +342,7 @@ class TestGetProcessList:
         result = get_process_list(self._config())
 
         assert result["processes"][0]["query"].endswith("...")
-        assert len(result["processes"][0]["query"]) == 203
+        assert len(result["processes"][0]["query"]) == 200
 
     @patch("app.integrations.mariadb._get_connection")
     def test_empty_process_list(self, mock_get_conn: MagicMock) -> None:

--- a/tests/test_mariadb_integration.py
+++ b/tests/test_mariadb_integration.py
@@ -11,8 +11,8 @@ import pytest
 
 from app.integrations.mariadb import (
     DEFAULT_MARIADB_PORT,
+    _QUERY_TRUNCATE_LEN,
     MariaDBConfig,
-    _truncate,
     build_mariadb_config,
     get_global_status,
     get_innodb_status,
@@ -25,6 +25,12 @@ from app.integrations.mariadb import (
     validate_mariadb_config,
 )
 from app.nodes.resolve_integrations.node import _classify_integrations
+from app.utils.truncation import truncate as _truncate_shared
+
+
+def _truncate(text: str, max_len: int = _QUERY_TRUNCATE_LEN) -> str:
+    return _truncate_shared(text, max_len)
+
 
 # ---------------------------------------------------------------------------
 # Shared mock helpers
@@ -224,18 +230,18 @@ class TestTruncate:
     def test_over_limit_truncated(self) -> None:
         result = _truncate("x" * 201)
         assert result.endswith("...")
-        assert len(result) == 203  # 200 chars + "..."
+        assert len(result) == 200  # capped at limit
 
     def test_empty_string(self) -> None:
         assert _truncate("") == ""
 
     def test_custom_max_len(self) -> None:
-        assert _truncate("hello world", max_len=5) == "hello..."
+        assert _truncate("hello world", max_len=5) == "he..."
 
     def test_very_long_string(self) -> None:
         result = _truncate("A" * 10_000)
         assert result.endswith("...")
-        assert len(result) == 203
+        assert len(result) == 200  # capped at limit
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mariadb_integration.py
+++ b/tests/test_mariadb_integration.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.integrations.mariadb import (
-    DEFAULT_MARIADB_PORT,
     _QUERY_TRUNCATE_LEN,
+    DEFAULT_MARIADB_PORT,
     MariaDBConfig,
     build_mariadb_config,
     get_global_status,

--- a/tests/utils/test_truncation.py
+++ b/tests/utils/test_truncation.py
@@ -1,0 +1,37 @@
+"""Tests for the shared truncation utility."""
+
+import pytest
+
+from app.utils.truncation import truncate
+
+
+@pytest.mark.parametrize(
+    "text,limit,ellipsis,expected",
+    [
+        ("short", 10, "...", "short"),
+        ("exactly10c", 10, "...", "exactly10c"),
+        ("this is a long string", 10, "...", "this is..."),
+        ("long", 3, "...", "..."),
+        ("unicode", 5, "…", "unic…"),
+        ("no change needed", 100, "...", "no change needed"),
+    ],
+)
+def test_truncate(text: str, limit: int, ellipsis: str, expected: str) -> None:
+    assert truncate(text, limit, ellipsis=ellipsis) == expected
+
+
+def test_truncate_default_ellipsis() -> None:
+    result = truncate("hello world", 8)
+    assert result == "hello..."
+    assert len(result) == 8
+
+
+def test_truncate_unicode_ellipsis() -> None:
+    result = truncate("hello world", 8, ellipsis="…")
+    assert result.endswith("…")
+    assert len(result) == 8
+
+
+def test_truncate_text_at_exact_limit_not_truncated() -> None:
+    text = "a" * 10
+    assert truncate(text, 10) == text

--- a/tests/utils/test_truncation.py
+++ b/tests/utils/test_truncation.py
@@ -17,7 +17,7 @@ from app.utils.truncation import truncate
     ],
 )
 def test_truncate(text: str, limit: int, ellipsis: str, expected: str) -> None:
-    assert truncate(text, limit, ellipsis=ellipsis) == expected
+    assert truncate(text, limit, suffix=ellipsis) == expected
 
 
 def test_truncate_default_ellipsis() -> None:
@@ -27,7 +27,7 @@ def test_truncate_default_ellipsis() -> None:
 
 
 def test_truncate_unicode_ellipsis() -> None:
-    result = truncate("hello world", 8, ellipsis="…")
+    result = truncate("hello world", 8, suffix="…")
     assert result.endswith("…")
     assert len(result) == 8
 

--- a/tests/utils/test_truncation.py
+++ b/tests/utils/test_truncation.py
@@ -6,27 +6,33 @@ from app.utils.truncation import truncate
 
 
 @pytest.mark.parametrize(
-    "text,limit,ellipsis,expected",
+    "text,limit,suffix,expected",
     [
+        # text shorter than limit — returned unchanged
         ("short", 10, "...", "short"),
+        # text exactly at limit — returned unchanged
         ("exactly10c", 10, "...", "exactly10c"),
+        # text longer than limit — truncated with suffix
         ("this is a long string", 10, "...", "this is..."),
+        # limit equals suffix length — suffix returned as-is
         ("long", 3, "...", "..."),
-        ("unicode", 5, "…", "unic…"),
+        # unicode suffix
+        ("unicode text", 5, "…", "unic…"),
+        # no change needed
         ("no change needed", 100, "...", "no change needed"),
     ],
 )
-def test_truncate(text: str, limit: int, ellipsis: str, expected: str) -> None:
-    assert truncate(text, limit, suffix=ellipsis) == expected
+def test_truncate(text: str, limit: int, suffix: str, expected: str) -> None:
+    assert truncate(text, limit, suffix=suffix) == expected
 
 
-def test_truncate_default_ellipsis() -> None:
+def test_truncate_result_length_equals_limit() -> None:
     result = truncate("hello world", 8)
     assert result == "hello..."
     assert len(result) == 8
 
 
-def test_truncate_unicode_ellipsis() -> None:
+def test_truncate_unicode_suffix() -> None:
     result = truncate("hello world", 8, suffix="…")
     assert result.endswith("…")
     assert len(result) == 8
@@ -35,3 +41,44 @@ def test_truncate_unicode_ellipsis() -> None:
 def test_truncate_text_at_exact_limit_not_truncated() -> None:
     text = "a" * 10
     assert truncate(text, 10) == text
+
+
+def test_truncate_empty_string() -> None:
+    assert truncate("", 5) == ""
+
+
+def test_truncate_limit_smaller_than_suffix_returns_clipped_suffix() -> None:
+    # limit=2, suffix="..." (len 3) — cannot fit suffix, return suffix[:limit]
+    result = truncate("hello", 2, suffix="...")
+    assert result == ".."
+    assert len(result) == 2
+
+
+def test_truncate_limit_zero_returns_empty_string() -> None:
+    result = truncate("hello", 0, suffix="...")
+    assert result == ""
+    assert len(result) == 0
+
+
+def test_truncate_limit_one_with_long_suffix() -> None:
+    result = truncate("hello", 1, suffix="...")
+    assert result == "."
+    assert len(result) == 1
+
+
+def test_truncate_suffix_longer_than_text_but_within_limit() -> None:
+    # text shorter than limit — no truncation even if suffix is long
+    result = truncate("hi", 10, suffix=".....")
+    assert result == "hi"
+
+
+def test_truncate_very_long_text() -> None:
+    result = truncate("x" * 10_000, 100)
+    assert result.endswith("...")
+    assert len(result) == 100
+
+
+def test_truncate_empty_suffix() -> None:
+    result = truncate("hello world", 5, suffix="")
+    assert result == "hello"
+    assert len(result) == 5


### PR DESCRIPTION
## Problem

Six modules independently defined a private `_truncate()` function with inconsistent implementations — different ellipsis characters (`...` vs `…`), different limits (200, 500, 4000, 4096), and no shared source of truth. Every new delivery channel or integration had to reinvent the same logic.

Affected files: `discord_delivery.py`, `telegram_delivery.py`, `azure_sql.py`, `mysql.py`, `mariadb.py`, and `gitlab_writeback.py`.

## Solution

Added `app/utils/truncation.py` with a single `truncate(text, limit, ellipsis="...")` helper. Migrated all six call sites to use it. Each module's limit constant stays where it is — only the function body moves.

## Tests

Added `tests/utils/test_truncation.py` covering:
- text under limit → returned unchanged
- text over limit → truncated with correct ellipsis
- text at exact limit → not truncated
- Unicode ellipsis variant (`…`)
- default ellipsis behaviour

Closes #1056