### PR TITLE
Fix: Verify JWT signature in resolve_integrations before trusting org_id

### DIFF
--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -63,7 +63,11 @@ def node_resolve_integrations(
     )
     if webhook_token:
         if not org_id:
-            org_id = extract_org_id_from_jwt(webhook_token) or ""
+            try:
+                org_id = extract_org_id_from_jwt(webhook_token) or ""
+            except Exception:
+                logger.debug("JWT verification failed for webhook token", exc_info=True)
+                org_id = ""
         if not org_id:
             logger.warning("_auth_token present but could not decode org_id")
             tracker.complete(
@@ -90,7 +94,14 @@ def node_resolve_integrations(
         env_token = _strip_bearer(os.getenv("JWT_TOKEN", "").strip())
         if env_token:
             if not org_id:
-                org_id = extract_org_id_from_jwt(env_token) or ""
+                try:
+                    org_id = extract_org_id_from_jwt(env_token) or ""
+                except Exception:
+                    logger.debug(
+                        "JWT verification failed for env token, falling back to local",
+                        exc_info=True,
+                    )
+                    return _resolve_from_local_sources(tracker)
             if not org_id:
                 return _resolve_from_local_sources(tracker)
             try:

--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
+from app.auth.jwt_auth import extract_org_id_from_jwt
 from app.integrations.catalog import (
     classify_integrations as _classify_integrations,
 )
@@ -28,20 +29,6 @@ from app.output import get_tracker
 from app.state import InvestigationState
 
 logger = logging.getLogger(__name__)
-
-
-def _decode_org_id_from_token(token: str) -> str:
-    import base64
-    import json as _json
-
-    try:
-        payload_b64 = token.split(".")[1]
-        payload_b64 += "=" * (4 - len(payload_b64) % 4)
-        claims = _json.loads(base64.urlsafe_b64decode(payload_b64))
-        return claims.get("organization") or claims.get("org_id") or ""
-    except Exception:
-        logger.debug("Failed to decode org_id from JWT token", exc_info=True)
-        return ""
 
 
 def _strip_bearer(token: str) -> str:
@@ -76,7 +63,7 @@ def node_resolve_integrations(
     )
     if webhook_token:
         if not org_id:
-            org_id = _decode_org_id_from_token(webhook_token)
+            org_id = extract_org_id_from_jwt(webhook_token) or ""
         if not org_id:
             logger.warning("_auth_token present but could not decode org_id")
             tracker.complete(
@@ -103,7 +90,7 @@ def node_resolve_integrations(
         env_token = _strip_bearer(os.getenv("JWT_TOKEN", "").strip())
         if env_token:
             if not org_id:
-                org_id = _decode_org_id_from_token(env_token)
+                org_id = extract_org_id_from_jwt(env_token) or ""
             if not org_id:
                 return _resolve_from_local_sources(tracker)
             try:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                  
- Replace insecure `_decode_org_id_from_token()` (base64-decoded JWT without signature verification) with `extract_org_id_from_jwt()` which performs proper JWKS-based cryptographic verification                                           
- An attacker could forge a JWT with any organization claim and impersonate any org ID; tokens are now rejected at verification time if signature is invalid                                                                                
- Wrap both JWT verification call sites in `try/except Exception` to restore resilient degradation behaviour — unexpected exceptions (e.g. `JSONDecodeError` from malformed JWKS) fall back to local sources instead of crashing the node

Fixes #1204
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
