### PR TITLE
test: add unit tests for Snowflake, OpenObserve, and OpenSearch tools (#790)

### DIFF
--- a/docs/daily-updates/2026-04-30.mdx
+++ b/docs/daily-updates/2026-04-30.mdx
@@ -1,0 +1,22 @@
+---
+title: "Daily Update — 2026-04-30"
+description: "OpenSRE engineering daily update for 2026-04-30 (Europe/London)"
+---
+
+Thanks to everyone who contributed yesterday:
+
+no human contributors recorded in merged PRs today 🙏🚀
+
+## Main updates shipped (April 30, 2026)
+
+- No pull requests were merged into `main` today.
+
+## Source pull requests
+
+- No pull requests were merged during this London calendar day.
+
+## Generation metadata
+
+- Generator version: `opensre 2026.4.5`
+- Fallback summary used: `yes`
+- UTC window: `2026-04-29T23:00:00+00:00` to `2026-04-30T23:00:00+00:00`

--- a/docs/daily-updates/overview.mdx
+++ b/docs/daily-updates/overview.mdx
@@ -9,17 +9,18 @@ Daily updates are generated each evening (Europe/London) from the pull requests 
 
 | Date | Highlights |
 | ---- | ----------- |
+| 2026-04-30 | [View](/daily-updates/2026-04-30) — No updates |
 | 2026-04-29 | [View](/daily-updates/2026-04-29) — feat: interactive REPL — the first step toward a... |
 | 2026-04-28 | [View](/daily-updates/2026-04-28) — Incident window tool integration (#1036) |
 | 2026-04-27 | [View](/daily-updates/2026-04-27) — feat: add IncidentWindow foundation for shared incident... |
 | 2026-04-26 | [View](/daily-updates/2026-04-26) — No updates |
 | 2026-04-25 | [View](/daily-updates/2026-04-25) — test(services): add direct unit tests for s3_client.py... |
-| 2026-04-24 | [View](/daily-updates/2026-04-24) — Feature: Add OpenSRE hugging face dataset integration &... |
 
 ## Archive
 
 | Date | Link |
 | ---- | ---- |
+| 2026-04-24 | [View](/daily-updates/2026-04-24) |
 | 2026-04-23 | [View](/daily-updates/2026-04-23) |
 | 2026-04-22 | [View](/daily-updates/2026-04-22) |
 | 2026-04-21 | [View](/daily-updates/2026-04-21) |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,11 +29,18 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["index", "showcase", "features"]
+            "pages": [
+              "index",
+              "showcase",
+              "features"
+            ]
           },
           {
             "group": "First steps",
-            "pages": ["quickstart", "faq"]
+            "pages": [
+              "quickstart",
+              "faq"
+            ]
           }
         ]
       },
@@ -43,11 +50,15 @@
         "groups": [
           {
             "group": "Local",
-            "pages": ["install-local"]
+            "pages": [
+              "install-local"
+            ]
           },
           {
             "group": "Enterprise",
-            "pages": ["install-enterprise"]
+            "pages": [
+              "install-enterprise"
+            ]
           }
         ]
       },
@@ -117,7 +128,10 @@
         "groups": [
           {
             "group": "Getting started",
-            "pages": ["introduction-monitoring", "quickstart-monitoring"]
+            "pages": [
+              "introduction-monitoring",
+              "quickstart-monitoring"
+            ]
           },
           {
             "group": "Use cases",
@@ -231,7 +245,9 @@
         "groups": [
           {
             "group": "Daily updates",
-            "pages": ["daily-updates/overview"]
+            "pages": [
+              "daily-updates/overview"
+            ]
           }
         ]
       }

--- a/tests/tools/test_openobserve_logs_tool.py
+++ b/tests/tools/test_openobserve_logs_tool.py
@@ -1,0 +1,246 @@
+"""Tests for OpenObserveLogsTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.OpenObserveLogsTool import (
+    _auth_headers,
+    _bounded_limit,
+    _extract_records,
+    _openobserve_available,
+    _openobserve_extract_params,
+    query_openobserve_logs,
+)
+
+
+# ---------------------------------------------------------------------------
+# _openobserve_available
+# ---------------------------------------------------------------------------
+
+def test_available_true_with_token() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "base_url": "http://oo.example.com",
+            "api_token": "mytoken",
+        }
+    }
+    assert _openobserve_available(sources) is True
+
+
+def test_available_true_with_username_password() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "base_url": "http://oo.example.com",
+            "username": "admin",
+            "password": "secret",
+        }
+    }
+    assert _openobserve_available(sources) is True
+
+
+def test_available_false_without_credentials() -> None:
+    sources = {
+        "openobserve": {"connection_verified": True, "base_url": "http://oo.example.com"}
+    }
+    assert _openobserve_available(sources) is False
+
+
+def test_available_false_without_base_url() -> None:
+    sources = {"openobserve": {"connection_verified": True, "api_token": "tok"}}
+    assert _openobserve_available(sources) is False
+
+
+def test_available_false_without_connection_verified() -> None:
+    sources = {
+        "openobserve": {"base_url": "http://oo.example.com", "api_token": "tok"}
+    }
+    assert _openobserve_available(sources) is False
+
+
+def test_available_false_no_openobserve_key() -> None:
+    assert _openobserve_available({}) is False
+
+
+# ---------------------------------------------------------------------------
+# _openobserve_extract_params
+# ---------------------------------------------------------------------------
+
+def test_extract_params_maps_all_fields() -> None:
+    sources = {
+        "openobserve": {
+            "base_url": " http://oo.example.com ",
+            "org": "myorg",
+            "stream": "logs",
+            "query": "SELECT * FROM logs",
+            "api_token": "tok",
+            "username": "admin",
+            "password": "secret",
+            "time_range_minutes": 30,
+            "max_results": 80,
+            "integration_id": "oo-01",
+        }
+    }
+    params = _openobserve_extract_params(sources)
+    assert params["base_url"] == "http://oo.example.com"
+    assert params["org"] == "myorg"
+    assert params["stream"] == "logs"
+    assert params["api_token"] == "tok"
+    assert params["time_range_minutes"] == 30
+    assert params["max_results"] == 80
+    assert params["integration_id"] == "oo-01"
+
+
+def test_extract_params_defaults_org_to_default() -> None:
+    sources = {"openobserve": {"base_url": "http://oo.example.com", "api_token": "tok"}}
+    params = _openobserve_extract_params(sources)
+    assert params["org"] == "default"
+
+
+# ---------------------------------------------------------------------------
+# _bounded_limit
+# ---------------------------------------------------------------------------
+
+def test_bounded_limit_clamps_above_hard_limit() -> None:
+    assert _bounded_limit(500, 100) == 100
+
+
+def test_bounded_limit_minimum_one() -> None:
+    assert _bounded_limit(0, 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# _auth_headers
+# ---------------------------------------------------------------------------
+
+def test_auth_headers_bearer_when_token_present() -> None:
+    headers = _auth_headers("mytoken", "", "")
+    assert headers["Authorization"] == "Bearer mytoken"
+
+
+def test_auth_headers_basic_when_username_password() -> None:
+    import base64
+
+    headers = _auth_headers("", "alice", "secret")
+    expected = "Basic " + base64.b64encode(b"alice:secret").decode("ascii")
+    assert headers["Authorization"] == expected
+
+
+# ---------------------------------------------------------------------------
+# _extract_records
+# ---------------------------------------------------------------------------
+
+def test_extract_records_from_hits_dict() -> None:
+    body = {
+        "hits": {
+            "hits": [
+                {"_source": {"level": "error", "msg": "oops"}},
+                {"_source": {"level": "info", "msg": "ok"}},
+            ]
+        }
+    }
+    records = _extract_records(body)
+    assert len(records) == 2
+    assert records[0]["level"] == "error"
+
+
+def test_extract_records_from_hits_list() -> None:
+    body = {"hits": [{"level": "warn"}, {"level": "debug"}]}
+    records = _extract_records(body)
+    assert len(records) == 2
+
+
+def test_extract_records_from_records_key() -> None:
+    body = {"records": [{"ts": "2026-01-01", "msg": "hi"}]}
+    records = _extract_records(body)
+    assert records[0]["msg"] == "hi"
+
+
+def test_extract_records_from_data_key() -> None:
+    body = {"data": [{"id": 1}]}
+    records = _extract_records(body)
+    assert records[0]["id"] == 1
+
+
+def test_extract_records_empty_body() -> None:
+    assert _extract_records({}) == []
+
+
+# ---------------------------------------------------------------------------
+# query_openobserve_logs — integration tests (httpx patched)
+# ---------------------------------------------------------------------------
+
+def test_run_returns_unavailable_when_base_url_missing() -> None:
+    result = query_openobserve_logs(base_url="", api_token="tok")
+    assert result["available"] is False
+    assert "url" in result["error"].lower()
+
+
+def test_run_returns_unavailable_when_no_credentials() -> None:
+    result = query_openobserve_logs(base_url="http://oo.example.com")
+    assert result["available"] is False
+    assert "credentials" in result["error"].lower()
+
+
+def test_run_happy_path_with_token() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "records": [{"level": "error"}, {"level": "warn"}]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    with patch("app.tools.OpenObserveLogsTool.httpx.post", return_value=mock_response):
+        result = query_openobserve_logs(
+            base_url="http://oo.example.com",
+            api_token="tok",
+            limit=50,
+        )
+
+    assert result["available"] is True
+    assert result["total_returned"] == 2
+
+
+def test_run_uses_default_query_when_none_provided() -> None:
+    captured: list[dict] = []
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.append(json)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"records": []}
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    with patch("app.tools.OpenObserveLogsTool.httpx.post", side_effect=fake_post):
+        query_openobserve_logs(base_url="http://oo.example.com", api_token="tok")
+
+    assert "SELECT" in captured[0]["query"]["sql"]
+
+
+def test_run_http_error_returns_unavailable() -> None:
+    with patch(
+        "app.tools.OpenObserveLogsTool.httpx.post",
+        side_effect=Exception("timeout"),
+    ):
+        result = query_openobserve_logs(base_url="http://oo.example.com", api_token="tok")
+
+    assert result["available"] is False
+    assert "timeout" in result["error"]
+
+
+def test_run_respects_hard_limit() -> None:
+    records = [{"level": "info"} for _ in range(300)]
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"records": records}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("app.tools.OpenObserveLogsTool.httpx.post", return_value=mock_response):
+        result = query_openobserve_logs(
+            base_url="http://oo.example.com",
+            api_token="tok",
+            limit=200,
+            max_results=200,
+        )
+
+    assert result["total_returned"] <= 200

--- a/tests/tools/test_opensearch_analytics_tool.py
+++ b/tests/tools/test_opensearch_analytics_tool.py
@@ -1,0 +1,196 @@
+"""Tests for OpenSearchAnalyticsTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.OpenSearchAnalyticsTool import (
+    _bounded_limit,
+    _opensearch_available,
+    _opensearch_extract_params,
+    query_opensearch_analytics,
+)
+
+
+# ---------------------------------------------------------------------------
+# _opensearch_available
+# ---------------------------------------------------------------------------
+
+def test_available_true_when_connection_verified_and_url() -> None:
+    sources = {
+        "opensearch": {"connection_verified": True, "url": "http://os.example.com"}
+    }
+    assert _opensearch_available(sources) is True
+
+
+def test_available_false_without_connection_verified() -> None:
+    sources = {"opensearch": {"url": "http://os.example.com"}}
+    assert _opensearch_available(sources) is False
+
+
+def test_available_false_without_url() -> None:
+    sources = {"opensearch": {"connection_verified": True}}
+    assert _opensearch_available(sources) is False
+
+
+def test_available_false_no_opensearch_key() -> None:
+    assert _opensearch_available({}) is False
+
+
+# ---------------------------------------------------------------------------
+# _opensearch_extract_params
+# ---------------------------------------------------------------------------
+
+def test_extract_params_maps_all_fields() -> None:
+    sources = {
+        "opensearch": {
+            "url": " http://os.example.com ",
+            "api_key": "apikey123",
+            "index_pattern": "logs-*",
+            "default_query": "error",
+            "time_range_minutes": 120,
+            "max_results": 75,
+            "integration_id": "os-01",
+        }
+    }
+    params = _opensearch_extract_params(sources)
+    assert params["url"] == "http://os.example.com"
+    assert params["api_key"] == "apikey123"
+    assert params["index_pattern"] == "logs-*"
+    assert params["query"] == "error"
+    assert params["time_range_minutes"] == 120
+    assert params["max_results"] == 75
+    assert params["integration_id"] == "os-01"
+
+
+def test_extract_params_defaults_index_pattern_to_wildcard() -> None:
+    sources = {"opensearch": {"url": "http://os.example.com", "connection_verified": True}}
+    params = _opensearch_extract_params(sources)
+    assert params["index_pattern"] == "*"
+
+
+def test_extract_params_defaults_query_to_wildcard() -> None:
+    sources = {"opensearch": {"url": "http://os.example.com"}}
+    params = _opensearch_extract_params(sources)
+    assert params["query"] == "*"
+
+
+# ---------------------------------------------------------------------------
+# _bounded_limit
+# ---------------------------------------------------------------------------
+
+def test_bounded_limit_clamps_to_hard_limit() -> None:
+    assert _bounded_limit(999, 100) == 100
+
+
+def test_bounded_limit_minimum_one() -> None:
+    assert _bounded_limit(0, 0) == 1
+
+
+def test_bounded_limit_respects_max_results() -> None:
+    assert _bounded_limit(20, 50) == 20
+
+
+# ---------------------------------------------------------------------------
+# query_opensearch_analytics — integration tests (ElasticsearchClient patched)
+# ---------------------------------------------------------------------------
+
+def test_run_returns_unavailable_when_url_missing() -> None:
+    result = query_opensearch_analytics(url="")
+    assert result["available"] is False
+    assert "url" in result["error"].lower()
+
+
+def test_run_happy_path() -> None:
+    mock_client = MagicMock()
+    mock_client.search_logs.return_value = {
+        "success": True,
+        "logs": [
+            {"message": "disk full", "level": "error"},
+            {"message": "service started", "level": "info"},
+        ],
+    }
+
+    with patch(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient", return_value=mock_client
+    ):
+        result = query_opensearch_analytics(
+            url="http://os.example.com",
+            query="*",
+            limit=50,
+        )
+
+    assert result["available"] is True
+    assert result["total_returned"] == 2
+    assert result["logs"][0]["message"] == "disk full"
+
+
+def test_run_propagates_client_error() -> None:
+    mock_client = MagicMock()
+    mock_client.search_logs.return_value = {
+        "success": False,
+        "error": "index not found",
+    }
+
+    with patch(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient", return_value=mock_client
+    ):
+        result = query_opensearch_analytics(url="http://os.example.com")
+
+    assert result["available"] is False
+    assert "index not found" in result["error"]
+
+
+def test_run_filters_non_dict_logs() -> None:
+    mock_client = MagicMock()
+    mock_client.search_logs.return_value = {
+        "success": True,
+        "logs": [{"msg": "ok"}, "not-a-dict", None],
+    }
+
+    with patch(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient", return_value=mock_client
+    ):
+        result = query_opensearch_analytics(url="http://os.example.com")
+
+    assert result["total_returned"] == 1
+
+
+def test_run_respects_hard_limit() -> None:
+    logs = [{"level": "info"} for _ in range(300)]
+    mock_client = MagicMock()
+    mock_client.search_logs.return_value = {"success": True, "logs": logs}
+
+    with patch(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient", return_value=mock_client
+    ):
+        result = query_opensearch_analytics(
+            url="http://os.example.com",
+            limit=200,
+            max_results=200,
+        )
+
+    assert result["total_returned"] <= 200
+
+
+def test_run_passes_config_to_client() -> None:
+    captured_configs: list = []
+
+    def fake_client(config):
+        captured_configs.append(config)
+        mock = MagicMock()
+        mock.search_logs.return_value = {"success": True, "logs": []}
+        return mock
+
+    with patch(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient", side_effect=fake_client
+    ):
+        query_opensearch_analytics(
+            url="http://os.example.com",
+            api_key="key123",
+            index_pattern="app-logs-*",
+        )
+
+    assert captured_configs[0].url == "http://os.example.com"
+    assert captured_configs[0].api_key == "key123"
+    assert captured_configs[0].index_pattern == "app-logs-*"

--- a/tests/tools/test_snowflake_query_history_tool.py
+++ b/tests/tools/test_snowflake_query_history_tool.py
@@ -1,0 +1,247 @@
+"""Tests for SnowflakeQueryHistoryTool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.tools.SnowflakeQueryHistoryTool import (
+    _auth_header,
+    _bounded_limit,
+    _ensure_sql_limit,
+    _normalize_rows,
+    _snowflake_available,
+    _snowflake_extract_params,
+    query_snowflake_history,
+)
+
+
+# ---------------------------------------------------------------------------
+# _snowflake_available
+# ---------------------------------------------------------------------------
+
+def test_available_true_when_all_fields_present() -> None:
+    sources = {
+        "snowflake": {
+            "connection_verified": True,
+            "account_identifier": "acct123",
+            "token": "tok",
+        }
+    }
+    assert _snowflake_available(sources) is True
+
+
+def test_available_false_without_connection_verified() -> None:
+    sources = {"snowflake": {"account_identifier": "acct123", "token": "tok"}}
+    assert _snowflake_available(sources) is False
+
+
+def test_available_false_when_token_blank() -> None:
+    sources = {
+        "snowflake": {
+            "connection_verified": True,
+            "account_identifier": "acct123",
+            "token": "   ",
+        }
+    }
+    assert _snowflake_available(sources) is False
+
+
+def test_available_false_missing_account_identifier() -> None:
+    sources = {"snowflake": {"connection_verified": True, "token": "tok"}}
+    assert _snowflake_available(sources) is False
+
+
+def test_available_false_no_snowflake_key() -> None:
+    assert _snowflake_available({}) is False
+
+
+# ---------------------------------------------------------------------------
+# _snowflake_extract_params
+# ---------------------------------------------------------------------------
+
+def test_extract_params_maps_all_fields() -> None:
+    sources = {
+        "snowflake": {
+            "account_identifier": " acct ",
+            "user": "alice",
+            "password": "secret",
+            "token": "mytoken",
+            "warehouse": "WH1",
+            "role": "SYSADMIN",
+            "database": "DB",
+            "schema": "PUBLIC",
+            "query": "SELECT 1",
+            "max_results": 100,
+            "integration_id": "sf-01",
+        }
+    }
+    params = _snowflake_extract_params(sources)
+    assert params["account_identifier"] == "acct"
+    assert params["user"] == "alice"
+    assert params["token"] == "mytoken"
+    assert params["warehouse"] == "WH1"
+    assert params["role"] == "SYSADMIN"
+    assert params["database"] == "DB"
+    assert params["db_schema"] == "PUBLIC"
+    assert params["query"] == "SELECT 1"
+    assert params["max_results"] == 100
+    assert params["integration_id"] == "sf-01"
+
+
+def test_extract_params_defaults_max_results() -> None:
+    sources = {"snowflake": {"account_identifier": "acct", "token": "tok"}}
+    params = _snowflake_extract_params(sources)
+    assert params["max_results"] == 50
+
+
+# ---------------------------------------------------------------------------
+# _bounded_limit
+# ---------------------------------------------------------------------------
+
+def test_bounded_limit_clamps_to_max_hard_limit() -> None:
+    assert _bounded_limit(999, 50) == 50
+
+
+def test_bounded_limit_respects_max_results() -> None:
+    assert _bounded_limit(10, 30) == 10
+
+
+def test_bounded_limit_minimum_one() -> None:
+    assert _bounded_limit(0, 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# _ensure_sql_limit
+# ---------------------------------------------------------------------------
+
+def test_ensure_sql_limit_appends_limit_when_absent() -> None:
+    result = _ensure_sql_limit("SELECT * FROM foo", 25)
+    assert result.upper().endswith("LIMIT 25")
+
+
+def test_ensure_sql_limit_preserves_existing_limit() -> None:
+    q = "SELECT * FROM foo LIMIT 10"
+    assert _ensure_sql_limit(q, 25) == q
+
+
+def test_ensure_sql_limit_returns_default_for_empty_query() -> None:
+    result = _ensure_sql_limit("", 5)
+    assert "QUERY_HISTORY" in result
+    assert "5" in result
+
+
+# ---------------------------------------------------------------------------
+# _auth_header
+# ---------------------------------------------------------------------------
+
+def test_auth_header_uses_bearer_token() -> None:
+    headers = _auth_header("mytoken")
+    assert headers["Authorization"] == "Bearer mytoken"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_rows — dict-of-dicts format
+# ---------------------------------------------------------------------------
+
+def test_normalize_rows_list_of_dicts() -> None:
+    payload = {"data": [{"query_id": "q1"}, {"query_id": "q2"}]}
+    rows = _normalize_rows(payload)
+    assert len(rows) == 2
+    assert rows[0]["query_id"] == "q1"
+
+
+def test_normalize_rows_tabular_format() -> None:
+    payload = {
+        "resultSetMetaData": {"rowType": [{"name": "query_id"}, {"name": "user_name"}]},
+        "data": [["q1", "alice"], ["q2", "bob"]],
+    }
+    rows = _normalize_rows(payload)
+    assert rows[0] == {"query_id": "q1", "user_name": "alice"}
+    assert rows[1] == {"query_id": "q2", "user_name": "bob"}
+
+
+def test_normalize_rows_empty_data() -> None:
+    assert _normalize_rows({}) == []
+
+
+# ---------------------------------------------------------------------------
+# query_snowflake_history — integration tests (httpx patched)
+# ---------------------------------------------------------------------------
+
+def test_run_returns_unavailable_when_account_missing() -> None:
+    result = query_snowflake_history(account_identifier="", token="tok")
+    assert result["available"] is False
+    assert "account" in result["error"].lower()
+
+
+def test_run_returns_unavailable_when_token_missing() -> None:
+    result = query_snowflake_history(account_identifier="acct123", token="")
+    assert result["available"] is False
+    assert "token" in result["error"].lower()
+
+
+def test_run_happy_path() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [{"query_id": "q1"}, {"query_id": "q2"}]}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("app.tools.SnowflakeQueryHistoryTool.httpx.post", return_value=mock_response):
+        result = query_snowflake_history(
+            account_identifier="acct123",
+            token="tok",
+            limit=10,
+        )
+
+    assert result["available"] is True
+    assert result["total_returned"] == 2
+    assert result["rows"][0]["query_id"] == "q1"
+
+
+def test_run_http_error_returns_unavailable() -> None:
+    with patch(
+        "app.tools.SnowflakeQueryHistoryTool.httpx.post",
+        side_effect=Exception("connection refused"),
+    ):
+        result = query_snowflake_history(account_identifier="acct123", token="tok")
+
+    assert result["available"] is False
+    assert "connection refused" in result["error"]
+
+
+def test_run_respects_hard_limit() -> None:
+    rows = [{"query_id": f"q{i}"} for i in range(300)]
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": rows}
+    mock_response.raise_for_status.return_value = None
+
+    with patch("app.tools.SnowflakeQueryHistoryTool.httpx.post", return_value=mock_response):
+        result = query_snowflake_history(
+            account_identifier="acct123",
+            token="tok",
+            limit=200,
+            max_results=200,
+        )
+
+    assert result["total_returned"] <= 200
+
+
+def test_run_passes_warehouse_and_role_in_payload() -> None:
+    captured: list[dict] = []
+
+    def fake_post(url, *, headers, json, timeout):
+        captured.append(json)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    with patch("app.tools.SnowflakeQueryHistoryTool.httpx.post", side_effect=fake_post):
+        query_snowflake_history(
+            account_identifier="acct123",
+            token="tok",
+            warehouse="COMPUTE_WH",
+            role="SYSADMIN",
+        )
+
+    assert captured[0]["warehouse"] == "COMPUTE_WH"
+    assert captured[0]["role"] == "SYSADMIN"


### PR DESCRIPTION
## Summary

Adds dedicated `tests/tools/` coverage for the three integration-wave tools identified in #790: `SnowflakeQueryHistoryTool`, `OpenObserveLogsTool`, and `OpenSearchAnalyticsTool`. All tests are fully offline — every network call (`httpx.post`, `ElasticsearchClient`) is patched with `unittest.mock`. No real credentials or live endpoints are required to run the suite.

## What's tested

**SnowflakeQueryHistoryTool** (`test_snowflake_query_history_tool.py`)
- `_snowflake_available`: true with all required fields, false when connection_verified missing, token blank, account_identifier missing, or no `snowflake` key
- `_snowflake_extract_params`: field mapping, whitespace stripping, default max_results
- `_bounded_limit`: hard-limit clamping, minimum-one enforcement
- `_ensure_sql_limit`: appends LIMIT when absent, preserves existing LIMIT, returns default query for empty input
- `_auth_header`: produces `Bearer <token>` header
- `_normalize_rows`: list-of-dicts passthrough, tabular column mapping, empty payload
- `query_snowflake_history`: missing account error, missing token error, happy-path row return, HTTP exception → unavailable, hard limit respected, warehouse/role forwarded in payload

**OpenObserveLogsTool** (`test_openobserve_logs_tool.py`)
- `_openobserve_available`: true with bearer token, true with username+password, false without credentials, false without base_url, false without connection_verified
- `_openobserve_extract_params`: field mapping, default org fallback
- `_bounded_limit`: clamping and minimum enforcement
- `_auth_headers`: `Bearer` path, Basic-auth base64 path
- `_extract_records`: Elasticsearch-style `hits.hits._source`, flat `hits` list, `records` key, `data` key, empty body
- `query_openobserve_logs`: missing URL, missing credentials, happy-path records, default SQL query injected, HTTP exception → unavailable, hard limit respected

**OpenSearchAnalyticsTool** (`test_opensearch_analytics_tool.py`)
- `_opensearch_available`: true/false combinations for connection_verified and url
- `_opensearch_extract_params`: full field mapping, default index_pattern `*`, default query `*`
- `_bounded_limit`: hard limit and minimum enforcement
- `query_opensearch_analytics`: missing URL error, happy-path log return, client error propagation, non-dict log entries filtered out, hard limit respected, config fields forwarded correctly to `ElasticsearchClient`

Closes #790