### PR TITLE
fix: Ctrl+C double-exit in interactive shell

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -117,9 +117,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         cli(args=argv, standalone_mode=True)
     except KeyboardInterrupt:
-        # Suppress Click's "Aborted!" message; a clean exit with no output is
-        # correct here because handle_ctrl_c_press already printed the hint or
-        # "Goodbye!" before raising SystemExit / letting the interrupt propagate.
+        # A KeyboardInterrupt that escapes cli() was not handled by our
+        # double-exit logic (e.g. click.prompt, an unpatched library prompt).
+        # Print a newline so the terminal cursor lands on a clean line, then
+        # exit quietly — Click's "Aborted!" message is intentionally suppressed.
+        print(flush=True)
         return 0
     except SystemExit as exc:
         if isinstance(exc.code, int):

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -10,6 +10,7 @@ Enable shell tab-completion (add to your shell profile for persistence):
 from __future__ import annotations
 
 import os
+import signal
 import sys
 
 import click
@@ -19,7 +20,11 @@ from app.analytics.cli import capture_cli_invoked
 from app.analytics.provider import capture_first_run_if_needed, shutdown_analytics
 from app.cli.commands import register_commands
 from app.cli.layout import RichGroup, render_landing
-from app.cli.prompt_support import install_questionary_escape_cancel
+from app.cli.prompt_support import (
+    handle_ctrl_c_press,
+    install_questionary_ctrl_c_double_exit,
+    install_questionary_escape_cancel,
+)
 from app.version import get_version
 
 
@@ -87,14 +92,35 @@ def cli(
 register_commands(cli)
 
 
+def _install_sigint_handler() -> None:
+    """Handle Ctrl+C between prompts (when prompt_toolkit is not active).
+
+    prompt_toolkit intercepts Ctrl+C internally while a prompt is running, so
+    the key binding in prompt_support.py handles that case.  This SIGINT handler
+    covers everything else: long-running operations, streaming output, etc.
+    """
+
+    def _handler(signum: int, frame: object) -> None:  # noqa: ARG001
+        handle_ctrl_c_press()
+
+    signal.signal(signal.SIGINT, _handler)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``opensre`` console script."""
     load_dotenv(override=False)
     install_questionary_escape_cancel()
+    install_questionary_ctrl_c_double_exit()
+    _install_sigint_handler()
     capture_first_run_if_needed()
 
     try:
         cli(args=argv, standalone_mode=True)
+    except KeyboardInterrupt:
+        # Suppress Click's "Aborted!" message; a clean exit with no output is
+        # correct here because handle_ctrl_c_press already printed the hint or
+        # "Goodbye!" before raising SystemExit / letting the interrupt propagate.
+        return 0
     except SystemExit as exc:
         if isinstance(exc.code, int):
             return exc.code

--- a/app/cli/prompt_support.py
+++ b/app/cli/prompt_support.py
@@ -57,6 +57,7 @@ def install_questionary_escape_cancel() -> None:
     import questionary
     import questionary.prompts.checkbox as checkbox_mod
     import questionary.prompts.confirm as confirm_mod
+    import questionary.prompts.password as password_mod
     import questionary.prompts.path as path_mod
     import questionary.prompts.select as select_mod
     import questionary.prompts.text as text_mod
@@ -66,12 +67,14 @@ def install_questionary_escape_cancel() -> None:
     confirm_mod.confirm = _wrap_question_prompt(confirm_mod.confirm)
     text_mod.text = _wrap_question_prompt(text_mod.text)
     path_mod.path = _wrap_question_prompt(path_mod.path)
+    password_mod.password = _wrap_question_prompt(password_mod.password)
 
     questionary.select = select_mod.select
     questionary.checkbox = checkbox_mod.checkbox
     questionary.confirm = confirm_mod.confirm
     questionary.text = text_mod.text
     questionary.path = path_mod.path
+    questionary.password = password_mod.password
 
     _escape_patch_installed[0] = True
 
@@ -147,6 +150,7 @@ def install_questionary_ctrl_c_double_exit() -> None:
     import questionary
     import questionary.prompts.checkbox as checkbox_mod
     import questionary.prompts.confirm as confirm_mod
+    import questionary.prompts.password as password_mod
     import questionary.prompts.path as path_mod
     import questionary.prompts.select as select_mod
     import questionary.prompts.text as text_mod
@@ -156,11 +160,13 @@ def install_questionary_ctrl_c_double_exit() -> None:
     confirm_mod.confirm = _wrap_question_ctrl_c(confirm_mod.confirm)
     text_mod.text = _wrap_question_ctrl_c(text_mod.text)
     path_mod.path = _wrap_question_ctrl_c(path_mod.path)
+    password_mod.password = _wrap_question_ctrl_c(password_mod.password)
 
     questionary.select = select_mod.select
     questionary.checkbox = checkbox_mod.checkbox
     questionary.confirm = confirm_mod.confirm
     questionary.text = text_mod.text
     questionary.path = path_mod.path
+    questionary.password = password_mod.password
 
     _ctrl_c_patch_installed[0] = True

--- a/app/cli/prompt_support.py
+++ b/app/cli/prompt_support.py
@@ -113,7 +113,9 @@ def _with_ctrl_c_double_exit(
             try:
                 # unsafe_ask() propagates KeyboardInterrupt instead of
                 # swallowing it the way ask() does.
-                return question.unsafe_ask(*args, **kwargs)
+                result = question.unsafe_ask(*args, **kwargs)
+                _last_ctrl_c[0] = None  # reset on clean exit so next prompt starts fresh
+                return result
             except KeyboardInterrupt as exc:
                 if isinstance(exc, _HardQuitInterrupt):
                     raise  # Ctrl+Q hard-quit — bypass retry logic

--- a/app/cli/prompt_support.py
+++ b/app/cli/prompt_support.py
@@ -14,8 +14,8 @@ from prompt_toolkit.keys import Keys
 _escape_patch_installed: list[bool] = [False]
 _ctrl_c_patch_installed: list[bool] = [False]
 
-# Shared timestamp of the last Ctrl+C press (0.0 = never pressed).
-_last_ctrl_c: list[float] = [0.0]
+# Shared timestamp of the last Ctrl+C press (None = never pressed).
+_last_ctrl_c: list[float | None] = [None]
 _CTRL_C_EXIT_WINDOW: float = 2.0
 
 
@@ -86,7 +86,7 @@ def handle_ctrl_c_press() -> None:
     Second call within _CTRL_C_EXIT_WINDOW seconds:  prints Goodbye and exits.
     """
     now = time.monotonic()
-    if now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
+    if _last_ctrl_c[0] is not None and now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
         print("\nGoodbye!", flush=True)
         sys.exit(0)
     _last_ctrl_c[0] = now
@@ -118,7 +118,7 @@ def _with_ctrl_c_double_exit(
                 if isinstance(exc, _HardQuitInterrupt):
                     raise  # Ctrl+Q hard-quit — bypass retry logic
                 now = time.monotonic()
-                if now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
+                if _last_ctrl_c[0] is not None and now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
                     print("\nGoodbye!", flush=True)
                     sys.exit(0)
                 _last_ctrl_c[0] = now

--- a/app/cli/prompt_support.py
+++ b/app/cli/prompt_support.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -10,6 +12,15 @@ from prompt_toolkit.key_binding import KeyBindings, KeyBindingsBase, merge_key_b
 from prompt_toolkit.keys import Keys
 
 _escape_patch_installed: list[bool] = [False]
+_ctrl_c_patch_installed: list[bool] = [False]
+
+# Shared timestamp of the last Ctrl+C press (0.0 = never pressed).
+_last_ctrl_c: list[float] = [0.0]
+_CTRL_C_EXIT_WINDOW: float = 2.0
+
+
+class _HardQuitInterrupt(KeyboardInterrupt):
+    """Raised by explicit quit keys (Ctrl+Q) to bypass the Ctrl+C double-exit guard."""
 
 
 def _with_escape_cancel(question: questionary.question.Question) -> questionary.question.Question:
@@ -63,3 +74,93 @@ def install_questionary_escape_cancel() -> None:
     questionary.path = path_mod.path
 
     _escape_patch_installed[0] = True
+
+
+def handle_ctrl_c_press() -> None:
+    """Handle Ctrl+C from the SIGINT signal handler (between prompts).
+
+    First call:  prints hint.
+    Second call within _CTRL_C_EXIT_WINDOW seconds:  prints Goodbye and exits.
+    """
+    now = time.monotonic()
+    if now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
+        print("\nGoodbye!", flush=True)
+        sys.exit(0)
+    _last_ctrl_c[0] = now
+    print("\n(Press Ctrl+C again to exit)", flush=True)
+
+
+def _with_ctrl_c_double_exit(
+    question: questionary.question.Question,
+) -> questionary.question.Question:
+    """Add Ctrl+C double-exit handling to a questionary prompt.
+
+    Patches question.ask() to call unsafe_ask() (which does NOT swallow
+    KeyboardInterrupt) in a retry loop.  On the first Ctrl+C the hint is
+    printed and the prompt is re-displayed; on the second Ctrl+C within
+    _CTRL_C_EXIT_WINDOW seconds the process exits.
+
+    We do NOT add extra key bindings — the prompt_toolkit default Ctrl+C
+    binding already raises KeyboardInterrupt from application.run(), and
+    fighting it with another eager binding causes unpredictable ordering.
+    """
+
+    def _patched_ask(*args: Any, **kwargs: Any) -> Any:
+        while True:
+            try:
+                # unsafe_ask() propagates KeyboardInterrupt instead of
+                # swallowing it the way ask() does.
+                return question.unsafe_ask(*args, **kwargs)
+            except KeyboardInterrupt as exc:
+                if isinstance(exc, _HardQuitInterrupt):
+                    raise  # Ctrl+Q hard-quit — bypass retry logic
+                now = time.monotonic()
+                if now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
+                    print("\nGoodbye!", flush=True)
+                    sys.exit(0)
+                _last_ctrl_c[0] = now
+                print("\n(Press Ctrl+C again to exit)", flush=True)
+                # Loop: re-run the same application (Application.run() is
+                # safe to call again after a clean exit or KeyboardInterrupt).
+
+    question.ask = _patched_ask  # type: ignore[method-assign]
+    return question
+
+
+def _wrap_question_ctrl_c(
+    orig: Callable[..., questionary.question.Question],
+) -> Callable[..., questionary.question.Question]:
+    def wrapped(*args: Any, **kwargs: Any) -> questionary.question.Question:
+        return _with_ctrl_c_double_exit(orig(*args, **kwargs))
+
+    wrapped.__name__ = orig.__name__
+    wrapped.__doc__ = orig.__doc__
+    wrapped.__qualname__ = getattr(orig, "__qualname__", orig.__name__)
+    return wrapped
+
+
+def install_questionary_ctrl_c_double_exit() -> None:
+    """Make Ctrl+C show a hint on first press and exit on second press within 2 s."""
+    if _ctrl_c_patch_installed[0]:
+        return
+
+    import questionary
+    import questionary.prompts.checkbox as checkbox_mod
+    import questionary.prompts.confirm as confirm_mod
+    import questionary.prompts.path as path_mod
+    import questionary.prompts.select as select_mod
+    import questionary.prompts.text as text_mod
+
+    select_mod.select = _wrap_question_ctrl_c(select_mod.select)
+    checkbox_mod.checkbox = _wrap_question_ctrl_c(checkbox_mod.checkbox)
+    confirm_mod.confirm = _wrap_question_ctrl_c(confirm_mod.confirm)
+    text_mod.text = _wrap_question_ctrl_c(text_mod.text)
+    path_mod.path = _wrap_question_ctrl_c(path_mod.path)
+
+    questionary.select = select_mod.select
+    questionary.checkbox = checkbox_mod.checkbox
+    questionary.confirm = confirm_mod.confirm
+    questionary.text = text_mod.text
+    questionary.path = path_mod.path
+
+    _ctrl_c_patch_installed[0] = True

--- a/app/cli/wizard/prompts.py
+++ b/app/cli/wizard/prompts.py
@@ -20,6 +20,8 @@ from questionary.prompts.common import (
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
+from app.cli.prompt_support import _HardQuitInterrupt, _with_ctrl_c_double_exit
+
 
 class _CheckboxControl(InquirerControl):
     """Render checked items neutrally unless they are the active row."""
@@ -104,8 +106,15 @@ def _base_bindings(
     bindings = KeyBindings()
 
     @bindings.add(Keys.ControlQ, eager=True)
+    def _quit(event: Any) -> None:
+        # ControlQ is an intentional hard-quit; use _HardQuitInterrupt so the
+        # Ctrl+C double-exit retry loop does not swallow this as a first press.
+        event.app.exit(exception=_HardQuitInterrupt(), style="class:aborting")
+
     @bindings.add(Keys.ControlC, eager=True)
-    def _abort(event: Any) -> None:
+    def _ctrl_c(event: Any) -> None:
+        # Raise KeyboardInterrupt so the double-exit logic in _with_ctrl_c_double_exit
+        # can implement hint-on-first / exit-on-second behavior via the retry loop.
         event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
 
     def _move_down(_event: Any) -> None:
@@ -207,17 +216,19 @@ def select(
         ic.is_answered = True
         event.app.exit(result=ic.get_pointed_at().value)
 
-    return Question(
-        Application(
-            layout=common.create_inquirer_layout(
-                ic,
-                _tokens,
-                **_layout_kwargs(input=input, output=output),
-            ),
-            key_bindings=bindings,
-            style=merge_styles_default([style]),
-            input=input,
-            output=output,
+    return _with_ctrl_c_double_exit(
+        Question(
+            Application(
+                layout=common.create_inquirer_layout(
+                    ic,
+                    _tokens,
+                    **_layout_kwargs(input=input, output=output),
+                ),
+                key_bindings=bindings,
+                style=merge_styles_default([style]),
+                input=input,
+                output=output,
+            )
         )
     )
 
@@ -272,16 +283,18 @@ def checkbox(
         ic.is_answered = True
         event.app.exit(result=[choice.value for choice in ic.get_selected_values()])
 
-    return Question(
-        Application(
-            layout=common.create_inquirer_layout(
-                ic,
-                _tokens,
-                **_layout_kwargs(input=input, output=output),
-            ),
-            key_bindings=bindings,
-            style=merge_styles_default([style]),
-            input=input,
-            output=output,
+    return _with_ctrl_c_double_exit(
+        Question(
+            Application(
+                layout=common.create_inquirer_layout(
+                    ic,
+                    _tokens,
+                    **_layout_kwargs(input=input, output=output),
+                ),
+                key_bindings=bindings,
+                style=merge_styles_default([style]),
+                input=input,
+                output=output,
+            )
         )
     )

--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import time
+
+import pytest
 import questionary
 from prompt_toolkit.input.defaults import create_pipe_input  # type: ignore[import-not-found]
 from prompt_toolkit.output import DummyOutput  # type: ignore[import-not-found]
 
-from app.cli.prompt_support import install_questionary_escape_cancel
+from app.cli.prompt_support import (
+    _last_ctrl_c,
+    handle_ctrl_c_press,
+    install_questionary_ctrl_c_double_exit,
+    install_questionary_escape_cancel,
+)
 
 
 def test_install_questionary_escape_cancel_is_idempotent() -> None:
@@ -28,3 +36,46 @@ def test_stock_questionary_select_escape_cancels() -> None:
         app.input = pipe_input
         app.output = DummyOutput()
         assert app.run() is None
+
+
+def test_install_questionary_ctrl_c_double_exit_is_idempotent() -> None:
+    install_questionary_ctrl_c_double_exit()
+    first = questionary.select
+    install_questionary_ctrl_c_double_exit()
+    assert questionary.select is first
+
+
+def test_ctrl_c_first_press_shows_hint_and_reprompts(capsys) -> None:
+    """First Ctrl+C prints the hint and re-displays the prompt; Enter then submits."""
+    _last_ctrl_c[0] = 0.0
+    install_questionary_ctrl_c_double_exit()
+    with create_pipe_input() as pipe_input:
+        q = questionary.select(
+            "Pick",
+            choices=["a", "b"],
+            input=pipe_input,
+            output=DummyOutput(),
+        )
+        # Ctrl+C cancels the first run; Enter submits the re-displayed prompt.
+        pipe_input.send_bytes(b"\x03\r")
+        result = q.ask()
+    assert "(Press Ctrl+C again to exit)" in capsys.readouterr().out
+    # After the hint the prompt was re-run and "a" was selected (first choice).
+    assert result == "a"
+
+
+def test_ctrl_c_second_press_exits(capsys) -> None:
+    # Simulate a previous Ctrl+C just now so the second press fires immediately.
+    _last_ctrl_c[0] = time.monotonic()
+    with pytest.raises(SystemExit) as exc_info:
+        handle_ctrl_c_press()
+    assert exc_info.value.code == 0
+    assert "Goodbye" in capsys.readouterr().out
+
+
+def test_ctrl_c_hint_resets_after_window(capsys) -> None:
+    # A press older than the exit window should show the hint again, not exit.
+    _last_ctrl_c[0] = 0.0  # effectively "long ago"
+    handle_ctrl_c_press()
+    out = capsys.readouterr().out
+    assert "(Press Ctrl+C again to exit)" in out

--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -47,7 +47,7 @@ def test_install_questionary_ctrl_c_double_exit_is_idempotent() -> None:
 
 def test_ctrl_c_first_press_shows_hint_and_reprompts(capsys) -> None:
     """First Ctrl+C prints the hint and re-displays the prompt; Enter then submits."""
-    _last_ctrl_c[0] = 0.0
+    _last_ctrl_c[0] = None
     install_questionary_ctrl_c_double_exit()
     with create_pipe_input() as pipe_input:
         q = questionary.select(
@@ -75,7 +75,7 @@ def test_ctrl_c_second_press_exits(capsys) -> None:
 
 def test_ctrl_c_hint_resets_after_window(capsys) -> None:
     # A press older than the exit window should show the hint again, not exit.
-    _last_ctrl_c[0] = 0.0  # effectively "long ago"
+    _last_ctrl_c[0] = None  # effectively "long ago"
     handle_ctrl_c_press()
     out = capsys.readouterr().out
     assert "(Press Ctrl+C again to exit)" in out

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -612,10 +612,12 @@ def test_integrations_remove_datadog_interactive_smoke(cli_sandbox: CliSandbox) 
 
 @pytest.mark.skipif(os.name == "nt", reason="interactive smoke uses POSIX PTYs")
 def test_tests_interactive_launcher_smoke(cli_sandbox: CliSandbox) -> None:
+    # The prompt instruction reads "Esc exit"; Escape is the PTY-safe way to
+    # dismiss the prompt in automation (no SIGINT/raw-mode race conditions).
     result = _run_cli_pty(
         cli_sandbox,
         "tests",
-        actions=[PtyAction(expect="Choose a test category:", send=b"\x03")],
+        actions=[PtyAction(expect="Choose a test category:", send=b"\x1b")],
     )
 
     assert result.exit_code == 0


### PR DESCRIPTION
Fixes #1091

## Changes

Implements the two-press Ctrl+C exit pattern, consistent with Claude CLI:
- **First Ctrl+C**: displays `(Press Ctrl+C again to exit)` and re-displays the prompt
- **Second Ctrl+C** within 2 seconds: prints `Goodbye!` and exits cleanly (exit code 0)

### Implementation

- Added `_with_ctrl_c_double_exit()` in `app/cli/prompt_support.py` — wraps `question.unsafe_ask()` in a retry loop. This avoids key-binding conflicts that caused an earlier sentinel approach to fail (`Application.exit()` raises if called twice).
- Added `_HardQuitInterrupt(KeyboardInterrupt)` subclass so Ctrl+Q hard-quit bypasses the retry guard.
- Restored an explicit `ControlC` key binding in wizard `_base_bindings()` — `InquirerControl` is not a `BufferControl`, so prompt_toolkit's default Ctrl+C binding is inactive for custom wizard prompts; without this, `\x03` was silently ignored.
- Installed a SIGINT handler in `main()` via `_install_sigint_handler()` to handle Ctrl+C between prompts (streaming output, long-running ops, etc.).
- Updated unit tests in `tests/cli/test_prompt_support.py` covering hint-on-first-press, exit-on-second-press, and window reset.
- Fixed `test_tests_interactive_launcher_smoke` to use Escape instead of Ctrl+C — single Ctrl+C no longer exits immediately, and double Ctrl+C in PTY cooked mode has SIGINT race conditions. Escape is PTY-safe and already the documented exit key in the prompt instruction.

### Verification
Before
<img width="629" height="325" alt="image" src="https://github.com/user-attachments/assets/134e29a3-29d1-4633-90c6-d7f2518177b2" />
After
<img width="628" height="327" alt="image" src="https://github.com/user-attachments/assets/e2fe0d4b-043b-42f4-9f35-847a4ffcbf4c" />



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The core insight is that `question.unsafe_ask()` propagates `KeyboardInterrupt` while `question.ask()` swallows it. By wrapping `unsafe_ask()` in a `while True` retry loop, the first Ctrl+C is caught, the hint is printed, and the same `Application` instance is re-run (safe because `Application.run()` resets `_is_running` and creates a new future on each call). The second Ctrl+C within the time window exits. This avoids fighting prompt_toolkit's key binding merge order entirely.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions