### PR TITLE
Fixed detection of direct shell commands (e.g., `pwd`) in the interactive CLI.

### DIFF
--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -204,9 +204,18 @@ def _looks_like_direct_shell_command(text: str) -> bool:
         return False
     if first.lower() in _NON_COMMAND_STARTS:
         return False
+    if first.lower() in COMMON_SHELL_COMMANDS:
+        return True
     if first.startswith(("./", "../", "/")):
         return Path(first).exists()
     return shutil.which(first) is not None
+
+
+COMMON_SHELL_COMMANDS = {
+    "pwd", "ls", "cd", "echo", "cat", "touch",
+    "mkdir", "rm", "cp", "mv", "grep", "find",
+    "kubectl", "docker", "git"
+}
 
 
 def _extract_shell_command(clause: PromptClause) -> PlannedAction | None:

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -147,6 +147,10 @@ _NON_COMMAND_STARTS = frozenset(
         "why",
     }
 )
+
+COMMON_SHELL_BUILTINS = {
+    "pwd", "cd", "echo"
+}
 _SHELL_COMMAND_TIMEOUT_SECONDS = 120
 _SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
@@ -205,18 +209,14 @@ def _looks_like_direct_shell_command(text: str) -> bool:
         return False
     if first.lower() in _NON_COMMAND_STARTS:
         return False
-    if first.lower() in COMMON_SHELL_COMMANDS:
+    if first.lower() in COMMON_SHELL_BUILTINS:
         return True
     if first.startswith(("./", "../", "/")):
         return Path(first).exists()
     return shutil.which(first) is not None
 
 
-COMMON_SHELL_COMMANDS = {
-    "pwd", "ls", "cd", "echo", "cat", "touch",
-    "mkdir", "rm", "cp", "mv", "grep", "find",
-    "kubectl", "docker", "git"
-}
+
 
 
 def _extract_shell_command(clause: PromptClause) -> PlannedAction | None:

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -148,9 +148,7 @@ _NON_COMMAND_STARTS = frozenset(
     }
 )
 
-COMMON_SHELL_BUILTINS = {
-    "pwd", "cd", "echo"
-}
+COMMON_SHELL_BUILTINS = {"pwd", "cd", "echo"}
 _SHELL_COMMAND_TIMEOUT_SECONDS = 120
 _SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
@@ -214,9 +212,6 @@ def _looks_like_direct_shell_command(text: str) -> bool:
     if first.startswith(("./", "../", "/")):
         return Path(first).exists()
     return shutil.which(first) is not None
-
-
-
 
 
 def _extract_shell_command(clause: PromptClause) -> PlannedAction | None:


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

This PR fixes detection of direct shell commands (e.g., `pwd`) in the interactive CLI.

Previously, `_looks_like_direct_shell_command` relied on `shutil.which`, which only detects executables available in the system PATH. However, common shell built-in commands like `pwd`, `cd`, and `echo` are not discoverable via `shutil.which`, especially on Windows.

As a result, direct inputs such as `"pwd"` were not recognized as shell actions, causing:

```
plan_terminal_tasks("pwd") → []
```

This PR adds a fallback mechanism to detect common shell built-in commands while preserving the existing executable detection logic.

---

### Demo/Screenshot for feature changes and bug fixes -

**Before fix:**

```
plan_terminal_tasks("pwd") → []
```

**After fix:**

```
plan_terminal_tasks("pwd") → ["shell"]
```

All related CLI tests now pass successfully.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**

* [ ] No, I wrote all the code myself
* [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**

* [x] I have reviewed every single line of the AI-generated code
* [x] I can explain the purpose and logic of each function/component I added
* [x] I have tested edge cases and understand how the code handles them
* [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

* **Problem:**
  Shell built-in commands (e.g., `pwd`) were not detected because `shutil.which` does not recognize them.

* **Approach:**
  Extended `_looks_like_direct_shell_command` to include a fallback check for common shell built-in commands.

* **Alternative approaches considered:**

  * Modifying `_extract_shell_command` or `_plan_clause_actions`
  * These were avoided to preserve separation of concerns and existing architecture

* **Why this approach:**

  * Minimal and localized fix
  * Maintains backward compatibility
  * Improves cross-platform behavior (especially Windows)

* **Key logic added:**

  * Introduced a set of common shell commands
  * Checked against this set before falling back to `shutil.which`

---

## Checklist before requesting a review

* [x] I have added proper PR title and linked to the issue
* [x] I have performed a self-review of my code
* [x] **I can explain the purpose of every function, class, and logic block I added**
* [x] I understand why my changes work and have tested them thoroughly
* [x] I have considered potential edge cases and how my code handles them
* [x] If it is a core feature, I have added thorough tests
* [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
