### PR TITLE
Fix 1208 mode defaults to chat

### DIFF
--- a/app/pipeline/routing.py
+++ b/app/pipeline/routing.py
@@ -14,8 +14,20 @@ logger = logging.getLogger(__name__)
 
 
 def route_by_mode(state: AgentState) -> str:
-    """Route based on agent mode. Defaults to chat when mode is not set."""
-    return "investigation" if state.get("mode") == "investigation" else "chat"
+    """Route based on agent mode. Defaults to chat when mode is missing or invalid."""
+    mode = state.get("mode")
+    if mode is None:
+        logger.warning(
+            "route_by_mode: mode is missing or None; defaulting to 'chat'. "
+            "Set state['mode'] = 'investigation' to trigger the investigation pipeline."
+        )
+    elif mode not in ("investigation", "chat"):
+        logger.warning(
+            "route_by_mode: unrecognized mode %r; defaulting to 'chat'. "
+            "Valid values are 'investigation' and 'chat'.",
+            mode,
+        )
+    return "investigation" if mode == "investigation" else "chat"
 
 
 def route_chat(state: AgentState) -> str:

--- a/tests/pipeline/test_route_by_mode.py
+++ b/tests/pipeline/test_route_by_mode.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import pytest
+
+from app.pipeline.routing import route_by_mode
+from app.state import AgentState
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_route"),
+    [
+        ({"mode": "investigation"}, "investigation"),
+        ({"mode": "chat"}, "chat"),
+    ],
+)
+def test_route_by_mode_valid_modes_do_not_warn(
+    state: dict[str, Any],
+    expected_route: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="app.pipeline.routing"):
+        assert route_by_mode(cast(AgentState, state)) == expected_route
+
+    assert not caplog.records
+
+
+@pytest.mark.parametrize("state", [{}, {"mode": None}])
+def test_route_by_mode_missing_or_none_mode_warns_and_defaults_to_chat(
+    state: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="app.pipeline.routing"):
+        assert route_by_mode(cast(AgentState, state)) == "chat"
+
+    assert any("mode is missing or None" in record.message for record in caplog.records)
+
+
+def test_route_by_mode_unrecognized_mode_warns_and_defaults_to_chat(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="app.pipeline.routing"):
+        assert route_by_mode(cast(AgentState, {"mode": "invalid"})) == "chat"
+
+    assert any("unrecognized mode 'invalid'" in record.message for record in caplog.records)


### PR DESCRIPTION
Fixes #1208 

<!-- Add issue number above -->

#### Changes made in this PR -

Adds warnings in `route_by_mode()` when the pipeline state has a missing, `None`, or unrecognized `mode`, while preserving the existing fallback to `chat`.

Adds regression tests covering:
- valid `investigation` and `chat` modes without warnings
- missing/`None` mode warning and chat fallback
- unrecognized mode warning and chat fallback

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->
 Check 1:
<img width="1431" height="486" alt="image" src="https://github.com/user-attachments/assets/eef63256-fd94-4edb-a212-13074f3dbc83" />
Ckeck 2:
<img width="870" height="158" alt="image" src="https://github.com/user-attachments/assets/f30e783a-549d-432e-8ce5-12d85d400fff" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions


<!-- 

This helps reviewers understand your thought process and ensures you understand the code.
-->
#### Implemented approach:

This PR fixes a silent fallback in the pipeline router. Previously, `route_by_mode()` routed to `chat` whenever `state["mode"]` was missing, `None`, or any unrecognized value. That preserved runtime behavior, but made bad caller state hard to debug because there was no warning explaining why the investigation path was skipped.

I considered making invalid modes raise an error, but that would change existing behavior and could break callers that currently rely on the safe chat fallback. I also considered only warning for unknown string values, but the issue specifically calls out `None` and missing mode as debugging problems too.

I chose a narrow implementation that keeps the existing fallback behavior while making it observable. `route_by_mode()` now reads the mode once, logs a warning when it is missing/`None`, logs a warning when it is not `chat` or `investigation`, and still returns `chat` unless the mode is exactly `investigation`.

The main component changed is `app/pipeline/routing.py`, specifically `route_by_mode()`, which decides whether the LangGraph pipeline enters chat or investigation mode. I also added `tests/pipeline/test_route_by_mode.py` to cover valid modes, missing/`None` mode, and unrecognized mode so this behavior does not regress.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
