### PR TITLE
API Response Test: direct unit tests for app/services/datadog/client.py

### DIFF
--- a/tests/services/test_datadog_async_client.py
+++ b/tests/services/test_datadog_async_client.py
@@ -1,0 +1,182 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.datadog.client import DatadogAsyncClient, DatadogConfig
+
+# -------------------------
+# fixtures
+# -------------------------
+
+
+@pytest.fixture
+def config():
+    return DatadogConfig(
+        api_key="test-api-key",
+        app_key="test-app-key",
+        site="datadoghq.com",
+    )
+
+
+@pytest.fixture
+def async_client(config):
+    return DatadogAsyncClient(config)
+
+
+@pytest.fixture
+def mock_async_httpx():
+    with patch("app.services.datadog.client.httpx.AsyncClient") as mock:
+        yield mock
+
+
+# -------------------------
+# success test (FIXED)
+# -------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_success_strong(async_client, mock_async_httpx):
+    mock_instance = MagicMock()
+    mock_async_httpx.return_value.__aenter__.return_value = mock_instance
+
+    # -------- logs --------
+    log_response = MagicMock()
+    log_response.json.return_value = {"data": [{"attributes": {"message": "log message"}}]}
+    log_response.raise_for_status.return_value = None
+
+    # -------- monitors --------
+    monitor_response = MagicMock()
+    monitor_response.json.return_value = [{"id": 1, "name": "CPU Monitor"}]
+    monitor_response.raise_for_status.return_value = None
+
+    # -------- events --------
+    event_response = MagicMock()
+    event_response.json.return_value = {"data": [{"attributes": {"title": "event title"}}]}
+    event_response.raise_for_status.return_value = None
+
+    async def post_router(*args, **kwargs):
+        url = str(args[0])
+
+        if "logs" in url:
+            return log_response
+        if "events" in url:
+            return event_response
+
+        raise AssertionError(f"Unexpected POST url: {url}")
+
+    mock_instance.post = AsyncMock(side_effect=post_router)
+    mock_instance.get = AsyncMock(return_value=monitor_response)
+
+    result = await async_client.fetch_all(
+        logs_query="error",
+        time_range_minutes=15,
+        logs_limit=100,
+        monitor_query="error",
+        events_query="error",
+    )
+
+    # -------------------------
+    # structure
+    # -------------------------
+    assert "logs" in result
+    assert "monitors" in result
+    assert "events" in result
+
+    # -------------------------
+    # REQUIRED: success per leg
+    # -------------------------
+    assert result["logs"]["success"] is True
+    assert result["monitors"]["success"] is True
+    assert result["events"]["success"] is True
+
+    # -------------------------
+    # REQUIRED: field validation
+    # -------------------------
+
+    assert result["logs"]["logs"][0]["message"] == "log message"
+    assert result["monitors"]["monitors"][0]["name"] == "CPU Monitor"
+    assert result["events"]["events"][0]["title"] == "event title"
+
+    # -------------------------
+    # call validation
+    # -------------------------
+    assert mock_instance.post.call_count == 2
+    assert mock_instance.get.call_count == 1
+
+
+# -------------------------
+# partial failure (FIXED LOGIC)
+# -------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_partial_failure(async_client, mock_async_httpx):
+    mock_instance = MagicMock()
+    mock_async_httpx.return_value.__aenter__.return_value = mock_instance
+
+    mock_instance.post = AsyncMock(side_effect=Exception("boom"))
+    mock_instance.get = AsyncMock(side_effect=Exception("boom"))
+
+    result = await async_client.fetch_all(
+        logs_query="error",
+        time_range_minutes=15,
+        logs_limit=100,
+        monitor_query="error",
+        events_query="error",
+    )
+
+    assert result["logs"]["success"] is False
+    assert result["monitors"]["success"] is False
+    assert result["events"]["success"] is False
+
+    assert result["logs"]["error"] is not None
+    assert result["monitors"]["error"] is not None
+    assert result["events"]["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_http_error(async_client, mock_async_httpx):
+    mock_instance = MagicMock()
+    mock_async_httpx.return_value.__aenter__.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 401
+    mock_response.text = "unauthorized"
+
+    mock_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "err",
+            request=MagicMock(),
+            response=mock_response,
+        )
+    )
+
+    mock_instance.post = AsyncMock(return_value=mock_response)
+    mock_instance.get = AsyncMock(return_value=mock_response)
+
+    result = await async_client.fetch_all(
+        logs_query="error",
+        time_range_minutes=15,
+        logs_limit=100,
+        monitor_query="error",
+        events_query="error",
+    )
+
+    assert result["logs"]["success"] is False
+    assert "HTTP 401" in result["logs"]["error"]
+
+
+# -------------------------
+# is_configured
+# -------------------------
+
+
+def test_async_is_configured_true(config):
+    client = DatadogAsyncClient(config)
+    assert client.is_configured is True
+
+
+def test_async_is_configured_false():
+    client = DatadogAsyncClient(DatadogConfig(api_key="", app_key=""))
+    assert client.is_configured is False

--- a/tests/services/test_datadog_async_client.py
+++ b/tests/services/test_datadog_async_client.py
@@ -31,7 +31,7 @@ def mock_async_httpx():
 
 
 # -------------------------
-# success test (FIXED)
+# success test
 # -------------------------
 
 
@@ -106,7 +106,7 @@ async def test_fetch_all_success_strong(async_client, mock_async_httpx):
 
 
 # -------------------------
-# partial failure (FIXED LOGIC)
+# partial failure
 # -------------------------
 
 
@@ -163,8 +163,17 @@ async def test_fetch_all_http_error(async_client, mock_async_httpx):
         events_query="error",
     )
 
+    # logs
     assert result["logs"]["success"] is False
     assert "HTTP 401" in result["logs"]["error"]
+
+    # monitors
+    assert result["monitors"]["success"] is False
+    assert "HTTP 401" in result["monitors"]["error"]
+
+    # events
+    assert result["events"]["success"] is False
+    assert "HTTP 401" in result["events"]["error"]
 
 
 # -------------------------

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -46,6 +46,7 @@ def test_search_logs_success(client, mock_httpx_client):
     mock_httpx_client.return_value = mock_instance
 
     result = client.search_logs("error")
+    mock_instance.post.assert_called_once()
 
     assert "logs" in result
     assert result["success"] is True
@@ -63,6 +64,8 @@ def test_search_logs_empty_data(client, mock_httpx_client):
     mock_httpx_client.return_value = mock_instance
 
     result = client.search_logs("error")
+
+    mock_instance.post.assert_called_once()
 
     assert result["success"] is True
     assert result["logs"] == []
@@ -87,7 +90,7 @@ def test_search_logs_http_error(client, mock_httpx_client):
     mock_instance.post.return_value = mock_response
 
     result = client.search_logs("error")
-
+    mock_instance.post.assert_called_once()
     assert result["success"] is False
     assert "HTTP 500" in result["error"]
 
@@ -100,6 +103,7 @@ def test_search_logs_generic_exception(client, mock_httpx_client):
     mock_httpx_client.return_value = mock_instance
 
     result = client.search_logs("error")
+    mock_instance.post.assert_called_once()
 
     assert result["success"] is False
     assert result["error"] == "unexpected error"
@@ -121,6 +125,7 @@ def test_list_monitors_success(client, mock_httpx_client):
     mock_httpx_client.return_value = mock_instance
 
     result = client.list_monitors()
+    mock_instance.get.assert_called_once()
 
     assert result["success"] is True
     assert result["monitors"][0]["name"] == "CPU Monitor"
@@ -137,6 +142,7 @@ def test_list_monitors_empty(client, mock_httpx_client):
 
     result = client.list_monitors()
 
+    mock_instance.get.assert_called_once()
     assert result["success"] is True
     assert result["monitors"] == []
     assert result["total"] == 0
@@ -160,7 +166,7 @@ def test_list_monitors_http_error(client, mock_httpx_client):
     mock_instance.get.return_value = mock_response
 
     result = client.list_monitors()
-
+    mock_instance.get.assert_called_once()
     assert result["success"] is False
     assert "HTTP 403" in result["error"]
 
@@ -172,6 +178,7 @@ def test_list_monitors_generic_exception(client, mock_httpx_client):
     mock_instance.get.side_effect = Exception("boom")
 
     result = client.list_monitors()
+    mock_instance.get.assert_called_once()
 
     assert result["success"] is False
     assert result["error"] == "boom"
@@ -193,6 +200,7 @@ def test_get_events_success(client, mock_httpx_client):
     mock_httpx_client.return_value = mock_instance
 
     result = client.get_events("error")
+    mock_instance.post.assert_called_once()
 
     assert result["success"] is True
     assert result["events"][0]["title"] == "event title"
@@ -209,6 +217,7 @@ def test_get_events_empty(client, mock_httpx_client):
 
     result = client.get_events()
 
+    mock_instance.post.assert_called_once()
     assert result["success"] is True
     assert result["events"] == []
     assert result["total"] == 0
@@ -233,6 +242,7 @@ def test_get_events_http_error(client, mock_httpx_client):
 
     result = client.get_events("error")
 
+    mock_instance.post.assert_called_once()
     assert result["success"] is False
     assert "HTTP 500" in result["error"]
 
@@ -245,6 +255,7 @@ def test_get_events_generic_exception(client, mock_httpx_client):
 
     result = client.get_events("error")
 
+    mock_instance.post.assert_called_once()
     assert result["success"] is False
     assert result["error"] == "timeout"
 

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -1,0 +1,353 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.datadog.client import DatadogClient, DatadogConfig
+
+# -------------------------
+# Fixtures
+# -------------------------
+
+
+@pytest.fixture
+def config():
+    return DatadogConfig(
+        api_key="test-api-key",
+        app_key="test-app-key",
+        site="datadoghq.com",
+    )
+
+
+@pytest.fixture
+def client(config):
+    return DatadogClient(config)
+
+
+@pytest.fixture
+def mock_httpx_client():
+    with patch("app.services.datadog.client.httpx.Client") as mock:
+        yield mock
+
+
+# -------------------------
+# search_logs
+# -------------------------
+
+
+def test_search_logs_success(client, mock_httpx_client):
+    mock_instance = MagicMock()
+
+    mock_instance.post.return_value = MagicMock(
+        json=lambda: {"data": [{"attributes": {"message": "log message"}}]},
+        raise_for_status=MagicMock(),
+    )
+
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.search_logs("error")
+
+    assert "logs" in result
+    assert result["success"] is True
+    assert result["logs"][0]["message"] == "log message"
+
+
+def test_search_logs_empty_data(client, mock_httpx_client):
+    mock_instance = MagicMock()
+
+    mock_instance.post.return_value = MagicMock(
+        json=lambda: {"data": []},
+        raise_for_status=MagicMock(),
+    )
+
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.search_logs("error")
+
+    assert result["success"] is True
+    assert result["logs"] == []
+    assert result["total"] == 0
+
+
+def test_search_logs_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "server error"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_response.raise_for_status.side_effect = error
+    mock_instance.post.return_value = mock_response
+
+    result = client.search_logs("error")
+
+    assert result["success"] is False
+    assert "HTTP 500" in result["error"]
+
+
+def test_search_logs_generic_exception(client, mock_httpx_client):
+    mock_instance = MagicMock()
+
+    mock_instance.post.side_effect = Exception("unexpected error")
+
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.search_logs("error")
+
+    assert result["success"] is False
+    assert result["error"] == "unexpected error"
+
+
+# -------------------------
+# list_monitors
+# -------------------------
+
+
+def test_list_monitors_success(client, mock_httpx_client):
+    mock_instance = MagicMock()
+
+    mock_instance.get.return_value = MagicMock(
+        json=lambda: [{"name": "CPU Monitor"}],
+        raise_for_status=MagicMock(),
+    )
+
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.list_monitors()
+
+    assert result["success"] is True
+    assert result["monitors"][0]["name"] == "CPU Monitor"
+
+
+def test_list_monitors_empty(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status.return_value = None
+    mock_instance.get.return_value = mock_response
+
+    result = client.list_monitors()
+
+    assert result["success"] is True
+    assert result["monitors"] == []
+    assert result["total"] == 0
+
+
+def test_list_monitors_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.text = "forbidden"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_response.raise_for_status.side_effect = error
+    mock_instance.get.return_value = mock_response
+
+    result = client.list_monitors()
+
+    assert result["success"] is False
+    assert "HTTP 403" in result["error"]
+
+
+def test_list_monitors_generic_exception(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_instance.get.side_effect = Exception("boom")
+
+    result = client.list_monitors()
+
+    assert result["success"] is False
+    assert result["error"] == "boom"
+
+
+# -------------------------
+# get_events
+# -------------------------
+
+
+def test_get_events_success(client, mock_httpx_client):
+    mock_instance = MagicMock()
+
+    mock_instance.post.return_value = MagicMock(
+        json=lambda: {"data": [{"attributes": {"title": "event title"}}]},
+        raise_for_status=MagicMock(),
+    )
+
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.get_events("error")
+
+    assert result["success"] is True
+    assert result["events"][0]["title"] == "event title"
+
+
+def test_get_events_empty(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": []}
+    mock_response.raise_for_status.return_value = None
+    mock_instance.post.return_value = mock_response
+
+    result = client.get_events()
+
+    assert result["success"] is True
+    assert result["events"] == []
+    assert result["total"] == 0
+
+
+def test_get_events_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "server error"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_response.raise_for_status.side_effect = error
+    mock_instance.post.return_value = mock_response
+
+    result = client.get_events("error")
+
+    assert result["success"] is False
+    assert "HTTP 500" in result["error"]
+
+
+def test_get_events_generic_exception(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_instance.post.side_effect = Exception("timeout")
+
+    result = client.get_events("error")
+
+    assert result["success"] is False
+    assert result["error"] == "timeout"
+
+
+# -------------------------
+# is_configured
+# -------------------------
+
+
+def test_is_configured_true():
+    client = DatadogClient(DatadogConfig(api_key="a", app_key="b"))
+    assert client.is_configured is True
+
+
+def test_is_configured_false():
+    client = DatadogClient(DatadogConfig(api_key="", app_key=""))
+    assert client.is_configured is False
+
+
+def test_is_configured_missing_api_key():
+    config = DatadogConfig(api_key="", app_key="key")
+    client = DatadogClient(config)
+
+    assert client.is_configured is False
+
+
+def test_is_configured_missing_app_key():
+    config = DatadogConfig(api_key="key", app_key="")
+    client = DatadogClient(config)
+
+    assert client.is_configured is False
+
+
+# -------------------------
+# POD NODE
+# -------------------------
+
+
+def test_get_pods_on_node_success(client):
+    client.search_logs = MagicMock(
+        return_value={
+            "success": True,
+            "logs": [
+                {
+                    "tags": [
+                        "pod_name:pod-1",
+                        "node_ip:10.0.0.1",
+                        "exit_code:1",
+                    ]
+                },
+                {
+                    "tags": [
+                        "pod_name:pod-2",
+                        "node_ip:10.0.0.1",
+                    ]
+                },
+                {
+                    "tags": [
+                        "pod_name:pod-1",
+                        "node_ip:10.0.0.1",
+                    ]
+                },
+            ],
+        }
+    )
+
+    result = client.get_pods_on_node("10.0.0.1")
+
+    assert result["success"] is True
+    assert result["total"] == 2
+
+    pod1 = next(p for p in result["pods"] if p["pod_name"] == "pod-1")
+    assert pod1["status"] == "failed"
+    assert pod1["exit_code"] == "1"
+
+    pod2 = next(p for p in result["pods"] if p["pod_name"] == "pod-2")
+    assert pod2["status"] == "running"
+
+
+def test_get_pods_on_node_failure(client):
+    client.search_logs = MagicMock(
+        return_value={
+            "success": False,
+            "error": "datadog failure",
+        }
+    )
+
+    result = client.get_pods_on_node("10.0.0.1")
+
+    assert result["success"] is False
+    assert result["pods"] == []
+    assert result["error"] == "datadog failure"
+
+
+def test_get_pods_on_node_missing_tags(client):
+    client.search_logs = MagicMock(
+        return_value={
+            "success": True,
+            "logs": [{}],
+        }
+    )
+
+    result = client.get_pods_on_node("10.0.0.1")
+
+    assert result["success"] is True
+    assert result["pods"] == []

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -37,16 +37,15 @@ def mock_httpx_client():
 
 def test_search_logs_success(client, mock_httpx_client):
     mock_instance = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [{"attributes": {"message": "log message"}}]}
 
-    mock_instance.post.return_value = MagicMock(
-        json=lambda: {"data": [{"attributes": {"message": "log message"}}]},
-        raise_for_status=MagicMock(),
-    )
-
+    mock_instance.post.return_value = mock_response
     mock_httpx_client.return_value = mock_instance
 
     result = client.search_logs("error")
 
+    mock_response.raise_for_status.assert_called_once()
     assert "logs" in result
     assert result["success"] is True
     assert result["logs"][0]["message"] == "log message"


### PR DESCRIPTION
Fixes #878 

<!-- Add issue number above --> 


#### Describe the changes you have made in this PR -

Added a dedicated service-layer test suite for the `DatadogClient` integration to ensure direct coverage of core Datadog API interactions without relying on tool-layer tests.

### Key changes:
- Introduced `tests/services/test_datadog_client.py`
- Added unit tests for:
  - `search_logs()` (success, HTTP failure, empty response)
  - `list_monitors()` (success, HTTP failure, empty response)
  - `get_events()` (success, HTTP failure, empty response)
  - `is_configured` validation
- Mocked `httpx.Client` to ensure no real Datadog API calls are made
- Ensured service-layer isolation so tool tests no longer implicitly validate client logic
- Verified consistent response normalization across logs, monitors, and events APIs

---


### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

## Explain your implementation approach:

This PR introduces service-level testing for the Datadog integration to improve test isolation, reliability, and maintainability.

Previously, Datadog client behavior was only indirectly validated through tool-layer tests. This created tight coupling between layers and made failures harder to trace and debug.

---

## What this solves:
- Ensures Datadog API logic is directly tested at the service layer  
- Removes dependency on tool-layer tests for validating core client behavior  
- Improves test clarity, isolation, and maintainability  
- Makes failures easier to debug by localizing responsibility to the service layer  

---

## Implementation approach:
- Used `httpx.Client` mocking to simulate Datadog API responses without making real network calls  
- Covered both success and failure scenarios for each endpoint:
  - logs (`search_logs`)
  - monitors (`list_monitors`)
  - events (`get_events`)  
- Verified response normalization logic (ensuring consistent structure for logs, monitors, and events)  
- Added coverage for configuration state validation via `is_configured`  

---

## Key design choice:

I chose service-layer mocking instead of integration testing to ensure:

- Deterministic and stable test execution in CI  
- No dependency on external Datadog credentials or network availability  
- Faster test execution and improved developer feedback loop  
- Clear separation between service logic and tool-layer orchestration  

This approach ensures that the Datadog client is independently verifiable and does not rely on higher-level tool tests for correctness.

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
