### PR TITLE
Add unit tests for Kafka tools (topic health + consumer group lag)

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -41,6 +41,14 @@ def mock_agent_state(overrides: dict | None = None) -> dict[str, Any]:
             "pipeline_name": "my-pipeline",
             "time_range_minutes": 60,
         },
+        "kafka": {
+            "connection_verified": True,
+            "bootstrap_servers": "broker:9092",
+            "security_protocol": "PLAINTEXT",
+            "sasl_mechanism": "",
+            "sasl_username": "",
+            "sasl_password": "",
+        },
         "eks": {
             "connection_verified": True,
             "cluster_name": "my-cluster",

--- a/tests/tools/test_kafka_consumer_group_tool.py
+++ b/tests/tools/test_kafka_consumer_group_tool.py
@@ -1,0 +1,88 @@
+"""Tests for KafkaConsumerGroupTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.KafkaConsumerGroupTool import get_kafka_consumer_group_lag
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestKafkaConsumerGroupToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_kafka_consumer_group_lag.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_verified() -> None:
+    rt = get_kafka_consumer_group_lag.__opensre_registered_tool__
+    assert rt.is_available({"kafka": {"connection_verified": True}}) is True
+    assert rt.is_available({"kafka": {"connection_verified": False}}) is False
+    assert rt.is_available({"kafka": {}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_kafka_consumer_group_lag.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "kafka": {
+                "connection_verified": True,
+                "bootstrap_servers": "  broker:9092  ",
+                "security_protocol": " sasl_ssl ",
+                "sasl_mechanism": " PLAIN ",
+                "sasl_username": " user ",
+                "sasl_password": " pass ",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["bootstrap_servers"] == "broker:9092"
+    assert params["security_protocol"] == "sasl_ssl"
+    assert params["sasl_mechanism"] == "PLAIN"
+    assert params["sasl_username"] == "user"
+    assert params["sasl_password"] == "pass"
+
+
+def test_run_happy_path_calls_integration_helper() -> None:
+    fake_response = {
+        "source": "kafka",
+        "available": True,
+        "group_id": "my-group",
+        "partitions": [],
+    }
+    with patch(
+        "app.tools.KafkaConsumerGroupTool.get_consumer_group_lag",
+        return_value=fake_response,
+    ) as mock_get_consumer_group_lag:
+        result = get_kafka_consumer_group_lag(
+            bootstrap_servers="broker:9092",
+            group_id="my-group",
+            security_protocol="SASL_SSL",
+            sasl_mechanism="PLAIN",
+            sasl_username="alice",
+            sasl_password="secret",
+        )
+
+    assert result == fake_response
+
+    (config,), kwargs = mock_get_consumer_group_lag.call_args
+    assert config.bootstrap_servers == "broker:9092"
+    assert config.security_protocol == "SASL_SSL"
+    assert config.sasl_mechanism == "PLAIN"
+    assert config.sasl_username == "alice"
+    assert config.sasl_password == "secret"
+    assert kwargs["group_id"] == "my-group"
+
+
+def test_run_returns_error_dict_from_integration_helper() -> None:
+    fake_error = {"source": "kafka", "available": False, "error": "boom"}
+    with patch(
+        "app.tools.KafkaConsumerGroupTool.get_consumer_group_lag",
+        return_value=fake_error,
+    ):
+        result = get_kafka_consumer_group_lag(
+            bootstrap_servers="broker:9092",
+            group_id="my-group",
+        )
+
+    assert result == fake_error

--- a/tests/tools/test_kafka_topic_health_tool.py
+++ b/tests/tools/test_kafka_topic_health_tool.py
@@ -1,0 +1,90 @@
+"""Tests for KafkaTopicHealthTool (function-based, @tool decorated)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.KafkaTopicHealthTool import get_kafka_topic_health
+from tests.tools.conftest import BaseToolContract, mock_agent_state
+
+
+class TestKafkaTopicHealthToolContract(BaseToolContract):
+    def get_tool_under_test(self):
+        return get_kafka_topic_health.__opensre_registered_tool__
+
+
+def test_is_available_requires_connection_verified() -> None:
+    rt = get_kafka_topic_health.__opensre_registered_tool__
+    assert rt.is_available({"kafka": {"connection_verified": True}}) is True
+    assert rt.is_available({"kafka": {"connection_verified": False}}) is False
+    assert rt.is_available({"kafka": {}}) is False
+    assert rt.is_available({}) is False
+
+
+def test_extract_params_maps_fields() -> None:
+    rt = get_kafka_topic_health.__opensre_registered_tool__
+    sources = mock_agent_state(
+        {
+            "kafka": {
+                "connection_verified": True,
+                "bootstrap_servers": "  broker:9092  ",
+                "security_protocol": None,
+                "sasl_mechanism": " PLAIN ",
+                "sasl_username": " user ",
+                "sasl_password": " pass ",
+            }
+        }
+    )
+    params = rt.extract_params(sources)
+    assert params["bootstrap_servers"] == "broker:9092"
+    assert params["security_protocol"] == "PLAINTEXT"
+    assert params["sasl_mechanism"] == "PLAIN"
+    assert params["sasl_username"] == "user"
+    assert params["sasl_password"] == "pass"
+
+
+def test_run_happy_path_calls_integration_helper() -> None:
+    fake_response = {"source": "kafka", "available": True, "topics_returned": 1}
+    with patch(
+        "app.tools.KafkaTopicHealthTool.get_topic_health", return_value=fake_response
+    ) as mock_get_topic_health:
+        result = get_kafka_topic_health(
+            bootstrap_servers="broker:9092",
+            topic="my-topic",
+            security_protocol="SASL_SSL",
+            sasl_mechanism="PLAIN",
+            sasl_username="alice",
+            sasl_password="secret",
+            limit=12,
+        )
+
+    assert result == fake_response
+
+    (config,), kwargs = mock_get_topic_health.call_args
+    assert config.bootstrap_servers == "broker:9092"
+    assert config.security_protocol == "SASL_SSL"
+    assert config.sasl_mechanism == "PLAIN"
+    assert config.sasl_username == "alice"
+    assert config.sasl_password == "secret"
+    assert kwargs["topic"] == "my-topic"
+    assert kwargs["limit"] == 12
+
+
+def test_run_empty_topic_passes_none() -> None:
+    fake_response = {"source": "kafka", "available": True, "topics_returned": 1}
+    with patch(
+        "app.tools.KafkaTopicHealthTool.get_topic_health", return_value=fake_response
+    ) as mock_get_topic_health:
+        result = get_kafka_topic_health(bootstrap_servers="broker:9092", topic="")
+
+    assert result == fake_response
+    (_,), kwargs = mock_get_topic_health.call_args
+    assert kwargs["topic"] is None
+
+
+def test_run_returns_error_dict_from_integration_helper() -> None:
+    fake_error = {"source": "kafka", "available": False, "error": "boom"}
+    with patch("app.tools.KafkaTopicHealthTool.get_topic_health", return_value=fake_error):
+        result = get_kafka_topic_health(bootstrap_servers="broker:9092", topic="my-topic")
+
+    assert result == fake_error


### PR DESCRIPTION
Fixes #994

#### Describe the changes you have made in this PR -
- Added unit tests for the Kafka tools registered via `@tool`:
  - `tests/tools/test_kafka_topic_health_tool.py` (availability, param extraction, and run wiring)
  - `tests/tools/test_kafka_consumer_group_tool.py` (availability, param extraction, and run wiring)
- Tests patch the integration helpers so everything runs fully offline (no Kafka broker required).

### Demo/Screenshot for feature changes and bug fixes -
- `pytest`: ran the two new test files locally (all passing)
- `ruff`: `check` + `format` on the new tests

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I followed the existing tool-test pattern (e.g. Grafana logs tool): contract tests via `BaseToolContract`, plus direct unit tests for `is_available`/`extract_params` and for the function tool’s “run” wiring. I patch the integration-layer functions (`get_topic_health` / `get_consumer_group_lag`) to validate config construction + arguments, and to keep the suite deterministic and offline.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
