### PR TITLE
fix(tests): skip localhost-bound update smoke test when sockets are blocked

### DIFF
--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -342,7 +342,13 @@ class _ReleaseHandler(BaseHTTPRequestHandler):
 
 @pytest.fixture()
 def release_api_url() -> str:
-    server = ThreadingHTTPServer(("127.0.0.1", 0), _ReleaseHandler)
+    try:
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _ReleaseHandler)
+    except OSError as exc:
+        if exc.errno in {errno.EPERM, errno.EACCES}:
+            pytest.skip("localhost HTTP server binding is not permitted in this environment")
+        raise
+
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:


### PR DESCRIPTION
Fixes #1256

#### Describe the changes you have made in this PR -

This makes the `release_api_url` smoke-test fixture skip gracefully when the environment blocks binding a localhost socket.

The fixture now wraps `ThreadingHTTPServer(("127.0.0.1", 0), _ReleaseHandler)` in a `try/except OSError` and only skips for the permission-denied cases that were reported (`EPERM` / `EACCES`). Other bind failures still raise normally so we don't hide unrelated bugs.

### Demo/Screenshot for feature changes and bug fixes - 

```text
$ .venv/bin/python -m pytest tests/cli_smoke_test.py::test_update_check_smoke_uses_local_stub -q
.                                                                        [100%]
1 passed in 1.72s

$ .venv/bin/python -m pytest tests/cli_smoke_test.py -q
...............                                                          [100%]
15 passed in 47.95s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The failure happens before the update-check code runs, so the right fix is in the fixture rather than in the CLI. I kept the change local to `release_api_url()` and used `OSError` instead of only `PermissionError`, because some restricted environments surface socket bind denial through the parent exception class. Filtering to `errno.EPERM` and `errno.EACCES` keeps the skip narrow and avoids masking unrelated server setup failures.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.