### PR TITLE
refactor: improve RDS storage-full RCA evidence handling

### DIFF
--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -1,10 +1,13 @@
 """Post-processing: merge evidence and track hypotheses."""
 
 import json
+import re
 from collections.abc import Callable
+from datetime import UTC, datetime
 
 from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
 from app.nodes.investigate.types import ExecutedHypothesis, FailedAction, PlanAudit
+from app.tools.utils.metric_summary import summarize_prometheus_metrics
 
 MAX_RETRYABLE_ACTION_FAILURES = 2
 _NON_RETRYABLE_FAILURE_INDICATORS = (
@@ -219,13 +222,106 @@ def _map_s3_object(data: dict) -> dict:
     }
 
 
-def _map_grafana_logs(data: dict) -> dict:
+def _timestamp_from_loki_ns(value: object) -> str:
+    try:
+        timestamp = int(float(str(value))) / 1_000_000_000
+    except (TypeError, ValueError):
+        return str(value or "")
+    return datetime.fromtimestamp(timestamp, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _derive_rds_events_from_grafana_logs(logs: list) -> list[dict]:
+    events: list[dict] = []
+    for log in logs:
+        if not isinstance(log, dict):
+            continue
+        source_type = str(log.get("source_type", "")).lower()
+        message = str(log.get("message", ""))
+        if source_type != "db-instance" and "db instance" not in message.lower():
+            continue
+        events.append(
+            {
+                "timestamp": _timestamp_from_loki_ns(log.get("timestamp")),
+                "message": message,
+                "source_type": log.get("source_type"),
+                "source_identifier": log.get("source_identifier"),
+            }
+        )
+    return events
+
+
+def _derive_performance_insights_from_grafana_logs(logs: list) -> dict:
+    observations: list[str] = []
+    top_sql: list[dict] = []
+    wait_events: list[dict] = []
+
+    for log in logs:
+        if not isinstance(log, dict):
+            continue
+        source_type = str(log.get("source_type", "")).lower()
+        message = str(log.get("message", ""))
+        is_pi = source_type == "aws_performance_insights" or message.startswith(
+            ("Top SQL Activity:", "Top Wait Event:")
+        )
+        if not is_pi:
+            continue
+        observations.append(message)
+
+        sql_match = re.match(
+            r"Top SQL Activity:\s*(?P<sql>.*?)\s*\|\s*Avg Load:\s*"
+            r"(?P<load>[0-9.]+)\s*AAS\s*\|\s*Waits:\s*(?P<waits>.*)",
+            message,
+        )
+        if sql_match:
+            top_sql.append(
+                {
+                    "sql": sql_match.group("sql"),
+                    "db_load": float(sql_match.group("load")),
+                    "wait_event": sql_match.group("waits"),
+                }
+            )
+            continue
+
+        wait_match = re.match(
+            r"Top Wait Event:\s*(?P<name>.*?)\s*\|\s*db_load_avg:\s*"
+            r"(?P<load>[0-9.]+)\s*AAS",
+            message,
+        )
+        if wait_match:
+            wait_events.append(
+                {
+                    "name": wait_match.group("name"),
+                    "db_load": float(wait_match.group("load")),
+                }
+            )
+
+    if not observations:
+        return {}
     return {
+        "observations": observations,
+        "top_sql": top_sql,
+        "wait_events": wait_events,
+    }
+
+
+def _map_grafana_logs(data: dict) -> dict:
+    logs = data.get("logs", [])
+    mapped: dict[str, object] = {
         "grafana_logs": data.get("logs", []),
         "grafana_error_logs": data.get("error_logs", []),
         "grafana_logs_query": data.get("query", ""),
         "grafana_logs_service": data.get("service_name", ""),
     }
+
+    rds_events = _derive_rds_events_from_grafana_logs(logs)
+    if rds_events:
+        mapped["aws_rds_events"] = rds_events
+
+    performance_insights = _derive_performance_insights_from_grafana_logs(logs)
+    if performance_insights:
+        mapped["aws_performance_insights"] = performance_insights
+
+    return mapped
 
 
 def _map_grafana_traces(data: dict) -> dict:
@@ -236,12 +332,60 @@ def _map_grafana_traces(data: dict) -> dict:
     }
 
 
-def _map_grafana_metrics(data: dict) -> dict:
+def _build_rds_cloudwatch_metrics(summaries: list[dict]) -> dict:
+    rds_summaries = [
+        summary
+        for summary in summaries
+        if str(summary.get("raw_metric_name", "")).startswith("aws_rds_")
+    ]
+    if not rds_summaries:
+        return {}
+
+    db_instance = ""
+    metrics: list[dict] = []
+    observations: list[str] = []
+    for summary in rds_summaries:
+        labels = summary.get("labels", {})
+        if isinstance(labels, dict) and not db_instance:
+            db_instance = str(
+                labels.get("dbinstanceidentifier")
+                or labels.get("db_instance_identifier")
+                or labels.get("db_instance")
+                or ""
+            )
+        metrics.append(
+            {
+                "metric_name": summary.get("metric_name", "unknown"),
+                "summary": summary.get("summary", ""),
+                "labels": labels if isinstance(labels, dict) else {},
+                "datapoint_count": summary.get("datapoint_count", 0),
+            }
+        )
+        if summary.get("summary"):
+            observations.append(str(summary["summary"]))
+
     return {
-        "grafana_metrics": data.get("metrics", []),
+        "db_instance_identifier": db_instance,
+        "metrics": metrics,
+        "observations": observations,
+    }
+
+
+def _map_grafana_metrics(data: dict) -> dict:
+    metrics = data.get("metrics", [])
+    summaries = summarize_prometheus_metrics(metrics)
+    mapped: dict[str, object] = {
+        "grafana_metrics": metrics,
+        "grafana_metric_summaries": summaries,
         "grafana_metric_name": data.get("metric_name", ""),
         "grafana_metrics_service": data.get("service_name", ""),
     }
+
+    rds_metrics = _build_rds_cloudwatch_metrics(summaries)
+    if rds_metrics:
+        mapped["aws_cloudwatch_metrics"] = rds_metrics
+
+    return mapped
 
 
 def _map_grafana_alert_rules(data: dict) -> dict:

--- a/app/nodes/plan_actions/build_prompt.py
+++ b/app/nodes/plan_actions/build_prompt.py
@@ -116,6 +116,7 @@ def _build_available_sources_hint(available_sources: dict[str, dict]) -> str:
 - Service Name: {grafana.get("service_name")}
 - Pipeline: {grafana.get("pipeline_name")}
 - Use query_grafana_logs to search Loki for pipeline errors, or to fetch AWS Performance Insights and RDS events for database diagnostics{traces_hint}
+- Use query_grafana_metrics for database resource metrics such as FreeStorageSpace, WriteIOPS, CPU, connections, and latency
 - Use query_grafana_alert_rules to inspect alert configuration"""
         )
 
@@ -432,6 +433,7 @@ When selecting actions, optimize for:
 Additionally:
 - When connection counts are high, explicitly evaluate whether idle connections are contributing to the issue and include this explicitly in your reasoning if relevant.
 - When storage pressure is observed, explicitly consider audit logs or database-specific logging mechanisms (e.g. audit_log for PostgreSQL/Aurora)
+- For RDS/Postgres storage alerts, collect metrics, logs/events, and alert rules together when Grafana is available so the final RCA can connect FreeStorageSpace, WriteIOPS, RDS events, and the triggering alert.
 
 Avoid:
 - collecting general context that does not help separate hypotheses

--- a/app/nodes/root_cause_diagnosis/prompt_builder.py
+++ b/app/nodes/root_cause_diagnosis/prompt_builder.py
@@ -532,8 +532,19 @@ def _build_evidence_sections(
         sections.append(section)
 
     # Grafana metrics
+    grafana_metric_summaries = evidence.get("grafana_metric_summaries", [])
     grafana_metrics = evidence.get("grafana_metrics", [])
-    if grafana_metrics:
+    if grafana_metric_summaries:
+        metric_name = evidence.get("grafana_metric_name", "unknown")
+        section = f"\nGrafana Metrics ({metric_name}):\n"
+        for metric in grafana_metric_summaries[:8]:
+            if not isinstance(metric, dict):
+                continue
+            summary = metric.get("summary")
+            if summary:
+                section += f"- {summary}\n"
+        sections.append(section)
+    elif grafana_metrics:
         metric_name = evidence.get("grafana_metric_name", "unknown")
         section = f"\nGrafana Metrics ({metric_name}):\n"
         for metric in grafana_metrics[:5]:
@@ -745,9 +756,15 @@ def _build_performance_insights_section(performance_insights: dict[str, Any]) ->
         for item in top_sql[:5]:
             if not isinstance(item, dict):
                 continue
-            sql = str(item.get("sql", ""))[:180]
-            db_load = item.get("db_load")
+            sql = str(item.get("sql") or item.get("statement") or "")[:180]
+            db_load = item.get("db_load", item.get("db_load_avg"))
             wait_event = item.get("wait_event")
+            if not wait_event and isinstance(item.get("wait_events"), list):
+                wait_event = ", ".join(
+                    str(wait.get("name", "unknown"))
+                    for wait in item.get("wait_events", [])[:3]
+                    if isinstance(wait, dict)
+                )
             section += f"- sql={sql}"
             if db_load is not None:
                 section += f" | db_load={db_load}"

--- a/app/tools/GrafanaAlertRulesTool/__init__.py
+++ b/app/tools/GrafanaAlertRulesTool/__init__.py
@@ -25,6 +25,34 @@ def _query_grafana_alert_rules_available(sources: dict[str, dict]) -> bool:
     return _grafana_available(sources)
 
 
+def _normalize_backend_alert_rules(raw: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize fixture/backend ruler responses to the client rule shape."""
+    rules: list[dict[str, Any]] = []
+    for group in raw.get("groups", []):
+        if not isinstance(group, dict):
+            continue
+        group_name = str(group.get("name", ""))
+        folder = str(group.get("folder", ""))
+        for rule in group.get("rules", []):
+            if not isinstance(rule, dict):
+                continue
+            annotations = rule.get("annotations", {})
+            labels = rule.get("labels", {})
+            rules.append(
+                {
+                    "rule_name": rule.get("name") or rule.get("title") or "unknown",
+                    "state": rule.get("state", ""),
+                    "folder": folder,
+                    "group": group_name,
+                    "queries": rule.get("queries", []),
+                    "labels": labels if isinstance(labels, dict) else {},
+                    "annotations": annotations if isinstance(annotations, dict) else {},
+                    "no_data_state": rule.get("no_data_state") or rule.get("noDataState"),
+                }
+            )
+    return rules
+
+
 @tool(
     name="query_grafana_alert_rules",
     display_name="Grafana alerts",
@@ -58,7 +86,14 @@ def query_grafana_alert_rules(
     """Query Grafana alert rules to understand what is being monitored."""
     if grafana_backend is not None:
         raw = grafana_backend.query_alert_rules()
-        return {"source": "grafana_alerts", "available": True, "raw": raw}
+        rules = _normalize_backend_alert_rules(raw)
+        return {
+            "source": "grafana_alerts",
+            "available": True,
+            "rules": rules,
+            "total_rules": len(rules),
+            "raw": raw,
+        }
 
     client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
     if not client or not client.is_configured:

--- a/app/tools/utils/metric_summary.py
+++ b/app/tools/utils/metric_summary.py
@@ -1,0 +1,267 @@
+"""Compact summaries for time-series metric evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+_PROM_STAT_SUFFIXES = (
+    "_average",
+    "_minimum",
+    "_maximum",
+    "_sum",
+    "_sample_count",
+    "_samplecount",
+)
+
+_AWS_RDS_NAME_OVERRIDES = {
+    "bin_log_disk_usage": "BinLogDiskUsage",
+    "commit_latency": "CommitLatency",
+    "commit_throughput": "CommitThroughput",
+    "cpu_utilization": "CPUUtilization",
+    "database_connections": "DatabaseConnections",
+    "disk_queue_depth": "DiskQueueDepth",
+    "free_storage_space": "FreeStorageSpace",
+    "freeable_memory": "FreeableMemory",
+    "maximum_used_transaction_i_ds": "MaximumUsedTransactionIDs",
+    "maximum_used_transaction_ids": "MaximumUsedTransactionIDs",
+    "network_receive_throughput": "NetworkReceiveThroughput",
+    "network_transmit_throughput": "NetworkTransmitThroughput",
+    "read_iops": "ReadIOPS",
+    "read_latency": "ReadLatency",
+    "read_throughput": "ReadThroughput",
+    "replica_lag": "ReplicaLag",
+    "swap_usage": "SwapUsage",
+    "transaction_logs_generation": "TransactionLogsGeneration",
+    "write_iops": "WriteIOPS",
+    "write_latency": "WriteLatency",
+    "write_throughput": "WriteThroughput",
+}
+
+_BYTE_METRIC_TOKENS = (
+    "bin_log_disk_usage",
+    "free_storage_space",
+    "freeable_memory",
+    "network_receive_throughput",
+    "network_transmit_throughput",
+    "read_throughput",
+    "storage",
+    "memory",
+    "disk_usage",
+    "transaction_logs_generation",
+    "write_throughput",
+    "bin_log",
+    "swap",
+)
+
+
+@dataclass(frozen=True)
+class _MetricStats:
+    datapoint_count: int
+    first_ts: float
+    first_value: float
+    latest_ts: float
+    latest_value: float
+    min_ts: float
+    min_value: float
+    max_ts: float
+    max_value: float
+
+
+def summarize_prometheus_metrics(series: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return compact summaries for Prometheus/Mimir matrix series."""
+    summaries: list[dict[str, Any]] = []
+    for item in series:
+        if not isinstance(item, dict):
+            continue
+
+        metric = item.get("metric", {})
+        if not isinstance(metric, dict):
+            metric = {}
+        raw_name = str(metric.get("__name__", "unknown")).strip() or "unknown"
+        values = _parse_values(item.get("values", []))
+        stats = _compute_stats(values)
+        labels = {str(k): str(v) for k, v in metric.items() if k != "__name__"}
+        display_name = _display_metric_name(raw_name)
+
+        summary = {
+            "metric_name": display_name,
+            "raw_metric_name": raw_name,
+            "labels": labels,
+            "datapoint_count": len(values),
+            "summary": _build_summary_line(display_name, raw_name, labels, stats),
+        }
+        if stats:
+            summary.update(
+                {
+                    "first": stats.first_value,
+                    "first_timestamp": _format_timestamp(stats.first_ts),
+                    "latest": stats.latest_value,
+                    "latest_timestamp": _format_timestamp(stats.latest_ts),
+                    "min": stats.min_value,
+                    "min_timestamp": _format_timestamp(stats.min_ts),
+                    "max": stats.max_value,
+                    "max_timestamp": _format_timestamp(stats.max_ts),
+                    "peak": stats.max_value,
+                    "peak_timestamp": _format_timestamp(stats.max_ts),
+                    "trend": _trend(stats.first_value, stats.latest_value),
+                    "peak_to_latest_change": _change(stats.max_value, stats.latest_value),
+                }
+            )
+        else:
+            summary["trend"] = "no datapoints"
+        summaries.append(summary)
+    return summaries
+
+
+def _compute_stats(values: list[tuple[float, float]]) -> _MetricStats | None:
+    if not values:
+        return None
+
+    first_ts, first_value = values[0]
+    latest_ts, latest_value = values[-1]
+    min_ts, min_value = first_ts, first_value
+    max_ts, max_value = first_ts, first_value
+    for timestamp, value in values[1:]:
+        if value < min_value:
+            min_ts, min_value = timestamp, value
+        if value > max_value:
+            max_ts, max_value = timestamp, value
+
+    return _MetricStats(
+        datapoint_count=len(values),
+        first_ts=first_ts,
+        first_value=first_value,
+        latest_ts=latest_ts,
+        latest_value=latest_value,
+        min_ts=min_ts,
+        min_value=min_value,
+        max_ts=max_ts,
+        max_value=max_value,
+    )
+
+
+def _parse_values(raw_values: Any) -> list[tuple[float, float]]:
+    parsed: list[tuple[float, float]] = []
+    if not isinstance(raw_values, list):
+        return parsed
+    for item in raw_values:
+        if not isinstance(item, (list, tuple)) or len(item) < 2:
+            continue
+        try:
+            timestamp = float(item[0])
+            value = float(item[1])
+        except (TypeError, ValueError):
+            continue
+        parsed.append((timestamp, value))
+    return parsed
+
+
+def _display_metric_name(raw_name: str) -> str:
+    base = raw_name
+    if base.startswith("aws_rds_"):
+        base = base.removeprefix("aws_rds_")
+        for suffix in _PROM_STAT_SUFFIXES:
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        return _AWS_RDS_NAME_OVERRIDES.get(base, _title_from_snake(base))
+    return raw_name
+
+
+def _title_from_snake(value: str) -> str:
+    return "".join(part.capitalize() for part in value.split("_") if part)
+
+
+def _build_summary_line(
+    display_name: str,
+    raw_name: str,
+    labels: dict[str, str],
+    stats: _MetricStats | None,
+) -> str:
+    label_text = _format_labels(labels)
+    if not stats:
+        return f"{display_name}{label_text}: no datapoints"
+
+    value_context = _value_context(raw_name, display_name)
+    return (
+        f"{display_name}{label_text}: datapoints={stats.datapoint_count}, "
+        f"first={_format_value(stats.first_value, value_context)} at "
+        f"{_format_timestamp(stats.first_ts)}, "
+        f"latest={_format_value(stats.latest_value, value_context)} at "
+        f"{_format_timestamp(stats.latest_ts)}, "
+        f"min={_format_value(stats.min_value, value_context)} at "
+        f"{_format_timestamp(stats.min_ts)}, "
+        f"max/peak={_format_value(stats.max_value, value_context)} at "
+        f"{_format_timestamp(stats.max_ts)}, "
+        f"trend={_trend(stats.first_value, stats.latest_value)}, "
+        f"peak_to_latest={_change(stats.max_value, stats.latest_value)}"
+    )
+
+
+def _format_labels(labels: dict[str, str]) -> str:
+    if not labels:
+        return ""
+    label_text = ", ".join(f"{key}={value}" for key, value in sorted(labels.items()))
+    return f" ({label_text})"
+
+
+def _value_context(raw_name: str, display_name: str) -> str:
+    name = f"{raw_name} {display_name}".lower()
+    if any(token in name for token in _BYTE_METRIC_TOKENS):
+        return "bytes"
+    return "number"
+
+
+def _format_value(value: float, value_context: str) -> str:
+    if value_context == "bytes":
+        return _format_bytes(value)
+    if value.is_integer():
+        return str(int(value))
+    return f"{value:.4g}"
+
+
+def _format_bytes(value: float) -> str:
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    amount = abs(value)
+    unit_index = 0
+    while amount >= 1024 and unit_index < len(units) - 1:
+        amount /= 1024
+        unit_index += 1
+    signed = -amount if value < 0 else amount
+    if unit_index == 0:
+        return f"{signed:.0f} {units[unit_index]}"
+    return f"{signed:.2f} {units[unit_index]}"
+
+
+def _format_timestamp(value: float) -> str:
+    try:
+        return datetime.fromtimestamp(value, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (OverflowError, OSError, ValueError):
+        return str(value)
+
+
+def _trend(first: float, latest: float) -> str:
+    change = _change(first, latest)
+    if latest > first:
+        return f"increased {change}"
+    if latest < first:
+        return f"decreased {change}"
+    return "flat"
+
+
+def _change(start: float, end: float) -> str:
+    delta = end - start
+    if start == 0:
+        if end == 0:
+            return "0"
+        return f"{_format_signed_number(delta)} from zero"
+    pct = abs(delta / start) * 100
+    return f"{pct:.1f}% ({_format_signed_number(delta)})"
+
+
+def _format_signed_number(value: float) -> str:
+    if value.is_integer():
+        return f"{int(value):+d}"
+    return f"{value:+.4g}"

--- a/tests/nodes/root_cause_diagnosis/test_rds_grafana_evidence.py
+++ b/tests/nodes/root_cause_diagnosis/test_rds_grafana_evidence.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
+from app.nodes.investigate.processing.post_process import merge_evidence
+from app.nodes.root_cause_diagnosis.prompt_builder import build_diagnosis_prompt
+from app.tools.GrafanaAlertRulesTool import query_grafana_alert_rules
+from app.tools.GrafanaLogsTool import query_grafana_logs
+from app.tools.GrafanaMetricsTool import query_grafana_metrics
+from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
+from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_scenario
+
+
+def test_rds_storage_fixture_prompt_surfaces_structured_grafana_evidence() -> None:
+    fixture = load_scenario(SUITE_DIR / "003-storage-full")
+    backend = FixtureGrafanaBackend(fixture)
+
+    execution_results = {
+        "query_grafana_metrics": ActionExecutionResult(
+            "query_grafana_metrics",
+            True,
+            query_grafana_metrics(
+                metric_name="pipeline_runs_total",
+                service_name="rds-postgres-synthetic",
+                grafana_backend=backend,
+            ),
+        ),
+        "query_grafana_logs": ActionExecutionResult(
+            "query_grafana_logs",
+            True,
+            query_grafana_logs(
+                service_name="rds-postgres-synthetic",
+                grafana_backend=backend,
+            ),
+        ),
+        "query_grafana_alert_rules": ActionExecutionResult(
+            "query_grafana_alert_rules",
+            True,
+            query_grafana_alert_rules(
+                folder="rds-postgres-synthetic",
+                grafana_backend=backend,
+            ),
+        ),
+    }
+    evidence = merge_evidence({}, execution_results)
+
+    assert "aws_cloudwatch_metrics" in evidence
+    assert "aws_rds_events" in evidence
+    assert "aws_performance_insights" in evidence
+    assert evidence["grafana_alert_rules_count"] == 1
+
+    state = {
+        "problem_md": fixture.problem_md,
+        "hypotheses": [],
+        "raw_alert": fixture.alert,
+        "alert_name": fixture.alert["title"],
+        "pipeline": "rds-postgres-synthetic",
+    }
+    prompt = build_diagnosis_prompt(state, evidence)
+
+    assert "RDS CloudWatch Metrics:" in prompt
+    assert "FreeStorageSpace" in prompt
+    assert "WriteIOPS" in prompt
+    assert "orders-prod" in prompt
+    assert "DB instance ran out of storage space" in prompt
+    assert "Performance Insights:" in prompt
+    assert "INSERT INTO order_archive" in prompt
+    assert "RDSFreeStorageSpaceLow" in prompt
+
+
+def test_grafana_rds_event_timestamp_handles_float_nanoseconds() -> None:
+    evidence = merge_evidence(
+        {},
+        {
+            "query_grafana_logs": ActionExecutionResult(
+                "query_grafana_logs",
+                True,
+                {
+                    "logs": [
+                        {
+                            "timestamp": 1_774_577_553_000_000_000.0,
+                            "message": "DB instance ran out of storage space.",
+                            "source_type": "db-instance",
+                            "source_identifier": "orders-prod",
+                        }
+                    ],
+                    "error_logs": [],
+                    "query": "",
+                    "service_name": "rds-postgres-synthetic",
+                },
+            )
+        },
+    )
+
+    assert evidence["aws_rds_events"][0]["timestamp"] == "2026-03-27T02:12:33Z"

--- a/tests/tools/test_grafana_alert_rules_tool.py
+++ b/tests/tools/test_grafana_alert_rules_tool.py
@@ -29,10 +29,27 @@ def test_extract_params_maps_fields() -> None:
 
 def test_run_with_backend() -> None:
     mock_backend = MagicMock()
-    mock_backend.query_alert_rules.return_value = {"groups": [{"name": "my-group"}]}
+    mock_backend.query_alert_rules.return_value = {
+        "groups": [
+            {
+                "name": "my-group",
+                "rules": [
+                    {
+                        "name": "RDSFreeStorageSpaceLow",
+                        "state": "firing",
+                        "labels": {"service": "rds"},
+                        "annotations": {"summary": "storage low"},
+                    }
+                ],
+            }
+        ]
+    }
     result = query_grafana_alert_rules(grafana_backend=mock_backend)
     assert result["available"] is True
     assert "raw" in result
+    assert result["total_rules"] == 1
+    assert result["rules"][0]["rule_name"] == "RDSFreeStorageSpaceLow"
+    assert result["rules"][0]["group"] == "my-group"
 
 
 def test_run_no_client() -> None:

--- a/tests/tools/test_grafana_metrics_tool.py
+++ b/tests/tools/test_grafana_metrics_tool.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from app.tools.GrafanaMetricsTool import query_grafana_metrics
+from app.tools.utils.metric_summary import summarize_prometheus_metrics
+from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
+from tests.synthetic.rds_postgres.scenario_loader import SUITE_DIR, load_scenario
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
 
@@ -36,6 +39,27 @@ def test_run_with_backend() -> None:
     result = query_grafana_metrics(metric_name="pipeline_runs_total", grafana_backend=mock_backend)
     assert result["available"] is True
     assert result["total_series"] == 1
+
+
+def test_rds_storage_fixture_metrics_have_compact_summaries() -> None:
+    fixture = load_scenario(SUITE_DIR / "003-storage-full")
+    backend = FixtureGrafanaBackend(fixture)
+
+    result = query_grafana_metrics(
+        metric_name="pipeline_runs_total",
+        service_name="rds-postgres-synthetic",
+        grafana_backend=backend,
+    )
+    summaries = summarize_prometheus_metrics(result["metrics"])
+
+    by_name = {summary["metric_name"]: summary for summary in summaries}
+    assert "FreeStorageSpace" in by_name
+    assert "WriteIOPS" in by_name
+    assert "orders-prod" in by_name["FreeStorageSpace"]["summary"]
+    assert "decreased" in by_name["FreeStorageSpace"]["trend"]
+    assert "orders-prod" in by_name["WriteIOPS"]["summary"]
+    assert "8100" in by_name["WriteIOPS"]["summary"]
+    assert "peak_to_latest" in by_name["WriteIOPS"]["summary"]
 
 
 def test_run_no_client() -> None:


### PR DESCRIPTION
Fixes #599

#### Describe the changes you have made in this PR -

This PR improves RDS storage exhaustion diagnosis for the synthetic `003-storage-full` case by making Grafana-backed RDS evidence more explicit in the RCA prompt.

Changes:
- Adds compact Prometheus/Mimir metric summaries for time-series evidence.
- Maps Grafana-backed RDS metrics into structured CloudWatch-style evidence.
- Derives RDS events and Performance Insights evidence from Grafana log streams.
- Renders `FreeStorageSpace` and `WriteIOPS` summaries in the diagnosis prompt instead of truncated raw metric JSON.
- Normalizes fixture-backed Grafana alert rules to match the production `rules` shape.
- Adds focused regression tests for the storage-full Grafana evidence path.

### Demo/Screenshot for feature changes and bug fixes -

Proof:
- `pytest tests\tools\test_grafana_metrics_tool.py tests\tools\test_grafana_alert_rules_tool.py tests\nodes\root_cause_diagnosis\test_rds_grafana_evidence.py -q` passed: `26 passed`
- `pytest tests\synthetic\rds_postgres\test_suite.py -k "score_result or scenario_metadata or scenario_evidence or load_all or inheritance" -q` passed: `12 passed`
- `make typecheck` passed
- `make format-check` passed



### Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue requires the RCA prompt to expose the full storage-exhaustion evidence path: `FreeStorageSpace` collapsing, elevated `WriteIOPS`, the definitive RDS storage event, and the bulk archival `INSERT` shown by Performance Insights. I chose to improve evidence shaping and rendering rather than changing the answer key or hard-coding the scenario.

The main implementation keeps the existing architecture intact: Grafana tools collect raw metrics/logs/rules, post-processing derives structured RDS evidence, and the diagnosis prompt renders concise evidence summaries. The new metric-summary utility preserves raw time-series data while adding first/latest/min/max/peak/trend summaries so the model can reason over the storage and write I/O signals reliably. Tests assert that the generated prompt contains the storage trend, RDS event, alert rule, and bulk `INSERT` evidence.


### Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

### Note for Maintainer/Team/Reviewer Members
please run the following test after setting up your `ANTHROPIC_API_KEY`

```
python -m tests.synthetic.rds_postgres.run_suite --scenario 003-storage-full --mock-grafana --json

```