### PR TITLE
 test: add Vercel deployment sort regression tests for bad timestamps

### DIFF
--- a/tests/app/remote/test_vercel_poller.py
+++ b/tests/app/remote/test_vercel_poller.py
@@ -384,3 +384,29 @@ def test_parse_vercel_url_trims_whitespace_stores_cleaned_url() -> None:
         parsed.original_url
         == "https://vercel.com/vincenthus-projects/tracer-marketing-website-v3/logs?page=3&logId=54w4s-1775494460431-b04b1df81301"
     )
+def test_sort_deployment_stubs_handles_malformed_timestamps() -> None:
+    stubs = [
+        {"id": "old", "created_at": "2024-01-01T00:00:00Z"},
+        {"id": "new", "created_at": "2024-03-01T00:00:00Z"},
+        {"id": "missing_ts"},  # Missing created_at
+        {"id": "empty_ts", "created_at": ""},  # Empty string
+        {"id": "space_ts", "created_at": "   "},  # Whitespace
+    ]
+    ordered = _sort_deployment_stubs_newest_first(stubs)
+    ids = [s["id"] for s in ordered]
+    
+    # 'new' should be first, 'old' second. 
+    # Others are treated as 1970 and should be at the end.
+    assert ids[0] == "new"
+    assert ids[1] == "old"
+    assert set(ids[2:]) == {"missing_ts", "empty_ts", "space_ts"}
+
+def test_sort_deployment_stubs_filters_invalid_ids() -> None:
+    stubs = [
+        {"id": "valid", "created_at": "2024-01-01T00:00:00Z"},
+        {"created_at": "2024-01-01T00:00:00Z"},  # Missing id
+        {"id": "  ", "created_at": "2024-01-01T00:00:00Z"},  # Whitespace id
+    ]
+    ordered = _sort_deployment_stubs_newest_first(stubs)
+    assert len(ordered) == 1
+    assert ordered[0]["id"] == "valid"

--- a/tests/app/remote/test_vercel_poller.py
+++ b/tests/app/remote/test_vercel_poller.py
@@ -397,7 +397,7 @@ def test_sort_deployment_stubs_handles_malformed_timestamps() -> None:
     ordered = _sort_deployment_stubs_newest_first(stubs)
     ids = [s["id"] for s in ordered]
     
-    # 'new' should be first, 'old' second.
+    #'new' should be first, 'old' second.
     # Others are treated as 1970 and should be at the end.
     assert ids[0] == "new"
     assert ids[1] == "old"

--- a/tests/app/remote/test_vercel_poller.py
+++ b/tests/app/remote/test_vercel_poller.py
@@ -384,6 +384,8 @@ def test_parse_vercel_url_trims_whitespace_stores_cleaned_url() -> None:
         parsed.original_url
         == "https://vercel.com/vincenthus-projects/tracer-marketing-website-v3/logs?page=3&logId=54w4s-1775494460431-b04b1df81301"
     )
+
+
 def test_sort_deployment_stubs_handles_malformed_timestamps() -> None:
     stubs = [
         {"id": "old", "created_at": "2024-01-01T00:00:00Z"},
@@ -395,11 +397,12 @@ def test_sort_deployment_stubs_handles_malformed_timestamps() -> None:
     ordered = _sort_deployment_stubs_newest_first(stubs)
     ids = [s["id"] for s in ordered]
     
-    # 'new' should be first, 'old' second. 
+    # 'new' should be first, 'old' second.
     # Others are treated as 1970 and should be at the end.
     assert ids[0] == "new"
     assert ids[1] == "old"
     assert set(ids[2:]) == {"missing_ts", "empty_ts", "space_ts"}
+
 
 def test_sort_deployment_stubs_filters_invalid_ids() -> None:
     stubs = [

--- a/tests/app/remote/test_vercel_poller.py
+++ b/tests/app/remote/test_vercel_poller.py
@@ -396,8 +396,8 @@ def test_sort_deployment_stubs_handles_malformed_timestamps() -> None:
     ]
     ordered = _sort_deployment_stubs_newest_first(stubs)
     ids = [s["id"] for s in ordered]
-    
-    #'new' should be first, 'old' second.
+
+    # 'new' should be first, 'old' second.
     # Others are treated as 1970 and should be at the end.
     assert ids[0] == "new"
     assert ids[1] == "old"


### PR DESCRIPTION
Fixes #1121

### Describe the changes you have made in this PR -
Added regression tests for `_sort_deployment_stubs_newest_first` in `tests/app/remote/test_vercel_poller.py`. These tests ensure that the Vercel deployment sorter handles malformed timestamps (missing, empty, or whitespace) gracefully and correctly filters out entries without a valid ID.

### Demo/Screenshot for feature changes and bug fixes -
Verified the logic in a standalone environment using the correct field names (`id` and `created_at`).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The implementation adds two test functions to the existing Vercel poller test suite. 
1. `test_sort_deployment_stubs_handles_malformed_timestamps`: Tests that the sorter doesn't crash when `created_at` is missing or empty, and that it treats these as the oldest possible date for sorting.
2. `test_sort_deployment_stubs_filters_invalid_ids`: Confirms that the list comprehension correctly filters out stubs that don't have a valid `id` key.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
