### PR TITLE
fix(cli): remove summary block from onboard completion output

### DIFF
--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -44,12 +44,6 @@ _ASCII_HEADER = """\
  \\___/|_|   |_____|_| \\_|____/|_| \\_\\_____|"""
 
 
-def build_demo_action_response():
-    from app.cli.wizard.validation import build_demo_action_response as _build
-
-    return _build()
-
-
 def validate_grafana_integration(**kwargs):
     from app.cli.wizard.integration_health import validate_grafana_integration as _validate
 
@@ -1600,7 +1594,6 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         )
 
     return configured, last_env_path
-
 
 
 def _render_next_steps() -> None:

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -1602,23 +1602,6 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
     return configured, last_env_path
 
 
-def _render_demo_response(demo_response: dict) -> None:
-    topics = ", ".join(demo_response.get("topics", [])) or "none"
-    guidance = demo_response.get("guidance") or []
-    summary = [
-        f"demo      {'ready' if demo_response.get('success') else 'failed'}",
-        f"topics    {topics}",
-    ]
-    if guidance:
-        first = guidance[0]
-        summary.append(f"sample    {first.get('topic', 'unknown')}")
-        content = str(first.get("content", "")).strip().splitlines()
-        if content:
-            summary.append(f"preview   {content[0][:140]}")
-    _console.print("\n[bold]summary[/]")
-    for line in summary:
-        _console.print(f"[dim]{line}[/]")
-
 
 def _render_next_steps() -> None:
     _console.print("\n[bold]next[/]")
@@ -1879,7 +1862,5 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         configured_integrations=configured_integrations,
         credential_line=_credential_line_for_saved_summary(provider),
     )
-    demo_response = build_demo_action_response()
-    _render_demo_response(demo_response)
     _render_next_steps()
     return 0

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -62,7 +62,7 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     assert saved_llm_keys == [("ANTHROPIC_API_KEY", "secret-key")]
 
     output = capsys.readouterr().out
-    assert "summary" in output
+    assert "next" in output
     assert "Done." in output
 
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -40,15 +40,6 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
     monkeypatch.setattr(
         flow, "probe_remote_target", lambda: ProbeResult("remote", True, "remote ok")
     )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {
-            "success": True,
-            "topics": ["recovery_remediation"],
-            "guidance": [{"topic": "recovery_remediation"}],
-        },
-    )
 
     def _save_local_config(**kwargs):
         saved.update(kwargs)
@@ -96,11 +87,6 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
     monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
     monkeypatch.setattr(flow, "save_llm_api_key", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
 
     exit_code = flow.run_wizard()
     assert exit_code == 0
@@ -209,11 +195,6 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
     )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": ["recovery_remediation"], "guidance": []},
-    )
 
     exit_code = flow.run_wizard()
 
@@ -283,11 +264,6 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
         flow,
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
-    )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
     )
 
     exit_code = flow.run_wizard()
@@ -364,11 +340,6 @@ def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
         flow,
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
-    )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
     )
 
     exit_code = flow.run_wizard()
@@ -466,11 +437,6 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
     )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": ["recovery_remediation"], "guidance": []},
-    )
 
     exit_code = flow.run_wizard()
 
@@ -547,11 +513,6 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
     )
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "has_llm_api_key", lambda _env: False)
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
 
     def _save_local_config(**kwargs):
         saved.update(kwargs)
@@ -596,11 +557,6 @@ def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
     monkeypatch.setattr(
         flow,
         "save_local_config",
@@ -656,11 +612,6 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
     monkeypatch.setattr(flow, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
     monkeypatch.setattr(
         flow,
         "save_local_config",
@@ -975,11 +926,6 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
     )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
 
     exit_code = flow.run_wizard()
 
@@ -1061,11 +1007,6 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
         "upsert_integration",
         lambda service, payload: saved_integrations.append((service, payload)),
     )
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
 
     exit_code = flow.run_wizard()
 
@@ -1139,11 +1080,6 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
     monkeypatch.setattr(flow.questionary, "password", _mock_password)
     monkeypatch.setattr(flow, "get_store_path", lambda: store_path)
     monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
-    monkeypatch.setattr(
-        flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
     monkeypatch.setattr(
         flow,
         "save_local_config",

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -517,7 +517,7 @@ def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
 
     assert result.exit_code == 0
     assert "Done." in result.stdout
-    assert "summary" in result.stdout
+    assert "next" in result.stdout
 
     store = cli_sandbox.read_wizard_store()
     assert store["targets"]["local"]["provider"] == "anthropic"
@@ -561,7 +561,7 @@ def test_onboard_interactive_smoke_codex(cli_sandbox: CliSandbox) -> None:
 
     assert result.exit_code == 0
     assert "Done." in result.stdout
-    assert "summary" in result.stdout
+    assert "next" in result.stdout
 
     store = cli_sandbox.read_wizard_store()
     assert store["targets"]["local"]["provider"] == "anthropic"


### PR DESCRIPTION
Fixes #1290 

#### Describe the changes you have made in this PR -
Removed the `summary` block from the end of the `opensre onboard` completion output. This deletes the `_render_demo_response()` function in "app/cli/wizard/flow.py" and its call site. The `next` section is unchanged.

### Demo/Screenshot for feature changes and bug fixes - 
<img width="726" height="687" alt="image" src="https://github.com/user-attachments/assets/f3e0f8ac-70c5-4fac-a79d-9c41fb106e3b" />


Before:
```
summary
demo      ready
topics    recovery_remediation
sample    Recovery and Remediation
preview   Pipeline Recovery Strategies (Google SRE Workbook):
next
opensre onboard
opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
```

After:
```
next
opensre onboard
opensre investigate -i tests/e2e/kubernetes/fixtures/datadog_k8s_alert.json
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)


**Explain your implementation approach:**

Deleted the _render_demo_response() function and its call site. The summary block printed internal state (demo status, topics, sample preview) that isn't actionable for users. The next section already provides everything needed to proceed after onboarding.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
