### PR TITLE
tests: add Escape-cancel coverage for confirm, text, and path prompts

### DIFF
--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -38,6 +38,66 @@ def test_stock_questionary_select_escape_cancels() -> None:
         assert app.run() is None
 
 
+def test_stock_questionary_confirm_escape_cancels() -> None:
+    """Verify that pressing Escape cancels a confirm prompt (Issue #1117).
+
+    Sends the Escape byte (\\x1b) to a questionary.confirm application
+    and asserts that it returns None instead of hanging.
+    """
+    install_questionary_escape_cancel()
+    with create_pipe_input() as pipe_input:
+        q = questionary.confirm(
+            "Are you sure?",
+            input=pipe_input,
+            output=DummyOutput(),
+        )
+        pipe_input.send_bytes(b"\x1b")
+        app = q.application
+        app.input = pipe_input
+        app.output = DummyOutput()
+        assert app.run() is None
+
+
+def test_stock_questionary_text_escape_cancels() -> None:
+    """Verify that pressing Escape cancels a text input prompt (Issue #1117).
+
+    Sends the Escape byte (\\x1b) to a questionary.text application
+    and asserts that it returns None.
+    """
+    install_questionary_escape_cancel()
+    with create_pipe_input() as pipe_input:
+        q = questionary.text(
+            "Name",
+            input=pipe_input,
+            output=DummyOutput(),
+        )
+        pipe_input.send_bytes(b"\x1b")
+        app = q.application
+        app.input = pipe_input
+        app.output = DummyOutput()
+        assert app.run() is None
+
+
+def test_stock_questionary_path_escape_cancels() -> None:
+    """Verify that pressing Escape cancels a path selection prompt (Issue #1117).
+
+    Sends the Escape byte (\\x1b) to a questionary.path application
+    and asserts that it returns None.
+    """
+    install_questionary_escape_cancel()
+    with create_pipe_input() as pipe_input:
+        q = questionary.path(
+            "Path",
+            input=pipe_input,
+            output=DummyOutput(),
+        )
+        pipe_input.send_bytes(b"\x1b")
+        app = q.application
+        app.input = pipe_input
+        app.output = DummyOutput()
+        assert app.run() is None
+
+
 def test_install_questionary_ctrl_c_double_exit_is_idempotent() -> None:
     install_questionary_ctrl_c_double_exit()
     first = questionary.select


### PR DESCRIPTION

<img width="1708" height="998" alt="PrImage" src="https://github.com/user-attachments/assets/29516c4d-fc38-4919-8488-359f36535cbe" />
Fixes #1117 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Added unit test coverage for the "Escape To cancel" functionality in the CLI. Specifically ,added tests for confirm,text,and path prompts to ensure they return None when the Escape key is pressed,Preventing the CLI from hanging
<img width="1169" height="878" alt="PR_CODE" src="https://github.com/user-attachments/assets/1e3186eb-0d8c-4b70-b596-a1289452fa68" />
[](url)
### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

The problem was missing test coverage for the Escape-cancel feature across all CLI prompt types — only `select` was covered.

I followed the existing `test_stock_questionary_select_escape_cancels` pattern already present in the file:

1. Call `install_questionary_escape_cancel()` to activate the Escape-cancel patch before each test.
2. Use `create_pipe_input()` from `prompt_toolkit` as a context manager to simulate a real terminal input.
3. Create the prompt (`confirm`, `text`, or `path`) with the pipe as its input.
4. Send the Escape byte (`b"\x1b"`) to simulate the user pressing Escape.
5. Assert that `app.run()` returns `None` — confirming the prompt was cancelled cleanly.

No alternative approaches were considered since the existing pattern in the file was clear and correct. AI assistance was used only to add the docstrings/comments to the test functions.




---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
