### PR TITLE
feat: add automated investigation benchmarking entry point and result…

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f837f1fc-f852-4520-8cf0-65cc82b316c1","pid":13020,"acquiredAt":1777779993932}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .env.local
 .env.*.local
 
+# Claude Code runtime artifacts
+.claude/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/app/cli/support/args.py
+++ b/app/cli/support/args.py
@@ -45,6 +45,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "(rubric is stripped from the agent copy of the alert)."
         ),
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Emit Cloud-OpsBench-style ranked predictions instead of the default report.",
+    )
+    parser.add_argument("--case-name", default="", help="Benchmark case identifier.")
+    parser.add_argument("--case-path", default="", help="Benchmark case directory path.")
+    parser.add_argument(
+        "--fault-category", default="", help="Benchmark fault category label (e.g. 'scheduling')."
+    )
+    parser.add_argument(
+        "--prompt-strategy", default="base", help="Prompt strategy label recorded in benchmark output."
+    )
+    parser.add_argument(
+        "--model",
+        default="",
+        help="Model identifier recorded in benchmark output. Defaults to the configured provider model.",
+    )
     return parser.parse_args(argv)
 
 

--- a/app/entrypoints/benchmark.py
+++ b/app/entrypoints/benchmark.py
@@ -1,0 +1,225 @@
+"""Benchmark output mode — emits Cloud-OpsBench-style results from the pipeline.
+
+Wraps the standard investigation runner and formats its final state into a
+ranked-prediction record suitable for offline scoring against labeled fault
+cases. The default investigation output is unchanged.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from app.investigation_constants import MAX_INVESTIGATION_LOOPS
+
+StopReason = Literal[
+    "final_answer",
+    "max_loops",
+    "no_actions_available",
+    "error",
+    "unknown",
+]
+
+
+class Prediction(BaseModel):
+    rank: int
+    fault_taxonomy: str
+    fault_object: str
+    root_cause: str
+
+
+class BenchmarkResult(BaseModel):
+    model: str
+    fault_category: str
+    prompt_strategy: str = Field(alias="prompt_strat")
+    case_name: str
+    case_path: str
+    finished: bool
+    stop_reason: StopReason
+    steps_used: int
+    elapsed_seconds: float
+    trace_path: str = "/"
+    result_path: str = "/"
+    key_evidence_summary: str
+    top_3_predictions: list[Prediction]
+
+    model_config = {"populate_by_name": True}
+
+
+@dataclass
+class BenchmarkInputs:
+    """Caller-supplied metadata that the pipeline itself does not own."""
+
+    case_name: str
+    case_path: str
+    fault_category: str = ""
+    model: str = ""
+    prompt_strategy: str = "base"
+    trace_path: str = "/"
+    result_path: str = "/"
+    raw_alert: str | dict[str, Any] | None = None
+    alert_name: str = "Incident"
+    pipeline_name: str = "events_fact"
+    severity: str = "warning"
+    resolved_integrations: dict[str, Any] | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _derive_stop_reason(state: dict[str, Any], errored: bool) -> StopReason:
+    if errored:
+        return "error"
+    if state.get("root_cause"):
+        return "final_answer"
+    if state.get("investigation_loop_count", 0) > MAX_INVESTIGATION_LOOPS:
+        return "max_loops"
+    if not state.get("available_action_names"):
+        return "no_actions_available"
+    return "unknown"
+
+
+def _summarize_evidence(state: dict[str, Any]) -> str:
+    """Concatenate validated claims into a short evidence blurb. No LLM call."""
+    claims = state.get("validated_claims") or []
+    parts: list[str] = []
+    for claim in claims:
+        if not isinstance(claim, dict):
+            continue
+        text = (
+            claim.get("claim")
+            or claim.get("statement")
+            or claim.get("description")
+            or claim.get("text")
+            or ""
+        )
+        text = str(text).strip()
+        if text:
+            parts.append(text)
+    if parts:
+        return " ".join(parts)
+    return str(state.get("root_cause") or "").strip()
+
+
+def _resolve_fault_object(state: dict[str, Any]) -> str:
+    alert = state.get("alert_json") or {}
+    if isinstance(alert, dict):
+        for key in ("fault_object", "service", "resource", "pod", "deployment"):
+            value = alert.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return str(state.get("alert_name") or "").strip()
+
+
+def _build_predictions(state: dict[str, Any]) -> list[Prediction]:
+    category = str(state.get("root_cause_category") or "").strip()
+    fault_object = _resolve_fault_object(state)
+    root_cause = str(state.get("root_cause") or "").strip()
+
+    predictions: list[Prediction] = []
+    if category or root_cause:
+        predictions.append(
+            Prediction(
+                rank=1,
+                fault_taxonomy=category or "unknown",
+                fault_object=fault_object,
+                root_cause=root_cause or "unknown",
+            )
+        )
+
+    hypotheses = state.get("hypotheses") or []
+    for hypo in hypotheses:
+        if len(predictions) >= 3:
+            break
+        text = str(hypo).strip() if hypo is not None else ""
+        if not text:
+            continue
+        predictions.append(
+            Prediction(
+                rank=len(predictions) + 1,
+                fault_taxonomy=category or "unknown",
+                fault_object=fault_object,
+                root_cause=text,
+            )
+        )
+
+    return predictions
+
+
+def _resolve_model(explicit: str) -> str:
+    if explicit:
+        return explicit
+    try:
+        from app.config import LLMSettings
+
+        settings = LLMSettings.from_env()
+        provider = settings.provider
+        attr = f"{provider}_reasoning_model"
+        return getattr(settings, attr, provider)
+    except Exception:
+        return "unknown"
+
+
+def run_benchmark_case(inputs: BenchmarkInputs) -> BenchmarkResult:
+    """Run the investigation pipeline and return a benchmark-formatted result."""
+    from app.pipeline.runners import run_investigation
+
+    started = time.monotonic()
+    errored = False
+    state: dict[str, Any] = {}
+    try:
+        state = dict(
+            run_investigation(
+                inputs.alert_name,
+                inputs.pipeline_name,
+                inputs.severity,
+                raw_alert=inputs.raw_alert,
+                resolved_integrations=inputs.resolved_integrations,
+            )
+        )
+    except Exception:
+        errored = True
+    elapsed = time.monotonic() - started
+
+    stop_reason = _derive_stop_reason(state, errored)
+    return BenchmarkResult(
+        model=_resolve_model(inputs.model),
+        fault_category=inputs.fault_category or str(state.get("root_cause_category") or ""),
+        prompt_strat=inputs.prompt_strategy,
+        case_name=inputs.case_name,
+        case_path=inputs.case_path,
+        finished=stop_reason == "final_answer",
+        stop_reason=stop_reason,
+        steps_used=int(state.get("investigation_loop_count", 0)),
+        elapsed_seconds=round(elapsed, 3),
+        trace_path=inputs.trace_path,
+        result_path=inputs.result_path,
+        key_evidence_summary=_summarize_evidence(state),
+        top_3_predictions=_build_predictions(state),
+    )
+
+
+def format_benchmark_block(result: BenchmarkResult) -> str:
+    """Render a BenchmarkResult in the Cloud-OpsBench plaintext layout."""
+    payload = {
+        "key_evidence_summary": result.key_evidence_summary,
+        "top_3_predictions": [p.model_dump() for p in result.top_3_predictions],
+    }
+    import json
+
+    lines = [
+        f"Model         : {result.model}",
+        f"Fault Category: {result.fault_category}",
+        f"Prompt Strat. : {result.prompt_strategy}",
+        f"Case Name     : {result.case_name}",
+        f"Case Path     : {result.case_path}",
+        f"Finished      : {result.finished}",
+        f"Stop Reason   : {result.stop_reason}",
+        f"Steps Used    : {result.steps_used}",
+        f"Trace Path    : {result.trace_path}",
+        f"Result Path   : {result.result_path}",
+        "Final Answer:",
+        json.dumps(payload),
+    ]
+    return "\n".join(lines)

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,27 @@ def main(argv: list[str] | None = None) -> int:
         input_json=getattr(args, "input_json", None),
         interactive=getattr(args, "interactive", False),
     )
+
+    if getattr(args, "benchmark", False):
+        from app.entrypoints.benchmark import (
+            BenchmarkInputs,
+            format_benchmark_block,
+            run_benchmark_case,
+        )
+
+        result = run_benchmark_case(
+            BenchmarkInputs(
+                case_name=getattr(args, "case_name", "") or "case",
+                case_path=getattr(args, "case_path", "") or "/",
+                fault_category=getattr(args, "fault_category", "") or "",
+                model=getattr(args, "model", "") or "",
+                prompt_strategy=getattr(args, "prompt_strategy", "base") or "base",
+                raw_alert=payload,
+            )
+        )
+        print(format_benchmark_block(result))
+        return 0
+
     result = run_investigation_cli(
         raw_alert=payload,
         alert_name=getattr(args, "alert_name", None),

--- a/tests/entrypoints/test_benchmark.py
+++ b/tests/entrypoints/test_benchmark.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from app.entrypoints import benchmark as bench
+
+
+def _fake_state(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "root_cause": "node_selector_mismatch",
+        "root_cause_category": "Scheduling_Fault",
+        "validated_claims": [
+            {"claim": "cartservice pod is Pending."},
+            {"claim": "Node label disk-type=ssd does not match selector disktype=ssd."},
+        ],
+        "hypotheses": ["node_affinity_mismatch", "taint_toleration_mismatch"],
+        "investigation_loop_count": 5,
+        "available_action_names": ["k8s_describe"],
+        "alert_json": {"service": "app/cartservice"},
+        "alert_name": "cartservice down",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_run_benchmark_case_happy_path(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.pipeline.runners.run_investigation",
+        lambda *a, **kw: _fake_state(),
+    )
+
+    result = bench.run_benchmark_case(
+        bench.BenchmarkInputs(
+            case_name="105",
+            case_path="/cases/105",
+            fault_category="scheduling",
+            model="claude-sonnet-4-5-20250929",
+            prompt_strategy="base",
+            raw_alert={"alert_name": "cartservice down"},
+        )
+    )
+
+    assert result.finished is True
+    assert result.stop_reason == "final_answer"
+    assert result.steps_used == 5
+    assert result.case_name == "105"
+    assert result.fault_category == "scheduling"
+    assert result.model == "claude-sonnet-4-5-20250929"
+    assert "cartservice" in result.key_evidence_summary
+    assert len(result.top_3_predictions) == 3
+    assert result.top_3_predictions[0].rank == 1
+    assert result.top_3_predictions[0].fault_taxonomy == "Scheduling_Fault"
+    assert result.top_3_predictions[0].fault_object == "app/cartservice"
+    assert result.top_3_predictions[0].root_cause == "node_selector_mismatch"
+    assert result.top_3_predictions[1].root_cause == "node_affinity_mismatch"
+    assert result.top_3_predictions[2].root_cause == "taint_toleration_mismatch"
+
+
+def test_run_benchmark_case_max_loops(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.pipeline.runners.run_investigation",
+        lambda *a, **kw: _fake_state(root_cause="", investigation_loop_count=99),
+    )
+
+    result = bench.run_benchmark_case(
+        bench.BenchmarkInputs(case_name="x", case_path="/x", model="m")
+    )
+
+    assert result.finished is False
+    assert result.stop_reason == "max_loops"
+
+
+def test_run_benchmark_case_pipeline_error(monkeypatch: MonkeyPatch) -> None:
+    def boom(*a: Any, **kw: Any) -> dict[str, Any]:
+        raise RuntimeError("pipeline blew up")
+
+    monkeypatch.setattr("app.pipeline.runners.run_investigation", boom)
+
+    result = bench.run_benchmark_case(
+        bench.BenchmarkInputs(case_name="x", case_path="/x", model="m")
+    )
+
+    assert result.finished is False
+    assert result.stop_reason == "error"
+    assert result.steps_used == 0
+    assert result.top_3_predictions == []
+
+
+def test_format_benchmark_block_round_trip(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.pipeline.runners.run_investigation",
+        lambda *a, **kw: _fake_state(),
+    )
+
+    result = bench.run_benchmark_case(
+        bench.BenchmarkInputs(
+            case_name="105",
+            case_path="/cases/105",
+            fault_category="scheduling",
+            model="claude-sonnet-4-5-20250929",
+        )
+    )
+    block = bench.format_benchmark_block(result)
+
+    assert "Model         : claude-sonnet-4-5-20250929" in block
+    assert "Fault Category: scheduling" in block
+    assert "Stop Reason   : final_answer" in block
+    assert "Final Answer:" in block
+
+    final_answer_json = block.splitlines()[-1]
+    parsed = json.loads(final_answer_json)
+    assert "key_evidence_summary" in parsed
+    assert len(parsed["top_3_predictions"]) == 3
+    assert parsed["top_3_predictions"][0]["rank"] == 1


### PR DESCRIPTION
Summary of changes
New benchmark output mode — opt-in entrypoint that emits Cloud-OpsBench-style ranked predictions. Default investigation output is unchanged.

Files added
[app/entrypoints/benchmark.py](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/app/entrypoints/benchmark.py) — run_benchmark_case(BenchmarkInputs) -> BenchmarkResult and format_benchmark_block(). Wraps the existing pipeline runner, derives stop_reason / steps_used / elapsed_seconds from final state, builds top-3 predictions from root_cause_category + hypotheses, and concatenates validated_claims for key_evidence_summary (deterministic, no LLM call).
[tests/entrypoints/test_benchmark.py](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/tests/entrypoints/test_benchmark.py) — 4 tests: happy path, max-loops stop reason, pipeline-error stop reason, format round-trip. All passing.
Files touched
[app/cli/support/args.py:40-58](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/app/cli/support/args.py#L40-L58) — added --benchmark, --case-name, --case-path, --fault-category, --prompt-strategy, --model.
[app/main.py:20-43](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/app/main.py#L20-L43) — when --benchmark is set, route to the benchmark entrypoint and print the formatted block; otherwise the existing CLI path runs unchanged.
Not touched (by design)
No state schema changes ([app/state/agent_state.py](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/app/state/agent_state.py))
No routing changes ([app/pipeline/routing.py](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/app/pipeline/routing.py))
No publish-node changes ([app/nodes/publish_findings/node.py](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/app/nodes/publish_findings/node.py))
All metadata derivation (stop reason, elapsed time, predictions) lives in the entrypoint, keeping the change isolated.

Verification
python -m pytest tests/entrypoints/test_benchmark.py -x -q → 4 passed