### PR TITLE
fix(repl): Ctrl+C once cancels input, twice exits the shell (#1091)

### DIFF
--- a/app/cli/repl/loop.py
+++ b/app/cli/repl/loop.py
@@ -1,0 +1,144 @@
+"""Async REPL loop — the zero-exit heart of the OpenSRE interactive terminal."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.formatted_text import ANSI
+from rich.console import Console
+from rich.markup import escape
+
+from app.cli.repl.banner import render_banner
+from app.cli.repl.commands import dispatch_slash
+from app.cli.repl.config import ReplConfig
+from app.cli.repl.follow_up import answer_follow_up
+from app.cli.repl.router import classify_input
+from app.cli.repl.session import ReplSession
+
+
+def _run_new_alert(text: str, session: ReplSession, console: Console) -> None:
+    """Dispatch a free-text alert description to the streaming pipeline."""
+    from app.cli.investigate import run_investigation_for_session
+
+    try:
+        final_state = run_investigation_for_session(
+            alert_text=text,
+            context_overrides=session.accumulated_context or None,
+        )
+    except KeyboardInterrupt:
+        console.print("[yellow]investigation cancelled.[/yellow]")
+        session.record("alert", text, ok=False)
+        return
+    except Exception as exc:  # noqa: BLE001
+        # Exception repr may contain brackets (stack frame refs, config
+        # dicts) that Rich would eat as markup tags — escape before printing.
+        console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
+        session.record("alert", text, ok=False)
+        return
+
+    session.last_state = final_state
+    session.accumulate_from_state(final_state)
+    session.record("alert", text)
+
+
+async def _run_one_turn(
+    prompt: PromptSession[str],
+    session: ReplSession,
+    console: Console,
+    *,
+    _interrupt_count: list[int],
+) -> bool:
+    """Read one line of input and dispatch. Returns False to exit."""
+    try:
+        text = await prompt.prompt_async(ANSI("\x1b[1;36m› \x1b[0m"))
+        _interrupt_count[0] = 0  # reset on successful input
+    except EOFError:
+        console.print()
+        return False
+    except KeyboardInterrupt:
+        _interrupt_count[0] += 1
+        if _interrupt_count[0] >= 2:
+            console.print()
+            return False
+        console.print("\n[dim](Press Ctrl+C again to exit.)[/dim]")
+        return True
+
+    text = text.strip()
+    if not text:
+        return True
+
+    kind = classify_input(text, session)
+    if kind == "slash":
+        # Rewrite bare-word commands to their slash form before dispatch.
+        cmd_text = text if text.startswith("/") else f"/{text}"
+        session.record("slash", cmd_text)
+        return dispatch_slash(cmd_text, session, console)
+
+    if kind == "new_alert":
+        _run_new_alert(text, session, console)
+        return True
+
+    # follow_up — grounded answer against session.last_state
+    answer_follow_up(text, session, console)
+    session.record("follow_up", text)
+    return True
+
+
+async def _repl_main(initial_input: str | None = None, config: ReplConfig | None = None) -> int:  # noqa: ARG001
+    # force_terminal + truecolor so Rich always emits full ANSI, even after
+    # prompt_toolkit has claimed and released stdout for input handling.
+    # Without this, slash-command output after the first prompt renders as
+    # literal escape codes in some terminal emulators.
+    console = Console(highlight=False, force_terminal=True, color_system="truecolor")
+    render_banner(console)
+    session = ReplSession()
+    prompt: PromptSession[str] = PromptSession()
+    _interrupt_count: list[int] = [0]
+
+    # Allow a single pre-seeded input for test harnesses
+    if initial_input:
+        for line in initial_input.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            kind = classify_input(stripped, session)
+            if kind == "slash":
+                cmd_text = stripped if stripped.startswith("/") else f"/{stripped}"
+                session.record("slash", cmd_text)
+                if not dispatch_slash(cmd_text, session, console):
+                    return 0
+            elif kind == "new_alert":
+                _run_new_alert(stripped, session, console)
+            else:
+                answer_follow_up(stripped, session, console)
+                session.record("follow_up", stripped)
+
+    while True:
+        should_continue = await _run_one_turn(
+            prompt, session, console, _interrupt_count=_interrupt_count
+        )
+        if not should_continue:
+            return 0
+
+
+def run_repl(initial_input: str | None = None, config: ReplConfig | None = None) -> int:
+    """Enter the interactive REPL. Returns the exit code."""
+    cfg = config or ReplConfig.load()
+
+    if not cfg.enabled:
+        return 0
+
+    if not sys.stdin.isatty() and initial_input is None:
+        # In non-TTY contexts (piped input, CI), don't start an interactive loop.
+        # Callers should use `opensre investigate` instead.
+        return 0
+
+    try:
+        return asyncio.run(_repl_main(initial_input=initial_input, config=cfg))
+    except (EOFError, KeyboardInterrupt):
+        return 0
+
+
+__all__ = ["run_repl"]

--- a/app/cli/repl/loop.py
+++ b/app/cli/repl/loop.py
@@ -50,7 +50,12 @@ async def _run_one_turn(
     *,
     _interrupt_count: list[int],
 ) -> bool:
-    """Read one line of input and dispatch. Returns False to exit."""
+    """Read one line of input and dispatch. Returns False to exit.
+
+    The ``_interrupt_count`` list is a one-element mutable counter shared
+    with the caller so that two consecutive Ctrl+C presses exit the REPL
+    while a single press merely cancels the current input line.
+    """
     try:
         text = await prompt.prompt_async(ANSI("\x1b[1;36m› \x1b[0m"))
         _interrupt_count[0] = 0  # reset on successful input

--- a/app/cli/repl/loop.py
+++ b/app/cli/repl/loop.py
@@ -100,7 +100,6 @@ async def _repl_main(initial_input: str | None = None, config: ReplConfig | None
     render_banner(console)
     session = ReplSession()
     prompt: PromptSession[str] = PromptSession()
-    _interrupt_count: list[int] = [0]
 
     # Allow a single pre-seeded input for test harnesses
     if initial_input:
@@ -119,6 +118,8 @@ async def _repl_main(initial_input: str | None = None, config: ReplConfig | None
             else:
                 answer_follow_up(stripped, session, console)
                 session.record("follow_up", stripped)
+
+    _interrupt_count: list[int] = [0]
 
     while True:
         should_continue = await _run_one_turn(


### PR DESCRIPTION
## Summary

Closes #1091

Adds double-Ctrl+C exit to the interactive REPL. **Replaces #1092 and #1098** — both had merge conflicts because our fork was behind upstream. Fork has now been synced and this PR is conflict-free.

## Behaviour

- **First Ctrl+C** — cancels current input, prints `(Press Ctrl+C again to exit.)`, continues the loop
- **Second consecutive Ctrl+C** — exits cleanly
- Successful input resets the counter — Ctrl+C always needs two consecutive presses to exit
- `EOFError` (Ctrl+D) still exits immediately — unchanged

## Changes

`_run_one_turn` gets a keyword-only `_interrupt_count: list[int]` parameter — a one-element mutable list so the async function can update the caller's counter without `nonlocal`. Counter resets to 0 on every successful prompt. `_repl_main` initialises the counter and passes it on every iteration.
