### PR TITLE
feat: add Requesty as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ OPENROUTER_API_KEY=
 OPENROUTER_REASONING_MODEL=
 OPENROUTER_TOOLCALL_MODEL=
 
+# Requesty is an OpenAI-compatible LLM gateway with fallback routing and caching.
+REQUESTY_API_KEY=
+REQUESTY_REASONING_MODEL=
+REQUESTY_TOOLCALL_MODEL=
+
 # Gemini uses the OpenAI-compatible endpoint in this project.
 GEMINI_API_KEY=
 GEMINI_REASONING_MODEL=

--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -49,6 +49,7 @@ def _check_llm_provider() -> tuple[bool, str]:
         "anthropic": "ANTHROPIC_API_KEY",
         "openai": "OPENAI_API_KEY",
         "openrouter": "OPENROUTER_API_KEY",
+        "requesty": "REQUESTY_API_KEY",
         "gemini": "GEMINI_API_KEY",
         "nvidia": "NVIDIA_API_KEY",
         "bedrock": "AWS_DEFAULT_REGION",

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -85,6 +85,7 @@ _LLM_PROVIDER_NAMES = frozenset(
         "anthropic",
         "openai",
         "openrouter",
+        "requesty",
         "gemini",
         "nvidia",
         "ollama",

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -16,6 +16,7 @@ from app.config import (
     NVIDIA_REASONING_MODEL,
     OPENAI_REASONING_MODEL,
     OPENROUTER_REASONING_MODEL,
+    REQUESTY_REASONING_MODEL,
 )
 from app.integrations.llm_cli.base import LLMCLIAdapter
 
@@ -107,6 +108,20 @@ OPENROUTER_MODELS = (
     ModelOption(value="minimax/minimax-m2", label="MiniMax M2 (via OpenRouter)"),
     ModelOption(value="deepseek/deepseek-v3.2", label="DeepSeek V3.2 (via OpenRouter)"),
     ModelOption(value="qwen/qwen-3.6-plus-preview", label="Qwen 3.6 Plus (via OpenRouter)"),
+)
+
+REQUESTY_MODELS = (
+    ModelOption(value=REQUESTY_REASONING_MODEL, label="Claude Sonnet 4.6 (via Requesty)"),
+    ModelOption(value="bedrock/claude-opus-4-7", label="Claude Opus 4.7 (via Requesty)"),
+    ModelOption(value="bedrock/claude-sonnet-4-6", label="Claude Sonnet 4.6 (via Requesty)"),
+    ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via Requesty)"),
+    ModelOption(
+        value="vertex/gemini-3.1-pro-preview", label="Gemini 3.1 Pro (preview, via Requesty)"
+    ),
+    ModelOption(
+        value="vertex/gemini-3.1-flash-lite-preview",
+        label="Gemini 3.1 Flash-Lite (preview, via Requesty)",
+    ),
 )
 
 GEMINI_MODELS = (
@@ -204,6 +219,16 @@ SUPPORTED_PROVIDERS = (
         default_model=OPENROUTER_REASONING_MODEL,
         models=OPENROUTER_MODELS,
         legacy_model_env="OPENROUTER_MODEL",
+    ),
+    ProviderOption(
+        value="requesty",
+        label="Requesty",
+        group="Hosted providers",
+        api_key_env="REQUESTY_API_KEY",
+        model_env="REQUESTY_REASONING_MODEL",
+        default_model=REQUESTY_REASONING_MODEL,
+        models=REQUESTY_MODELS,
+        legacy_model_env="REQUESTY_MODEL",
     ),
     ProviderOption(
         value="gemini",

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -112,8 +112,10 @@ OPENROUTER_MODELS = (
 
 REQUESTY_MODELS = (
     ModelOption(value=REQUESTY_REASONING_MODEL, label="Claude Sonnet 4.6 (via Requesty)"),
-    ModelOption(value="bedrock/claude-opus-4-7", label="Claude Opus 4.7 (via Requesty)"),
-    ModelOption(value="bedrock/claude-sonnet-4-6", label="Claude Sonnet 4.6 (via Requesty)"),
+    ModelOption(value="bedrock/claude-opus-4-7", label="Claude Opus 4.7 Bedrock (via Requesty)"),
+    ModelOption(
+        value="bedrock/claude-sonnet-4-6", label="Claude Sonnet 4.6 Bedrock (via Requesty)"
+    ),
     ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via Requesty)"),
     ModelOption(
         value="vertex/gemini-3.1-pro-preview", label="Gemini 3.1 Pro (preview, via Requesty)"

--- a/app/cli/wizard/validation.py
+++ b/app/cli/wizard/validation.py
@@ -54,6 +54,10 @@ def _get_provider_base_url(provider_value: str) -> str | None:
         from app.config import OPENROUTER_BASE_URL
 
         return OPENROUTER_BASE_URL
+    if provider_value == "requesty":
+        from app.config import REQUESTY_BASE_URL
+
+        return REQUESTY_BASE_URL
     if provider_value == "gemini":
         from app.config import GEMINI_BASE_URL
 

--- a/app/config.py
+++ b/app/config.py
@@ -82,6 +82,10 @@ OPENAI_TOOLCALL_MODEL = "gpt-5.4-mini"
 OPENROUTER_REASONING_MODEL = "openrouter/auto"
 OPENROUTER_TOOLCALL_MODEL = "openrouter/auto"
 
+# Requesty model constants (OpenAI-compatible gateway; uses provider/model naming)
+REQUESTY_REASONING_MODEL = "anthropic/claude-sonnet-4-6"
+REQUESTY_TOOLCALL_MODEL = "anthropic/claude-haiku-4-5"
+
 # Gemini model constants (Google AI preview IDs; OpenAI-compatible endpoint)
 # UNVERIFIED PLACEHOLDER — gemini-3.1-pro-preview / gemini-3.1-flash-lite-preview are
 # forward-looking IDs that may not yet exist. Override via GEMINI_REASONING_MODEL env var.
@@ -100,6 +104,7 @@ MINIMAX_TOOLCALL_MODEL = "MiniMax-M2.7-highspeed"
 
 # Base URLs for OpenAI-compatible providers
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+REQUESTY_BASE_URL = "https://router.requesty.ai/v1"
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
@@ -116,6 +121,7 @@ LLMProvider = Literal[
     "anthropic",
     "openai",
     "openrouter",
+    "requesty",
     "gemini",
     "nvidia",
     "ollama",
@@ -133,6 +139,7 @@ class LLMSettings(StrictConfigModel):
     anthropic_api_key: str = ""
     openai_api_key: str = ""
     openrouter_api_key: str = ""
+    requesty_api_key: str = ""
     gemini_api_key: str = ""
     nvidia_api_key: str = ""
     minimax_api_key: str = ""
@@ -144,6 +151,8 @@ class LLMSettings(StrictConfigModel):
     openai_toolcall_model: str = OPENAI_TOOLCALL_MODEL
     openrouter_reasoning_model: str = OPENROUTER_REASONING_MODEL
     openrouter_toolcall_model: str = OPENROUTER_TOOLCALL_MODEL
+    requesty_reasoning_model: str = REQUESTY_REASONING_MODEL
+    requesty_toolcall_model: str = REQUESTY_TOOLCALL_MODEL
     gemini_reasoning_model: str = GEMINI_REASONING_MODEL
     gemini_toolcall_model: str = GEMINI_TOOLCALL_MODEL
     nvidia_reasoning_model: str = NVIDIA_REASONING_MODEL
@@ -162,6 +171,7 @@ class LLMSettings(StrictConfigModel):
             "anthropic",
             "openai",
             "openrouter",
+            "requesty",
             "gemini",
             "nvidia",
             "ollama",
@@ -307,6 +317,12 @@ OPENAI_LLM_CONFIG = LLMModelConfig(
 OPENROUTER_LLM_CONFIG = LLMModelConfig(
     reasoning_model=OPENROUTER_REASONING_MODEL,
     toolcall_model=OPENROUTER_TOOLCALL_MODEL,
+    max_tokens=DEFAULT_MAX_TOKENS,
+)
+
+REQUESTY_LLM_CONFIG = LLMModelConfig(
+    reasoning_model=REQUESTY_REASONING_MODEL,
+    toolcall_model=REQUESTY_TOOLCALL_MODEL,
     max_tokens=DEFAULT_MAX_TOKENS,
 )
 

--- a/app/config.py
+++ b/app/config.py
@@ -199,6 +199,7 @@ class LLMSettings(StrictConfigModel):
             "anthropic": self.anthropic_api_key,
             "openai": self.openai_api_key,
             "openrouter": self.openrouter_api_key,
+            "requesty": self.requesty_api_key,
             "gemini": self.gemini_api_key,
             "nvidia": self.nvidia_api_key,
             "minimax": self.minimax_api_key,
@@ -210,6 +211,7 @@ class LLMSettings(StrictConfigModel):
             "anthropic": "ANTHROPIC_API_KEY",
             "openai": "OPENAI_API_KEY",
             "openrouter": "OPENROUTER_API_KEY",
+            "requesty": "REQUESTY_API_KEY",
             "gemini": "GEMINI_API_KEY",
             "nvidia": "NVIDIA_API_KEY",
             "minimax": "MINIMAX_API_KEY",
@@ -254,6 +256,17 @@ class LLMSettings(StrictConfigModel):
                     os.getenv("OPENROUTER_MODEL", OPENROUTER_TOOLCALL_MODEL),
                 ).strip()
                 or OPENROUTER_TOOLCALL_MODEL,
+                "requesty_api_key": resolve_llm_api_key("REQUESTY_API_KEY"),
+                "requesty_reasoning_model": os.getenv(
+                    "REQUESTY_REASONING_MODEL",
+                    os.getenv("REQUESTY_MODEL", REQUESTY_REASONING_MODEL),
+                ).strip()
+                or REQUESTY_REASONING_MODEL,
+                "requesty_toolcall_model": os.getenv(
+                    "REQUESTY_TOOLCALL_MODEL",
+                    os.getenv("REQUESTY_MODEL", REQUESTY_TOOLCALL_MODEL),
+                ).strip()
+                or REQUESTY_TOOLCALL_MODEL,
                 "gemini_reasoning_model": os.getenv(
                     "GEMINI_REASONING_MODEL",
                     os.getenv("GEMINI_MODEL", GEMINI_REASONING_MODEL),

--- a/app/config.py
+++ b/app/config.py
@@ -227,6 +227,7 @@ class LLMSettings(StrictConfigModel):
                 "anthropic_api_key": resolve_llm_api_key("ANTHROPIC_API_KEY"),
                 "openai_api_key": resolve_llm_api_key("OPENAI_API_KEY"),
                 "openrouter_api_key": resolve_llm_api_key("OPENROUTER_API_KEY"),
+                "requesty_api_key": resolve_llm_api_key("REQUESTY_API_KEY"),
                 "gemini_api_key": resolve_llm_api_key("GEMINI_API_KEY"),
                 "nvidia_api_key": resolve_llm_api_key("NVIDIA_API_KEY"),
                 "minimax_api_key": resolve_llm_api_key("MINIMAX_API_KEY"),
@@ -256,7 +257,6 @@ class LLMSettings(StrictConfigModel):
                     os.getenv("OPENROUTER_MODEL", OPENROUTER_TOOLCALL_MODEL),
                 ).strip()
                 or OPENROUTER_TOOLCALL_MODEL,
-                "requesty_api_key": resolve_llm_api_key("REQUESTY_API_KEY"),
                 "requesty_reasoning_model": os.getenv(
                     "REQUESTY_REASONING_MODEL",
                     os.getenv("REQUESTY_MODEL", REQUESTY_REASONING_MODEL),

--- a/app/config.py
+++ b/app/config.py
@@ -84,7 +84,7 @@ OPENROUTER_TOOLCALL_MODEL = "openrouter/auto"
 
 # Requesty model constants (OpenAI-compatible gateway; uses provider/model naming)
 REQUESTY_REASONING_MODEL = "anthropic/claude-sonnet-4-6"
-REQUESTY_TOOLCALL_MODEL = "anthropic/claude-haiku-4-5"
+REQUESTY_TOOLCALL_MODEL = "anthropic/claude-sonnet-4-6"
 
 # Gemini model constants (Google AI preview IDs; OpenAI-compatible endpoint)
 # UNVERIFIED PLACEHOLDER — gemini-3.1-pro-preview / gemini-3.1-flash-lite-preview are

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -245,14 +245,16 @@ class OpenAILLMClient:
         base_url: str | None = None,
         api_key_env: str = "OPENAI_API_KEY",
         api_key_default: str = "",
+        default_headers: dict[str, str] | None = None,
     ) -> None:
         api_key = resolve_llm_api_key(api_key_env) or api_key_default
         self._api_key = api_key
         self._api_key_default = api_key_default
         self._base_url = base_url
         self._api_key_env = api_key_env
+        self._default_headers = default_headers
         self._provider_label = api_key_env.removesuffix("_API_KEY").replace("_", " ").title()
-        self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=60.0)
+        self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=60.0, default_headers=default_headers)
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
@@ -274,7 +276,7 @@ class OpenAILLMClient:
             )
         if api_key != self._api_key:
             self._api_key = api_key
-            self._client = OpenAI(api_key=api_key, base_url=self._base_url, timeout=60.0)
+            self._client = OpenAI(api_key=api_key, base_url=self._base_url, timeout=60.0, default_headers=self._default_headers)
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
         self._ensure_client()

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -254,7 +254,9 @@ class OpenAILLMClient:
         self._api_key_env = api_key_env
         self._default_headers = default_headers
         self._provider_label = api_key_env.removesuffix("_API_KEY").replace("_", " ").title()
-        self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=60.0, default_headers=default_headers)
+        self._client = OpenAI(
+            api_key=api_key, base_url=base_url, timeout=60.0, default_headers=default_headers
+        )
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
@@ -276,7 +278,12 @@ class OpenAILLMClient:
             )
         if api_key != self._api_key:
             self._api_key = api_key
-            self._client = OpenAI(api_key=api_key, base_url=self._base_url, timeout=60.0, default_headers=self._default_headers)
+            self._client = OpenAI(
+                api_key=api_key,
+                base_url=self._base_url,
+                timeout=60.0,
+                default_headers=self._default_headers,
+            )
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
         self._ensure_client()

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -501,6 +501,22 @@ def _create_llm_client(model_type: str) -> _LLMClientType:
             base_url=OPENROUTER_BASE_URL,
             api_key_env="OPENROUTER_API_KEY",
         )
+    elif provider == "requesty":
+        from app.config import REQUESTY_BASE_URL, REQUESTY_LLM_CONFIG
+
+        config = REQUESTY_LLM_CONFIG
+        model = (
+            settings.requesty_reasoning_model
+            if model_type == "reasoning"
+            else settings.requesty_toolcall_model
+        )
+        return OpenAILLMClient(
+            model=model,
+            max_tokens=config.max_tokens,
+            base_url=REQUESTY_BASE_URL,
+            api_key_env="REQUESTY_API_KEY",
+            default_headers={"X-Title": "OpenSRE"},
+        )
     elif provider == "gemini":
         from app.config import GEMINI_LLM_CONFIG
 


### PR DESCRIPTION
#### Describe the changes you have made in this PR -

Hey! We're [Requesty](https://requesty.ai), an OpenAI-compatible LLM gateway (300+ models, fallback routing, caching, cost optimization). We've been using OpenSRE for our SRE workflows and wanted to add native support for routing LLM calls through Requesty.

The integration follows the exact same pattern as OpenRouter since we're also OpenAI-compatible. Every request sent through Requesty includes an `X-Title: OpenSRE` header so traffic is identifiable on both sides. Would love to explore a deeper connection between the two projects if there's interest!

**What changed:**

- **`app/config.py`** — added Requesty model constants (`anthropic/claude-sonnet-4-6` for both reasoning and toolcall), base URL, `LLMModelConfig`, `LLMProvider` literal, `LLMSettings` fields, validator, and `from_env()` env var resolution
- **`app/services/llm_client.py`** — added `default_headers` param to `OpenAILLMClient` (forwarded to the OpenAI constructor), and a new `elif provider == "requesty"` branch that passes `X-Title: OpenSRE`
- **`app/cli/wizard/config.py`** — added `REQUESTY_MODELS` (5 curated models: Claude Opus 4.7, Claude Sonnet 4.6, GPT-5.5, Gemini 3.1 Pro, Gemini 3.1 Flash-Lite) and a `ProviderOption` entry in `SUPPORTED_PROVIDERS`
- **`app/cli/wizard/validation.py`** — added base URL resolution for credential validation
- **`app/cli/commands/doctor.py`** — `opensre health` now recognizes `REQUESTY_API_KEY`
- **`app/cli/interactive_shell/agent_actions.py`** — runtime provider switching support
- **`.env.example`** — documented `REQUESTY_API_KEY`, `REQUESTY_REASONING_MODEL`, `REQUESTY_TOOLCALL_MODEL`

### Demo/Screenshot for feature changes and bug fixes -

```
$ REQUESTY_API_KEY=test-key LLM_PROVIDER=requesty python3 -c "
from app.config import REQUESTY_BASE_URL, REQUESTY_LLM_CONFIG, LLMSettings
s = LLMSettings.from_env()
print(f'Provider: {s.provider}')
print(f'Reasoning: {s.requesty_reasoning_model}')
print(f'Toolcall: {s.requesty_toolcall_model}')
print(f'Base URL: {REQUESTY_BASE_URL}')
"
Provider: requesty
Reasoning: anthropic/claude-sonnet-4-6
Toolcall: anthropic/claude-sonnet-4-6
Base URL: https://router.requesty.ai/v1
```
<img width="616" height="239" alt="image" src="https://github.com/user-attachments/assets/9b7835a2-2bca-43f3-9be9-b6e053da9b41" />

Local checks on changed files all pass:
```
ruff check (6 changed files)  -> All checks passed!
ruff format --check            -> 6 files already formatted
mypy                           -> 0 errors in changed files
pytest                         -> 3815 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Requesty is OpenAI-compatible so it slots right into the existing `OpenAILLMClient` path, same as OpenRouter, Gemini, and NVIDIA. The only new concept is the `default_headers` parameter on `OpenAILLMClient` which lets us pass `X-Title: OpenSRE` without touching other providers. The OpenAI Python SDK already supports `default_headers` natively so this is just threading it through.

Followed the exact same pattern as the OpenRouter integration across all 7 files: constants, config model, client factory, wizard, validation, doctor check, and interactive shell. No new abstractions, no new dependencies.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
