### PR TITLE
fix(rca): surface bad-query Performance Insights evidence

### DIFF
--- a/app/nodes/root_cause_diagnosis/prompt_builder.py
+++ b/app/nodes/root_cause_diagnosis/prompt_builder.py
@@ -232,6 +232,7 @@ When evaluating database health metrics (especially RDS/Postgres):
 - Connection pool leaks (exhausting `max_connections`) are a `resource_exhaustion` root cause. High CPU is often just a secondary symptom of accumulated idle sessions. If connections are near 100%, the root cause is connection exhaustion, not CPU saturation. If connections are near 100% AND CPU is near 100%, look for a single shared root cause: a connection pool leak holding open scan-heavy queries, causing both (do not treat them as two independent problems).
 - Storage exhaustion (when `FreeStorageSpace` approaches 0) blocks all writes and causes Write IOPS to collapse to 0. The root cause is `resource_exhaustion` due to storage limits. If the `FreeStorageSpace` metric is completely missing, you MUST infer storage exhaustion from indirect signals: WriteIOPS dropping to 0, WriteLatency spiking, and RDS events indicating 'ran out of storage space'.
 - A single bad query driving CPU near 100% while connections and storage are healthy is `resource_exhaustion` due to CPU saturation (e.g. missing index, full table scans at high ReadIOPS). Pay close attention to Performance Insights to identify the exact query.
+- For bad-query CPU saturation, name the exact SQL statement from Performance Insights, cite its db_load/wait event if present, and explicitly rule out connection exhaustion when DatabaseConnections is stable.
 - Checkpoint Storms / VACUUM FREEZE: If CPU is high but the dominant wait event is `LWLock:BufferMapping` with massive WriteIOPS, the root cause is an I/O storm from checkpointing (e.g., `VACUUM FREEZE`) and should be classified as `resource_exhaustion`, NOT `code_defect`. The high CPU is a downstream symptom of I/O contention.
 - Replication lag: If a massive write-heavy workload on the primary generates WAL faster than the read replica can replay it, resulting in ReplicaLag spikes, the root cause is `resource_exhaustion` driven by the write workload on the primary. Watch out for red herrings: if concurrent analytics queries cause high CPU, do NOT classify the root cause as CPU-driven if the actual failing metric (like ReplicaLag) is driven by the write-heavy workload. Treat the CPU spike as an unrelated confounder/red herring and explicitly describe it as a red herring (i.e., not the root cause) in the final answer. Do not treat it as a second root cause or a contributing cause. Explicitly state that the analytics SELECT is not the root cause when the evidence shows it is causally independent from WAL generation. If the `ReplicaLag` metric is missing, infer lag from RDS events (e.g., 'exceeded 900s') and high `TransactionLogsGeneration`.
 - Compositional Faults: If two completely independent workloads cause two separate faults simultaneously (e.g., CPU saturation from an analytics SELECT AND storage exhaustion from an audit_log INSERT), explicitly identify BOTH as independent root causes (do not merge them into a single IOPS fault). You MUST explicitly state they are two independent, coincidental faults. Provide evidence for both the analytics query and the audit_log query. Use `resource_exhaustion` as ROOT_CAUSE_CATEGORY and describe both causes clearly in ROOT_CAUSE (e.g., "Two independent root causes: ..."). Trace each causal chain separately in CAUSAL_CHAIN. You MUST explicitly state that connection growth is a symptom of blocked writers, not connection exhaustion. You MUST explicitly state that ReplicaLag growth is a downstream symptom of the write burst (not an independent fault). NEVER diagnose `connection_exhaustion` as a root cause when connections spike due to a blocked write queue.
@@ -490,14 +491,12 @@ def _build_evidence_sections(
     if grafana_error_logs:
         section = f"\nGrafana Error Logs ({len(grafana_error_logs)} events):\n"
         for log in grafana_error_logs[:10]:
-            message = log.get("message", "") if isinstance(log, dict) else str(log)
-            section += f"- {message[:300]}\n"
+            section += f"- {_format_grafana_log_entry(log)}\n"
         sections.append(section)
     elif grafana_logs:
         section = f"\nGrafana Logs ({len(grafana_logs)} events):\n"
         for log in grafana_logs[:10]:
-            message = log.get("message", "") if isinstance(log, dict) else str(log)
-            section += f"- {message[:300]}\n"
+            section += f"- {_format_grafana_log_entry(log)}\n"
         sections.append(section)
 
     # Better Stack Telemetry logs (ClickHouse JSONEachRow rows with dt + raw)
@@ -729,6 +728,40 @@ def _build_rds_events_section(rds_events: list[dict[str, Any]]) -> str:
     return section
 
 
+def _format_grafana_log_entry(log: Any) -> str:
+    if not isinstance(log, dict):
+        return str(log)[:300]
+
+    message = str(log.get("message") or "")[:300]
+    source_type = str(log.get("source_type") or "").strip()
+    if source_type == "aws_performance_insights":
+        source_type = "Performance Insights"
+    source_parts = [source_type, str(log.get("source_identifier") or "").strip()]
+    source = " ".join(part for part in source_parts if part)
+    if not source:
+        return message
+    return f"[{source}] {message}" if message else f"[{source}]"
+
+
+def _db_load_value(item: dict[str, Any]) -> Any:
+    db_load = item.get("db_load")
+    return item.get("db_load_avg") if db_load is None else db_load
+
+
+def _format_wait_events(wait_events: list[Any]) -> str:
+    formatted: list[str] = []
+    for wait in wait_events[:3]:
+        if not isinstance(wait, dict):
+            continue
+        name = wait.get("name") or wait.get("wait_event") or "unknown"
+        db_load = _db_load_value(wait)
+        if db_load is None:
+            formatted.append(str(name))
+        else:
+            formatted.append(f"{name}({db_load})")
+    return ", ".join(formatted)
+
+
 def _build_performance_insights_section(performance_insights: dict[str, Any]) -> str:
     """Build RDS Performance Insights evidence section."""
     section = "\nPerformance Insights:\n"
@@ -745,25 +778,60 @@ def _build_performance_insights_section(performance_insights: dict[str, Any]) ->
         for item in top_sql[:5]:
             if not isinstance(item, dict):
                 continue
-            sql = str(item.get("sql", ""))[:180]
-            db_load = item.get("db_load")
+            sql = str(item.get("sql") or item.get("statement") or "unknown")[:180]
+            db_load = _db_load_value(item)
             wait_event = item.get("wait_event")
             section += f"- sql={sql}"
             if db_load is not None:
                 section += f" | db_load={db_load}"
             if wait_event:
                 section += f" | wait_event={wait_event}"
+            wait_events = item.get("wait_events", [])
+            if isinstance(wait_events, list) and wait_events:
+                section += f" | wait_events={_format_wait_events(wait_events)}"
+            if item.get("calls_per_sec") is not None:
+                section += f" | calls_per_sec={item['calls_per_sec']}"
             section += "\n"
 
-    wait_events = performance_insights.get("wait_events", [])
+    wait_events = (
+        performance_insights.get("wait_events") or performance_insights.get("top_wait_events") or []
+    )
     if wait_events:
         section += "Top Wait Events:\n"
         for item in wait_events[:5]:
             if not isinstance(item, dict):
                 continue
             name = item.get("name", "unknown")
-            db_load = item.get("db_load")
+            db_load = _db_load_value(item)
             section += f"- {name}"
+            if item.get("type"):
+                section += f" [{item['type']}]"
+            if db_load is not None:
+                section += f" | db_load={db_load}"
+            section += "\n"
+
+    top_users = performance_insights.get("top_users", [])
+    if top_users:
+        section += "Top Users:\n"
+        for item in top_users[:5]:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name", "unknown")
+            db_load = _db_load_value(item)
+            section += f"- {name}"
+            if db_load is not None:
+                section += f" | db_load={db_load}"
+            section += "\n"
+
+    top_hosts = performance_insights.get("top_hosts", [])
+    if top_hosts:
+        section += "Top Hosts:\n"
+        for item in top_hosts[:5]:
+            if not isinstance(item, dict):
+                continue
+            host = item.get("id") or item.get("host") or "unknown"
+            db_load = _db_load_value(item)
+            section += f"- {host}"
             if db_load is not None:
                 section += f" | db_load={db_load}"
             section += "\n"

--- a/app/nodes/root_cause_diagnosis/prompt_builder.py
+++ b/app/nodes/root_cause_diagnosis/prompt_builder.py
@@ -34,6 +34,17 @@ ALLOWED_EVIDENCE_SOURCES = [
     "github",
 ]
 
+_GRAFANA_SOURCE_TYPE_LABELS = {
+    "aws_performance_insights": "Performance Insights",
+    "aws_rds_events": "RDS Events",
+    "cloudwatch_logs": "CloudWatch Logs",
+    "datadog_logs": "Datadog Logs",
+    "db-instance": "RDS Event",
+    "grafana_loki": "Grafana Logs",
+    "opensre_log": "OpenSRE Log",
+    "rds_enhanced_monitoring": "RDS Enhanced Monitoring",
+}
+
 
 def build_diagnosis_prompt(
     state: InvestigationState, evidence: dict[str, Any], memory_context: str = ""
@@ -734,9 +745,10 @@ def _format_grafana_log_entry(log: Any) -> str:
 
     message = str(log.get("message") or "")[:300]
     source_type = str(log.get("source_type") or "").strip()
-    if source_type == "aws_performance_insights":
-        source_type = "Performance Insights"
-    source_parts = [source_type, str(log.get("source_identifier") or "").strip()]
+    source_parts = [
+        _GRAFANA_SOURCE_TYPE_LABELS.get(source_type, ""),
+        str(log.get("source_identifier") or "").strip(),
+    ]
     source = " ".join(part for part in source_parts if part)
     if not source:
         return message

--- a/tests/nodes/root_cause_diagnosis/test_prompt_builder.py
+++ b/tests/nodes/root_cause_diagnosis/test_prompt_builder.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from app.nodes.root_cause_diagnosis.prompt_builder import build_diagnosis_prompt
+
+
+def _rds_state() -> dict[str, object]:
+    return {
+        "problem_md": "CPUUtilization on catalog-prod is above threshold.",
+        "alert_name": "RDSCPUUtilizationHigh",
+        "pipeline": "rds-postgres-synthetic",
+        "raw_alert": {
+            "commonAnnotations": {
+                "summary": "RDS PostgreSQL database CPU saturation on catalog-prod",
+            },
+        },
+        "hypotheses": [],
+    }
+
+
+def test_performance_insights_fixture_fields_are_rendered() -> None:
+    evidence = {
+        "aws_performance_insights": {
+            "db_instance_identifier": "catalog-prod",
+            "top_sql": [
+                {
+                    "statement": "SELECT * FROM orders WHERE status = $1",
+                    "db_load_avg": 7.2,
+                    "wait_events": [
+                        {"name": "CPU:user", "type": "CPU", "db_load_avg": 5.9},
+                        {"name": "IO:DataFileRead", "type": "IO", "db_load_avg": 1.3},
+                    ],
+                    "calls_per_sec": 3.8,
+                }
+            ],
+            "top_wait_events": [
+                {"name": "CPU:user", "type": "CPU", "db_load_avg": 6.2},
+            ],
+            "top_users": [
+                {"name": "api_reader", "db_load_avg": 7.2},
+            ],
+            "top_hosts": [
+                {"id": "10.0.2.71", "db_load_avg": 4.1},
+            ],
+        }
+    }
+
+    prompt = build_diagnosis_prompt(_rds_state(), evidence)
+
+    assert "Performance Insights:" in prompt
+    assert "sql=SELECT * FROM orders WHERE status = $1" in prompt
+    assert "db_load=7.2" in prompt
+    assert "wait_events=CPU:user(5.9), IO:DataFileRead(1.3)" in prompt
+    assert "calls_per_sec=3.8" in prompt
+    assert "- CPU:user [CPU] | db_load=6.2" in prompt
+    assert "- api_reader | db_load=7.2" in prompt
+    assert "- 10.0.2.71 | db_load=4.1" in prompt
+
+
+def test_grafana_logs_show_performance_insights_source() -> None:
+    evidence = {
+        "grafana_logs": [
+            {
+                "message": (
+                    "Top SQL Activity: SELECT * FROM orders WHERE status = $1 "
+                    "| Avg Load: 7.2 AAS | Waits: CPU:user(5.9)"
+                ),
+                "source_type": "aws_performance_insights",
+                "source_identifier": "catalog-prod",
+            }
+        ]
+    }
+
+    prompt = build_diagnosis_prompt(_rds_state(), evidence)
+
+    assert "[Performance Insights catalog-prod] Top SQL Activity" in prompt
+    assert "SELECT * FROM orders WHERE status = $1" in prompt
+
+
+def test_database_directive_requires_exact_bad_query_reasoning() -> None:
+    prompt = build_diagnosis_prompt(_rds_state(), {"grafana_logs": []})
+
+    assert "name the exact SQL statement from Performance Insights" in prompt
+    assert "explicitly rule out connection exhaustion" in prompt

--- a/tests/nodes/root_cause_diagnosis/test_prompt_builder.py
+++ b/tests/nodes/root_cause_diagnosis/test_prompt_builder.py
@@ -76,6 +76,39 @@ def test_grafana_logs_show_performance_insights_source() -> None:
     assert "SELECT * FROM orders WHERE status = $1" in prompt
 
 
+def test_grafana_error_logs_show_performance_insights_source() -> None:
+    evidence = {
+        "grafana_error_logs": [
+            {
+                "message": "Top Wait Event: CPU:user | db_load_avg: 6.2 AAS",
+                "source_type": "aws_performance_insights",
+                "source_identifier": "catalog-prod",
+            }
+        ]
+    }
+
+    prompt = build_diagnosis_prompt(_rds_state(), evidence)
+
+    assert "[Performance Insights catalog-prod] Top Wait Event" in prompt
+
+
+def test_unknown_grafana_source_type_is_not_rendered() -> None:
+    evidence = {
+        "grafana_logs": [
+            {
+                "message": "Internal telemetry event",
+                "source_type": "custom_internal_source",
+                "source_identifier": "catalog-prod",
+            }
+        ]
+    }
+
+    prompt = build_diagnosis_prompt(_rds_state(), evidence)
+
+    assert "[catalog-prod] Internal telemetry event" in prompt
+    assert "custom_internal_source" not in prompt
+
+
 def test_database_directive_requires_exact_bad_query_reasoning() -> None:
     prompt = build_diagnosis_prompt(_rds_state(), {"grafana_logs": []})
 


### PR DESCRIPTION
Fixes #600

#### Describe the changes you have made in this PR -

This PR improves RDS CPU saturation diagnosis for the synthetic bad-query case by making Performance Insights evidence more explicit in the RCA prompt.

Changes:
- Renders fixture-native Performance Insights fields such as `statement`, `db_load_avg`, nested `wait_events`, `top_wait_events`, `top_users`, and `top_hosts`.
- Labels Grafana log entries sourced from `aws_performance_insights` as `Performance Insights`.
- Adds guidance to name the exact SQL statement and rule out connection exhaustion when DB connections are stable.
- Adds focused prompt-builder tests for the issue evidence path.

### Demo/Screenshot for feature changes and bug fixes -

Proof:
- `pytest tests\nodes\root_cause_diagnosis\test_prompt_builder.py -q` passed
- `pytest tests\nodes\root_cause_diagnosis -q` passed: `198 passed`
- `ruff check app\nodes\root_cause_diagnosis\prompt_builder.py tests\nodes\root_cause_diagnosis\test_prompt_builder.py` passed



### Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue requires the RCA prompt to expose the exact bad SQL query and Performance Insights signals behind RDS CPU saturation. I chose to improve evidence rendering rather than loosen scoring, because the fixture already contains the correct ground truth.

The main implementation adds support for both existing and fixture-native Performance Insights field names, including `statement`/`sql`, `db_load_avg`/`db_load`, nested wait events, top users, and top hosts. Grafana log entries sourced from Performance Insights are now labeled clearly so the model can connect the evidence to the required reasoning. Tests assert the exact SQL, db load, wait events, source label, and bad-query directive appear in the generated prompt.


### Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

### Note for Maintainer/Team Members
please run the following test after setting up your  `ANTHROPIC_API_KEY`

```
python -m tests.synthetic.rds_postgres.run_suite --scenario 004-cpu-saturation-bad-query --mock-grafana --json

```