### PR TITLE
ci(github): split default CI and label-triggered optional checks

### DIFF
--- a/.github/workflows/ci-labels.yml
+++ b/.github/workflows/ci-labels.yml
@@ -1,0 +1,157 @@
+name: CI Labels
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-labels-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-quality:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:windows')
+    name: windows quality
+    runs-on: windows-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Lint
+        run: python -m ruff check app/ tests/
+
+      - name: Format check
+        run: python -m ruff format --check app/ tests/
+
+  windows-typecheck:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:windows')
+    name: windows typecheck
+    needs: [windows-quality]
+    runs-on: windows-latest
+    timeout-minutes: 20
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Typecheck
+        run: python -m mypy app/
+
+  windows-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:windows')
+    name: windows test
+    needs: [windows-quality, windows-typecheck]
+    runs-on: windows-latest
+    timeout-minutes: 25
+    continue-on-error: true
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      JWT_TOKEN: ${{ secrets.JWT_TOKEN }}
+      TRACER_ORG_ID: ${{ secrets.TRACER_ORG_ID }}
+      TRACER_WEB_APP_URL: ${{ secrets.TRACER_WEB_APP_URL }}
+      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+      LANGSMITH_ENDPOINT: ${{ secrets.LANGSMITH_ENDPOINT }}
+      LANGSMITH_PROJECT: ${{ secrets.LANGSMITH_PROJECT }}
+      LANGSMITH_TRACING: ${{ secrets.LANGSMITH_TRACING }}
+      GRAFANA_READ_TOKEN: ${{ secrets.GRAFANA_READ_TOKEN }}
+      GCLOUD_HOSTED_METRICS_ID: ${{ secrets.GCLOUD_HOSTED_METRICS_ID }}
+      GCLOUD_HOSTED_METRICS_URL: ${{ secrets.GCLOUD_HOSTED_METRICS_URL }}
+      GCLOUD_HOSTED_LOGS_ID: ${{ secrets.GCLOUD_HOSTED_LOGS_ID }}
+      GCLOUD_HOSTED_LOGS_URL: ${{ secrets.GCLOUD_HOSTED_LOGS_URL }}
+      GCLOUD_RW_API_KEY: ${{ secrets.GCLOUD_RW_API_KEY }}
+      GCLOUD_OTLP_ENDPOINT: ${{ secrets.GCLOUD_OTLP_ENDPOINT }}
+      GCLOUD_OTLP_AUTH_HEADER: ${{ secrets.GCLOUD_OTLP_AUTH_HEADER }}
+      PYTHONUTF8: "1"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Run full tests
+        run: >-
+          python -m pytest -n auto -v
+          --cov=app
+          --cov-report=term-missing
+          --cov-report=html
+          --ignore=tests/e2e/kubernetes_local_alert_simulation
+          --ignore=tests/synthetic
+          -m "not synthetic and not integration"
+
+  k8s-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:k8s')
+    name: k8s label test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Run Kubernetes tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: python -m tests.e2e.kubernetes.test_local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,13 @@ on:
 
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "app/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "pytest.ini"
+      - "Makefile"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
@@ -25,38 +31,20 @@ concurrency:
   cancel-in-progress: true
 
 # ---------------------------------------------------------------
-# MATRIX: Ubuntu only by default (push and PR). Windows runs only when a PR has
-# label `ci:windows`; add/remove that label (pull_request labeled/unlabeled) to re-run CI.
-# Kubernetes local tests: push to main, PR title contains k8s/kubernetes, or label `ci:k8s`.
+# MATRIX: Ubuntu-only default matrix for push and pull_request in this workflow.
+# Optional label-driven checks (windows + ci:k8s) run in `.github/workflows/ci-labels.yml`.
+# Kubernetes local tests here run on push to main or PR titles containing k8s/kubernetes.
 # ---------------------------------------------------------------
 jobs:
-  matrix-prep:
-    runs-on: ubuntu-latest
-    outputs:
-      os_json: ${{ steps.set.outputs.os_json }}
-    steps:
-      - id: set
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
-            case ",${labels}," in
-              *,ci:windows,*) echo 'os_json=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT" ;;
-              *) echo 'os_json=["ubuntu-latest"]' >> "$GITHUB_OUTPUT" ;;
-            esac
-          else
-            echo 'os_json=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
-          fi
-
 # ---------------------------------------------------------------
 # QUALITY CHECKS (lint + format)
 # ---------------------------------------------------------------
   quality:
     name: quality (${{ matrix.os }})
-    needs: [matrix-prep]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(needs.matrix-prep.outputs.os_json) }}
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -90,11 +78,10 @@ jobs:
 # ---------------------------------------------------------------
   typecheck:
     name: typecheck (${{ matrix.os }})
-    needs: [matrix-prep]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(needs.matrix-prep.outputs.os_json) }}
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -125,12 +112,12 @@ jobs:
 # ---------------------------------------------------------------
   test:
     name: test (${{ matrix.os }})
-    needs: [matrix-prep, quality, typecheck]
+    needs: [quality, typecheck]
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(needs.matrix-prep.outputs.os_json) }}
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
@@ -215,8 +202,7 @@ jobs:
         github.event_name == 'pull_request' &&
         (
           contains(github.event.pull_request.title, 'k8s') ||
-          contains(github.event.pull_request.title, 'kubernetes') ||
-          contains(github.event.pull_request.labels.*.name, 'ci:k8s')
+          contains(github.event.pull_request.title, 'kubernetes')
         )
       )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+# PR: no paths filter so `labeled` / `unlabeled` (e.g. ci:windows) still trigger runs.
+# Push to main stays path-filtered to avoid noise.
 on:
   push:
     branches: [main]
@@ -13,13 +15,7 @@ on:
 
   pull_request:
     branches: [main]
-    paths:
-      - "app/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - "pytest.ini"
-      - "Makefile"
-      - ".github/workflows/ci.yml"
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -29,15 +25,40 @@ concurrency:
   cancel-in-progress: true
 
 # ---------------------------------------------------------------
-# QUALITY CHECKS (lint + format)
+# MATRIX: Windows on push to main, or on PR when label `ci:windows` is present.
+# Re-run the PR checks after adding/removing that label (pull_request labeled).
+# Kubernetes local tests: push to main, PR title contains k8s/kubernetes, or label `ci:k8s`.
 # ---------------------------------------------------------------
 jobs:
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      os_json: ${{ steps.set.outputs.os_json }}
+    steps:
+      - id: set
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo 'os_json=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
+            case ",${labels}," in
+              *,ci:windows,*) echo 'os_json=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT" ;;
+              *) echo 'os_json=["ubuntu-latest"]' >> "$GITHUB_OUTPUT" ;;
+            esac
+          else
+            echo 'os_json=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+
+# ---------------------------------------------------------------
+# QUALITY CHECKS (lint + format)
+# ---------------------------------------------------------------
   quality:
     name: quality (${{ matrix.os }})
+    needs: [matrix-prep]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: ${{ fromJSON(needs.matrix-prep.outputs.os_json) }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -71,10 +92,11 @@ jobs:
 # ---------------------------------------------------------------
   typecheck:
     name: typecheck (${{ matrix.os }})
+    needs: [matrix-prep]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: ${{ fromJSON(needs.matrix-prep.outputs.os_json) }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -105,12 +127,12 @@ jobs:
 # ---------------------------------------------------------------
   test:
     name: test (${{ matrix.os }})
-    needs: [quality, typecheck]
+    needs: [matrix-prep, quality, typecheck]
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest","windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: ${{ fromJSON(needs.matrix-prep.outputs.os_json) }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
@@ -191,8 +213,14 @@ jobs:
 
     if: >-
       github.event_name == 'push' ||
-      contains(github.event.pull_request.title, 'k8s') ||
-      contains(github.event.pull_request.title, 'kubernetes')
+      (
+        github.event_name == 'pull_request' &&
+        (
+          contains(github.event.pull_request.title, 'k8s') ||
+          contains(github.event.pull_request.title, 'kubernetes') ||
+          contains(github.event.pull_request.labels.*.name, 'ci:k8s')
+        )
+      )
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ concurrency:
   cancel-in-progress: true
 
 # ---------------------------------------------------------------
-# MATRIX: Windows on push to main, or on PR when label `ci:windows` is present.
-# Re-run the PR checks after adding/removing that label (pull_request labeled).
+# MATRIX: Ubuntu only by default (push and PR). Windows runs only when a PR has
+# label `ci:windows`; add/remove that label (pull_request labeled/unlabeled) to re-run CI.
 # Kubernetes local tests: push to main, PR title contains k8s/kubernetes, or label `ci:k8s`.
 # ---------------------------------------------------------------
 jobs:
@@ -37,9 +37,7 @@ jobs:
     steps:
       - id: set
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo 'os_json=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
             case ",${labels}," in
               *,ci:windows,*) echo 'os_json=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT" ;;


### PR DESCRIPTION
## Trigger flow for reviewers
1. Open PR as usual: default CI runs only when relevant code paths change.
2. Add `ci:windows` label: `CI Labels` workflow runs Windows jobs.
3. Add `ci:k8s` label: `CI Labels` workflow runs k8s job.
4. Remove labels when done; `unlabeled` events re-evaluate optional jobs.
