### PR TITLE
feat(llm_cli): integrate Claude Code CLI as LLM_PROVIDER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,13 +12,19 @@
 # --- Most important ---------------------------------------------------------
 
 # Provider used for LLM calls. Common values: anthropic, openai, openrouter,
-# gemini, nvidia, codex.
+# gemini, nvidia, codex, claude-code.
 LLM_PROVIDER=anthropic
 
 # Codex CLI works for `opensre investigate` after `codex login`.
 # Leave CODEX_MODEL empty to use the CLI's currently configured model.
 CODEX_MODEL=
 CODEX_BIN=
+
+# Claude Code CLI works for `opensre investigate` after `claude login` or setting ANTHROPIC_API_KEY.
+# Install: npm i -g @anthropic-ai/claude-code
+# Leave CLAUDE_CODE_MODEL empty to use the CLI's currently configured model.
+CLAUDE_CODE_MODEL=
+CLAUDE_CODE_BIN=
 
 # Set the key for the provider you choose above.
 ANTHROPIC_API_KEY=

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -132,6 +132,17 @@ OLLAMA_MODELS = (
     ModelOption(value="qwen2.5:7b", label="Qwen 2.5 (7B)"),
 )
 
+# Empty value means "no --model" so Claude Code uses its configured default.
+CLAUDE_CODE_MODELS = (
+    ModelOption(
+        value="",
+        label="CLI default (no --model; use Claude Code configured model)",
+    ),
+    ModelOption(value="claude-opus-4-7", label="Claude Opus 4.7 — most capable"),
+    ModelOption(value="claude-sonnet-4-6", label="Claude Sonnet 4.6 — balanced"),
+    ModelOption(value="claude-haiku-4-5-20251001", label="Claude Haiku 4.5 — fast, cost-efficient"),
+)
+
 # Empty value means "no -m" so the Codex CLI uses its configured default/current model.
 CODEX_MODELS = (
     ModelOption(
@@ -155,6 +166,12 @@ def _codex_adapter_factory() -> LLMCLIAdapter:
     from app.integrations.llm_cli.codex import CodexAdapter
 
     return CodexAdapter()
+
+
+def _claude_code_adapter_factory() -> LLMCLIAdapter:
+    from app.integrations.llm_cli.claude_code import ClaudeCodeAdapter
+
+    return ClaudeCodeAdapter()
 
 
 SUPPORTED_PROVIDERS = (
@@ -219,6 +236,18 @@ SUPPORTED_PROVIDERS = (
         credential_kind="cli",
         credential_secret=False,
         adapter_factory=_codex_adapter_factory,
+    ),
+    ProviderOption(
+        value="claude-code",
+        label="Anthropic Claude Code CLI",
+        group="Local CLI providers",
+        api_key_env="",
+        model_env="CLAUDE_CODE_MODEL",
+        default_model="",
+        models=CLAUDE_CODE_MODELS,
+        credential_kind="cli",
+        credential_secret=False,
+        adapter_factory=_claude_code_adapter_factory,
     ),
     ProviderOption(
         value="ollama",

--- a/app/config.py
+++ b/app/config.py
@@ -122,6 +122,7 @@ LLMProvider = Literal[
     "bedrock",
     "minimax",
     "codex",
+    "claude-code",
 ]
 
 
@@ -167,6 +168,7 @@ class LLMSettings(StrictConfigModel):
             "bedrock",
             "minimax",
             "codex",
+            "claude-code",
         )
         if provider in valid_providers:
             return provider
@@ -181,8 +183,8 @@ class LLMSettings(StrictConfigModel):
 
     @model_validator(mode="after")
     def _require_api_key_for_selected_provider(self) -> "LLMSettings":
-        if self.provider in ("ollama", "bedrock", "codex"):
-            return self  # ollama: local; bedrock: IAM; codex: `codex login` (CLI)
+        if self.provider in ("ollama", "bedrock", "codex", "claude-code"):
+            return self  # ollama: local; bedrock: IAM; codex/claude-code: CLI auth
         provider_to_key = {
             "anthropic": self.anthropic_api_key,
             "openai": self.openai_api_key,

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -1,0 +1,198 @@
+"""Anthropic Claude Code CLI adapter (``claude -p``, non-interactive / print mode).
+
+Env vars
+--------
+CLAUDE_CODE_BIN   Optional explicit path to the ``claude`` binary.
+                  Blank or non-runnable paths are ignored; PATH + fallbacks apply.
+CLAUDE_CODE_MODEL Optional model override (e.g. ``claude-opus-4-7``).
+                  Unset or empty → omit ``--model``; CLI default applies.
+
+Auth
+----
+Claude Code authenticates via ``ANTHROPIC_API_KEY`` (env var) or OAuth credentials
+stored in ``~/.claude/.credentials.json`` after ``claude login``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
+from app.integrations.llm_cli.binary_resolver import (
+    candidate_binary_names as _candidate_binary_names,
+)
+from app.integrations.llm_cli.binary_resolver import (
+    default_cli_fallback_paths as _default_cli_fallback_paths,
+)
+from app.integrations.llm_cli.binary_resolver import (
+    resolve_cli_binary,
+)
+
+_CLAUDE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+# Claude Code's `--version` does config/cache init that can spike past Codex's 3s
+# budget on cold starts or when another claude process holds shared state.
+_PROBE_TIMEOUT_SEC = 8.0
+
+
+def _parse_semver(text: str) -> str | None:
+    m = _CLAUDE_VERSION_RE.search(text)
+    return m.group(1) if m else None
+
+
+def _classify_claude_code_auth() -> tuple[bool | None, str]:
+    """Return (logged_in, detail) without spawning a subprocess.
+
+    Resolution order:
+    1. ANTHROPIC_API_KEY in env → True (definitive; build() forwards it).
+    2. ~/.claude/.credentials.json present and non-empty → True (OAuth login).
+    3. macOS without either → None: Claude Code stores OAuth in Keychain on
+       darwin, so file absence is not proof of no-auth — let invocation reveal.
+    4. Otherwise → False (Linux/Windows: file is the canonical credential store).
+    """
+    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        return True, "Authenticated via ANTHROPIC_API_KEY."
+    creds_path = Path.home() / ".claude" / ".credentials.json"
+    try:
+        if creds_path.exists() and creds_path.stat().st_size > 2:
+            return True, "Authenticated via ~/.claude/.credentials.json (OAuth login)."
+    except OSError:
+        return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
+    if sys.platform == "darwin":
+        return None, (
+            "ANTHROPIC_API_KEY not set and ~/.claude/.credentials.json absent; "
+            "macOS may use Keychain — auth state unclear, invocation will verify."
+        )
+    return (
+        False,
+        "Not authenticated. Run: claude login  or set ANTHROPIC_API_KEY.",
+    )
+
+
+def _fallback_claude_code_paths() -> list[str]:
+    return _default_cli_fallback_paths("claude")
+
+
+class ClaudeCodeAdapter:
+    """Non-interactive Claude Code CLI (``claude -p``, print mode, no TTY)."""
+
+    name = "claude-code"
+    binary_env_key = "CLAUDE_CODE_BIN"
+    install_hint = "npm i -g @anthropic-ai/claude-code"
+    auth_hint = "Run: claude login  or set ANTHROPIC_API_KEY"
+    min_version: str | None = None
+    default_exec_timeout_sec = 120.0
+
+    def _resolve_binary(self) -> str | None:
+        return resolve_cli_binary(
+            explicit_env_key="CLAUDE_CODE_BIN",
+            binary_names=_candidate_binary_names("claude"),
+            fallback_paths=_fallback_claude_code_paths,
+        )
+
+    def _probe_binary(self, binary_path: str) -> CLIProbe:
+        try:
+            ver_proc = subprocess.run(
+                [binary_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=_PROBE_TIMEOUT_SEC,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return CLIProbe(
+                installed=False,
+                version=None,
+                logged_in=None,
+                bin_path=None,
+                detail=f"Could not run `{binary_path} --version`: {exc}",
+            )
+
+        if ver_proc.returncode != 0:
+            err = (ver_proc.stderr or ver_proc.stdout or "").strip()
+            return CLIProbe(
+                installed=False,
+                version=None,
+                logged_in=None,
+                bin_path=None,
+                detail=f"`{binary_path} --version` failed: {err or 'unknown error'}",
+            )
+
+        version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
+        logged_in, auth_detail = _classify_claude_code_auth()
+        return CLIProbe(
+            installed=True,
+            version=version,
+            logged_in=logged_in,
+            bin_path=binary_path,
+            detail=auth_detail,
+        )
+
+    def detect(self) -> CLIProbe:
+        binary = self._resolve_binary()
+        if not binary:
+            return CLIProbe(
+                installed=False,
+                version=None,
+                logged_in=None,
+                bin_path=None,
+                detail=(
+                    "Claude Code CLI not found on PATH or known install locations. "
+                    f"Install with: {self.install_hint}  or set CLAUDE_CODE_BIN."
+                ),
+            )
+        return self._probe_binary(binary)
+
+    def build(self, *, prompt: str, model: str | None, workspace: str) -> CLIInvocation:
+        binary = self._resolve_binary()
+        if not binary:
+            raise RuntimeError(
+                f"Claude Code CLI not found. {self.install_hint}"
+                " or set CLAUDE_CODE_BIN to the full binary path."
+            )
+
+        cwd = workspace or os.getcwd()
+
+        argv: list[str] = [
+            binary,
+            "-p",
+            "--output-format",
+            "text",
+        ]
+
+        resolved_model = (model or "").strip()
+        if resolved_model:
+            argv.extend(["--model", resolved_model])
+
+        # Forward Anthropic auth vars explicitly rather than relying on a blanket
+        # prefix allowlist, so they don't leak into other CLI adapters (e.g. Codex).
+        env: dict[str, str] = {"NO_COLOR": "1"}
+        for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"):
+            val = os.environ.get(key, "").strip()
+            if val:
+                env[key] = val
+
+        return CLIInvocation(
+            argv=tuple(argv),
+            stdin=prompt,
+            cwd=cwd,
+            env=env,
+            timeout_sec=self.default_exec_timeout_sec,
+        )
+
+    def parse(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        del stderr, returncode
+        return (stdout or "").strip()
+
+    def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        err = (stderr or "").strip()
+        out = (stdout or "").strip()
+        bits = [f"claude -p exited with code {returncode}"]
+        if err:
+            bits.append(err[:2000])
+        elif out:
+            bits.append(out[:2000])
+        return ". ".join(bits)

--- a/app/integrations/llm_cli/registry.py
+++ b/app/integrations/llm_cli/registry.py
@@ -23,8 +23,17 @@ def _codex_factory() -> LLMCLIAdapter:
     return CodexAdapter()
 
 
+def _claude_code_factory() -> LLMCLIAdapter:
+    from app.integrations.llm_cli.claude_code import ClaudeCodeAdapter
+
+    return ClaudeCodeAdapter()
+
+
 CLI_PROVIDER_REGISTRY: dict[str, CLIProviderRegistration] = {
     "codex": CLIProviderRegistration(adapter_factory=_codex_factory, model_env_key="CODEX_MODEL"),
+    "claude-code": CLIProviderRegistration(
+        adapter_factory=_claude_code_factory, model_env_key="CLAUDE_CODE_MODEL"
+    ),
 }
 
 

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -24,6 +24,10 @@ _PROBE_CACHE_TTL_SEC = 45.0
 _SAFE_SUBPROCESS_ENV_KEYS = frozenset(
     {
         "HOME",
+        # macOS Keychain item lookup (where `claude login` stores OAuth on darwin)
+        # requires USER. LOGNAME is the POSIX/Linux equivalent kept for parity.
+        "USER",
+        "LOGNAME",
         "USERPROFILE",
         "APPDATA",
         "LOCALAPPDATA",
@@ -56,7 +60,7 @@ _SAFE_SUBPROCESS_ENV_KEYS = frozenset(
         "XDG_STATE_HOME",
     }
 )
-_SAFE_SUBPROCESS_ENV_PREFIXES = ("LC_", "CODEX_")
+_SAFE_SUBPROCESS_ENV_PREFIXES = ("LC_", "CODEX_", "CLAUDE_")
 
 
 def _strip_ansi(text: str) -> str:

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -1,0 +1,414 @@
+"""Tests for the Claude Code CLI adapter (detect / build / failure / env forwarding)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.integrations.llm_cli.binary_resolver import npm_prefix_bin_dirs
+from app.integrations.llm_cli.claude_code import (
+    ClaudeCodeAdapter,
+    _classify_claude_code_auth,
+    _fallback_claude_code_paths,
+)
+
+
+def _posix_path_set(paths: list[str]) -> set[str]:
+    return {Path(p).as_posix() for p in paths}
+
+
+# ---------------------------------------------------------------------------
+# Auth classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_auth_api_key_set() -> None:
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test-key"}, clear=False):
+        logged_in, detail = _classify_claude_code_auth()
+    assert logged_in is True
+    assert "ANTHROPIC_API_KEY" in detail
+
+
+def test_classify_auth_no_credentials_linux() -> None:
+    """On Linux, no env var and no credentials file → definitive False."""
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.sys.platform", "linux"),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = False
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        logged_in, _detail = _classify_claude_code_auth()
+    assert logged_in is False
+
+
+def test_classify_auth_no_credentials_macos_returns_none() -> None:
+    """On macOS, no env var and no file → None (Keychain may still hold OAuth)."""
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.sys.platform", "darwin"),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = False
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        logged_in, detail = _classify_claude_code_auth()
+    assert logged_in is None
+    assert "Keychain" in detail
+
+
+def test_classify_auth_credentials_file_present(tmp_path: Path) -> None:
+    # Create a fake ~/.claude/.credentials.json under tmp_path.
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    creds = claude_dir / ".credentials.json"
+    creds.write_text('{"token": "abc"}')
+
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.Path.home", return_value=tmp_path),
+    ):
+        logged_in, detail = _classify_claude_code_auth()
+
+    assert logged_in is True
+    assert "credentials.json" in detail
+
+
+def test_classify_auth_credentials_file_unreadable() -> None:
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = True
+        mock_creds.stat.side_effect = OSError("permission denied")
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        logged_in, _detail = _classify_claude_code_auth()
+
+    assert logged_in is None
+
+
+# ---------------------------------------------------------------------------
+# detect()
+# ---------------------------------------------------------------------------
+
+
+def _version_proc() -> MagicMock:
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = "1.2.3\n"
+    m.stderr = ""
+    return m
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_logged_in_via_api_key(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    mock_which.return_value = "/usr/bin/claude"
+    mock_run.return_value = _version_proc()
+
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=False):
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert probe.bin_path == "/usr/bin/claude"
+    assert probe.version == "1.2.3"
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_not_authenticated_linux(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """On Linux, missing creds file with no env var produces definitive logged_in=False."""
+    mock_which.return_value = "/usr/bin/claude"
+    mock_run.return_value = _version_proc()
+
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.sys.platform", "linux"),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = False
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is False
+
+
+@patch("app.integrations.llm_cli.claude_code._fallback_claude_code_paths", return_value=[])
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value=None)
+def test_detect_not_installed(_mock_which: MagicMock, _mock_fallback: MagicMock) -> None:
+    probe = ClaudeCodeAdapter().detect()
+    assert probe.installed is False
+    assert probe.logged_in is None
+    assert probe.bin_path is None
+    assert "not found" in probe.detail.lower()
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_version_command_fails(_mock_which: MagicMock, mock_run: MagicMock) -> None:
+    _mock_which.return_value = "/usr/bin/claude"
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = "some error\n"
+    mock_run.return_value = m
+
+    probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is False
+    assert probe.logged_in is None
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_version_os_error(_mock_which: MagicMock, mock_run: MagicMock) -> None:
+    _mock_which.return_value = "/usr/bin/claude"
+    mock_run.side_effect = OSError("not found")
+
+    probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is False
+    assert probe.logged_in is None
+
+
+# ---------------------------------------------------------------------------
+# build()
+# ---------------------------------------------------------------------------
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_build_basic_invocation(_mock_which: MagicMock) -> None:
+    inv = ClaudeCodeAdapter().build(prompt="explain this alert", model=None, workspace="")
+    assert inv.argv[0] == "/usr/bin/claude"
+    assert "-p" in inv.argv
+    assert "--output-format" in inv.argv
+    assert "text" in inv.argv
+    assert inv.stdin == "explain this alert"
+    assert inv.timeout_sec == 120.0
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_build_adds_model_flag(_mock_which: MagicMock) -> None:
+    inv = ClaudeCodeAdapter().build(prompt="p", model="claude-opus-4-7", workspace="")
+    assert "--model" in inv.argv
+    idx = inv.argv.index("--model")
+    assert inv.argv[idx + 1] == "claude-opus-4-7"
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_build_omits_model_flag_when_empty(_mock_which: MagicMock) -> None:
+    inv = ClaudeCodeAdapter().build(prompt="p", model="", workspace="")
+    assert "--model" not in inv.argv
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_build_omits_model_flag_when_none(_mock_which: MagicMock) -> None:
+    inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace="")
+    assert "--model" not in inv.argv
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_build_uses_provided_workspace(_mock_which: MagicMock) -> None:
+    inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace="/my/project")
+    assert inv.cwd == "/my/project"
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_build_sets_no_color_env(_mock_which: MagicMock) -> None:
+    inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace="")
+    assert inv.env is not None
+    assert inv.env.get("NO_COLOR") == "1"
+
+
+@patch("app.integrations.llm_cli.claude_code._fallback_claude_code_paths", return_value=[])
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value=None)
+def test_build_raises_when_binary_not_found(_mock_which: MagicMock, _mock_fallback: MagicMock) -> None:
+    import pytest
+
+    with pytest.raises(RuntimeError, match="Claude Code CLI not found"):
+        ClaudeCodeAdapter().build(prompt="p", model=None, workspace="")
+
+
+# ---------------------------------------------------------------------------
+# parse / explain_failure
+# ---------------------------------------------------------------------------
+
+
+def test_parse_returns_stripped_stdout() -> None:
+    adapter = ClaudeCodeAdapter()
+    result = adapter.parse(stdout="  hello world  \n", stderr="", returncode=0)
+    assert result == "hello world"
+
+
+def test_explain_failure_includes_returncode_and_stderr() -> None:
+    adapter = ClaudeCodeAdapter()
+    msg = adapter.explain_failure(stdout="", stderr="auth error", returncode=1)
+    assert "1" in msg
+    assert "auth error" in msg
+
+
+def test_explain_failure_falls_back_to_stdout() -> None:
+    adapter = ClaudeCodeAdapter()
+    msg = adapter.explain_failure(stdout="some output", stderr="", returncode=2)
+    assert "some output" in msg
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE_CODE_BIN env override
+# ---------------------------------------------------------------------------
+
+
+def test_detect_uses_claude_code_bin_env(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "my-claude"
+    fake_bin.write_bytes(b"")
+    os.chmod(fake_bin, 0o700)
+
+    with (
+        patch.dict(
+            os.environ,
+            {"CLAUDE_CODE_BIN": str(fake_bin), "ANTHROPIC_API_KEY": "sk-t"},
+            clear=False,
+        ),
+        patch("app.integrations.llm_cli.claude_code.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = _version_proc()
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.bin_path == str(fake_bin)
+    assert probe.installed is True
+    assert mock_run.call_args[0][0][0] == str(fake_bin)
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
+def test_detect_falls_back_when_bin_env_invalid(_mock_which: MagicMock, mock_run: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {"CLAUDE_CODE_BIN": "/does/not/exist/claude", "ANTHROPIC_API_KEY": "sk-t"},
+        clear=False,
+    ):
+        mock_run.return_value = _version_proc()
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.bin_path == "/usr/bin/claude"
+    assert probe.installed is True
+
+
+# ---------------------------------------------------------------------------
+# Fallback paths
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_paths_macos() -> None:
+    npm_prefix_bin_dirs.cache_clear()
+    with (
+        patch("app.integrations.llm_cli.binary_resolver.sys.platform", "darwin"),
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        paths = _fallback_claude_code_paths()
+
+    normalized = _posix_path_set(paths)
+    assert "/opt/homebrew/bin/claude" in normalized
+    assert "/usr/local/bin/claude" in normalized
+    assert (Path.home() / ".local/bin/claude").as_posix() in normalized
+
+
+def test_fallback_paths_linux() -> None:
+    npm_prefix_bin_dirs.cache_clear()
+    with (
+        patch("app.integrations.llm_cli.binary_resolver.sys.platform", "linux"),
+        patch.dict(os.environ, {"npm_config_prefix": "/custom/npm"}, clear=False),
+    ):
+        paths = _fallback_claude_code_paths()
+
+    normalized = _posix_path_set(paths)
+    assert "/custom/npm/bin/claude" in normalized
+
+
+def test_fallback_paths_windows() -> None:
+    npm_prefix_bin_dirs.cache_clear()
+    with (
+        patch("app.integrations.llm_cli.binary_resolver.sys.platform", "win32"),
+        patch.dict(
+            os.environ,
+            {
+                "APPDATA": r"C:\Users\me\AppData\Roaming",
+                "LOCALAPPDATA": r"C:\Users\me\AppData\Local",
+            },
+            clear=False,
+        ),
+    ):
+        paths = _fallback_claude_code_paths()
+
+    normalized = {p.replace("\\", "/") for p in paths}
+    assert "C:/Users/me/AppData/Roaming/npm/claude.cmd" in normalized
+    assert "C:/Users/me/AppData/Roaming/npm/claude.exe" in normalized
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_claude_code_registry_entry() -> None:
+    from app.integrations.llm_cli.registry import get_cli_provider_registration
+
+    reg = get_cli_provider_registration("claude-code")
+    assert reg is not None
+    assert reg.model_env_key == "CLAUDE_CODE_MODEL"
+    assert reg.adapter_factory().name == "claude-code"
+
+
+# ---------------------------------------------------------------------------
+# Subprocess env forwarding — ANTHROPIC_ and CLAUDE_ prefixes must be safe
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_key_forwarded_via_build() -> None:
+    """ANTHROPIC_API_KEY is forwarded explicitly by build(), not via the blanket prefix allowlist.
+
+    This keeps Codex subprocesses from receiving Anthropic credentials.
+    """
+    with (
+        patch.dict(
+            os.environ,
+            {"ANTHROPIC_API_KEY": "sk-forward-me", "ANTHROPIC_BASE_URL": "https://proxy.example.com"},
+            clear=False,
+        ),
+        patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude"),
+    ):
+        inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace="")
+
+    assert inv.env is not None
+    assert inv.env["ANTHROPIC_API_KEY"] == "sk-forward-me"
+    assert inv.env["ANTHROPIC_BASE_URL"] == "https://proxy.example.com"
+
+
+def test_anthropic_key_not_in_blanket_subprocess_env() -> None:
+    """ANTHROPIC_API_KEY must NOT be forwarded via the global prefix allowlist (would leak to Codex)."""
+    from app.integrations.llm_cli.runner import _build_subprocess_env
+
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-secret"}, clear=False):
+        env = _build_subprocess_env(None)
+
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_claude_prefix_forwarded_to_subprocess() -> None:
+    from app.integrations.llm_cli.runner import _build_subprocess_env
+
+    with patch.dict(
+        os.environ,
+        {"CLAUDE_CODE_MODEL": "claude-opus-4-7", "CLAUDE_CODE_BIN": "/usr/bin/claude"},
+        clear=False,
+    ):
+        env = _build_subprocess_env(None)
+
+    assert env["CLAUDE_CODE_MODEL"] == "claude-opus-4-7"
+    assert env["CLAUDE_CODE_BIN"] == "/usr/bin/claude"

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -177,6 +177,26 @@ def test_detect_version_os_error(_mock_which: MagicMock, mock_run: MagicMock) ->
     assert probe.logged_in is None
 
 
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_version_timeout_expired(_mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Cold-start `claude --version` can exceed the probe timeout; must not raise."""
+    import subprocess
+
+    _mock_which.return_value = "/usr/bin/claude"
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["/usr/bin/claude", "--version"], timeout=8.0
+    )
+
+    probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is False
+    assert probe.logged_in is None
+    assert probe.bin_path is None
+    assert "could not run" in probe.detail.lower()
+    assert "--version" in probe.detail
+
+
 # ---------------------------------------------------------------------------
 # build()
 # ---------------------------------------------------------------------------
@@ -228,7 +248,9 @@ def test_build_sets_no_color_env(_mock_which: MagicMock) -> None:
 
 @patch("app.integrations.llm_cli.claude_code._fallback_claude_code_paths", return_value=[])
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value=None)
-def test_build_raises_when_binary_not_found(_mock_which: MagicMock, _mock_fallback: MagicMock) -> None:
+def test_build_raises_when_binary_not_found(
+    _mock_which: MagicMock, _mock_fallback: MagicMock
+) -> None:
     import pytest
 
     with pytest.raises(RuntimeError, match="Claude Code CLI not found"):
@@ -287,7 +309,9 @@ def test_detect_uses_claude_code_bin_env(tmp_path: Path) -> None:
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
-def test_detect_falls_back_when_bin_env_invalid(_mock_which: MagicMock, mock_run: MagicMock) -> None:
+def test_detect_falls_back_when_bin_env_invalid(
+    _mock_which: MagicMock, mock_run: MagicMock
+) -> None:
     with patch.dict(
         os.environ,
         {"CLAUDE_CODE_BIN": "/does/not/exist/claude", "ANTHROPIC_API_KEY": "sk-t"},
@@ -378,10 +402,15 @@ def test_anthropic_key_forwarded_via_build() -> None:
     with (
         patch.dict(
             os.environ,
-            {"ANTHROPIC_API_KEY": "sk-forward-me", "ANTHROPIC_BASE_URL": "https://proxy.example.com"},
+            {
+                "ANTHROPIC_API_KEY": "sk-forward-me",
+                "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            },
             clear=False,
         ),
-        patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude"
+        ),
     ):
         inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace="")
 


### PR DESCRIPTION
Fixes #1108

#### Describe the changes you have made in this PR -

Adds Anthropic Claude Code as a non-interactive CLI-backed LLM provider, selectable via `LLM_PROVIDER=claude-code`. The integration mirrors the existing OpenAI Codex CLI adapter shape end-to-end (adapter, registry, wizard option, env forwarding, fallback binary paths) so users can run `opensre investigate` against an alert using their local `claude` binary instead of an HTTP API key.

Highlights:
- New `ClaudeCodeAdapter` in `app/integrations/llm_cli/claude_code.py` that runs `claude -p --output-format text` with the prompt on stdin — strictly non-interactive, no TTY, no approval loops.
- Three-state auth probe (True / False / None) that checks `ANTHROPIC_API_KEY` env, then `~/.claude/.credentials.json`. On macOS, when neither is present, returns `None` instead of `False` because `claude login` stores OAuth tokens in Keychain on darwin — a strict file-only check would falsely block Keychain-authenticated users.
- Binary resolution via the shared `resolve_cli_binary` helper — `CLAUDE_CODE_BIN` override → PATH → npm/Homebrew/volta/pnpm/XDG fallbacks.
- Provider registered in `CLI_PROVIDER_REGISTRY` and selectable through the onboarding wizard under "Local CLI providers".
- 29 unit tests covering detect / build / parse / explain_failure, the `CLAUDE_CODE_BIN` override and PATH fallback, fallback paths on macOS / Linux / Windows (mocked `sys.platform`), registry registration, and env-forwarding security guarantees (specifically: `ANTHROPIC_API_KEY` is forwarded ONLY by the Claude Code invocation, not via the global allowlist, so credentials don't leak into Codex subprocesses).
- `.env.example` documents `CLAUDE_CODE_BIN` and `CLAUDE_CODE_MODEL`.
- `runner.py`: added `CLAUDE_` to `_SAFE_SUBPROCESS_ENV_PREFIXES` so `CLAUDE_CODE_*` settings reach the subprocess; added `USER` and `LOGNAME` to safe keys (macOS Keychain item lookup needs `USER`).

### Demo/Screenshot for feature changes and bug fixes -

<img width="1512" height="982" alt="Screenshot 2026-04-30 at 17 46 14" src="https://github.com/user-attachments/assets/a4bf864c-98d2-4649-a06d-8bc691edf34d" />
<img width="1007" height="275" alt="Screenshot 2026-04-30 at 18 07 57" src="https://github.com/user-attachments/assets/21c20575-c3df-4313-8579-212a33712505" />
<img width="1512" height="982" alt="Screenshot 2026-04-30 at 18 12 56" src="https://github.com/user-attachments/assets/773744b0-6d65-4bf2-8e47-c92bb5aa3eed" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** OpenSRE supported Codex CLI as a non-interactive LLM provider but had no equivalent for Claude Code. Issue #1108 asks for the same shape: a one-shot, scriptable CLI invocation that runs to completion under `subprocess.run` with no TTY, no approval prompts, and no REPL.

**Alternatives considered:**
1. **Interactive mode** (just `claude` with stdin) — rejected because the issue explicitly excludes interactive flows; the agent runtime can't sit in a REPL waiting for prompts.
2. **HTTP via Anthropic SDK** — that path already exists as `LLM_PROVIDER=anthropic`. The point of this issue is to support users whose only auth is `claude login` (no API key on file), via subprocess to their local CLI.
3. **A subprocess auth probe** (e.g. `claude doctor`) — rejected because Claude Code has no clean machine-readable auth-status command, so I went with a fast file-and-env check that doesn't fork a process for the probe at all.

**Why this implementation:**
The repo already has a clean `LLMCLIAdapter` Protocol and `CLIBackedLLMClient` runner that drive Codex. Implementing Claude Code as another adapter (instead of carving a new pathway) means I get caching of probes, ANSI stripping, env allowlisting, structured output, and timeout handling for free, and the change stays tightly scoped. Following the same shape is also explicitly requested by `app/integrations/llm_cli/AGENTS.md`.

**Key components:**
- `ClaudeCodeAdapter._resolve_binary()` — defers to the shared `resolve_cli_binary` so `CLAUDE_CODE_BIN` override behaviour matches Codex (blank/invalid env value falls back instead of erroring).
- `ClaudeCodeAdapter._probe_binary()` — runs `claude --version` with a generous 8s timeout (Codex's 3s was too tight: Claude Code does config/cache init at startup and times out when another `claude` process holds shared state). On version success, defers to `_classify_claude_code_auth()`.
- `_classify_claude_code_auth()` — env-var check first, then OAuth credentials file. The macOS branch deliberately returns `None` (not `False`) when both are absent, because Claude Code on darwin stores tokens in Keychain and the runner only blocks invocation on `False`; `None` lets the actual `claude -p` call surface the real auth state via `explain_failure`.
- `ClaudeCodeAdapter.build()` — produces `argv = (claude, -p, --output-format, text [, --model …])` with the prompt on stdin and `NO_COLOR=1` in env. It explicitly forwards `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` here rather than via the global subprocess allowlist — this prevents Anthropic credentials from leaking into other CLI adapters' subprocesses (e.g. Codex).
- `parse()` / `explain_failure()` — minimal, mirroring Codex; `parse` returns trimmed stdout, `explain_failure` includes the return code and a clipped stderr/stdout for the runner to surface.

**Edge cases tested:**
- Binary missing entirely → clear install hint
- `CLAUDE_CODE_BIN` points at a non-existent path → falls back to PATH
- `claude --version` fails → `installed=False` with diagnostic detail
- Missing creds on Linux → `False` (definitive); on macOS → `None` (Keychain may hold tokens)
- Empty / `None` model → `--model` flag omitted (CLI default applies)
- `parse()` with whitespace-only stdout
- `explain_failure()` falls back to stdout when stderr is empty
- Cross-OS fallback paths verified for macOS / Linux / Windows via patched `sys.platform`
- Env-forwarding: `CLAUDE_*` reaches the subprocess; `ANTHROPIC_API_KEY` reaches Claude Code's subprocess only, not the global allowlist (so it isn't forwarded to Codex runs)

---
