### PR TITLE
fix: move stdlib json import to module level in hot-path tracer + lambda functions

### DIFF
--- a/app/services/lambda_client.py
+++ b/app/services/lambda_client.py
@@ -1,6 +1,7 @@
 """Lambda client for function inspection and log retrieval."""
 
 import base64
+import json
 from contextlib import suppress
 from io import BytesIO
 from typing import Any
@@ -324,8 +325,6 @@ def invoke_function(
     credentials_error = require_aws_credentials(context="lambda_client.invoke_function")
     if credentials_error:
         return credentials_error
-
-    import json
 
     try:
         kwargs = {

--- a/app/services/tracer_client/tracer_integrations.py
+++ b/app/services/tracer_client/tracer_integrations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -65,8 +66,6 @@ class TracerIntegrationsMixin(TracerClientBase):
         for integration in integrations:
             creds = integration.get("credentials", {})
             if isinstance(creds, str):
-                import json
-
                 try:
                     integration["credentials"] = json.loads(creds)
                 except (json.JSONDecodeError, TypeError):
@@ -98,8 +97,6 @@ class TracerIntegrationsMixin(TracerClientBase):
 
         credentials = integration.get("credentials", {})
         if isinstance(credentials, str):
-            import json
-
             try:
                 credentials = json.loads(credentials)
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
Fixes #1242

#### Describe the changes you have made in this PR -

Hoists \`import json\` from inside hot-path function bodies to module top in two services, matching the pattern from #1216 (which fixed #1209 for \`copy\` and \`datetime\` in \`app/nodes/\`). Same class of issue, different sites.

### Files changed

- **app/services/tracer_client/tracer_integrations.py** — added \`import json\` at module top; removed it from inside two functions:
  - \`get_all_integrations()\` — the import was inside a \`for\` loop iterating integration records, re-running once per iteration
  - \`get_grafana_credentials()\` — per-call during integration resolution
- **app/services/lambda_client.py** — added \`import json\` at module top; removed it from inside \`invoke_function()\` (per Lambda invocation)

### Diff summary

\`\`\`
2 files changed, 2 insertions(+), 6 deletions(-)
\`\`\`

### Demo/Screenshot for feature changes and bug fixes -

\`\`\`
# Before — re-run on every call (loop case re-runs per iteration):
def get_all_integrations(self):
    ...
    for integration in integrations:
        if isinstance(creds, str):
            import json   # executes per integration record
            integration["credentials"] = json.loads(creds)

# After — imported once at module load:
import json   # module top
...
def get_all_integrations(self):
    ...
    for integration in integrations:
        if isinstance(creds, str):
            integration["credentials"] = json.loads(creds)
\`\`\`

Local checks (clean baseline preserved):

\`\`\`
$ make lint && make format-check && make typecheck && make test-cov
ruff check app/ tests/        -> All checks passed!
ruff format --check app/ tests/  -> 1057 files already formatted
mypy app/                     -> Success: no issues found in 456 source files
pytest                        -> 4656 passed, 2 skipped, 21 warnings in ~49s
\`\`\`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The change is the same surgical pattern as #1216: \`import json\` is moved out of the function body and added to the module's top-level imports, sorted alphabetically alongside the existing stdlib imports. Once \`json\` is in \`sys.modules\` after first import, the inside-function \`import json\` statement is not "free" — the interpreter still re-runs the import statement on every call, performing a \`sys.modules\` lookup and binding the name into the function's local namespace. The most egregious case here is \`tracer_integrations.py:68\`, where the original import sat inside a \`for\` loop iterating integration records, so the statement re-ran once per record.

No semantic change: \`json.loads\` and \`json.JSONDecodeError\` are referenced identically before and after; the only difference is where the name binding originates. The full test suite (4656 tests) continues to pass with the same skip count and no new warnings.

I considered also touching \`app/nodes/resolve_integrations/node.py\` (which has \`import base64\` and \`import json\` inside \`_decode_org_id_from_token\`) but kept it out of scope to keep this PR small and to avoid a function that was the subject of an unrelated, contentious prior PR — happy to send a follow-up if maintainers want it covered.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests (n/a — semantic-noop import hoist; existing suite covers these code paths)
- [x] My code follows the project's style guidelines and conventions