### PR TITLE
fix: move stdlib base64 and json imports to module level in resolve_integrations node

### DIFF
--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -5,6 +5,8 @@ integration credentials available for all downstream nodes. This replaces
 per-node credential fetching with a single upfront resolution.
 """
 
+import base64
+import json
 import logging
 import os
 from typing import Any, Optional
@@ -31,13 +33,10 @@ logger = logging.getLogger(__name__)
 
 
 def _decode_org_id_from_token(token: str) -> str:
-    import base64
-    import json as _json
-
     try:
         payload_b64 = token.split(".")[1]
         payload_b64 += "=" * (4 - len(payload_b64) % 4)
-        claims = _json.loads(base64.urlsafe_b64decode(payload_b64))
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
         return claims.get("organization") or claims.get("org_id") or ""
     except Exception:
         logger.debug("Failed to decode org_id from JWT token", exc_info=True)


### PR DESCRIPTION
Fixes #1265

#### Describe the changes you have made in this PR -

`app/nodes/resolve_integrations/node.py` placed `base64` and `json` imports **inside** the helper `_decode_org_id_from_token`. This helper is called from `node_resolve_integrations`, which runs early in every investigation that uses webhook auth or `JWT_TOKEN`-based auth, so every investigation paid the per-call import overhead (`sys.modules` lookup + local namespace binding) unnecessarily.

Both modules are pure stdlib with no circular-import risk and no optional-dependency concerns, so they are safe to hoist to module level. The `import json as _json` alias was unnecessary now that `json` is the only `json` name in scope, so it is replaced with a plain `import json` and the in-function `_json` references collapse to `json`.

This is the same pattern as the fix landed in #1242 / PR #1243 (`tracer_integrations.py` and `lambda_client.py`), now applied to a graph node rather than a service module.

**Diff:** 1 file, +3 / -4 lines.

```diff
+import base64
+import json
 import logging
 import os
 from typing import Any, Optional
 ...
 def _decode_org_id_from_token(token: str) -> str:
-    import base64
-    import json as _json
-
     try:
         payload_b64 = token.split(".")[1]
         payload_b64 += "=" * (4 - len(payload_b64) % 4)
-        claims = _json.loads(base64.urlsafe_b64decode(payload_b64))
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
```

### Demo/Screenshot for feature changes and bug fixes -

All four quality gates pass on `fix/1265-resolve-integrations-imports`:

```
$ make lint
.venv/bin/python -m ruff check app/ tests/
All checks passed!

$ make format-check
.venv/bin/python -m ruff format --check app/ tests/
1065 files already formatted

$ make typecheck
.venv/bin/python -m mypy app/
Success: no issues found in 456 source files

$ make test-cov
================ 4867 passed, 2 skipped, 21 warnings in 51.04s =================
TOTAL                                                            29481   8696    71%
```

Behavior of `_decode_org_id_from_token` is unchanged — the same stdlib calls run on the same inputs, just resolved at module-import time rather than per-call.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: function-scoped stdlib imports in a hot path. `_decode_org_id_from_token` is called from `node_resolve_integrations` on the webhook-token path (line 79) and the `JWT_TOKEN` env path (line 106), so every investigation that authenticates via either of those paths re-runs the import statements. Even though Python caches the module in `sys.modules` after the first import, each subsequent call still pays a `sys.modules` lookup and a local-namespace binding, which is wasted work for modules as cheap and ubiquitous as `base64` and `json`.

Alternatives considered:
1. **Leave as-is** — cheap individually, but the previously merged PR #1243 established that the project values removing this exact pattern from hot paths, and graph nodes are at least as hot as the tracer/Lambda paths fixed there.
2. **Use a module-level alias like `import json as _json`** to preserve the in-function name — rejected, because the alias only existed to avoid an unused-import shadow that no longer exists once the import is at module level. Plain `import json` is clearer.
3. **Hoist to module level (chosen)** — minimal, behavior-preserving, mirrors the accepted pattern from PR #1243.

Key code blocks added:
- Two new module-level imports (`import base64`, `import json`) placed alphabetically with the existing stdlib block.
- The function body of `_decode_org_id_from_token` is reduced by three lines (two imports + the blank separator); the call site change is `_json.loads` → `json.loads`.

Edge cases checked:
- Malformed token (the `try/except Exception` path) — unaffected; the imports are no longer in the `try` scope, but they were never inside it before either (Python evaluated them on every call before any exception could occur).
- Padded base64 with `=` characters and missing `org_id`/`organization` claims — unchanged behavior, covered by the existing fallback `return ""`.
- Module-level import safety — both modules are pure stdlib, present in CPython since the language existed, and have no import-time side effects, so adding them to the module-level block cannot fail.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions