### PR TITLE
fix(ci): restore CLI help sync + uninstall help text

### DIFF
--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -24,7 +24,7 @@ from app.version import get_version
 @click.command(name="uninstall")
 @click.option("--yes", "-y", "local_yes", is_flag=True, help="Skip the confirmation prompt.")
 def uninstall_command(local_yes: bool) -> None:
-    """Remove opensre and all local data from this machine."""
+    """Uninstall opensre and remove all local data from this machine."""
     from app.cli.support.uninstall import run_uninstall
 
     capture_cli_invoked()

--- a/tests/cli/test_command_help_sync.py
+++ b/tests/cli/test_command_help_sync.py
@@ -1,13 +1,15 @@
 """Regression test: CLI command registration must stay in sync with help copy.
 
-If a command is added to _COMMANDS but forgotten in _HELP_COMMANDS (or vice
-versa) this test will fail and name exactly which command is out of sync.
+The root help view derives its command list from the live Click group at runtime.
+This test ensures that every command registered in `_COMMANDS` is represented in
+that derived help command list (and vice versa).
 """
 
 from __future__ import annotations
 
+from app.cli.__main__ import cli
 from app.cli.commands import _COMMANDS
-from app.cli.support.layout import _HELP_COMMANDS
+from app.cli.support.layout import _commands_from_group
 
 
 def test_registered_commands_match_help_table() -> None:
@@ -16,16 +18,16 @@ def test_registered_commands_match_help_table() -> None:
         "A command in _COMMANDS has no name set. "
         "Ensure every click.Command is decorated with an explicit name."
     )
-    documented = {name for name, _ in _HELP_COMMANDS}
+    documented = {name for name, _ in _commands_from_group(cli)}
 
     missing_from_help = registered - documented
     missing_from_registry = documented - registered
 
     assert not missing_from_help, (
-        f"Commands registered in _COMMANDS but missing from _HELP_COMMANDS: {missing_from_help}. "
-        "Add an entry to _HELP_COMMANDS in app/cli/layout.py."
+        f"Commands registered in _COMMANDS but missing from the rendered help list: {missing_from_help}. "
+        "Ensure the root CLI group is registering all commands."
     )
     assert not missing_from_registry, (
-        f"Commands in _HELP_COMMANDS but not registered in _COMMANDS: {missing_from_registry}. "
+        f"Commands shown in the rendered help list but not registered in _COMMANDS: {missing_from_registry}. "
         "Add the command to _COMMANDS in app/cli/commands/__init__.py."
     )


### PR DESCRIPTION
CI is currently failing because `tests/cli/test_command_help_sync.py` still expects a `_HELP_COMMANDS` table that no longer exists (the root help now derives its command list from the live Click group).

This PR updates the regression test to compare `_COMMANDS` against the command list derived from the root `cli` group, and adjusts the `uninstall` command’s help text to include “Uninstall …” so the uninstall help test matches the displayed copy.

Repro: `python -m pytest -n auto --ignore=tests/e2e/kubernetes_local_alert_simulation --ignore=tests/synthetic -m 'not synthetic'`