### PR TITLE
fix(root-cause): recognize healthy observability evidence

### DIFF
--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -25,6 +25,11 @@ INVESTIGATED_EVIDENCE_KEYS = frozenset(
         "datadog_logs",
         "datadog_monitors",
         "betterstack_logs",
+        "honeycomb_traces",
+        "coralogix_logs",
+        "coralogix_error_logs",
+        "alertmanager_alerts",
+        "alertmanager_silences",
         # Kubernetes / EKS evidence keys — written by the _map_eks_* mappers in
         # app/nodes/investigate/processing/post_process.py.  Without these, a pure
         # Kubernetes healthy investigation never satisfies the evidence gate below

--- a/app/nodes/root_cause_diagnosis/evidence_checker.py
+++ b/app/nodes/root_cause_diagnosis/evidence_checker.py
@@ -92,10 +92,6 @@ CLAIM_EVIDENCE_KEYS = INVESTIGATED_EVIDENCE_KEYS | frozenset(
         "datadog_error_logs",
         "datadog_events",
         "datadog_failed_pods",
-        # Other observability stacks
-        "honeycomb_traces",
-        "coralogix_logs",
-        "coralogix_error_logs",
         # Diagnostic code sandbox
         "diagnostic_executions",
         # Vercel
@@ -111,9 +107,7 @@ CLAIM_EVIDENCE_KEYS = INVESTIGATED_EVIDENCE_KEYS | frozenset(
         "github_commits",
         "git_deploy_timeline",
         # Alertmanager
-        "alertmanager_alerts",
         "alertmanager_firing_alerts",
-        "alertmanager_silences",
         "alertmanager_active_silences",
         # EKS adjacent
         "eks_failing_pods",

--- a/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
+++ b/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
@@ -144,6 +144,12 @@ class TestIsClearlyHealthyRejectsUnhealthyStates:
         evidence = {"eks_pods": [{"name": "x"}]}
         assert is_clearly_healthy(alert, evidence) is False
 
+    def test_critical_severity_with_new_observability_key_returns_false(self) -> None:
+        alert = _healthy_alert()
+        alert["commonLabels"] = {"severity": "critical"}
+        evidence = {"alertmanager_alerts": []}
+        assert is_clearly_healthy(alert, evidence) is False
+
     def test_error_annotation_returns_false(self) -> None:
         alert = _healthy_alert()
         alert["commonAnnotations"] = {"error": "something went wrong"}

--- a/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
+++ b/tests/nodes/root_cause_diagnosis/test_evidence_checker.py
@@ -106,6 +106,26 @@ class TestIsClearlyHealthyExistingSources:
         assert is_clearly_healthy(_healthy_alert(), evidence) is True
 
 
+class TestIsClearlyHealthyMissingObservabilitySources:
+    """Healthy states from shipped observability integrations must also fast-path."""
+
+    @pytest.mark.parametrize(
+        "evidence_key",
+        [
+            "alertmanager_alerts",
+            "alertmanager_silences",
+            "coralogix_logs",
+            "coralogix_error_logs",
+            "honeycomb_traces",
+        ],
+    )
+    def test_single_missing_observability_key_triggers_short_circuit(
+        self, evidence_key: str
+    ) -> None:
+        evidence = {evidence_key: []}
+        assert is_clearly_healthy(_healthy_alert(), evidence) is True
+
+
 class TestIsClearlyHealthyRejectsUnhealthyStates:
     """Every gate condition must still reject non-healthy alerts."""
 


### PR DESCRIPTION
Fixes #670

#### Describe the changes you have made in this PR -
- add `alertmanager_alerts`, `alertmanager_silences`, `coralogix_logs`, `coralogix_error_logs`, and `honeycomb_traces` to `INVESTIGATED_EVIDENCE_KEYS`
- add regression coverage proving these shipped observability sources now satisfy `is_clearly_healthy()` when a resolved low-severity alert has empty-but-present investigation results
- add a safety regression showing critical severity still does not short-circuit with the new keys present

### Demo/Screenshot for feature changes and bug fixes -
Terminal proof:

```text
Before the fix, the new regression tests failed for all five keys because
is_clearly_healthy(...) returned False.

After the fix:
- tests/nodes/root_cause_diagnosis/test_evidence_checker.py: 32 passed
- tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py: 162 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
`is_clearly_healthy()` uses `INVESTIGATED_EVIDENCE_KEYS` as the gate for “a healthy investigation really happened”. The bug was that Alertmanager, Coralogix, and Honeycomb outputs were already written into evidence by the investigation merge step, but those five primary evidence keys were missing from that gate. As a result, pure healthy investigations from those sources could miss the deterministic healthy short-circuit even when the source had been queried successfully.

I kept the fix intentionally small rather than switching the gate to `CLAIM_EVIDENCE_KEYS`, because `CLAIM_EVIDENCE_KEYS` is broader and includes adjacent data that should not automatically count as proof that a healthy investigation was completed. Adding the five missing primary evidence keys preserves the existing design: empty-but-present investigation results still count as “we checked and found nothing bad”, while severity and annotation safeguards remain unchanged.

Validation I ran locally:
- `.venv/bin/python -m pytest tests/nodes/root_cause_diagnosis/test_evidence_checker.py -vv`
- `.venv/bin/python -m pytest tests/nodes/root_cause_diagnosis/test_healthy_short_circuit.py -vv`
- `make lint`
- `make format-check`
- `make typecheck`

Note: `make test-cov` on the latest upstream main currently hits one unrelated suite-order failure in `tests/services/test_honeycomb_client.py::test_create_query_success` due extra PostHog calls; that test passes in isolation and is outside this PR’s scope.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---