### PR TITLE
fix: improve WAL-driven replication lag RCA (scenario 001) + add QA validation

### DIFF
--- a/tests/synthetic/rds_postgres/001-replication-lag/QA_VALIDATION.md
+++ b/tests/synthetic/rds_postgres/001-replication-lag/QA_VALIDATION.md
@@ -1,0 +1,56 @@
+# Scenario 001 — WAL-driven Replication Lag
+
+## Overview
+
+This scenario validates that the agent identifies replication lag caused by a write-heavy workload on the primary database.
+
+The key mechanism is not simply “replication lag”; the agent must explain that WAL generation on the primary outpaced WAL replay on the read replica.
+
+## Correct Diagnosis
+
+| Field | Expected |
+|---|---|
+| Root cause category | `resource_exhaustion` |
+| Root cause | Write-heavy workload on the primary generated WAL faster than the read replica could replay it |
+| Affected component | `payments-prod-replica-1` |
+| Primary symptom | Replica lag / stale reads |
+| Non-root cause | CPU saturation or connection exhaustion |
+
+## Required Reasoning
+
+A correct answer should include the full causal chain:
+
+1. A write-heavy workload runs on the primary.
+2. WriteIOPS and `TransactionLogsGeneration` increase.
+3. WAL generation exceeds replica replay capacity.
+4. `ReplicaLag` grows on `payments-prod-replica-1`.
+5. Stale reads trigger the replication lag alert.
+
+The replica is affected, but the initiating cause must be attributed to the primary workload.
+
+## Evidence Expectations
+
+The agent should cite evidence such as:
+
+- `aws_cloudwatch_metrics`: `ReplicaLag`, `WriteIOPS`, `TransactionLogsGeneration`
+- `aws_performance_insights`: write-heavy SQL activity with WAL-related waits (e.g. IO:WALWrite)
+
+## Pass Criteria
+
+The answer is considered correct if it:
+
+- Identifies replication lag accurately
+- Explains the WAL generation vs replay mismatch
+- Mentions the replica explicitly
+- Links the issue to a primary write-heavy workload
+- Uses both metric-level and query-level evidence
+
+## Common Failure Modes
+
+The answer should be considered incorrect if it:
+
+- Diagnoses `cpu_saturation` or `connection_exhaustion`
+- Mentions replication lag without explaining the WAL generation/replay mechanism
+- Blames the replica alone without identifying the primary workload
+- Omits the replica from the causal chain
+- Treats CPU as the initiating cause rather than a secondary effect

--- a/tests/synthetic/rds_postgres/001-replication-lag/answer.yml
+++ b/tests/synthetic/rds_postgres/001-replication-lag/answer.yml
@@ -4,8 +4,12 @@ required_keywords:
   - write-heavy workload
   - replica
   - wal
+required_evidence_sources:
+  - aws_cloudwatch_metrics
+  - aws_performance_insights
 forbidden_categories:
   - cpu_saturation
+  - connection_exhaustion
 optimal_trajectory:
   - query_grafana_metrics
   - query_grafana_logs

--- a/tests/synthetic/rds_postgres/001-replication-lag/answer.yml
+++ b/tests/synthetic/rds_postgres/001-replication-lag/answer.yml
@@ -4,6 +4,7 @@ required_keywords:
   - write-heavy workload
   - replica
   - wal
+  - replay
 required_evidence_sources:
   - aws_cloudwatch_metrics
   - aws_performance_insights

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -340,7 +340,9 @@ def score_result(
                 state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
 
                 has_state_evidence = bool(evidence.get(state_key))
-                has_pi_signal = any(token in normalized_output for token in performance_insights_tokens)
+                has_pi_signal = any(
+                    token in normalized_output for token in performance_insights_tokens
+                )
 
                 if not (has_state_evidence and has_pi_signal):
                     failure_reason = f"required evidence not gathered: {source_key!r}"

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -337,9 +337,15 @@ def score_result(
 
         for source_key in answer_key.required_evidence_sources:
             if source_key == "aws_performance_insights":
-                if not any(token in normalized_output for token in performance_insights_tokens):
+                state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
+
+                has_state_evidence = bool(evidence.get(state_key))
+                has_pi_signal = any(token in normalized_output for token in performance_insights_tokens)
+
+                if not (has_state_evidence and has_pi_signal):
                     failure_reason = f"required evidence not gathered: {source_key!r}"
                     break
+
                 continue
 
             state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -327,7 +327,21 @@ def score_result(
     # internal evidence keys (grafana_metrics, grafana_logs) set by _map_grafana_*.
     if not failure_reason and answer_key.required_evidence_sources:
         evidence = final_state.get("evidence") or {}
+        performance_insights_tokens = (
+            "top sql activity",
+            "avg load",
+            "aas",
+            "db load",
+            "walwrite",
+        )
+
         for source_key in answer_key.required_evidence_sources:
+            if source_key == "aws_performance_insights":
+                if not any(token in normalized_output for token in performance_insights_tokens):
+                    failure_reason = f"required evidence not gathered: {source_key!r}"
+                    break
+                continue
+
             state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
             if not evidence.get(state_key):
                 failure_reason = f"required evidence not gathered: {source_key!r}"


### PR DESCRIPTION
Fixes #597

## The changes

This PR improves root cause analysis (RCA) quality for the `001-replication-lag` synthetic scenario by enforcing correct WAL-driven replication reasoning.

## Key improvements

**Improves replication lag reasoning:**
- Ensures the agent identifies replication lag as a downstream effect of a write-heavy workload on the primary
- Enforces correct causal chain: write workload → WAL generation → replica replay lag

**Enforces mechanism-level RCA:**
- Requires explanation of WAL generation vs replica replay mismatch
- Prevents shallow “replication lag” diagnoses without causal explanation
- Requires `replay` to enforce WAL vs replica replay mechanism

**Strengthens evidence usage:**
- Requires both CloudWatch metrics (`ReplicaLag`, `WriteIOPS`, `TransactionLogsGeneration`)
- Requires Performance Insights evidence (write-heavy SQL + WAL waits)

**Prevents common misdiagnoses:**
- Disallows `cpu_saturation` and `connection_exhaustion` as root causes
- Ensures CPU is treated as a downstream effect, not the initiating cause
- Prevents blaming the replica instead of the primary workload

**Adds QA validation:**
- Introduces `QA_VALIDATION.md` for scenario 001
- Documents expected reasoning, evidence usage, and failure modes
- Helps prevent regressions in replication-related RCA

## Result

Scenario `001-replication-lag` now produces stronger, mechanism-level RCA output with correct attribution and evidence grounding.

PASS 001-replication-lag category=resource_exhaustion

Results: 1/1 passed

## Run

```bash
python -m tests.synthetic.rds_postgres.run_suite --scenario 001-replication-lag --mock-grafana