### PR TITLE
test: add unit tests for AlertmanagerClient (#876)

### DIFF
--- a/tests/services/test_alertmanager_client.py
+++ b/tests/services/test_alertmanager_client.py
@@ -1,0 +1,511 @@
+"""Tests for AlertmanagerClient."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.integrations.config_models import AlertmanagerIntegrationConfig
+from app.services.alertmanager.client import (
+    AlertmanagerClient,
+    make_alertmanager_client,
+)
+
+AlertmanagerConfig = AlertmanagerIntegrationConfig
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = str(payload)[:200]
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=None,  # type: ignore[arg-type]
+                response=self,  # type: ignore[arg-type]
+            )
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _client(**kwargs: Any) -> AlertmanagerClient:
+    default_config = {
+        "base_url": "https://alertmanager.example.com",
+        "bearer_token": "test-token",
+        "username": "",
+        "password": "",
+    }
+    default_config.update(kwargs)
+    return AlertmanagerClient(AlertmanagerConfig(**default_config))
+
+
+# --- Config ---
+
+
+def test_bearer_token_auth_includes_header() -> None:
+    c = _client(bearer_token="my-secret-token")
+    assert c.config.headers["Authorization"] == "Bearer my-secret-token"
+
+
+def test_basic_auth_config_set() -> None:
+    c = _client(bearer_token="", username="admin", password="secret123")
+    assert c.config.username == "admin"
+    assert c.config.password == "secret123"
+    assert c.config.bearer_token == ""
+    assert c.config.basic_auth == ("admin", "secret123")
+
+
+def test_basic_auth_headers_do_not_include_bearer() -> None:
+    c = _client(bearer_token="", username="admin", password="secret123")
+    assert "Authorization" not in c.config.headers
+
+
+def test_is_configured_with_bearer_token() -> None:
+    c = _client(bearer_token="test-token")
+    assert c.is_configured is True
+
+
+def test_is_configured_with_basic_auth() -> None:
+    c = _client(bearer_token="", username="user", password="pass")
+    assert c.is_configured is True
+
+
+def test_is_configured_without_credentials() -> None:
+    c = _client(bearer_token="", username="", password="")
+    # Has base_url so is configured
+    assert c.is_configured is True
+
+
+def test_is_configured_false_without_base_url() -> None:
+    client = AlertmanagerClient(AlertmanagerConfig(base_url="", bearer_token="token"))
+    assert client.is_configured is False
+
+
+def test_dual_auth_rejected() -> None:
+    with pytest.raises(ValueError, match="both bearer_token and username"):
+        AlertmanagerConfig(
+            base_url="https://example.com",
+            bearer_token="token",
+            username="user",
+            password="pass",
+        )
+
+
+def test_get_client_forwards_auth_config_to_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("app.services.alertmanager.client.httpx.Client", _FakeClient)
+
+    c = _client(bearer_token="", username="admin", password="secret123")
+    _ = c._get_client()
+
+    assert captured["base_url"] == "https://alertmanager.example.com"
+    assert captured["headers"] == {"Content-Type": "application/json"}
+    assert captured["auth"] == ("admin", "secret123")
+    assert captured["timeout"] == 30
+
+
+# --- get_status ---
+
+
+def test_get_status_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "cluster": {
+            "status": "ok",
+            "peers": ["peer1", "peer2"],
+        }
+    }
+
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse(payload),
+    )
+
+    result = _client().get_status()
+    assert result["success"] is True
+    assert result["status"]["cluster"]["status"] == "ok"
+
+
+def test_get_status_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"message": "forbidden"}, 403),
+    )
+
+    result = _client().get_status()
+    assert result["success"] is False
+    assert "403" in result["error"]
+
+
+def test_get_status_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    def _raise(_self: Any, _path: str, **_kw: Any) -> _FakeResponse:
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("app.services.alertmanager.client.httpx.Client.get", _raise)
+
+    result = _client().get_status()
+    assert result["success"] is False
+    assert "connection refused" in result["error"]
+
+
+def test_get_status_calls_correct_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_get(_self: Any, path: str, **_kwargs: Any) -> _FakeResponse:
+        captured["path"] = path
+        return _FakeResponse({"cluster": {"status": "ok"}})
+
+    monkeypatch.setattr("app.services.alertmanager.client.httpx.Client.get", _fake_get)
+
+    _client().get_status()
+    assert captured["path"] == "/api/v2/status"
+
+
+# --- list_alerts ---
+
+
+def test_list_alerts_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "fingerprint": "abc123",
+            "status": {"state": "firing", "inhibitedBy": [], "silencedBy": []},
+            "labels": {"alertname": "HighErrorRate", "severity": "critical"},
+            "annotations": {"description": "Error rate > 50%"},
+            "startsAt": "2026-05-02T10:00:00Z",
+            "endsAt": "0001-01-01T00:00:00Z",
+            "generatorURL": "http://prometheus.example.com",
+        }
+    ]
+
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse(payload),
+    )
+
+    result = _client().list_alerts()
+    assert result["success"] is True
+    assert len(result["alerts"]) == 1
+    assert result["alerts"][0]["fingerprint"] == "abc123"
+    assert result["alerts"][0]["status"] == "firing"
+
+
+def test_list_alerts_with_filter_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_get(_self: Any, _path: str, **kwargs: Any) -> _FakeResponse:
+        captured["params"] = kwargs.get("params", {})
+        return _FakeResponse([])
+
+    monkeypatch.setattr("app.services.alertmanager.client.httpx.Client.get", _fake_get)
+
+    _client().list_alerts(active=True, silenced=False, filter_labels=['alertname="Test"'])
+
+    assert captured["params"]["active"] == "true"
+    assert captured["params"]["silenced"] == "false"
+    assert captured["params"]["filter"] == ['alertname="Test"']
+
+
+def test_list_alerts_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"error": "unauthorized"}, 401),
+    )
+
+    result = _client().list_alerts()
+    assert result["success"] is False
+    assert "401" in result["error"]
+
+
+def test_list_alerts_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse([]),
+    )
+
+    result = _client().list_alerts()
+    assert result["success"] is True
+    assert result["alerts"] == []
+    assert result["total"] == 0
+
+
+def test_list_alerts_unexpected_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"not": "a list"}),
+    )
+
+    result = _client().list_alerts()
+    assert result["success"] is False
+    assert "Unexpected response format" in result["error"]
+
+
+def test_list_alerts_limit_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "fingerprint": f"fp{i}",
+            "status": {"state": "firing", "inhibitedBy": [], "silencedBy": []},
+        }
+        for i in range(10)
+    ]
+
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse(payload),
+    )
+
+    result = _client().list_alerts(limit=5)
+    assert result["success"] is True
+    assert result["total"] == 5
+
+
+# --- list_silences ---
+
+
+def test_list_silences_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "id": "silence-123",
+            "status": {"state": "active"},
+            "matchers": [{"name": "service", "value": "api", "isRegex": False}],
+            "comment": "Planned maintenance",
+            "createdBy": "admin@example.com",
+            "startsAt": "2026-05-02T10:00:00Z",
+            "endsAt": "2026-05-02T12:00:00Z",
+        },
+        {
+            "id": "silence-456",
+            "status": {"state": "expired"},
+            "matchers": [],
+            "comment": "Old maintenance",
+            "createdBy": "admin@example.com",
+            "startsAt": "2026-05-01T10:00:00Z",
+            "endsAt": "2026-05-01T12:00:00Z",
+        },
+    ]
+
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse(payload),
+    )
+
+    result = _client().list_silences()
+
+    assert result["success"] is True
+    assert result["total"] == 2
+    assert result["silences"][0]["id"] == "silence-123"
+    assert result["silences"][0]["comment"] == "Planned maintenance"
+    assert result["active_silences"] == [result["silences"][0]]
+
+
+def test_list_silences_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"error": "forbidden"}, 403),
+    )
+
+    result = _client().list_silences()
+
+    assert result["success"] is False
+    assert "HTTP 403" in result["error"]
+
+
+def test_list_silences_empty_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse([]),
+    )
+
+    result = _client().list_silences()
+
+    assert result["success"] is True
+    assert result["silences"] == []
+    assert result["active_silences"] == []
+    assert result["total"] == 0
+
+
+def test_list_silences_unexpected_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"silences": []}),
+    )
+
+    result = _client().list_silences()
+
+    assert result["success"] is False
+    assert "Unexpected response format" in result["error"]
+
+
+def test_list_silences_limit_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "id": f"silence-{i}",
+            "status": {"state": "active"},
+        }
+        for i in range(10)
+    ]
+
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse(payload),
+    )
+
+    result = _client().list_silences(limit=5)
+
+    assert result["success"] is True
+    assert result["total"] == 5
+    assert len(result["active_silences"]) == 5
+
+
+# --- Context Manager ---
+
+
+def test_close_releases_http_client() -> None:
+    c = _client()
+    mock_client = MagicMock()
+    c._client = mock_client
+
+    assert c._client is not None
+    c.close()
+    assert c._client is None
+    mock_client.close.assert_called_once()
+
+
+def test_close_is_idempotent() -> None:
+    c = _client()
+    mock_client = MagicMock()
+    c._client = mock_client
+
+    c.close()
+    c.close()  # Should not raise
+    mock_client.close.assert_called_once()
+
+
+def test_context_manager_closes_on_exit() -> None:
+    c = _client()
+    mock_client = MagicMock()
+    c._client = mock_client
+
+    with c:
+        assert c._client is not None
+
+    assert c._client is None
+    mock_client.close.assert_called_once()
+
+
+def _raise_value_error() -> None:
+    raise ValueError("test error")
+
+
+def test_context_manager_closes_on_exception() -> None:
+    c = _client()
+    mock_client = MagicMock()
+    c._client = mock_client
+
+    with pytest.raises(ValueError), c:
+        _raise_value_error()
+
+    assert c._client is None
+    mock_client.close.assert_called_once()
+
+
+def test_context_manager_returns_self() -> None:
+    c = _client()
+    with c as entered:
+        assert entered is c
+
+
+# --- Factory Function ---
+
+
+def test_make_client_with_bearer_token() -> None:
+    client = make_alertmanager_client(
+        base_url="https://alertmanager.example.com",
+        bearer_token="test-token",
+    )
+    assert client is not None
+    assert client.is_configured is True
+    assert client.config.bearer_token == "test-token"
+
+
+def test_make_client_with_basic_auth() -> None:
+    client = make_alertmanager_client(
+        base_url="https://alertmanager.example.com",
+        username="admin",
+        password="secret",
+    )
+    assert client is not None
+    assert client.config.username == "admin"
+    assert client.config.password == "secret"
+
+
+def test_make_client_returns_none_when_no_url() -> None:
+    assert make_alertmanager_client("") is None
+    assert make_alertmanager_client(None) is None
+    assert make_alertmanager_client("   ") is None
+
+
+def test_make_client_normalizes_url() -> None:
+    client = make_alertmanager_client(
+        base_url="https://alertmanager.example.com/",
+        bearer_token="token",
+    )
+    assert client is not None
+    assert client.config.base_url == "https://alertmanager.example.com"
+
+
+def test_make_client_strips_whitespace() -> None:
+    client = make_alertmanager_client(
+        base_url="  https://alertmanager.example.com  ",
+        bearer_token="token",
+    )
+    assert client is not None
+    assert client.config.base_url == "https://alertmanager.example.com"
+
+
+# --- Probe Access ---
+
+
+def test_probe_access_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"cluster": {"status": "ok"}}),
+    )
+
+    result = _client().probe_access()
+    assert result.status == "passed"
+    assert "Connected to Alertmanager" in result.detail
+
+
+def test_probe_access_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.alertmanager.client.httpx.Client.get",
+        lambda _self, _path, **_kw: _FakeResponse({"error": "unauthorized"}, 401),
+    )
+
+    result = _client().probe_access()
+    assert result.status == "failed"
+    assert "Status check failed" in result.detail
+
+
+def test_probe_access_not_configured() -> None:
+    client = AlertmanagerClient(AlertmanagerConfig(base_url="", bearer_token="token"))
+    result = client.probe_access()
+    assert result.status == "missing"
+    assert "Missing base_url" in result.detail


### PR DESCRIPTION
Fixes #876 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Added 37 direct unit tests for the AlertmanagerClient class following the OpsGenie/Vercel test patterns. The tests use a `_FakeResponse` helper class and monkeypatch to mock `httpx.Client`, ensuring no real HTTP calls are made.

**Coverage:** 92% of `app/services/alertmanager/client.py`

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

```bash
$ python -m pytest tests/services/test_alertmanager_client.py -v                                                                             ─╯
============================================================= test session starts ==============================================================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0 -- /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre
configfile: pytest.ini
plugins: cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, langsmith-0.7.36, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 37 items                                                                                                                             

tests/services/test_alertmanager_client.py::test_bearer_token_auth_includes_header PASSED                                                [  2%]
tests/services/test_alertmanager_client.py::test_basic_auth_config_set PASSED                                                            [  5%]
tests/services/test_alertmanager_client.py::test_basic_auth_headers_do_not_include_bearer PASSED                                         [  8%]
tests/services/test_alertmanager_client.py::test_is_configured_with_bearer_token PASSED                                                  [ 10%]
tests/services/test_alertmanager_client.py::test_is_configured_with_basic_auth PASSED                                                    [ 13%]
tests/services/test_alertmanager_client.py::test_is_configured_without_credentials PASSED                                                [ 16%]
tests/services/test_alertmanager_client.py::test_is_configured_false_without_base_url PASSED                                             [ 18%]
tests/services/test_alertmanager_client.py::test_dual_auth_rejected PASSED                                                               [ 21%]
tests/services/test_alertmanager_client.py::test_get_client_forwards_auth_config_to_httpx PASSED                                         [ 24%]
tests/services/test_alertmanager_client.py::test_get_status_success PASSED                                                               [ 27%]
tests/services/test_alertmanager_client.py::test_get_status_http_error PASSED                                                            [ 29%]
tests/services/test_alertmanager_client.py::test_get_status_network_error PASSED                                                         [ 32%]
tests/services/test_alertmanager_client.py::test_get_status_calls_correct_endpoint PASSED                                                [ 35%]
tests/services/test_alertmanager_client.py::test_list_alerts_success PASSED                                                              [ 37%]
tests/services/test_alertmanager_client.py::test_list_alerts_with_filter_params PASSED                                                   [ 40%]
tests/services/test_alertmanager_client.py::test_list_alerts_http_error PASSED                                                           [ 43%]
tests/services/test_alertmanager_client.py::test_list_alerts_empty_response PASSED                                                       [ 45%]
tests/services/test_alertmanager_client.py::test_list_alerts_unexpected_format PASSED                                                    [ 48%]
tests/services/test_alertmanager_client.py::test_list_alerts_limit_respected PASSED                                                      [ 51%]
tests/services/test_alertmanager_client.py::test_list_silences_success PASSED                                                            [ 54%]
tests/services/test_alertmanager_client.py::test_list_silences_http_error PASSED                                                         [ 56%]
tests/services/test_alertmanager_client.py::test_list_silences_empty_response PASSED                                                     [ 59%]
tests/services/test_alertmanager_client.py::test_list_silences_unexpected_format PASSED                                                  [ 62%]
tests/services/test_alertmanager_client.py::test_list_silences_limit_respected PASSED                                                    [ 64%]
tests/services/test_alertmanager_client.py::test_close_releases_http_client PASSED                                                       [ 67%]
tests/services/test_alertmanager_client.py::test_close_is_idempotent PASSED                                                              [ 70%]
tests/services/test_alertmanager_client.py::test_context_manager_closes_on_exit PASSED                                                   [ 72%]
tests/services/test_alertmanager_client.py::test_context_manager_closes_on_exception PASSED                                              [ 75%]
tests/services/test_alertmanager_client.py::test_context_manager_returns_self PASSED                                                     [ 78%]
tests/services/test_alertmanager_client.py::test_make_client_with_bearer_token PASSED                                                    [ 81%]
tests/services/test_alertmanager_client.py::test_make_client_with_basic_auth PASSED                                                      [ 83%]
tests/services/test_alertmanager_client.py::test_make_client_returns_none_when_no_url PASSED                                             [ 86%]
tests/services/test_alertmanager_client.py::test_make_client_normalizes_url PASSED                                                       [ 89%]
tests/services/test_alertmanager_client.py::test_make_client_strips_whitespace PASSED                                                    [ 91%]
tests/services/test_alertmanager_client.py::test_probe_access_success PASSED                                                             [ 94%]
tests/services/test_alertmanager_client.py::test_probe_access_failure PASSED                                                             [ 97%]
tests/services/test_alertmanager_client.py::test_probe_access_not_configured PASSED                                                      [100%]

============================================================= slowest 20 durations =============================================================
0.04s call     tests/services/test_alertmanager_client.py::test_get_status_success
0.01s call     tests/services/test_alertmanager_client.py::test_list_alerts_success
0.01s call     tests/services/test_alertmanager_client.py::test_list_alerts_http_error
0.01s call     tests/services/test_alertmanager_client.py::test_probe_access_failure
0.01s call     tests/services/test_alertmanager_client.py::test_list_alerts_unexpected_format
0.01s call     tests/services/test_alertmanager_client.py::test_get_status_network_error
0.01s call     tests/services/test_alertmanager_client.py::test_list_silences_http_error
0.01s call     tests/services/test_alertmanager_client.py::test_list_silences_unexpected_format
0.01s call     tests/services/test_alertmanager_client.py::test_probe_access_success
0.01s call     tests/services/test_alertmanager_client.py::test_list_silences_success
0.01s call     tests/services/test_alertmanager_client.py::test_get_status_http_error
0.01s call     tests/services/test_alertmanager_client.py::test_get_status_calls_correct_endpoint
0.01s call     tests/services/test_alertmanager_client.py::test_list_silences_empty_response
0.01s call     tests/services/test_alertmanager_client.py::test_list_alerts_empty_response
0.01s call     tests/services/test_alertmanager_client.py::test_list_alerts_limit_respected
0.01s call     tests/services/test_alertmanager_client.py::test_list_silences_limit_respected
0.01s call     tests/services/test_alertmanager_client.py::test_list_alerts_with_filter_params
0.00s call     tests/services/test_alertmanager_client.py::test_context_manager_closes_on_exception
0.00s setup    tests/services/test_alertmanager_client.py::test_bearer_token_auth_includes_header
0.00s teardown tests/services/test_alertmanager_client.py::test_get_status_network_error
============================================================== 37 passed in 0.87s ==============================================================

$ make lint && make format-check && make typecheck                                                                                          
.venv/bin/python -m ruff check app/ tests/
All checks passed!
.venv/bin/python -m ruff format --check app/ tests/
1047 files already formatted
.venv/bin/python -m mypy app/
Success: no issues found in 452 source files

```
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

Added unit tests for AlertmanagerClient using the same mocking pattern as OpsGenie/Vercel client tests (`_FakeResponse` class with monkeypatch for httpx.Client). This ensures fast, isolated tests without real HTTP calls.

Key components:

- `_FakeResponse`: Mock HTTP response class that simulates success/error responses
- `_client()`: Helper factory for creating test clients
- Config tests: Verify bearer-token and basic-auth configuration
- get_status tests: Cover success, HTTP errors, network errors
- list_alerts tests: Cover filters, pagination, and error cases
- list_silences tests: Cover success, HTTP errors, empty response, unexpected response format, and limit handling
- Context manager tests: Verify close() and with statement behavior
- Factory function tests: Verify make_alertmanager_client() edge cases
- Probe access tests: Verify connectivity checking


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
