### PR TITLE
test(grafana): add direct unit tests for LokiMixin.query_loki

### DIFF
--- a/tests/services/test_grafana_loki.py
+++ b/tests/services/test_grafana_loki.py
@@ -1,0 +1,247 @@
+"""Direct unit tests for app.services.grafana.loki.LokiMixin.
+
+Exercise the Loki query path with a fake mixin host so we never hit a real
+Grafana datasource. Covers the happy path (stream flattening, metadata
+propagation), the not-configured short-circuit, exception handling with and
+without a wrapped HTTP response, and the empty-result envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.grafana.loki import LokiMixin
+
+# ---------------------------------------------------------------------------
+# Test host
+# ---------------------------------------------------------------------------
+
+
+class _FakeLokiHost(LokiMixin):
+    """Minimal stand-in for GrafanaClientBase that satisfies LokiMixin's needs.
+
+    LokiMixin reads ``is_configured``, ``account_id``, and
+    ``loki_datasource_uid`` and calls ``_build_datasource_url`` and
+    ``_make_request``. Everything else on the real base is irrelevant here.
+    """
+
+    def __init__(
+        self,
+        *,
+        is_configured: bool = True,
+        account_id: str = "acct-1",
+        loki_datasource_uid: str = "loki-uid",
+        instance_url: str = "https://grafana.example.com",
+    ) -> None:
+        self.is_configured = is_configured  # type: ignore[assignment]
+        self.account_id = account_id
+        self.loki_datasource_uid = loki_datasource_uid
+        self.instance_url = instance_url
+        self.last_url: str | None = None
+        self.last_params: dict[str, str] | None = None
+        self.make_request_mock: MagicMock = MagicMock()
+
+    def _build_datasource_url(self, datasource_uid: str, path: str) -> str:
+        return f"{self.instance_url}/api/datasources/proxy/uid/{datasource_uid}{path}"
+
+    def _make_request(
+        self,
+        url: str,
+        params: dict[str, str] | None = None,
+        timeout: int = 10,
+    ) -> dict[str, Any]:
+        self.last_url = url
+        self.last_params = params
+        return self.make_request_mock(url, params=params, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+
+_QUERY = '{service_name="lambda-mock-dag"}'
+
+_TWO_STREAM_RESPONSE = {
+    "status": "success",
+    "data": {
+        "resultType": "streams",
+        "result": [
+            {
+                "stream": {"service_name": "lambda-mock-dag", "level": "error"},
+                "values": [
+                    ["1700000000000000000", "boom"],
+                    ["1700000000000000001", "crash"],
+                ],
+            },
+            {
+                "stream": {"service_name": "lambda-mock-dag", "level": "info"},
+                "values": [["1700000000000000002", "started"]],
+            },
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLokiSuccess:
+    """Configured client returns a flattened, well-formed envelope."""
+
+    def test_flattens_streams_into_log_rows(self) -> None:
+        host = _FakeLokiHost()
+        host.make_request_mock.return_value = _TWO_STREAM_RESPONSE
+
+        result = host.query_loki(_QUERY)
+
+        assert result["success"] is True
+        assert result["query"] == _QUERY
+        assert result["account_id"] == "acct-1"
+        assert result["total_streams"] == 2
+        assert result["total_logs"] == 3
+        assert len(result["logs"]) == 3
+
+    def test_each_log_row_carries_timestamp_message_and_labels(self) -> None:
+        host = _FakeLokiHost()
+        host.make_request_mock.return_value = _TWO_STREAM_RESPONSE
+
+        result = host.query_loki(_QUERY)
+        first = result["logs"][0]
+
+        assert first == {
+            "timestamp": "1700000000000000000",
+            "message": "boom",
+            "labels": {"service_name": "lambda-mock-dag", "level": "error"},
+        }
+        assert result["logs"][2]["labels"]["level"] == "info"
+        assert result["logs"][2]["message"] == "started"
+
+    def test_uses_loki_datasource_url_and_passes_query_params(self) -> None:
+        host = _FakeLokiHost(loki_datasource_uid="my-loki")
+        host.make_request_mock.return_value = _TWO_STREAM_RESPONSE
+
+        host.query_loki(_QUERY, time_range_minutes=5, limit=42)
+
+        assert host.last_url is not None
+        assert "/api/datasources/proxy/uid/my-loki/loki/api/v1/query_range" in host.last_url
+        assert host.last_params is not None
+        assert host.last_params["query"] == _QUERY
+        assert host.last_params["limit"] == "42"
+        start = int(host.last_params["start"])
+        end = int(host.last_params["end"])
+        assert end > start
+        assert end - start == 5 * 60 * 10**9
+
+
+# ---------------------------------------------------------------------------
+# Not configured short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLokiNotConfigured:
+    """When is_configured is False we never reach the HTTP layer."""
+
+    def test_returns_not_configured_envelope(self) -> None:
+        host = _FakeLokiHost(is_configured=False, account_id="missing-acct")
+
+        result = host.query_loki(_QUERY)
+
+        assert result == {
+            "success": False,
+            "error": "Grafana client not configured for account 'missing-acct'",
+            "logs": [],
+        }
+
+    def test_does_not_invoke_make_request(self) -> None:
+        host = _FakeLokiHost(is_configured=False)
+
+        host.query_loki(_QUERY)
+
+        host.make_request_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLokiExceptions:
+    """Exceptions surface as a stable failure envelope."""
+
+    def test_plain_exception_returns_str_error_and_empty_response(self) -> None:
+        host = _FakeLokiHost()
+        host.make_request_mock.side_effect = RuntimeError("connection refused")
+
+        result = host.query_loki(_QUERY)
+
+        assert result == {
+            "success": False,
+            "error": "connection refused",
+            "response": "",
+            "logs": [],
+        }
+
+    def test_exception_with_response_includes_status_and_truncated_text(self) -> None:
+        host = _FakeLokiHost()
+
+        long_text = "x" * 500
+        response = MagicMock(status_code=502, text=long_text)
+        err = RuntimeError("bad gateway")
+        err.response = response  # type: ignore[attr-defined]
+        host.make_request_mock.side_effect = err
+
+        result = host.query_loki(_QUERY)
+
+        assert result["success"] is False
+        assert result["error"] == "Loki query failed: 502"
+        assert result["response"] == long_text[:300]
+        assert len(result["response"]) == 300
+        assert result["logs"] == []
+
+    def test_exception_with_none_response_falls_back_to_str_error(self) -> None:
+        host = _FakeLokiHost()
+        err = RuntimeError("transport error")
+        err.response = None  # type: ignore[attr-defined]
+        host.make_request_mock.side_effect = err
+
+        result = host.query_loki(_QUERY)
+
+        assert result["success"] is False
+        assert result["error"] == "transport error"
+        assert result["response"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Empty-result envelope stability
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLokiEmptyResult:
+    """No streams returned should still yield a valid success envelope."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"data": {"result": []}},
+            {"data": {}},
+            {},
+        ],
+    )
+    def test_zero_streams_yields_empty_logs_but_success(self, payload: dict) -> None:
+        host = _FakeLokiHost()
+        host.make_request_mock.return_value = payload
+
+        result = host.query_loki(_QUERY)
+
+        assert result["success"] is True
+        assert result["logs"] == []
+        assert result["total_streams"] == 0
+        assert result["total_logs"] == 0
+        assert result["query"] == _QUERY
+        assert result["account_id"] == "acct-1"


### PR DESCRIPTION
Fixes #880

#### Describe the changes you have made in this PR

- Add `tests/services/test_grafana_loki.py` with a fake mixin host that stubs `_build_datasource_url` and `_make_request`, so Loki logic is exercised without a real Grafana datasource.
- 11 tests across 4 classes covering the four scopes in the issue:
  - configured success: stream flattening, label/timestamp propagation, URL + query/limit/start/end params
  - `is_configured=False` short-circuit (no request made, correct envelope)
  - exceptions with and without a wrapped HTTP `.response` (status-coded error + truncated text)
  - empty / missing `data.result` payloads still yield a stable success envelope
- No changes to `app/services/grafana/loki.py` or `app/services/grafana/base.py`.

### Demo/Screenshot for feature changes and bug fixes
N/A — pure test addition, no behaviour change. Verified locally:
- `pytest tests/services/test_grafana_loki.py -v` → 11 passed in ~1.1s
- `ruff check tests/services/test_grafana_loki.py` → clean
- `ruff format --check tests/services/test_grafana_loki.py` → clean

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`query_loki` has four behavioural branches — not-configured short-circuit, happy-path stream flattening, exception with a wrapped HTTP `.response`, and exception without one. The fixture host `_FakeLokiHost` subclasses `LokiMixin` and supplies only the attributes/methods the method actually reads (`is_configured`, `account_id`, `loki_datasource_uid`, `_build_datasource_url`, `_make_request`), so we exercise the real method body rather than re-implementing it. `_make_request` is backed by a `MagicMock` so each test can configure return values or `side_effect` for exceptions, and the recorded `last_url`/`last_params` let one test assert URL shape and the time-window math (`end − start == 5 * 60 * 10**9` ns for `time_range_minutes=5`). The empty-result test is parametrised over three differently-malformed payloads to lock the envelope shape against drift.

---

#### Self-review checklist
- [x ] I have added proper PR title and linked to the issue
- [x ] I have performed a self-review of my code
- [x ] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x ] I have considered potential edge cases and how my code handles them
- [x ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
