### PR TITLE
fix(test): set TEST_KEY before OpenAILLMClient in guardrail test

### DIFF
--- a/tests/test_guardrails/test_llm_integration.py
+++ b/tests/test_guardrails/test_llm_integration.py
@@ -238,8 +238,8 @@ class TestOpenAIClientGuardrails:
 
         from app.services.llm_client import OpenAILLMClient
 
-        client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
         monkeypatch.setenv("TEST_KEY", "fake-key")
+        client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
         monkeypatch.setattr(client, "_client", _FakeClient())
         monkeypatch.setattr(client, "_ensure_client", lambda: None)
 


### PR DESCRIPTION
## Summary

OpenAI 2.34+ rejects an empty `api_key` in `OpenAI()`. `TestOpenAIClientGuardrails::test_redacts_before_api_call` constructed `OpenAILLMClient` before setting `TEST_KEY`, so CI failed once the resolver picked 2.34.x.

## Change

- Set `TEST_KEY` before instantiating `OpenAILLMClient` (same order as the `openai_capture` fixture).

No dependency cap: staying on `openai>=2.0.0` and fixing the test is sufficient.
