### PR TITLE
feat(cli): allow switching toolcall model at runtime (#1182)

### DIFF
--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -38,9 +38,11 @@ _ACTION_RULE = (
     "return ONLY a compact JSON object with an `actions` array. Do not give "
     "instructions when an allowed action can satisfy the request. Allowed "
     "action object schemas: "
-    '`{"action":"switch_llm_provider","provider":"anthropic","model":""}` '
+    '`{"action":"switch_llm_provider","provider":"anthropic","model":"","toolcall_model":""}` '
     "where provider is one of anthropic, openai, openrouter, gemini, nvidia, "
-    "ollama, codex and model is optional; "
+    "ollama, codex; both `model` (reasoning) and `toolcall_model` are optional; "
+    '`{"action":"switch_toolcall_model","model":"claude-opus-4-7"}` '
+    "to change ONLY the toolcall model on the currently active provider; "
     '`{"action":"slash","command":"/model show"}` where command is one of '
     "/model show, /list models, /health, /doctor, /version. For ordinary "
     "questions, return normal Markdown."
@@ -161,7 +163,11 @@ def _execute_action_plan(
     if not actions:
         return False
 
-    from app.cli.interactive_shell.commands import dispatch_slash, switch_llm_provider
+    from app.cli.interactive_shell.commands import (
+        dispatch_slash,
+        switch_llm_provider,
+        switch_toolcall_model,
+    )
 
     console.print()
     console.print(f"[{TERMINAL_ACCENT_BOLD}]assistant:[/]")
@@ -171,9 +177,17 @@ def _execute_action_plan(
         if kind == "switch_llm_provider":
             provider = str(action.get("provider", "")).strip()
             model = str(action.get("model", "")).strip()
+            toolcall = str(action.get("toolcall_model", "")).strip()
             label = f"switch LLM provider to {provider}"
             if model:
                 label += f" ({model})"
+            if toolcall:
+                label += f" + toolcall {toolcall}"
+        elif kind == "switch_toolcall_model":
+            requested = str(action.get("model", "")).strip()
+            label = (
+                f"switch toolcall model to {requested}" if requested else "switch toolcall model"
+            )
         elif kind == "slash":
             label = str(action.get("command", "")).strip()
         else:
@@ -188,12 +202,33 @@ def _execute_action_plan(
         if kind == "switch_llm_provider":
             provider = str(action.get("provider", "")).strip()
             requested_model = str(action.get("model", "")).strip() or None
+            requested_toolcall = str(action.get("toolcall_model", "")).strip() or None
             if not provider:
                 console.print("[red]missing provider for switch_llm_provider action[/red]")
                 continue
-            console.print(f"[bold]$ /model set {escape(provider)}[/bold]")
-            switch_llm_provider(provider, console, model=requested_model)
-            session.record("slash", f"/model set {provider}")
+            slash_label = f"/model set {provider}"
+            if requested_model:
+                slash_label += f" {requested_model}"
+            if requested_toolcall:
+                slash_label += f" --toolcall-model {requested_toolcall}"
+            console.print(f"[bold]$ {escape(slash_label)}[/bold]")
+            switch_llm_provider(
+                provider,
+                console,
+                model=requested_model,
+                toolcall_model=requested_toolcall,
+            )
+            session.record("slash", slash_label)
+            continue
+
+        if kind == "switch_toolcall_model":
+            requested_model = str(action.get("model", "")).strip()
+            if not requested_model:
+                console.print("[red]missing model for switch_toolcall_model action[/red]")
+                continue
+            console.print(f"[bold]$ /model toolcall set {escape(requested_model)}[/bold]")
+            switch_toolcall_model(requested_model, console)
+            session.record("slash", f"/model toolcall set {requested_model}")
             continue
 
         if kind == "slash":

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -165,7 +165,13 @@ def _render_models_table(console: Console) -> None:
     console.print(table)
 
 
-def switch_llm_provider(provider_name: str, console: Console, model: str | None = None) -> bool:
+def switch_llm_provider(
+    provider_name: str,
+    console: Console,
+    model: str | None = None,
+    *,
+    toolcall_model: str | None = None,
+) -> bool:
     from app.cli.wizard.config import PROVIDER_BY_VALUE
     from app.cli.wizard.env_sync import sync_env_values
 
@@ -184,6 +190,18 @@ def switch_llm_provider(provider_name: str, console: Console, model: str | None 
     if provider.legacy_model_env:
         values[provider.legacy_model_env] = selected_model
 
+    selected_toolcall: str | None = None
+    if toolcall_model is not None:
+        if not provider.toolcall_model_env:
+            console.print(
+                f"[yellow]provider {provider.value} does not expose a separate "
+                "toolcall model[/yellow] — toolcall override ignored."
+            )
+        else:
+            selected_toolcall = toolcall_model.strip()
+            if selected_toolcall:
+                values[provider.toolcall_model_env] = selected_toolcall
+
     env_path = sync_env_values(values)
     os.environ.update(values)
 
@@ -191,9 +209,91 @@ def switch_llm_provider(provider_name: str, console: Console, model: str | None 
         f"[green]switched LLM provider:[/green] {provider.value} "
         f"[dim]({selected_model or 'provider default'})[/dim]"
     )
+    if selected_toolcall:
+        console.print(
+            f"[green]toolcall model:[/green] {selected_toolcall} "
+            f"[dim]({provider.toolcall_model_env})[/dim]"
+        )
     console.print(f"[dim]updated {env_path}[/dim]")
     _render_models_table(console)
     return True
+
+
+def switch_toolcall_model(
+    toolcall_model: str,
+    console: Console,
+    *,
+    provider_name: str | None = None,
+) -> bool:
+    """Set the toolcall model for the active (or named) provider."""
+    from app.cli.wizard.config import PROVIDER_BY_VALUE
+    from app.cli.wizard.env_sync import sync_env_values
+
+    raw_name = provider_name if provider_name else os.getenv("LLM_PROVIDER", "anthropic")
+    resolved_name = (raw_name or "anthropic").strip().lower()
+    provider = PROVIDER_BY_VALUE.get(resolved_name)
+    if provider is None:
+        choices = ", ".join(sorted(PROVIDER_BY_VALUE))
+        console.print(
+            f"[red]unknown LLM provider:[/red] {escape(resolved_name)} "
+            f"[dim](choices: {choices})[/dim]"
+        )
+        return False
+    if not provider.toolcall_model_env:
+        console.print(
+            f"[yellow]provider {provider.value} does not expose a separate "
+            "toolcall model[/yellow] — nothing to set."
+        )
+        return False
+    new_model = toolcall_model.strip()
+    if not new_model:
+        console.print("[red]toolcall model cannot be empty[/red]")
+        return False
+
+    values = {provider.toolcall_model_env: new_model}
+    env_path = sync_env_values(values)
+    os.environ.update(values)
+
+    console.print(
+        f"[green]toolcall model set to:[/green] {new_model} "
+        f"[dim]({provider.value} · {provider.toolcall_model_env})[/dim]"
+    )
+    console.print(f"[dim]updated {env_path}[/dim]")
+    _render_models_table(console)
+    return True
+
+
+def _parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None] | None:
+    """Parse `set <provider> [reasoning_model] [--toolcall-model <m>]`.
+
+    ``args`` is the slice after the ``set``/``use``/``switch`` keyword.
+    Returns ``(provider, reasoning_model, toolcall_model)`` or ``None`` if the
+    arguments are malformed.
+    """
+    if not args:
+        return None
+
+    provider = args[0]
+    reasoning_model: str | None = None
+    toolcall_model: str | None = None
+
+    i = 1
+    while i < len(args):
+        token = args[i]
+        if token in ("--toolcall-model", "--toolcall"):
+            if i + 1 >= len(args):
+                return None
+            toolcall_model = args[i + 1]
+            i += 2
+            continue
+        if token.startswith("--"):
+            return None
+        if reasoning_model is not None:
+            return None
+        reasoning_model = token
+        i += 1
+
+    return provider, reasoning_model, toolcall_model
 
 
 def _cmd_integrations(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
@@ -276,16 +376,45 @@ def _cmd_model(session: ReplSession, console: Console, args: list[str]) -> bool:
         _render_models_table(console)
         return True
 
-    if sub in ("set", "use", "switch"):
-        if len(args) < 2:
-            console.print("[red]usage:[/red] /model set <provider> [model]")
+    if sub == "toolcall":
+        # /model toolcall set <model>   — set toolcall model for active provider
+        # /model toolcall show          — alias for /model show
+        if len(args) >= 2 and args[1].lower() == "show":
+            _render_models_table(console)
             return True
-        switch_llm_provider(args[1], console, model=args[2] if len(args) > 2 else None)
+        if len(args) >= 2 and args[1].lower() in ("set", "use", "switch"):
+            if len(args) < 3:
+                console.print("[red]usage:[/red] /model toolcall set <model>")
+                return True
+            switch_toolcall_model(args[2], console)
+            return True
+        console.print(
+            "[red]usage:[/red] /model toolcall set <model> "
+            "[dim](sets the toolcall model for the active provider)[/dim]"
+        )
+        return True
+
+    if sub in ("set", "use", "switch"):
+        parsed = _parse_model_set_args(args[1:])
+        if parsed is None:
+            console.print(
+                "[red]usage:[/red] /model set <provider> [model] [--toolcall-model <model>]"
+            )
+            return True
+        provider_name, reasoning_model, toolcall_model = parsed
+        switch_llm_provider(
+            provider_name,
+            console,
+            model=reasoning_model,
+            toolcall_model=toolcall_model,
+        )
         return True
 
     console.print(
         f"[red]unknown subcommand:[/red] {escape(sub)}  "
-        "(try [bold]/model show[/bold] or [bold]/model set <provider> [model][/bold])"
+        "(try [bold]/model show[/bold], "
+        "[bold]/model set <provider> [model] [--toolcall-model <m>][/bold], "
+        "or [bold]/model toolcall set <model>[/bold])"
     )
     return True
 
@@ -601,7 +730,9 @@ SLASH_COMMANDS: dict[str, SlashCommand] = {
     ),
     "/model": SlashCommand(
         "/model",
-        "show or set the active LLM ('/model show', '/model set <id>')",
+        "show or set the active LLM ('/model show', "
+        "'/model set <provider> [model] [--toolcall-model <m>]', "
+        "'/model toolcall set <model>')",
         _cmd_model,
     ),
     "/health": SlashCommand("/health", "show integration and agent health", _cmd_health),

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -231,9 +231,15 @@ def switch_llm_provider(
     env_path = sync_env_values(values)
     os.environ.update(values)
 
+    # Be explicit about which slot each model lands in. The previous output
+    # ("switched LLM provider: anthropic (X)") read ambiguously: a reviewer
+    # ran `/model set anthropic claude-haiku-...` and asked "how is the
+    # reasoning model changing then?" because `(X)` did not say *which*
+    # slot X went into. Always label both slots on a switch.
+    console.print(f"[green]switched LLM provider:[/green] {provider.value}")
     console.print(
-        f"[green]switched LLM provider:[/green] {provider.value} "
-        f"[dim]({selected_model or 'provider default'})[/dim]"
+        f"[green]reasoning model:[/green] {selected_model or 'provider default'} "
+        f"[dim]({provider.model_env})[/dim]"
     )
     if selected_toolcall:
         console.print(

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -280,7 +280,7 @@ def _parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None]
     i = 1
     while i < len(args):
         token = args[i]
-        if token in ("--toolcall-model", "--toolcall"):
+        if token == "--toolcall-model":
             if i + 1 >= len(args):
                 return None
             toolcall_model = args[i + 1]

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -174,6 +174,7 @@ def switch_llm_provider(
 ) -> bool:
     from app.cli.wizard.config import PROVIDER_BY_VALUE
     from app.cli.wizard.env_sync import sync_env_values
+    from app.llm_credentials import has_llm_api_key
 
     provider_key = provider_name.strip().lower()
     provider = PROVIDER_BY_VALUE.get(provider_key)
@@ -182,6 +183,31 @@ def switch_llm_provider(
         console.print(
             f"[red]unknown LLM provider:[/red] {escape(provider_name)} "
             f"[dim](choices: {choices})[/dim]"
+        )
+        return False
+
+    # Refuse to half-update .env when the target provider has no usable
+    # credential. Without this the user lands in a state where LLM_PROVIDER
+    # points at e.g. anthropic but ANTHROPIC_API_KEY is unset, so the very
+    # next call into LLMSettings.from_env() raises and /model show prints
+    # "LLM settings unavailable" — which is exactly what reviewers caught
+    # in #1192. Skip the check for providers whose credential isn't a
+    # secret (ollama uses OLLAMA_HOST which has a working default) and for
+    # CLI-backed providers (codex, claude-code) that authenticate through
+    # the vendor CLI and have no api_key_env at all.
+    if (
+        provider.credential_secret
+        and provider.api_key_env
+        and not has_llm_api_key(provider.api_key_env)
+    ):
+        console.print(
+            f"[red]missing credential for {provider.value}:[/red] "
+            f"{provider.api_key_env} is not set in env or the keyring."
+        )
+        console.print(
+            f"[dim]set it with[/dim] [bold]export {provider.api_key_env}=<your-key>[/bold] "
+            "[dim]or run[/dim] [bold]opensre onboard[/bold] "
+            "[dim]to save it to the keyring, then rerun this command.[/dim]"
         )
         return False
 

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -263,15 +263,16 @@ def switch_toolcall_model(
     return True
 
 
-def _parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None] | None:
+def _parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None]:
     """Parse `set <provider> [reasoning_model] [--toolcall-model <m>]`.
 
     ``args`` is the slice after the ``set``/``use``/``switch`` keyword.
-    Returns ``(provider, reasoning_model, toolcall_model)`` or ``None`` if the
-    arguments are malformed.
+    Raises :class:`ValueError` with a user-facing message when the input is
+    malformed, so the caller can surface a specific reason ("missing value
+    for --toolcall-model") instead of a generic usage line.
     """
     if not args:
-        return None
+        raise ValueError("missing provider name")
 
     provider = args[0]
     reasoning_model: str | None = None
@@ -282,14 +283,14 @@ def _parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None]
         token = args[i]
         if token == "--toolcall-model":
             if i + 1 >= len(args):
-                return None
+                raise ValueError("missing value for --toolcall-model")
             toolcall_model = args[i + 1]
             i += 2
             continue
         if token.startswith("--"):
-            return None
+            raise ValueError(f"unknown flag: {token}")
         if reasoning_model is not None:
-            return None
+            raise ValueError(f"unexpected extra argument: {token}")
         reasoning_model = token
         i += 1
 
@@ -395,13 +396,14 @@ def _cmd_model(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if sub in ("set", "use", "switch"):
-        parsed = _parse_model_set_args(args[1:])
-        if parsed is None:
+        try:
+            provider_name, reasoning_model, toolcall_model = _parse_model_set_args(args[1:])
+        except ValueError as exc:
+            console.print(f"[red]{escape(str(exc))}[/red]")
             console.print(
-                "[red]usage:[/red] /model set <provider> [model] [--toolcall-model <model>]"
+                "[dim]usage:[/dim] /model set <provider> [model] [--toolcall-model <model>]"
             )
             return True
-        provider_name, reasoning_model, toolcall_model = parsed
         switch_llm_provider(
             provider_name,
             console,

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -10,17 +10,12 @@ from typing import Literal
 
 from app.config import (
     ANTHROPIC_REASONING_MODEL,
-    ANTHROPIC_TOOLCALL_MODEL,
     DEFAULT_OLLAMA_HOST,
     DEFAULT_OLLAMA_MODEL,
     GEMINI_REASONING_MODEL,
-    GEMINI_TOOLCALL_MODEL,
     NVIDIA_REASONING_MODEL,
-    NVIDIA_TOOLCALL_MODEL,
     OPENAI_REASONING_MODEL,
-    OPENAI_TOOLCALL_MODEL,
     OPENROUTER_REASONING_MODEL,
-    OPENROUTER_TOOLCALL_MODEL,
 )
 from app.integrations.llm_cli.base import LLMCLIAdapter
 
@@ -55,9 +50,6 @@ class ProviderOption:
     #: providers that don't expose a separate toolcall model (e.g. CLI-backed
     #: providers like ``codex``/``claude-code``, or Ollama).
     toolcall_model_env: str | None = None
-    #: Default toolcall model to use when the user has not picked one. Empty
-    #: string means "no default" (e.g. CLI providers).
-    default_toolcall_model: str = ""
     #: Human-readable name for the credential requested during onboarding. Most
     #: providers want an API key; Ollama wants a host URL. Used as the wizard
     #: prompt label, e.g. ``{label} {credential_label} ({api_key_env})``.
@@ -197,7 +189,6 @@ SUPPORTED_PROVIDERS = (
         models=ANTHROPIC_MODELS,
         legacy_model_env="ANTHROPIC_MODEL",
         toolcall_model_env="ANTHROPIC_TOOLCALL_MODEL",
-        default_toolcall_model=ANTHROPIC_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="openai",
@@ -209,7 +200,6 @@ SUPPORTED_PROVIDERS = (
         models=OPENAI_MODELS,
         legacy_model_env="OPENAI_MODEL",
         toolcall_model_env="OPENAI_TOOLCALL_MODEL",
-        default_toolcall_model=OPENAI_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="openrouter",
@@ -221,7 +211,6 @@ SUPPORTED_PROVIDERS = (
         models=OPENROUTER_MODELS,
         legacy_model_env="OPENROUTER_MODEL",
         toolcall_model_env="OPENROUTER_TOOLCALL_MODEL",
-        default_toolcall_model=OPENROUTER_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="gemini",
@@ -233,7 +222,6 @@ SUPPORTED_PROVIDERS = (
         models=GEMINI_MODELS,
         legacy_model_env="GEMINI_MODEL",
         toolcall_model_env="GEMINI_TOOLCALL_MODEL",
-        default_toolcall_model=GEMINI_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="nvidia",
@@ -245,7 +233,6 @@ SUPPORTED_PROVIDERS = (
         models=NVIDIA_MODELS,
         legacy_model_env="NVIDIA_MODEL",
         toolcall_model_env="NVIDIA_TOOLCALL_MODEL",
-        default_toolcall_model=NVIDIA_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="codex",

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -10,12 +10,17 @@ from typing import Literal
 
 from app.config import (
     ANTHROPIC_REASONING_MODEL,
+    ANTHROPIC_TOOLCALL_MODEL,
     DEFAULT_OLLAMA_HOST,
     DEFAULT_OLLAMA_MODEL,
     GEMINI_REASONING_MODEL,
+    GEMINI_TOOLCALL_MODEL,
     NVIDIA_REASONING_MODEL,
+    NVIDIA_TOOLCALL_MODEL,
     OPENAI_REASONING_MODEL,
+    OPENAI_TOOLCALL_MODEL,
     OPENROUTER_REASONING_MODEL,
+    OPENROUTER_TOOLCALL_MODEL,
 )
 from app.integrations.llm_cli.base import LLMCLIAdapter
 
@@ -46,6 +51,13 @@ class ProviderOption:
     models: tuple[ModelOption, ...]
     #: If set, ``sync_provider_env`` also writes this key (same value) for legacy .env files.
     legacy_model_env: str | None = None
+    #: Env var that holds the *toolcall* model for this provider. ``None`` for
+    #: providers that don't expose a separate toolcall model (e.g. CLI-backed
+    #: providers like ``codex``/``claude-code``, or Ollama).
+    toolcall_model_env: str | None = None
+    #: Default toolcall model to use when the user has not picked one. Empty
+    #: string means "no default" (e.g. CLI providers).
+    default_toolcall_model: str = ""
     #: Human-readable name for the credential requested during onboarding. Most
     #: providers want an API key; Ollama wants a host URL. Used as the wizard
     #: prompt label, e.g. ``{label} {credential_label} ({api_key_env})``.
@@ -184,6 +196,8 @@ SUPPORTED_PROVIDERS = (
         default_model=ANTHROPIC_REASONING_MODEL,
         models=ANTHROPIC_MODELS,
         legacy_model_env="ANTHROPIC_MODEL",
+        toolcall_model_env="ANTHROPIC_TOOLCALL_MODEL",
+        default_toolcall_model=ANTHROPIC_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="openai",
@@ -194,6 +208,8 @@ SUPPORTED_PROVIDERS = (
         default_model=OPENAI_REASONING_MODEL,
         models=OPENAI_MODELS,
         legacy_model_env="OPENAI_MODEL",
+        toolcall_model_env="OPENAI_TOOLCALL_MODEL",
+        default_toolcall_model=OPENAI_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="openrouter",
@@ -204,6 +220,8 @@ SUPPORTED_PROVIDERS = (
         default_model=OPENROUTER_REASONING_MODEL,
         models=OPENROUTER_MODELS,
         legacy_model_env="OPENROUTER_MODEL",
+        toolcall_model_env="OPENROUTER_TOOLCALL_MODEL",
+        default_toolcall_model=OPENROUTER_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="gemini",
@@ -214,6 +232,8 @@ SUPPORTED_PROVIDERS = (
         default_model=GEMINI_REASONING_MODEL,
         models=GEMINI_MODELS,
         legacy_model_env="GEMINI_MODEL",
+        toolcall_model_env="GEMINI_TOOLCALL_MODEL",
+        default_toolcall_model=GEMINI_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="nvidia",
@@ -224,6 +244,8 @@ SUPPORTED_PROVIDERS = (
         default_model=NVIDIA_REASONING_MODEL,
         models=NVIDIA_MODELS,
         legacy_model_env="NVIDIA_MODEL",
+        toolcall_model_env="NVIDIA_TOOLCALL_MODEL",
+        default_toolcall_model=NVIDIA_TOOLCALL_MODEL,
     ),
     ProviderOption(
         value="codex",

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -219,6 +219,9 @@ class TestAssistantOutputRendering:
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
         monkeypatch.setattr(command_module, "_load_llm_settings", lambda: _Fake())
+        # /model set now requires the target provider's credential to exist;
+        # provide one so the cli-agent's planned switch actually runs.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
 
         session = ReplSession()
         console, buf = _capture()
@@ -262,6 +265,7 @@ class TestAssistantOutputRendering:
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
         monkeypatch.setattr(command_module, "_load_llm_settings", lambda: _Fake())
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
 
         session = ReplSession()
         console, buf = _capture()

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -447,7 +447,29 @@ class TestModelCommand:
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
         console, buf = _capture()
         dispatch_slash("/model set anthropic --made-up-flag x", ReplSession(), console)
-        assert "usage" in buf.getvalue()
+        output = buf.getvalue()
+        assert "unknown flag" in output
+        assert "--made-up-flag" in output
+        assert "usage" in output
+
+    def test_set_toolcall_flag_without_value_prints_specific_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Reviewer ask: a missing flag value must say *which* flag, not just
+        echo the generic usage line."""
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        console, buf = _capture()
+        dispatch_slash("/model set anthropic --toolcall-model", ReplSession(), console)
+        output = buf.getvalue()
+        assert "missing value for --toolcall-model" in output
+        # And we must not have written anything to .env on a parse failure.
+        assert not env_path.exists() or "ANTHROPIC_TOOLCALL_MODEL" not in env_path.read_text()
 
     def test_toolcall_set_updates_only_toolcall_model(
         self,

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -410,6 +410,90 @@ class TestModelCommand:
         dispatch_slash("/model set", ReplSession(), console)
         assert "usage" in buf.getvalue()
 
+    def test_set_with_toolcall_flag_writes_both_env_vars(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """`/model set <provider> [model] --toolcall-model <m>` must persist both."""
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        console, buf = _capture()
+        dispatch_slash(
+            "/model set anthropic claude-opus-4-7 --toolcall-model claude-opus-4-7",
+            ReplSession(),
+            console,
+        )
+
+        output = buf.getvalue()
+        assert "switched LLM provider" in output
+        assert "toolcall model" in output
+        contents = env_path.read_text(encoding="utf-8")
+        assert "LLM_PROVIDER=anthropic" in contents
+        assert "ANTHROPIC_REASONING_MODEL=claude-opus-4-7" in contents
+        assert "ANTHROPIC_TOOLCALL_MODEL=claude-opus-4-7" in contents
+
+    def test_set_unknown_flag_prints_usage(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        console, buf = _capture()
+        dispatch_slash("/model set anthropic --made-up-flag x", ReplSession(), console)
+        assert "usage" in buf.getvalue()
+
+    def test_toolcall_set_updates_only_toolcall_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """`/model toolcall set <m>` must persist only the toolcall env var."""
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+
+        console, buf = _capture()
+        dispatch_slash("/model toolcall set claude-opus-4-7", ReplSession(), console)
+
+        output = buf.getvalue()
+        assert "toolcall model set to" in output
+        contents = env_path.read_text(encoding="utf-8")
+        assert "ANTHROPIC_TOOLCALL_MODEL=claude-opus-4-7" in contents
+        # Reasoning model is left untouched.
+        assert "ANTHROPIC_REASONING_MODEL" not in contents
+        # LLM_PROVIDER must not be rewritten by a toolcall-only switch.
+        assert "LLM_PROVIDER=" not in contents
+
+    def test_toolcall_set_missing_arg_prints_usage(self) -> None:
+        console, buf = _capture()
+        dispatch_slash("/model toolcall set", ReplSession(), console)
+        assert "usage" in buf.getvalue()
+
+    def test_toolcall_set_for_codex_provider_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Providers without a separate toolcall model (codex/claude-code/ollama)
+        must not silently accept toolcall overrides."""
+        import app.cli.wizard.env_sync as env_sync
+
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setenv("LLM_PROVIDER", "codex")
+        console, buf = _capture()
+        dispatch_slash("/model toolcall set gpt-5.4", ReplSession(), console)
+        assert "does not expose a separate toolcall model" in buf.getvalue()
+
     def test_switch_alias_switches_provider(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -397,6 +397,9 @@ class TestModelCommand:
         import app.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        # /model set now refuses to half-update .env when the target provider
+        # has no usable credential; supply one so the happy path still runs.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model set anthropic", ReplSession(), console)
 
@@ -404,6 +407,43 @@ class TestModelCommand:
         assert "switched LLM provider" in output
         assert "anthropic" in output
         assert "LLM_PROVIDER=anthropic" in (tmp_path / ".env").read_text(encoding="utf-8")
+
+    def test_set_refuses_when_credential_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Reviewer ask (#1192): if the target provider has no API key in env
+        or keyring, /model set must NOT touch .env or os.environ — otherwise
+        the user lands in a broken half-state where LLM_PROVIDER points at a
+        provider with no usable credential and the next /model show prints
+        'LLM settings unavailable'."""
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        # Keyring lookups in CI / sandboxes are flaky; force the helper into
+        # the env-only path so the test is deterministic.
+        monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
+        # LLM_PROVIDER must not be rewritten by a rejected switch — capture
+        # what it was before so we can assert it is unchanged.
+        monkeypatch.setenv("LLM_PROVIDER", "gemini")
+
+        console, buf = _capture()
+        dispatch_slash("/model set anthropic", ReplSession(), console)
+
+        output = buf.getvalue()
+        assert "missing credential for anthropic" in output
+        assert "ANTHROPIC_API_KEY" in output
+        assert "switched LLM provider" not in output
+        # No .env should have been written.
+        assert not env_path.exists()
+        # And the live LLM_PROVIDER must be untouched.
+        import os
+
+        assert os.environ.get("LLM_PROVIDER") == "gemini"
 
     def test_set_missing_provider_prints_usage(self) -> None:
         console, buf = _capture()
@@ -421,6 +461,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash(
             "/model set anthropic claude-opus-4-7 --toolcall-model claude-opus-4-7",
@@ -445,6 +486,7 @@ class TestModelCommand:
         import app.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model set anthropic --made-up-flag x", ReplSession(), console)
         output = buf.getvalue()
@@ -464,6 +506,7 @@ class TestModelCommand:
 
         env_path = tmp_path / ".env"
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model set anthropic --toolcall-model", ReplSession(), console)
         output = buf.getvalue()
@@ -525,6 +568,7 @@ class TestModelCommand:
         import app.cli.wizard.env_sync as env_sync
 
         monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         console, buf = _capture()
         dispatch_slash("/model switch anthropic", ReplSession(), console)
 

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -406,6 +406,11 @@ class TestModelCommand:
         output = buf.getvalue()
         assert "switched LLM provider" in output
         assert "anthropic" in output
+        # Reviewer (#1192) couldn't tell from "anthropic (X)" which slot the
+        # model went into; the success message must now explicitly label the
+        # reasoning slot and name the env var it lands in.
+        assert "reasoning model:" in output
+        assert "ANTHROPIC_REASONING_MODEL" in output
         assert "LLM_PROVIDER=anthropic" in (tmp_path / ".env").read_text(encoding="utf-8")
 
     def test_set_refuses_when_credential_missing(


### PR DESCRIPTION
Fixes #1182

#### Describe the changes you have made in this PR -

The interactive shell now exposes a runtime-supported way to change the toolcall model, matching the "Expected behavior" in the issue.

- New flag: `/model set <provider> [model] --toolcall-model <model>` — switch provider, reasoning model, and toolcall model in one command.
- New subcommand: `/model toolcall set <model>` — change only the toolcall model on the currently active provider, leaving the reasoning model untouched.
- The connection table's `toolcall model` row now reflects the value the user just set (it was previously stuck at the default).
- Providers that don't expose a separate toolcall model (`codex`, `claude-code`, `ollama`) reject the override with a clear yellow message instead of silently lying.
- The natural-language assistant action schema now accepts an optional `toolcall_model` on `switch_llm_provider`, plus a new `switch_toolcall_model` action — so requests like "switch the toolcall model also to claude-opus-4-7" actually work instead of returning the "OpenSRE doesn't currently expose a separate action..." refusal shown in the bug report.

Files touched:
- `app/cli/wizard/config.py` — added `toolcall_model_env` and `default_toolcall_model` to `ProviderOption`; populated for anthropic/openai/openrouter/gemini/nvidia.
- `app/cli/interactive_shell/commands.py` — extended `switch_llm_provider`, added `switch_toolcall_model`, added a small flag parser for `/model set`, added `/model toolcall` subcommand, and updated the `/model` help text.
- `app/cli/interactive_shell/cli_agent.py` — updated `_ACTION_RULE` and `_execute_action_plan` so the LLM-driven assistant can request a toolcall switch.
- `tests/cli/interactive_shell/test_commands.py` — added 5 tests covering the flag, the subcommand, the unsupported-provider rejection, and the missing-arg usage paths.

### Demo/Screenshot for feature changes and bug fixes -
<img width="861" height="560" alt="Screenshot 2026-05-01 at 20 13 30" src="https://github.com/user-attachments/assets/bfa1b2f5-0675-47cb-b127-4fdde9079990" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug was a write/read asymmetry: `LLMSettings.from_env()` already reads `<PROVIDER>_TOOLCALL_MODEL`, and the connection table already renders that value, but `switch_llm_provider` only ever wrote `LLM_PROVIDER` and the reasoning model env var — so the toolcall row was effectively read-only from the user's perspective.

Two alternatives I considered and rejected:

1. Auto-mirror the toolcall model from the reasoning model on every `/model set`. Rejected because it silently destroys the user's explicit toolcall override and makes the two values uncontrollable independently — the connection table would still display two rows but they'd always be equal.
2. Add a separate `/toolcall` top-level slash command. Rejected because the discoverability story is worse: users already type `/model` when thinking about models, and the help text for one command is easier to maintain than two.

Chosen approach: keep `/model` as the single entry point. Add a flag (`--toolcall-model`) for the combined case and a subcommand (`/model toolcall set`) for the toolcall-only case, both of which funnel through the same env-sync path that already handles the reasoning model. Provider metadata gains a `toolcall_model_env` field so each provider declares which env var holds its toolcall model; CLI providers (codex/claude-code/ollama) set it to `None` and the helper returns a polite rejection instead of writing nothing or pretending it worked.

Key functions:

- `switch_llm_provider(provider, console, model=None, *, toolcall_model=None)` — extended with a keyword-only `toolcall_model`. When provided, it adds `provider.toolcall_model_env=<value>` to the dict that `sync_env_values` writes, so the reasoning + toolcall + provider all land in `.env` atomically.
- `switch_toolcall_model(model, console, *, provider_name=None)` — new helper. Resolves the active provider from `LLM_PROVIDER` (defaulting to anthropic, mirroring how the rest of the shell defaults), looks up `toolcall_model_env`, and writes only that one key. This is what makes `/model toolcall set` non-destructive to the reasoning model.
- `_parse_model_set_args(args)` — small flag parser. Returns `None` for malformed input (unknown flag, missing flag value, two positional models) so `/model set` can print a single usage line instead of guessing.
- `_cmd_model` — adds a `toolcall` branch and routes `set` through the new parser.
- `_ACTION_RULE` / `_execute_action_plan` in `cli_agent.py` — taught the assistant about the new action shapes, including a label that shows both reasoning and toolcall in the action preview ("switch LLM provider to anthropic (claude-opus-4-7) + toolcall claude-opus-4-7").

Edge cases tested:

- Unknown flag (`--made-up-flag`) → prints usage, no env write.
- Toolcall-only switch on a provider with no separate toolcall env (`codex`) → prints "does not expose a separate toolcall model", no env write.
- `/model toolcall set` with no model → prints usage.
- Toolcall-only switch must NOT rewrite `LLM_PROVIDER` or the reasoning model — verified by asserting absence of those keys in the resulting `.env`.
- Combined `/model set anthropic claude-opus-4-7 --toolcall-model claude-opus-4-7` writes all three keys.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
