### PR TITLE
fix(extract): prevent health checks with state=normal from being marked as noise

### DIFF
--- a/app/nodes/extract_alert/extract.py
+++ b/app/nodes/extract_alert/extract.py
@@ -54,7 +54,7 @@ def extract_alert_details(state: InvestigationState) -> AlertDetails:
     prompt = f"""Classify and extract fields from this alert message.
 
 is_noise=true ONLY for: casual chat, greetings, trivial messages ("ok", "thanks"), or replies to existing investigation reports.
-is_noise=false (default) for: any alert, error, failure, incident, warning, monitoring notification (including health checks and informational states).
+is_noise=false (default) for: any alert, error, failure, incident, warning, monitoring notification (including health checks and informational states). A payload with state=normal, a scheduled health check, or a summary saying "no errors found" is still a monitoring event and must not be treated as noise.
 When in doubt, set is_noise=false.
 
 Extract these fields from the message text:


### PR DESCRIPTION
## What and why

Closes #655.

The `is_noise` classifier in `extract_alert_details` was silently dropping scheduled health checks and normal-state payloads. The prompt already said health checks are not noise, but the wording was not strong enough. The LLM would see `state: normal` or a summary like "Periodic health check passed. All Kubernetes signals within normal operating bounds." and override the rule anyway.

This PR adds one clarifying sentence to the `is_noise=false` rule to name the exact patterns that were being misclassified.

## Change

One sentence added to the prompt in `app/nodes/extract_alert/extract.py` (line 57).

Before:
> is_noise=false (default) for: any alert, error, failure, incident, warning, monitoring notification (including health checks and informational states).

After:
> is_noise=false (default) for: any alert, error, failure, incident, warning, monitoring notification (including health checks and informational states). A payload with state=normal, a scheduled health check, or a summary saying "no errors found" is still a monitoring event and must not be treated as noise.

No logic, schema, or import changes.

## Proof

Tested against all 29 synthetic alert fixtures in `tests/synthetic/` using the Groq API (llama-3.3-70b-versatile, temp=0, same prompt template as production).

| Alert | Before | After |
|---|---|---|
| eks/000-healthy (state=normal health check) | is_noise=True (wrong) | is_noise=False (correct) |
| All other 28 alerts | is_noise=False (correct) | is_noise=False (correct) |

Result: 28/29 to 29/29. Zero regressions.

<details>
<summary>Full run output (29 alerts, new prompt)</summary>

```
Running all 29 synthetic alerts through the NEW prompt...

  ok     is_noise=False  eks/000-healthy
  ok     is_noise=False  eks/001-oomkilled-crashloop
  ok     is_noise=False  eks/002-image-pull-backoff
  ok     is_noise=False  eks/003-pending-insufficient-resources
  ok     is_noise=False  eks/004-liveness-probe-killing
  ok     is_noise=False  eks/005-resource-quota-exceeded
  ok     is_noise=False  eks/006-dns-resolution-failure
  ok     is_noise=False  eks/007-node-not-ready
  ok     is_noise=False  eks/008-deployment-rollout-stuck
  ok     is_noise=False  eks/009-noisy-healthy-restart-recovered
  ok     is_noise=False  eks/010-red-herring-old-rollout
  ok     is_noise=False  eks/011-recovered-rollout
  ok     is_noise=False  eks/012-pending-recovered
  ok     is_noise=False  eks/013-spurious-alert-storm
  ok     is_noise=False  rds_postgres/000-healthy
  ok     is_noise=False  rds_postgres/001-replication-lag
  ok     is_noise=False  rds_postgres/002-connection-exhaustion
  ok     is_noise=False  rds_postgres/003-storage-full
  ok     is_noise=False  rds_postgres/004-cpu-saturation-bad-query
  ok     is_noise=False  rds_postgres/005-failover
  ok     is_noise=False  rds_postgres/006-replication-lag-cpu-redherring
  ok     is_noise=False  rds_postgres/007-connection-pressure-noisy-healthy
  ok     is_noise=False  rds_postgres/008-storage-full-missing-metric
  ok     is_noise=False  rds_postgres/009-dual-fault-connection-cpu
  ok     is_noise=False  rds_postgres/010-replication-lag-missing-metric
  ok     is_noise=False  rds_postgres/011-cpu-storage-compositional
  ok     is_noise=False  rds_postgres/012-replication-lag-misleading-events
  ok     is_noise=False  rds_postgres/013-storage-recovery-false-alert
  ok     is_noise=False  rds_postgres/014-checkpoint-storm-cpu-saturation

Result: 29/29 correct
Zero regressions.
```

</details>

## Quality gates

- `ruff check app/nodes/extract_alert/extract.py`: all checks passed
- `mypy app/nodes/extract_alert/extract.py`: no issues found