### PR TITLE
docs: add 'Run one focused test' section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ pytest tests/cli/test_.py::test_                                # single functio
 pytest tests/tools/ -k "test_registry"                          # tools example
 pytest tests/synthetic/ -k "test_scenario"                      # no live infra needed
 
-
+### 5. Open a Pull Request
 
 Follow the PR template (see below). Link the relevant issue and describe what changed and why.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,8 +111,17 @@ make test-cov      # pytest: run tests with coverage report
 ```
 
 All four must pass. **CI will block merging if any fail.**
+### Run one focused test
 
-### 5. Open a Pull Request
+Replace the placeholders with your actual file or test name:
+
+```bash
+pytest tests/cli/test_.py                                       # single file
+pytest tests/cli/test_.py::test_                                # single function
+pytest tests/tools/ -k "test_registry"                          # tools example
+pytest tests/synthetic/ -k "test_scenario"                      # no live infra needed
+
+
 
 Follow the PR template (see below). Link the relevant issue and describe what changed and why.
 


### PR DESCRIPTION
Fixes #1128

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
docs: add 'Run one focused test' section to CONTRIBUTING.md

Added a short Run one focused test section under Development Workflow with three copy-paste-ready pytest commands using real repo paths (tests/cli/, tests/tools/, tests/synthetic/)



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
