### PR TITLE
test: cover _check_memory_health threshold branches

### DIFF
--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -362,6 +362,52 @@ def test_imds_get_returns_none_on_os_error(monkeypatch: pytest.MonkeyPatch) -> N
     assert _imds_get("latest/meta-data/instance-id", token="test-token") is None
 
 
+def test_check_memory_health_returns_passed_when_below_warn_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeHealthyMeminfoPath:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def exists(self) -> bool:
+            return True
+
+        def read_text(self, **_kwargs: object) -> str:
+            return "NoiseWithoutSeparator\nMemTotal:       102400 kB\nMemAvailable:    51200 kB\n"
+
+    monkeypatch.setattr("app.remote.server.Path", _FakeHealthyMeminfoPath)
+    result = _check_memory_health()
+
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
+    assert result.status == "passed"
+    assert "50% used" in result.detail
+    assert "50MiB / 100MiB" in result.detail
+
+
+def test_check_memory_health_returns_warn_when_at_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeHighUsageMeminfoPath:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def exists(self) -> bool:
+            return True
+
+        def read_text(self, **_kwargs: object) -> str:
+            return "MemTotal:       102400 kB\nMemAvailable:    10240 kB\n"
+
+    monkeypatch.setattr("app.remote.server.Path", _FakeHighUsageMeminfoPath)
+    result = _check_memory_health()
+
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
+    assert result.status == "warn"
+    assert "90% used" in result.detail
+    assert "90MiB / 100MiB" in result.detail
+
+
 def test_check_memory_health_returns_missing_when_proc_file_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -380,6 +426,28 @@ def test_check_memory_health_returns_missing_when_proc_file_absent(
     assert result.name == "Memory"
     assert result.status == "missing"
     assert "/proc/meminfo unavailable on this platform." in result.detail
+
+
+def test_check_memory_health_returns_missing_when_memtotal_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeIncompletePath:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def exists(self) -> bool:
+            return True
+
+        def read_text(self, **_kwargs: object) -> str:
+            return "MemAvailable:    8192 kB\n"
+
+    monkeypatch.setattr("app.remote.server.Path", _FakeIncompletePath)
+    result = _check_memory_health()
+
+    assert isinstance(result, DeepHealthCheck)
+    assert result.name == "Memory"
+    assert result.status == "missing"
+    assert "Incomplete /proc/meminfo data." in result.detail
 
 
 def test_check_memory_health_returns_missing_when_memavailable_absent(


### PR DESCRIPTION
Fixes #1156

#### Describe the changes you have made in this PR -

Added deterministic unit coverage for the remaining `_check_memory_health()` cases not handled by #1212:

- memory usage below 90% returns `passed`
- memory usage at the 90% warning threshold returns `warn`
- missing `MemTotal` returns `missing`
- meminfo parsing ignores non-key/value noise lines without touching the real `/proc/meminfo`

No production code changes were needed.

### Demo/Screenshot for feature changes and bug fixes - 

Terminal validation:

```bash
uv run python -m pytest tests/remote/test_server.py -q --cov=app.remote.server --cov-report=term-missing
# 43 passed; _check_memory_health parsing/threshold lines covered

make lint
# All checks passed

make format-check
# 1065 files already formatted

make typecheck
# Success: no issues found in 456 source files

env PATH=".venv/bin:/usr/bin:/bin:/usr/sbin:/sbin" make test-cov
# 4866 passed, 3 skipped
```

The adjusted `PATH` makes the local authenticated `codex` binary unavailable so the Codex CLI smoke test follows its intended skip path.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

#1212 covered the missing-file, incomplete-`MemAvailable`, and `OSError` branches. This PR covers the remaining threshold behavior by replacing `app.remote.server.Path` with small per-test fake path classes. That keeps the tests deterministic and prevents reads from the host `/proc/meminfo`.

The fixtures use fixed `MemTotal` and `MemAvailable` values so the expected percentages are clear: 50% for the `passed` branch and exactly 90% for the `warn` branch. I also added a `MemTotal`-missing case because the issue explicitly calls out both required meminfo fields.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.