### PR TITLE
test(cli): use dummy app session in prompt-session tests so they pass…

### DIFF
--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from prompt_toolkit.application import create_app_session
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 from prompt_toolkit.history import FileHistory, InMemoryHistory
+from prompt_toolkit.input import DummyInput
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.output import DummyOutput
 
 from app.cli.interactive_shell import loop
 
@@ -21,7 +24,8 @@ def test_build_prompt_session_uses_persistent_history(
 
     monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
 
-    prompt = loop._build_prompt_session()
+    with create_app_session(input=DummyInput(), output=DummyOutput()):
+        prompt = loop._build_prompt_session()
 
     assert isinstance(prompt.history, FileHistory)
     assert prompt.history.filename == str(tmp_path / "interactive_history")
@@ -40,7 +44,8 @@ def test_build_prompt_session_falls_back_to_memory_history(
     blocked_home.write_text("", encoding="utf-8")
     monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", blocked_home)
 
-    prompt = loop._build_prompt_session()
+    with create_app_session(input=DummyInput(), output=DummyOutput()):
+        prompt = loop._build_prompt_session()
 
     assert isinstance(prompt.history, InMemoryHistory)
 


### PR DESCRIPTION
Follow-up to #1215

#### Describe the changes you have made in this PR -

Fixes the two interactive-shell prompt tests that fail on the `windows-latest` GitHub Actions runner. While reviewing #1215, @muddlebee pointed out that the Windows CI job was red, and the failures turned out to be in unrelated tests — `test_build_prompt_session_uses_persistent_history` and `test_build_prompt_session_falls_back_to_memory_history` in `tests/cli/interactive_shell/test_loop.py`. Both raise `prompt_toolkit.output.win32.NoConsoleScreenBufferError: No Windows console found. Are you running cmd.exe?` because `PromptSession`'s constructor probes the terminal output and the GitHub Actions Windows runner does not expose a real Windows console buffer.

What this PR does:
- Wraps the two `_build_prompt_session()` calls inside `with create_app_session(input=DummyInput(), output=DummyOutput()):` so prompt_toolkit uses an injected fake terminal for the duration of construction.
- Adds the three required `prompt_toolkit` imports (`create_app_session`, `DummyInput`, `DummyOutput`).

What this PR does not do:
- No production code changes — only the test file is touched.
- No `pytest.mark.skipif` for Windows. The fix exercises the same code on every platform; we do not want Windows coverage to silently disappear.
- No changes to the other 5 tests in the file — they don't construct a `PromptSession`, so they were already platform-safe.



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: `PromptSession(...)` calls into prompt_toolkit's output layer during construction. On Linux/macOS, when there is no controlling TTY (as in CI), prompt_toolkit silently falls back to a dummy output. On Windows, the same code path tries to attach to a real console screen buffer through `win32` APIs, and when none is available — which is the case on the `windows-latest` GitHub Actions runner — it raises `NoConsoleScreenBufferError`. So the bug is purely environmental: the production code under test is fine, but the test was implicitly relying on a TTY-fallback that does not exist on Windows.

I considered three approaches:
1. `@pytest.mark.skipif(sys.platform == "win32" and not sys.stdin.isatty(), ...)` — simple, but it removes the test from Windows coverage entirely. If `_build_prompt_session()` ever regresses on Windows (e.g., a wrong history type), no test would catch it.
2. Mock `prompt_toolkit.output.create_output` with `unittest.mock.patch` — works, but couples the test to a private prompt_toolkit symbol that could move between releases.
3. Use prompt_toolkit's public testing API: `create_app_session(input=DummyInput(), output=DummyOutput())`. This is the maintainer-recommended way to construct prompt_toolkit objects in tests with no real terminal. It's a context manager that swaps in `DummyInput`/`DummyOutput` for any code running inside the `with` block.

I chose option 3 because:
- It keeps Windows in the coverage map.
- It uses a public, stable API rather than a private one.
- It is platform-agnostic — the same test body runs on Linux, macOS, and Windows with no branching.
- The asserted behavior (`prompt.history` type, `prompt.history.filename`, `prompt.completer` type, `prompt.app.key_bindings is not None`) is set during `PromptSession.__init__`, so it is captured by the time the `with` block exits — there is no need to keep the session active during the assertions.

Key things I added:
- `with create_app_session(input=DummyInput(), output=DummyOutput()):` around the two `loop._build_prompt_session()` calls.
- Imports for `create_app_session`, `DummyInput`, `DummyOutput`. Imports are sorted alphabetically within their `prompt_toolkit.*` group, matching ruff's default isort rules.

Edge cases considered:
- What if a future test adds another `_build_prompt_session()` call elsewhere in this file? It will need the same `with` wrapper, but adding a module-level autouse fixture now would be premature — only two tests need it today.
- What if prompt_toolkit changes the public API of `create_app_session`? It has been stable since 3.0.x and is the documented testing pattern.
- What if `DummyOutput` ever stops being importable? It's a public, documented part of `prompt_toolkit.output` and used widely in prompt_toolkit's own test suite.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
