### PR TITLE
test(cli): cherry-pick #1101 to verify ci:windows label CI

### DIFF
--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -3,8 +3,28 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
+
+import pytest
+
+# install.sh is a POSIX shell script that exercises zsh/bash/fish rc-file
+# behaviour, and these tests drive it via ``subprocess.run(["bash", "-c", ...])``.
+# On the GitHub Actions ``windows-latest`` runner, ``bash`` is resolved to
+# ``wsl.exe`` and the runner has no installed WSL distribution — every
+# ``_run`` call exits 1 with a "Windows Subsystem for Linux has no installed
+# distributions" message and none of the asserted rc files get written.
+# Skip the whole module rather than chase a Windows analogue for a Unix-only
+# installer script.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "install.sh is POSIX-only; the Windows runner has no usable bash "
+        "(resolves to unconfigured WSL), so this module's subprocess-driven "
+        "tests cannot run there. See issue #1099."
+    ),
+)
 
 INSTALL_SH = Path(__file__).parents[2] / "install.sh"
 _LOCAL_BIN = ".local/bin"

--- a/tests/cli/test_install_sh_resolution.py
+++ b/tests/cli/test_install_sh_resolution.py
@@ -4,10 +4,30 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+
+# Same Windows-skip rationale as ``test_install_sh_path.py`` — install.sh is
+# POSIX-only and the GitHub Actions ``windows-latest`` runner has no usable
+# bash. See issue #1099.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "install.sh is POSIX-only; the Windows runner has no usable bash "
+        "(resolves to unconfigured WSL), so this module's subprocess-driven "
+        "tests cannot run there. See issue #1099."
+    ),
+)
+
+# ``os.geteuid`` does not exist on Windows. The skipif decorator below is
+# evaluated at decorator-application time (i.e. module import), so a bare
+# ``os.geteuid() == 0`` check would raise ``AttributeError`` on Windows
+# *before* ``pytestmark`` ever takes effect. ``hasattr`` short-circuits the
+# ``and`` so the ``os.geteuid()`` call only runs on platforms that have it.
+_RUNNING_AS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
 
 INSTALL_SH = Path(__file__).parents[2] / "install.sh"
 
@@ -62,7 +82,7 @@ def test_prefers_writable_user_path_dir(tmp_path: Path) -> None:
     assert "INSTALL_WITH_SUDO=0" in result.stdout
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="sudo fallback is only meaningful for non-root users")
+@pytest.mark.skipif(_RUNNING_AS_ROOT, reason="sudo fallback is only meaningful for non-root users")
 def test_uses_sudo_for_non_writable_system_path_dir(tmp_path: Path) -> None:
     system_bin = tmp_path / "system-bin"
     system_bin.mkdir()


### PR DESCRIPTION
## Purpose
Smoke-test the merged **CI Labels** workflow (`ci:windows`) on a branch based on latest `main`.

This is a cherry-pick of [#1101](https://github.com/Tracer-Cloud/opensre/pull/1101) (`11ca577`) onto current `main` so the PR head branch includes `.github/workflows/ci-labels.yml` from upstream.

## How to verify
1. Wait for default **CI** to complete.
2. Add label `ci:windows` on this PR.
3. Confirm **CI Labels** run shows Windows quality / typecheck / test jobs.

## Note
Contributor fork PRs do not inherit new workflow files until the branch syncs with `main`; this duplicates the logical change here for validation only. Close/replace once #1101 is updated from `main` if redundant.