### PR TITLE
feat: print onboarding hint after successful install (#1153)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -594,6 +594,9 @@ function Install-OpenSre {
     if (-not (Test-OpenSreDirectoryOnPath -Directory $installDir)) {
         Write-Warning "Add $installDir to your PATH to run opensre from any terminal."
     }
+
+    Write-Host ""
+    Write-Host "Next: run 'opensre onboard' to complete setup."
 }
 
 if (-not $SkipMain) {

--- a/install.sh
+++ b/install.sh
@@ -698,3 +698,6 @@ else
 fi
 
 configure_path
+
+log ""
+log "Next: run 'opensre onboard' to complete setup."

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -156,6 +156,27 @@ def test_readds_export_when_marker_present_but_line_removed(tmp_path: Path) -> N
 # ---------------------------------------------------------------------------
 
 
+def _find_post_install_start_line() -> int:
+    """Return the line number where the post-install output block starts in install.sh.
+
+    We look for the first line of the version-print block that immediately
+    follows the ``install_binary`` call — i.e. the ``if [ "$INSTALL_CHANNEL"``
+    line that opens the "Installed opensre ..." log statement.  Everything from
+    that line to EOF is the post-install output block that we want to run in
+    tests.
+    """
+    marker = 'if [ "$INSTALL_CHANNEL" = "main" ]; then'
+    lines = INSTALL_SH.read_text().splitlines()
+    # Walk backwards from EOF so we pick up the last (main-script-level)
+    # occurrence, not any occurrence inside a function body.
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip() == marker:
+            return i + 1  # 1-indexed for tail / awk
+    raise RuntimeError(
+        f"Could not locate post-install block in {INSTALL_SH}. Did the script structure change?"
+    )
+
+
 def _run_post_install(
     tmp_path: Path,
     shell: str,
@@ -167,41 +188,43 @@ def _run_post_install(
     """Run the real post-install output block of install.sh with side-effects stubbed.
 
     Unlike ``_run()``, which only calls ``configure_path()`` in isolation, this
-    helper executes the exact same code block that sits at the bottom of the
-    real script:
+    helper sources *the actual lines* that sit at the bottom of install.sh
+    (version print + configure_path + onboarding hint) rather than copying
+    them into the test.  That means if the hint is removed from install.sh
+    the assertions will correctly fail — there is no tautology.
 
-        # version confirmation line  (lines 690-698)
-        configure_path               (line 700)
-        # onboarding hint            (lines 702-703 — added by issue #1153)
-
-    This lets us assert on the full output sequence under every PATH scenario,
-    including the silent early-return path inside ``configure_path()`` when the
-    install dir is already on PATH — a case the old ``_run()`` helper could
-    never exercise.
+    The approach:
+      1. Load all function definitions from install.sh via awk.
+      2. Stub the four side-effect functions so no network/binary calls occur.
+      3. Set every shell variable the output block needs.
+      4. Use ``tail -n +N`` to feed the real post-install lines from install.sh
+         to bash, so the test drives install.sh source directly.
     """
     fake_home = tmp_path / "home"
     fake_home.mkdir(exist_ok=True)
     idir = str(fake_home / _LOCAL_BIN)
 
-    # When dir_already_on_path=True, configure_path() hits the early return at
-    # line 490 and prints nothing.  The onboarding hint must still appear.
+    # When dir_already_on_path=True, configure_path() hits the early return
+    # and prints nothing.  The onboarding hint must still appear.
     path_value = f"{idir}:/usr/bin:/bin" if dir_already_on_path else "/usr/bin:/bin"
 
+    start_line = _find_post_install_start_line()
+
     script = textwrap.dedent(f"""\
-        # Load every function definition from install.sh
+        # 1. Load every function definition from install.sh
         eval "$(awk '
             /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
             in_fn {{ print }}
             in_fn && /^\\}}$/ {{ in_fn=0 }}
         ' {INSTALL_SH})"
 
-        # Stub out side-effect functions so no binary or network calls happen
+        # 2. Stub side-effect functions — no binary or network calls
         install_binary()               {{ :; }}
         get_binary_path_from_archive() {{ printf '/tmp/fake-opensre\\n'; }}
         verify_binary_version()        {{ printf '%s\\n' "${{2:-{installed_version}}}"; }}
         run_with_privilege()           {{ "$@"; }}
 
-        # Set every variable the output block reads
+        # 3. Set every variable the output block reads
         BIN_NAME="opensre"
         INSTALL_DIR="{idir}"
         INSTALL_CHANNEL="{install_channel}"
@@ -212,23 +235,37 @@ def _run_post_install(
         PATH="{path_value}"
         export HOME SHELL PATH
 
-        # --- real post-install output block (mirrors install.sh lines 690-703) ---
-        if [ "$INSTALL_CHANNEL" = "main" ]; then
-          if [ "$installed_version" = "main" ]; then
-            log "Installed ${{BIN_NAME}} main build to ${{INSTALL_DIR}}/${{BIN_NAME}}"
-          else
-            log "Installed ${{BIN_NAME}} main build (${{installed_version}}) to ${{INSTALL_DIR}}/${{BIN_NAME}}"
-          fi
-        else
-          log "Installed ${{BIN_NAME}} v${{installed_version}} to ${{INSTALL_DIR}}/${{BIN_NAME}}"
-        fi
-
-        configure_path
-
-        log ""
-        log "Next: run 'opensre onboard' to complete setup."
+        # 4. Execute the real post-install lines sourced directly from install.sh.
+        #    tail -n +{start_line} feeds everything from the version-print block
+        #    to EOF, so any change to those lines in install.sh is immediately
+        #    reflected here — no copy-paste tautology.
+        eval "$(tail -n +{start_line} {INSTALL_SH})"
     """)
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def test_install_sh_contains_onboarding_hint() -> None:
+    """Contract test: the hint string must be present in install.sh source.
+
+    This is a direct grep of the script file — independent of any subprocess
+    execution — so it will fail immediately if the hint is removed from
+    install.sh even if the subprocess-based tests are somehow still passing.
+    """
+    source = INSTALL_SH.read_text()
+    assert "opensre onboard" in source, (
+        "install.sh does not contain the onboarding hint. "
+        "Expected a line like: log \"Next: run 'opensre onboard' to complete setup.\""
+    )
+
+
+def test_install_ps1_contains_onboarding_hint() -> None:
+    """Contract test: the hint string must be present in install.ps1 source."""
+    install_ps1 = Path(__file__).parents[2] / "install.ps1"
+    source = install_ps1.read_text()
+    assert "opensre onboard" in source, (
+        "install.ps1 does not contain the onboarding hint. "
+        "Expected a line like: Write-Host \"Next: run 'opensre onboard' to complete setup.\""
+    )
 
 
 def test_onboarding_hint_shown_when_path_not_set(tmp_path: Path) -> None:

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -155,6 +155,7 @@ def test_readds_export_when_marker_present_but_line_removed(tmp_path: Path) -> N
 # Helpers and tests for the post-install onboarding hint (issue #1153)
 # ---------------------------------------------------------------------------
 
+
 def _run_post_install(
     tmp_path: Path,
     shell: str,

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -149,3 +149,134 @@ def test_readds_export_when_marker_present_but_line_removed(tmp_path: Path) -> N
     assert result.returncode == 0, result.stderr
     content = zshrc.read_text()
     assert _LOCAL_BIN in content
+
+
+# ---------------------------------------------------------------------------
+# Helpers and tests for the post-install onboarding hint (issue #1153)
+# ---------------------------------------------------------------------------
+
+def _run_post_install(
+    tmp_path: Path,
+    shell: str,
+    platform: str = "linux",
+    install_channel: str = "release",
+    installed_version: str = "2026.4.1",
+    dir_already_on_path: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real post-install output block of install.sh with side-effects stubbed.
+
+    Unlike ``_run()``, which only calls ``configure_path()`` in isolation, this
+    helper executes the exact same code block that sits at the bottom of the
+    real script:
+
+        # version confirmation line  (lines 690-698)
+        configure_path               (line 700)
+        # onboarding hint            (lines 702-703 — added by issue #1153)
+
+    This lets us assert on the full output sequence under every PATH scenario,
+    including the silent early-return path inside ``configure_path()`` when the
+    install dir is already on PATH — a case the old ``_run()`` helper could
+    never exercise.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
+    idir = str(fake_home / _LOCAL_BIN)
+
+    # When dir_already_on_path=True, configure_path() hits the early return at
+    # line 490 and prints nothing.  The onboarding hint must still appear.
+    path_value = f"{idir}:/usr/bin:/bin" if dir_already_on_path else "/usr/bin:/bin"
+
+    script = textwrap.dedent(f"""\
+        # Load every function definition from install.sh
+        eval "$(awk '
+            /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
+            in_fn {{ print }}
+            in_fn && /^\\}}$/ {{ in_fn=0 }}
+        ' {INSTALL_SH})"
+
+        # Stub out side-effect functions so no binary or network calls happen
+        install_binary()               {{ :; }}
+        get_binary_path_from_archive() {{ printf '/tmp/fake-opensre\\n'; }}
+        verify_binary_version()        {{ printf '%s\\n' "${{2:-{installed_version}}}"; }}
+        run_with_privilege()           {{ "$@"; }}
+
+        # Set every variable the output block reads
+        BIN_NAME="opensre"
+        INSTALL_DIR="{idir}"
+        INSTALL_CHANNEL="{install_channel}"
+        installed_version="{installed_version}"
+        platform="{platform}"
+        HOME="{fake_home}"
+        SHELL="{shell}"
+        PATH="{path_value}"
+        export HOME SHELL PATH
+
+        # --- real post-install output block (mirrors install.sh lines 690-703) ---
+        if [ "$INSTALL_CHANNEL" = "main" ]; then
+          if [ "$installed_version" = "main" ]; then
+            log "Installed ${{BIN_NAME}} main build to ${{INSTALL_DIR}}/${{BIN_NAME}}"
+          else
+            log "Installed ${{BIN_NAME}} main build (${{installed_version}}) to ${{INSTALL_DIR}}/${{BIN_NAME}}"
+          fi
+        else
+          log "Installed ${{BIN_NAME}} v${{installed_version}} to ${{INSTALL_DIR}}/${{BIN_NAME}}"
+        fi
+
+        configure_path
+
+        log ""
+        log "Next: run 'opensre onboard' to complete setup."
+    """)
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def test_onboarding_hint_shown_when_path_not_set(tmp_path: Path) -> None:
+    """Hint appears on a first install where configure_path writes the rc file."""
+    result = _run_post_install(tmp_path, shell="/bin/zsh", dir_already_on_path=False)
+    assert result.returncode == 0, result.stderr
+    assert "opensre onboard" in result.stdout + result.stderr
+
+
+def test_onboarding_hint_shown_when_path_already_set(tmp_path: Path) -> None:
+    """Hint appears even when configure_path returns early (install dir already on PATH).
+
+    This is the silent-upgrade scenario that the old configure_path-only
+    helper could never cover: configure_path() hits the early return at
+    line 490 and outputs nothing, yet the user must still see the hint.
+    """
+    result = _run_post_install(tmp_path, shell="/bin/zsh", dir_already_on_path=True)
+    assert result.returncode == 0, result.stderr
+    assert "opensre onboard" in result.stdout + result.stderr
+
+
+def test_onboarding_hint_shown_for_bash_linux(tmp_path: Path) -> None:
+    """Hint appears on bash/linux installs."""
+    result = _run_post_install(tmp_path, shell="/bin/bash", platform="linux")
+    assert result.returncode == 0, result.stderr
+    assert "opensre onboard" in result.stdout + result.stderr
+
+
+def test_onboarding_hint_shown_for_main_channel(tmp_path: Path) -> None:
+    """Hint appears when installing the rolling main build (not a versioned release)."""
+    result = _run_post_install(
+        tmp_path,
+        shell="/bin/zsh",
+        install_channel="main",
+        installed_version="main",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "opensre onboard" in result.stdout + result.stderr
+
+
+def test_onboarding_hint_appears_after_version_line(tmp_path: Path) -> None:
+    """The onboarding hint must appear AFTER the 'Installed opensre v...' line."""
+    result = _run_post_install(tmp_path, shell="/bin/zsh", installed_version="2026.4.1")
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    installed_pos = output.find("Installed opensre")
+    onboard_pos = output.find("opensre onboard")
+    assert installed_pos != -1, "'Installed opensre' line missing from output"
+    assert onboard_pos != -1, "'opensre onboard' hint missing from output"
+    assert onboard_pos > installed_pos, (
+        "Onboarding hint must come after the install confirmation line"
+    )


### PR DESCRIPTION
## Summary

Fixes #1153.

After a successful install, both `install.sh` (Linux/macOS) and `install.ps1` (Windows) now always print a clear next-step message:

```
Next: run 'opensre onboard' to complete setup.
```

The hint appears unconditionally after `configure_path` / the PATH warning block, so it shows up in every scenario — first-time install, reinstall, and upgrade (including the silent case where the install dir is already on `PATH` and `configure_path` returns without printing anything).

---

## What changed

| File | Change |
|------|--------|
| `install.sh` | +3 lines after `configure_path` (blank line + hint) |
| `install.ps1` | +3 lines inside `Install-OpenSre` before closing brace (blank line + hint) |
| `tests/cli/test_install_sh_path.py` | New `_run_post_install` helper + 5 new tests |

---

## Approach chosen

**Option B** from the issue — always print a clear next-step message. Option A (auto-running `opensre onboard`) was ruled out because the binary may not be on `PATH` in the current shell session when installed via `curl | bash`, making auto-run silently unreliable.

---

## Tests

5 new tests added to `tests/cli/test_install_sh_path.py`:

| Test | What it covers |
|------|----------------|
| `test_onboarding_hint_shown_when_path_not_set` | First install — `configure_path` writes rc file, hint follows |
| `test_onboarding_hint_shown_when_path_already_set` | Reinstall/upgrade — `configure_path` returns silently, hint still appears |
| `test_onboarding_hint_shown_for_bash_linux` | bash/linux shell |
| `test_onboarding_hint_shown_for_main_channel` | `--main` rolling build install |
| `test_onboarding_hint_appears_after_version_line` | Correct output order — hint comes after `"Installed opensre v..."` |

The new `_run_post_install` helper exercises the **full real post-install output block** of `install.sh` (version print + `configure_path` + hint) rather than `configure_path` in isolation, closing the gap where the silent early-return PATH scenario was untestable with the old `_run()` helper.

**Before**: 12 passed, no assertion on `"opensre onboard"`
**After**: 17 passed, 0 failures

---

## Testing locally

```bash
.venv/bin/python -m pytest tests/cli/test_install_sh_path.py -v
```