### PR TITLE
clearing backloag -test: add shutdown analytics tests for idempotency…

### DIFF
--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -127,3 +127,30 @@ def test_analytics_disabled_when_do_not_track_opt_out(monkeypatch, tmp_path: Pat
     assert analytics._pending == 0
     assert analytics._queue.qsize() == 0
     assert client_inits == 0
+
+
+def test_shutdown_is_idempotent_and_capture_after_shutdown_is_noop(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+
+    analytics = provider.Analytics()
+
+    analytics.shutdown(flush=False)
+    analytics.shutdown(flush=False)
+    pending_before_capture = analytics._pending
+    analytics.capture(Event.INSTALL_DETECTED, {"install_source": "make_install"})
+
+    assert analytics._shutdown is True
+    assert analytics._pending == pending_before_capture == 0
+
+
+def test_shutdown_analytics_is_noop_when_singleton_not_initialized(monkeypatch) -> None:
+    monkeypatch.setattr(provider, "_instance", None)
+
+    provider.shutdown_analytics(flush=False)
+
+    assert provider._instance is None

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -136,16 +136,45 @@ def test_shutdown_is_idempotent_and_capture_after_shutdown_is_noop(
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
     monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
     monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+
+    posted_payloads: list[dict[str, object]] = []
+
+    class _StubResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _StubClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self) -> _StubClient:
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, object]) -> _StubResponse:
+            posted_payloads.append({"url": url, "json": json})
+            return _StubResponse()
+
+    monkeypatch.setattr(provider.httpx, "Client", _StubClient)
 
     analytics = provider.Analytics()
+    analytics.capture(Event.INSTALL_DETECTED, {"install_source": "make_install"})
+
+    analytics.shutdown(flush=True)
+    sent_before_post_shutdown_capture = len(posted_payloads)
+    pending_before_capture = analytics._pending
+    queue_size_before_capture = analytics._queue.qsize()
 
     analytics.shutdown(flush=False)
-    analytics.shutdown(flush=False)
-    pending_before_capture = analytics._pending
     analytics.capture(Event.INSTALL_DETECTED, {"install_source": "make_install"})
 
     assert analytics._shutdown is True
     assert analytics._pending == pending_before_capture == 0
+    assert analytics._queue.qsize() == queue_size_before_capture
+    assert len(posted_payloads) == sent_before_post_shutdown_capture == 1
 
 
 def test_shutdown_analytics_is_noop_when_singleton_not_initialized(monkeypatch) -> None:


### PR DESCRIPTION
This pull request adds new tests to improve the reliability of the analytics provider's shutdown behavior. The main focus is on ensuring the shutdown process is idempotent and that no events are captured after shutdown, as well as verifying that shutting down analytics when the singleton is uninitialized is a no-op.

**Testing improvements:**

* Added `test_shutdown_is_idempotent_and_capture_after_shutdown_is_noop` to verify that calling `shutdown` multiple times does not cause issues and that `capture` is a no-op after shutdown.
* Added `test_shutdown_analytics_is_noop_when_singleton_not_initialized` to ensure that shutting down analytics when the singleton is not initialized does nothing and does not raise errors.