### PR TITLE
test(remote): add threshold + memtotal-absent tests for _check_memory_health (#1156)

### DIFF
--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -419,3 +419,90 @@ def test_check_memory_health_returns_missing_on_oserror(
     assert result.name == "Memory"
     assert result.status == "missing"
     assert "Unable to read meminfo:" in result.detail
+
+
+def _patch_meminfo(monkeypatch: pytest.MonkeyPatch, content: str) -> None:
+    """Replace ``app.remote.server.Path`` with a stub that yields ``content``.
+
+    Keeps each threshold test isolated from the host's real /proc/meminfo so
+    the assertions are deterministic across Linux, macOS, and Windows runners.
+    """
+
+    class _FakeMeminfoPath:
+        def __init__(self, *_args: object, **_kwargs: object) -> None: ...
+        def exists(self) -> bool:
+            return True
+
+        def read_text(self, **_kwargs: object) -> str:
+            return content
+
+    monkeypatch.setattr("app.remote.server.Path", _FakeMeminfoPath)
+
+
+def test_check_memory_health_returns_passed_when_below_warn_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Memory usage below 90% should return status='passed'."""
+    # MemTotal = 16,000 MiB (16384000 kB); MemAvailable = 8,000 MiB => 50% used
+    meminfo = "MemTotal:       16384000 kB\nMemAvailable:    8192000 kB\n"
+    _patch_meminfo(monkeypatch, meminfo)
+
+    result = _check_memory_health()
+
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
+    assert result.status == "passed"
+    assert "50% used" in result.detail
+    assert "8000MiB / 16000MiB" in result.detail
+
+
+def test_check_memory_health_returns_warn_when_at_or_above_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Memory usage at or above 90% should return status='warn' at the boundary."""
+    # MemTotal = 16,000 MiB (16384000 kB); MemAvailable = 1,600 MiB => 90% used exactly
+    meminfo = "MemTotal:       16384000 kB\nMemAvailable:    1638400 kB\n"
+    _patch_meminfo(monkeypatch, meminfo)
+
+    result = _check_memory_health()
+
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
+    assert result.status == "warn"
+    assert "90% used" in result.detail
+    assert "14400MiB / 16000MiB" in result.detail
+
+
+def test_check_memory_health_returns_missing_when_memtotal_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing MemTotal should be treated as incomplete data, not crash."""
+    # MemAvailable present but MemTotal absent — exercises the ``not total_kb`` guard
+    meminfo = "MemAvailable:    8388608 kB\nBuffers:           65536 kB\n"
+    _patch_meminfo(monkeypatch, meminfo)
+
+    result = _check_memory_health()
+
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
+    assert result.status == "missing"
+    assert "Incomplete /proc/meminfo data." in result.detail
+
+
+def test_check_memory_health_skips_malformed_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lines without a colon, with non-numeric values, or with stray text are ignored."""
+    # First line lacks ':', second has a non-digit value, MemTotal/MemAvailable still parse
+    meminfo = (
+        "Garbage line without colon\n"
+        "MemFree:        not-a-number kB\n"
+        "MemTotal:       16384000 kB\n"
+        "MemAvailable:    8192000 kB\n"
+    )
+    _patch_meminfo(monkeypatch, meminfo)
+
+    result = _check_memory_health()
+
+    assert result.status == "passed"
+    assert "50% used" in result.detail

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -504,5 +504,7 @@ def test_check_memory_health_skips_malformed_lines(
 
     result = _check_memory_health()
 
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
     assert result.status == "passed"
     assert "50% used" in result.detail


### PR DESCRIPTION
Fixes #1156

#### Describe the changes you have made in this PR

PR #1212 already covered the missing-file, incomplete-data (no `MemAvailable`), and `OSError` branches of `_check_memory_health()`. This PR closes the rest of the gap listed in #1156:

- **`passed` branch (< 90% used)** — analog to the existing `_check_disk_health` passed test
- **`warn` branch at the `>= 90%` boundary** — exact 90% used, which is where `int(used / total * 100)` lands (verified with `MemTotal=16384000 kB`, `MemAvailable=1638400 kB` → `used_pct = 90`)
- **`MemTotal` absent** — explicit mirror of the existing `MemAvailable`-absent test, exercising the `not total_kb` branch of the guard
- **Malformed-line skip path** — line without `:`, value that is not a digit; both should be silently ignored while the well-formed `MemTotal`/`MemAvailable` lines still parse

All four tests use a small private helper `_patch_meminfo(monkeypatch, content)` that swaps `app.remote.server.Path` with a stub yielding deterministic `/proc/meminfo` content, so they pass on Linux, macOS, and Windows runners and never touch the host's real `/proc`.

### Demo/Screenshot for feature changes and bug fixes

```
\$ .venv/Scripts/python -m pytest tests/remote/test_server.py -k memory_health -v

tests/remote/test_server.py::test_check_memory_health_returns_missing_when_proc_file_absent      PASSED [ 14%]
tests/remote/test_server.py::test_check_memory_health_returns_missing_when_memavailable_absent   PASSED [ 28%]
tests/remote/test_server.py::test_check_memory_health_returns_missing_on_oserror                 PASSED [ 42%]
tests/remote/test_server.py::test_check_memory_health_returns_passed_when_below_warn_threshold   PASSED [ 57%]
tests/remote/test_server.py::test_check_memory_health_returns_warn_when_at_or_above_threshold    PASSED [ 71%]
tests/remote/test_server.py::test_check_memory_health_returns_missing_when_memtotal_absent       PASSED [ 85%]
tests/remote/test_server.py::test_check_memory_health_skips_malformed_lines                      PASSED [100%]

7 passed, 37 deselected in 2.85s
```

Full module: `tests/remote/` → **254 passed in 6.20s** (was 250 before this PR; +4 new tests, no regressions).

Local CI gates:
- `ruff check tests/remote/test_server.py` → All checks passed!
- `ruff format --check tests/remote/test_server.py` → 1 file already formatted

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (Claude Code)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The function `_check_memory_health()` in `app/remote/server.py` already had three test cases written by PR #1212 — but only for the `missing` branch (file absent, incomplete data, OSError). The two threshold branches (`passed` < 90% and `warn` ≥ 90%) and the explicit \"`MemTotal` absent\" sub-case were never exercised, so #1156 stayed open.

I mirrored the existing `_check_disk_health` test pattern verbatim (same parametrization style, same `monkeypatch.setattr` approach, same assertion style on `result.name`/`result.status`/`result.detail`), and extracted the meminfo stubbing into a tiny `_patch_meminfo` helper so each new test reads as 4–6 lines.

Boundary value chosen with care: `MemTotal=16384000 kB`, `MemAvailable=1638400 kB` gives `used = 14745600 kB`, and `int((used / total) * 100) == 90` exactly — landing right on the `>= 90` boundary so the test is meaningful, not just \"obviously above threshold\". I verified the float arithmetic by hand and by running the test before opening the PR.

The malformed-line test exists because the function has defensive code (`if \":\" not in line: continue` and `if number.isdigit():`) that was uncovered. Adding one fixture that mixes garbage lines with valid `MemTotal`/`MemAvailable` lines exercises both guards in one shot.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions