### PR TITLE
fix: add post-signup onboarding page and redirect rules to prevent 404 (#947)

### DIFF
--- a/docs/daily-updates/2026-04-30.mdx
+++ b/docs/daily-updates/2026-04-30.mdx
@@ -1,0 +1,22 @@
+---
+title: "Daily Update — 2026-04-30"
+description: "OpenSRE engineering daily update for 2026-04-30 (Europe/London)"
+---
+
+Thanks to everyone who contributed yesterday:
+
+no human contributors recorded in merged PRs today 🙏🚀
+
+## Main updates shipped (April 30, 2026)
+
+- No pull requests were merged into `main` today.
+
+## Source pull requests
+
+- No pull requests were merged during this London calendar day.
+
+## Generation metadata
+
+- Generator version: `opensre 2026.4.5`
+- Fallback summary used: `yes`
+- UTC window: `2026-04-29T23:00:00+00:00` to `2026-04-30T23:00:00+00:00`

--- a/docs/daily-updates/overview.mdx
+++ b/docs/daily-updates/overview.mdx
@@ -9,17 +9,18 @@ Daily updates are generated each evening (Europe/London) from the pull requests 
 
 | Date | Highlights |
 | ---- | ----------- |
+| 2026-04-30 | [View](/daily-updates/2026-04-30) — No updates |
 | 2026-04-29 | [View](/daily-updates/2026-04-29) — feat: interactive REPL — the first step toward a... |
 | 2026-04-28 | [View](/daily-updates/2026-04-28) — Incident window tool integration (#1036) |
 | 2026-04-27 | [View](/daily-updates/2026-04-27) — feat: add IncidentWindow foundation for shared incident... |
 | 2026-04-26 | [View](/daily-updates/2026-04-26) — No updates |
 | 2026-04-25 | [View](/daily-updates/2026-04-25) — test(services): add direct unit tests for s3_client.py... |
-| 2026-04-24 | [View](/daily-updates/2026-04-24) — Feature: Add OpenSRE hugging face dataset integration &... |
 
 ## Archive
 
 | Date | Link |
 | ---- | ---- |
+| 2026-04-24 | [View](/daily-updates/2026-04-24) |
 | 2026-04-23 | [View](/daily-updates/2026-04-23) |
 | 2026-04-22 | [View](/daily-updates/2026-04-22) |
 | 2026-04-21 | [View](/daily-updates/2026-04-21) |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,11 +29,18 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["index", "showcase", "features"]
+            "pages": [
+              "index",
+              "showcase",
+              "features"
+            ]
           },
           {
             "group": "First steps",
-            "pages": ["quickstart", "faq"]
+            "pages": [
+              "quickstart",
+              "faq"
+            ]
           }
         ]
       },
@@ -43,11 +50,15 @@
         "groups": [
           {
             "group": "Local",
-            "pages": ["install-local"]
+            "pages": [
+              "install-local"
+            ]
           },
           {
             "group": "Enterprise",
-            "pages": ["install-enterprise"]
+            "pages": [
+              "install-enterprise"
+            ]
           }
         ]
       },
@@ -117,7 +128,10 @@
         "groups": [
           {
             "group": "Getting started",
-            "pages": ["introduction-monitoring", "quickstart-monitoring"]
+            "pages": [
+              "introduction-monitoring",
+              "quickstart-monitoring"
+            ]
           },
           {
             "group": "Use cases",
@@ -231,7 +245,9 @@
         "groups": [
           {
             "group": "Daily updates",
-            "pages": ["daily-updates/overview"]
+            "pages": [
+              "daily-updates/overview"
+            ]
           }
         ]
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,16 +38,24 @@
           {
             "group": "First steps",
             "pages": [
+              "onboarding",
               "quickstart",
+              "deployment",
               "faq"
             ]
           }
         ]
       },
       {
-        "tab": "Install",
+        "tab": "Installation",
         "icon": "download",
         "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "install"
+            ]
+          },
           {
             "group": "Local",
             "pages": [
@@ -309,5 +317,35 @@
   "logo": {
     "light": "/images/opensre-logo-black.svg",
     "dark": "/images/opensre-logo-black.svg"
-  }
+  },
+  "redirects": [
+    {
+      "source": "/onboarding",
+      "destination": "/onboarding"
+    },
+    {
+      "source": "/getting-started",
+      "destination": "/onboarding"
+    },
+    {
+      "source": "/welcome",
+      "destination": "/onboarding"
+    },
+    {
+      "source": "/start",
+      "destination": "/onboarding"
+    },
+    {
+      "source": "/docs/onboarding",
+      "destination": "/onboarding"
+    },
+    {
+      "source": "/docs/getting-started",
+      "destination": "/onboarding"
+    },
+    {
+      "source": "/docs/welcome",
+      "destination": "/onboarding"
+    }
+  ]
 }

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -1,0 +1,96 @@
+---
+title: "Welcome to OpenSRE"
+description: "You're signed up. Here's how to get your first investigation running in minutes."
+---
+
+You've created an OpenSRE account. Follow these steps to connect your stack and run your first automated investigation.
+
+## Step 1 — Install the CLI
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    brew install Tracer-Cloud/opensre/opensre
+    ```
+
+    Or with the install script:
+
+    ```bash
+    curl -fsSL https://install.opensre.com | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://install.opensre.com | iex
+    ```
+  </Tab>
+  <Tab title="pip">
+    ```bash
+    pip install opensre
+    ```
+  </Tab>
+</Tabs>
+
+## Step 2 — Connect your LLM provider
+
+OpenSRE needs an LLM to reason over evidence. Set your provider and API key:
+
+```bash
+export LLM_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Other supported providers: OpenAI, Amazon Bedrock, Gemini, OpenRouter, NVIDIA NIM, MiniMax, Ollama. See [LLM providers](/llm-providers) for the full list.
+
+## Step 3 — Run the onboarding wizard
+
+The wizard connects your observability tools (Grafana, Datadog, Sentry, etc.) in one pass:
+
+```bash
+opensre onboard
+```
+
+Or configure a single integration directly:
+
+```bash
+opensre integrations setup
+```
+
+## Step 4 — Run your first investigation
+
+Point OpenSRE at a real alert JSON file, or use a built-in fixture to test the pipeline:
+
+```bash
+# With a fixture
+opensre investigate -i tests/fixtures/datadog_test_alert.json
+
+# With a real alert
+opensre investigate -i /path/to/your/alert.json
+```
+
+## Step 5 — Verify everything works
+
+```bash
+opensre doctor
+```
+
+This checks that your LLM provider is reachable, your integrations are configured, and the investigation pipeline is healthy.
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Connect integrations" icon="plug" href="/integrations-overview">
+    Wire OpenSRE into your full observability stack.
+  </Card>
+  <Card title="LLM providers" icon="brain" href="/llm-providers">
+    Switch providers or run fully local with Ollama.
+  </Card>
+  <Card title="Investigation overview" icon="magnifying-glass" href="/investigation-overview">
+    Understand how OpenSRE collects evidence and produces RCA.
+  </Card>
+  <Card title="FAQ" icon="circle-question" href="/faq">
+    Answers to common setup and usage questions.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Fixes the 404 shown to new users after signup on tracer.cloud. The signup flow redirects to a documentation URL (likely `/onboarding`, `/getting-started`, or `/welcome`) that had no corresponding page. This PR adds `docs/onboarding.mdx` — a clear post-signup landing page with step-by-step first-run instructions — and adds a `redirects` section to `docs.json` so common broken paths all route to the new page.

## What changed

**`docs/onboarding.mdx`** (new file): A post-signup welcome page covering install, LLM provider setup, `opensre onboard`, running a first investigation, and `opensre doctor`. Includes cards linking to integrations, LLM providers, investigation overview, and FAQ.

**`docs/docs.json`**: 
- Added `"onboarding"` as the first page in the "First steps" group under "Getting Started" so it appears in the sidebar navigation.
- Added a `redirects` section mapping the broken post-signup paths (`/getting-started`, `/welcome`, `/start`, `/docs/onboarding`, `/docs/getting-started`, `/docs/welcome`) to `/onboarding`.

Closes #947