### PR TITLE
test: add filesystem fallback coverage for analytics provider (#1119)

### DIFF
--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 
 from app.analytics import install, provider
@@ -127,3 +128,40 @@ def test_analytics_disabled_when_do_not_track_opt_out(monkeypatch, tmp_path: Pat
     assert analytics._pending == 0
     assert analytics._queue.qsize() == 0
     assert client_inits == 0
+
+
+def test_get_or_create_anonymous_id_returns_uuid_when_write_fails(monkeypatch, tmp_path: Path) -> None:
+    """Test that _get_or_create_anonymous_id returns a UUID when file write fails."""
+    anonymous_id_path = tmp_path / "anonymous_id"
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", anonymous_id_path)
+
+    def _raise_oserror(*_args, **_kwargs) -> None:
+        raise OSError("disk write failed")
+
+    monkeypatch.setattr(Path, "write_text", _raise_oserror)
+
+    value = provider._get_or_create_anonymous_id()
+    assert isinstance(value, str)
+    assert value.strip() != ""
+    # Verify it's a valid UUID
+    uuid.UUID(value)
+
+
+def test_capture_install_detected_if_needed_returns_false_when_marker_write_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Test that capture_install_detected_if_needed returns False when marker file write fails."""
+    stub = _StubAnalytics()
+    marker_path = tmp_path / "installed"
+    monkeypatch.setattr(provider, "_FIRST_RUN_PATH", marker_path)
+    monkeypatch.setattr(provider, "get_analytics", lambda: stub)
+
+    def _raise_oserror(*_args, **_kwargs) -> None:
+        raise OSError("touch failed")
+
+    monkeypatch.setattr(Path, "touch", _raise_oserror)
+
+    captured = provider.capture_install_detected_if_needed({"install_source": "make_install"})
+    assert captured is False
+    assert stub.events == []


### PR DESCRIPTION
- Add test for _get_or_create_anonymous_id() when file write fails (OSError)
- Add test for capture_install_detected_if_needed() when marker touch fails
- Both tests verify fail-safe behavior with monkeypatching (no real filesystem tricks)

Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
