### PR TITLE
test(output): add direct unit tests for app/output.py (#871)

### DIFF
--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,6 +1,96 @@
 from __future__ import annotations
 
-from app.output import _humanise_message
+import re
+from typing import Any
+
+import pytest
+
+from app import output
+from app.output import (
+    ProgressEvent,
+    ProgressTracker,
+    _fmt_timing,
+    _humanise_message,
+    get_output_format,
+    get_tracker,
+    reset_tracker,
+)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+@pytest.fixture(autouse=True)
+def _clear_output_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep output-format env vars deterministic across tests."""
+    for name in ("TRACER_OUTPUT_FORMAT", "NO_COLOR", "SLACK_WEBHOOK_URL", "TRACER_VERBOSE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def force_text_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the tracker to pick the plain-text rendering path."""
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "text")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_output_format
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_get_output_format_honours_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "json")
+    assert get_output_format() == "json"
+
+
+def test_get_output_format_returns_text_when_no_color_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert get_output_format() == "text"
+
+
+def test_get_output_format_returns_text_when_no_color_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # NO_COLOR semantics: presence of the variable is the signal, not its value.
+    monkeypatch.setenv("NO_COLOR", "")
+    assert get_output_format() == "text"
+
+
+def test_get_output_format_returns_text_when_slack_webhook_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/abc")
+    assert get_output_format() == "text"
+
+
+def test_get_output_format_returns_rich_for_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(output.sys.stdout, "isatty", lambda: True, raising=False)
+    assert get_output_format() == "rich"
+
+
+def test_get_output_format_returns_text_when_not_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(output.sys.stdout, "isatty", lambda: False, raising=False)
+    assert get_output_format() == "text"
+
+
+def test_get_output_format_override_wins_over_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TRACER_OUTPUT_FORMAT", "rich")
+    assert get_output_format() == "rich"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _humanise_message
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_humanise_message_returns_empty_for_empty_input() -> None:
+    assert _humanise_message("") == ""
 
 
 def test_humanise_message_uses_registered_tool_display_names() -> None:
@@ -13,3 +103,206 @@ def test_humanise_message_falls_back_for_unknown_tool_names() -> None:
     message = "Planned actions: ['my_custom_tool']"
 
     assert _humanise_message(message) == "my custom tool"
+
+
+def test_humanise_message_drops_no_new_actions() -> None:
+    assert _humanise_message("No new actions to plan") == ""
+
+
+def test_humanise_message_extracts_resolved_integrations_list() -> None:
+    msg = "Resolved integrations: ['datadog', 'grafana', 'pagerduty']"
+    assert _humanise_message(msg) == "datadog, grafana, pagerduty"
+
+
+def test_humanise_message_extracts_integrations_when_keyword_present() -> None:
+    msg = "Loaded integrations from store: ['github']"
+    assert _humanise_message(msg) == "github"
+
+
+def test_humanise_message_returns_input_when_resolved_has_no_list() -> None:
+    # Falls through to the trailing return when no '[...]' segment is present.
+    msg = "resolved without list"
+    assert _humanise_message(msg) == msg
+
+
+def test_humanise_message_formats_validity_as_confidence() -> None:
+    assert _humanise_message("validity:87%") == "confidence 87%"
+
+
+def test_humanise_message_strips_datadog_prefix() -> None:
+    assert _humanise_message("datadog:fetched 5 logs") == "fetched 5 logs"
+
+
+def test_humanise_message_passes_through_unrecognised_messages() -> None:
+    assert _humanise_message("ready") == "ready"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _fmt_timing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("elapsed_ms", "expected"),
+    [
+        (0, "0ms"),
+        (1, "1ms"),
+        (250, "250ms"),
+        (999, "999ms"),
+        (1000, "1.0s"),
+        (1500, "1.5s"),
+        (12345, "12.3s"),
+    ],
+)
+def test_fmt_timing(elapsed_ms: int, expected: str) -> None:
+    assert _fmt_timing(elapsed_ms) == expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ProgressTracker — text mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_start_prints_node_label_in_text_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    tracker = ProgressTracker()
+    tracker.start("investigate")
+
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "Gathering evidence" in out
+    assert "…" in out
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_start_records_event_and_uses_fallback_label(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    tracker = ProgressTracker()
+    tracker.start("custom_node", message="loading")
+
+    out = _strip_ansi(capsys.readouterr().out)
+    # Unknown node names are humanised via title-case.
+    assert "Custom Node" in out
+    assert tracker.events[-1].node_name == "custom_node"
+    assert tracker.events[-1].status == "started"
+    assert tracker.events[-1].message == "loading"
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_complete_emits_dot_label_and_timing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    tracker = ProgressTracker()
+
+    # ``_finish`` calls ``time.monotonic`` twice (once eagerly as the default for
+    # ``dict.pop``), so we yield a sentinel and then a constant tail value.
+    clock = iter([100.0, 100.5, 100.5])
+    monkeypatch.setattr(output.time, "monotonic", lambda: next(clock))
+
+    tracker.start("plan_actions")
+    tracker.complete("plan_actions", message="No new actions to plan")
+
+    out = _strip_ansi(capsys.readouterr().out)
+    lines = [line for line in out.splitlines() if line.strip()]
+
+    assert lines[-1].strip().startswith("●")
+    assert "Planning" in lines[-1]
+    assert "500ms" in lines[-1]
+    assert "No new actions" not in lines[-1]
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_complete_appends_humanised_message_when_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    tracker = ProgressTracker()
+
+    clock = iter([0.0, 1.25, 1.25])
+    monkeypatch.setattr(output.time, "monotonic", lambda: next(clock))
+
+    tracker.start("diagnose_root_cause")
+    tracker.complete("diagnose_root_cause", message="validity:75%")
+
+    out = _strip_ansi(capsys.readouterr().out)
+    last = [line for line in out.splitlines() if line.strip()][-1]
+
+    assert "Diagnosing" in last
+    assert "1.2s" in last
+    assert "confidence 75%" in last
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_complete_records_event_with_status_and_fields() -> None:
+    tracker = ProgressTracker()
+    tracker.start("investigate")
+    tracker.complete("investigate", fields_updated=["evidence"], message="datadog:ok")
+
+    completed = [e for e in tracker.events if e.status == "completed"]
+    assert len(completed) == 1
+    event = completed[0]
+    assert event.node_name == "investigate"
+    assert event.fields_updated == ["evidence"]
+    assert event.message == "datadog:ok"
+    assert event.elapsed_ms >= 0
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_error_path_uses_x_marker(capsys: pytest.CaptureFixture[str]) -> None:
+    tracker = ProgressTracker()
+    tracker.start("investigate")
+    tracker.error("investigate", "boom")
+
+    last = [line for line in _strip_ansi(capsys.readouterr().out).splitlines() if line.strip()][-1]
+    assert "✗" in last
+    assert "Gathering evidence" in last
+    assert tracker.events[-1].status == "error"
+    assert tracker.events[-1].message == "boom"
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_tracker_update_subtext_is_a_noop_in_text_mode() -> None:
+    tracker = ProgressTracker()
+    tracker.start("investigate")
+    # No spinner is registered in text mode, so this must not raise.
+    tracker.update_subtext("investigate", "querying logs")
+    tracker.complete("investigate")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Singleton tracker
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_get_tracker_returns_singleton() -> None:
+    a = get_tracker(reset=True)
+    b = get_tracker()
+    assert a is b
+
+
+@pytest.mark.usefixtures("force_text_mode")
+def test_reset_tracker_creates_a_fresh_instance() -> None:
+    first = reset_tracker()
+    second = reset_tracker()
+    assert first is not second
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ProgressEvent dataclass
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_progress_event_defaults() -> None:
+    event = ProgressEvent(node_name="investigate", elapsed_ms=10)
+    assert event.fields_updated == []
+    assert event.status == "completed"
+    assert event.message is None
+
+
+def test_progress_event_independent_default_lists() -> None:
+    a: Any = ProgressEvent(node_name="a", elapsed_ms=0)
+    b: Any = ProgressEvent(node_name="b", elapsed_ms=0)
+    a.fields_updated.append("x")
+    assert b.fields_updated == []

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -24,10 +24,13 @@ def _strip_ansi(text: str) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _clear_output_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep output-format env vars deterministic across tests."""
+def _isolate_output_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every test a clean slate for output-format env and the tracker singleton."""
     for name in ("TRACER_OUTPUT_FORMAT", "NO_COLOR", "SLACK_WEBHOOK_URL", "TRACER_VERBOSE"):
         monkeypatch.delenv(name, raising=False)
+    # The module-level ``_tracker`` is a session-scoped singleton; without resetting it
+    # a tracker created in an earlier test would leak its ``_rich`` flag into later ones.
+    monkeypatch.setattr(output, "_tracker", None)
 
 
 @pytest.fixture
@@ -196,8 +199,9 @@ def test_tracker_complete_emits_dot_label_and_timing(
 ) -> None:
     tracker = ProgressTracker()
 
-    # ``_finish`` calls ``time.monotonic`` twice (once eagerly as the default for
-    # ``dict.pop``), so we yield a sentinel and then a constant tail value.
+    # ``_finish`` calls ``time.monotonic`` twice: once for the elapsed delta, and
+    # once via ``dict.pop(node, time.monotonic())`` whose default is always evaluated
+    # before ``pop`` runs — even when ``node`` is present. So we yield three values.
     clock = iter([100.0, 100.5, 100.5])
     monkeypatch.setattr(output.time, "monotonic", lambda: next(clock))
 


### PR DESCRIPTION
Fixes #871

#### Describe the changes you have made in this PR -
Adds a direct unit test module for `app/output.py` at `tests/test_output.py`.
The module previously had no dedicated tests despite controlling progress
spinners, output-format selection, and humanised messages.

Coverage added:
- `get_output_format()` — explicit override, NO_COLOR (set and empty),
  SLACK_WEBHOOK_URL, TTY/non-TTY, override precedence over NO_COLOR.
- `_humanise_message()` — empty input, registered tool display names,
  fallback for unknown tools, "No new actions" collapse, integrations
  list extraction, validity → confidence formatting, datadog: prefix
  stripping, unrecognised pass-through.
- `_fmt_timing()` — parametrised across the ms/seconds boundary
  (0, 1, 250, 999, 1000, 1500, 12345).
- `ProgressTracker.start()` and `complete()` in text mode — node label,
  ellipsis prefix, fallback label for unknown nodes, dot marker, timing,
  humanised message rendering, recorded events, plus the error path
  (`✗` marker), `update_subtext` no-op in text mode, singleton/reset
  behaviour, and `ProgressEvent` dataclass defaults.

Tests are deterministic: env vars are scrubbed via an autouse fixture,
`time.monotonic` is monkeypatched where elapsed time matters, and the
output format is forced to `text` via `TRACER_OUTPUT_FORMAT` so no real
TTY is required.

### Demo/Screenshot for feature changes and bug fixes -
<img width="1512" height="982" alt="Screenshot 2026-04-30 at 19 23 27" src="https://github.com/user-attachments/assets/bbd03050-293c-4afd-b32e-6531f07be17c" />
<img width="1512" height="982" alt="Screenshot 2026-04-30 at 19 24 06" src="https://github.com/user-attachments/assets/9f22b9cb-0368-4878-8176-5aa5d8b8b3d6" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem: `app/output.py` had no direct test module, so refactors to
the progress tracker, format detection, or message humanisation could
silently break the CLI's output without a failing test.

Approach: a single `tests/test_output.py` that exercises each public/
helper function directly, instead of going through the graph runner.
Helpers like `_humanise_message` and `_fmt_timing` are pure functions,
so they get straightforward input/output assertions (parametrised for
`_fmt_timing` to keep the boundary cases obvious).

For `ProgressTracker`, the tracker has two render paths (rich spinner
vs plain text). The issue scope is text mode only — testing the rich
spinner would mean asserting on threaded ANSI output, which is exactly
the kind of brittle terminal snapshot the issue tells us to avoid. So
the tests force `TRACER_OUTPUT_FORMAT=text` via a fixture and assert
on the captured `print()` output (with ANSI codes stripped).

Determinism comes from three things: an autouse fixture that scrubs
the env vars `get_output_format()` reads (`TRACER_OUTPUT_FORMAT`,
`NO_COLOR`, `SLACK_WEBHOOK_URL`, `TRACER_VERBOSE`); monkeypatching
`time.monotonic` for the timing assertions; and a `force_text_mode`
fixture applied via `@pytest.mark.usefixtures` to keep tracker tests
off the rich path.

One subtlety worth calling out: `ProgressTracker._finish` calls
`time.monotonic` twice (the second time is the eager default for
`dict.pop`), so the patched clock has to yield three values, not two.
That's commented in the test.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
