### PR TITLE
fix: make test-cov use shell-safe Windows venv path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ ifneq ($(wildcard .venv/bin/python),)
     PIP = .venv/bin/python -m pip
 else ifeq ($(OS),Windows_NT)
     ifneq ($(wildcard .venv/Scripts/python.exe),)
-        PYTHON = .venv\\Scripts\\python.exe
-        PIP = .venv\\Scripts\\python.exe -m pip
+        PYTHON = .venv/Scripts/python.exe
+        PIP = .venv/Scripts/python.exe -m pip
     else
         PYTHON = python
         PIP = python -m pip


### PR DESCRIPTION
## hotfix

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Updated the Windows virtualenv Python/PIP paths in the Makefile to use forward slashes instead of escaped backslashes.

This prevents Unix-like shells such as Git Bash/MSYS `/usr/bin/sh` from interpreting backslashes as escape characters and mangling `.venv\Scripts\python.exe` into `.venvScriptspython.exe`.

before:
```
.venv\\Scripts\\python.exe -m pytest -n auto -v --cov=app --cov-report=term-missing --ignore=tests/e2e/kubernetes_local_alert_simulation --ignore=tests/synthetic -m "not synthetic"
/usr/bin/sh: line 1: .venvScriptspython.exe: command not found
make: *** [test-cov] Error 127

```
after : ran successfully 

Dry-run verification:

```text
make -n test-cov
.venv/Scripts/python.exe -m pytest -n auto -v --cov=app --cov-report=term-missing --ignore=tests/e2e/kubernetes_local_alert_simulation --ignore=tests/synthetic -m "not synthetic"
