### PR TITLE
test(coralogix): add direct unit tests for CoralogixClient

### DIFF
--- a/tests/services/test_coralogix_client.py
+++ b/tests/services/test_coralogix_client.py
@@ -1,0 +1,217 @@
+"""Direct tests for CoralogixClient HTTP envelope, NDJSON parsing, and probes."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.integrations.config_models import CoralogixIntegrationConfig
+from app.services.coralogix.client import (
+    CoralogixClient,
+    build_coralogix_logs_query,
+)
+
+# -------------------------
+# Fixtures
+# -------------------------
+
+
+@pytest.fixture
+def config() -> CoralogixIntegrationConfig:
+    return CoralogixIntegrationConfig(
+        api_key="test-key",
+        base_url="https://api.eu2.coralogix.com",
+        application_name="opensre",
+        subsystem_name="api",
+    )
+
+
+@pytest.fixture
+def client(config: CoralogixIntegrationConfig) -> CoralogixClient:
+    return CoralogixClient(config)
+
+
+def _make_ndjson_success_line() -> str:
+    return json.dumps(
+        {
+            "result": {
+                "results": [
+                    {
+                        "metadata": [
+                            {"key": "timestamp", "value": "2026-05-04T00:00:00Z"},
+                        ],
+                        "labels": [
+                            {"key": "applicationname", "value": "opensre"},
+                            {"key": "subsystemname", "value": "api"},
+                        ],
+                        "userData": json.dumps(
+                            {
+                                "log_obj": {
+                                    "message": "boom",
+                                    "level": "ERROR",
+                                    "timestamp": "2026-05-04T00:00:00Z",
+                                },
+                                "trace_id": "abc-123",
+                            }
+                        ),
+                    }
+                ]
+            }
+        }
+    )
+
+
+# -------------------------
+# query_logs
+# -------------------------
+
+
+def test_query_logs_success_parses_ndjson_rows(client: CoralogixClient) -> None:
+    mock_response = MagicMock(text=_make_ndjson_success_line())
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("app.services.coralogix.client.httpx.post", return_value=mock_response) as mock_post:
+        result = client.query_logs("source logs")
+
+    mock_post.assert_called_once()
+    assert result["success"] is True
+    assert result["total"] == 1
+    assert result["logs"][0]["message"] == "boom"
+    assert result["logs"][0]["level"] == "ERROR"
+    assert result["logs"][0]["trace_id"] == "abc-123"
+    assert result["logs"][0]["application_name"] == "opensre"
+    assert result["logs"][0]["subsystem_name"] == "api"
+
+
+def test_query_logs_http_error_returns_failure_envelope(client: CoralogixClient) -> None:
+    mock_response = MagicMock(status_code=500, text="server error")
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    with patch("app.services.coralogix.client.httpx.post", return_value=mock_response):
+        result = client.query_logs("source logs")
+
+    assert result["success"] is False
+    assert "HTTP 500" in result["error"]
+
+
+def test_query_logs_empty_response_returns_zero_logs(client: CoralogixClient) -> None:
+    mock_response = MagicMock(text="")
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("app.services.coralogix.client.httpx.post", return_value=mock_response):
+        result = client.query_logs("source logs")
+
+    assert result["success"] is True
+    assert result["total"] == 0
+    assert result["logs"] == []
+
+
+def test_query_logs_invalid_json_lines_silently_skipped(client: CoralogixClient) -> None:
+    mock_response = MagicMock(text="not json\n{bad json\n")
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("app.services.coralogix.client.httpx.post", return_value=mock_response):
+        result = client.query_logs("source logs")
+
+    assert result["success"] is True
+    assert result["total"] == 0
+    assert result["logs"] == []
+
+
+def test_query_logs_network_exception_returns_failure_envelope(
+    client: CoralogixClient,
+) -> None:
+    with patch(
+        "app.services.coralogix.client.httpx.post",
+        side_effect=httpx.RequestError("connection refused"),
+    ):
+        result = client.query_logs("source logs")
+
+    assert result["success"] is False
+    assert "connection refused" in result["error"]
+
+
+# -------------------------
+# validate_access
+# -------------------------
+
+
+def test_validate_access_passes_through_total_and_warnings(client: CoralogixClient) -> None:
+    with patch.object(
+        client,
+        "query_logs",
+        return_value={
+            "success": True,
+            "total": 3,
+            "warnings": ["heads up"],
+            "logs": [],
+        },
+    ):
+        result = client.validate_access()
+
+    assert result["success"] is True
+    assert result["total"] == 3
+    assert result["warnings"] == ["heads up"]
+
+
+# -------------------------
+# probe_access
+# -------------------------
+
+
+def test_probe_access_missing_when_unconfigured() -> None:
+    bare_client = CoralogixClient(
+        CoralogixIntegrationConfig(api_key="", base_url="https://example.com")
+    )
+
+    probe = bare_client.probe_access()
+
+    assert probe.status == "missing"
+    assert "Missing Coralogix" in probe.detail
+
+
+def test_probe_access_failed_when_query_fails(client: CoralogixClient) -> None:
+    with patch.object(
+        client,
+        "validate_access",
+        return_value={"success": False, "error": "boom"},
+    ):
+        probe = client.probe_access()
+
+    assert probe.status == "failed"
+    assert "DataPrime check failed" in probe.detail
+    assert "boom" in probe.detail
+
+
+def test_probe_access_passed_with_scope_in_message(client: CoralogixClient) -> None:
+    with patch.object(
+        client,
+        "validate_access",
+        return_value={"success": True, "total": 7, "warnings": []},
+    ):
+        probe = client.probe_access()
+
+    assert probe.status == "passed"
+    assert "opensre" in probe.detail
+    assert "api" in probe.detail
+    assert "7 row" in probe.detail
+
+
+# -------------------------
+# build_coralogix_logs_query (pure helper)
+# -------------------------
+
+
+def test_build_coralogix_logs_query_appends_limit_clause() -> None:
+    result = build_coralogix_logs_query(application_name="opensre", limit=5)
+
+    assert result.startswith("source logs")
+    assert "filter $l.applicationname == 'opensre'" in result
+    assert result.endswith("limit 5")

--- a/tests/services/test_coralogix_client.py
+++ b/tests/services/test_coralogix_client.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from app.integrations.config_models import CoralogixIntegrationConfig
+from app.integrations.models import CoralogixIntegrationConfig
 from app.services.coralogix.client import (
     CoralogixClient,
     build_coralogix_logs_query,
@@ -75,8 +75,8 @@ def test_query_logs_success_parses_ndjson_rows(client: CoralogixClient) -> None:
 
     with patch("app.services.coralogix.client.httpx.post", return_value=mock_response) as mock_post:
         result = client.query_logs("source logs")
+        mock_post.assert_called_once()
 
-    mock_post.assert_called_once()
     assert result["success"] is True
     assert result["total"] == 1
     assert result["logs"][0]["message"] == "boom"
@@ -214,4 +214,25 @@ def test_build_coralogix_logs_query_appends_limit_clause() -> None:
 
     assert result.startswith("source logs")
     assert "filter $l.applicationname == 'opensre'" in result
+    assert result.endswith("limit 5")
+
+
+def test_build_coralogix_logs_query_raw_query_passthrough_appends_limit() -> None:
+    result = build_coralogix_logs_query(
+        raw_query="source logs | filter foo == 'bar'",
+        application_name="ignored",
+        subsystem_name="ignored",
+        limit=10,
+    )
+
+    assert result == "source logs | filter foo == 'bar' | limit 10"
+    assert "applicationname" not in result
+    assert "subsystemname" not in result
+
+
+def test_build_coralogix_logs_query_subsystem_name_filter() -> None:
+    result = build_coralogix_logs_query(subsystem_name="api-gateway", limit=5)
+
+    assert result.startswith("source logs")
+    assert "filter $l.subsystemname == 'api-gateway'" in result
     assert result.endswith("limit 5")


### PR DESCRIPTION
Fixes #877 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Adds direct unit tests for CoralogixClient at tests/services/test_coralogix_client.py. The client was only tested indirectly through the tool layer, so its return envelopes weren't pinned.

10 tests covering query_logs (success, HTTP error, empty, invalid JSON, network exception), validate_access, probe_access (missing/failed/passed), and the build_coralogix_logs_query helper.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->
<img width="843" height="252" alt="image" src="https://github.com/user-attachments/assets/5dadd47d-af89-4168-9734-1b7383a96815" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

 - CoralogixClient was only tested transitively via the tool tests, so its envelope shape wasn't directly asserted. The new tests patch app.services.coralogix.client.httpx.post (module-level, not httpx.Client) and verify each branch: success returns parsed logs, HTTP errors return {success: False, error: "HTTP <code>..."}, empty/garbage responses don't crash, and probe_access returns the right ProbeResult status for each branch. Style follows tests/services/test_datadog_client.py.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


