### PR TITLE
fix(github): disambiguate contributors workflow push refspec

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -159,6 +159,7 @@ jobs:
           git add README.md
           git diff --staged --quiet || git commit -m "docs(contributor): contrib-readme-action has updated readme"
           if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
-            git pull --rebase origin "${GITHUB_REF_NAME}"
+            git pull --rebase origin "refs/heads/${GITHUB_REF_NAME}"
           fi
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          # refs/heads/ avoids ambiguity when a tag shares the branch name (e.g. tag "main").
+          git push origin "HEAD:refs/heads/${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Problem

The **Update Contributors** workflow fails on push with:

```
error: dst refspec main matches more than one
```

This happens when both `refs/heads/main` and `refs/tags/main` exist; `HEAD:main` is ambiguous.

## Change

Use explicit branch refs for pull/rebase and push:

- `git pull --rebase origin "refs/heads/${GITHUB_REF_NAME}"`
- `git push origin "HEAD:refs/heads/${GITHUB_REF_NAME}"`
