### PR TITLE
Issue 1127 harden remote tool end payloads

### DIFF
--- a/app/remote/reasoning.py
+++ b/app/remote/reasoning.py
@@ -52,7 +52,8 @@ def _on_tool_start(data: dict[str, Any]) -> str:
 
 
 def _on_tool_end(data: dict[str, Any], _node_name: str) -> str | None:
-    output = data.get("data", {}).get("output", "")
+    payload = data.get("data")
+    output = payload.get("output", "") if isinstance(payload, dict) else ""
     if isinstance(output, str) and len(output) > 120:
         output = output[:117] + "..."
     name = data.get("name", "")

--- a/tests/app/remote/test_reasoning.py
+++ b/tests/app/remote/test_reasoning.py
@@ -44,6 +44,16 @@ class TestReasoningText:
         result = reasoning_text("on_tool_end", data, "investigate")
         assert result == "error logs done"
 
+    def test_tool_end_malformed_data_string(self) -> None:
+        data = {"name": "query_datadog_logs", "data": "bad-payload"}
+        result = reasoning_text("on_tool_end", data, "investigate")
+        assert result == "Datadog logs done"
+
+    def test_tool_end_malformed_data_none(self) -> None:
+        data = {"name": "query_datadog_logs", "data": None}
+        result = reasoning_text("on_tool_end", data, "investigate")
+        assert result == "Datadog logs done"
+
     def test_chat_model_start_investigate(self) -> None:
         result = reasoning_text("on_chat_model_start", {}, "investigate")
         assert result == "querying"


### PR DESCRIPTION
Fixes #1127 

<!-- Add issue number above -->

#### Changes made:
- This PR hardens remote reasoning text generation for malformed LangGraph tool-end stream events.
- Previously, `_on_tool_end()` assumed the nested event payload was always a dictionary. If a malformed event sent `"data": "bad-payload"` or `"data": None`, the remote UI reasoning layer could crash while generating spinner/status text.
- This change safely handles non-dict nested payloads and falls back to the existing done message, such as `Datadog logs done`.
- I also added regression tests for string and null malformed payloads.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Focused regression test passing:

#### pytest reasoning regression
<img width="801" height="409" alt="image" src="https://github.com/user-attachments/assets/1be4591c-5dde-4a70-b709-a1b4fd33d6d4" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
