### PR TITLE
test: add _id_to_iso helper coverage in remote server tests

### DIFF
--- a/tests/app/remote/test_server.py
+++ b/tests/app/remote/test_server.py
@@ -222,6 +222,11 @@ async def test_lifespan_starts_and_cancels_vercel_poller(
     assert cancelled.is_set()
 
 
+# ---------------------------------------------------------------------------
+# _id_to_iso tests
+# ---------------------------------------------------------------------------
+
+
 def test_id_to_iso_converts_valid_id_to_utc_iso_string() -> None:
     # Valid format: YYYYMMDD_HHMMSS_slug
     inv_id = "20260430_120001_alert-name"

--- a/tests/app/remote/test_server.py
+++ b/tests/app/remote/test_server.py
@@ -212,3 +212,25 @@ async def test_lifespan_starts_and_cancels_vercel_poller(
         await asyncio.wait_for(started.wait(), timeout=1)
 
     assert cancelled.is_set()
+
+
+def test_id_to_iso_converts_valid_id_to_utc_iso_string() -> None:
+    # Valid format: YYYYMMDD_HHMMSS_slug
+    inv_id = "20260430_120001_alert-name"
+    iso_string = remote_server._id_to_iso(inv_id)
+    # Should convert to standard ISO format with +00:00 (UTC)
+    assert iso_string == "2026-04-30T12:00:01+00:00"
+
+
+@pytest.mark.parametrize(
+    "malformed_id",
+    [
+        "",
+        "invalid",
+        "20260430-120001-alert",  # wrong separator
+        "abc_def_ghi",  # non-numeric date part
+    ],
+)
+def test_id_to_iso_returns_empty_string_for_malformed_input(malformed_id: str) -> None:
+    # Function should fail quietly and return an empty string, not crash
+    assert remote_server._id_to_iso(malformed_id) == ""


### PR DESCRIPTION
Fixes #1123

Describe the changes you have made in this PR -
Added unit test coverage for the _id_to_iso helper function in app/remote/server.py.

These tests verify that:

- [X] Valid investigation IDs (YYYYMMDD_HHMMSS_slug) are correctly converted to ISO 8601 UTC strings.

- [X] Malformed inputs return an empty string instead of raising exceptions.

Demo/Screenshot for feature changes and bug fixes -
Verified locally using pytest:

python -m pytest tests/app/remote/test_server.py -v
Output: 28 passed in 3.68s
<img width="932" height="424" alt="image" src="https://github.com/user-attachments/assets/6ce67faa-8043-4b97-95d1-8278c696ded3" />


Code Understanding and AI Usage
Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?

- [ ]  No, I wrote all the code myself
- [X] Yes, I used AI assistance (continue below)

If you used AI assistance:

- [X] I have reviewed every single line of the AI-generated code
- [X] I can explain the purpose and logic of each function/component I added
- [X] I have tested edge cases and understand how the code handles them
- [X]  I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach: Added two focused test functions in tests/app/remote/test_server.py:

test_id_to_iso_converts_valid_id_to_utc_iso_string: Verifies correct conversion for a valid ID (happy path).
test_id_to_iso_returns_empty_string_for_malformed_input: Uses pytest.mark.parametrize to test multiple edge cases (Empty strings, Incorrect separators, Non-numeric values).
Ensures the helper safely handles errors via try/except as intended.

Checklist before requesting a review

- [X] I have added proper PR title and linked to the issue
- [X] I have performed a self-review of my code
- [X] I can explain the purpose of every function, class, and logic block I added
- [X]  I understand why my changes work and have tested them thoroughly
- [X]  I have considered potential edge cases and how my code handles them
- [X]  If it is a core feature, I have added thorough tests
- [X] My code follows the project's style guidelines and conventions