### PR TITLE
Feat/add registry import failure test

### DIFF
--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -128,7 +128,7 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
         except ModuleNotFoundError as exc:
             logger.warning("[tools] Skipping %s: %s", module_name, exc)
             continue
-        except Exception as exc:  # pragma: no cover - defensive logging path
+        except Exception as exc:
             logger.warning(
                 "[tools] Skipping %s due to import failure: %s",
                 module_name,

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -391,7 +391,6 @@ def test_registry_regression_import_failures(
     tool_names = [t.name for t in tools]
 
     assert "valid_tool" in tool_names
-    assert len(tools) >= 1
     assert registry_module.get_registered_tool_map()["valid_tool"].run() == {"status": "ok"}
 
     assert any(

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -347,3 +347,52 @@ def test_registry_regression_duplicate_tool_names_across_modules(
         for record in caplog.records
         if record.levelname == "WARNING"
     )
+
+
+def test_registry_regression_import_failures(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that registry gracefully skips modules with import failures."""
+    module: Any = ModuleType("app.tools.valid_tool")
+
+    @tool(
+        name="valid_tool",
+        description="A valid tool.",
+        source="knowledge",
+    )
+    def valid_tool() -> dict[str, str]:
+        return {"status": "ok"}
+
+    valid_tool.__module__ = module.__name__
+    module.valid_tool = valid_tool
+
+    def mock_import(name: str) -> ModuleType:
+        if name == "broken_module":
+            raise RuntimeError("Module initialization failed")
+        return module
+
+    monkeypatch.setattr(
+        registry_module,
+        "_iter_tool_module_names",
+        lambda: ["broken_module", "valid_tool"],
+    )
+    monkeypatch.setattr(
+        registry_module,
+        "_import_tool_module",
+        mock_import,
+    )
+
+    tools = registry_module.get_registered_tools()
+    tool_names = [t.name for t in tools]
+
+    assert "valid_tool" in tool_names
+    assert len(tools) >= 1
+    assert registry_module.get_registered_tool_map()["valid_tool"].run() == {
+        "status": "ok"
+    }
+
+    assert any(
+        "Skipping broken_module" in record.message
+        and record.levelname == "WARNING"
+        for record in caplog.records
+    )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -387,12 +387,9 @@ def test_registry_regression_import_failures(
 
     assert "valid_tool" in tool_names
     assert len(tools) >= 1
-    assert registry_module.get_registered_tool_map()["valid_tool"].run() == {
-        "status": "ok"
-    }
+    assert registry_module.get_registered_tool_map()["valid_tool"].run() == {"status": "ok"}
 
     assert any(
-        "Skipping broken_module" in record.message
-        and record.levelname == "WARNING"
+        "Skipping broken_module" in record.message and record.levelname == "WARNING"
         for record in caplog.records
     )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -298,3 +298,52 @@ def test_real_registry_discovers_honeycomb_and_coralogix_tools() -> None:
 def test_real_registry_preserves_existing_chat_tool_surface() -> None:
     chat_names = {tool_def.name for tool_def in registry_module.get_registered_tools("chat")}
     assert {"fetch_failed_run", "get_tracer_run", "search_github_code"} <= chat_names
+
+
+def test_registry_regression_duplicate_tool_names_across_modules(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that when two modules export the same tool name, only the first is kept."""
+    module1: Any = ModuleType("app.tools.first_module")
+    module2: Any = ModuleType("app.tools.second_module")
+
+    first_tool = tool(
+        name="shared_tool_name",
+        description="Tool in first module.",
+        source="knowledge",
+    )(lambda: {"module": "first"})
+
+    second_tool = tool(
+        name="shared_tool_name",
+        description="Tool in second module.",
+        source="knowledge",
+    )(lambda: {"module": "second"})
+
+    first_tool.__module__ = module1.__name__
+    second_tool.__module__ = module2.__name__
+    module1.shared_tool_first = first_tool
+    module2.shared_tool_second = second_tool
+
+    monkeypatch.setattr(
+        registry_module,
+        "_iter_tool_module_names",
+        lambda: ["first_module", "second_module"],
+    )
+    monkeypatch.setattr(
+        registry_module,
+        "_import_tool_module",
+        lambda name: module1 if name == "first_module" else module2,
+    )
+
+    tools = registry_module.get_registered_tools()
+    tool_names = [t.name for t in tools]
+
+    assert tool_names.count("shared_tool_name") == 1
+    registered_tool = registry_module.get_registered_tool_map()["shared_tool_name"]
+    assert registered_tool.run() == {"module": "first"}
+
+    assert any(
+        "Duplicate tool name 'shared_tool_name' across modules" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -396,12 +396,4 @@ def test_registry_regression_import_failures(
     assert any(
         "Skipping broken_module" in record.message and record.levelname == "WARNING"
         for record in caplog.records
-    assert tool_names.count("shared_tool_name") == 1
-    registered_tool = registry_module.get_registered_tool_map()["shared_tool_name"]
-    assert registered_tool.run() == {"module": "first"}
-
-    assert any(
-        "Duplicate tool name 'shared_tool_name' across modules" in record.message
-        for record in caplog.records
-        if record.levelname == "WARNING"
     )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator
 from types import ModuleType
 from typing import Any
@@ -335,7 +336,9 @@ def test_registry_regression_duplicate_tool_names_across_modules(
         lambda name: module1 if name == "first_module" else module2,
     )
 
-    tools = registry_module.get_registered_tools()
+    with caplog.at_level(logging.WARNING, logger="app.tools.registry"):
+        tools = registry_module.get_registered_tools()
+
     tool_names = [t.name for t in tools]
 
     assert tool_names.count("shared_tool_name") == 1
@@ -382,7 +385,9 @@ def test_registry_regression_import_failures(
         mock_import,
     )
 
-    tools = registry_module.get_registered_tools()
+    with caplog.at_level(logging.WARNING, logger="app.tools.registry"):
+        tools = registry_module.get_registered_tools()
+
     tool_names = [t.name for t in tools]
 
     assert "valid_tool" in tool_names


### PR DESCRIPTION
Fixes #1115

  #### Describe the changes you have made in this PR -

  Added regression test to verify the tool registry properly handles modules that fail to import. The test checks that when a module raises
  an exception during import, the registry skips it gracefully and continues loading valid tools from other modules.

  The test creates a mock scenario with a broken module and a valid module, then verifies:
  - Valid tools still get registered despite the broken module
  - Import failures are logged as warnings
  - The tool map remains functional and can access valid tools

  ### Demo/Screenshot for feature changes and bug fixes -

  Test passes with current code:
  tests/tools/test_registry.py::test_registry_regression_import_failures PASSED

  Test catches the regression when `continue` statement is removed from exception handler:
  UnboundLocalError: cannot access local variable 'module' where it is not associated with a value

  This proves the test correctly detects when import error handling is broken.

  ---

  ## Code Understanding and AI Usage

  **Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

  - [x] Yes, I used AI assistance (continue below)

  **If you used AI assistance:**

  - [x] I have reviewed every single line of the AI-generated code
  - [x] I can explain the purpose and logic of each function/component I added
  - [x] I have tested edge cases and understand how the code handles them
  - [x] I have modified the AI output to follow this project's coding standards and conventions

  **Explain your implementation approach:**

  The test mirrors the pattern from the duplicate tool names regression test. It uses monkeypatch to mock the module import process, creates
  a scenario where one module fails with RuntimeError while another succeeds, then verifies the registry recovers gracefully.

  Key parts:
  - `mock_import()` function simulates import failures for "broken_module"
  - Valid tool is still created and registered in a separate module
  - Test asserts that valid tools are found despite the failure
  - caplog captures and verifies the warning is logged

  The implementation catches a real bug: if the `continue` statement after exception handling is removed, the code tries to use an
  uninitialized `module` variable, causing UnboundLocalError.

  ---

  ## Checklist before requesting a review

  - [x] I have added proper PR title and linked to the issue
  - [x] I have performed a self-review of my code
  - [x] I can explain the purpose of every function, class, and logic block I added
  - [x] I understand why my changes work and have tested them thoroughly
  - [x] I have considered potential edge cases and how my code handles them
  - [x] If it is a core feature, I have added thorough tests
  - [x] My code follows the project's style guidelines and conventions
