### PR TITLE
fix(cli): recognize cd/pwd as shell commands

### DIFF
--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -146,6 +146,8 @@ _NON_COMMAND_STARTS = frozenset(
         "why",
     }
 )
+# Shell builtins that may not be discoverable via `shutil.which()` on all platforms.
+# Keep this list intentionally small and add tests when extending it.
 _SHELL_BUILTINS = frozenset({"cd", "pwd"})
 _SHELL_COMMAND_TIMEOUT_SECONDS = 120
 _SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
@@ -399,6 +401,9 @@ def _run_shell_command(command: str, session: ReplSession, console: Console) -> 
     if token is not None and token.lower() == "cd":
         _run_cd_command(command, session, console)
         return
+    if token is not None and token.lower() == "pwd":
+        _run_pwd_command(command, session, console)
+        return
 
     try:
         completed = subprocess.run(
@@ -449,6 +454,23 @@ def _run_cd_command(command: str, session: ReplSession, console: Console) -> Non
         os.chdir(target)
     except Exception as exc:  # noqa: BLE001
         console.print(f"[red]cd failed:[/red] {escape(str(exc))}")
+        session.record("shell", command, ok=False)
+        return
+
+    console.print(Text(str(Path.cwd())))
+    session.record("shell", command)
+
+
+def _run_pwd_command(command: str, session: ReplSession, console: Console) -> None:
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError as exc:
+        console.print(f"[red]pwd failed:[/red] {escape(str(exc))}")
+        session.record("shell", command, ok=False)
+        return
+
+    if len(tokens) != 1:
+        console.print("[red]pwd failed:[/red] too many arguments")
         session.record("shell", command, ok=False)
         return
 

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -146,6 +146,7 @@ _NON_COMMAND_STARTS = frozenset(
         "why",
     }
 )
+_SHELL_BUILTINS = frozenset({"cd", "pwd"})
 _SHELL_COMMAND_TIMEOUT_SECONDS = 120
 _SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
@@ -204,6 +205,8 @@ def _looks_like_direct_shell_command(text: str) -> bool:
         return False
     if first.lower() in _NON_COMMAND_STARTS:
         return False
+    if first.lower() in _SHELL_BUILTINS:
+        return True
     if first.startswith(("./", "../", "/")):
         return Path(first).exists()
     return shutil.which(first) is not None
@@ -392,7 +395,8 @@ def _print_planned_actions(console: Console, actions: list[PlannedAction]) -> No
 
 def _run_shell_command(command: str, session: ReplSession, console: Console) -> None:
     console.print(f"[bold]$ {escape(command)}[/bold]")
-    if _first_command_token(command) == "cd":
+    token = _first_command_token(command)
+    if token is not None and token.lower() == "cd":
         _run_cd_command(command, session, console)
         return
 

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import subprocess
+from pathlib import Path
 
 from rich.console import Console
 
@@ -196,6 +197,7 @@ def test_explicit_shell_command_plans_shell_action() -> None:
 
 def test_direct_shell_command_plans_shell_action() -> None:
     assert plan_terminal_tasks("pwd") == ["shell"]
+    assert plan_terminal_tasks("cd /tmp") == ["shell"]
 
 
 def test_sample_alert_launch_plans_sample_alert_action() -> None:
@@ -392,26 +394,16 @@ def test_execute_cli_actions_falls_through_for_chat() -> None:
     assert session.history == []
 
 
-def test_execute_cli_actions_runs_shell_command(monkeypatch: object) -> None:
-    completed = subprocess.CompletedProcess(
-        args="pwd",
-        returncode=0,
-        stdout="/tmp/project\n",
-        stderr="",
-    )
-    calls: list[str] = []
+def test_execute_cli_actions_runs_pwd_builtin(monkeypatch: object) -> None:
+    def _fail_run(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+        raise AssertionError("subprocess.run should not be used for pwd")
 
-    def _fake_run(command: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append(command)
-        return completed
-
-    monkeypatch.setattr(agent_actions.subprocess, "run", _fake_run)
+    monkeypatch.setattr(agent_actions.subprocess, "run", _fail_run)
 
     session = ReplSession()
     console, buf = _capture()
 
     assert execute_cli_actions("run `pwd`", session, console) is True
-    assert calls == ["pwd"]
     assert session.history == [
         {"type": "cli_agent", "text": "run `pwd`", "ok": True},
         {"type": "shell", "text": "pwd", "ok": True},
@@ -419,7 +411,26 @@ def test_execute_cli_actions_runs_shell_command(monkeypatch: object) -> None:
     output = buf.getvalue()
     assert "Running requested actions" in output
     assert "$ pwd" in output
-    assert "/tmp/project" in output
+    assert str(Path.cwd()) in output.replace("\n", "").replace("\r", "")
+
+
+def test_execute_cli_actions_routes_cd_case_insensitive(monkeypatch: object) -> None:
+    cd_calls: list[str] = []
+
+    def _fake_cd(command: str, _session: ReplSession, _console: Console) -> None:
+        cd_calls.append(command)
+
+    def _fail_run(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+        raise AssertionError("subprocess.run should not be used for cd")
+
+    monkeypatch.setattr(agent_actions, "_run_cd_command", _fake_cd)
+    monkeypatch.setattr(agent_actions.subprocess, "run", _fail_run)
+
+    session = ReplSession()
+    console, _ = _capture()
+
+    assert execute_cli_actions("CD /tmp", session, console) is True
+    assert cd_calls == ["CD /tmp"]
 
 
 def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:


### PR DESCRIPTION
### What changed
- Fixes the interactive terminal assistant’s direct-shell-command detection for `pwd` (and `cd`) by treating them as shell builtins instead of requiring `shutil.which()`.
- Normalizes `cd` detection in `_run_shell_command()` to be case-insensitive.

### Why
On Windows (and for `cd` everywhere), these commands are often shell builtins/aliases rather than standalone executables, so `plan_terminal_tasks("pwd")` incorrectly returned `[]`.

### Verification
- `python -m pytest -q --ignore=tests/synthetic -m "not synthetic"`
- `python -m pytest -q tests/cli/interactive_shell/test_agent_actions.py`
