### PR TITLE
fix(discord,slack): harden delivery against non-JSON failures and token leakage (#865)

### DIFF
--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -18,8 +18,33 @@ def _discord_auth_headers(bot_token: str) -> dict[str, str]:
     return {"Authorization": f"Bot {bot_token}"}
 
 
+def _redact_token(text: str, bot_token: str) -> str:
+    """Replace ``bot_token`` with ``<redacted>`` to prevent accidental log/error leakage."""
+    if bot_token and bot_token in text:
+        return text.replace(bot_token, "<redacted>")
+    return text
+
+
 def _discord_error_from_data(data: Mapping[str, Any]) -> str:
     return str(data.get("message", data.get("error", "unknown")))
+
+
+def _extract_error(data: Mapping[str, Any], status_code: int, text: str) -> str:
+    """Return a human-readable error string from a Discord API response.
+
+    Tries ``data["message"]`` / ``data["error"]`` first, then falls back to
+    the raw response body or the HTTP status code so non-JSON failure bodies
+    (HTML, plain text) never cause a crash.
+    """
+    msg = data.get("message")
+    if msg:
+        return str(msg)
+    err = data.get("error")
+    if err:
+        return str(err)
+    if text:
+        return text[:500]
+    return f"HTTP {status_code}"
 
 
 def post_discord_message(
@@ -39,14 +64,15 @@ def post_discord_message(
         headers=_discord_auth_headers(bot_token),
     )
     if not response.ok:
-        logger.warning("[discord] post message exception: %s", response.error)
-        return False, response.error, ""
+        safe_error = _redact_token(response.error, bot_token)
+        logger.warning("[discord] post message exception: %s", safe_error)
+        return False, safe_error, ""
     if response.status_code not in (200, 201):
         logger.warning("[discord] post message failed: %s", response.status_code)
-        logger.warning("[discord] api response %s", response.data)
-        error_message = _discord_error_from_data(response.data)
-        logger.warning("[discord] post message failed: %s", error_message)
-        return False, error_message, ""
+        error_message = _extract_error(response.data, response.status_code, response.text)
+        safe_error = _redact_token(error_message, bot_token)
+        logger.warning("[discord] post message failed: %s", safe_error)
+        return False, safe_error, ""
     message_id = str(response.data.get("id") or "")
     return True, "", message_id
 
@@ -67,12 +93,14 @@ def create_discord_thread(
         headers=_discord_auth_headers(bot_token),
     )
     if not response.ok:
-        logger.warning("[discord] create thread exception: %s", response.error)
-        return False, response.error, ""
+        safe_error = _redact_token(response.error, bot_token)
+        logger.warning("[discord] create thread exception: %s", safe_error)
+        return False, safe_error, ""
     if response.status_code not in (200, 201):
-        error_message = _discord_error_from_data(response.data)
-        logger.warning("[discord] create thread failed: %s", error_message)
-        return False, error_message, ""
+        error_message = _extract_error(response.data, response.status_code, response.text)
+        safe_error = _redact_token(error_message, bot_token)
+        logger.warning("[discord] create thread failed: %s", safe_error)
+        return False, safe_error, ""
     thread_id = str(response.data.get("id") or "")
     return True, "", thread_id
 

--- a/app/utils/discord_delivery.py
+++ b/app/utils/discord_delivery.py
@@ -25,10 +25,6 @@ def _redact_token(text: str, bot_token: str) -> str:
     return text
 
 
-def _discord_error_from_data(data: Mapping[str, Any]) -> str:
-    return str(data.get("message", data.get("error", "unknown")))
-
-
 def _extract_error(data: Mapping[str, Any], status_code: int, text: str) -> str:
     """Return a human-readable error string from a Discord API response.
 

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 from app.config import SLACK_CHANNEL
@@ -11,6 +12,30 @@ from app.output import debug_print
 from app.utils.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
+
+_ACCESS_TOKEN_RE = re.compile(r"(xox[baprs]-)[^/\s]+")
+
+
+def _redact_token(text: str, access_token: str) -> str:
+    """Replace ``access_token`` with ``<redacted>`` to prevent accidental log/error leakage."""
+    if access_token and access_token in text:
+        return text.replace(access_token, "<redacted>")
+    return text
+
+
+def _extract_error(data: dict[str, Any], status_code: int, text: str) -> str:
+    """Return a human-readable error string from a Slack API response.
+
+    Tries ``data["error"]`` first, then falls back to the raw response body
+    or the HTTP status code so non-JSON failure bodies (HTML, plain text)
+    never cause a crash.
+    """
+    error = data.get("error")
+    if error:
+        return str(error)
+    if text:
+        return text[:500]
+    return f"HTTP {status_code}"
 
 
 def _slack_bearer_headers(token: str) -> dict[str, str]:
@@ -38,7 +63,8 @@ def _call_reactions_api(method: str, token: str, channel: str, timestamp: str, e
         timeout=8.0,
     )
     if not response.ok:
-        logger.warning("[slack] %s(%s) exception: %s", method, emoji, response.error)
+        safe_error = _redact_token(response.error, token)
+        logger.warning("[slack] %s(%s) exception: %s", method, emoji, safe_error)
         return False
     if not response.data.get("ok"):
         error = response.data.get("error", "unknown")
@@ -189,12 +215,13 @@ def send_slack_report(
             slack_message, channel, thread_ts, access_token, blocks=blocks, **extra
         )
         if not success:
+            safe_error = _redact_token(direct_error, access_token)
             logger.info(
-                "[slack] Direct post failed (%s), falling back to webapp delivery", direct_error
+                "[slack] Direct post failed (%s), falling back to webapp delivery", safe_error
             )
             webapp_ok = _post_via_webapp(slack_message, channel, thread_ts, blocks=blocks, **extra)
             if not webapp_ok:
-                return False, f"direct={direct_error}, webapp=failed"
+                return False, f"direct={safe_error}, webapp=failed"
             return True, ""
         return True, ""
     else:
@@ -222,17 +249,20 @@ def _post_direct(
         headers=_slack_bearer_headers(token),
     )
     if not response.ok:
+        safe_error = _redact_token(response.error, token)
         logger.error(
             "[slack] Direct post exception type=%s channel=%s thread_ts=%s detail=%s "
             "(caller may attempt fallback)",
             response.exc_type or "Exception",
             channel,
             thread_ts,
-            response.error,
+            safe_error,
         )
-        return False, f"exception={response.error}"
-    if not response.data.get("ok"):
-        error = response.data.get("error", "unknown")
+        return False, f"exception={safe_error}"
+    if response.data.get("ok") is not True:
+        error = response.data.get("error")
+        if not error:
+            error = _extract_error(dict(response.data), response.status_code, response.text)
         response_meta = response.data.get("response_metadata", {})
         logger.error(
             "[slack] Direct post FAILED: error=%s, metadata=%s (channel=%s, thread_ts=%s)",

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -13,14 +13,15 @@ from app.utils.delivery_transport import post_json
 
 logger = logging.getLogger(__name__)
 
-_ACCESS_TOKEN_RE = re.compile(r"(xox[baprs]-)[^/\s]+")
+_ACCESS_TOKEN_RE = re.compile(r"(xox[baprs]-)[A-Za-z0-9-]+")
 
 
 def _redact_token(text: str, access_token: str) -> str:
     """Replace ``access_token`` with ``<redacted>`` to prevent accidental log/error leakage."""
+    redacted = text
     if access_token and access_token in text:
-        return text.replace(access_token, "<redacted>")
-    return text
+        redacted = text.replace(access_token, "<redacted>")
+    return _ACCESS_TOKEN_RE.sub(r"\1<redacted>", redacted)
 
 
 def _extract_error(data: dict[str, Any], status_code: int, text: str) -> str:
@@ -263,15 +264,16 @@ def _post_direct(
         error = response.data.get("error")
         if not error:
             error = _extract_error(dict(response.data), response.status_code, response.text)
+        safe_error = _redact_token(str(error), token)
         response_meta = response.data.get("response_metadata", {})
         logger.error(
             "[slack] Direct post FAILED: error=%s, metadata=%s (channel=%s, thread_ts=%s)",
-            error,
+            safe_error,
             response_meta,
             channel,
             thread_ts,
         )
-        return False, f"slack_error={error}"
+        return False, f"slack_error={safe_error}"
     warnings = response.data.get("response_metadata", {}).get("warnings", [])
     if warnings:
         logger.warning("[slack] Reply posted with warnings: %s", warnings)

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -326,7 +326,9 @@ class TestDiscordExtractError:
 
 
 class TestDiscordNonJsonBody:
-    def test_post_discord_message_handles_html_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_post_discord_message_handles_html_error_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from app.utils.delivery_transport import DeliveryResponse
 
         monkeypatch.setattr(
@@ -345,7 +347,9 @@ class TestDiscordNonJsonBody:
         assert "<html>Bad Gateway</html>" in error
         assert message_id == ""
 
-    def test_create_discord_thread_handles_html_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_create_discord_thread_handles_html_error_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from app.utils.delivery_transport import DeliveryResponse
 
         monkeypatch.setattr(
@@ -396,7 +400,9 @@ class TestDiscordExceptionRedaction:
             "app.utils.discord_delivery.post_json",
             lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
         )
-        ok, error = discord_delivery.send_discord_report("Report", {"channel_id": "c1", "bot_token": token})
+        ok, error = discord_delivery.send_discord_report(
+            "Report", {"channel_id": "c1", "bot_token": token}
+        )
         assert ok is False
         assert token not in error
         assert "<redacted>" in error

--- a/tests/utils/test_discord_delivery.py
+++ b/tests/utils/test_discord_delivery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -281,3 +282,142 @@ class TestDelegatesToSharedTransport:
         assert "/messages/m1/threads" in captured["url"]
         assert captured["payload"]["name"] == "Investigation"
         assert captured["payload"]["auto_archive_duration"] == 1440
+
+
+# ---------------------------------------------------------------------------
+# Issue #865 – Discord hardening: non-JSON bodies and token redaction
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordRedaction:
+    def test_redact_token_in_error_string(self) -> None:
+        token = "MTIzNDU2Nzg5.MTg4NjY2.NqIIjOjHrFJzE5jgwSGM1Nz"
+        error = f"connect failed with {token}"
+        result = discord_delivery._redact_token(error, token)
+        assert token not in result
+        assert "<redacted>" in result
+
+    def test_redact_token_returns_original_when_token_not_present(self) -> None:
+        result = discord_delivery._redact_token("some error", "MTIzNDU2Nzg5.MTg4NjY2.NqIIjO")
+        assert result == "some error"
+
+
+class TestDiscordExtractError:
+    def test_prefers_message_field(self) -> None:
+        result = discord_delivery._extract_error({"message": "Missing Permissions"}, 403, "html")
+        assert result == "Missing Permissions"
+
+    def test_falls_back_to_error_field(self) -> None:
+        result = discord_delivery._extract_error({"error": "invalid_form_data"}, 400, "html")
+        assert result == "invalid_form_data"
+
+    def test_falls_back_to_text(self) -> None:
+        result = discord_delivery._extract_error({}, 502, "<html>Bad Gateway</html>")
+        assert result == "<html>Bad Gateway</html>"
+
+    def test_falls_back_to_http_status(self) -> None:
+        result = discord_delivery._extract_error({}, 500, "")
+        assert result == "HTTP 500"
+
+    def test_truncates_text_to_500_chars(self) -> None:
+        long_text = "x" * 1000
+        result = discord_delivery._extract_error({}, 502, long_text)
+        assert len(result) == 500
+
+
+class TestDiscordNonJsonBody:
+    def test_post_discord_message_handles_html_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        monkeypatch.setattr(
+            "app.utils.discord_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(
+                ok=True,
+                status_code=502,
+                data={},
+                text="<html>Bad Gateway</html>",
+            ),
+        )
+        ok, error, message_id = discord_delivery.post_discord_message(
+            "chan-1", [{"title": "Alert"}], "bot-token"
+        )
+        assert ok is False
+        assert "<html>Bad Gateway</html>" in error
+        assert message_id == ""
+
+    def test_create_discord_thread_handles_html_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        monkeypatch.setattr(
+            "app.utils.discord_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(
+                ok=True,
+                status_code=502,
+                data={},
+                text="<html>Bad Gateway</html>",
+            ),
+        )
+        ok, error, thread_id = discord_delivery.create_discord_thread(
+            "chan-1", "msg-1", "Test Thread", "bot-token"
+        )
+        assert ok is False
+        assert "<html>Bad Gateway</html>" in error
+        assert thread_id == ""
+
+
+class TestDiscordExceptionRedaction:
+    def test_exception_error_redacts_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "MTIzNDU2Nzg5.MTg4NjY2.NqIIjOjHrFJzE5jgwSGM1Nz"
+        leak_msg = f"connect failed with {token}"
+
+        monkeypatch.setattr(
+            "app.utils.discord_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
+        )
+        ok, error, message_id = discord_delivery.post_discord_message(
+            "chan-1", [{"title": "Alert"}], token
+        )
+        assert ok is False
+        assert token not in error
+        assert "<redacted>" in error
+        assert message_id == ""
+
+    def test_send_discord_report_returns_redacted_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "MTIzNDU2Nzg5.MTg4NjY2.NqIIjOjHrFJzE5jgwSGM1Nz"
+        leak_msg = f"connect failed with {token}"
+
+        monkeypatch.setattr(
+            "app.utils.discord_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
+        )
+        ok, error = discord_delivery.send_discord_report("Report", {"channel_id": "c1", "bot_token": token})
+        assert ok is False
+        assert token not in error
+        assert "<redacted>" in error
+
+
+class TestDiscordExceptionLogRedaction:
+    def test_exception_log_redacts_token(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "MTIzNDU2Nzg5.MTg4NjY2.NqIIjOjHrFJzE5jgwSGM1Nz"
+        leak_msg = f"connect failed with {token}"
+
+        monkeypatch.setattr(
+            "app.utils.discord_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
+        )
+        with caplog.at_level(logging.WARNING, logger="app.utils.discord_delivery"):
+            discord_delivery.post_discord_message("chan-1", [{"title": "Alert"}], token)
+
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert token not in joined
+        assert "<redacted>" in joined

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -484,6 +484,12 @@ class TestRedaction:
         result = slack_delivery._redact_token("some error", "xoxb-missing")
         assert result == "some error"
 
+    def test_redact_token_scrubs_slack_token_pattern_without_exact_match(self) -> None:
+        leaked_token = "xoxb-token-from-response-body"
+        result = slack_delivery._redact_token(f"proxy echoed {leaked_token}", "different-token")
+        assert leaked_token not in result
+        assert "xoxb-<redacted>" in result
+
 
 class TestExtractError:
     def test_prefers_error_field(self) -> None:
@@ -520,6 +526,32 @@ class TestNonJsonBody:
         ok, err = slack_delivery._post_direct("hi", "C1", "1.0", "tok")
         assert ok is False
         assert "<html>Bad Gateway</html>" in err
+
+    def test_post_direct_redacts_token_from_html_error_body(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "xoxb-1234567890-abcdefghij"
+        monkeypatch.setattr(
+            "app.utils.slack_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(
+                ok=True,
+                status_code=502,
+                data={},
+                text=f"<html>proxy echoed {token}</html>",
+            ),
+        )
+
+        with caplog.at_level(logging.ERROR, logger="app.utils.slack_delivery"):
+            ok, err = slack_delivery._post_direct("hi", "C1", "1.0", token)
+
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert ok is False
+        assert token not in err
+        assert token not in joined
+        assert "<redacted>" in err
+        assert "<redacted>" in joined
 
 
 class TestExceptionRedaction:

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -459,3 +459,122 @@ class TestDelegatesToSharedTransport:
         assert captured["payload"]["text"] == "hi"
         assert captured["payload"]["blocks"] == [{"b": 1}]
         assert captured["follow_redirects"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #865 – Slack hardening: non-JSON bodies and token redaction
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    def test_redact_token_in_error_string(self) -> None:
+        token = "xoxb-1234567890-abcdefghij"
+        error = "connect failed for url=https://slack.com/api/chat.postMessage"
+        result = slack_delivery._redact_token(error, token)
+        assert result == error
+
+    def test_redact_token_in_error_string_with_token_present(self) -> None:
+        token = "xoxb-1234567890-abcdefghij"
+        error = "connect failed with xoxb-1234567890-abcdefghij"
+        result = slack_delivery._redact_token(error, token)
+        assert token not in result
+        assert "<redacted>" in result
+
+    def test_redact_token_returns_original_when_token_not_present(self) -> None:
+        result = slack_delivery._redact_token("some error", "xoxb-missing")
+        assert result == "some error"
+
+
+class TestExtractError:
+    def test_prefers_error_field(self) -> None:
+        result = slack_delivery._extract_error({"error": "channel_not_found"}, 400, "html body")
+        assert result == "channel_not_found"
+
+    def test_falls_back_to_text_when_no_error_field(self) -> None:
+        result = slack_delivery._extract_error({}, 502, "<html>Bad Gateway</html>")
+        assert result == "<html>Bad Gateway</html>"
+
+    def test_falls_back_to_http_status_when_no_data(self) -> None:
+        result = slack_delivery._extract_error({}, 500, "")
+        assert result == "HTTP 500"
+
+    def test_truncates_text_to_500_chars(self) -> None:
+        long_text = "x" * 1000
+        result = slack_delivery._extract_error({}, 502, long_text)
+        assert len(result) == 500
+
+
+class TestNonJsonBody:
+    def test_post_direct_handles_html_error_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        monkeypatch.setattr(
+            "app.utils.slack_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(
+                ok=True,
+                status_code=502,
+                data={},
+                text="<html>Bad Gateway</html>",
+            ),
+        )
+        ok, err = slack_delivery._post_direct("hi", "C1", "1.0", "tok")
+        assert ok is False
+        assert "<html>Bad Gateway</html>" in err
+
+
+class TestExceptionRedaction:
+    def test_exception_error_redacts_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "xoxb-1234567890-abcdefghij"
+        leak_msg = f"connect failed with {token}"
+
+        monkeypatch.setattr(
+            "app.utils.slack_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
+        )
+        ok, err = slack_delivery._post_direct("hi", "C1", "1.0", token)
+        assert ok is False
+        assert token not in err
+        assert "<redacted>" in err
+
+    def test_send_slack_report_redacts_token_in_composed_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "xoxb-1234567890-abcdefghij"
+
+        def _stub_post_json(url: str, payload: dict, **kw: Any) -> DeliveryResponse:
+            if "chat.postMessage" in url:
+                return DeliveryResponse(ok=False, error=f"connect with {token}")
+            return DeliveryResponse(ok=False, error="webapp down")
+
+        monkeypatch.setattr("app.utils.slack_delivery.post_json", _stub_post_json)
+        ok, err = slack_delivery.send_slack_report(
+            "hi", channel="C1", thread_ts="1.0", access_token=token
+        )
+        assert ok is False
+        assert token not in err
+        assert "<redacted>" in err
+
+
+class TestExceptionLogRedaction:
+    def test_exception_log_redacts_token(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from app.utils.delivery_transport import DeliveryResponse
+
+        token = "xoxb-1234567890-abcdefghij"
+        leak_msg = f"connect failed with {token}"
+
+        monkeypatch.setattr(
+            "app.utils.slack_delivery.post_json",
+            lambda *_a, **_kw: DeliveryResponse(ok=False, error=leak_msg),
+        )
+        with caplog.at_level(logging.ERROR, logger="app.utils.slack_delivery"):
+            slack_delivery._post_direct("hi", "C1", "1.0", token)
+
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert token not in joined
+        assert "<redacted>" in joined


### PR DESCRIPTION
Fixes #865

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR hardens Slack and Discord delivery helpers to match Telegram's existing safety behavior.

Changes made:

- Slack and Discord delivery now survive non-JSON failure bodies such as HTML and plain text.
- Slack and Discord error extraction now falls back to raw response text, then `HTTP <status>` when structured JSON is unavailable.
- Slack access tokens and Discord bot tokens are redacted before errors are logged or returned.
- Slack now applies redaction in both transport-exception paths and API-error response paths.
- Slack includes a defensive `xox*` token-pattern fallback for response bodies that contain a Slack token even when it does not exactly match the token argument.
- Removed the dead Discord `_discord_error_from_data` helper after replacing all call sites with `_extract_error`.
- Added regression tests for non-JSON responses, exceptions containing tokens, returned error redaction, and log redaction.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Before:

```text
[slack] Direct post exception type=ConnectionError channel=C1 thread_ts=1.0 detail=connect failed with xoxb-1234567890-abcdefghij
```

After:

```text
[slack] Direct post exception type=ConnectionError channel=C1 thread_ts=1.0 detail=connect failed with <redacted>
```

Non-JSON error body behavior:

```text
Before: slack_error=unknown
After:  slack_error=<html>Bad Gateway</html>
```

Local verification:

```bash
pytest tests/utils/ -v
# 203 passed

ruff check app/utils/slack_delivery.py app/utils/discord_delivery.py tests/utils/test_slack_delivery.py tests/utils/test_discord_delivery.py
# No issues found

ruff format --check app/utils/slack_delivery.py app/utils/discord_delivery.py tests/utils/test_slack_delivery.py tests/utils/test_discord_delivery.py
# 4 files already formatted

mypy app/utils/slack_delivery.py app/utils/discord_delivery.py
# No issues found
```

CI verification:

```text
quality (ubuntu-latest): success
typecheck (ubuntu-latest): success
test (ubuntu-latest): success
CodeQL: success
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This fixes a reliability and security gap in Slack and Discord delivery. Telegram already handled non-JSON failures and redacted bot tokens before propagating errors; Slack and Discord now follow the same pattern.

I kept the implementation local to the delivery helpers instead of centralizing it in `delivery_transport.py` because each provider has different credential shapes and response semantics. The transport layer should stay provider-neutral, while Slack and Discord know how to redact their own tokens and extract their own API errors.

Key functions added or updated:

- `slack_delivery._redact_token()` replaces exact Slack access-token matches and also uses a defensive `xox*` pattern fallback.
- `slack_delivery._extract_error()` extracts Slack API errors from JSON first, then raw text, then HTTP status.
- `discord_delivery._redact_token()` replaces Discord bot-token matches before logging or returning errors.
- `discord_delivery._extract_error()` extracts Discord `message` / `error` fields first, then raw text, then HTTP status.
- Slack `_post_direct()` now redacts both transport errors and API response-body errors before logging or returning them.
- Discord `post_discord_message()` and `create_discord_thread()` now redact every propagated failure string.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.