### PR TITLE
test(cli): skip install.sh tests on Windows runner (#1099)

### DIFF
--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -3,8 +3,28 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
+
+import pytest
+
+# install.sh is a POSIX shell script that exercises zsh/bash/fish rc-file
+# behaviour, and these tests drive it via ``subprocess.run(["bash", "-c", ...])``.
+# On the GitHub Actions ``windows-latest`` runner, ``bash`` is resolved to
+# ``wsl.exe`` and the runner has no installed WSL distribution — every
+# ``_run`` call exits 1 with a "Windows Subsystem for Linux has no installed
+# distributions" message and none of the asserted rc files get written.
+# Skip the whole module rather than chase a Windows analogue for a Unix-only
+# installer script.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "install.sh is POSIX-only; the Windows runner has no usable bash "
+        "(resolves to unconfigured WSL), so this module's subprocess-driven "
+        "tests cannot run there. See issue #1099."
+    ),
+)
 
 INSTALL_SH = Path(__file__).parents[2] / "install.sh"
 _LOCAL_BIN = ".local/bin"

--- a/tests/cli/test_install_sh_resolution.py
+++ b/tests/cli/test_install_sh_resolution.py
@@ -4,10 +4,30 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+
+# Same Windows-skip rationale as ``test_install_sh_path.py`` — install.sh is
+# POSIX-only and the GitHub Actions ``windows-latest`` runner has no usable
+# bash. See issue #1099.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "install.sh is POSIX-only; the Windows runner has no usable bash "
+        "(resolves to unconfigured WSL), so this module's subprocess-driven "
+        "tests cannot run there. See issue #1099."
+    ),
+)
+
+# ``os.geteuid`` does not exist on Windows. The skipif decorator below is
+# evaluated at decorator-application time (i.e. module import), so a bare
+# ``os.geteuid() == 0`` check would raise ``AttributeError`` on Windows
+# *before* ``pytestmark`` ever takes effect. ``hasattr`` short-circuits the
+# ``and`` so the ``os.geteuid()`` call only runs on platforms that have it.
+_RUNNING_AS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
 
 INSTALL_SH = Path(__file__).parents[2] / "install.sh"
 
@@ -62,7 +82,7 @@ def test_prefers_writable_user_path_dir(tmp_path: Path) -> None:
     assert "INSTALL_WITH_SUDO=0" in result.stdout
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="sudo fallback is only meaningful for non-root users")
+@pytest.mark.skipif(_RUNNING_AS_ROOT, reason="sudo fallback is only meaningful for non-root users")
 def test_uses_sudo_for_non_writable_system_path_dir(tmp_path: Path) -> None:
     system_bin = tmp_path / "system-bin"
     system_bin.mkdir()


### PR DESCRIPTION
Closes #1099.

## Root cause

The post-merge `test (windows-latest)` job on `67dc64d1` (the merge of #1090) is failing with **two distinct symptoms** in the `install.sh` test suite added by #1064:

### 1. `tests/cli/test_install_sh_path.py` — 12 failures

The helper `_run` calls `subprocess.run(["bash", "-c", script])`. On the GitHub Actions `windows-latest` runner, `bash` resolves to `wsl.exe`, and that runner has no installed WSL distribution. Every `_run` exits with code 1 and the literal message:

> `Windows Subsystem for Linux has no installed distributions.`
> `You can resolve this by installing a distribution with the instructions below`

So none of the asserted rc files (`.zshrc`, `.bashrc`, `config.fish`) ever get written, and assertions like `assert zshrc.exists()` and `assert result.returncode == 0` fail.

### 2. `tests/cli/test_install_sh_resolution.py` — module collection error

```python
@pytest.mark.skipif(os.geteuid() == 0, reason="sudo fallback is only meaningful for non-root users")
```

`os.geteuid` does not exist on Windows. The decorator condition is evaluated at **decorator-application time** (i.e. module import), so `AttributeError: module 'os' has no attribute 'geteuid'` fires *before* pytest gets a chance to read any markers. The whole module fails to collect.

## Why skip rather than fix the test scaffolding

Both files exclusively test `install.sh`, which is a POSIX shell script driving zsh/bash/fish rc-file behaviour. There's no Windows analogue (the project ships a separate Windows installer / `pip install` path), so installing WSL or porting the test scaffolding to PowerShell would be busywork. Skipping the module on Windows matches what the codebase actually claims to support.

## Changes

```python
# test_install_sh_path.py
pytestmark = pytest.mark.skipif(
    sys.platform == "win32",
    reason="install.sh is POSIX-only; the Windows runner has no usable bash "
           "(resolves to unconfigured WSL), so this module's subprocess-driven "
           "tests cannot run there. See issue #1099.",
)
```

`test_install_sh_resolution.py` gets the same `pytestmark`, *plus* a defensive replacement of the bare `os.geteuid()` access:

```python
# Evaluated once at module load. hasattr short-circuits the `and` on
# Windows, so os.geteuid() is never called there — the module imports
# cleanly even before pytest reads ``pytestmark``.
_RUNNING_AS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0

@pytest.mark.skipif(_RUNNING_AS_ROOT, reason="sudo fallback is only meaningful for non-root users")
```

Without that defensive guard the module still wouldn't *import* on Windows, even with `pytestmark` defined — and `pytestmark` only kicks in once pytest has collected the module.

## Verification

| | macOS / Linux | Windows |
|---|---|---|
| Module imports | ✅ unchanged | ✅ no more AttributeError |
| Tests run | ✅ all 15 pass on local macOS | Skipped cleanly with reason text |
| Existing root-skip | ✅ still active on Unix when running as root | n/a (whole module skipped) |
| `ruff check` / `ruff format --check` | ✅ clean | ✅ clean |
| Full unit suite | **4164 / 2 skipped / 1 xfailed** | (will skip 13 from these modules + still fail count = 0) |

## Scope

| File | Change |
|---|---|
| `tests/cli/test_install_sh_path.py` | +13 / -0 (module-level pytestmark + comment block) |
| `tests/cli/test_install_sh_resolution.py` | +28 / -1 (pytestmark + defensive `_RUNNING_AS_ROOT` constant; existing decorator references the new constant) |

No production code touched. No test logic changed for the platforms where these tests *do* run.

cc @muddlebee — this is the post-#1090 Windows CI fix. Both files were added by #1064 and have been failing on Windows since that landed; this PR makes the Windows runner green again without changing any Unix-side behaviour.