### PR TITLE
feat(ci): auto-assign good first issues for new contributors

### DIFF
--- a/.github/scripts/good_first_issue_assign.py
+++ b/.github/scripts/good_first_issue_assign.py
@@ -1,0 +1,169 @@
+"""Assign and notify **new** contributors on `good first issue` threads.
+
+Here *new* means **zero merged PRs** in this repo authored by the commenter (Search API),
+not GitHub's ``FIRST_TIME_CONTRIBUTOR`` / ``FIRST_TIMER`` flags.
+
+Also skips repo insiders (OWNER / MEMBER / COLLABORATOR), bots, closed issues,
+and commenters already listed as assignees.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+GOOD_FIRST_LABEL = "good first issue"
+# Do not auto-assign maintainers/collaborators; eligibility is 0 merged PRs + not insider.
+EXCLUDED_COMMENTER_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+GITHUB_API = "https://api.github.com"
+
+
+def screen_event_without_api(event: dict[str, Any]) -> str | None:
+    """Return a skip reason before calling the GitHub API, or None if checks should continue."""
+    issue = event.get("issue") or {}
+    comment = event.get("comment") or {}
+    if issue.get("state") != "open":
+        return "issue_not_open"
+    labels = issue.get("labels") or []
+    if not isinstance(labels, list):
+        return "invalid_labels"
+    names = {item.get("name") for item in labels if isinstance(item, dict)}
+    if GOOD_FIRST_LABEL not in names:
+        return "not_good_first_issue"
+
+    c_user = comment.get("user") or {}
+    if c_user.get("type") == "Bot":
+        return "bot_commenter"
+    c_login = c_user.get("login") or ""
+    if not c_login:
+        return "missing_commenter_login"
+
+    c_assoc = comment.get("author_association") or ""
+    if c_assoc in EXCLUDED_COMMENTER_ASSOCIATIONS:
+        return "commenter_repo_insider"
+
+    assignees = issue.get("assignees") or []
+    if isinstance(assignees, list):
+        for a in assignees:
+            if isinstance(a, dict) and a.get("login") == c_login:
+                return "already_assignee"
+
+    return None
+
+
+def assign_decision(
+    *,
+    skip_reason_pre_api: str | None,
+    merged_pr_count_for_commenter: int,
+) -> tuple[bool, str]:
+    """Return (should_assign_and_comment, skip_reason_or_empty).
+
+    Eligible "new contributor" means ``merged_pr_count_for_commenter == 0`` (enforced here).
+    """
+    if skip_reason_pre_api is not None:
+        return False, skip_reason_pre_api
+    if merged_pr_count_for_commenter > 0:
+        return False, "has_merged_prs"
+    return True, ""
+
+
+def _request_json(url: str, token: str) -> Any:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_merged_pr_count(owner: str, repo: str, login: str, token: str) -> int:
+    q = f"repo:{owner}/{repo} is:pr is:merged author:{login}"
+    params = urllib.parse.urlencode({"q": q})
+    url = f"{GITHUB_API}/search/issues?{params}"
+    try:
+        data = _request_json(url, token)
+    except urllib.error.HTTPError as exc:
+        print(f"GitHub search failed: {exc}", file=sys.stderr)
+        raise
+    total = data.get("total_count")
+    if not isinstance(total, int):
+        return 0
+    return total
+
+
+def build_assign_notice_body(*, assignee_login: str) -> str:
+    return (
+        f"@{assignee_login} You've been **assigned** to this issue. Thanks for picking it up."
+    )
+
+
+def set_github_output(name: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not event_path or not repository or not token:
+        print("Missing GITHUB_EVENT_PATH, GITHUB_REPOSITORY, or GITHUB_TOKEN.", file=sys.stderr)
+        return 1
+
+    raw = Path(event_path).read_text(encoding="utf-8")
+    event = json.loads(raw)
+
+    pre = screen_event_without_api(event)
+    merged_count = 0
+
+    if pre is None:
+        owner, _, repo = repository.partition("/")
+        if not owner or not repo:
+            print("Invalid GITHUB_REPOSITORY.", file=sys.stderr)
+            return 1
+        comment = event.get("comment") or {}
+        c_login = (comment.get("user") or {}).get("login") or ""
+        try:
+            merged_count = fetch_merged_pr_count(owner, repo, c_login, token)
+        except urllib.error.HTTPError:
+            return 1
+
+    should, reason = assign_decision(
+        skip_reason_pre_api=pre,
+        merged_pr_count_for_commenter=merged_count,
+    )
+
+    if not should:
+        print(f"Skip: {reason}")
+        set_github_output("should_assign", "false")
+        return 0
+
+    comment_user = (event.get("comment") or {}).get("user") or {}
+    login = comment_user.get("login") if isinstance(comment_user, dict) else ""
+    if not isinstance(login, str) or not login:
+        print("Missing commenter login.", file=sys.stderr)
+        return 1
+
+    body = build_assign_notice_body(assignee_login=login)
+    Path("assign_comment.md").write_text(body, encoding="utf-8")
+    set_github_output("should_assign", "true")
+    print("Wrote assign_comment.md; assignment will be applied in workflow.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/good_first_issue_assign.py
+++ b/.github/scripts/good_first_issue_assign.py
@@ -4,7 +4,8 @@ Here *new* means **zero merged PRs** in this repo authored by the commenter (Sea
 not GitHub's ``FIRST_TIME_CONTRIBUTOR`` / ``FIRST_TIMER`` flags.
 
 Also skips repo insiders (OWNER / MEMBER / COLLABORATOR), bots, closed issues,
-and commenters already listed as assignees.
+comments on **pull request** threads (``issue_comment`` fires for PRs too; those
+use ``issue.pull_request``), and commenters already listed as assignees.
 """
 
 from __future__ import annotations
@@ -28,6 +29,8 @@ def screen_event_without_api(event: dict[str, Any]) -> str | None:
     """Return a skip reason before calling the GitHub API, or None if checks should continue."""
     issue = event.get("issue") or {}
     comment = event.get("comment") or {}
+    if issue.get("pull_request") is not None:
+        return "comment_on_pull_request"
     if issue.get("state") != "open":
         return "issue_not_open"
     labels = issue.get("labels") or []

--- a/.github/workflows/good-first-issue-assign.yml
+++ b/.github/workflows/good-first-issue-assign.yml
@@ -1,10 +1,15 @@
 # When someone with zero merged PRs in this repo (and not OWNER/MEMBER/COLLABORATOR) comments
 # on an open issue labeled `good first issue`, assign them and reply.
+# issue_comment also fires for PR review threads; those payloads include issue.pull_request.
 name: Good first issue — auto-assign
 
 on:
   issue_comment:
     types: [created]
+
+concurrency:
+  group: good-first-issue-assign-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -16,7 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.issue.state == 'open' &&
-      github.event.comment.user.type != 'Bot'
+      github.event.comment.user.type != 'Bot' &&
+      !github.event.issue.pull_request
     steps:
       - uses: actions/checkout@v5
 
@@ -32,10 +38,13 @@ jobs:
         if: steps.decide.outputs.should_assign == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          gh issue edit "${{ github.event.issue.number }}"
-          --repo "${{ github.repository }}"
-          --add-assignee "${{ github.event.comment.user.login }}"
-          && gh issue comment "${{ github.event.issue.number }}"
-          --repo "${{ github.repository }}"
-          --body-file assign_comment.md
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO_FULL: ${{ github.repository }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" \
+            --repo "${REPO_FULL}" \
+            --add-assignee "${COMMENTER_LOGIN}"
+          gh issue comment "${ISSUE_NUMBER}" \
+            --repo "${REPO_FULL}" \
+            --body-file assign_comment.md

--- a/.github/workflows/good-first-issue-assign.yml
+++ b/.github/workflows/good-first-issue-assign.yml
@@ -1,0 +1,41 @@
+# When someone with zero merged PRs in this repo (and not OWNER/MEMBER/COLLABORATOR) comments
+# on an open issue labeled `good first issue`, assign them and reply.
+name: Good first issue — auto-assign
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  assign:
+    name: Assign new contributor on good first issue
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.state == 'open' &&
+      github.event.comment.user.type != 'Bot'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Decide assign + notice body
+        id: decide
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/good_first_issue_assign.py
+
+      - name: Add assignee and notify
+        if: steps.decide.outputs.should_assign == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh issue edit "${{ github.event.issue.number }}"
+          --repo "${{ github.repository }}"
+          --add-assignee "${{ github.event.comment.user.login }}"
+          && gh issue comment "${{ github.event.issue.number }}"
+          --repo "${{ github.repository }}"
+          --body-file assign_comment.md

--- a/tests/github/test_good_first_issue_assign.py
+++ b/tests/github/test_good_first_issue_assign.py
@@ -23,6 +23,23 @@ def _label(name: str) -> dict:
     return {"name": name}
 
 
+def test_screen_skips_pull_request_comment_thread(gfi):
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label(gfi.GOOD_FIRST_LABEL)],
+            "assignees": [],
+            "user": {"login": "alice"},
+            "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/1"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": "NONE",
+        },
+    }
+    assert gfi.screen_event_without_api(event) == "comment_on_pull_request"
+
+
 def test_screen_skips_without_label(gfi):
     event = {
         "issue": {

--- a/tests/github/test_good_first_issue_assign.py
+++ b/tests/github/test_good_first_issue_assign.py
@@ -1,0 +1,128 @@
+"""Tests for `.github/scripts/good_first_issue_assign.py`."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "good_first_issue_assign.py"
+
+
+@pytest.fixture(scope="module")
+def gfi():
+    spec = importlib.util.spec_from_file_location("good_first_issue_assign", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _label(name: str) -> dict:
+    return {"name": name}
+
+
+def test_screen_skips_without_label(gfi):
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label("bug")],
+            "assignees": [],
+            "user": {"login": "alice"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": "NONE",
+        },
+    }
+    assert gfi.screen_event_without_api(event) == "not_good_first_issue"
+
+
+@pytest.mark.parametrize("association", ["OWNER", "MEMBER", "COLLABORATOR"])
+def test_screen_skips_repo_insider(gfi, association):
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label(gfi.GOOD_FIRST_LABEL)],
+            "assignees": [],
+            "user": {"login": "alice"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": association,
+        },
+    }
+    assert gfi.screen_event_without_api(event) == "commenter_repo_insider"
+
+
+def test_screen_allows_contributor_with_zero_merges_checked_later(gfi):
+    """CONTRIBUTOR is allowed here; merged-PR count is enforced in assign_decision."""
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label(gfi.GOOD_FIRST_LABEL)],
+            "assignees": [],
+            "user": {"login": "alice"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": "CONTRIBUTOR",
+        },
+    }
+    assert gfi.screen_event_without_api(event) is None
+
+
+def test_screen_skips_already_assignee(gfi):
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label(gfi.GOOD_FIRST_LABEL)],
+            "assignees": [{"login": "bob"}],
+            "user": {"login": "alice"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": "FIRST_TIMER",
+        },
+    }
+    assert gfi.screen_event_without_api(event) == "already_assignee"
+
+
+def test_screen_allows_none_association(gfi):
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label(gfi.GOOD_FIRST_LABEL)],
+            "assignees": [],
+            "user": {"login": "alice"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": "NONE",
+        },
+    }
+    assert gfi.screen_event_without_api(event) is None
+
+
+def test_assign_decision_skips_merged_prs(gfi):
+    ok, reason = gfi.assign_decision(
+        skip_reason_pre_api=None,
+        merged_pr_count_for_commenter=1,
+    )
+    assert ok is False
+    assert reason == "has_merged_prs"
+
+
+def test_assign_decision_ok_zero_merges(gfi):
+    ok, reason = gfi.assign_decision(
+        skip_reason_pre_api=None,
+        merged_pr_count_for_commenter=0,
+    )
+    assert ok is True
+    assert reason == ""
+
+
+def test_build_notice_short(gfi):
+    body = gfi.build_assign_notice_body(assignee_login="bob")
+    assert body == "@bob You've been **assigned** to this issue. Thanks for picking it up."


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that assigns someone to an issue when they comment on an open issue labeled `good first issue`, they are not a repo insider (OWNER, MEMBER, or COLLABORATOR), they are not already an assignee, and a search shows zero merged PRs in this repo authored by them. Posts a short issue comment confirming assignment.

## Changes

- `.github/scripts/good_first_issue_assign.py` — decision logic and notice text
- `.github/workflows/good-first-issue-assign.yml` — `issue_comment` trigger, assign + comment steps
- `tests/github/test_good_first_issue_assign.py` — unit tests for screening and decisions

## Testing

- `pytest tests/github/test_good_first_issue_assign.py`
- `make lint`
