### PR TITLE
test: add direct unit tests for grafana config normalization and auth…

### DIFF
--- a/tests/services/test_grafana_config.py
+++ b/tests/services/test_grafana_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.grafana.config import GrafanaAccountConfig
+
+
+def test_grafana_config_normalizes_instance_url() -> None:
+    """Test that trailing slashes and whitespace are stripped from the instance URL."""
+    config = GrafanaAccountConfig(
+        account_id="test-acc",
+        instance_url=" https://grafana.example.com/  ",
+        read_token="secret",
+    )
+    assert config.instance_url == "https://grafana.example.com"
+
+
+@pytest.mark.parametrize(
+    "url, token, expected",
+    [
+        ("http://localhost:3000", "", True),
+        ("http://127.0.0.1:3000", "", True),
+        ("http://0.0.0.0:3000", "", True),
+        ("http://localhost:3000", "has-token", False),  # Token presence disables anon auth
+        ("https://grafana.example.com", "", False),      # External host requires token
+        ("", "", False),                                # Empty URL
+    ],
+)
+def test_grafana_config_uses_local_anonymous_auth(url: str, token: str, expected: bool) -> None:
+    """Test the logic for determining if local anonymous auth is allowed."""
+    config = GrafanaAccountConfig(
+        account_id="test",
+        instance_url=url,
+        read_token=token,
+    )
+    assert config.uses_local_anonymous_auth is expected
+
+
+@pytest.mark.parametrize(
+    "url, token, expected",
+    [
+        ("https://grafana.com", "token", True),          # Standard config
+        ("http://localhost:3000", "", True),            # Local anon config
+        ("https://grafana.com", "", False),             # Hosted without token
+        ("", "token", False),                            # Missing URL
+        ("", "", False),                                 # Fully unconfigured
+    ],
+)
+def test_grafana_config_is_configured(url: str, token: str, expected: bool) -> None:
+    """Test that is_configured correctly identifies valid setups."""
+    config = GrafanaAccountConfig(
+        account_id="test",
+        instance_url=url,
+        read_token=token,
+    )
+    assert config.is_configured is expected

--- a/tests/services/test_grafana_config.py
+++ b/tests/services/test_grafana_config.py
@@ -22,8 +22,8 @@ def test_grafana_config_normalizes_instance_url() -> None:
         ("http://127.0.0.1:3000", "", True),
         ("http://0.0.0.0:3000", "", True),
         ("http://localhost:3000", "has-token", False),  # Token presence disables anon auth
-        ("https://grafana.example.com", "", False),      # External host requires token
-        ("", "", False),                                # Empty URL
+        ("https://grafana.example.com", "", False),  # External host requires token
+        ("", "", False),  # Empty URL
     ],
 )
 def test_grafana_config_uses_local_anonymous_auth(url: str, token: str, expected: bool) -> None:
@@ -39,11 +39,11 @@ def test_grafana_config_uses_local_anonymous_auth(url: str, token: str, expected
 @pytest.mark.parametrize(
     "url, token, expected",
     [
-        ("https://grafana.com", "token", True),          # Standard config
-        ("http://localhost:3000", "", True),            # Local anon config
-        ("https://grafana.com", "", False),             # Hosted without token
-        ("", "token", False),                            # Missing URL
-        ("", "", False),                                 # Fully unconfigured
+        ("https://grafana.com", "token", True),  # Standard config
+        ("http://localhost:3000", "", True),  # Local anon config
+        ("https://grafana.com", "", False),  # Hosted without token
+        ("", "token", False),  # Missing URL
+        ("", "", False),  # Fully unconfigured
     ],
 )
 def test_grafana_config_is_configured(url: str, token: str, expected: bool) -> None:


### PR DESCRIPTION
Fixes #879

##  Description

Added comprehensive unit tests for `app/services/grafana/config.py`.

###  Changes Made

* Added test coverage for Grafana config service
* Ensured robustness of configuration validation logic

### 🧪 Test Coverage Includes

* [x] **URL Normalization**
  Verifies trailing slashes and whitespace are stripped from `instance_url`

* [x] **Local Anonymous Auth**
  Tests security logic allowing `localhost` / `127.0.0.1` without tokens while enforcing tokens for hosted instances

* [x] **Config Validation (`is_configured`)**
  Ensures config works for both token-based and local setups

---

##  Demo / Verification

Verified locally using pytest:

```bash
python -m pytest tests/services/test_grafana_config.py -v
# Output: 12 passed in 2.11s
```

---

##  Code Understanding and AI Usage

Did you use AI assistance?

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance

### If yes:

* [x] I have reviewed every line of the generated code
* [x] I can explain the logic of my implementation
* [x] I have tested edge cases
* [x] I have modified the code to follow project standards

###  Implementation Approach

Implemented a test suite in `tests/services/test_grafana_config.py` using `pytest.mark.parametrize` to efficiently cover multiple edge cases related to authentication and URL formatting. This ensures strict enforcement of local anonymous auth rules and predictable behavior of the configuration model.

---

##  Checklist

* [x] PR title is clear and linked to the issue
* [x] Self-review completed
* [x] Code is understandable and well-structured
* [x] Changes are tested thoroughly
* [x] Edge cases considered
* [x] Tests added for core functionality
* [x] Code follows project conventions
