### PR TITLE
fix(cli): `opensre tests` crashes with FileNotFoundError in bundled binary (#1078)

### DIFF
--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -277,6 +277,25 @@ def _check_deploy_health(status: dict[str, str], console: Any) -> None:
         console.print(f"  [red]Unhealthy[/red]  {exc}")
 
 
+def _ec2_deploy_not_bundled_error() -> OpenSREError:
+    """Structured error for ``opensre deploy ec2`` when the deploy SDK isn't shipped.
+
+    The EC2 deployment SDK lives under ``tests/deployment/ec2/`` and is excluded
+    from PyInstaller bundles by ``packaging/opensre.spec``'s ``_is_runtime_submodule``
+    filter, so ``opensre deploy ec2`` (with or without ``--down``) cannot run from
+    a packaged binary.
+    """
+    return OpenSREError(
+        "EC2 deployment is not available in this build.",
+        suggestion=(
+            "Pre-built binaries do not bundle the EC2 deployment SDK under "
+            "'tests/deployment/ec2/'. Install from source (`git clone "
+            "https://github.com/Tracer-Cloud/opensre && pip install -e .`) "
+            "and re-run 'opensre deploy ec2'."
+        ),
+    )
+
+
 def _build_remote_url(outputs: Mapping[str, object]) -> str | None:
     ip = str(outputs.get("PublicIpAddress", "")).strip()
     if not ip:
@@ -320,13 +339,28 @@ def deploy_ec2(down: bool, branch: str) -> None:
       opensre deploy ec2 --branch main   # deploy from a specific branch
     """
     if down:
-        from tests.deployment.ec2.infrastructure_sdk.destroy_remote import destroy
+        try:
+            from tests.deployment.ec2.infrastructure_sdk.destroy_remote import destroy
+        except ModuleNotFoundError as exc:
+            # ``packaging/opensre.spec`` excludes the ``tests`` tree from
+            # PyInstaller bundles. Surface a clean OpenSREError instead of a
+            # raw ``ModuleNotFoundError`` traceback. Narrow on ``exc.name``
+            # so unrelated transitive missing-deps still bubble up.
+            if exc.name is None or not exc.name.startswith("tests.deployment.ec2"):
+                raise
+            raise _ec2_deploy_not_bundled_error() from exc
 
         destroy()
         return
 
     from app.cli.commands.remote_health import run_remote_health_check
-    from tests.deployment.ec2.infrastructure_sdk.deploy_remote import deploy as run_deploy
+
+    try:
+        from tests.deployment.ec2.infrastructure_sdk.deploy_remote import deploy as run_deploy
+    except ModuleNotFoundError as exc:
+        if exc.name is None or not exc.name.startswith("tests.deployment.ec2"):
+            raise
+        raise _ec2_deploy_not_bundled_error() from exc
 
     outputs = run_deploy(branch=branch)
     _persist_remote_url(outputs)

--- a/app/cli/commands/tests.py
+++ b/app/cli/commands/tests.py
@@ -105,22 +105,36 @@ def tests(ctx: click.Context) -> None:
 )
 def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) -> None:
     """Run the synthetic RDS PostgreSQL RCA benchmark."""
+    # ``packaging/opensre.spec`` only collects ``app/`` data files, so neither
+    # the synthetic Python package's submodules nor the per-scenario data
+    # directories are reliably present in PyInstaller bundles. Two failure
+    # modes can trip a bundled binary here:
+    #
+    # 1. The ``tests.synthetic.rds_postgres.*`` Python package is missing
+    #    entirely  →  ``ModuleNotFoundError`` raised at import time.
+    # 2. The package is included transitively but its data dir
+    #    (``tests/synthetic/rds_postgres/<scenario>/``) is absent
+    #    →  ``run_suite`` crashes later with ``FileNotFoundError`` from
+    #    ``Path.iterdir()`` inside the scenario loader.
+    #
+    # We pre-check the data dir explicitly *and* catch a narrow
+    # ``ModuleNotFoundError`` so users see one structured message regardless
+    # of which failure mode their bundle produces.
+    from app.cli.tests.discover import REPO_ROOT
+
+    scenarios_dir = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
+    if not scenarios_dir.is_dir():
+        raise _synthetic_suite_not_bundled_error()
+
     try:
-        # ``packaging/opensre.spec`` excludes the ``tests`` tree from
-        # PyInstaller bundles, so this import will raise ``ModuleNotFoundError``
-        # in a packaged binary. Surface a clear error rather than a raw
-        # traceback so users know to run from a source checkout.
         from tests.synthetic.rds_postgres.run_suite import main as run_suite_main
     except ModuleNotFoundError as exc:
-        raise OpenSREError(
-            "The synthetic RDS PostgreSQL suite is not available in this build.",
-            suggestion=(
-                "Run 'opensre tests synthetic' from a source checkout (clone "
-                "https://github.com/Tracer-Cloud/opensre) — the synthetic "
-                "scenarios under 'tests/synthetic/rds_postgres/' are not "
-                "bundled into the released binary."
-            ),
-        ) from exc
+        # Narrow to the actual missing-bundle case; re-raise unrelated import
+        # failures (e.g. a missing transitive dep like ``psycopg``) so users
+        # see the real cause instead of a misleading "not bundled" message.
+        if exc.name is None or not exc.name.startswith("tests.synthetic.rds_postgres"):
+            raise
+        raise _synthetic_suite_not_bundled_error() from exc
 
     capture_test_synthetic_started(scenario or "all", mock_grafana=mock_grafana)
     raise SystemExit(
@@ -131,6 +145,19 @@ def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) ->
                 mock_grafana=mock_grafana,
             )
         )
+    )
+
+
+def _synthetic_suite_not_bundled_error() -> OpenSREError:
+    """Structured error for ``opensre tests synthetic`` when the suite isn't shipped."""
+    return OpenSREError(
+        "The synthetic RDS PostgreSQL suite is not available in this build.",
+        suggestion=(
+            "Pre-built binaries do not bundle the per-scenario data files "
+            "under 'tests/synthetic/rds_postgres/'. Install from source "
+            "(`git clone https://github.com/Tracer-Cloud/opensre && pip "
+            "install -e .`) and re-run 'opensre tests synthetic'."
+        ),
     )
 
 

--- a/app/cli/commands/tests.py
+++ b/app/cli/commands/tests.py
@@ -91,6 +91,19 @@ def tests(ctx: click.Context) -> None:
     raise SystemExit(exit_code)
 
 
+def _synthetic_suite_not_bundled_error() -> OpenSREError:
+    """Structured error for ``opensre tests synthetic`` when the suite isn't shipped."""
+    return OpenSREError(
+        "The synthetic RDS PostgreSQL suite is not available in this build.",
+        suggestion=(
+            "Pre-built binaries do not bundle the per-scenario data files "
+            "under 'tests/synthetic/rds_postgres/'. Install from source "
+            "(`git clone https://github.com/Tracer-Cloud/opensre && pip "
+            "install -e .`) and re-run 'opensre tests synthetic'."
+        ),
+    )
+
+
 @tests.command(name="synthetic")
 @click.option(
     "--scenario", default="", help="Pin to a single scenario directory, e.g. 001-replication-lag."
@@ -119,11 +132,12 @@ def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) ->
     #
     # We pre-check the data dir explicitly *and* catch a narrow
     # ``ModuleNotFoundError`` so users see one structured message regardless
-    # of which failure mode their bundle produces.
-    from app.cli.tests.discover import REPO_ROOT
+    # of which failure mode their bundle produces. The data-dir path is the
+    # ``SYNTHETIC_SCENARIOS_DIR`` constant from ``discover.py`` — single
+    # source of truth shared with ``_discover_rds_synthetic_scenarios``.
+    from app.cli.tests.discover import SYNTHETIC_SCENARIOS_DIR
 
-    scenarios_dir = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
-    if not scenarios_dir.is_dir():
+    if not SYNTHETIC_SCENARIOS_DIR.is_dir():
         raise _synthetic_suite_not_bundled_error()
 
     try:
@@ -145,19 +159,6 @@ def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) ->
                 mock_grafana=mock_grafana,
             )
         )
-    )
-
-
-def _synthetic_suite_not_bundled_error() -> OpenSREError:
-    """Structured error for ``opensre tests synthetic`` when the suite isn't shipped."""
-    return OpenSREError(
-        "The synthetic RDS PostgreSQL suite is not available in this build.",
-        suggestion=(
-            "Pre-built binaries do not bundle the per-scenario data files "
-            "under 'tests/synthetic/rds_postgres/'. Install from source "
-            "(`git clone https://github.com/Tracer-Cloud/opensre && pip "
-            "install -e .`) and re-run 'opensre tests synthetic'."
-        ),
     )
 
 

--- a/app/cli/commands/tests.py
+++ b/app/cli/commands/tests.py
@@ -105,7 +105,22 @@ def tests(ctx: click.Context) -> None:
 )
 def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) -> None:
     """Run the synthetic RDS PostgreSQL RCA benchmark."""
-    from tests.synthetic.rds_postgres.run_suite import main as run_suite_main
+    try:
+        # ``packaging/opensre.spec`` excludes the ``tests`` tree from
+        # PyInstaller bundles, so this import will raise ``ModuleNotFoundError``
+        # in a packaged binary. Surface a clear error rather than a raw
+        # traceback so users know to run from a source checkout.
+        from tests.synthetic.rds_postgres.run_suite import main as run_suite_main
+    except ModuleNotFoundError as exc:
+        raise OpenSREError(
+            "The synthetic RDS PostgreSQL suite is not available in this build.",
+            suggestion=(
+                "Run 'opensre tests synthetic' from a source checkout (clone "
+                "https://github.com/Tracer-Cloud/opensre) — the synthetic "
+                "scenarios under 'tests/synthetic/rds_postgres/' are not "
+                "bundled into the released binary."
+            ),
+        ) from exc
 
     capture_test_synthetic_started(scenario or "all", mock_grafana=mock_grafana)
     raise SystemExit(

--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -11,6 +11,7 @@ from app.cli.tests.catalog import TestCatalog, TestCatalogItem, TestRequirement
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MAKEFILE_PATH = REPO_ROOT / "Makefile"
 RCA_DIR = REPO_ROOT / "tests" / "e2e" / "rca"
+SYNTHETIC_SCENARIOS_DIR = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
 
 _TARGETS_TO_INDEX = (
     "test",
@@ -317,12 +318,11 @@ def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
     Skip cleanly in that case — the synthetic-suite catalog entries are
     only meaningful when the scenarios are on disk anyway.
     """
-    scenarios_dir = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
     items: list[TestCatalogItem] = []
-    if not scenarios_dir.is_dir():
+    if not SYNTHETIC_SCENARIOS_DIR.is_dir():
         return items
     req = TestRequirement(env_vars=("ANTHROPIC_API_KEY",))
-    for scenario_dir in sorted(scenarios_dir.iterdir()):
+    for scenario_dir in sorted(SYNTHETIC_SCENARIOS_DIR.iterdir()):
         if not scenario_dir.is_dir() or scenario_dir.name.startswith("_"):
             continue
         scenario_id = scenario_dir.name

--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -248,6 +248,12 @@ def _comment_map_for_makefile(path: Path) -> dict[str, str]:
 
 
 def discover_make_targets() -> list[TestCatalogItem]:
+    if not MAKEFILE_PATH.is_file():
+        # PyInstaller-bundled builds ship only the ``app/`` tree (see
+        # ``packaging/opensre.spec``), so the Makefile is absent at runtime.
+        # Return an empty catalog slice so ``opensre tests`` still launches
+        # against whatever sources *are* bundled.
+        return []
     comment_map = _comment_map_for_makefile(MAKEFILE_PATH)
     makefile_text = MAKEFILE_PATH.read_text(encoding="utf-8")
     items: list[TestCatalogItem] = []
@@ -276,6 +282,12 @@ def discover_make_targets() -> list[TestCatalogItem]:
 
 def discover_rca_files() -> list[TestCatalogItem]:
     items: list[TestCatalogItem] = []
+    if not RCA_DIR.is_dir():
+        # ``Path.glob`` on a missing parent returns an empty iterator on
+        # CPython, so this isn't a crash today — but the explicit guard
+        # documents the bundled-binary contract and matches the shape of
+        # the other ``discover_*`` helpers below.
+        return items
     for path in sorted(RCA_DIR.glob("*.md")):
         title = path.stem.replace("_", " ").title()
         first_line = path.read_text(encoding="utf-8").splitlines()[0].strip()
@@ -297,9 +309,18 @@ def discover_rca_files() -> list[TestCatalogItem]:
 
 
 def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
-    """One catalog item per RDS synthetic scenario directory."""
+    """One catalog item per RDS synthetic scenario directory.
+
+    Bundled (PyInstaller) builds collect only ``app/`` data files (see
+    ``packaging/opensre.spec``), so ``tests/synthetic/rds_postgres`` is
+    absent at runtime and ``iterdir()`` would raise ``FileNotFoundError``.
+    Skip cleanly in that case — the synthetic-suite catalog entries are
+    only meaningful when the scenarios are on disk anyway.
+    """
     scenarios_dir = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
     items: list[TestCatalogItem] = []
+    if not scenarios_dir.is_dir():
+        return items
     req = TestRequirement(env_vars=("ANTHROPIC_API_KEY",))
     for scenario_dir in sorted(scenarios_dir.iterdir()):
         if not scenario_dir.is_dir() or scenario_dir.name.startswith("_"):

--- a/tests/cli/test_cli_inventory.py
+++ b/tests/cli/test_cli_inventory.py
@@ -246,9 +246,10 @@ def test_tests_synthetic_clean_error_when_data_dir_missing(tmp_path: Path) -> No
     on the data dir must surface a structured error before the import fires."""
     runner = CliRunner()
 
-    # tmp_path has no ``tests/synthetic/rds_postgres`` subtree, so the
+    # Point SYNTHETIC_SCENARIOS_DIR at a path that doesn't exist so the
     # pre-check in ``run_synthetic_suite`` short-circuits to OpenSREError.
-    with unittest.mock.patch("app.cli.tests.discover.REPO_ROOT", tmp_path):
+    missing = tmp_path / "missing-rds-postgres"
+    with unittest.mock.patch("app.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", missing):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
 
     output = result.output or ""
@@ -277,11 +278,11 @@ def test_tests_synthetic_clean_error_when_module_not_bundled(tmp_path: Path) -> 
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
     # Make the data-dir pre-check pass so the import path is what fails.
-    scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+    scenarios_dir = tmp_path / "rds_postgres"
     (scenarios_dir / "001-replication-lag").mkdir(parents=True)
 
     with (
-        unittest.mock.patch("app.cli.tests.discover.REPO_ROOT", tmp_path),
+        unittest.mock.patch("app.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch("builtins.__import__", side_effect=_fail_synthetic_import),
     ):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
@@ -308,11 +309,11 @@ def test_tests_synthetic_unrelated_module_not_found_propagates(tmp_path: Path) -
             raise ModuleNotFoundError("No module named 'psycopg'", name="psycopg")
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
-    scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+    scenarios_dir = tmp_path / "rds_postgres"
     (scenarios_dir / "001-replication-lag").mkdir(parents=True)
 
     with (
-        unittest.mock.patch("app.cli.tests.discover.REPO_ROOT", tmp_path),
+        unittest.mock.patch("app.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
         unittest.mock.patch("builtins.__import__", side_effect=_fail_unrelated_import),
     ):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
@@ -361,21 +362,41 @@ def test_deploy_ec2_clean_error_when_not_bundled(argv: list[str]) -> None:
     assert "Traceback" not in output
 
 
-def test_deploy_ec2_unrelated_module_not_found_propagates() -> None:
+@pytest.mark.parametrize(
+    ("argv", "patched_module"),
+    [
+        # Destroy path (--down): try/except wraps `destroy_remote` import.
+        (
+            ["deploy", "ec2", "--down"],
+            "tests.deployment.ec2.infrastructure_sdk.destroy_remote",
+        ),
+        # Deploy path (no --down): try/except wraps `deploy_remote` import,
+        # which has its own narrow-catch in deploy_ec2 — covered separately
+        # so a regression in either branch is caught independently.
+        (
+            ["deploy", "ec2"],
+            "tests.deployment.ec2.infrastructure_sdk.deploy_remote",
+        ),
+    ],
+)
+def test_deploy_ec2_unrelated_module_not_found_propagates(
+    argv: list[str], patched_module: str
+) -> None:
     """Narrow-catch contract for EC2 deploy: an unrelated transitive
     missing dep (e.g. ``boto3``) must surface as the real error, not the
-    "EC2 not bundled" suggestion."""
+    "EC2 not bundled" suggestion. Both ``deploy ec2`` and ``deploy ec2 --down``
+    have their own try/except blocks — exercise both."""
     runner = CliRunner()
 
     real_import = __import__
 
     def _fail_unrelated_import(name: str, *args: object, **kwargs: object) -> object:
-        if name == "tests.deployment.ec2.infrastructure_sdk.destroy_remote":
+        if name == patched_module:
             raise ModuleNotFoundError("No module named 'boto3'", name="boto3")
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
     with unittest.mock.patch("builtins.__import__", side_effect=_fail_unrelated_import):
-        result = runner.invoke(cli, ["deploy", "ec2", "--down"])
+        result = runner.invoke(cli, argv)
 
     output = result.output or ""
     assert "EC2 deployment is not available" not in output

--- a/tests/cli/test_cli_inventory.py
+++ b/tests/cli/test_cli_inventory.py
@@ -238,24 +238,143 @@ def test_run_catalog_items_skips_non_runnable_and_prints_message(
 # ---------------------------------------------------------------------------
 
 
-def test_tests_synthetic_surfaces_clean_error_when_suite_not_bundled() -> None:
+def test_tests_synthetic_clean_error_when_data_dir_missing(tmp_path: object) -> None:
+    """Real bundled-binary failure mode (per live PyInstaller verification):
+    the ``tests.synthetic.rds_postgres`` Python package is bundled
+    transitively but the per-scenario data directories are absent. Pre-check
+    on the data dir must surface a structured error before the import fires."""
+    runner = CliRunner()
+
+    # tmp_path has no ``tests/synthetic/rds_postgres`` subtree, so the
+    # pre-check in ``run_synthetic_suite`` short-circuits to OpenSREError.
+    with unittest.mock.patch("app.cli.tests.discover.REPO_ROOT", tmp_path):
+        result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
+
+    output = result.output or ""
+    assert result.exit_code == 1, f"unexpected exit code {result.exit_code}; output={output!r}"
+    # Pin the contractual message — these strings are user-facing and a
+    # silent rewording would be a regression for support docs / scripts.
+    assert "synthetic RDS PostgreSQL suite is not available" in output
+    assert "pip install -e ." in output
+    # No raw traceback or stdlib exception name reaches the user.
+    assert "FileNotFoundError" not in output
+    assert "ModuleNotFoundError" not in output
+    assert "Traceback" not in output
+
+
+def test_tests_synthetic_clean_error_when_module_not_bundled(tmp_path) -> None:
+    """Adjacent failure mode: the synthetic Python package is missing
+    entirely. The narrowed ``ModuleNotFoundError`` catch must convert it
+    into the same structured error."""
     runner = CliRunner()
 
     real_import = __import__
 
     def _fail_synthetic_import(name: str, *args: object, **kwargs: object) -> object:
         if name.startswith("tests.synthetic.rds_postgres"):
-            raise ModuleNotFoundError(f"No module named {name!r}")
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
-    with unittest.mock.patch("builtins.__import__", side_effect=_fail_synthetic_import):
+    # Make the data-dir pre-check pass so the import path is what fails.
+    scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+    (scenarios_dir / "001-replication-lag").mkdir(parents=True)
+
+    with (
+        unittest.mock.patch("app.cli.tests.discover.REPO_ROOT", tmp_path),
+        unittest.mock.patch("builtins.__import__", side_effect=_fail_synthetic_import),
+    ):
         result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
 
-    # OpenSREError is rendered by the CLI as a non-zero exit + a clear
-    # message; we don't want the raw ModuleNotFoundError traceback.
-    assert result.exit_code != 0
     output = result.output or ""
-    assert "synthetic" in output.lower() or "rds_postgres" in output
-    # No raw traceback or stdlib exception name reaches the user.
+    assert result.exit_code == 1, f"unexpected exit code {result.exit_code}; output={output!r}"
+    assert "synthetic RDS PostgreSQL suite is not available" in output
     assert "ModuleNotFoundError" not in output
     assert "Traceback" not in output
+
+
+def test_tests_synthetic_unrelated_module_not_found_propagates(tmp_path) -> None:
+    """Narrow-catch contract: if the synthetic suite *is* available but a
+    transitive dep (e.g. ``psycopg``) is missing, the user must see the
+    real cause — not a misleading "not bundled" message."""
+    runner = CliRunner()
+
+    real_import = __import__
+
+    def _fail_unrelated_import(name: str, *args: object, **kwargs: object) -> object:
+        # Synthetic module's run_suite fails because of a missing transitive
+        # dep (``psycopg``), not because the synthetic package is absent.
+        if name == "tests.synthetic.rds_postgres.run_suite":
+            raise ModuleNotFoundError("No module named 'psycopg'", name="psycopg")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+    (scenarios_dir / "001-replication-lag").mkdir(parents=True)
+
+    with (
+        unittest.mock.patch("app.cli.tests.discover.REPO_ROOT", tmp_path),
+        unittest.mock.patch("builtins.__import__", side_effect=_fail_unrelated_import),
+    ):
+        result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
+
+    output = result.output or ""
+    # The misleading "not bundled" message MUST NOT be shown — the user
+    # needs to see the real missing-dep cause so they can fix it.
+    assert "synthetic RDS PostgreSQL suite is not available" not in output
+
+
+# ---------------------------------------------------------------------------
+# Bundled-binary degradation for ``opensre deploy ec2`` (audit finding)
+#
+# Same class of bug as #1078: ``app/cli/commands/deploy.py:323,329`` import
+# from ``tests.deployment.ec2.infrastructure_sdk`` which is excluded from
+# PyInstaller bundles. Without a guard, ``opensre deploy ec2`` and
+# ``opensre deploy ec2 --down`` both crash with raw ModuleNotFoundError.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["deploy", "ec2"],
+        ["deploy", "ec2", "--down"],
+    ],
+)
+def test_deploy_ec2_clean_error_when_not_bundled(argv: list[str]) -> None:
+    runner = CliRunner()
+
+    real_import = __import__
+
+    def _fail_ec2_import(name: str, *args: object, **kwargs: object) -> object:
+        if name.startswith("tests.deployment.ec2"):
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    with unittest.mock.patch("builtins.__import__", side_effect=_fail_ec2_import):
+        result = runner.invoke(cli, argv)
+
+    output = result.output or ""
+    assert result.exit_code == 1, f"unexpected exit code {result.exit_code}; output={output!r}"
+    assert "EC2 deployment is not available" in output
+    assert "pip install -e ." in output
+    assert "ModuleNotFoundError" not in output
+    assert "Traceback" not in output
+
+
+def test_deploy_ec2_unrelated_module_not_found_propagates() -> None:
+    """Narrow-catch contract for EC2 deploy: an unrelated transitive
+    missing dep (e.g. ``boto3``) must surface as the real error, not the
+    "EC2 not bundled" suggestion."""
+    runner = CliRunner()
+
+    real_import = __import__
+
+    def _fail_unrelated_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "tests.deployment.ec2.infrastructure_sdk.destroy_remote":
+            raise ModuleNotFoundError("No module named 'boto3'", name="boto3")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    with unittest.mock.patch("builtins.__import__", side_effect=_fail_unrelated_import):
+        result = runner.invoke(cli, ["deploy", "ec2", "--down"])
+
+    output = result.output or ""
+    assert "EC2 deployment is not available" not in output

--- a/tests/cli/test_cli_inventory.py
+++ b/tests/cli/test_cli_inventory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest.mock
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -238,7 +239,7 @@ def test_run_catalog_items_skips_non_runnable_and_prints_message(
 # ---------------------------------------------------------------------------
 
 
-def test_tests_synthetic_clean_error_when_data_dir_missing(tmp_path: object) -> None:
+def test_tests_synthetic_clean_error_when_data_dir_missing(tmp_path: Path) -> None:
     """Real bundled-binary failure mode (per live PyInstaller verification):
     the ``tests.synthetic.rds_postgres`` Python package is bundled
     transitively but the per-scenario data directories are absent. Pre-check
@@ -262,7 +263,7 @@ def test_tests_synthetic_clean_error_when_data_dir_missing(tmp_path: object) -> 
     assert "Traceback" not in output
 
 
-def test_tests_synthetic_clean_error_when_module_not_bundled(tmp_path) -> None:
+def test_tests_synthetic_clean_error_when_module_not_bundled(tmp_path: Path) -> None:
     """Adjacent failure mode: the synthetic Python package is missing
     entirely. The narrowed ``ModuleNotFoundError`` catch must convert it
     into the same structured error."""
@@ -292,7 +293,7 @@ def test_tests_synthetic_clean_error_when_module_not_bundled(tmp_path) -> None:
     assert "Traceback" not in output
 
 
-def test_tests_synthetic_unrelated_module_not_found_propagates(tmp_path) -> None:
+def test_tests_synthetic_unrelated_module_not_found_propagates(tmp_path: Path) -> None:
     """Narrow-catch contract: if the synthetic suite *is* available but a
     transitive dep (e.g. ``psycopg``) is missing, the user must see the
     real cause — not a misleading "not bundled" message."""

--- a/tests/cli/test_cli_inventory.py
+++ b/tests/cli/test_cli_inventory.py
@@ -225,3 +225,37 @@ def test_run_catalog_items_skips_non_runnable_and_prints_message(
     captured = capsys.readouterr()
     assert "suite:empty" in captured.err
     assert "Skipping" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Bundled-binary degradation for ``opensre tests synthetic`` (regression #1078)
+#
+# ``packaging/opensre.spec`` excludes the ``tests`` tree from PyInstaller
+# bundles, so ``from tests.synthetic.rds_postgres.run_suite import main``
+# raises ``ModuleNotFoundError`` in a packaged binary. Surface a clean
+# ``OpenSREError`` instead of a raw traceback so users know to run from a
+# source checkout.
+# ---------------------------------------------------------------------------
+
+
+def test_tests_synthetic_surfaces_clean_error_when_suite_not_bundled() -> None:
+    runner = CliRunner()
+
+    real_import = __import__
+
+    def _fail_synthetic_import(name: str, *args: object, **kwargs: object) -> object:
+        if name.startswith("tests.synthetic.rds_postgres"):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    with unittest.mock.patch("builtins.__import__", side_effect=_fail_synthetic_import):
+        result = runner.invoke(cli, ["tests", "synthetic", "--scenario", "001-replication-lag"])
+
+    # OpenSREError is rendered by the CLI as a non-zero exit + a clear
+    # message; we don't want the raw ModuleNotFoundError traceback.
+    assert result.exit_code != 0
+    output = result.output or ""
+    assert "synthetic" in output.lower() or "rds_postgres" in output
+    # No raw traceback or stdlib exception name reaches the user.
+    assert "ModuleNotFoundError" not in output
+    assert "Traceback" not in output

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -61,10 +61,11 @@ def _patch_discover_paths(
     repo_root: Path | None = None,
     makefile: Path | None = None,
     rca_dir: Path | None = None,
+    synthetic_dir: Path | None = None,
 ) -> None:
     """Helper: monkeypatch any subset of the discover module's path constants.
 
-    Reduces the ``monkeypatch.setattr("app.cli.tests.discover.X", ...)`` ×3
+    Reduces the ``monkeypatch.setattr("app.cli.tests.discover.X", ...)`` ×4
     repetition that tests in ``TestDiscoverGracefulOnMissingSource`` would
     otherwise carry. Per @muddlebee's PR #952 review nit on duplicated test
     setup."""
@@ -74,6 +75,8 @@ def _patch_discover_paths(
         monkeypatch.setattr("app.cli.tests.discover.MAKEFILE_PATH", makefile)
     if rca_dir is not None:
         monkeypatch.setattr("app.cli.tests.discover.RCA_DIR", rca_dir)
+    if synthetic_dir is not None:
+        monkeypatch.setattr("app.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", synthetic_dir)
 
 
 class TestDiscoverGracefulOnMissingSource:
@@ -81,8 +84,7 @@ class TestDiscoverGracefulOnMissingSource:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The reported #1078 crash: ``iterdir()`` on a missing path."""
-        # tmp_path has no ``tests/synthetic/rds_postgres`` subtree.
-        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        _patch_discover_paths(monkeypatch, synthetic_dir=tmp_path / "missing-rds-postgres")
         assert _discover_rds_synthetic_scenarios() == []
 
     def test_make_targets_returns_empty_when_makefile_missing(
@@ -115,6 +117,7 @@ class TestDiscoverGracefulOnMissingSource:
             repo_root=empty,
             makefile=empty / "Makefile",
             rca_dir=empty / "rca",
+            synthetic_dir=empty / "rds_postgres",
         )
 
         catalog = load_test_catalog()
@@ -129,9 +132,9 @@ class TestDiscoverGracefulOnMissingSource:
         """Sanity: the existence guard must not break the source-checkout
         path. With one scenario directory on disk, the helper must still
         emit one catalog item."""
-        scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+        scenarios_dir = tmp_path / "rds_postgres"
         (scenarios_dir / "001-replication-lag").mkdir(parents=True)
-        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        _patch_discover_paths(monkeypatch, synthetic_dir=scenarios_dir)
 
         items = _discover_rds_synthetic_scenarios()
         assert len(items) == 1
@@ -142,9 +145,9 @@ class TestDiscoverGracefulOnMissingSource:
     ) -> None:
         """Edge case from gap analysis: directory exists but is empty —
         ``iterdir()`` is fine, and the function must return ``[]``."""
-        scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+        scenarios_dir = tmp_path / "rds_postgres"
         scenarios_dir.mkdir(parents=True)
-        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        _patch_discover_paths(monkeypatch, synthetic_dir=scenarios_dir)
         assert _discover_rds_synthetic_scenarios() == []
 
     def test_rds_synthetic_skips_underscore_and_pycache_entries(
@@ -153,12 +156,12 @@ class TestDiscoverGracefulOnMissingSource:
         """The existing ``startswith('_')`` filter must skip ``__pycache__``
         and any other underscore-prefixed sibling. It must also skip stray
         files at the top level (only directories become catalog items)."""
-        scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+        scenarios_dir = tmp_path / "rds_postgres"
         (scenarios_dir / "001-real-scenario").mkdir(parents=True)
         (scenarios_dir / "__pycache__").mkdir()
         (scenarios_dir / "_template").mkdir()
         (scenarios_dir / "README.md").write_text("not a scenario")
-        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        _patch_discover_paths(monkeypatch, synthetic_dir=scenarios_dir)
 
         items = _discover_rds_synthetic_scenarios()
         ids = [item.id for item in items]
@@ -169,10 +172,11 @@ class TestDiscoverGracefulOnMissingSource:
     ) -> None:
         """Happy YAML path: ``scenario.yml`` with a ``failure_mode`` field
         produces the ``"<id>  [<mode>]"`` display name."""
-        scenario = tmp_path / "tests" / "synthetic" / "rds_postgres" / "001-replication-lag"
+        scenarios_dir = tmp_path / "rds_postgres"
+        scenario = scenarios_dir / "001-replication-lag"
         scenario.mkdir(parents=True)
         (scenario / "scenario.yml").write_text("failure_mode: replication-lag\n")
-        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        _patch_discover_paths(monkeypatch, synthetic_dir=scenarios_dir)
 
         items = _discover_rds_synthetic_scenarios()
         assert len(items) == 1
@@ -183,10 +187,11 @@ class TestDiscoverGracefulOnMissingSource:
     ) -> None:
         """Defensive YAML parse: malformed ``scenario.yml`` must not crash
         discovery — fall back to the bare directory name as display name."""
-        scenario = tmp_path / "tests" / "synthetic" / "rds_postgres" / "002-broken-yaml"
+        scenarios_dir = tmp_path / "rds_postgres"
+        scenario = scenarios_dir / "002-broken-yaml"
         scenario.mkdir(parents=True)
         (scenario / "scenario.yml").write_text(":::not yaml:::\n  - [unbalanced\n")
-        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        _patch_discover_paths(monkeypatch, synthetic_dir=scenarios_dir)
 
         items = _discover_rds_synthetic_scenarios()
         assert len(items) == 1

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -55,13 +55,34 @@ def test_discover_make_targets_finds_target_at_line_one() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _patch_discover_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repo_root: Path | None = None,
+    makefile: Path | None = None,
+    rca_dir: Path | None = None,
+) -> None:
+    """Helper: monkeypatch any subset of the discover module's path constants.
+
+    Reduces the ``monkeypatch.setattr("app.cli.tests.discover.X", ...)`` ×3
+    repetition that tests in ``TestDiscoverGracefulOnMissingSource`` would
+    otherwise carry. Per @muddlebee's PR #952 review nit on duplicated test
+    setup."""
+    if repo_root is not None:
+        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", repo_root)
+    if makefile is not None:
+        monkeypatch.setattr("app.cli.tests.discover.MAKEFILE_PATH", makefile)
+    if rca_dir is not None:
+        monkeypatch.setattr("app.cli.tests.discover.RCA_DIR", rca_dir)
+
+
 class TestDiscoverGracefulOnMissingSource:
     def test_rds_synthetic_returns_empty_when_dir_missing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The reported #1078 crash: ``iterdir()`` on a missing path."""
         # tmp_path has no ``tests/synthetic/rds_postgres`` subtree.
-        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", tmp_path)
+        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
         assert _discover_rds_synthetic_scenarios() == []
 
     def test_make_targets_returns_empty_when_makefile_missing(
@@ -70,7 +91,7 @@ class TestDiscoverGracefulOnMissingSource:
         """``discover_make_targets`` was the next class-of-bug landmine —
         ``MAKEFILE_PATH.read_text()`` would also raise ``FileNotFoundError``
         in the same bundled-binary scenario."""
-        monkeypatch.setattr("app.cli.tests.discover.MAKEFILE_PATH", tmp_path / "Makefile")
+        _patch_discover_paths(monkeypatch, makefile=tmp_path / "Makefile")
         assert discover_make_targets() == []
 
     def test_rca_files_returns_empty_when_dir_missing(
@@ -79,7 +100,7 @@ class TestDiscoverGracefulOnMissingSource:
         """``Path.glob`` on a missing parent already returned an empty
         iterator on CPython, but the explicit guard documents the contract
         and protects against future stdlib churn."""
-        monkeypatch.setattr("app.cli.tests.discover.RCA_DIR", tmp_path / "rca-not-here")
+        _patch_discover_paths(monkeypatch, rca_dir=tmp_path / "rca-not-here")
         assert discover_rca_files() == []
 
     def test_load_test_catalog_does_not_crash_with_no_sources(
@@ -89,9 +110,12 @@ class TestDiscoverGracefulOnMissingSource:
         must still produce a (possibly empty) catalog and not raise."""
         empty = tmp_path / "empty"
         empty.mkdir()
-        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", empty)
-        monkeypatch.setattr("app.cli.tests.discover.MAKEFILE_PATH", empty / "Makefile")
-        monkeypatch.setattr("app.cli.tests.discover.RCA_DIR", empty / "rca")
+        _patch_discover_paths(
+            monkeypatch,
+            repo_root=empty,
+            makefile=empty / "Makefile",
+            rca_dir=empty / "rca",
+        )
 
         catalog = load_test_catalog()
         # No exception, returns an empty catalog (no make/rca/synthetic items).
@@ -107,8 +131,63 @@ class TestDiscoverGracefulOnMissingSource:
         emit one catalog item."""
         scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
         (scenarios_dir / "001-replication-lag").mkdir(parents=True)
-        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", tmp_path)
+        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
 
         items = _discover_rds_synthetic_scenarios()
         assert len(items) == 1
         assert items[0].id == "synthetic:001-replication-lag"
+
+    def test_rds_synthetic_returns_empty_when_dir_present_but_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case from gap analysis: directory exists but is empty —
+        ``iterdir()`` is fine, and the function must return ``[]``."""
+        scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+        scenarios_dir.mkdir(parents=True)
+        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+        assert _discover_rds_synthetic_scenarios() == []
+
+    def test_rds_synthetic_skips_underscore_and_pycache_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The existing ``startswith('_')`` filter must skip ``__pycache__``
+        and any other underscore-prefixed sibling. It must also skip stray
+        files at the top level (only directories become catalog items)."""
+        scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+        (scenarios_dir / "001-real-scenario").mkdir(parents=True)
+        (scenarios_dir / "__pycache__").mkdir()
+        (scenarios_dir / "_template").mkdir()
+        (scenarios_dir / "README.md").write_text("not a scenario")
+        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+
+        items = _discover_rds_synthetic_scenarios()
+        ids = [item.id for item in items]
+        assert ids == ["synthetic:001-real-scenario"]
+
+    def test_rds_synthetic_enriches_display_name_from_scenario_yml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Happy YAML path: ``scenario.yml`` with a ``failure_mode`` field
+        produces the ``"<id>  [<mode>]"`` display name."""
+        scenario = tmp_path / "tests" / "synthetic" / "rds_postgres" / "001-replication-lag"
+        scenario.mkdir(parents=True)
+        (scenario / "scenario.yml").write_text("failure_mode: replication-lag\n")
+        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+
+        items = _discover_rds_synthetic_scenarios()
+        assert len(items) == 1
+        assert items[0].display_name == "001-replication-lag  [replication-lag]"
+
+    def test_rds_synthetic_tolerates_malformed_scenario_yml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defensive YAML parse: malformed ``scenario.yml`` must not crash
+        discovery — fall back to the bare directory name as display name."""
+        scenario = tmp_path / "tests" / "synthetic" / "rds_postgres" / "002-broken-yaml"
+        scenario.mkdir(parents=True)
+        (scenario / "scenario.yml").write_text(":::not yaml:::\n  - [unbalanced\n")
+        _patch_discover_paths(monkeypatch, repo_root=tmp_path)
+
+        items = _discover_rds_synthetic_scenarios()
+        assert len(items) == 1
+        assert items[0].display_name == "002-broken-yaml"

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import unittest.mock
+from pathlib import Path
 
-from app.cli.tests.discover import discover_make_targets, load_test_catalog
+import pytest
+
+from app.cli.tests.discover import (
+    _discover_rds_synthetic_scenarios,
+    discover_make_targets,
+    discover_rca_files,
+    load_test_catalog,
+)
 
 
 def test_load_test_catalog_includes_make_targets_and_rca_fixtures() -> None:
@@ -33,3 +41,74 @@ def test_discover_make_targets_finds_target_at_line_one() -> None:
 
     ids = [item.id for item in items]
     assert "make:test-cov" in ids
+
+
+# ---------------------------------------------------------------------------
+# Bundled-binary degradation (regression for #1078)
+#
+# ``packaging/opensre.spec`` collects only ``app/`` data files, so at runtime
+# in a PyInstaller-bundled ``opensre`` binary the ``tests/`` tree, ``Makefile``,
+# and ``tests/e2e/rca`` directory are absent. Each ``discover_*`` helper must
+# return cleanly so ``opensre tests`` and ``opensre tests list`` keep working
+# against whatever data files *are* bundled, instead of crashing with
+# ``FileNotFoundError`` from a raw ``iterdir()`` / ``read_text()`` call.
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverGracefulOnMissingSource:
+    def test_rds_synthetic_returns_empty_when_dir_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reported #1078 crash: ``iterdir()`` on a missing path."""
+        # tmp_path has no ``tests/synthetic/rds_postgres`` subtree.
+        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", tmp_path)
+        assert _discover_rds_synthetic_scenarios() == []
+
+    def test_make_targets_returns_empty_when_makefile_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``discover_make_targets`` was the next class-of-bug landmine —
+        ``MAKEFILE_PATH.read_text()`` would also raise ``FileNotFoundError``
+        in the same bundled-binary scenario."""
+        monkeypatch.setattr("app.cli.tests.discover.MAKEFILE_PATH", tmp_path / "Makefile")
+        assert discover_make_targets() == []
+
+    def test_rca_files_returns_empty_when_dir_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``Path.glob`` on a missing parent already returned an empty
+        iterator on CPython, but the explicit guard documents the contract
+        and protects against future stdlib churn."""
+        monkeypatch.setattr("app.cli.tests.discover.RCA_DIR", tmp_path / "rca-not-here")
+        assert discover_rca_files() == []
+
+    def test_load_test_catalog_does_not_crash_with_no_sources(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full-degradation contract: bundled binary with *no* data files
+        must still produce a (possibly empty) catalog and not raise."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", empty)
+        monkeypatch.setattr("app.cli.tests.discover.MAKEFILE_PATH", empty / "Makefile")
+        monkeypatch.setattr("app.cli.tests.discover.RCA_DIR", empty / "rca")
+
+        catalog = load_test_catalog()
+        # No exception, returns an empty catalog (no make/rca/synthetic items).
+        assert catalog.find("make:test-cov") is None
+        assert catalog.find("rca:pipeline_error_in_logs") is None
+        assert all(not item.id.startswith("synthetic:") for item in catalog.all_items())
+
+    def test_rds_synthetic_still_discovers_when_dir_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sanity: the existence guard must not break the source-checkout
+        path. With one scenario directory on disk, the helper must still
+        emit one catalog item."""
+        scenarios_dir = tmp_path / "tests" / "synthetic" / "rds_postgres"
+        (scenarios_dir / "001-replication-lag").mkdir(parents=True)
+        monkeypatch.setattr("app.cli.tests.discover.REPO_ROOT", tmp_path)
+
+        items = _discover_rds_synthetic_scenarios()
+        assert len(items) == 1
+        assert items[0].id == "synthetic:001-replication-lag"


### PR DESCRIPTION
Closes #1078.

## Summary

`opensre tests` and `opensre tests list` crash with `FileNotFoundError` when run from the PyInstaller-bundled binary (the released binary, not source-checkout runs). The reported crash is one of three of the same class — fixed all three.

## Root cause

[`packaging/opensre.spec`](packaging/opensre.spec) only collects `app/` data files (`collect_data_files("app")`) and explicitly filters `tests` out of the submodule list (`_is_runtime_submodule`). At runtime the bundled temp extraction path therefore has no `tests/synthetic/rds_postgres/`, no `tests/e2e/rca/`, and no `Makefile`. Three call sites in the test-discovery code path read directly from those paths without an existence guard:

| Location | Operation that crashes | Crash in bundled binary? |
|---|---|---|
| `_discover_rds_synthetic_scenarios` | `scenarios_dir.iterdir()` | ✅ **the reported #1078 crash** |
| `discover_make_targets` | `MAKEFILE_PATH.read_text()` | ✅ identical class of bug |
| `run_synthetic_suite` | `from tests.synthetic.rds_postgres.run_suite import …` | ✅ `ModuleNotFoundError` traceback |
| `discover_rca_files` | `RCA_DIR.glob("*.md")` | ❌ safe today (`Path.glob` returns empty), guard added for documentation + forward compatibility |

The reported crash was introduced by [`9a1b5c3d` _"add synthetic RDS postgres RCA suite (#194)"_](https://github.com/Tracer-Cloud/opensre/commit/9a1b5c3d) on 2026-04-01 (answers @muddlebee's regression-commit question).

## Fix

```python
# app/cli/tests/discover.py
def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
    scenarios_dir = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
    items: list[TestCatalogItem] = []
    if not scenarios_dir.is_dir():
        return items   # PyInstaller bundle has no tests/ tree
    ...

def discover_make_targets() -> list[TestCatalogItem]:
    if not MAKEFILE_PATH.is_file():
        return []   # PyInstaller bundle has no Makefile
    ...

def discover_rca_files() -> list[TestCatalogItem]:
    if not RCA_DIR.is_dir():
        return items   # explicit guard, currently a no-op on CPython
    ...
```

```python
# app/cli/commands/tests.py
def run_synthetic_suite(...):
    try:
        from tests.synthetic.rds_postgres.run_suite import main as run_suite_main
    except ModuleNotFoundError as exc:
        raise OpenSREError(
            "The synthetic RDS PostgreSQL suite is not available in this build.",
            suggestion="Run from a source checkout (clone the repo) — synthetic scenarios are not bundled.",
        ) from exc
    ...
```

`is_dir()` / `is_file()` return `False` on a missing path without raising, so they're cleaner than `exists()` followed by a separate type check.

## Test coverage

**`tests/cli/test_discover.py` (+5 tests, all in a new `TestDiscoverGracefulOnMissingSource` class):**
- `test_rds_synthetic_returns_empty_when_dir_missing` — the literal reported crash
- `test_make_targets_returns_empty_when_makefile_missing` — same-class regression
- `test_rca_files_returns_empty_when_dir_missing` — covers the explicit guard
- `test_load_test_catalog_does_not_crash_with_no_sources` — full degradation contract
- `test_rds_synthetic_still_discovers_when_dir_present` — sanity that the guard doesn't break the source-checkout path

**`tests/cli/test_cli_inventory.py` (+1 test):**
- `test_tests_synthetic_surfaces_clean_error_when_suite_not_bundled` — patches `builtins.__import__` to deny `tests.synthetic.*`, asserts the CLI exits non-zero with a clean message and no `Traceback` / `ModuleNotFoundError` reaches the user

## Live e2e verification

Wrote a probe that monkeypatches `REPO_ROOT`, `MAKEFILE_PATH`, and `RCA_DIR` to an empty tmp dir (the exact same file layout PyInstaller produces — no `tests/`, no `Makefile`, no `tests/e2e/rca`) and invokes the real Click CLI in-process. **17 / 17 live checks pass:**

| | Baseline (source tree) | Bundled-binary sim (empty REPO_ROOT) |
|---|---|---|
| `opensre tests list` | exit 0, full catalog | exit 0, empty output |
| `opensre --json tests list` | valid JSON, full catalog | valid JSON, empty `[]` |
| `opensre tests list --category synthetic` | finds `synthetic:001-replication-lag` | exit 0, empty (degraded) |
| `opensre tests synthetic --scenario X` | runs the suite | exits non-zero with `OpenSREError` and actionable suggestion — no `ModuleNotFoundError` / `Traceback` leaks |
| `load_test_catalog()` direct call | populated catalog | empty catalog, no exception |

User-facing degraded message:
```
Error: The synthetic RDS PostgreSQL suite is not available in this build.

Suggestion: Run 'opensre tests synthetic' from a source checkout
(clone https://github.com/Tracer-Cloud/opensre) — the synthetic
scenarios under 'tests/synthetic/rds_postgres/' are not bundled
into the released binary.
```

## Verification — final state

- `pytest tests/cli/test_discover.py tests/cli/test_cli_inventory.py`: **25 / 25 pass** (3 pre-existing + 22 including new)
- Full unit suite: **4151 pass / 2 skipped / 1 xfailed** (no regressions)
- `ruff check app/ tests/`: clean
- `ruff format --check app/ tests/`: clean
- `mypy app/cli/tests/ app/cli/commands/`: clean on the touched modules; the 3 errors mypy reports are pre-existing missing-stub warnings for `pymysql` in `app/integrations/` — unrelated to this PR

## Scope

| File | Change |
|---|---|
| `app/cli/tests/discover.py` | +14 / -1 (3 existence guards + docstring update) |
| `app/cli/commands/tests.py` | +14 / -1 (try/except around the synthetic-suite import) |
| `tests/cli/test_discover.py` | +85 / -1 (5 new regression tests) |
| `tests/cli/test_cli_inventory.py` | +39 / -0 (1 new bundled-binary CLI test) |

No public API changes. No state-shape changes. No behaviour change for source-checkout users — the existing source-tree happy path is verified by both the existing test `test_load_test_catalog_includes_make_targets_and_rca_fixtures` and the new sanity test `test_rds_synthetic_still_discovers_when_dir_present`.