### PR TITLE
Fix: keep CLI analytics disabled when users opt out (#1118)

### DIFF
--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -71,3 +71,59 @@ def test_install_main_reuses_shared_install_guard(monkeypatch) -> None:
 
     assert exit_code == 0
     assert captured == [{"install_source": "make_install", "entrypoint": "make install"}]
+
+
+def test_analytics_disabled_when_opensre_analytics_disabled_opt_out(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENSRE_ANALYTICS_DISABLED", "1")
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+
+    client_inits = 0
+
+    class _FailIfConstructedClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            nonlocal client_inits
+            client_inits += 1
+            raise AssertionError(
+                "httpx client should not be constructed when analytics is disabled"
+            )
+
+    monkeypatch.setattr(provider.httpx, "Client", _FailIfConstructedClient)
+    analytics = provider.Analytics()
+    analytics.capture(Event.INSTALL_DETECTED, {"install_source": "make_install"})
+
+    assert analytics._disabled is True
+    assert analytics._worker is None
+    assert analytics._pending == 0
+    assert analytics._queue.qsize() == 0
+    assert client_inits == 0
+
+
+def test_analytics_disabled_when_do_not_track_opt_out(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+
+    client_inits = 0
+
+    class _FailIfConstructedClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            nonlocal client_inits
+            client_inits += 1
+            raise AssertionError(
+                "httpx client should not be constructed when analytics is disabled"
+            )
+
+    monkeypatch.setattr(provider.httpx, "Client", _FailIfConstructedClient)
+    analytics = provider.Analytics()
+    analytics.capture(Event.INSTALL_DETECTED, {"install_source": "make_install"})
+
+    assert analytics._disabled is True
+    assert analytics._worker is None
+    assert analytics._pending == 0
+    assert analytics._queue.qsize() == 0
+    assert client_inits == 0


### PR DESCRIPTION
Fixes #

<!-- Add issue number above -->

Closes #1118

#### Describe the changes you have made in this PR -
- Added coverage in `tests/analytics/test_provider.py` for analytics opt-out behavior via both environment variables:
  - `OPENSRE_ANALYTICS_DISABLED=1`
  - `DO_NOT_TRACK=1`
- Verified `provider.Analytics()` initializes in disabled mode when either opt-out flag is set.
- Verified `capture()` does not enqueue events or trigger sending when analytics is disabled.
- Kept tests deterministic by isolating local state and preventing any real network activity.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<img width="2934" height="548" alt="image" src="https://github.com/user-attachments/assets/45d73abb-4750-4007-ae1d-4a6fa07566e9" />
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [] No, I wrote all the code myself
- [x ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- The added tests confirm that in opt-out mode our analytics client does not queue or attempt to send events.

- What alternative approaches did you consider?
- A simpler approach was to only assert the queue remains empty after `capture()`. That was rejected because it could miss issues where sending is attempted via other path.

- Why did you choose this specific implementation?
- Gives stronger testing.

- What are the key functions/components and what do they do?
- `test_analytics_disabled_when_opensre_analytics_disabled_opt_out` and `test_analytics_disabled_when_do_not_track_opt_out`

This helps reviewers understand your thought process and ensures you understand the code.
-->
- What problem does your code solve?
The added tests confirm that in opt-out mode our analytics client does not queue or attempt to send events.

- What alternative approaches did you consider?
A simpler approach was to only assert the queue remains empty after `capture()`. That was rejected because it could miss issues where sending is attempted via other path.

- Why did you choose this specific implementation?
Gives stronger testing.

- What are the key functions/components and what do they do?
`test_analytics_disabled_when_opensre_analytics_disabled_opt_out` and `test_analytics_disabled_when_do_not_track_opt_out`
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
