### PR TITLE
Add registry regression test for duplicate tool names across modules

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -344,6 +344,14 @@ def test_registry_regression_duplicate_tool_names_across_modules(
     assert tool_names.count("shared_tool_name") == 1
     registered_tool = registry_module.get_registered_tool_map()["shared_tool_name"]
     assert registered_tool.run() == {"module": "first"}
+    with caplog.at_level(logging.WARNING, logger="app.tools.registry"):
+        tools = registry_module.get_registered_tools()
+
+    tool_names = [t.name for t in tools]
+
+    assert tool_names.count("shared_tool_name") == 1
+    registered_tool = registry_module.get_registered_tool_map()["shared_tool_name"]
+    assert registered_tool.run() == {"module": "first"}
 
     assert any(
         "Duplicate tool name 'shared_tool_name' across modules" in record.message

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator
 from types import ModuleType
 from typing import Any
@@ -335,7 +336,9 @@ def test_registry_regression_duplicate_tool_names_across_modules(
         lambda name: module1 if name == "first_module" else module2,
     )
 
-    tools = registry_module.get_registered_tools()
+    with caplog.at_level(logging.WARNING, logger="app.tools.registry"):
+        tools = registry_module.get_registered_tools()
+
     tool_names = [t.name for t in tools]
 
     assert tool_names.count("shared_tool_name") == 1

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -298,3 +298,52 @@ def test_real_registry_discovers_honeycomb_and_coralogix_tools() -> None:
 def test_real_registry_preserves_existing_chat_tool_surface() -> None:
     chat_names = {tool_def.name for tool_def in registry_module.get_registered_tools("chat")}
     assert {"fetch_failed_run", "get_tracer_run", "search_github_code"} <= chat_names
+
+
+def test_registry_regression_duplicate_tool_names_across_modules(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that when two modules export the same tool name, only the first is kept."""
+    module1: Any = ModuleType("app.tools.first_module")
+    module2: Any = ModuleType("app.tools.second_module")
+
+    first_tool = tool(
+        name="shared_tool_name",
+        description="Tool in first module.",
+        source="knowledge",
+    )(lambda: {"module": "first"})
+
+    second_tool = tool(
+        name="shared_tool_name",
+        description="Tool in second module.",
+        source="knowledge",
+    )(lambda: {"module": "second"})
+
+    first_tool.__module__ = module1.__name__
+    second_tool.__module__ = module2.__name__
+    module1.shared_tool_first = first_tool
+    module2.shared_tool_second = second_tool
+
+    monkeypatch.setattr(
+        registry_module,
+        "_iter_tool_module_names",
+        lambda: ["first_module", "second_module"],
+    )
+    monkeypatch.setattr(
+        registry_module,
+        "_import_tool_module",
+        lambda name: module1 if name == "first_module" else module2,
+    )
+
+    tools = registry_module.get_registered_tools()
+    tool_names = [t.name for t in tools]
+
+    assert tool_names.count("shared_tool_name") == 1
+    registered_tool = registry_module.get_registered_tool_map()["shared_tool_name"]
+    assert registered_tool.run() == {"module": "first"}
+
+    assert any(
+        "Duplicate tool name 'shared_tool_name' across modules" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )


### PR DESCRIPTION
# Fixes #1116

  Add registry regression test for duplicate tool names across modules

  #### Describe the changes you have made in this PR

  Added a comprehensive regression test `test_registry_regression_duplicate_tool_names_across_modules` to ensure the tool registry correctly
  handles duplicate tool names when they appear across different modules.

  **What was added:**
  - New test that creates two fake modules with identically-named tools
  - Verifies registry keeps only the first tool definition and skips subsequent duplicates
  - Confirms warning is logged when duplicates are detected
  - Validates the first module's tool implementation is preserved

  **Test validates:**
  1. Two modules can export tools with the same name
  2. Registry deduplication logic keeps first definition (FIFO)
  3. Warning message "[tools] Duplicate tool name 'X' across modules; keeping first definition" is logged
  4. Subsequent modules' conflicting tools are skipped silently

  ### Demo/Screenshot for feature changes and bug fixes

  Test execution with broken duplicate handling (simulating bug):
  FAILED tests/tools/test_registry.py::test_registry_regression_duplicate_tool_names_across_modules
  AssertionError: assert {'module': 'second'} == {'module': 'first'}

  Test execution with fix in place:
  tests/tools/test_registry.py::test_registry_regression_duplicate_tool_names_across_modules PASSED

  All 13 registry tests passing after change.

  ---

  ## Code Understanding and AI Usage

  **Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

  - [x] Yes, I used AI assistance (continue below)

  **If you used AI assistance:**

  - [x] I have reviewed every single line of the AI-generated code
  - [x] I can explain the purpose and logic of each function/component I added
  - [x] I have tested edge cases and understand how the code handles them
  - [x] I have modified the AI output to follow this project's coding standards and conventions

  **Explain your implementation approach:**

  The test follows the existing pattern in `test_registry.py`:
  1. Create fake `ModuleType` instances to simulate tool modules
  2. Decorate functions with `@tool` decorator to register them
  3. Use `monkeypatch` to mock the module discovery mechanism
  4. Assert registry behavior: deduplication, warning logging, first-definition preservation

  The test proves the fix works by deliberately breaking the `continue` statement in `registry.py` line 146 and verifying the test fails
  (second module's tool overwrites first). With the fix restored, the test passes.

  **Why this approach:**
  - Mimics real-world scenario where modules might have naming collisions
  - Uses registry's own monkeypatch fixtures for consistency with other tests
  - Validates both the deduplication logic AND the warning mechanism
  - Non-destructive: test doesn't modify actual tool discovery

  ---

  ## Checklist before requesting a review

  - [x] I have added proper PR title and linked to the issue
  - [x] I have performed a self-review of my code
  - [x] **I can explain the purpose of every function, class, and logic block I added**
  - [x] I understand why my changes work and have tested them thoroughly
  - [x] I have considered potential edge cases and how my code handles them
  - [x] If it is a core feature, I have added thorough tests
  - [x] My code follows the project's style guidelines and conventions

  ---