### PR TITLE
fix(llm): lazy OpenAI client init fix regression tests and Run full tests in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,9 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
 
-      - name: Run safe tests (fork PRs)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
-        run: >-
-          python -m pytest -n auto -v
-          --ignore=tests/e2e
-          --ignore=tests/synthetic
-          -m "not synthetic"
-
-      - name: Run full tests
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+      # Fork PRs previously ran a narrower pytest set; run the same suite as main pushes
+      # so merge does not surface failures only seen on push.
+      - name: Run tests
         run: >-
           python -m pytest -n auto -v
           --cov=app
@@ -177,7 +170,7 @@ jobs:
           -m "${{ matrix.os == 'windows-latest' && 'not synthetic and not integration' || 'not synthetic' }}"
 
       - name: Upload coverage
-        if: always() && matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.os }}

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -276,7 +276,7 @@ class OpenAILLMClient:
     def bind_tools(self, _tools: list) -> OpenAILLMClient:
         return self
 
-    def _ensure_client(self) -> None:
+    def _ensure_client(self) -> OpenAI:
         api_key = resolve_llm_api_key(self._api_key_env) or self._api_key_default
         if not api_key:
             raise RuntimeError(
@@ -285,9 +285,10 @@ class OpenAILLMClient:
         if self._client is None or api_key != self._api_key:
             self._api_key = api_key
             self._client = self._build_client(api_key)
+        return self._client
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
-        self._ensure_client()
+        client = self._ensure_client()
         messages = _normalize_messages_openai(prompt_or_messages)
 
         from app.guardrails.engine import GuardrailBlockedError, get_guardrail_engine
@@ -311,9 +312,6 @@ class OpenAILLMClient:
         backoff_seconds = 1.0
         max_attempts = 3
         last_err: Exception | None = None
-        client = self._client
-        if client is None:
-            raise RuntimeError("OpenAI client was not initialized after credential validation.")
         for attempt in range(max_attempts):
             try:
                 response = client.chat.completions.create(**kwargs)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -254,12 +254,18 @@ class OpenAILLMClient:
         self._api_key_env = api_key_env
         self._default_headers = default_headers
         self._provider_label = api_key_env.removesuffix("_API_KEY").replace("_", " ").title()
-        self._client = OpenAI(
-            api_key=api_key, base_url=base_url, timeout=60.0, default_headers=default_headers
-        )
+        self._client: OpenAI | None = None
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
+
+    def _build_client(self, api_key: str) -> OpenAI:
+        return OpenAI(
+            api_key=api_key,
+            base_url=self._base_url,
+            timeout=60.0,
+            default_headers=self._default_headers,
+        )
 
     def with_config(self, **_kwargs) -> OpenAILLMClient:
         return self
@@ -276,14 +282,9 @@ class OpenAILLMClient:
             raise RuntimeError(
                 f"Missing {self._api_key_env}. Set it in your environment, .env, or secure local keychain before running LLM steps."
             )
-        if api_key != self._api_key:
+        if self._client is None or api_key != self._api_key:
             self._api_key = api_key
-            self._client = OpenAI(
-                api_key=api_key,
-                base_url=self._base_url,
-                timeout=60.0,
-                default_headers=self._default_headers,
-            )
+            self._client = self._build_client(api_key)
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
         self._ensure_client()
@@ -310,9 +311,12 @@ class OpenAILLMClient:
         backoff_seconds = 1.0
         max_attempts = 3
         last_err: Exception | None = None
+        client = self._client
+        if client is None:
+            raise RuntimeError("OpenAI client was not initialized after credential validation.")
         for attempt in range(max_attempts):
             try:
-                response = self._client.chat.completions.create(**kwargs)
+                response = client.chat.completions.create(**kwargs)
                 break
             except OpenAIAuthError as err:
                 raise RuntimeError(

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.services import llm_client
 
 
@@ -31,6 +33,7 @@ class _FakeOpenAI:
     last_api_key: str | None = None
     last_base_url: str | None = None
     last_default_headers: dict[str, str] | None = None
+    init_api_keys: list[str] = []
 
     def __init__(
         self,
@@ -43,13 +46,28 @@ class _FakeOpenAI:
         _FakeOpenAI.last_api_key = api_key
         _FakeOpenAI.last_base_url = base_url
         _FakeOpenAI.last_default_headers = default_headers
+        _FakeOpenAI.init_api_keys.append(api_key)
         self.base_url = base_url
         self.timeout = timeout
         self.default_headers = default_headers
         self.chat = _FakeOpenAIChat()
 
 
+def test_openai_llm_client_defers_openai_until_ensure(monkeypatch) -> None:
+    """Avoid constructing OpenAI in __init__: sdk 2.34+ rejects empty api_key."""
+    _FakeOpenAI.last_api_key = None  # class-level cache from other tests
+    _FakeOpenAI.init_api_keys = []
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env_var: "")
+    monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
+
+    llm_client.OpenAILLMClient(model="gpt-4.1-mini")
+
+    assert _FakeOpenAI.last_api_key is None
+    assert _FakeOpenAI.init_api_keys == []
+
+
 def test_openai_llm_client_reads_secure_local_api_key(monkeypatch) -> None:
+    _FakeOpenAI.init_api_keys = []
     monkeypatch.setattr(
         llm_client,
         "resolve_llm_api_key",
@@ -61,6 +79,29 @@ def test_openai_llm_client_reads_secure_local_api_key(monkeypatch) -> None:
     client._ensure_client()
 
     assert _FakeOpenAI.last_api_key == "stored-openai-key"
+    assert _FakeOpenAI.init_api_keys == ["stored-openai-key"]
+
+
+def test_openai_llm_client_invoke_fails_when_key_missing(monkeypatch) -> None:
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env_var: "")
+    client = llm_client.OpenAILLMClient(model="gpt-4.1-mini")
+
+    with pytest.raises(RuntimeError, match="Missing OPENAI_API_KEY"):
+        client.invoke("hello")
+
+
+def test_openai_llm_client_rebuilds_client_when_key_rotates(monkeypatch) -> None:
+    _FakeOpenAI.init_api_keys = []
+    state = {"key": "first-key"}
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env_var: state["key"])
+    monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
+    client = llm_client.OpenAILLMClient(model="gpt-4.1-mini")
+
+    client._ensure_client()
+    state["key"] = "second-key"
+    client._ensure_client()
+
+    assert _FakeOpenAI.init_api_keys == ["first-key", "second-key"]
 
 
 def test_anthropic_llm_client_reads_secure_local_api_key(monkeypatch) -> None:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -53,10 +53,16 @@ class _FakeOpenAI:
         self.chat = _FakeOpenAIChat()
 
 
+@pytest.fixture(autouse=True)
+def _reset_fake_openai_state() -> None:
+    _FakeOpenAI.last_api_key = None
+    _FakeOpenAI.last_base_url = None
+    _FakeOpenAI.last_default_headers = None
+    _FakeOpenAI.init_api_keys = []
+
+
 def test_openai_llm_client_defers_openai_until_ensure(monkeypatch) -> None:
     """Avoid constructing OpenAI in __init__: sdk 2.34+ rejects empty api_key."""
-    _FakeOpenAI.last_api_key = None  # class-level cache from other tests
-    _FakeOpenAI.init_api_keys = []
     monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env_var: "")
     monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)
 
@@ -67,7 +73,6 @@ def test_openai_llm_client_defers_openai_until_ensure(monkeypatch) -> None:
 
 
 def test_openai_llm_client_reads_secure_local_api_key(monkeypatch) -> None:
-    _FakeOpenAI.init_api_keys = []
     monkeypatch.setattr(
         llm_client,
         "resolve_llm_api_key",
@@ -91,7 +96,6 @@ def test_openai_llm_client_invoke_fails_when_key_missing(monkeypatch) -> None:
 
 
 def test_openai_llm_client_rebuilds_client_when_key_rotates(monkeypatch) -> None:
-    _FakeOpenAI.init_api_keys = []
     state = {"key": "first-key"}
     monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env_var: state["key"])
     monkeypatch.setattr(llm_client, "OpenAI", _FakeOpenAI)

--- a/tests/test_guardrails/test_llm_integration.py
+++ b/tests/test_guardrails/test_llm_integration.py
@@ -84,7 +84,7 @@ def openai_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, dict[str, Any]
     monkeypatch.setenv("TEST_KEY", "fake-key")
     client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
     monkeypatch.setattr(client, "_client", _FakeClient())
-    monkeypatch.setattr(client, "_ensure_client", lambda: None)
+    monkeypatch.setattr(client, "_ensure_client", lambda: client._client)
     return client, captured
 
 
@@ -241,7 +241,7 @@ class TestOpenAIClientGuardrails:
         monkeypatch.setenv("TEST_KEY", "fake-key")
         client = OpenAILLMClient(model="test", max_tokens=10, api_key_env="TEST_KEY")
         monkeypatch.setattr(client, "_client", _FakeClient())
-        monkeypatch.setattr(client, "_ensure_client", lambda: None)
+        monkeypatch.setattr(client, "_ensure_client", lambda: client._client)
 
         client.invoke("My key is AKIAIOSFODNN7EXAMPLE")
 


### PR DESCRIPTION
## Summary

Fixes CI failures when the OpenAI Python SDK rejects an empty `api_key` at `OpenAI()` construction (e.g. 2.34+). Construction is deferred until `_ensure_client` when a key is available.

## Changes

- `OpenAILLMClient`: lazy SDK init via `_build_client`; explicit guard in `invoke` if client is unset.
- `tests/services/test_llm_client.py`: defer-init, missing-key invoke, key rotation, and construction tracking.

## Related

Deps / lockfile / CI: **#1292**. Prefer merging this PR first.
