### PR TITLE
test(tools): add dedicated unit tests for Snowflake, OpenObserve, OpenSearch tools (#790)

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -182,6 +182,39 @@ def mock_http_response(status: int, json_body: Any) -> MagicMock:
     return response
 
 
+class MockHttpxResponse:
+    """Typed stand-in for an httpx.Response — only the surface tests touch.
+
+    Lets a single helper cover both response shapes the tools must handle:
+    a successful JSON body returned via ``json()``, OR an HTTP error raised
+    inside ``raise_for_status()`` (the tools wrap the call in ``try/except``
+    and treat both as the same failure path).
+
+    Use this from any tool test that mocks ``httpx.post``:
+
+        def _fake_post(url, headers, json, timeout):
+            return MockHttpxResponse({"data": []})
+
+        monkeypatch.setattr("app.tools.MyTool.httpx.post", _fake_post)
+    """
+
+    def __init__(
+        self,
+        payload: Any,
+        *,
+        raise_for_status_error: Exception | None = None,
+    ) -> None:
+        self._payload = payload
+        self._error = raise_for_status_error
+
+    def raise_for_status(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+    def json(self) -> Any:
+        return self._payload
+
+
 # ---------------------------------------------------------------------------
 # BaseToolContract mixin
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_openobserve_logs_tool.py
+++ b/tests/tools/test_openobserve_logs_tool.py
@@ -1,0 +1,509 @@
+"""Dedicated unit tests for OpenObserveLogsTool.
+
+Covers contract metadata, source-availability gating (token vs basic auth),
+parameter extraction, default query fallback, bounded result limits, record
+extraction across the supported response shapes (Elastic-style hits.hits,
+top-level list, ``records`` field, ``data`` field), bearer vs basic
+``Authorization`` header behavior, and HTTP failure handling.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+
+from app.tools.OpenObserveLogsTool import query_openobserve_logs
+from tests.tools.conftest import BaseToolContract
+
+
+class _MockResponse:
+    """Minimal stand-in for an httpx.Response — only what the tool touches."""
+
+    def __init__(self, payload: dict[str, Any], *, raise_for_status_error: Exception | None = None):
+        self._payload = payload
+        self._error = raise_for_status_error
+
+    def raise_for_status(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+# ---------------------------------------------------------------------------
+# Contract — metadata, is_available, extract_params surface
+# ---------------------------------------------------------------------------
+
+
+class TestOpenObserveLogsToolContract(BaseToolContract):
+    def get_tool_under_test(self) -> Any:
+        return query_openobserve_logs.__opensre_registered_tool__
+
+
+def _rt() -> Any:
+    return query_openobserve_logs.__opensre_registered_tool__
+
+
+def test_is_available_true_with_api_token() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "base_url": "https://oo.example.invalid",
+            "api_token": "oo-token",
+        }
+    }
+    assert _rt().is_available(sources) is True
+
+
+def test_is_available_true_with_username_password() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "base_url": "https://oo.example.invalid",
+            "username": "u",
+            "password": "p",
+        }
+    }
+    assert _rt().is_available(sources) is True
+
+
+def test_is_available_false_without_credentials() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "base_url": "https://oo.example.invalid",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_only_username_no_password() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "base_url": "https://oo.example.invalid",
+            "username": "u",
+            "password": "",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_connection_unverified() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": False,
+            "base_url": "https://oo.example.invalid",
+            "api_token": "oo-token",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_without_base_url() -> None:
+    sources = {
+        "openobserve": {
+            "connection_verified": True,
+            "api_token": "oo-token",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_no_openobserve_source() -> None:
+    assert _rt().is_available({}) is False
+
+
+def test_extract_params_strips_and_uses_defaults() -> None:
+    sources = {
+        "openobserve": {
+            "base_url": "  https://oo.example.invalid  ",
+            "stream": " app_logs ",
+            "query": "  level = 'error'  ",
+            "api_token": "  oo-token  ",
+            "username": " ",
+            "password": " ",
+            "integration_id": " oo-1 ",
+        }
+    }
+    params = _rt().extract_params(sources)
+    assert params["base_url"] == "https://oo.example.invalid"
+    assert params["org"] == "default"  # default fallback
+    assert params["stream"] == "app_logs"
+    assert params["query"] == "level = 'error'"
+    assert params["api_token"] == "oo-token"
+    assert params["username"] == ""
+    assert params["password"] == ""
+    assert params["time_range_minutes"] == 60  # default
+    assert params["limit"] == 50
+    assert params["max_results"] == 100  # _DEFAULT_MAX_RESULTS
+    assert params["integration_id"] == "oo-1"
+
+
+def test_extract_params_falls_back_to_default_org_for_blank() -> None:
+    sources = {"openobserve": {"base_url": "https://x.invalid", "org": "   "}}
+    assert _rt().extract_params(sources)["org"] == "default"
+
+
+def test_extract_params_uses_default_max_results_when_zero() -> None:
+    sources = {"openobserve": {"base_url": "https://x.invalid", "max_results": 0}}
+    assert _rt().extract_params(sources)["max_results"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Validation guards — missing config / required fields
+# ---------------------------------------------------------------------------
+
+
+def test_returns_missing_url_when_base_url_blank() -> None:
+    result = query_openobserve_logs(base_url="   ", api_token="oo-token")
+    assert result["available"] is False
+    assert result["error"] == "Missing OpenObserve URL."
+    assert result["records"] == []
+
+
+def test_returns_missing_credentials_when_no_auth_provided() -> None:
+    result = query_openobserve_logs(base_url="https://oo.example.invalid")
+    assert result["available"] is False
+    assert result["error"] == "Missing OpenObserve credentials."
+    assert result["records"] == []
+
+
+def test_returns_missing_credentials_when_only_username_no_password() -> None:
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        username="u",
+        password="",
+    )
+    assert result["available"] is False
+    assert result["error"] == "Missing OpenObserve credentials."
+
+
+# ---------------------------------------------------------------------------
+# Auth header behavior — bearer token vs HTTP basic
+# ---------------------------------------------------------------------------
+
+
+def test_uses_bearer_authorization_when_api_token_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["headers"] = headers
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert captured["headers"]["Authorization"] == "Bearer oo-token"
+    assert captured["headers"]["Content-Type"] == "application/json"
+
+
+def test_uses_basic_authorization_when_only_username_password_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["headers"] = headers
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        username="alice",
+        password="secret",
+    )
+    expected = base64.b64encode(b"alice:secret").decode("ascii")
+    assert captured["headers"]["Authorization"] == f"Basic {expected}"
+
+
+def test_bearer_takes_precedence_over_basic(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["headers"] = headers
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        username="alice",
+        password="secret",
+    )
+    # When both are provided, bearer wins
+    assert captured["headers"]["Authorization"] == "Bearer oo-token"
+
+
+# ---------------------------------------------------------------------------
+# Request shaping — endpoint, default query fallback, payload contents
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_uses_default_org_when_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["url"] = url
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid/",  # trailing slash should be stripped
+        org="",
+        api_token="oo-token",
+    )
+    assert captured["url"] == "https://oo.example.invalid/api/default/_search"
+
+
+def test_endpoint_includes_provided_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["url"] = url
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        org="acme",
+        api_token="oo-token",
+    )
+    assert captured["url"] == "https://oo.example.invalid/api/acme/_search"
+
+
+def test_default_sql_used_when_query_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["payload"] = json
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        query="",
+    )
+    sql = captured["payload"]["query"]["sql"]
+    assert sql == "SELECT * FROM \"default\" WHERE level = 'error' ORDER BY _timestamp DESC"
+
+
+def test_provided_query_is_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["payload"] = json
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        query="SELECT * FROM \"my_stream\" WHERE level = 'fatal'",
+    )
+    assert (
+        captured["payload"]["query"]["sql"] == "SELECT * FROM \"my_stream\" WHERE level = 'fatal'"
+    )
+
+
+def test_payload_includes_size_and_time_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["payload"] = json
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        time_range_minutes=15,
+        max_results=42,
+    )
+    payload = captured["payload"]
+    assert payload["size"] == 42
+    assert "start_time" in payload["query"]
+    assert "end_time" in payload["query"]
+    assert payload["query"]["end_time"] > payload["query"]["start_time"]
+
+
+def test_stream_name_only_included_when_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured.append(json)
+        return _MockResponse({"hits": []})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    # Without stream
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        stream="",
+    )
+    # With stream
+    query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        stream="app_logs",
+    )
+
+    assert "stream_name" not in captured[0]
+    assert captured[1]["stream_name"] == "app_logs"
+
+
+def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["size"] = json["size"]
+        return _MockResponse({"hits": [{"message": f"m{idx}"} for idx in range(50)]})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+        limit=1000,
+        max_results=4,
+    )
+    assert captured["size"] == 4
+    assert result["available"] is True
+    assert len(result["records"]) == 4
+    assert result["total_returned"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Response normalization across supported shapes
+# ---------------------------------------------------------------------------
+
+
+def test_records_from_top_level_hits_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse({"hits": [{"a": 1}, {"a": 2}]})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["records"] == [{"a": 1}, {"a": 2}]
+
+
+def test_records_from_elastic_style_nested_hits(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse(
+            {
+                "hits": {
+                    "hits": [
+                        {"_source": {"msg": "boom"}},
+                        {"_source": {"msg": "kaboom"}},
+                    ]
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["records"] == [{"msg": "boom"}, {"msg": "kaboom"}]
+
+
+def test_records_from_records_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse({"records": [{"x": 1}, "ignore-me", {"x": 2}]})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    # Only dict items are kept — strings are filtered out
+    assert result["records"] == [{"x": 1}, {"x": 2}]
+
+
+def test_records_from_data_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse({"data": [{"y": 9}]})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["records"] == [{"y": 9}]
+
+
+def test_records_empty_on_unrecognized_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse({"unrelated": True})
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["available"] is True
+    assert result["records"] == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_returns_unavailable_on_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse(
+            {"err": "boom"},
+            raise_for_status_error=RuntimeError("HTTP 502 from OpenObserve"),
+        )
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["available"] is False
+    assert "HTTP 502 from OpenObserve" in result["error"]
+    assert result["records"] == []
+
+
+def test_returns_unavailable_on_request_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise ConnectionError("connection refused")
+
+    monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _raise)
+
+    result = query_openobserve_logs(
+        base_url="https://oo.example.invalid",
+        api_token="oo-token",
+    )
+    assert result["available"] is False
+    assert "connection refused" in result["error"]
+    assert result["records"] == []

--- a/tests/tools/test_openobserve_logs_tool.py
+++ b/tests/tools/test_openobserve_logs_tool.py
@@ -15,23 +15,7 @@ from typing import Any
 import pytest
 
 from app.tools.OpenObserveLogsTool import query_openobserve_logs
-from tests.tools.conftest import BaseToolContract
-
-
-class _MockResponse:
-    """Minimal stand-in for an httpx.Response — only what the tool touches."""
-
-    def __init__(self, payload: dict[str, Any], *, raise_for_status_error: Exception | None = None):
-        self._payload = payload
-        self._error = raise_for_status_error
-
-    def raise_for_status(self) -> None:
-        if self._error is not None:
-            raise self._error
-
-    def json(self) -> dict[str, Any]:
-        return self._payload
-
+from tests.tools.conftest import BaseToolContract, MockHttpxResponse
 
 # ---------------------------------------------------------------------------
 # Contract — metadata, is_available, extract_params surface
@@ -194,7 +178,7 @@ def test_uses_bearer_authorization_when_api_token_present(
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["headers"] = headers
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -213,7 +197,7 @@ def test_uses_basic_authorization_when_only_username_password_present(
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["headers"] = headers
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -231,7 +215,7 @@ def test_bearer_takes_precedence_over_basic(monkeypatch: pytest.MonkeyPatch) -> 
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["headers"] = headers
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -255,7 +239,7 @@ def test_endpoint_uses_default_org_when_blank(monkeypatch: pytest.MonkeyPatch) -
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["url"] = url
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -272,7 +256,7 @@ def test_endpoint_includes_provided_org(monkeypatch: pytest.MonkeyPatch) -> None
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["url"] = url
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -289,7 +273,7 @@ def test_default_sql_used_when_query_blank(monkeypatch: pytest.MonkeyPatch) -> N
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["payload"] = json
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -307,7 +291,7 @@ def test_provided_query_is_passed_through(monkeypatch: pytest.MonkeyPatch) -> No
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["payload"] = json
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -326,7 +310,7 @@ def test_payload_includes_size_and_time_window(monkeypatch: pytest.MonkeyPatch) 
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["payload"] = json
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -348,7 +332,7 @@ def test_stream_name_only_included_when_provided(monkeypatch: pytest.MonkeyPatch
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured.append(json)
-        return _MockResponse({"hits": []})
+        return MockHttpxResponse({"hits": []})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -374,7 +358,7 @@ def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> N
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["size"] = json["size"]
-        return _MockResponse({"hits": [{"message": f"m{idx}"} for idx in range(50)]})
+        return MockHttpxResponse({"hits": [{"message": f"m{idx}"} for idx in range(50)]})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -396,8 +380,8 @@ def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_records_from_top_level_hits_list(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse({"hits": [{"a": 1}, {"a": 2}]})
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse({"hits": [{"a": 1}, {"a": 2}]})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -409,8 +393,8 @@ def test_records_from_top_level_hits_list(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_records_from_elastic_style_nested_hits(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse(
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse(
             {
                 "hits": {
                     "hits": [
@@ -431,8 +415,8 @@ def test_records_from_elastic_style_nested_hits(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_records_from_records_field(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse({"records": [{"x": 1}, "ignore-me", {"x": 2}]})
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse({"records": [{"x": 1}, "ignore-me", {"x": 2}]})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -445,8 +429,8 @@ def test_records_from_records_field(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_records_from_data_field(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse({"data": [{"y": 9}]})
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse({"data": [{"y": 9}]})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -458,8 +442,8 @@ def test_records_from_data_field(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_records_empty_on_unrecognized_shape(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse({"unrelated": True})
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse({"unrelated": True})
 
     monkeypatch.setattr("app.tools.OpenObserveLogsTool.httpx.post", _fake_post)
 
@@ -477,8 +461,8 @@ def test_records_empty_on_unrecognized_shape(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_returns_unavailable_on_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse(
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse(
             {"err": "boom"},
             raise_for_status_error=RuntimeError("HTTP 502 from OpenObserve"),
         )

--- a/tests/tools/test_opensearch_analytics_tool.py
+++ b/tests/tools/test_opensearch_analytics_tool.py
@@ -7,6 +7,7 @@ on the tool side (non-dict items dropped), and propagation of client errors.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -14,6 +15,44 @@ import pytest
 from app.services.elasticsearch import ElasticsearchConfig
 from app.tools.OpenSearchAnalyticsTool import query_opensearch_analytics
 from tests.tools.conftest import BaseToolContract
+
+# ---------------------------------------------------------------------------
+# Test helpers — keep ElasticsearchClient stubbing consistent
+# ---------------------------------------------------------------------------
+
+
+def _install_es_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    search_impl: Callable[..., dict[str, Any]],
+) -> dict[str, Any]:
+    """Patch ``ElasticsearchClient.__init__`` AND ``search_logs`` together.
+
+    Returns a dict that captures the ``ElasticsearchConfig`` the tool builds,
+    accessible as ``captured["config"]`` after the tool is invoked. Patching
+    both methods keeps every test isolated from the real client even if
+    ``__init__`` ever stops being lazy (e.g. starts validating URL reachability).
+    """
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
+        captured["config"] = config
+        self.config = config
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
+        _fake_init,
+    )
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        search_impl,
+    )
+    return captured
+
+
+def _ok_search(_self: Any, **_kwargs: Any) -> dict[str, Any]:
+    """Default ``search_logs`` stub — succeeds with an empty result set."""
+    return {"success": True, "logs": []}
+
 
 # ---------------------------------------------------------------------------
 # Contract — metadata, is_available, extract_params surface
@@ -117,23 +156,7 @@ def test_returns_missing_url_when_url_blank() -> None:
 def test_client_config_normalizes_url_api_key_and_index(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, Any] = {}
-
-    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
-        captured["config"] = config
-        self.config = config
-
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {"success": True, "logs": []}
-
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
-        _fake_init,
-    )
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    captured = _install_es_stubs(monkeypatch, _ok_search)
 
     query_opensearch_analytics(
         url="  https://os.example.invalid/  ",  # trailing slash + spaces stripped
@@ -148,23 +171,7 @@ def test_client_config_normalizes_url_api_key_and_index(
 
 
 def test_client_config_treats_blank_api_key_as_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, Any] = {}
-
-    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
-        captured["config"] = config
-        self.config = config
-
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {"success": True, "logs": []}
-
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
-        _fake_init,
-    )
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    captured = _install_es_stubs(monkeypatch, _ok_search)
 
     query_opensearch_analytics(
         url="https://os.example.invalid",
@@ -175,28 +182,17 @@ def test_client_config_treats_blank_api_key_as_none(monkeypatch: pytest.MonkeyPa
 
 
 def test_blank_index_pattern_becomes_star(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, Any] = {}
+    search_kwargs: dict[str, Any] = {}
 
-    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
-        captured["config"] = config
-        self.config = config
-
-    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
-        captured["search_kwargs"] = kwargs
+    def _impl(_self: Any, **kwargs: Any) -> dict[str, Any]:
+        search_kwargs.update(kwargs)
         return {"success": True, "logs": []}
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
-        _fake_init,
-    )
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    captured = _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(url="https://os.example.invalid", index_pattern="")
     assert captured["config"].index_pattern == "*"
-    assert captured["search_kwargs"]["index_pattern"] == "*"
+    assert search_kwargs["index_pattern"] == "*"
     assert result["index_pattern"] == "*"
 
 
@@ -208,14 +204,11 @@ def test_blank_index_pattern_becomes_star(monkeypatch: pytest.MonkeyPatch) -> No
 def test_search_query_defaults_to_star_when_blank(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **kwargs: Any) -> dict[str, Any]:
         captured.update(kwargs)
         return {"success": True, "logs": []}
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(
         url="https://os.example.invalid",
@@ -228,14 +221,11 @@ def test_search_query_defaults_to_star_when_blank(monkeypatch: pytest.MonkeyPatc
 def test_time_range_minutes_floor_one(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **kwargs: Any) -> dict[str, Any]:
         captured.update(kwargs)
         return {"success": True, "logs": []}
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     query_opensearch_analytics(
         url="https://os.example.invalid",
@@ -248,7 +238,7 @@ def test_time_range_minutes_floor_one(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **kwargs: Any) -> dict[str, Any]:
         captured["limit"] = kwargs["limit"]
         # Server returns more than the cap — tool must trim to effective_limit
         return {
@@ -256,10 +246,7 @@ def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> N
             "logs": [{"message": f"log-{idx}"} for idx in range(20)],
         }
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(
         url="https://os.example.invalid",
@@ -275,14 +262,11 @@ def test_bounded_limit_capped_by_hard_max(monkeypatch: pytest.MonkeyPatch) -> No
     """Caller may not request more than _MAX_HARD_LIMIT (200), even via max_results."""
     captured: dict[str, Any] = {}
 
-    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **kwargs: Any) -> dict[str, Any]:
         captured["limit"] = kwargs["limit"]
         return {"success": True, "logs": []}
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     query_opensearch_analytics(
         url="https://os.example.invalid",
@@ -298,7 +282,7 @@ def test_bounded_limit_capped_by_hard_max(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_filters_non_dict_log_entries(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **_kwargs: Any) -> dict[str, Any]:
         return {
             "success": True,
             "logs": [
@@ -310,10 +294,7 @@ def test_filters_non_dict_log_entries(monkeypatch: pytest.MonkeyPatch) -> None:
             ],
         }
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(
         url="https://os.example.invalid",
@@ -325,13 +306,10 @@ def test_filters_non_dict_log_entries(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_handles_missing_logs_field(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **_kwargs: Any) -> dict[str, Any]:
         return {"success": True}  # no 'logs' key at all
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(url="https://os.example.invalid")
     assert result["available"] is True
@@ -339,13 +317,10 @@ def test_handles_missing_logs_field(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_handles_non_list_logs_field(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **_kwargs: Any) -> dict[str, Any]:
         return {"success": True, "logs": "should-be-a-list-but-isnt"}
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(url="https://os.example.invalid")
     assert result["available"] is True
@@ -358,13 +333,10 @@ def test_handles_non_list_logs_field(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_propagates_client_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **_kwargs: Any) -> dict[str, Any]:
         return {"success": False, "error": "auth failed"}
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(url="https://os.example.invalid")
     assert result["available"] is False
@@ -373,13 +345,10 @@ def test_propagates_client_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_propagates_unknown_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+    def _impl(_self: Any, **_kwargs: Any) -> dict[str, Any]:
         return {"success": False}  # no 'error' field
 
-    monkeypatch.setattr(
-        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
-        _fake_search,
-    )
+    _install_es_stubs(monkeypatch, _impl)
 
     result = query_opensearch_analytics(url="https://os.example.invalid")
     assert result["available"] is False

--- a/tests/tools/test_opensearch_analytics_tool.py
+++ b/tests/tools/test_opensearch_analytics_tool.py
@@ -1,0 +1,387 @@
+"""Dedicated unit tests for OpenSearchAnalyticsTool.
+
+Covers contract metadata, source-availability gating, parameter extraction,
+client config normalization, bounded result limits, log filtering/normalization
+on the tool side (non-dict items dropped), and propagation of client errors.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.elasticsearch import ElasticsearchConfig
+from app.tools.OpenSearchAnalyticsTool import query_opensearch_analytics
+from tests.tools.conftest import BaseToolContract
+
+# ---------------------------------------------------------------------------
+# Contract — metadata, is_available, extract_params surface
+# ---------------------------------------------------------------------------
+
+
+class TestOpenSearchAnalyticsToolContract(BaseToolContract):
+    def get_tool_under_test(self) -> Any:
+        return query_opensearch_analytics.__opensre_registered_tool__
+
+
+def _rt() -> Any:
+    return query_opensearch_analytics.__opensre_registered_tool__
+
+
+def test_is_available_true_when_url_and_verified() -> None:
+    sources = {
+        "opensearch": {
+            "connection_verified": True,
+            "url": "https://os.example.invalid",
+        }
+    }
+    assert _rt().is_available(sources) is True
+
+
+def test_is_available_false_when_connection_not_verified() -> None:
+    sources = {
+        "opensearch": {
+            "connection_verified": False,
+            "url": "https://os.example.invalid",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_url_missing() -> None:
+    sources = {"opensearch": {"connection_verified": True}}
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_no_opensearch_source() -> None:
+    assert _rt().is_available({}) is False
+
+
+def test_extract_params_strips_and_uses_defaults() -> None:
+    sources = {
+        "opensearch": {
+            "url": "  https://os.example.invalid  ",
+            "api_key": "  os-key  ",
+            "index_pattern": "  logs-*  ",
+            "default_query": "  service:foo  ",
+            "integration_id": " os-1 ",
+        }
+    }
+    params = _rt().extract_params(sources)
+    assert params["url"] == "https://os.example.invalid"
+    assert params["api_key"] == "os-key"
+    assert params["index_pattern"] == "logs-*"
+    assert params["query"] == "service:foo"
+    assert params["time_range_minutes"] == 60  # default
+    assert params["limit"] == 50
+    assert params["max_results"] == 100  # _DEFAULT_MAX_RESULTS
+    assert params["integration_id"] == "os-1"
+
+
+def test_extract_params_falls_back_to_star_for_blank_index_and_query() -> None:
+    sources = {
+        "opensearch": {
+            "url": "https://os.example.invalid",
+            "index_pattern": "  ",
+            "default_query": "",
+        }
+    }
+    params = _rt().extract_params(sources)
+    assert params["index_pattern"] == "*"
+    assert params["query"] == "*"
+
+
+def test_extract_params_uses_default_max_results_when_zero() -> None:
+    sources = {"opensearch": {"url": "https://os.example.invalid", "max_results": 0}}
+    assert _rt().extract_params(sources)["max_results"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Validation guards — missing config
+# ---------------------------------------------------------------------------
+
+
+def test_returns_missing_url_when_url_blank() -> None:
+    result = query_opensearch_analytics(url="   ")
+    assert result["available"] is False
+    assert result["error"] == "Missing OpenSearch URL."
+    assert result["logs"] == []
+
+
+# ---------------------------------------------------------------------------
+# Client config normalization — what gets passed to ElasticsearchClient
+# ---------------------------------------------------------------------------
+
+
+def test_client_config_normalizes_url_api_key_and_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
+        captured["config"] = config
+        self.config = config
+
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"success": True, "logs": []}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
+        _fake_init,
+    )
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    query_opensearch_analytics(
+        url="  https://os.example.invalid/  ",  # trailing slash + spaces stripped
+        api_key="  os-key  ",
+        index_pattern="logs-prod-*",
+    )
+    cfg = captured["config"]
+    assert isinstance(cfg, ElasticsearchConfig)
+    assert cfg.url == "https://os.example.invalid"
+    assert cfg.api_key == "os-key"
+    assert cfg.index_pattern == "logs-prod-*"
+
+
+def test_client_config_treats_blank_api_key_as_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
+        captured["config"] = config
+        self.config = config
+
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"success": True, "logs": []}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
+        _fake_init,
+    )
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    query_opensearch_analytics(
+        url="https://os.example.invalid",
+        api_key="   ",
+        index_pattern="*",
+    )
+    assert captured["config"].api_key is None
+
+
+def test_blank_index_pattern_becomes_star(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, config: ElasticsearchConfig) -> None:
+        captured["config"] = config
+        self.config = config
+
+    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+        captured["search_kwargs"] = kwargs
+        return {"success": True, "logs": []}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.__init__",
+        _fake_init,
+    )
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(url="https://os.example.invalid", index_pattern="")
+    assert captured["config"].index_pattern == "*"
+    assert captured["search_kwargs"]["index_pattern"] == "*"
+    assert result["index_pattern"] == "*"
+
+
+# ---------------------------------------------------------------------------
+# Search call shape — query, time range, bounded limit
+# ---------------------------------------------------------------------------
+
+
+def test_search_query_defaults_to_star_when_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"success": True, "logs": []}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(
+        url="https://os.example.invalid",
+        query="",
+    )
+    assert captured["query"] == "*"
+    assert result["query"] == "*"
+
+
+def test_time_range_minutes_floor_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"success": True, "logs": []}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    query_opensearch_analytics(
+        url="https://os.example.invalid",
+        time_range_minutes=0,
+    )
+    # max(1, time_range_minutes) — never zero or negative
+    assert captured["time_range_minutes"] == 1
+
+
+def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+        captured["limit"] = kwargs["limit"]
+        # Server returns more than the cap — tool must trim to effective_limit
+        return {
+            "success": True,
+            "logs": [{"message": f"log-{idx}"} for idx in range(20)],
+        }
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(
+        url="https://os.example.invalid",
+        limit=999,
+        max_results=5,
+    )
+    assert captured["limit"] == 5
+    assert len(result["logs"]) == 5
+    assert result["total_returned"] == 5
+
+
+def test_bounded_limit_capped_by_hard_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller may not request more than _MAX_HARD_LIMIT (200), even via max_results."""
+    captured: dict[str, Any] = {}
+
+    def _fake_search(self: Any, **kwargs: Any) -> dict[str, Any]:
+        captured["limit"] = kwargs["limit"]
+        return {"success": True, "logs": []}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    query_opensearch_analytics(
+        url="https://os.example.invalid",
+        limit=10_000,
+        max_results=10_000,
+    )
+    assert captured["limit"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Response normalization — non-dict log entries are dropped
+# ---------------------------------------------------------------------------
+
+
+def test_filters_non_dict_log_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "logs": [
+                {"message": "ok"},
+                "garbage-string",
+                {"message": "ok2"},
+                None,
+                42,
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(
+        url="https://os.example.invalid",
+        max_results=10,
+    )
+    assert result["available"] is True
+    assert result["logs"] == [{"message": "ok"}, {"message": "ok2"}]
+    assert result["total_returned"] == 2
+
+
+def test_handles_missing_logs_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"success": True}  # no 'logs' key at all
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(url="https://os.example.invalid")
+    assert result["available"] is True
+    assert result["logs"] == []
+
+
+def test_handles_non_list_logs_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"success": True, "logs": "should-be-a-list-but-isnt"}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(url="https://os.example.invalid")
+    assert result["available"] is True
+    assert result["logs"] == []
+
+
+# ---------------------------------------------------------------------------
+# Client error propagation
+# ---------------------------------------------------------------------------
+
+
+def test_propagates_client_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"success": False, "error": "auth failed"}
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(url="https://os.example.invalid")
+    assert result["available"] is False
+    assert "auth failed" in result["error"]
+    assert result["logs"] == []
+
+
+def test_propagates_unknown_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_search(self: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"success": False}  # no 'error' field
+
+    monkeypatch.setattr(
+        "app.tools.OpenSearchAnalyticsTool.ElasticsearchClient.search_logs",
+        _fake_search,
+    )
+
+    result = query_opensearch_analytics(url="https://os.example.invalid")
+    assert result["available"] is False
+    # Tool falls back to a generic message rather than raising
+    assert "Unknown OpenSearch error" in result["error"]

--- a/tests/tools/test_snowflake_query_history_tool.py
+++ b/tests/tools/test_snowflake_query_history_tool.py
@@ -1,0 +1,423 @@
+"""Dedicated unit tests for SnowflakeQueryHistoryTool.
+
+Covers contract metadata, source-availability gating, parameter extraction,
+SQL limit enforcement, account/token validation, row normalization across the
+two response shapes the Snowflake SQL API returns, and HTTP failure handling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.tools.SnowflakeQueryHistoryTool import query_snowflake_history
+from tests.tools.conftest import BaseToolContract
+
+
+class _MockResponse:
+    """Minimal stand-in for an httpx.Response — only what the tool touches."""
+
+    def __init__(self, payload: dict[str, Any], *, raise_for_status_error: Exception | None = None):
+        self._payload = payload
+        self._error = raise_for_status_error
+
+    def raise_for_status(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+# ---------------------------------------------------------------------------
+# Contract — metadata, is_available, extract_params surface
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeQueryHistoryToolContract(BaseToolContract):
+    def get_tool_under_test(self) -> Any:
+        return query_snowflake_history.__opensre_registered_tool__
+
+
+def _rt() -> Any:
+    return query_snowflake_history.__opensre_registered_tool__
+
+
+def test_is_available_true_when_token_account_and_verified() -> None:
+    sources = {
+        "snowflake": {
+            "connection_verified": True,
+            "account_identifier": "xy12345.us-east-1",
+            "token": "sf-token",
+        }
+    }
+    assert _rt().is_available(sources) is True
+
+
+def test_is_available_false_when_connection_not_verified() -> None:
+    sources = {
+        "snowflake": {
+            "connection_verified": False,
+            "account_identifier": "xy12345.us-east-1",
+            "token": "sf-token",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_token_missing() -> None:
+    sources = {
+        "snowflake": {
+            "connection_verified": True,
+            "account_identifier": "xy12345.us-east-1",
+            "token": "   ",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_account_identifier_missing() -> None:
+    sources = {
+        "snowflake": {
+            "connection_verified": True,
+            "account_identifier": "",
+            "token": "sf-token",
+        }
+    }
+    assert _rt().is_available(sources) is False
+
+
+def test_is_available_false_when_no_snowflake_source() -> None:
+    assert _rt().is_available({}) is False
+
+
+def test_extract_params_strips_and_defaults_max_results() -> None:
+    sources = {
+        "snowflake": {
+            "account_identifier": "  xy12345.us-east-1  ",
+            "user": " sf-user ",
+            "password": " sf-pass ",
+            "token": "  sf-token  ",
+            "warehouse": "  WH_X  ",
+            "role": " ANALYST ",
+            "database": " ANALYTICS ",
+            "schema": " PUBLIC ",
+            "query": " SELECT 1 ",
+            "integration_id": " sf-1 ",
+        }
+    }
+    params = _rt().extract_params(sources)
+    assert params["account_identifier"] == "xy12345.us-east-1"
+    assert params["user"] == "sf-user"
+    assert params["password"] == "sf-pass"
+    assert params["token"] == "sf-token"
+    assert params["warehouse"] == "WH_X"
+    assert params["role"] == "ANALYST"
+    assert params["database"] == "ANALYTICS"
+    assert params["db_schema"] == "PUBLIC"
+    assert params["query"] == "SELECT 1"
+    assert params["integration_id"] == "sf-1"
+    # Default max_results when key absent
+    assert params["max_results"] == 50
+    # The tool always extracts a fixed limit of 50; bounding happens at run time
+    assert params["limit"] == 50
+
+
+def test_extract_params_uses_default_max_results_when_zero_or_missing() -> None:
+    # max_results explicitly 0 should fall back to the default (truthy guard)
+    sources = {"snowflake": {"account_identifier": "x", "token": "t", "max_results": 0}}
+    assert _rt().extract_params(sources)["max_results"] == 50
+
+
+# ---------------------------------------------------------------------------
+# Validation guards — missing config / required fields
+# ---------------------------------------------------------------------------
+
+
+def test_returns_missing_account_when_account_identifier_blank() -> None:
+    result = query_snowflake_history(account_identifier="   ", token="sf-token")
+    assert result["available"] is False
+    assert result["error"] == "Missing account identifier."
+    assert result["rows"] == []
+
+
+def test_returns_missing_token_when_token_blank() -> None:
+    result = query_snowflake_history(account_identifier="xy12345.us-east-1", token="   ")
+    assert result["available"] is False
+    assert result["error"] == "Missing Snowflake token."
+    assert result["rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Request shaping — SQL LIMIT enforcement, payload contents, endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_default_query_used_when_query_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["url"] = url
+        captured["statement"] = json["statement"]
+        captured["headers"] = headers
+        return _MockResponse({"data": []})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        query="",
+        max_results=10,
+    )
+    assert result["available"] is True
+    assert "INFORMATION_SCHEMA.QUERY_HISTORY" in captured["statement"]
+    # Default query embeds RESULT_LIMIT directly, not a trailing LIMIT clause
+    assert "RESULT_LIMIT => 10" in captured["statement"]
+    # Endpoint is correctly templated from the account identifier
+    assert captured["url"] == "https://xy12345.us-east-1.snowflakecomputing.com/api/v2/statements"
+    assert captured["headers"]["Authorization"] == "Bearer sf-token"
+    assert captured["headers"]["Content-Type"] == "application/json"
+
+
+def test_user_query_gets_limit_appended_if_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["statement"] = json["statement"]
+        return _MockResponse({"data": []})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        query="SELECT * FROM T;",
+        limit=1000,  # caller asks for 1000 but max_results caps it
+        max_results=7,
+    )
+
+    assert captured["statement"].endswith("LIMIT 7")
+    assert ";" not in captured["statement"]  # trailing semicolon stripped
+
+
+def test_user_query_with_existing_limit_is_left_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["statement"] = json["statement"]
+        return _MockResponse({"data": []})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        query="SELECT * FROM T LIMIT 3",
+        limit=500,
+        max_results=50,
+    )
+
+    # The ensure_sql_limit helper must not double-stamp the LIMIT clause
+    assert captured["statement"].lower().count("limit") == 1
+    assert captured["statement"].endswith("LIMIT 3")
+
+
+def test_optional_session_params_only_included_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["payload"] = json
+        return _MockResponse({"data": []})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        warehouse="WH_X",
+        role="ANALYST",
+        database="DB",
+        db_schema="PUBLIC",
+        max_results=5,
+    )
+    payload = captured["payload"]
+    assert payload["warehouse"] == "WH_X"
+    assert payload["role"] == "ANALYST"
+    assert payload["database"] == "DB"
+    assert payload["schema"] == "PUBLIC"
+    assert "statement" in payload
+    assert "timeout" in payload
+
+
+def test_optional_session_params_omitted_when_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        captured["payload"] = json
+        return _MockResponse({"data": []})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        max_results=5,
+    )
+    payload = captured["payload"]
+    for key in ("warehouse", "role", "database", "schema"):
+        assert key not in payload
+
+
+def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller asks for limit=500 but max_results=6 ⇒ server query and rows capped at 6."""
+
+    def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
+        # Server returns 20 rows — tool must trim to effective_limit (6)
+        return _MockResponse({"data": [{"id": idx} for idx in range(20)]})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        query="SELECT * FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY())",
+        limit=500,
+        max_results=6,
+    )
+
+    assert result["available"] is True
+    assert len(result["rows"]) == 6
+    assert result["total_returned"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Row normalization — both API response shapes
+# ---------------------------------------------------------------------------
+
+
+def test_normalizes_dict_rows_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the API returns ``data=[{...}, ...]``, rows are passed through as-is."""
+
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse(
+            {
+                "data": [
+                    {"query_id": "q1", "user_name": "alice"},
+                    {"query_id": "q2", "user_name": "bob"},
+                ]
+            }
+        )
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        max_results=10,
+    )
+    assert result["rows"] == [
+        {"query_id": "q1", "user_name": "alice"},
+        {"query_id": "q2", "user_name": "bob"},
+    ]
+
+
+def test_normalizes_tabular_rows_using_result_set_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the API returns lists of values + rowType metadata, rows are zipped to dicts."""
+
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse(
+            {
+                "data": [
+                    ["q1", "alice"],
+                    ["q2", "bob"],
+                ],
+                "resultSetMetaData": {
+                    "rowType": [
+                        {"name": "query_id"},
+                        {"name": "user_name"},
+                    ]
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        max_results=10,
+    )
+    assert result["rows"] == [
+        {"query_id": "q1", "user_name": "alice"},
+        {"query_id": "q2", "user_name": "bob"},
+    ]
+
+
+def test_normalizes_to_empty_when_payload_unrecognized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown response shapes degrade gracefully to an empty rows list, not an exception."""
+
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse({"unexpected": "shape"})
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        max_results=10,
+    )
+    assert result["available"] is True
+    assert result["rows"] == []
+    assert result["total_returned"] == 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_returns_unavailable_on_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        return _MockResponse(
+            {"error": "boom"},
+            raise_for_status_error=RuntimeError("HTTP 500 from Snowflake"),
+        )
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        max_results=5,
+    )
+    assert result["available"] is False
+    assert "HTTP 500 from Snowflake" in result["error"]
+    assert result["rows"] == []
+
+
+def test_returns_unavailable_on_request_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise ConnectionError("connection refused")
+
+    monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _raise)
+
+    result = query_snowflake_history(
+        account_identifier="xy12345.us-east-1",
+        token="sf-token",
+        max_results=5,
+    )
+    assert result["available"] is False
+    assert "connection refused" in result["error"]
+    assert result["rows"] == []

--- a/tests/tools/test_snowflake_query_history_tool.py
+++ b/tests/tools/test_snowflake_query_history_tool.py
@@ -12,23 +12,7 @@ from typing import Any
 import pytest
 
 from app.tools.SnowflakeQueryHistoryTool import query_snowflake_history
-from tests.tools.conftest import BaseToolContract
-
-
-class _MockResponse:
-    """Minimal stand-in for an httpx.Response — only what the tool touches."""
-
-    def __init__(self, payload: dict[str, Any], *, raise_for_status_error: Exception | None = None):
-        self._payload = payload
-        self._error = raise_for_status_error
-
-    def raise_for_status(self) -> None:
-        if self._error is not None:
-            raise self._error
-
-    def json(self) -> dict[str, Any]:
-        return self._payload
-
+from tests.tools.conftest import BaseToolContract, MockHttpxResponse
 
 # ---------------------------------------------------------------------------
 # Contract — metadata, is_available, extract_params surface
@@ -161,7 +145,7 @@ def test_default_query_used_when_query_blank(monkeypatch: pytest.MonkeyPatch) ->
         captured["url"] = url
         captured["statement"] = json["statement"]
         captured["headers"] = headers
-        return _MockResponse({"data": []})
+        return MockHttpxResponse({"data": []})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -186,7 +170,7 @@ def test_user_query_gets_limit_appended_if_missing(monkeypatch: pytest.MonkeyPat
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["statement"] = json["statement"]
-        return _MockResponse({"data": []})
+        return MockHttpxResponse({"data": []})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -209,7 +193,7 @@ def test_user_query_with_existing_limit_is_left_untouched(
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["statement"] = json["statement"]
-        return _MockResponse({"data": []})
+        return MockHttpxResponse({"data": []})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -233,7 +217,7 @@ def test_optional_session_params_only_included_when_set(
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["payload"] = json
-        return _MockResponse({"data": []})
+        return MockHttpxResponse({"data": []})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -262,7 +246,7 @@ def test_optional_session_params_omitted_when_blank(
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         captured["payload"] = json
-        return _MockResponse({"data": []})
+        return MockHttpxResponse({"data": []})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -281,7 +265,7 @@ def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> N
 
     def _fake_post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float):
         # Server returns 20 rows — tool must trim to effective_limit (6)
-        return _MockResponse({"data": [{"id": idx} for idx in range(20)]})
+        return MockHttpxResponse({"data": [{"id": idx} for idx in range(20)]})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -306,8 +290,8 @@ def test_bounded_limit_caps_caller_request(monkeypatch: pytest.MonkeyPatch) -> N
 def test_normalizes_dict_rows_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
     """When the API returns ``data=[{...}, ...]``, rows are passed through as-is."""
 
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse(
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse(
             {
                 "data": [
                     {"query_id": "q1", "user_name": "alice"},
@@ -334,8 +318,8 @@ def test_normalizes_tabular_rows_using_result_set_metadata(
 ) -> None:
     """When the API returns lists of values + rowType metadata, rows are zipped to dicts."""
 
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse(
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse(
             {
                 "data": [
                     ["q1", "alice"],
@@ -368,8 +352,8 @@ def test_normalizes_to_empty_when_payload_unrecognized(
 ) -> None:
     """Unknown response shapes degrade gracefully to an empty rows list, not an exception."""
 
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse({"unexpected": "shape"})
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse({"unexpected": "shape"})
 
     monkeypatch.setattr("app.tools.SnowflakeQueryHistoryTool.httpx.post", _fake_post)
 
@@ -389,8 +373,8 @@ def test_normalizes_to_empty_when_payload_unrecognized(
 
 
 def test_returns_unavailable_on_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_post(*_args: Any, **_kwargs: Any) -> _MockResponse:
-        return _MockResponse(
+    def _fake_post(*_args: Any, **_kwargs: Any) -> MockHttpxResponse:
+        return MockHttpxResponse(
             {"error": "boom"},
             raise_for_status_error=RuntimeError("HTTP 500 from Snowflake"),
         )


### PR DESCRIPTION
Fixes #790

#### Describe the changes you have made in this PR

Adds three new dedicated test files under \`tests/tools/\` with the file names and proposed coverage exactly as listed in #790. Each file mirrors the existing tool test conventions: inherits from \`BaseToolContract\` for the shared metadata/contract checks, uses pytest \`monkeypatch\` to stub \`httpx.post\` (or \`ElasticsearchClient\` for OpenSearch) — no live HTTP calls, no required external services.

| File | New tests | What it covers |
|---|---|---|
| \`tests/tools/test_snowflake_query_history_tool.py\` | **26** | \`is_available\` + \`extract_params\`, account/token validation, default vs custom SQL with \`LIMIT\` enforcement, optional session params (\`warehouse\`/\`role\`/\`database\`/\`schema\`), bounded limit cap, row normalization for both dict-rows AND tabular rows + \`resultSetMetaData\`, HTTP failure handling. |
| \`tests/tools/test_openobserve_logs_tool.py\` | **36** | \`is_available\` across token-only / basic-auth-only / both, \`extract_params\`, **bearer vs basic** \`Authorization\` header behavior (bearer wins when both provided), endpoint org templating, default SQL fallback, time window + \`size\` payload shape, \`stream_name\` only when set, bounded limit cap, record extraction across the four supported response shapes (top-level \`hits\` list, Elastic-style \`hits.hits._source\`, \`records\`, \`data\`), HTTP failure handling. |
| \`tests/tools/test_opensearch_analytics_tool.py\` | **26** | \`is_available\` + \`extract_params\`, \`ElasticsearchConfig\` normalization (URL trim, blank \`api_key\` → \`None\`, blank index → \`*\`), search call shape (\`query\` default, \`time_range_minutes\` floor 1, bounded limit, \`_MAX_HARD_LIMIT\` cap), log filtering (non-dict items dropped), missing / non-list \`logs\` field, client error propagation (with and without \`error\` field). |

### Demo/Screenshot for feature changes and bug fixes

\`\`\`
\$ .venv/Scripts/python -m pytest tests/tools/test_snowflake_query_history_tool.py tests/tools/test_openobserve_logs_tool.py tests/tools/test_opensearch_analytics_tool.py -v

============================= 88 passed in 1.55s ==============================
\`\`\`

Full \`tests/tools/\` suite: **1541 passed in 6.96s** (was 1453 before this PR; +88 new tests, **no regressions**).

Local CI gates:
- \`ruff check\` on the three new files → All checks passed!
- \`ruff format --check\` on the three new files → 3 files already formatted

### Note on the existing \`test_integration_wave_tools.py\`

That file already exists and contains 1 limit-bound smoke test per tool for Snowflake / OpenObserve / OpenSearch (plus Azure). The new dedicated files supersede those in scope (deeper coverage of normalization, auth, validation, error paths). No changes were made to \`test_integration_wave_tools.py\` in this PR — happy to drop the now-duplicative cases there in a follow-up if a maintainer prefers.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (Claude Code)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

For each tool, I started by reading \`app/tools/<X>/__init__.py\` to enumerate every branch the tool can take: validation guards, request shaping, response normalization, error handling. I then wrote one test per branch — each isolated, deterministic, and inheriting from \`BaseToolContract\` for the shared metadata checks (\`name\`/\`description\`/\`input_schema\`/\`source\`/\`is_available\` returns bool / \`extract_params\` returns dict).

Mocking strategy:
- **Snowflake & OpenObserve** call \`httpx.post\` directly. I built a tiny \`_MockResponse\` class with just \`raise_for_status()\` and \`.json()\` and patched \`app.tools.<Tool>.httpx.post\`. The \`raise_for_status_error\` kwarg lets one helper class cover both \"HTTP error status\" and \"raises during \`raise_for_status\`\" failure modes without duplicating boilerplate.
- **OpenSearch** wraps \`ElasticsearchClient\`. I patched \`ElasticsearchClient.__init__\` AND \`search_logs\` so I can both (a) capture the \`ElasticsearchConfig\` the tool builds and (b) control what \`search_logs\` returns. This let me write the \"blank \`api_key\` → \`None\`\" and \"blank \`index_pattern\` → \`*\`\" tests with no plumbing duplication.

Tricky cases that drove specific tests:
- OpenObserve auth precedence — when both bearer token AND basic credentials are present, the tool short-circuits on bearer in \`_auth_headers\`. I added \`test_bearer_takes_precedence_over_basic\` to lock that contract.
- Snowflake \`_ensure_sql_limit\` — must not double-stamp \`LIMIT\` if the caller already wrote one. I added a test that asserts \`statement.lower().count(\"limit\") == 1\` AND the trailing \`;\` is stripped.
- OpenSearch \`time_range_minutes=0\` — the tool floors it via \`max(1, time_range_minutes)\` to avoid zero-length windows. Without a test, future refactors could silently break this.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions