### PR TITLE
docs(tests): fix misleading FileNotFoundError message in AGENTS.md example (#861)

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -10,7 +10,10 @@
 # use_case.py - Pure business logic, no test infrastructure
 def extract_and_validate(input_path: str) -> str:
     if not os.path.exists(input_path):
-        raise FileNotFoundError(f"empty file not present: {input_path}")
+        raise FileNotFoundError(
+            f"input file not found at path {input_path!r} — "
+            "ensure the file exists locally before calling extract_and_validate()"
+        )
     return data
 
 # test_orchestrator.py - All test orchestration separate


### PR DESCRIPTION
## Summary

Fixes #861

The `FileNotFoundError` example in `tests/AGENTS.md` had an inaccurate message: `"empty file not present: {input_path}"`. The word "empty" is misleading — the error is raised because the file is **missing**, not because it is empty.

## Change

Updated the error message to:

```python
raise FileNotFoundError(
    f"input file not found at path {input_path!r} — "
    "ensure the file exists locally before calling extract_and_validate()"
)
```

This accurately describes:
- **What went wrong** — the file was not found at the given path
- **Why it happens** — the file must exist locally (e.g. pre-downloaded from S3) before calling the function
- **`!r` repr formatting** — makes the path unambiguous in error messages (handles spaces and unusual characters)

No logic changes — documentation / example fix only.
