### PR TITLE
fix(cli): guard rds_postgres path before iterdir() to prevent FileNotFoundError (#1078)

### DIFF
--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -300,6 +300,8 @@ def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
     """One catalog item per RDS synthetic scenario directory."""
     scenarios_dir = REPO_ROOT / "tests" / "synthetic" / "rds_postgres"
     items: list[TestCatalogItem] = []
+    if not scenarios_dir.is_dir():
+        return items
     req = TestRequirement(env_vars=("ANTHROPIC_API_KEY",))
     for scenario_dir in sorted(scenarios_dir.iterdir()):
         if not scenario_dir.is_dir() or scenario_dir.name.startswith("_"):


### PR DESCRIPTION
## Summary

Fixes #1078

Adds an existence guard in `_discover_rds_synthetic_scenarios` before calling `.iterdir()` on the `tests/synthetic/rds_postgres` directory.

## Problem

When the CLI binary is packaged with PyInstaller, `tests/synthetic/rds_postgres` is not bundled into the temporary extraction path. Calling `sorted(scenarios_dir.iterdir())` on a non-existent directory raises:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../tests/synthetic/rds_postgres'
```

This crashes `opensre tests` entirely.

## Fix

```python
if not scenarios_dir.is_dir():
    return items
```

Added a two-line guard right after the path is constructed. If the directory is absent (packaged binary without bundled scenarios, or a dev environment that has not seeded it), the function returns an empty list gracefully instead of crashing. All existing behavior when the directory exists is unchanged.
