### PR TITLE
fix: live-probe macOS Keychain auth for Claude Code CLI onboarding (#1199)

### DIFF
--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -44,10 +44,10 @@ def _parse_semver(text: str) -> str | None:
 
 
 def _probe_keychain_auth(binary_path: str) -> tuple[bool, str]:
-    """Live-probe Claude Code auth via subprocess (macOS Keychain path)."""
+    """Check Claude Code auth via `claude auth status` (local, no API call)."""
     try:
         proc = subprocess.run(
-            [binary_path, "-p", "ping", "--output-format", "text"],
+            [binary_path, "auth", "status"],
             capture_output=True,
             text=True,
             timeout=_PROBE_TIMEOUT_SEC,
@@ -57,14 +57,24 @@ def _probe_keychain_auth(binary_path: str) -> tuple[bool, str]:
     except subprocess.TimeoutExpired:
         return (
             False,
-            f"claude invocation timed out after {_PROBE_TIMEOUT_SEC:.0f} s — auth state unknown.",
+            f"claude auth status timed out after {_PROBE_TIMEOUT_SEC:.0f} s — auth state unknown.",
         )
     except OSError as exc:
-        return False, f"Could not spawn claude for Keychain probe: {exc}"
-    if proc.returncode == 0:
+        return False, f"Could not spawn claude for auth probe: {exc}"
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()[:500]
+        return False, f"claude auth status failed: {err or 'unknown error'}"
+    try:
+        import json
+
+        data = json.loads(proc.stdout)
+        if data.get("loggedIn"):
+            email = data.get("email", "")
+            return True, f"Authenticated via macOS Keychain{f' ({email})' if email else ''}."
+        return False, "claude auth status: not logged in. Run: claude auth login"
+    except (json.JSONDecodeError, AttributeError):
+        # Older CLI versions may not output JSON — treat exit 0 as authenticated.
         return True, "Authenticated via macOS Keychain."
-    err = (proc.stderr or proc.stdout or "").strip()[:500]
-    return False, f"claude invocation failed: {err or 'unknown error'}"
 
 
 def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | None, str]:

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -43,8 +43,14 @@ def _parse_semver(text: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _probe_keychain_auth(binary_path: str) -> tuple[bool, str]:
-    """Check Claude Code auth via `claude auth status` (local, no API call)."""
+def _probe_cli_auth(binary_path: str) -> tuple[bool, str]:
+    """Check Claude Code auth via `claude auth status` (local, no API call).
+
+    Covers both subscription login and ANTHROPIC_API_KEY; subscription takes
+    priority as reported by the CLI itself.
+    """
+    import json
+
     try:
         proc = subprocess.run(
             [binary_path, "auth", "status"],
@@ -65,46 +71,48 @@ def _probe_keychain_auth(binary_path: str) -> tuple[bool, str]:
         err = (proc.stderr or proc.stdout or "").strip()[:500]
         return False, f"claude auth status failed: {err or 'unknown error'}"
     try:
-        import json
-
         data = json.loads(proc.stdout)
-        if data.get("loggedIn"):
-            email = data.get("email", "")
-            return True, f"Authenticated via macOS Keychain{f' ({email})' if email else ''}."
-        return False, "claude auth status: not logged in. Run: claude auth login"
+        if not data.get("loggedIn"):
+            return False, "Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY."
+        api_key_source = data.get("apiKeySource", "")
+        if api_key_source:
+            return True, f"Authenticated via {api_key_source}."
+        email = data.get("email", "")
+        return True, f"Authenticated via Claude subscription{f' ({email})' if email else ''}."
     except (json.JSONDecodeError, AttributeError):
         # Older CLI versions may not output JSON — treat exit 0 as authenticated.
-        return True, "Authenticated via macOS Keychain."
+        return True, "Authenticated via Claude CLI."
 
 
 def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | None, str]:
-    """Return (logged_in, detail) without spawning a subprocess (unless macOS Keychain path).
+    """Return (logged_in, detail) for Claude Code auth.
 
     Resolution order:
-    1. ANTHROPIC_API_KEY in env → True (definitive; build() forwards it).
-    2. ~/.claude/.credentials.json present and non-empty → True (OAuth login).
-    3. macOS without either → if binary_path given, live-ping to verify Keychain;
-       otherwise None (caller has no binary yet).
-    4. Otherwise → False (Linux/Windows: file is the canonical credential store).
+    1. Binary available → `claude auth status` is the source of truth for all
+       platforms; covers both subscription login and ANTHROPIC_API_KEY.
+    2. No binary, credentials file present → True (OAuth login).
+    3. No binary, ANTHROPIC_API_KEY set → True (API key fallback).
+    4. No binary, macOS → None (Keychain may hold credentials; invocation will verify).
+    5. No binary, Linux/Windows → False.
     """
-    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
-        return True, "Authenticated via ANTHROPIC_API_KEY."
+    if binary_path:
+        return _probe_cli_auth(binary_path)
     creds_path = Path.home() / ".claude" / ".credentials.json"
     try:
         if creds_path.exists() and creds_path.stat().st_size > 2:
             return True, "Authenticated via ~/.claude/.credentials.json (OAuth login)."
     except OSError:
         return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
+    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        return True, "Authenticated via ANTHROPIC_API_KEY."
     if sys.platform == "darwin":
-        if binary_path:
-            return _probe_keychain_auth(binary_path)
         return None, (
-            "ANTHROPIC_API_KEY not set and ~/.claude/.credentials.json absent; "
-            "macOS may use Keychain — auth state unclear, invocation will verify."
+            "Auth state unclear — binary unavailable for verification. "
+            "Run: claude auth login  or set ANTHROPIC_API_KEY."
         )
     return (
         False,
-        "Not authenticated. Run: claude login  or set ANTHROPIC_API_KEY.",
+        "Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY.",
     )
 
 

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -15,6 +15,7 @@ stored in ``~/.claude/.credentials.json`` after ``claude login``.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -43,14 +44,12 @@ def _parse_semver(text: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _probe_cli_auth(binary_path: str) -> tuple[bool, str]:
+def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     """Check Claude Code auth via `claude auth status` (local, no API call).
 
     Covers both subscription login and ANTHROPIC_API_KEY; subscription takes
     priority as reported by the CLI itself.
     """
-    import json
-
     try:
         proc = subprocess.run(
             [binary_path, "auth", "status"],
@@ -69,7 +68,7 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool, str]:
         return False, f"Could not spawn claude for auth probe: {exc}"
     if proc.returncode != 0:
         err = (proc.stderr or proc.stdout or "").strip()[:500]
-        return False, f"claude auth status failed: {err or 'unknown error'}"
+        return None, f"claude auth status failed: {err or 'unknown error'}"
     try:
         data = json.loads(proc.stdout)
         if not data.get("loggedIn"):
@@ -90,21 +89,21 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
     Resolution order:
     1. Binary available → `claude auth status` is the source of truth for all
        platforms; covers both subscription login and ANTHROPIC_API_KEY.
-    2. No binary, credentials file present → True (OAuth login).
-    3. No binary, ANTHROPIC_API_KEY set → True (API key fallback).
+    2. No binary, ANTHROPIC_API_KEY set → True (filesystem-independent fallback).
+    3. No binary, credentials file present → True (OAuth login).
     4. No binary, macOS → None (Keychain may hold credentials; invocation will verify).
     5. No binary, Linux/Windows → False.
     """
     if binary_path:
         return _probe_cli_auth(binary_path)
+    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        return True, "Authenticated via ANTHROPIC_API_KEY."
     creds_path = Path.home() / ".claude" / ".credentials.json"
     try:
         if creds_path.exists() and creds_path.stat().st_size > 2:
             return True, "Authenticated via ~/.claude/.credentials.json (OAuth login)."
     except OSError:
         return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
-    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
-        return True, "Authenticated via ANTHROPIC_API_KEY."
     if sys.platform == "darwin":
         return None, (
             "Auth state unclear — binary unavailable for verification. "

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -43,14 +43,38 @@ def _parse_semver(text: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _classify_claude_code_auth() -> tuple[bool | None, str]:
-    """Return (logged_in, detail) without spawning a subprocess.
+def _probe_keychain_auth(binary_path: str) -> tuple[bool, str]:
+    """Live-probe Claude Code auth via subprocess (macOS Keychain path)."""
+    try:
+        proc = subprocess.run(
+            [binary_path, "-p", "ping", "--output-format", "text"],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SEC,
+            check=False,
+            env={**os.environ, "NO_COLOR": "1"},
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            False,
+            f"claude invocation timed out after {_PROBE_TIMEOUT_SEC:.0f} s — auth state unknown.",
+        )
+    except OSError as exc:
+        return False, f"Could not spawn claude for Keychain probe: {exc}"
+    if proc.returncode == 0:
+        return True, "Authenticated via macOS Keychain."
+    err = (proc.stderr or proc.stdout or "").strip()[:500]
+    return False, f"claude invocation failed: {err or 'unknown error'}"
+
+
+def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | None, str]:
+    """Return (logged_in, detail) without spawning a subprocess (unless macOS Keychain path).
 
     Resolution order:
     1. ANTHROPIC_API_KEY in env → True (definitive; build() forwards it).
     2. ~/.claude/.credentials.json present and non-empty → True (OAuth login).
-    3. macOS without either → None: Claude Code stores OAuth in Keychain on
-       darwin, so file absence is not proof of no-auth — let invocation reveal.
+    3. macOS without either → if binary_path given, live-ping to verify Keychain;
+       otherwise None (caller has no binary yet).
     4. Otherwise → False (Linux/Windows: file is the canonical credential store).
     """
     if os.environ.get("ANTHROPIC_API_KEY", "").strip():
@@ -62,6 +86,8 @@ def _classify_claude_code_auth() -> tuple[bool | None, str]:
     except OSError:
         return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
     if sys.platform == "darwin":
+        if binary_path:
+            return _probe_keychain_auth(binary_path)
         return None, (
             "ANTHROPIC_API_KEY not set and ~/.claude/.credentials.json absent; "
             "macOS may use Keychain — auth state unclear, invocation will verify."
@@ -122,7 +148,7 @@ class ClaudeCodeAdapter:
             )
 
         version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
-        logged_in, auth_detail = _classify_claude_code_auth()
+        logged_in, auth_detail = _classify_claude_code_auth(binary_path=binary_path)
         return CLIProbe(
             installed=True,
             version=version,

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -61,11 +61,11 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
         )
     except subprocess.TimeoutExpired:
         return (
-            False,
+            None,
             f"claude auth status timed out after {_PROBE_TIMEOUT_SEC:.0f} s — auth state unknown.",
         )
     except OSError as exc:
-        return False, f"Could not spawn claude for auth probe: {exc}"
+        return None, f"Could not spawn claude for auth probe: {exc}"
     if proc.returncode != 0:
         err = (proc.stderr or proc.stdout or "").strip()[:500]
         return None, f"claude auth status failed: {err or 'unknown error'}"

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -12,7 +12,7 @@ from app.integrations.llm_cli.claude_code import (
     ClaudeCodeAdapter,
     _classify_claude_code_auth,
     _fallback_claude_code_paths,
-    _probe_keychain_auth,
+    _probe_cli_auth,
 )
 
 
@@ -47,7 +47,7 @@ def test_classify_auth_no_credentials_linux() -> None:
 
 
 def test_classify_auth_no_credentials_macos_returns_none() -> None:
-    """On macOS, no env var and no file → None (Keychain may still hold OAuth)."""
+    """On macOS with no binary, no file, no API key → None (can't verify without binary)."""
     with (
         patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
         patch("app.integrations.llm_cli.claude_code.sys.platform", "darwin"),
@@ -58,7 +58,6 @@ def test_classify_auth_no_credentials_macos_returns_none() -> None:
         mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
         logged_in, detail = _classify_claude_code_auth()
     assert logged_in is None
-    assert "Keychain" in detail
 
 
 def test_classify_auth_credentials_file_present(tmp_path: Path) -> None:
@@ -93,84 +92,98 @@ def test_classify_auth_credentials_file_unreadable() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Keychain live-probe
+# CLI auth probe (_probe_cli_auth)
 # ---------------------------------------------------------------------------
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_success(mock_run: MagicMock) -> None:
+def test_probe_cli_auth_subscription(mock_run: MagicMock) -> None:
+    """Subscription login: loggedIn=true, no apiKeySource → subscription detail."""
     m = MagicMock()
     m.returncode = 0
     m.stdout = '{"loggedIn": true, "email": "user@example.com"}\n'
     m.stderr = ""
     mock_run.return_value = m
-    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
     assert logged_in is True
-    assert "Keychain" in detail
+    assert "subscription" in detail
     assert "user@example.com" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_logged_in_false(mock_run: MagicMock) -> None:
+def test_probe_cli_auth_api_key(mock_run: MagicMock) -> None:
+    """API key auth: loggedIn=true, apiKeySource present → API key detail."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = '{"loggedIn": true, "apiKeySource": "ANTHROPIC_API_KEY"}\n'
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is True
+    assert "ANTHROPIC_API_KEY" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_not_logged_in(mock_run: MagicMock) -> None:
     m = MagicMock()
     m.returncode = 0
     m.stdout = '{"loggedIn": false}\n'
     m.stderr = ""
     mock_run.return_value = m
-    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
-    assert logged_in is False
-    assert "not logged in" in detail
-
-
-@patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_nonzero_exit(mock_run: MagicMock) -> None:
-    m = MagicMock()
-    m.returncode = 1
-    m.stdout = ""
-    m.stderr = "Not authenticated"
-    mock_run.return_value = m
-    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
     assert logged_in is False
     assert "Not authenticated" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_timeout(mock_run: MagicMock) -> None:
+def test_probe_cli_auth_nonzero_exit(mock_run: MagicMock) -> None:
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = "Not authenticated"
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "Not authenticated" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_timeout(mock_run: MagicMock) -> None:
     import subprocess
 
     mock_run.side_effect = subprocess.TimeoutExpired(
         cmd=["/usr/bin/claude", "auth", "status"], timeout=_PROBE_TIMEOUT_SEC
     )
-    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
     assert logged_in is False
     assert "timed out" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_os_error(mock_run: MagicMock) -> None:
+def test_probe_cli_auth_os_error(mock_run: MagicMock) -> None:
     mock_run.side_effect = OSError("permission denied")
-    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
     assert logged_in is False
     assert "permission denied" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_non_json_exit_zero(mock_run: MagicMock) -> None:
+def test_probe_cli_auth_non_json_exit_zero(mock_run: MagicMock) -> None:
     """Older CLI versions that output non-JSON on exit 0 are treated as authenticated."""
     m = MagicMock()
     m.returncode = 0
     m.stdout = "Logged in\n"
     m.stderr = ""
     mock_run.return_value = m
-    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
     assert logged_in is True
-    assert "Keychain" in detail
+    assert "CLI" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
-def test_detect_macos_keychain_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
-    """On macOS with Keychain auth, detect() returns logged_in=True via auth status."""
+def test_detect_subscription_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """detect() returns logged_in=True via subscription when binary is available."""
     mock_which.return_value = "/usr/bin/claude"
 
     auth_proc = MagicMock()
@@ -179,19 +192,32 @@ def test_detect_macos_keychain_authenticated(mock_which: MagicMock, mock_run: Ma
     auth_proc.stderr = ""
     mock_run.side_effect = [_version_proc(), auth_proc]
 
-    with (
-        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
-        patch("app.integrations.llm_cli.claude_code.sys.platform", "darwin"),
-        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
-    ):
-        mock_creds = MagicMock()
-        mock_creds.exists.return_value = False
-        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False):
         probe = ClaudeCodeAdapter().detect()
 
     assert probe.installed is True
     assert probe.logged_in is True
-    assert "Keychain" in probe.detail
+    assert "subscription" in probe.detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_api_key_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """detect() returns logged_in=True via API key when binary reports apiKeySource."""
+    mock_which.return_value = "/usr/bin/claude"
+
+    auth_proc = MagicMock()
+    auth_proc.returncode = 0
+    auth_proc.stdout = '{"loggedIn": true, "apiKeySource": "ANTHROPIC_API_KEY"}\n'
+    auth_proc.stderr = ""
+    mock_run.side_effect = [_version_proc(), auth_proc]
+
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=False):
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "ANTHROPIC_API_KEY" in probe.detail
 
 
 # ---------------------------------------------------------------------------
@@ -207,11 +233,26 @@ def _version_proc() -> MagicMock:
     return m
 
 
+def _auth_status_proc(logged_in: bool, api_key_source: str = "", email: str = "") -> MagicMock:
+    import json
+
+    m = MagicMock()
+    m.returncode = 0
+    data: dict = {"loggedIn": logged_in}
+    if api_key_source:
+        data["apiKeySource"] = api_key_source
+    if email:
+        data["email"] = email
+    m.stdout = json.dumps(data) + "\n"
+    m.stderr = ""
+    return m
+
+
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
 def test_detect_logged_in_via_api_key(mock_which: MagicMock, mock_run: MagicMock) -> None:
     mock_which.return_value = "/usr/bin/claude"
-    mock_run.return_value = _version_proc()
+    mock_run.side_effect = [_version_proc(), _auth_status_proc(True, api_key_source="ANTHROPIC_API_KEY")]
 
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=False):
         probe = ClaudeCodeAdapter().detect()
@@ -224,19 +265,12 @@ def test_detect_logged_in_via_api_key(mock_which: MagicMock, mock_run: MagicMock
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
-def test_detect_not_authenticated_linux(mock_which: MagicMock, mock_run: MagicMock) -> None:
-    """On Linux, missing creds file with no env var produces definitive logged_in=False."""
+def test_detect_not_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """When claude auth status reports not logged in, detect() returns logged_in=False."""
     mock_which.return_value = "/usr/bin/claude"
-    mock_run.return_value = _version_proc()
+    mock_run.side_effect = [_version_proc(), _auth_status_proc(False)]
 
-    with (
-        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
-        patch("app.integrations.llm_cli.claude_code.sys.platform", "linux"),
-        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
-    ):
-        mock_creds = MagicMock()
-        mock_creds.exists.return_value = False
-        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False):
         probe = ClaudeCodeAdapter().detect()
 
     assert probe.installed is True

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -11,6 +11,8 @@ from app.integrations.llm_cli.claude_code import (
     ClaudeCodeAdapter,
     _classify_claude_code_auth,
     _fallback_claude_code_paths,
+    _probe_keychain_auth,
+    _PROBE_TIMEOUT_SEC,
 )
 
 
@@ -88,6 +90,80 @@ def test_classify_auth_credentials_file_unreadable() -> None:
         logged_in, _detail = _classify_claude_code_auth()
 
     assert logged_in is None
+
+
+# ---------------------------------------------------------------------------
+# Keychain live-probe
+# ---------------------------------------------------------------------------
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_keychain_auth_success(mock_run: MagicMock) -> None:
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = "ok\n"
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    assert logged_in is True
+    assert "Keychain" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_keychain_auth_failure(mock_run: MagicMock) -> None:
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = "Not authenticated"
+    mock_run.return_value = m
+    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "Not authenticated" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_keychain_auth_timeout(mock_run: MagicMock) -> None:
+    import subprocess
+
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["/usr/bin/claude", "-p"], timeout=_PROBE_TIMEOUT_SEC)
+    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "timed out" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_keychain_auth_os_error(mock_run: MagicMock) -> None:
+    mock_run.side_effect = OSError("permission denied")
+    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "permission denied" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_macos_keychain_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """On macOS with Keychain auth, detect() returns logged_in=True via live ping."""
+    mock_which.return_value = "/usr/bin/claude"
+
+    ping_proc = MagicMock()
+    ping_proc.returncode = 0
+    ping_proc.stdout = "ok\n"
+    ping_proc.stderr = ""
+    mock_run.side_effect = [_version_proc(), ping_proc]
+
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.sys.platform", "darwin"),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = False
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "Keychain" in probe.detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -252,7 +252,10 @@ def _auth_status_proc(logged_in: bool, api_key_source: str = "", email: str = ""
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
 def test_detect_logged_in_via_api_key(mock_which: MagicMock, mock_run: MagicMock) -> None:
     mock_which.return_value = "/usr/bin/claude"
-    mock_run.side_effect = [_version_proc(), _auth_status_proc(True, api_key_source="ANTHROPIC_API_KEY")]
+    mock_run.side_effect = [
+        _version_proc(),
+        _auth_status_proc(True, api_key_source="ANTHROPIC_API_KEY"),
+    ]
 
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=False):
         probe = ClaudeCodeAdapter().detect()

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -91,6 +92,22 @@ def test_classify_auth_credentials_file_unreadable() -> None:
     assert logged_in is None
 
 
+def test_classify_auth_api_key_not_blocked_by_unreadable_creds() -> None:
+    """ANTHROPIC_API_KEY must succeed even when credentials file raises OSError."""
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = True
+        mock_creds.stat.side_effect = OSError("permission denied")
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        logged_in, detail = _classify_claude_code_auth()
+
+    assert logged_in is True
+    assert "ANTHROPIC_API_KEY" in detail
+
+
 # ---------------------------------------------------------------------------
 # CLI auth probe (_probe_cli_auth)
 # ---------------------------------------------------------------------------
@@ -137,14 +154,15 @@ def test_probe_cli_auth_not_logged_in(mock_run: MagicMock) -> None:
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 def test_probe_cli_auth_nonzero_exit(mock_run: MagicMock) -> None:
+    """Non-zero exit → None (probe failure, not confirmed unauthenticated)."""
     m = MagicMock()
     m.returncode = 1
     m.stdout = ""
-    m.stderr = "Not authenticated"
+    m.stderr = "unknown command 'auth'"
     mock_run.return_value = m
     logged_in, detail = _probe_cli_auth("/usr/bin/claude")
-    assert logged_in is False
-    assert "Not authenticated" in detail
+    assert logged_in is None
+    assert "failed" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
@@ -234,8 +252,6 @@ def _version_proc() -> MagicMock:
 
 
 def _auth_status_proc(logged_in: bool, api_key_source: str = "", email: str = "") -> MagicMock:
-    import json
-
     m = MagicMock()
     m.returncode = 0
     data: dict = {"loggedIn": logged_in}

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -8,11 +8,11 @@ from unittest.mock import MagicMock, patch
 
 from app.integrations.llm_cli.binary_resolver import npm_prefix_bin_dirs
 from app.integrations.llm_cli.claude_code import (
+    _PROBE_TIMEOUT_SEC,
     ClaudeCodeAdapter,
     _classify_claude_code_auth,
     _fallback_claude_code_paths,
     _probe_keychain_auth,
-    _PROBE_TIMEOUT_SEC,
 )
 
 
@@ -101,16 +101,29 @@ def test_classify_auth_credentials_file_unreadable() -> None:
 def test_probe_keychain_auth_success(mock_run: MagicMock) -> None:
     m = MagicMock()
     m.returncode = 0
-    m.stdout = "ok\n"
+    m.stdout = '{"loggedIn": true, "email": "user@example.com"}\n'
     m.stderr = ""
     mock_run.return_value = m
     logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
     assert logged_in is True
     assert "Keychain" in detail
+    assert "user@example.com" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
-def test_probe_keychain_auth_failure(mock_run: MagicMock) -> None:
+def test_probe_keychain_auth_logged_in_false(mock_run: MagicMock) -> None:
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = '{"loggedIn": false}\n'
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "not logged in" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_keychain_auth_nonzero_exit(mock_run: MagicMock) -> None:
     m = MagicMock()
     m.returncode = 1
     m.stdout = ""
@@ -125,7 +138,9 @@ def test_probe_keychain_auth_failure(mock_run: MagicMock) -> None:
 def test_probe_keychain_auth_timeout(mock_run: MagicMock) -> None:
     import subprocess
 
-    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["/usr/bin/claude", "-p"], timeout=_PROBE_TIMEOUT_SEC)
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd=["/usr/bin/claude", "auth", "status"], timeout=_PROBE_TIMEOUT_SEC
+    )
     logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
     assert logged_in is False
     assert "timed out" in detail
@@ -140,16 +155,29 @@ def test_probe_keychain_auth_os_error(mock_run: MagicMock) -> None:
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_keychain_auth_non_json_exit_zero(mock_run: MagicMock) -> None:
+    """Older CLI versions that output non-JSON on exit 0 are treated as authenticated."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = "Logged in\n"
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_keychain_auth("/usr/bin/claude")
+    assert logged_in is True
+    assert "Keychain" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
 def test_detect_macos_keychain_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
-    """On macOS with Keychain auth, detect() returns logged_in=True via live ping."""
+    """On macOS with Keychain auth, detect() returns logged_in=True via auth status."""
     mock_which.return_value = "/usr/bin/claude"
 
-    ping_proc = MagicMock()
-    ping_proc.returncode = 0
-    ping_proc.stdout = "ok\n"
-    ping_proc.stderr = ""
-    mock_run.side_effect = [_version_proc(), ping_proc]
+    auth_proc = MagicMock()
+    auth_proc.returncode = 0
+    auth_proc.stdout = '{"loggedIn": true, "email": "user@example.com"}\n'
+    auth_proc.stderr = ""
+    mock_run.side_effect = [_version_proc(), auth_proc]
 
     with (
         patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -173,7 +173,7 @@ def test_probe_cli_auth_timeout(mock_run: MagicMock) -> None:
         cmd=["/usr/bin/claude", "auth", "status"], timeout=_PROBE_TIMEOUT_SEC
     )
     logged_in, detail = _probe_cli_auth("/usr/bin/claude")
-    assert logged_in is False
+    assert logged_in is None
     assert "timed out" in detail
 
 
@@ -181,7 +181,7 @@ def test_probe_cli_auth_timeout(mock_run: MagicMock) -> None:
 def test_probe_cli_auth_os_error(mock_run: MagicMock) -> None:
     mock_run.side_effect = OSError("permission denied")
     logged_in, detail = _probe_cli_auth("/usr/bin/claude")
-    assert logged_in is False
+    assert logged_in is None
     assert "permission denied" in detail
 
 


### PR DESCRIPTION
Fixes #1199

#### Describe the changes you have made in this PR

`_classify_claude_code_auth()` now accepts an optional `binary_path`. On macOS with no API key or credentials file, it runs a live `claude -p ping` to get a definitive auth result instead of returning `None`. Added 5 tests covering the new probe paths.

### Demo/Screenshot

```
# Before
? Could not verify Anthropic Claude Code CLI login. What next?  ← dead end

# After
✓ Authenticated via macOS Keychain.  ← proceeds
```

---

## Code Understanding and AI Usage

- [x] Yes, I used AI assistance
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Root cause and fix are documented in #1199.

---

## Checklist
- [x] Proper PR title and linked issue
- [x] Self-review done
- [x] Can explain every function added
- [x] Tested thoroughly
- [x] Edge cases considered
- [x] Tests added
- [x] Follows project style