### PR TITLE
fix(ci): single assignee per good first issue

### DIFF
--- a/.github/scripts/good_first_issue_assign.py
+++ b/.github/scripts/good_first_issue_assign.py
@@ -6,6 +6,9 @@ not GitHub's ``FIRST_TIME_CONTRIBUTOR`` / ``FIRST_TIMER`` flags.
 Also skips repo insiders (OWNER / MEMBER / COLLABORATOR), bots, closed issues,
 comments on **pull request** threads (``issue_comment`` fires for PRs too; those
 use ``issue.pull_request``), and commenters already listed as assignees.
+
+At most **one** auto-assignment per issue: if anyone else is already an assignee,
+further eligible commenters are skipped (manual pre-assignments count).
 """
 
 from __future__ import annotations
@@ -53,9 +56,13 @@ def screen_event_without_api(event: dict[str, Any]) -> str | None:
 
     assignees = issue.get("assignees") or []
     if isinstance(assignees, list):
-        for a in assignees:
-            if isinstance(a, dict) and a.get("login") == c_login:
-                return "already_assignee"
+        assigned_logins = {
+            a.get("login") for a in assignees if isinstance(a, dict) and a.get("login")
+        }
+        if c_login in assigned_logins:
+            return "already_assignee"
+        if assigned_logins:
+            return "issue_already_claimed"
 
     return None
 

--- a/.github/workflows/good-first-issue-assign.yml
+++ b/.github/workflows/good-first-issue-assign.yml
@@ -1,5 +1,6 @@
 # When someone with zero merged PRs in this repo (and not OWNER/MEMBER/COLLABORATOR) comments
-# on an open issue labeled `good first issue`, assign them and reply.
+# on an open issue labeled `good first issue`, assign them and reply — only if the issue has no
+# assignees yet (first eligible commenter wins; includes when a human pre-assigned someone).
 # issue_comment also fires for PR review threads; those payloads include issue.pull_request.
 name: Good first issue — auto-assign
 

--- a/tests/github/test_good_first_issue_assign.py
+++ b/tests/github/test_good_first_issue_assign.py
@@ -106,6 +106,22 @@ def test_screen_skips_already_assignee(gfi):
     assert gfi.screen_event_without_api(event) == "already_assignee"
 
 
+def test_screen_skips_when_issue_claimed_by_other(gfi):
+    event = {
+        "issue": {
+            "state": "open",
+            "labels": [_label(gfi.GOOD_FIRST_LABEL)],
+            "assignees": [{"login": "alice"}],
+            "user": {"login": "maintainer"},
+        },
+        "comment": {
+            "user": {"login": "bob", "type": "User"},
+            "author_association": "NONE",
+        },
+    }
+    assert gfi.screen_event_without_api(event) == "issue_already_claimed"
+
+
 def test_screen_allows_none_association(gfi):
     event = {
         "issue": {


### PR DESCRIPTION
## Context

Follow-up to [#1179](https://github.com/Tracer-Cloud/opensre/pull/1179) (already merged). That PR added auto-assignment for eligible commenters on `good first issue` threads. This change tightens behavior so only the **first** assignee counts: if anyone is already assigned (bot or human), further eligible commenters are **not** added.

## Changes

- **`issue_already_claimed`** when `assignees` is non-empty and the commenter is not already in that list.
- Doc comment + workflow header note; unit test `test_screen_skips_when_issue_claimed_by_other`.

## Testing

- `pytest tests/github/test_good_first_issue_assign.py`
