### PR TITLE
docs(claude-code): audit subscription vs API key, cross-OS parity (#1…

### DIFF
--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -9,8 +9,10 @@ CLAUDE_CODE_MODEL Optional model override (e.g. ``claude-opus-4-7``).
 
 Auth
 ----
-Claude Code authenticates via ``ANTHROPIC_API_KEY`` (env var) or OAuth credentials
-stored in ``~/.claude/.credentials.json`` after ``claude login``.
+Claude Code authenticates via OAuth from ``claude login`` (subscription, the
+preferred path; OAuth tokens land in the macOS Keychain on darwin and in
+``~/.claude/.credentials.json`` on Linux/Windows). ``ANTHROPIC_API_KEY`` is an
+explicit fallback for environments where interactive login is not possible.
 """
 
 from __future__ import annotations

--- a/docs/notes/audit-claude-code-cli-1260.md
+++ b/docs/notes/audit-claude-code-cli-1260.md
@@ -151,8 +151,10 @@ was not. **Added `test_classify_auth_no_credentials_windows` in this branch.**
   via Claude subscription"). Fix: read `authMethod` (e.g. `apiKey` →
   "Authenticated via ANTHROPIC_API_KEY"; `claude.ai` → subscription). Verify
   the exact value the CLI emits for each path before changing the parser.
-  Existing test `test_probe_cli_auth_api_key` mocks `apiKeySource` and would
-  need updating alongside the parser.
+  Existing tests `test_probe_cli_auth_api_key`, `test_detect_api_key_authenticated`,
+  and the `_auth_status_proc` helper mock `apiKeySource`. They are annotated
+  in-tree with a pointer back to this note so the false coverage is visible
+  next to the assertions; update them alongside the parser.
 - **P2** — `opensre doctor` does not surface anything for CLI-backed providers.
   When `LLM_PROVIDER=claude-code` it currently passes silently
   ([doctor.py:46-64](../../app/cli/commands/doctor.py#L46-L64)). A small

--- a/docs/notes/audit-claude-code-cli-1260.md
+++ b/docs/notes/audit-claude-code-cli-1260.md
@@ -1,0 +1,173 @@
+# Audit: Claude Code CLI — subscription login vs API key, cross-OS parity
+
+Tracking: [#1260](https://github.com/Tracer-Cloud/opensre/issues/1260) — follow-up
+to [#1199 (comment)](https://github.com/Tracer-Cloud/opensre/issues/1199) and the
+[#1217](https://github.com/Tracer-Cloud/opensre/pull/1217) onboarding fix.
+
+## TL;DR
+
+- **#1217 fully addresses the `#1199` false-negative path.** When the binary is
+  on disk, `claude auth status` is the source of truth on every platform; macOS
+  Keychain auth no longer reads as "uncertain" during onboarding.
+- **Subscription is architecturally first-class** (live probe, JSON parsing,
+  wizard handles `True/False/None`) and **first-class in user-facing copy**
+  (`auth_hint`, probe detail strings, `.env.example`, `docs/llm-providers.mdx`).
+  One stale internal docstring put `ANTHROPIC_API_KEY` first; fixed in this
+  branch.
+- **Cross-OS coverage is complete in code** (binary names, fallback dirs,
+  subprocess env keys, no-binary fallback ordering). One **test gap**
+  (Windows-no-binary case) — added in this branch.
+- **Latent bug found while verifying the JSON shape live:** `_probe_cli_auth`
+  parses a key (`apiKeySource`) that the current CLI does not emit. The
+  `loggedIn` boolean still parses correctly, so the wizard verdict is correct,
+  but the detail string is wrong for API-key users. Cosmetic only; tracked as
+  a P2 follow-up below (not fixed in this branch — needs verification of the
+  exact JSON shape under API-key auth).
+- Optional follow-ups listed below; none of them block closing this issue.
+
+## 1. Goal 1 — confirm #1217 fully addresses #1199
+
+`#1199` reported that on macOS, when OAuth lives in the Keychain (no
+`~/.claude/.credentials.json` on disk), the wizard treated the unknown auth
+state as a hard failure with no recovery path.
+
+`#1217` fixed this by:
+
+1. Adding `_probe_cli_auth()` in [claude_code.py:47-83](../../app/integrations/llm_cli/claude_code.py#L47-L83)
+   that runs `claude auth status` and parses the JSON. The `loggedIn` boolean
+   is the source of truth for the wizard verdict — definitive `True`/`False`
+   when the probe succeeds, `None` only when the probe itself fails (timeout,
+   OS error, non-zero exit, malformed JSON). (The detail-string parser also
+   reads `apiKeySource` and `email`; see the latent-bug note in §2 — `loggedIn`
+   parsing is correct, the auxiliary fields are partly stale.)
+2. Routing `_classify_claude_code_auth()` through `_probe_cli_auth()` whenever
+   a binary is resolved ([claude_code.py:97-98](../../app/integrations/llm_cli/claude_code.py#L97-L98)).
+   The Keychain question never has to be answered by inspecting the filesystem
+   — the CLI itself reports auth state.
+3. Wiring the wizard to handle all three states distinctly
+   ([flow.py:1654-1682](../../app/cli/wizard/flow.py#L1654-L1682)):
+   - `installed && logged_in is True` → success
+   - `installed && logged_in is False` → "requires login" + retry/repick
+   - `installed && logged_in is None` → "could not verify" + retry/repick
+   The previous behaviour (treat `None` as failure) is gone.
+
+**Verdict:** ✅ The original bug class is closed. The wizard no longer
+short-circuits on uncertain Keychain state, and the live probe gives a
+definitive answer in the common case (binary present + reachable).
+
+**Edge cases that still surface as `None` (by design):**
+
+- `claude auth status` exits non-zero (e.g. an older CLI without the `auth`
+  subcommand, or a partly-installed binary). The wizard prompts retry.
+- `claude auth status` exceeds the 8 s probe timeout
+  ([claude_code.py:39](../../app/integrations/llm_cli/claude_code.py#L39)). The
+  wizard prompts retry.
+- No binary on PATH/fallback locations on macOS, no env var, no creds file.
+  Returns `None` because the Keychain may still hold creds; the wizard tells
+  the user to install or run `claude login`.
+
+These are all intentional and recoverable through the wizard's retry/repick
+menu — none of them re-introduce the original false-negative.
+
+## 2. Goal 2 — auth ordering and messaging
+
+The intent is "subscription/CLI login is first-class; API key is an explicit
+fallback." Audit of every user-visible string:
+
+| Surface | String | Treatment |
+| --- | --- | --- |
+| `auth_hint` ([claude_code.py:128](../../app/integrations/llm_cli/claude_code.py#L128)) | `Run: claude login  or set ANTHROPIC_API_KEY` | Subscription first ✅ |
+| Live probe — not authenticated ([claude_code.py:75](../../app/integrations/llm_cli/claude_code.py#L75)) | `Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY.` | Subscription first ✅ |
+| Live probe — API key auth ([claude_code.py:78](../../app/integrations/llm_cli/claude_code.py#L78)) | `Authenticated via {apiKeySource}.` | Branch is unreachable in the current CLI — see latent-bug note ⚠️ |
+| Live probe — subscription auth ([claude_code.py:80](../../app/integrations/llm_cli/claude_code.py#L80)) | `Authenticated via Claude subscription ({email}).` | Subscription called out by name ✅ |
+| No-binary fallback ([claude_code.py:107-115](../../app/integrations/llm_cli/claude_code.py#L107-L115)) | `Run: claude auth login  or set ANTHROPIC_API_KEY.` | Subscription first ✅ |
+| `.env.example` ([line 23](../../.env.example)) | `Claude Code CLI works for opensre investigate after claude login or setting ANTHROPIC_API_KEY.` | Subscription first ✅ |
+| `docs/llm-providers.mdx` ([table row](../llm-providers.mdx)) | `Auth: claude login (CLI)` (API key not even listed for `claude-code`) | Subscription only ✅ |
+| `docs/llm-providers.mdx` ([Claude Code section](../llm-providers.mdx)) | Mentions only `claude login` | Subscription only ✅ |
+
+**Found gap:** the module-level docstring at the top of `claude_code.py` was
+the one place that put `ANTHROPIC_API_KEY` first, which contradicts the rest of
+the codebase. **Fixed in this branch.**
+
+**Found gap (real, latent):** `_probe_cli_auth` reads a field called
+`apiKeySource` from the CLI's JSON output, but the current CLI
+(`claude --version` 2.1.123) does not emit that key at all. Verified by running
+`claude auth status` locally — the actual fields are
+`['apiProvider', 'authMethod', 'email', 'loggedIn', 'orgId', 'orgName', 'subscriptionType']`.
+Practical impact: subscription users still get the right detail (the code falls
+through to the `email` branch). API-key users would also fall through to the
+`email` branch and be **misreported as "Authenticated via Claude subscription"**
+in the detail string, even though `loggedIn` is correctly `True`. This is
+cosmetic — it does not affect the auth verdict the wizard uses (`logged_in`
+True/False/None), so it does not re-introduce the `#1199` failure mode — but
+the detail string is wrong for one class of users. Likely cause: the field
+name `apiKeySource` was either based on an older CLI version or speculative at
+the time `#1217` was written. Recommended follow-up below (P2). Not fixed in
+this branch because the right fix needs verification of what the CLI emits for
+an actual API-key authenticated session, which I could not test from a
+subscription-authed machine.
+
+## 3. Goal 3 — cross-OS matrix
+
+| Aspect | macOS (`darwin`) | Linux | Windows (`win32`) |
+| --- | --- | --- | --- |
+| **Install detection (PATH)** | `shutil.which("claude")` | `shutil.which("claude")` | `shutil.which` over `claude.{cmd,exe,ps1,bat}` |
+| **Install detection (fallback dirs)** | `/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, `~/.npm-global/bin`, `~/.volta/bin`, `$PNPM_HOME`, `$XDG_DATA_HOME/pnpm`, npm prefix | same as macOS minus Homebrew | `%APPDATA%\npm`, `%LOCALAPPDATA%\Programs\claude`, npm prefix |
+| **Login detection (binary present)** | `claude auth status` (live probe) | `claude auth status` | `claude auth status` |
+| **Login detection (no binary)** | env → file → `None` (Keychain may hold creds) | env → file → `False` | env → file → `False` |
+| **OAuth credential storage** | macOS Keychain | `~/.claude/.credentials.json` | `~/.claude/.credentials.json` |
+| **Env vars forwarded into subprocess** | adapter forwards `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`; `runner.py` also passes through the platform-agnostic [allowlist](../../app/integrations/llm_cli/runner.py) (`HOME`, `USER`, `LOGNAME`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `PATH`, `PATHEXT`, `SYSTEMROOT`, `WINDIR`, `COMSPEC`, `SHELL`, `TMP`, `TEMP`, `TMPDIR`, `LANG`, `TERM`, `TZ`, proxy vars, CA-bundle vars, `NO_COLOR`/`FORCE_COLOR`/`COLORTERM`, `XDG_*`, plus prefixes `LC_*`, `CODEX_*`, `CLAUDE_*`). Allowlist is one shared frozenset; OS-specific keys (Windows `APPDATA`/`LOCALAPPDATA`/`USERPROFILE`, POSIX `LOGNAME`) are present in the allowlist on every platform but only have values on the platform that sets them. | same | same |
+| **Failure: no binary** | Recovery menu → install / enter path / repick | same | same |
+| **Failure: not logged in** | `requires login` → `claude login` / set env / repick | same | same |
+| **Failure: probe timeout / unknown** | `could not verify` → retry / repick | same | same |
+| **Failure: ANTHROPIC_API_KEY invalid at runtime** | Surfaced by `claude -p` exit code; `explain_failure` returns CLI stderr | same | same |
+
+**Verdict:** ✅ End-to-end parity holds across the three platforms. The only
+intentional divergence is the no-binary fallback returning `None` on macOS vs
+`False` on Linux/Windows, which exists because Keychain creds can outlive a
+missing binary on macOS but cannot on the other two platforms.
+
+**Test-coverage gap:** Linux and macOS no-binary cases were tested; Windows
+was not. **Added `test_classify_auth_no_credentials_windows` in this branch.**
+
+## 4. Prioritised fixes
+
+### Landed in this branch
+
+- **P1** — `claude_code.py` module docstring updated to lead with `claude login`
+  (subscription) and treat `ANTHROPIC_API_KEY` as fallback, matching the rest
+  of the codebase.
+- **P1** — Added `test_classify_auth_no_credentials_windows` mirroring the
+  Linux test, closing the cross-OS test-coverage gap.
+
+### Optional follow-ups (separate issues)
+
+- **P2** — `_probe_cli_auth` parses a JSON field name (`apiKeySource`) that the
+  current Claude Code CLI does not emit. Verified against `claude` 2.1.123:
+  fields are `loggedIn`, `authMethod`, `apiProvider`, `email`,
+  `subscriptionType`, `orgId`, `orgName`. The functional outcome is correct
+  for subscription users and `loggedIn` itself is parsed correctly, but
+  API-key-authenticated users get a misleading detail string ("Authenticated
+  via Claude subscription"). Fix: read `authMethod` (e.g. `apiKey` →
+  "Authenticated via ANTHROPIC_API_KEY"; `claude.ai` → subscription). Verify
+  the exact value the CLI emits for each path before changing the parser.
+  Existing test `test_probe_cli_auth_api_key` mocks `apiKeySource` and would
+  need updating alongside the parser.
+- **P2** — `opensre doctor` does not surface anything for CLI-backed providers.
+  When `LLM_PROVIDER=claude-code` it currently passes silently
+  ([doctor.py:46-64](../../app/cli/commands/doctor.py#L46-L64)). A small
+  enhancement would call into the existing adapter's `detect()` and report
+  installed/logged-in state. Low-risk, user-visible improvement.
+- **P3** — On macOS, when `claude auth status` times out, the wizard surfaces
+  `auth state unknown` and offers retry. If the underlying cause is a locked
+  Keychain, a hint pointing at `security unlock-keychain` would shorten
+  diagnosis. Niche; only worth doing if support tickets show this in the wild.
+- **P3** — The probe timeout is a single 8-second budget that has to absorb
+  Claude Code's cold-start cache init. If real-world telemetry shows it firing,
+  consider extending it for the first-run case only. Premature otherwise.
+
+## Files changed in this branch
+
+- [`app/integrations/llm_cli/claude_code.py`](../../app/integrations/llm_cli/claude_code.py) — docstring ordering.
+- [`tests/integrations/llm_cli/test_claude_code_adapter.py`](../../tests/integrations/llm_cli/test_claude_code_adapter.py) — added Windows no-binary test.
+- This note.

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -61,6 +61,24 @@ def test_classify_auth_no_credentials_macos_returns_none() -> None:
     assert logged_in is None
 
 
+def test_classify_auth_no_credentials_windows() -> None:
+    """On Windows, no env var and no credentials file → definitive False.
+
+    Mirror of the Linux case: Windows stores OAuth in ``~/.claude/.credentials.json``
+    (not in a system credential store), so the file's absence is conclusive.
+    """
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.sys.platform", "win32"),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = False
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        logged_in, _detail = _classify_claude_code_auth()
+    assert logged_in is False
+
+
 def test_classify_auth_credentials_file_present(tmp_path: Path) -> None:
     # Create a fake ~/.claude/.credentials.json under tmp_path.
     claude_dir = tmp_path / ".claude"

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -147,7 +147,14 @@ def test_probe_cli_auth_subscription(mock_run: MagicMock) -> None:
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 def test_probe_cli_auth_api_key(mock_run: MagicMock) -> None:
-    """API key auth: loggedIn=true, apiKeySource present → API key detail."""
+    """API key auth: loggedIn=true, apiKeySource present → API key detail.
+
+    NOTE: ``claude auth status`` on CLI 2.1.123 does not emit ``apiKeySource``
+    (actual fields: ``loggedIn``, ``authMethod``, ``apiProvider``, ``email``,
+    ``subscriptionType``, ``orgId``, ``orgName``). This test exercises a branch
+    that is currently unreachable in production. Update alongside the parser
+    fix tracked as P2 in ``docs/notes/audit-claude-code-cli-1260.md``.
+    """
     m = MagicMock()
     m.returncode = 0
     m.stdout = '{"loggedIn": true, "apiKeySource": "ANTHROPIC_API_KEY"}\n'
@@ -239,7 +246,11 @@ def test_detect_subscription_authenticated(mock_which: MagicMock, mock_run: Magi
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
 def test_detect_api_key_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
-    """detect() returns logged_in=True via API key when binary reports apiKeySource."""
+    """detect() returns logged_in=True via API key when binary reports apiKeySource.
+
+    NOTE: ``apiKeySource`` is not emitted by current CLI versions; see the note
+    on ``test_probe_cli_auth_api_key`` and the P2 follow-up in the audit doc.
+    """
     mock_which.return_value = "/usr/bin/claude"
 
     auth_proc = MagicMock()
@@ -270,6 +281,12 @@ def _version_proc() -> MagicMock:
 
 
 def _auth_status_proc(logged_in: bool, api_key_source: str = "", email: str = "") -> MagicMock:
+    """Build a mocked ``claude auth status`` JSON payload.
+
+    NOTE: ``api_key_source`` populates ``apiKeySource``, which is not emitted by
+    current CLI versions (see ``test_probe_cli_auth_api_key`` and the P2
+    follow-up in ``docs/notes/audit-claude-code-cli-1260.md``).
+    """
     m = MagicMock()
     m.returncode = 0
     data: dict = {"loggedIn": logged_in}


### PR DESCRIPTION


Fixes #1260

#### Describe the changes you have made in this PR -

Audit follow-up to #1217 (live-probe macOS Keychain auth) and the discussion in #1199. Verifies that #1217 fully closes the onboarding false-negative path, walks the auth-ordering surface so subscription/CLI login is treated as first-class everywhere (with ANTHROPIC_API_KEY as an explicit fallback), and enumerates the Linux / macOS / Windows matrix for install detection, login detection, execution, env vars, and failure modes.

Concrete changes on this branch:
- docs/notes/audit-claude-code-cli-1260.md — full audit write-up: TL;DR, #1217 verification, messaging table, cross-OS matrix, prioritised fixes.
- app/integrations/llm_cli/claude_code.py — module docstring fixed to lead with `claude login` (subscription) and treat ANTHROPIC_API_KEY as fallback. This was the only place in the codebase that put the API key first; every user-facing string (auth_hint, probe detail, .env.example, docs/llm-providers.mdx) was already subscription-first.
- tests/integrations/llm_cli/test_claude_code_adapter.py : added test_classify_auth_no_credentials_windows mirroring the existing Linux case. Linux and macOS no-binary fallbacks were tested; Windows was not.

While verifying the live `claude auth status` JSON shape on CLI 2.1.123, I found that `_probe_cli_auth` parses an `apiKeySource` field that the current CLI does not emit. The `loggedIn` boolean (the wizard's actual verdict) parses correctly so the wizard outcome is right, but API-key users get a misleading detail string. This is cosmetic, not a regression of #1199, so it's tracked as a P2 follow-up in the audit note rather than fixed here, the right fix needs verification of what the CLI emits for an actual API-key authenticated session.

### Demo/Screenshot for feature changes and bug fixes -

Quality gates locally (audit-claude-code-cli-1260):

<img width="1512" height="982" alt="Screenshot 2026-05-04 at 22 21 39" src="https://github.com/user-attachments/assets/4fa1821a-5686-4e62-9fc4-75e49eb3bdc8" />
<img width="1512" height="982" alt="Screenshot 2026-05-04 at 22 22 12" src="https://github.com/user-attachments/assets/23b12586-b7ff-465a-892d-56768fd66dad" />
<img width="440" height="84" alt="Screenshot 2026-05-04 at 22 23 11" src="https://github.com/user-attachments/assets/b62f9a9d-299a-43c9-898e-171bbc7886a2" />
<img width="1512" height="982" alt="Screenshot 2026-05-04 at 22 26 34" src="https://github.com/user-attachments/assets/d2d6cd61-3cda-4a01-bbcf-2dac06e0d792" />
<img width="1512" height="982" alt="Screenshot 2026-05-04 at 22 29 40" src="https://github.com/user-attachments/assets/93168152-9366-4d18-932c-4a8f6209672c" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The work is mostly an audit, so the "code" surface is small and the write-up is the deliverable.

What problem this solves: #1260 asks whether #1217 fully closed the macOS Keychain false-negative onboarding path from #1199, whether subscription/CLI login is consistently treated as first-class with ANTHROPIC_API_KEY as a fallback, and whether behaviour holds across Linux/macOS/Windows. The deliverable in the issue is a "short write-up: gaps found, prioritised fixes, optional follow-up issues."

Approach I considered:
1. Post the write-up as a GitHub issue comment only — easiest, but no diff to review and any small fixes get lost.
2. Land both the write-up and the small fixes that fall out of it as one PR — gives reviewers a single artifact and keeps the audit linkable from the codebase.

I went with (2). The note lives at docs/notes/audit-claude-code-cli-1260.md so it can be linked from the issue and read alongside the diff. Two clear-cut, low-risk fixes were obvious from the audit and are folded in:

- The module docstring at the top of app/integrations/llm_cli/claude_code.py was the one place in the integration that listed ANTHROPIC_API_KEY before `claude login`. Every other user-facing surface already leads with `claude login`. I rewrote the docstring so it matches: subscription is preferred, OAuth tokens land in macOS Keychain on darwin and ~/.claude/.credentials.json on Linux/Windows, ANTHROPIC_API_KEY is the explicit fallback for non-interactive environments.
- _classify_claude_code_auth() returns False on Linux and Windows when no binary, no env var, and no creds file are present, but None on macOS because the Keychain may still hold credentials. The Linux and macOS branches were tested; Windows was not. I added test_classify_auth_no_credentials_windows mirroring the Linux test. Same patching pattern — patch sys.platform to "win32", mock the credentials path to not exist, assert the result is False.

How I verified my own audit (this is the part that matters): I ran `claude auth status --json` against CLI 2.1.123 directly to confirm the JSON shape the parser is reading. The actual fields are loggedIn, authMethod, apiProvider, email, subscriptionType, orgId, orgName — there is no apiKeySource key. The code does `data.get("apiKeySource", "")` which always returns "", so the API-key branch is unreachable in the current CLI; subscription users still get correct output because the code falls through to the email branch. This isn't a Goal-1 regression (loggedIn parses fine, the wizard verdict is correct) but the detail string is wrong for API-key users. I tracked this as a P2 follow-up rather than fixing it in this PR because the correct fix needs to know what `authMethod` actually emits under API-key auth, and I can't verify that from a subscription-authed machine.

Edge cases I checked while writing the matrix:
- Probe timeout (8s) → returns None, wizard prompts retry, does not block.
- Probe non-zero exit (older CLI without `auth status`) → returns None, retry path.
- Malformed JSON on exit 0 (older CLI) → treated as authenticated for backward compatibility.
- No binary on macOS → returns None instead of False, since Keychain creds can outlive a missing binary; wizard guides install or `claude login`.
- No binary on Linux/Windows → returns False, since the credentials file is the canonical store on those platforms.
- ANTHROPIC_API_KEY succeeding even when ~/.claude/.credentials.json is unreadable (already covered by an existing test).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
