### PR TITLE
fix(tests): add default_headers param to _FakeOpenAI stub

### DIFF
--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -31,11 +31,19 @@ class _FakeOpenAI:
     last_api_key: str | None = None
     last_base_url: str | None = None
 
-    def __init__(self, *, api_key: str, base_url: str | None = None, timeout: float) -> None:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str | None = None,
+        timeout: float,
+        default_headers: dict[str, str] | None = None,
+    ) -> None:
         _FakeOpenAI.last_api_key = api_key
         _FakeOpenAI.last_base_url = base_url
         self.base_url = base_url
         self.timeout = timeout
+        self.default_headers = default_headers
         self.chat = _FakeOpenAIChat()
 
 


### PR DESCRIPTION
## Summary

- `OpenAILLMClient.__init__` and `_ensure_client` both pass `default_headers` to the real `OpenAI(...)` constructor after the `requesty` provider support was added in #2888
- The `_FakeOpenAI` test stub was never updated with this new keyword argument, causing `TypeError: _FakeOpenAI.__init__() got an unexpected keyword argument 'default_headers'` in CI for three tests:
  - `test_openai_llm_client_reads_secure_local_api_key`
  - `test_minimax_llm_client_reads_api_key_and_base_url`
  - `test_minimax_llm_client_temperature_is_set`
- Add `default_headers: dict[str, str] | None = None` to `_FakeOpenAI.__init__` and store it on `self` to mirror the real API surface

## Test plan

- [ ] All 4 tests in `tests/services/test_llm_client.py` pass locally
- [ ] `make lint` passes
- [ ] `make typecheck` passes