### PR TITLE
feat(rds): RDS integration with describe instance and events tools

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -41,6 +41,11 @@ from app.integrations.mysql import build_mysql_config
 from app.integrations.openclaw import build_openclaw_config
 from app.integrations.postgresql import build_postgresql_config
 from app.integrations.rabbitmq import build_rabbitmq_config
+from app.integrations.rds import (
+    DEFAULT_RDS_REGION,
+    build_rds_config,
+    rds_config_from_env,
+)
 from app.integrations.registry import (
     DIRECT_CLASSIFIED_EFFECTIVE_SERVICES,
     SKIP_CLASSIFIED_SERVICES,
@@ -517,6 +522,20 @@ def _classify_service_instance(
                 "verify_ssl": rabbitmq_config.verify_ssl,
                 "integration_id": record_id,
             }, "rabbitmq"
+        return None, None
+
+    if key == "rds":
+        try:
+            rds_config = build_rds_config(
+                {
+                    "db_instance_identifier": credentials.get("db_instance_identifier", ""),
+                    "region": credentials.get("region", DEFAULT_RDS_REGION),
+                }
+            )
+        except Exception:
+            return None, None
+        if rds_config.is_configured:
+            return {**rds_config.model_dump(), "integration_id": record_id}, "rds"
         return None, None
 
     if key == "airflow":
@@ -1272,6 +1291,19 @@ def load_env_integrations() -> list[dict[str, Any]]:
             )
         except Exception:
             logger.debug("Failed to load RabbitMQ config from env", exc_info=True)
+
+    try:
+        rds_config = rds_config_from_env()
+    except Exception:
+        rds_config = None
+        logger.debug("Failed to load RDS config from env", exc_info=True)
+    if rds_config is not None and rds_config.is_configured:
+        integrations.append(
+            _active_env_record(
+                "rds",
+                rds_config.model_dump(exclude={"integration_id"}),
+            )
+        )
 
     bs_endpoint = os.getenv("BETTERSTACK_QUERY_ENDPOINT", "").strip()
     bs_username = os.getenv("BETTERSTACK_USERNAME", "").strip()

--- a/app/integrations/rds.py
+++ b/app/integrations/rds.py
@@ -40,9 +40,7 @@ def rds_config_from_env() -> RDSConfig | None:
     return build_rds_config(
         {
             "db_instance_identifier": db_id,
-            "region": env_str("AWS_REGION")
-            or env_str("RDS_REGION")
-            or DEFAULT_RDS_REGION,
+            "region": env_str("AWS_REGION") or env_str("RDS_REGION") or DEFAULT_RDS_REGION,
         }
     )
 

--- a/app/integrations/rds.py
+++ b/app/integrations/rds.py
@@ -1,0 +1,62 @@
+"""Shared AWS RDS integration helpers.
+
+Provides configuration normalization, source detection, and parameter
+extraction for the RDS investigation tools. All AWS API calls are
+read-only and routed through the shared aws_sdk_client allowlist.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from app.integrations._relational import env_str
+from app.strict_config import StrictConfigModel
+
+DEFAULT_RDS_REGION = "us-east-1"
+
+
+class RDSConfig(StrictConfigModel):
+    """Normalized RDS connection settings."""
+
+    db_instance_identifier: str = ""
+    region: str = DEFAULT_RDS_REGION
+    integration_id: str = ""
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.db_instance_identifier and self.region)
+
+
+def build_rds_config(raw: dict[str, Any] | None) -> RDSConfig:
+    """Build a normalized RDS config object from env/store data."""
+    return RDSConfig.model_validate(raw or {})
+
+
+def rds_config_from_env() -> RDSConfig | None:
+    """Load an RDS config from env vars."""
+    db_id = env_str("RDS_DB_INSTANCE_IDENTIFIER")
+    if not db_id:
+        return None
+    return build_rds_config(
+        {
+            "db_instance_identifier": db_id,
+            "region": env_str("AWS_REGION", DEFAULT_RDS_REGION)
+            or env_str("RDS_REGION", DEFAULT_RDS_REGION),
+        }
+    )
+
+
+def rds_is_available(sources: dict[str, dict]) -> bool:
+    """Check if RDS integration identifying params are present."""
+    rds = sources.get("rds", {})
+    return bool(rds.get("db_instance_identifier"))
+
+
+def rds_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    """Extract RDS identifying params (db_instance_identifier, region)."""
+    rds = sources.get("rds", {})
+    return {
+        "db_instance_identifier": str(rds.get("db_instance_identifier", "")).strip(),
+        "region": str(rds.get("region") or os.getenv("AWS_REGION", DEFAULT_RDS_REGION)).strip(),
+    }

--- a/app/integrations/rds.py
+++ b/app/integrations/rds.py
@@ -7,7 +7,6 @@ read-only and routed through the shared aws_sdk_client allowlist.
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 from app.integrations._relational import env_str
@@ -41,8 +40,9 @@ def rds_config_from_env() -> RDSConfig | None:
     return build_rds_config(
         {
             "db_instance_identifier": db_id,
-            "region": env_str("AWS_REGION", DEFAULT_RDS_REGION)
-            or env_str("RDS_REGION", DEFAULT_RDS_REGION),
+            "region": env_str("AWS_REGION")
+            or env_str("RDS_REGION")
+            or DEFAULT_RDS_REGION,
         }
     )
 
@@ -56,7 +56,13 @@ def rds_is_available(sources: dict[str, dict]) -> bool:
 def rds_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     """Extract RDS identifying params (db_instance_identifier, region)."""
     rds = sources.get("rds", {})
+    region = (
+        str(rds.get("region") or "").strip()
+        or env_str("AWS_REGION")
+        or env_str("RDS_REGION")
+        or DEFAULT_RDS_REGION
+    )
     return {
         "db_instance_identifier": str(rds.get("db_instance_identifier", "")).strip(),
-        "region": str(rds.get("region") or os.getenv("AWS_REGION", DEFAULT_RDS_REGION)).strip(),
+        "region": region,
     }

--- a/app/nodes/plan_actions/detect_sources.py
+++ b/app/nodes/plan_actions/detect_sources.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from app.integrations.azure_sql import DEFAULT_AZURE_SQL_PORT
 from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
 from app.integrations.opensre.inject import inject_opensre_into_resolved_integrations
+from app.integrations.rds import DEFAULT_RDS_REGION
 from app.services.coralogix import build_coralogix_logs_query
 from app.services.splunk import build_splunk_spl_query
 from app.tools.GrafanaLogsTool import _map_pipeline_to_service_name
@@ -1213,6 +1214,14 @@ def detect_sources(
             "ssl": rabbitmq_int.get("ssl", False),
             "verify_ssl": rabbitmq_int.get("verify_ssl", True),
             "connection_verified": True,
+        }
+
+    rds_int = (resolved_integrations or {}).get("rds")
+    if rds_int and str(rds_int.get("db_instance_identifier", "")).strip():
+        sources["rds"] = {
+            "db_instance_identifier": str(rds_int.get("db_instance_identifier", "")).strip(),
+            "region": str(rds_int.get("region") or DEFAULT_RDS_REGION).strip()
+            or DEFAULT_RDS_REGION,
         }
 
     betterstack_int = (resolved_integrations or {}).get("betterstack")

--- a/app/tools/RDSDescribeInstanceTool/__init__.py
+++ b/app/tools/RDSDescribeInstanceTool/__init__.py
@@ -1,0 +1,102 @@
+"""RDS instance description tool — backed by aws_sdk_client."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.integrations.rds import (
+    DEFAULT_RDS_REGION,
+    rds_extract_params,
+    rds_is_available,
+)
+from app.services.aws_sdk_client import execute_aws_sdk_call
+from app.tools.tool_decorator import tool
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    name="describe_rds_instance",
+    source="rds",
+    description=(
+        "Describe an AWS RDS database instance — engine, version, status, "
+        "storage, Multi-AZ, endpoint, and parameter groups."
+    ),
+    use_cases=[
+        "Investigating instance-level issues: status, availability, engine version",
+        "Checking if Multi-AZ is enabled or storage is misconfigured",
+        "Verifying RDS instance status (available, modifying, failed)",
+    ],
+    requires=["db_instance_identifier"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "db_instance_identifier": {"type": "string"},
+            "region": {"type": "string", "default": DEFAULT_RDS_REGION},
+        },
+        "required": ["db_instance_identifier"],
+    },
+    is_available=rds_is_available,
+    extract_params=rds_extract_params,
+)
+def describe_rds_instance(
+    db_instance_identifier: str,
+    region: str = DEFAULT_RDS_REGION,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Describe an RDS instance — status, engine, storage, networking."""
+    logger.info(
+        "[rds] describe_rds_instance db=%s region=%s",
+        db_instance_identifier,
+        region,
+    )
+
+    result = execute_aws_sdk_call(
+        service_name="rds",
+        operation_name="describe_db_instances",
+        parameters={"DBInstanceIdentifier": db_instance_identifier},
+        region=region,
+    )
+
+    if not result.get("success"):
+        return {
+            "source": "rds",
+            "available": False,
+            "db_instance_identifier": db_instance_identifier,
+            "error": result.get("error"),
+        }
+
+    instances = (result.get("data") or {}).get("DBInstances") or []
+    if not instances:
+        return {
+            "source": "rds",
+            "available": False,
+            "db_instance_identifier": db_instance_identifier,
+            "error": "No RDS instance found with the given identifier.",
+        }
+
+    instance = instances[0]
+    endpoint = instance.get("Endpoint") or {}
+
+    return {
+        "source": "rds",
+        "available": True,
+        "db_instance_identifier": db_instance_identifier,
+        "status": instance.get("DBInstanceStatus"),
+        "engine": instance.get("Engine"),
+        "engine_version": instance.get("EngineVersion"),
+        "instance_class": instance.get("DBInstanceClass"),
+        "multi_az": instance.get("MultiAZ"),
+        "publicly_accessible": instance.get("PubliclyAccessible"),
+        "storage_type": instance.get("StorageType"),
+        "allocated_storage_gb": instance.get("AllocatedStorage"),
+        "endpoint": {
+            "address": endpoint.get("Address"),
+            "port": endpoint.get("Port"),
+        },
+        "availability_zone": instance.get("AvailabilityZone"),
+        "preferred_backup_window": instance.get("PreferredBackupWindow"),
+        "backup_retention_period": instance.get("BackupRetentionPeriod"),
+        "error": None,
+    }

--- a/app/tools/RDSDescribeInstanceTool/__init__.py
+++ b/app/tools/RDSDescribeInstanceTool/__init__.py
@@ -60,11 +60,17 @@ def describe_rds_instance(
     )
 
     if not result.get("success"):
+        logger.error(
+            "[rds] describe_db_instances failed for db=%s region=%s: %s",
+            db_instance_identifier,
+            region,
+            result.get("error"),
+        )
         return {
             "source": "rds",
             "available": False,
             "db_instance_identifier": db_instance_identifier,
-            "error": result.get("error"),
+            "error": "Failed to describe the RDS instance. Check server logs for details.",
         }
 
     instances = (result.get("data") or {}).get("DBInstances") or []
@@ -75,6 +81,14 @@ def describe_rds_instance(
             "db_instance_identifier": db_instance_identifier,
             "error": "No RDS instance found with the given identifier.",
         }
+
+    if len(instances) > 1:
+        logger.warning(
+            "[rds] describe_db_instances returned %d instances for db=%s; "
+            "using the first result only.",
+            len(instances),
+            db_instance_identifier,
+        )
 
     instance = instances[0]
     endpoint = instance.get("Endpoint") or {}

--- a/app/tools/RDSEventsTool/__init__.py
+++ b/app/tools/RDSEventsTool/__init__.py
@@ -74,11 +74,17 @@ def describe_rds_events(
     )
 
     if not result.get("success"):
+        logger.error(
+            "[rds] describe_events failed for db=%s region=%s: %s",
+            db_instance_identifier,
+            region,
+            result.get("error"),
+        )
         return {
             "source": "rds",
             "available": False,
             "db_instance_identifier": db_instance_identifier,
-            "error": result.get("error"),
+            "error": "Failed to describe RDS events. Check server logs for details.",
         }
 
     raw_events = (result.get("data") or {}).get("Events") or []

--- a/app/tools/RDSEventsTool/__init__.py
+++ b/app/tools/RDSEventsTool/__init__.py
@@ -1,0 +1,103 @@
+"""RDS events tool — recent failover, maintenance, and configuration events."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.integrations.rds import (
+    DEFAULT_RDS_REGION,
+    rds_extract_params,
+    rds_is_available,
+)
+from app.services.aws_sdk_client import execute_aws_sdk_call
+from app.tools.tool_decorator import tool
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DURATION_MINUTES = 60
+
+
+@tool(
+    name="describe_rds_events",
+    source="rds",
+    description=(
+        "Describe recent AWS RDS events for a DB instance — failovers, "
+        "maintenance windows, parameter changes, and backup events."
+    ),
+    use_cases=[
+        "Investigating Multi-AZ failover events",
+        "Checking recent maintenance or parameter group changes",
+        "Tracing backup or recovery events around an incident",
+    ],
+    requires=["db_instance_identifier"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "db_instance_identifier": {"type": "string"},
+            "region": {"type": "string", "default": DEFAULT_RDS_REGION},
+            "duration_minutes": {
+                "type": "integer",
+                "default": DEFAULT_DURATION_MINUTES,
+                "minimum": 1,
+                "maximum": 20160,
+            },
+        },
+        "required": ["db_instance_identifier"],
+    },
+    is_available=rds_is_available,
+    extract_params=rds_extract_params,
+)
+def describe_rds_events(
+    db_instance_identifier: str,
+    region: str = DEFAULT_RDS_REGION,
+    duration_minutes: int = DEFAULT_DURATION_MINUTES,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    """Describe recent RDS events for a DB instance."""
+    logger.info(
+        "[rds] describe_rds_events db=%s region=%s duration=%s",
+        db_instance_identifier,
+        region,
+        duration_minutes,
+    )
+
+    result = execute_aws_sdk_call(
+        service_name="rds",
+        operation_name="describe_events",
+        parameters={
+            "SourceIdentifier": db_instance_identifier,
+            "SourceType": "db-instance",
+            "Duration": duration_minutes,
+        },
+        region=region,
+    )
+
+    if not result.get("success"):
+        return {
+            "source": "rds",
+            "available": False,
+            "db_instance_identifier": db_instance_identifier,
+            "error": result.get("error"),
+        }
+
+    raw_events = (result.get("data") or {}).get("Events") or []
+    events = [
+        {
+            "date": event.get("Date"),
+            "message": event.get("Message"),
+            "categories": event.get("EventCategories", []),
+            "source_type": event.get("SourceType"),
+        }
+        for event in raw_events
+    ]
+
+    return {
+        "source": "rds",
+        "available": True,
+        "db_instance_identifier": db_instance_identifier,
+        "duration_minutes": duration_minutes,
+        "total_events": len(events),
+        "events": events,
+        "error": None,
+    }

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -46,4 +46,5 @@ EvidenceSource = Literal[
     "airflow",
     "argocd",
     "victoria_logs",
+    "rds",
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -130,7 +130,8 @@
               "openclaw",
               "postgresql",
               "prefect",
-              "rabbitmq"
+              "rabbitmq",
+              "rds"
             ]
           }
         ]

--- a/docs/rds.mdx
+++ b/docs/rds.mdx
@@ -1,0 +1,81 @@
+---
+title: "AWS RDS"
+description: "Investigate AWS RDS instance health and recent events during incidents"
+---
+
+OpenSRE uses AWS RDS to investigate database instance health and surface recent operational events — failovers, maintenance windows, parameter changes, and backup activity — when an alert fires against a managed RDS database.
+
+All RDS API calls are read-only and routed through the shared `aws_sdk_client` allowlist, so the integration cannot mutate your RDS resources.
+
+## Prerequisites
+
+- AWS credentials configured per the [AWS integration](/aws) (role ARN recommended)
+- An RDS DB instance you want OpenSRE to investigate
+- IAM permissions for the two RDS describe actions listed below
+
+## Setup
+
+### Environment variables
+
+```bash
+RDS_DB_INSTANCE_IDENTIFIER=prod-orders-db
+AWS_REGION=us-east-1
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RDS_DB_INSTANCE_IDENTIFIER` | — | Required. The DB instance identifier OpenSRE should investigate. |
+| `AWS_REGION` | `us-east-1` | AWS region the instance lives in. Used by both the integration config and per-tool param extraction. |
+| `RDS_REGION` | `us-east-1` | Fallback used only when `AWS_REGION` is not set. |
+
+Region resolution order (highest priority first):
+
+1. `region` field on the source dict (when configured via the integrations store)
+2. `AWS_REGION` environment variable
+3. `RDS_REGION` environment variable
+4. `us-east-1` (default)
+
+## IAM permissions
+
+The integration only needs two read-only RDS actions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBInstances",
+        "rds:DescribeEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Attach this policy to the same IAM role or user already configured for the [AWS integration](/aws). If you are already using the AWS managed `ReadOnlyAccess` policy, both actions are already covered.
+
+## Tools
+
+| Tool | AWS API call | What it returns |
+| --- | --- | --- |
+| `describe_rds_instance` | `rds:DescribeDBInstances` | Instance status, engine + version, instance class, Multi-AZ flag, endpoint address/port, storage type and size, availability zone, and backup window. |
+| `describe_rds_events` | `rds:DescribeEvents` | Recent events for the DB instance — failovers, maintenance, parameter group changes, and backup activity. Defaults to the last 60 minutes; bounded to 20160 minutes (14 days, the AWS limit). |
+
+Both tools become available to the planner whenever `rds.db_instance_identifier` is present in the resolved sources.
+
+### Use cases
+
+- Verifying RDS instance status (`available`, `modifying`, `failed`) when an alert fires
+- Detecting Multi-AZ failover events around an incident timestamp
+- Tracing recent maintenance, parameter group changes, or backup activity that may correlate with the incident
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| **AccessDenied on `rds:DescribeDBInstances`** | Add the IAM policy above to the role or user used by the AWS integration. |
+| **DBInstanceNotFound** | Confirm `RDS_DB_INSTANCE_IDENTIFIER` matches an instance in `AWS_REGION`. |
+| **Tool reports the wrong region** | Either `AWS_REGION` is set to a different region, or the source dict has a stale `region` field. Check the resolution order above. |

--- a/tests/integrations/test_rds.py
+++ b/tests/integrations/test_rds.py
@@ -93,3 +93,46 @@ def test_rds_config_from_env_uses_rds_region_when_aws_region_unset() -> None:
         config = rds_config_from_env()
         assert config is not None
         assert config.region == "ap-northeast-1"
+
+
+def test_rds_env_discovery_to_sources_pipeline() -> None:
+    """Regression: env-set RDS config flows through env-discovery,
+    catalog classification, and detect_sources into the sources dict."""
+    from app.integrations._catalog_impl import (
+        _classify_service_instance,
+        load_env_integrations,
+    )
+    from app.nodes.plan_actions.detect_sources import detect_sources
+
+    env = {
+        "RDS_DB_INSTANCE_IDENTIFIER": "prod-orders-db",
+        "AWS_REGION": "eu-west-1",
+    }
+
+    with patch.dict(os.environ, env, clear=True):
+        env_records = load_env_integrations()
+
+    rds_records = [r for r in env_records if r.get("service") == "rds"]
+    assert len(rds_records) == 1, "load_env_integrations must register an rds record"
+    record = rds_records[0]
+    assert record["status"] == "active"
+    assert record["credentials"]["db_instance_identifier"] == "prod-orders-db"
+    assert record["credentials"]["region"] == "eu-west-1"
+
+    flat, resolved_key = _classify_service_instance(
+        "rds", record["credentials"], record_id=record["id"]
+    )
+    assert resolved_key == "rds"
+    assert flat is not None
+    assert flat["db_instance_identifier"] == "prod-orders-db"
+    assert flat["region"] == "eu-west-1"
+    assert "credentials" not in flat, "rds classifier must produce a flat shape"
+
+    sources = detect_sources(
+        raw_alert={},
+        context={},
+        resolved_integrations={"rds": flat},
+    )
+    assert "rds" in sources, "detect_sources must propagate rds into the sources dict"
+    assert sources["rds"]["db_instance_identifier"] == "prod-orders-db"
+    assert sources["rds"]["region"] == "eu-west-1"

--- a/tests/integrations/test_rds.py
+++ b/tests/integrations/test_rds.py
@@ -1,0 +1,70 @@
+"""Tests for app.integrations.rds helpers."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from app.integrations.rds import (
+    DEFAULT_RDS_REGION,
+    RDSConfig,
+    build_rds_config,
+    rds_config_from_env,
+    rds_extract_params,
+    rds_is_available,
+)
+
+
+def test_build_rds_config_with_data() -> None:
+    config = build_rds_config({"db_instance_identifier": "prod-db", "region": "us-west-2"})
+    assert isinstance(config, RDSConfig)
+    assert config.db_instance_identifier == "prod-db"
+    assert config.region == "us-west-2"
+    assert config.is_configured is True
+
+
+def test_build_rds_config_with_none_returns_empty() -> None:
+    config = build_rds_config(None)
+    assert config.db_instance_identifier == ""
+    assert config.region == DEFAULT_RDS_REGION
+    assert config.is_configured is False
+
+
+def test_rds_config_from_env_returns_none_when_db_missing() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        assert rds_config_from_env() is None
+
+
+def test_rds_config_from_env_returns_config_when_set() -> None:
+    env = {
+        "RDS_DB_INSTANCE_IDENTIFIER": "staging-db",
+        "AWS_REGION": "eu-west-1",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        config = rds_config_from_env()
+        assert config is not None
+        assert config.db_instance_identifier == "staging-db"
+        assert config.region == "eu-west-1"
+
+
+def test_rds_is_available_true_when_db_present() -> None:
+    sources = {"rds": {"db_instance_identifier": "prod-db"}}
+    assert rds_is_available(sources) is True
+
+
+def test_rds_is_available_false_when_missing() -> None:
+    assert rds_is_available({}) is False
+    assert rds_is_available({"rds": {}}) is False
+
+
+def test_rds_extract_params_returns_normalized_dict() -> None:
+    sources = {"rds": {"db_instance_identifier": "  prod-db  ", "region": "  us-east-2 "}}
+    params = rds_extract_params(sources)
+    assert params == {"db_instance_identifier": "prod-db", "region": "us-east-2"}
+
+
+def test_rds_extract_params_falls_back_to_env_region() -> None:
+    sources = {"rds": {"db_instance_identifier": "prod-db"}}
+    with patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=True):
+        params = rds_extract_params(sources)
+        assert params["region"] == "ap-south-1"

--- a/tests/integrations/test_rds.py
+++ b/tests/integrations/test_rds.py
@@ -136,3 +136,91 @@ def test_rds_env_discovery_to_sources_pipeline() -> None:
     assert "rds" in sources, "detect_sources must propagate rds into the sources dict"
     assert sources["rds"]["db_instance_identifier"] == "prod-orders-db"
     assert sources["rds"]["region"] == "eu-west-1"
+
+
+def test_load_env_integrations_skips_rds_when_db_id_missing() -> None:
+    """Gap #1 — negative: with no RDS_DB_INSTANCE_IDENTIFIER, no rds record."""
+    from app.integrations._catalog_impl import load_env_integrations
+
+    with patch.dict(os.environ, {"AWS_REGION": "us-west-2"}, clear=True):
+        env_records = load_env_integrations()
+
+    assert not [r for r in env_records if r.get("service") == "rds"]
+
+
+def test_classify_service_instance_rds_remote_store_returns_flat_shape() -> None:
+    """Gap #2 — remote-store path: a stored RDS record must classify to a flat
+    shape, not the generic {credentials: ...} fallback that broke rds_is_available."""
+    from app.integrations._catalog_impl import _classify_service_instance
+
+    credentials = {
+        "db_instance_identifier": "remote-db",
+        "region": "ap-southeast-2",
+    }
+    flat, resolved_key = _classify_service_instance("rds", credentials, record_id="store-record-42")
+
+    assert resolved_key == "rds"
+    assert flat is not None
+    assert flat["db_instance_identifier"] == "remote-db"
+    assert flat["region"] == "ap-southeast-2"
+    assert flat["integration_id"] == "store-record-42"
+    assert "credentials" not in flat, (
+        "remote-store rds must NOT nest fields under 'credentials' — "
+        "rds_is_available reads sources['rds']['db_instance_identifier'] directly"
+    )
+
+
+def test_classify_service_instance_rds_skips_when_db_id_missing() -> None:
+    """Gap #2 — negative: an unconfigured rds record must classify to (None, None)."""
+    from app.integrations._catalog_impl import _classify_service_instance
+
+    flat, resolved_key = _classify_service_instance(
+        "rds", {"region": "us-east-1"}, record_id="incomplete"
+    )
+
+    assert flat is None and resolved_key is None
+
+
+def test_detect_sources_propagates_rds_into_sources() -> None:
+    """Gap #3 — propagation: a resolved 'rds' integration must land in sources."""
+    from app.nodes.plan_actions.detect_sources import detect_sources
+
+    sources = detect_sources(
+        raw_alert={},
+        context={},
+        resolved_integrations={
+            "rds": {
+                "db_instance_identifier": "prod-orders-db",
+                "region": "eu-west-1",
+                "integration_id": "env-rds",
+            }
+        },
+    )
+
+    assert sources.get("rds") == {
+        "db_instance_identifier": "prod-orders-db",
+        "region": "eu-west-1",
+    }
+
+
+def test_detect_sources_skips_rds_when_not_in_resolved_integrations() -> None:
+    """Gap #3 — negative: no rds in resolved means no rds in sources."""
+    from app.nodes.plan_actions.detect_sources import detect_sources
+
+    sources = detect_sources(raw_alert={}, context={}, resolved_integrations={})
+
+    assert "rds" not in sources
+
+
+def test_detect_sources_skips_rds_when_db_id_blank() -> None:
+    """Gap #3 — negative: a resolved rds entry with empty db_instance_identifier
+    must not produce a sources['rds'] entry that would mislead rds_is_available."""
+    from app.nodes.plan_actions.detect_sources import detect_sources
+
+    sources = detect_sources(
+        raw_alert={},
+        context={},
+        resolved_integrations={"rds": {"db_instance_identifier": "  ", "region": "us-east-1"}},
+    )
+
+    assert "rds" not in sources

--- a/tests/integrations/test_rds.py
+++ b/tests/integrations/test_rds.py
@@ -68,3 +68,28 @@ def test_rds_extract_params_falls_back_to_env_region() -> None:
     with patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=True):
         params = rds_extract_params(sources)
         assert params["region"] == "ap-south-1"
+
+
+def test_rds_extract_params_falls_back_to_rds_region_when_aws_region_unset() -> None:
+    sources = {"rds": {"db_instance_identifier": "prod-db"}}
+    with patch.dict(os.environ, {"RDS_REGION": "ca-central-1"}, clear=True):
+        params = rds_extract_params(sources)
+        assert params["region"] == "ca-central-1"
+
+
+def test_rds_extract_params_defaults_when_no_env_or_source_region() -> None:
+    sources = {"rds": {"db_instance_identifier": "prod-db"}}
+    with patch.dict(os.environ, {}, clear=True):
+        params = rds_extract_params(sources)
+        assert params["region"] == DEFAULT_RDS_REGION
+
+
+def test_rds_config_from_env_uses_rds_region_when_aws_region_unset() -> None:
+    env = {
+        "RDS_DB_INSTANCE_IDENTIFIER": "staging-db",
+        "RDS_REGION": "ap-northeast-1",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        config = rds_config_from_env()
+        assert config is not None
+        assert config.region == "ap-northeast-1"

--- a/tests/tools/test_rds_tools.py
+++ b/tests/tools/test_rds_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 from app.tools.RDSDescribeInstanceTool import describe_rds_instance
@@ -56,6 +57,39 @@ def test_describe_rds_instance_aws_failure(mock_call) -> None:
     result = describe_rds_instance("prod-db")
     assert result["available"] is False
     assert result["error"] == "Failed to describe the RDS instance. Check server logs for details."
+
+
+@patch("app.tools.RDSDescribeInstanceTool.execute_aws_sdk_call")
+def test_describe_rds_instance_multiple_instances_warns(mock_call, caplog) -> None:
+    """When AWS returns >1 instance, use the first and emit a warning."""
+    mock_call.return_value = {
+        "success": True,
+        "data": {
+            "DBInstances": [
+                {
+                    "DBInstanceStatus": "available",
+                    "Engine": "postgres",
+                    "EngineVersion": "15.4",
+                    "DBInstanceClass": "db.t4g.micro",
+                    "Endpoint": {"Address": "prod.abc.rds.aws", "Port": 5432},
+                },
+                {
+                    "DBInstanceStatus": "available",
+                    "Engine": "mysql",
+                    "EngineVersion": "8.0",
+                    "DBInstanceClass": "db.r6g.large",
+                    "Endpoint": {"Address": "replica.abc.rds.aws", "Port": 3306},
+                },
+            ]
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = describe_rds_instance("prod-db")
+
+    assert result["available"] is True
+    assert result["engine"] == "postgres"  # first instance used
+    assert "returned 2 instances" in caplog.text
 
 
 @patch("app.tools.RDSEventsTool.execute_aws_sdk_call")

--- a/tests/tools/test_rds_tools.py
+++ b/tests/tools/test_rds_tools.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from app.tools.RDSDescribeInstanceTool import describe_rds_instance
-
 from app.tools.RDSEventsTool import describe_rds_events
 
 

--- a/tests/tools/test_rds_tools.py
+++ b/tests/tools/test_rds_tools.py
@@ -1,0 +1,100 @@
+"""Tests for the RDS investigation tools."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.tools.RDSDescribeInstanceTool import describe_rds_instance
+
+from app.tools.RDSEventsTool import describe_rds_events
+
+
+@patch("app.tools.RDSDescribeInstanceTool.execute_aws_sdk_call")
+def test_describe_rds_instance_success(mock_call) -> None:
+    mock_call.return_value = {
+        "success": True,
+        "data": {
+            "DBInstances": [
+                {
+                    "DBInstanceStatus": "available",
+                    "Engine": "postgres",
+                    "EngineVersion": "15.4",
+                    "DBInstanceClass": "db.t4g.micro",
+                    "MultiAZ": True,
+                    "PubliclyAccessible": False,
+                    "StorageType": "gp3",
+                    "AllocatedStorage": 20,
+                    "Endpoint": {"Address": "prod.abc.rds.aws", "Port": 5432},
+                    "AvailabilityZone": "us-east-1a",
+                    "PreferredBackupWindow": "03:00-04:00",
+                    "BackupRetentionPeriod": 7,
+                }
+            ]
+        },
+    }
+
+    result = describe_rds_instance("prod-db", region="us-east-1")
+    assert result["available"] is True
+    assert result["status"] == "available"
+    assert result["engine"] == "postgres"
+    assert result["multi_az"] is True
+    assert result["endpoint"]["port"] == 5432
+
+
+@patch("app.tools.RDSDescribeInstanceTool.execute_aws_sdk_call")
+def test_describe_rds_instance_not_found(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"DBInstances": []}}
+
+    result = describe_rds_instance("missing-db")
+    assert result["available"] is False
+    assert "No RDS instance" in result["error"]
+
+
+@patch("app.tools.RDSDescribeInstanceTool.execute_aws_sdk_call")
+def test_describe_rds_instance_aws_failure(mock_call) -> None:
+    mock_call.return_value = {"success": False, "error": "AccessDenied"}
+
+    result = describe_rds_instance("prod-db")
+    assert result["available"] is False
+    assert result["error"] == "AccessDenied"
+
+
+@patch("app.tools.RDSEventsTool.execute_aws_sdk_call")
+def test_describe_rds_events_success(mock_call) -> None:
+    mock_call.return_value = {
+        "success": True,
+        "data": {
+            "Events": [
+                {
+                    "Date": "2026-05-05T12:00:00Z",
+                    "Message": "Multi-AZ instance failover started",
+                    "EventCategories": ["failover"],
+                    "SourceType": "db-instance",
+                }
+            ]
+        },
+    }
+
+    result = describe_rds_events("prod-db", duration_minutes=120)
+    assert result["available"] is True
+    assert result["total_events"] == 1
+    assert result["events"][0]["categories"] == ["failover"]
+
+
+@patch("app.tools.RDSEventsTool.execute_aws_sdk_call")
+def test_describe_rds_events_no_events(mock_call) -> None:
+    mock_call.return_value = {"success": True, "data": {"Events": []}}
+
+    result = describe_rds_events("prod-db")
+    assert result["available"] is True
+    assert result["total_events"] == 0
+    assert result["events"] == []
+
+
+@patch("app.tools.RDSEventsTool.execute_aws_sdk_call")
+def test_describe_rds_events_failure(mock_call) -> None:
+    mock_call.return_value = {"success": False, "error": "ThrottlingException"}
+
+    result = describe_rds_events("prod-db")
+    assert result["available"] is False
+    assert result["error"] == "ThrottlingException"

--- a/tests/tools/test_rds_tools.py
+++ b/tests/tools/test_rds_tools.py
@@ -55,7 +55,7 @@ def test_describe_rds_instance_aws_failure(mock_call) -> None:
 
     result = describe_rds_instance("prod-db")
     assert result["available"] is False
-    assert result["error"] == "AccessDenied"
+    assert result["error"] == "Failed to describe the RDS instance. Check server logs for details."
 
 
 @patch("app.tools.RDSEventsTool.execute_aws_sdk_call")
@@ -96,4 +96,4 @@ def test_describe_rds_events_failure(mock_call) -> None:
 
     result = describe_rds_events("prod-db")
     assert result["available"] is False
-    assert result["error"] == "ThrottlingException"
+    assert result["error"] == "Failed to describe RDS events. Check server logs for details."


### PR DESCRIPTION
- Add app/integrations/rds.py for source detection and param extraction
- Add RDSDescribeInstanceTool for instance status and configuration
- Add RDSEventsTool for failover, maintenance, and parameter events
- Use shared aws_sdk_client read-only allowlist for safety
- Add unit tests for integration helpers and both tools
- Add "rds" to EvidenceSource literal in app/types/evidence.py

Closes #125

Fixes #125

#### Describe the changes you have made in this PR -

This PR adds AWS RDS as a first-class integration source so the agent can investigate RDS instance health and recent events during incidents.

- **`app/integrations/rds.py`** — config builder, env-based config, `rds_is_available` source detector, and `rds_extract_params` to normalize tool inputs. Mirrors the shape used by other AWS integrations.
- **`app/tools/RDSDescribeInstanceTool/`** — read-only tool that calls `rds:DescribeDBInstances` and returns status, engine, version, instance class, Multi-AZ, networking, storage, and backup config.
- **`app/tools/RDSEventsTool/`** — read-only tool that calls `rds:DescribeEvents` to surface failovers, maintenance, parameter changes, and backup events around an incident window.
- **`app/types/evidence.py`** — adds `"rds"` to the `EvidenceSource` literal. Without this, the `@tool(source="rds", ...)` decorator on both new tools fails `mypy` (no matching overload).
- **Tests** — `tests/integrations/test_rds.py` (4) and `tests/tools/test_rds_tools.py` (6); 14 new tests total, all passing.

Both tools route through the existing `app/services/aws_sdk_client.py`, which enforces a read-only boto3 allowlist — RDS gets the same safety treatment as the existing CloudWatch, EKS, and Lambda tools.

### Demo/Screenshot for feature changes and bug fixes -

```
$ .venv/bin/python -m pytest tests/integrations/test_rds.py tests/tools/test_rds_tools.py
...
============================== 14 passed in 0.77s ==============================

$ .venv/bin/python -m mypy app/
Success: no issues found in 460 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem: the agent had no way to investigate RDS during incidents — there was an `app/integrations/rds.py` skeleton with 0% coverage but no tools wired up.

I followed the pattern already established for AWS services in the repo (CloudWatch, EKS, Lambda):

1. **Integration layer first** (`app/integrations/rds.py`) — defines what an RDS source looks like in the integration store, when it's "available", and how to extract tool params from the source dict. This is what the planner uses to decide whether to call RDS tools.
2. **Tools second** (`app/tools/RDSDescribeInstanceTool/`, `app/tools/RDSEventsTool/`) — thin wrappers around `execute_aws_sdk_call(...)` so I get the read-only allowlist, error handling, and credential management for free. Each tool returns a flat dict matching the project's tool-output convention.
3. **Type literal** — adding `"rds"` to `EvidenceSource` was needed because `@tool(source=...)` is typed against that literal. I considered using the existing `"aws_sdk"` source instead, but that would have broken source-based filtering downstream and mixed RDS evidence into a generic bucket.
4. **Tests cover** the happy path, "no instance found" / "no events", and AWS SDK failures, plus availability detection and param extraction from both explicit configs and env-fallback.

Alternative considered: rolling a dedicated `RDSClient` under `app/services/rds/` like the Datadog and Grafana clients. Rejected because RDS only needs two boto3 calls — adding a client class would be over-abstraction. The `aws_sdk_client` pattern is the right fit and matches what CloudWatch/EKS/Lambda do.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions