### PR TITLE
fix(llm-cli): harden codex and claude-code auth probe paths

### DIFF
--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -58,6 +58,22 @@ def _check_llm_provider() -> tuple[bool, str]:
     if provider == "not set":
         return False, "LLM_PROVIDER env var is not set"
 
+    if provider in {"codex", "claude-code"}:
+        from app.integrations.llm_cli.registry import get_cli_provider_registration
+
+        cli_reg = get_cli_provider_registration(provider)
+        if cli_reg is None:
+            return False, f"provider={provider}, CLI adapter not registered"
+
+        probe = cli_reg.adapter_factory().detect()
+        if not probe.installed or not probe.bin_path:
+            return False, f"provider={provider}, CLI not installed ({probe.detail})"
+        if probe.logged_in is False:
+            return False, f"provider={provider}, CLI not authenticated ({probe.detail})"
+        if probe.logged_in is None:
+            return False, f"provider={provider}, CLI auth status unclear ({probe.detail})"
+        return True, f"provider={provider}, CLI ready ({probe.detail})"
+
     expected_key = key_vars.get(provider)
     if expected_key and not os.getenv(expected_key):
         return False, f"provider={provider}, but {expected_key} is not set"

--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -58,13 +58,10 @@ def _check_llm_provider() -> tuple[bool, str]:
     if provider == "not set":
         return False, "LLM_PROVIDER env var is not set"
 
-    if provider in {"codex", "claude-code"}:
-        from app.integrations.llm_cli.registry import get_cli_provider_registration
+    from app.integrations.llm_cli.registry import get_cli_provider_registration
 
-        cli_reg = get_cli_provider_registration(provider)
-        if cli_reg is None:
-            return False, f"provider={provider}, CLI adapter not registered"
-
+    cli_reg = get_cli_provider_registration(provider)
+    if cli_reg is not None:
         probe = cli_reg.adapter_factory().detect()
         if not probe.installed or not probe.bin_path:
             return False, f"provider={provider}, CLI not installed ({probe.detail})"

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -40,7 +40,7 @@ _ACTION_RULE = (
     "action object schemas: "
     '`{"action":"switch_llm_provider","provider":"anthropic","model":"","toolcall_model":""}` '
     "where provider is one of anthropic, openai, openrouter, gemini, nvidia, "
-    "ollama, codex; both `model` (reasoning) and `toolcall_model` are optional; "
+    "ollama, codex, claude-code; both `model` (reasoning) and `toolcall_model` are optional; "
     '`{"action":"switch_toolcall_model","model":"claude-opus-4-7"}` '
     "to change ONLY the toolcall model on the currently active provider; "
     '`{"action":"slash","command":"/model show"}` where command is one of '

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -155,6 +155,36 @@ def _parse_action_plan(text: str) -> list[dict[str, object]]:
     ]
 
 
+def _response_text(response: object) -> str:
+    """Extract text from heterogeneous LLM response content payloads."""
+    content = getattr(response, "content", None)
+    if content is None:
+        return str(response)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        text_value = content.get("text")
+        return text_value if isinstance(text_value, str) else str(content)
+    if isinstance(content, list):
+        blocks: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                blocks.append(item)
+                continue
+            if isinstance(item, dict):
+                text_value = item.get("text")
+                blocks.append(text_value if isinstance(text_value, str) else str(item))
+                continue
+            text_value = getattr(item, "text", None)
+            blocks.append(text_value if isinstance(text_value, str) else str(item))
+        joined = "\n".join(part for part in blocks if part.strip()).strip()
+        return joined or str(content)
+    text_value = getattr(content, "text", None)
+    if isinstance(text_value, str):
+        return text_value
+    return str(content)
+
+
 def _execute_action_plan(
     actions: list[dict[str, object]],
     session: ReplSession,
@@ -282,8 +312,7 @@ def answer_cli_agent(
         console.print(f"[red]assistant failed:[/red] {escape(str(exc))}")
         return
 
-    text = getattr(response, "content", None) or str(response)
-    text_str = str(text)
+    text_str = _response_text(response)
     actions = _parse_action_plan(text_str)
     if _execute_action_plan(actions, session, console):
         session.cli_agent_messages.append(("user", message))

--- a/app/integrations/llm_cli/AGENTS.md
+++ b/app/integrations/llm_cli/AGENTS.md
@@ -8,7 +8,8 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 | File                 | Role                                                                                        |
 | -------------------- | ------------------------------------------------------------------------------------------- |
 | `base.py`            | `LLMCLIAdapter` protocol, `CLIProbe`, `CLIInvocation`.                                      |
-| `registry.py`        | `CLI_PROVIDER_REGISTRY`: maps `LLM_PROVIDER` → `adapter_factory` + optional `model_env_key`. |
+| `registry.py`        | `CLI_PROVIDER_REGISTRY`: maps `LLM_PROVIDER` → `adapter_factory` + optional `model_env_key`. `opensre doctor` uses `get_cli_provider_registration()` so any key in this registry is treated as CLI-backed—do not hardcode provider IDs in `doctor.py`. |
+| `subprocess_env.py` | Filtered `env` passed to CLI subprocesses (`build_cli_subprocess_env`). Extend `_SAFE_SUBPROCESS_ENV_PREFIXES` here when a CLI needs vendor-specific env prefixes. |
 | `binary_resolver.py` | Shared executable resolution helpers (`env -> PATH -> fallback paths`).                     |
 | `runner.py`          | `CLIBackedLLMClient`: guardrails, `detect()`, `subprocess.run`, ANSI strip, `LLMResponse`.  |
 | `text.py`            | `flatten_messages_to_prompt` for stdin from chat-style payloads.                            |
@@ -17,7 +18,7 @@ Use this package when adding a new **non-interactive** LLM that shells out to a 
 
 ## Wiring a new provider
 
-**Before merging**, read **[Subprocess environment allowlist](#subprocess-environment-allowlist)** below: if your CLI reads vendor-specific env vars, you must extend `_SAFE_SUBPROCESS_ENV_PREFIXES` in `runner.py` or the subprocess will not see them (auth and config will break silently).
+**Before merging**, read **[Subprocess environment allowlist](#subprocess-environment-allowlist)** below: if your CLI reads vendor-specific env vars, you must extend `_SAFE_SUBPROCESS_ENV_PREFIXES` in `subprocess_env.py` or the subprocess will not see them (auth and config will break silently).
 
 1. **Adapter** — Implement `LLMCLIAdapter`: `detect()` must not raise; `build()` returns argv + optional stdin; `parse` / `explain_failure` for success and non-zero exits. Put prompt text on stdin and/or in argv as appropriate — the runner does not branch on a separate “delivery mode”; `CLIInvocation` carries what `build()` produced.
 2. **Registry** — Add an entry to `CLI_PROVIDER_REGISTRY` in `registry.py` (`adapter_factory`, `model_env_key`). The dict key must match `LLM_PROVIDER` / `ProviderOption.value` / `LLMProvider` in `app/config.py`. `_create_llm_client` picks up registered CLI providers automatically (no new `elif` in `llm_client.py` for normal cases).
@@ -85,13 +86,14 @@ See `_classify_codex_auth` in `codex.py` for a complete reference implementation
 
 ## Subprocess environment allowlist
 
-`CLIBackedLLMClient` in `runner.py` passes only a safe subset of env vars to the
-subprocess (`_SAFE_SUBPROCESS_ENV_KEYS` + `_SAFE_SUBPROCESS_ENV_PREFIXES`).
+`CLIBackedLLMClient` passes only a safe subset of env vars to the subprocess via
+`build_cli_subprocess_env` in `subprocess_env.py` (`_SAFE_SUBPROCESS_ENV_KEYS` +
+`_SAFE_SUBPROCESS_ENV_PREFIXES`).
 
-The current prefix allowlist is `("LC_", "CODEX_")`.
+The current prefix allowlist includes `CODEX_`, `CLAUDE_`, and locale keys (`LC_`).
 
-**If your CLI reads custom env vars** (e.g. `CLAUDE_*`, `GEMINI_*`) you must add the
-relevant prefix to `_SAFE_SUBPROCESS_ENV_PREFIXES` in `runner.py`, otherwise the
+**If your CLI reads custom env vars** (e.g. `GEMINI_*`) you must add the
+relevant prefix to `_SAFE_SUBPROCESS_ENV_PREFIXES` in `subprocess_env.py`, otherwise the
 subprocess will not receive those vars and authentication or configuration will silently
 fail. Add a test that asserts the required keys are forwarded.
 
@@ -121,7 +123,7 @@ CODEX_BIN=
 - Define `<PROVIDER>_BIN` + `<PROVIDER>_MODEL` per [Per-provider env vars](#per-provider-env-vars-required-for-every-new-cli); reuse `resolve_cli_binary(..., explicit_env_key=...)` for `_resolve_binary`.
 - Implement `detect()` with `--version` + auth status checks; follow the three-state `logged_in` pattern above.
 - Write `_classify_<name>_auth` — test against a real logged-in **and** logged-out session before merging.
-- If the CLI reads custom env vars (e.g. `CLAUDE_*`), add the prefix to `_SAFE_SUBPROCESS_ENV_PREFIXES` in `runner.py`.
+- If the CLI reads custom env vars (e.g. `GEMINI_*`), add the prefix to `_SAFE_SUBPROCESS_ENV_PREFIXES` in `subprocess_env.py`.
 - Register the provider in `registry.py` and add the same `LLM_PROVIDER` value in `app/config.py`.
 - (Optional) Add wizard onboarding option in `app/cli/wizard/config.py`.
 - Add tests under `tests/integrations/llm_cli/` for detect/build/failure paths, including env forwarding.

--- a/app/integrations/llm_cli/binary_resolver.py
+++ b/app/integrations/llm_cli/binary_resolver.py
@@ -138,6 +138,16 @@ def default_cli_fallback_paths(binary_name: str) -> list[str]:
             Path(os.getenv("LOCALAPPDATA", "")) / "Programs" / binary_name,
             names,
         )
+        # Match Unix branch: Volta / pnpm globals are common on Windows dev machines too.
+        localappdata = os.getenv("LOCALAPPDATA", "").strip()
+        volta_home = os.getenv("VOLTA_HOME", "").strip()
+        if volta_home:
+            _append_candidate_paths(candidates, Path(volta_home) / "bin", names)
+        elif localappdata:
+            _append_candidate_paths(candidates, Path(localappdata) / "Volta" / "bin", names)
+        _append_candidate_paths(candidates, os.getenv("PNPM_HOME", ""), names)
+        if localappdata:
+            _append_candidate_paths(candidates, Path(localappdata) / "pnpm", names)
     else:
         if sys.platform == "darwin":
             _append_candidate_paths(candidates, "/opt/homebrew/bin", names)

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -9,8 +9,10 @@ CLAUDE_CODE_MODEL Optional model override (e.g. ``claude-opus-4-7``).
 
 Auth
 ----
-Claude Code authenticates via ``ANTHROPIC_API_KEY`` (env var) or OAuth credentials
-stored in ``~/.claude/.credentials.json`` after ``claude login``.
+When the ``claude`` binary is available, OpenSRE probes ``claude auth status``
+and treats Claude subscription login as first-class auth. ``ANTHROPIC_API_KEY``
+and ``~/.claude/.credentials.json`` are used as fallbacks when the binary is
+unavailable.
 """
 
 from __future__ import annotations
@@ -44,6 +46,16 @@ def _parse_semver(text: str) -> str | None:
     return m.group(1) if m else None
 
 
+def _anthropic_env_overrides() -> dict[str, str]:
+    """Build Claude subprocess auth/config overrides used by probe and invoke."""
+    env: dict[str, str] = {"NO_COLOR": "1"}
+    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            env[key] = val
+    return env
+
+
 def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     """Check Claude Code auth via `claude auth status` (local, no API call).
 
@@ -51,13 +63,15 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     priority as reported by the CLI itself.
     """
     try:
+        from app.integrations.llm_cli.runner import _build_subprocess_env
+
         proc = subprocess.run(
             [binary_path, "auth", "status"],
             capture_output=True,
             text=True,
             timeout=_PROBE_TIMEOUT_SEC,
             check=False,
-            env={**os.environ, "NO_COLOR": "1"},
+            env=_build_subprocess_env(_anthropic_env_overrides()),
         )
     except subprocess.TimeoutExpired:
         return (
@@ -79,7 +93,17 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
         email = data.get("email", "")
         return True, f"Authenticated via Claude subscription{f' ({email})' if email else ''}."
     except (json.JSONDecodeError, AttributeError):
-        # Older CLI versions may not output JSON — treat exit 0 as authenticated.
+        # Older CLI versions may not output JSON; classify explicit negative
+        # phrases first to avoid false positives like "Not logged in" (exit 0).
+        plain = (proc.stdout or proc.stderr or "").strip().lower()
+        negative_markers = (
+            "not logged in",
+            "not authenticated",
+            "login required",
+            "unauthenticated",
+        )
+        if any(marker in plain for marker in negative_markers):
+            return False, "Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY."
         return True, "Authenticated via Claude CLI."
 
 
@@ -125,7 +149,7 @@ class ClaudeCodeAdapter:
     name = "claude-code"
     binary_env_key = "CLAUDE_CODE_BIN"
     install_hint = "npm i -g @anthropic-ai/claude-code"
-    auth_hint = "Run: claude login  or set ANTHROPIC_API_KEY"
+    auth_hint = "Run: claude auth login  or set ANTHROPIC_API_KEY"
     min_version: str | None = None
     default_exec_timeout_sec = 120.0
 
@@ -212,11 +236,7 @@ class ClaudeCodeAdapter:
 
         # Forward Anthropic auth vars explicitly rather than relying on a blanket
         # prefix allowlist, so they don't leak into other CLI adapters (e.g. Codex).
-        env: dict[str, str] = {"NO_COLOR": "1"}
-        for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"):
-            val = os.environ.get(key, "").strip()
-            if val:
-                env[key] = val
+        env = _anthropic_env_overrides()
 
         return CLIInvocation(
             argv=tuple(argv),

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -11,8 +11,16 @@ Auth
 ----
 When the ``claude`` binary is available, OpenSRE probes ``claude auth status``
 and treats Claude subscription login as first-class auth. ``ANTHROPIC_API_KEY``
-and ``~/.claude/.credentials.json`` are used as fallbacks when the binary is
-unavailable.
+and ``~/.claude/.credentials.json`` (under ``Path.home()`` on all platforms)
+are used as fallbacks when the binary is unavailable.
+
+Platforms
+---------
+Binary resolution uses ``shutil.which`` with ``claude.cmd`` / ``claude.exe`` /
+``.bat`` / ``.ps1`` on Windows, plus npm / Volta / pnpm style fallback dirs
+(see ``default_cli_fallback_paths``). Without the CLI binary, macOS Keychain
+may still hold OAuth credentials, so auth is reported as unclear until the
+binary runs; Linux and Windows without env or creds file → not authenticated.
 """
 
 from __future__ import annotations
@@ -218,7 +226,8 @@ class ClaudeCodeAdapter:
                 " or set CLAUDE_CODE_BIN to the full binary path."
             )
 
-        cwd = workspace or os.getcwd()
+        ws = (workspace or "").strip()
+        cwd = str(Path(ws).expanduser()) if ws else os.getcwd()
 
         argv: list[str] = [
             binary,

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -136,9 +136,7 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
     except OSError:
         return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
     if sys.platform == "darwin":
-        return None, (
-            f"Auth state unclear — binary unavailable for verification. {_AUTH_HINT}"
-        )
+        return None, (f"Auth state unclear — binary unavailable for verification. {_AUTH_HINT}")
     return (
         False,
         f"Not authenticated. {_AUTH_HINT}",

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -17,7 +17,6 @@ unavailable.
 
 from __future__ import annotations
 
-import importlib
 import json
 import os
 import re
@@ -35,6 +34,7 @@ from app.integrations.llm_cli.binary_resolver import (
 from app.integrations.llm_cli.binary_resolver import (
     resolve_cli_binary,
 )
+from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 
 _CLAUDE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 # Claude Code's `--version` does config/cache init that can spike past Codex's 3s
@@ -65,20 +65,13 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     priority as reported by the CLI itself.
     """
     try:
-        runner_module = importlib.import_module("app.integrations.llm_cli.runner")
-        build_subprocess_env = getattr(runner_module, "_build_subprocess_env", None)
-        if not callable(build_subprocess_env):
-            return None, "Could not prepare claude auth probe environment."
-    except ImportError as exc:
-        return None, f"Could not prepare claude auth probe environment: {exc}"
-    try:
         proc = subprocess.run(
             [binary_path, "auth", "status"],
             capture_output=True,
             text=True,
             timeout=_PROBE_TIMEOUT_SEC,
             check=False,
-            env=build_subprocess_env(_anthropic_env_overrides()),
+            env=build_cli_subprocess_env(_anthropic_env_overrides()),
         )
     except subprocess.TimeoutExpired:
         return (

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -17,6 +17,7 @@ unavailable.
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import re
@@ -39,6 +40,7 @@ _CLAUDE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 # Claude Code's `--version` does config/cache init that can spike past Codex's 3s
 # budget on cold starts or when another claude process holds shared state.
 _PROBE_TIMEOUT_SEC = 8.0
+_AUTH_HINT = "Run: claude auth login or set ANTHROPIC_API_KEY."
 
 
 def _parse_semver(text: str) -> str | None:
@@ -63,15 +65,20 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     priority as reported by the CLI itself.
     """
     try:
-        from app.integrations.llm_cli.runner import _build_subprocess_env
-
+        runner_module = importlib.import_module("app.integrations.llm_cli.runner")
+        build_subprocess_env = getattr(runner_module, "_build_subprocess_env", None)
+        if not callable(build_subprocess_env):
+            return None, "Could not prepare claude auth probe environment."
+    except ImportError as exc:
+        return None, f"Could not prepare claude auth probe environment: {exc}"
+    try:
         proc = subprocess.run(
             [binary_path, "auth", "status"],
             capture_output=True,
             text=True,
             timeout=_PROBE_TIMEOUT_SEC,
             check=False,
-            env=_build_subprocess_env(_anthropic_env_overrides()),
+            env=build_subprocess_env(_anthropic_env_overrides()),
         )
     except subprocess.TimeoutExpired:
         return (
@@ -86,7 +93,7 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     try:
         data = json.loads(proc.stdout)
         if not data.get("loggedIn"):
-            return False, "Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY."
+            return False, f"Not authenticated. {_AUTH_HINT}"
         api_key_source = data.get("apiKeySource", "")
         if api_key_source:
             return True, f"Authenticated via {api_key_source}."
@@ -103,7 +110,7 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
             "unauthenticated",
         )
         if any(marker in plain for marker in negative_markers):
-            return False, "Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY."
+            return False, f"Not authenticated. {_AUTH_HINT}"
         return True, "Authenticated via Claude CLI."
 
 
@@ -130,12 +137,11 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
         return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
     if sys.platform == "darwin":
         return None, (
-            "Auth state unclear — binary unavailable for verification. "
-            "Run: claude auth login  or set ANTHROPIC_API_KEY."
+            f"Auth state unclear — binary unavailable for verification. {_AUTH_HINT}"
         )
     return (
         False,
-        "Not authenticated. Run: claude auth login  or set ANTHROPIC_API_KEY.",
+        f"Not authenticated. {_AUTH_HINT}",
     )
 
 
@@ -149,7 +155,7 @@ class ClaudeCodeAdapter:
     name = "claude-code"
     binary_env_key = "CLAUDE_CODE_BIN"
     install_hint = "npm i -g @anthropic-ai/claude-code"
-    auth_hint = "Run: claude auth login  or set ANTHROPIC_API_KEY"
+    auth_hint = _AUTH_HINT.removesuffix(".")
     min_version: str | None = None
     default_exec_timeout_sec = 120.0
 
@@ -208,7 +214,7 @@ class ClaudeCodeAdapter:
                 bin_path=None,
                 detail=(
                     "Claude Code CLI not found on PATH or known install locations. "
-                    f"Install with: {self.install_hint}  or set CLAUDE_CODE_BIN."
+                    f"Install with: {self.install_hint} or set CLAUDE_CODE_BIN."
                 ),
             )
         return self._probe_binary(binary)

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -66,6 +66,16 @@ def _anthropic_env_overrides() -> dict[str, str]:
     return env
 
 
+def _anthropic_auth_env_source() -> str | None:
+    """Return the active Anthropic auth env key, if present."""
+    env = _anthropic_env_overrides()
+    if env.get("ANTHROPIC_API_KEY"):
+        return "ANTHROPIC_API_KEY"
+    if env.get("ANTHROPIC_AUTH_TOKEN"):
+        return "ANTHROPIC_AUTH_TOKEN"
+    return None
+
+
 def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     """Check Claude Code auth via `claude auth status` (local, no API call).
 
@@ -128,8 +138,9 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
     """
     if binary_path:
         return _probe_cli_auth(binary_path)
-    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
-        return True, "Authenticated via ANTHROPIC_API_KEY."
+    auth_env_source = _anthropic_auth_env_source()
+    if auth_env_source:
+        return True, f"Authenticated via {auth_env_source}."
     creds_path = Path.home() / ".claude" / ".credentials.json"
     try:
         if creds_path.exists() and creds_path.stat().st_size > 2:
@@ -195,6 +206,10 @@ class ClaudeCodeAdapter:
 
         version = _parse_semver(ver_proc.stdout + ver_proc.stderr)
         logged_in, auth_detail = _classify_claude_code_auth(binary_path=binary_path)
+        auth_env_source = _anthropic_auth_env_source()
+        if logged_in is not True and auth_env_source:
+            logged_in = True
+            auth_detail = f"Authenticated via {auth_env_source} fallback."
         return CLIProbe(
             installed=True,
             version=version,

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -107,6 +107,10 @@ def _openai_platform_env_overrides() -> dict[str, str]:
     return out
 
 
+def _has_openai_api_key() -> bool:
+    return bool(os.environ.get("OPENAI_API_KEY", "").strip())
+
+
 class CodexAdapter:
     """Non-interactive Codex CLI (`codex exec` with read-only sandbox)."""
 
@@ -175,6 +179,11 @@ class CodexAdapter:
             logged_in, auth_detail = _classify_codex_auth(
                 auth_proc.returncode, auth_proc.stdout, auth_proc.stderr
             )
+
+        if logged_in is not True and _has_openai_api_key():
+            # Allow API-key auth when ChatGPT/session login is absent or unclear.
+            logged_in = True
+            auth_detail = "Authenticated via OPENAI_API_KEY fallback."
 
         detail = auth_detail + upgrade_note
         return CLIProbe(

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -1,4 +1,9 @@
-"""OpenAI Codex CLI adapter (`codex exec`, non-interactive)."""
+"""OpenAI Codex CLI adapter (`codex exec`, non-interactive).
+
+OpenAI Platform env vars (``OPENAI_API_KEY``, ``OPENAI_ORG_ID``, ``OPENAI_PROJECT_ID``,
+``OPENAI_BASE_URL``) are forwarded on invoke when set, so Codex runs work with
+usage-based API key auth as well as ``codex login`` sessions.
+"""
 
 from __future__ import annotations
 
@@ -79,6 +84,27 @@ def _codex_workspace_and_skip_git() -> tuple[str, bool]:
 
 def _fallback_codex_paths() -> list[str]:
     return _default_cli_fallback_paths("codex")
+
+
+def _openai_platform_env_overrides() -> dict[str, str]:
+    """Copy OpenAI Platform env vars into the Codex subprocess (invoke path only).
+
+    `build_cli_subprocess_env` does not forward `OPENAI_*` globally, so other CLI
+    adapters do not see them. Codex can authenticate via API key (usage billing)
+    in addition to `codex login` / ChatGPT subscription sessions.
+    """
+    keys = (
+        "OPENAI_API_KEY",
+        "OPENAI_ORG_ID",
+        "OPENAI_PROJECT_ID",
+        "OPENAI_BASE_URL",
+    )
+    out: dict[str, str] = {}
+    for key in keys:
+        val = os.environ.get(key, "").strip()
+        if val:
+            out[key] = val
+    return out
 
 
 class CodexAdapter:
@@ -202,11 +228,12 @@ class CodexAdapter:
 
         argv.append("-")
 
+        oai = _openai_platform_env_overrides()
         return CLIInvocation(
             argv=tuple(argv),
             stdin=prompt,
             cwd=ws,
-            env=None,
+            env=oai or None,
             timeout_sec=self.default_exec_timeout_sec,
         )
 

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -151,6 +151,7 @@ class CLIBackedLLMClient:
                 f"{self._adapter.name} is not authenticated. {self._adapter.auth_hint} "
                 f"({probe.detail})"
             )
+        auth_probe_unclear = probe.logged_in is None
 
         invocation = self._adapter.build(prompt=flat, model=self._model, workspace="")
         merged_env = _build_subprocess_env(invocation.env)
@@ -177,8 +178,14 @@ class CLIBackedLLMClient:
         err = _strip_ansi(proc.stderr or "")
 
         if proc.returncode != 0:
+            message = self._adapter.explain_failure(stdout=out, stderr=err, returncode=proc.returncode)
+            if auth_probe_unclear:
+                message = (
+                    f"{message}. Auth status could not be verified before invocation. "
+                    f"{self._adapter.auth_hint} ({probe.detail})"
+                )
             raise RuntimeError(
-                self._adapter.explain_failure(stdout=out, stderr=err, returncode=proc.returncode)
+                message
             )
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -133,15 +133,11 @@ class CLIBackedLLMClient:
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()
             if auth_probe_unclear:
-                suffix = (
+                message = (
+                    f"{base}\n\n"
                     f"Auth status could not be verified before invocation. "
                     f"{self._adapter.auth_hint} ({probe.detail})"
                 )
-                # Avoid \"..\" when explain_failure already ends with sentence punctuation.
-                if base.endswith((".", "!", "?")):
-                    message = f"{base} {suffix}"
-                else:
-                    message = f"{base}. {suffix}"
             else:
                 message = base
             raise RuntimeError(message)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 import subprocess
 import threading
@@ -13,6 +12,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
+from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.services.llm_client import LLMResponse
 
@@ -21,62 +21,13 @@ logger = logging.getLogger(__name__)
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 # Avoid re-running `detect()` (two subprocess probes) on every invoke during long investigations.
 _PROBE_CACHE_TTL_SEC = 45.0
-_SAFE_SUBPROCESS_ENV_KEYS = frozenset(
-    {
-        "HOME",
-        # macOS Keychain item lookup (where `claude login` stores OAuth on darwin)
-        # requires USER. LOGNAME is the POSIX/Linux equivalent kept for parity.
-        "USER",
-        "LOGNAME",
-        "USERPROFILE",
-        "APPDATA",
-        "LOCALAPPDATA",
-        "PATH",
-        "PATHEXT",
-        "SYSTEMROOT",
-        "WINDIR",
-        "COMSPEC",
-        "SHELL",
-        "TMP",
-        "TEMP",
-        "TMPDIR",
-        "LANG",
-        "TERM",
-        "TZ",
-        "NO_PROXY",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "ALL_PROXY",
-        "SSL_CERT_FILE",
-        "SSL_CERT_DIR",
-        "REQUESTS_CA_BUNDLE",
-        "CURL_CA_BUNDLE",
-        "NO_COLOR",
-        "FORCE_COLOR",
-        "COLORTERM",
-        "XDG_CONFIG_HOME",
-        "XDG_CACHE_HOME",
-        "XDG_DATA_HOME",
-        "XDG_STATE_HOME",
-    }
-)
-_SAFE_SUBPROCESS_ENV_PREFIXES = ("LC_", "CODEX_", "CLAUDE_")
+
+# Back-compat name for tests and imports that expect this symbol on runner.
+_build_subprocess_env = build_cli_subprocess_env
 
 
 def _strip_ansi(text: str) -> str:
     return _ANSI_ESCAPE.sub("", text)
-
-
-def _build_subprocess_env(overrides: dict[str, str] | None) -> dict[str, str]:
-    env: dict[str, str] = {}
-    for key, value in os.environ.items():
-        if key in _SAFE_SUBPROCESS_ENV_KEYS or any(
-            key.startswith(prefix) for prefix in _SAFE_SUBPROCESS_ENV_PREFIXES
-        ):
-            env[key] = value
-    if overrides:
-        env.update(overrides)
-    return env
 
 
 class CLIBackedLLMClient:
@@ -178,14 +129,21 @@ class CLIBackedLLMClient:
         err = _strip_ansi(proc.stderr or "")
 
         if proc.returncode != 0:
-            message = self._adapter.explain_failure(
+            base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
-            )
+            ).strip()
             if auth_probe_unclear:
-                message = (
-                    f"{message}. Auth status could not be verified before invocation. "
+                suffix = (
+                    f"Auth status could not be verified before invocation. "
                     f"{self._adapter.auth_hint} ({probe.detail})"
                 )
+                # Avoid \"..\" when explain_failure already ends with sentence punctuation.
+                if base.endswith((".", "!", "?")):
+                    message = f"{base} {suffix}"
+                else:
+                    message = f"{base}. {suffix}"
+            else:
+                message = base
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -178,15 +178,15 @@ class CLIBackedLLMClient:
         err = _strip_ansi(proc.stderr or "")
 
         if proc.returncode != 0:
-            message = self._adapter.explain_failure(stdout=out, stderr=err, returncode=proc.returncode)
+            message = self._adapter.explain_failure(
+                stdout=out, stderr=err, returncode=proc.returncode
+            )
             if auth_probe_unclear:
                 message = (
                     f"{message}. Auth status could not be verified before invocation. "
                     f"{self._adapter.auth_hint} ({probe.detail})"
                 )
-            raise RuntimeError(
-                message
-            )
+            raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)
         content = _strip_ansi(content).strip()

--- a/app/integrations/llm_cli/subprocess_env.py
+++ b/app/integrations/llm_cli/subprocess_env.py
@@ -1,0 +1,64 @@
+"""Filtered environment for spawning LLM CLI subprocesses.
+
+Only keys needed for binary resolution, locale, proxies, TLS, and adapter-specific
+prefixes are forwarded from ``os.environ``. Adapter implementations merge their
+own overrides (for example explicit API keys for that CLI only).
+"""
+
+from __future__ import annotations
+
+import os
+
+_SAFE_SUBPROCESS_ENV_KEYS = frozenset(
+    {
+        "HOME",
+        # macOS Keychain item lookup (where `claude login` stores OAuth on darwin)
+        # requires USER. LOGNAME is the POSIX/Linux equivalent kept for parity.
+        "USER",
+        "LOGNAME",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "SHELL",
+        "TMP",
+        "TEMP",
+        "TMPDIR",
+        "LANG",
+        "TERM",
+        "TZ",
+        "NO_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "COLORTERM",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+    }
+)
+_SAFE_SUBPROCESS_ENV_PREFIXES = ("LC_", "CODEX_", "CLAUDE_")
+
+
+def build_cli_subprocess_env(overrides: dict[str, str] | None) -> dict[str, str]:
+    """Return a subprocess ``env`` dict: safe inherited keys plus optional overrides."""
+    env: dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key in _SAFE_SUBPROCESS_ENV_KEYS or any(
+            key.startswith(prefix) for prefix in _SAFE_SUBPROCESS_ENV_PREFIXES
+        ):
+            env[key] = value
+    if overrides:
+        env.update(overrides)
+    return env

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -40,7 +40,7 @@ def _capture() -> tuple[Console, io.StringIO]:
 
 
 class _FakeLLMResponse:
-    def __init__(self, content: str) -> None:
+    def __init__(self, content: Any) -> None:
         self.content = content
 
 
@@ -180,6 +180,20 @@ class TestAssistantOutputRendering:
             ("user", "hello"),
             ("assistant", "Sure thing."),
         ]
+
+    def test_structured_content_blocks_are_rendered(self, monkeypatch: Any) -> None:
+        class _Block:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        _patch_llm(monkeypatch, [_Block("First line"), {"text": "Second line"}])
+        session = ReplSession()
+        console, buf = _capture()
+        answer_cli_agent("hello", session, console)
+        output = _strip_ansi(buf.getvalue())
+        assert "First line" in output
+        assert "Second line" in output
+        assert session.cli_agent_messages[-1] == ("assistant", "First line\nSecond line")
 
     def test_llm_failure_prints_red_error_and_does_not_record(self, monkeypatch: Any) -> None:
         class _Boom:

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -93,6 +93,7 @@ class TestSystemPromptTerminology:
         assert _ACTION_RULE in prompt
         assert "switch_llm_provider" in prompt
         assert '"action":"switch_llm_provider"' in prompt
+        assert "claude-code" in prompt
 
 
 class TestActionPlanParsing:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -54,3 +54,22 @@ def test_check_llm_provider_claude_code_auth_unclear(monkeypatch) -> None:
     ok, detail = doctor._check_llm_provider()
     assert ok is False
     assert "auth status unclear" in detail
+
+
+def test_check_llm_provider_cli_branch_follows_registry_not_hardcoded_ids(monkeypatch) -> None:
+    """Any LLM_PROVIDER listed in CLI_PROVIDER_REGISTRY gets the CLI probe path."""
+    monkeypatch.setenv("LLM_PROVIDER", "hypothetical-cli")
+    reg = MagicMock()
+    reg.adapter_factory.return_value.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/hypothetical",
+        logged_in=True,
+        detail="CLI OK.",
+    )
+    monkeypatch.setattr(
+        "app.integrations.llm_cli.registry.get_cli_provider_registration",
+        lambda provider: reg if provider == "hypothetical-cli" else None,
+    )
+    ok, detail = doctor._check_llm_provider()
+    assert ok is True
+    assert "CLI ready" in detail

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.cli.commands import doctor
+
+
+def test_check_llm_provider_not_set(monkeypatch) -> None:
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    ok, detail = doctor._check_llm_provider()
+    assert ok is False
+    assert "not set" in detail
+
+
+def test_check_llm_provider_hosted_missing_key(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    ok, detail = doctor._check_llm_provider()
+    assert ok is False
+    assert "ANTHROPIC_API_KEY" in detail
+
+
+def test_check_llm_provider_claude_code_ready(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "claude-code")
+    reg = MagicMock()
+    reg.adapter_factory.return_value.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/claude",
+        logged_in=True,
+        detail="Authenticated via Claude subscription.",
+    )
+    monkeypatch.setattr(
+        "app.integrations.llm_cli.registry.get_cli_provider_registration",
+        lambda provider: reg if provider == "claude-code" else None,
+    )
+    ok, detail = doctor._check_llm_provider()
+    assert ok is True
+    assert "CLI ready" in detail
+
+
+def test_check_llm_provider_claude_code_auth_unclear(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "claude-code")
+    reg = MagicMock()
+    reg.adapter_factory.return_value.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/claude",
+        logged_in=None,
+        detail="claude auth status failed: unknown command",
+    )
+    monkeypatch.setattr(
+        "app.integrations.llm_cli.registry.get_cli_provider_registration",
+        lambda provider: reg if provider == "claude-code" else None,
+    )
+    ok, detail = doctor._check_llm_provider()
+    assert ok is False
+    assert "auth status unclear" in detail

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -692,6 +692,65 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
     assert "CODEX_MODEL=\n" in env_values
 
 
+def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
+    monkeypatch, tmp_path
+) -> None:
+    select_responses = iter(["quickstart", "claude-code", "skip"])
+    saved_llm_keys: list[tuple[str, str]] = []
+    cli_onboarding_providers: list[str] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _cli_onboarding(provider):
+        cli_onboarding_providers.append(provider.value)
+        return "ok"
+
+    store_path = tmp_path / "opensre.json"
+    env_path = tmp_path / ".env"
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow, "get_store_path", lambda: store_path)
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
+    monkeypatch.setattr(
+        flow,
+        "build_demo_action_response",
+        lambda: {"success": True, "topics": [], "guidance": []},
+    )
+    monkeypatch.setattr(
+        flow,
+        "save_local_config",
+        lambda **kwargs: wizard_store.save_local_config(path=store_path, **kwargs),
+    )
+    monkeypatch.setattr(
+        flow,
+        "sync_provider_env",
+        lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
+    )
+    monkeypatch.setattr(
+        flow,
+        "save_llm_api_key",
+        lambda env_var, value: saved_llm_keys.append((env_var, value)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert cli_onboarding_providers == ["claude-code"]
+    assert saved_llm_keys == []
+
+    payload = json.loads(store_path.read_text(encoding="utf-8"))
+    env_values = env_path.read_text(encoding="utf-8")
+    assert payload["targets"]["local"]["provider"] == "claude-code"
+    assert payload["targets"]["local"]["api_key_env"] == ""
+    assert payload["targets"]["local"]["model_env"] == "CLAUDE_CODE_MODEL"
+    assert "LLM_PROVIDER=claude-code\n" in env_values
+    assert "CLAUDE_CODE_MODEL=\n" in env_values
+
+
 def test_run_cli_llm_onboarding_ok_when_logged_in(monkeypatch) -> None:
     adapter = MagicMock()
     adapter.name = "codex"
@@ -903,6 +962,15 @@ def test_credential_line_for_saved_summary_cli_codex() -> None:
 
     codex = next(p for p in wizard_config.SUPPORTED_PROVIDERS if p.value == "codex")
     assert flow._credential_line_for_saved_summary(codex) == ("OpenAI Codex CLI (Run: codex login)")
+
+
+def test_credential_line_for_saved_summary_cli_claude_code() -> None:
+    from app.cli.wizard import config as wizard_config
+
+    claude_code = next(p for p in wizard_config.SUPPORTED_PROVIDERS if p.value == "claude-code")
+    assert flow._credential_line_for_saved_summary(claude_code) == (
+        "Anthropic Claude Code CLI (Run: claude auth login or set ANTHROPIC_API_KEY)"
+    )
 
 
 def test_credential_line_for_saved_summary_anthropic() -> None:

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock
 
 from app.cli.wizard import flow
 from app.cli.wizard import store as wizard_store
 from app.cli.wizard.env_sync import sync_provider_env
 from app.cli.wizard.probes import ProbeResult
+from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
 
 
 def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, capsys) -> None:
@@ -890,12 +892,7 @@ def test_run_cli_llm_onboarding_repick_when_user_chooses_repick(monkeypatch) -> 
 
 
 def test_run_cli_llm_onboarding_path_override_then_ok(monkeypatch, tmp_path) -> None:
-    # Create a real executable so diagnose_binary_path accepts it.
-    fake_bin = tmp_path / "codex"
-    fake_bin.write_bytes(b"")
-    import os as _os
-
-    _os.chmod(fake_bin, 0o700)
+    fake_bin = write_fake_runnable_cli_bin(tmp_path, "codex")
 
     adapter = MagicMock()
     adapter.name = "codex"
@@ -920,7 +917,7 @@ def test_run_cli_llm_onboarding_path_override_then_ok(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(flow, "_prompt_value", lambda *_args, **_kwargs: str(fake_bin))
     monkeypatch.setattr(flow, "sync_env_values", lambda *_args, **_kwargs: None)
 
-    original_codex_bin = _os.environ.get("CODEX_BIN")
+    original_codex_bin = os.environ.get("CODEX_BIN")
     try:
         result = flow._run_cli_llm_onboarding(provider)
 
@@ -928,12 +925,12 @@ def test_run_cli_llm_onboarding_path_override_then_ok(monkeypatch, tmp_path) -> 
         assert len(detect_calls) == 2
         # os.environ must be updated in-process so the next detect() call in the
         # retry loop resolves the new binary without a process restart.
-        assert _os.environ.get("CODEX_BIN") == str(fake_bin)
+        assert os.environ.get("CODEX_BIN") == str(fake_bin)
     finally:
         if original_codex_bin is None:
-            _os.environ.pop("CODEX_BIN", None)
+            os.environ.pop("CODEX_BIN", None)
         else:
-            _os.environ["CODEX_BIN"] = original_codex_bin
+            os.environ["CODEX_BIN"] = original_codex_bin
 
 
 def test_run_cli_llm_onboarding_abort_after_max_retries(monkeypatch) -> None:

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -451,8 +451,9 @@ def test_build_omits_model_flag_when_none(_mock_which: MagicMock) -> None:
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")
 def test_build_uses_provided_workspace(_mock_which: MagicMock) -> None:
-    inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace="/my/project")
-    assert inv.cwd == "/my/project"
+    workspace = "/my/project"
+    inv = ClaudeCodeAdapter().build(prompt="p", model=None, workspace=workspace)
+    assert Path(inv.cwd) == Path(workspace)
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/claude")

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -199,6 +199,50 @@ def test_probe_cli_auth_non_json_exit_zero(mock_run: MagicMock) -> None:
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_non_json_not_logged_in_exit_zero(mock_run: MagicMock) -> None:
+    """Plain-text 'not logged in' on exit 0 must not be misclassified as authenticated."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = "Not logged in\n"
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "Not authenticated" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_uses_filtered_subprocess_env(mock_run: MagicMock) -> None:
+    """Auth probe should use the same filtered env shape as runtime invocation."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = '{"loggedIn": true, "apiKeySource": "ANTHROPIC_API_KEY"}\n'
+    m.stderr = ""
+    mock_run.return_value = m
+
+    with patch.dict(
+        os.environ,
+        {
+            "PATH": "/usr/bin",
+            "OPENAI_API_KEY": "should-not-leak",
+            "RANDOM_SECRET": "should-not-leak",
+            "CLAUDE_CODE_MODEL": "claude-opus-4-7",
+            "ANTHROPIC_API_KEY": "sk-visible",
+        },
+        clear=False,
+    ):
+        logged_in, _detail = _probe_cli_auth("/usr/bin/claude")
+
+    assert logged_in is True
+    env = mock_run.call_args.kwargs["env"]
+    assert env["PATH"] == "/usr/bin"
+    assert env["CLAUDE_CODE_MODEL"] == "claude-opus-4-7"
+    assert env["ANTHROPIC_API_KEY"] == "sk-visible"
+    assert "OPENAI_API_KEY" not in env
+    assert "RANDOM_SECRET" not in env
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
 def test_detect_subscription_authenticated(mock_which: MagicMock, mock_run: MagicMock) -> None:
     """detect() returns logged_in=True via subscription when binary is available."""
@@ -436,6 +480,11 @@ def test_explain_failure_falls_back_to_stdout() -> None:
     adapter = ClaudeCodeAdapter()
     msg = adapter.explain_failure(stdout="some output", stderr="", returncode=2)
     assert "some output" in msg
+
+
+def test_auth_hint_uses_claude_auth_login() -> None:
+    adapter = ClaudeCodeAdapter()
+    assert "claude auth login" in adapter.auth_hint
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -185,6 +185,14 @@ def test_probe_cli_auth_os_error(mock_run: MagicMock) -> None:
     assert "permission denied" in detail
 
 
+@patch("app.integrations.llm_cli.claude_code.importlib.import_module")
+def test_probe_cli_auth_import_error(mock_import_module: MagicMock) -> None:
+    mock_import_module.side_effect = ImportError("runner import failed")
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is None
+    assert "prepare claude auth probe environment" in detail
+
+
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 def test_probe_cli_auth_non_json_exit_zero(mock_run: MagicMock) -> None:
     """Older CLI versions that output non-JSON on exit 0 are treated as authenticated."""
@@ -485,6 +493,7 @@ def test_explain_failure_falls_back_to_stdout() -> None:
 def test_auth_hint_uses_claude_auth_login() -> None:
     adapter = ClaudeCodeAdapter()
     assert "claude auth login" in adapter.auth_hint
+    assert "  " not in adapter.auth_hint
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -62,6 +62,20 @@ def test_classify_auth_no_credentials_macos_returns_none() -> None:
     assert logged_in is None
 
 
+def test_classify_auth_no_credentials_windows_returns_false() -> None:
+    """On Windows, same as Linux: without binary or OAuth file, auth is definitively False."""
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}, clear=False),
+        patch("app.integrations.llm_cli.claude_code.sys.platform", "win32"),
+        patch("app.integrations.llm_cli.claude_code.Path") as mock_path,
+    ):
+        mock_creds = MagicMock()
+        mock_creds.exists.return_value = False
+        mock_path.home.return_value.__truediv__.return_value.__truediv__.return_value = mock_creds
+        logged_in, _detail = _classify_claude_code_auth()
+    assert logged_in is False
+
+
 def test_classify_auth_credentials_file_present(tmp_path: Path) -> None:
     # Create a fake ~/.claude/.credentials.json under tmp_path.
     claude_dir = tmp_path / ".claude"

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -15,6 +15,7 @@ from app.integrations.llm_cli.claude_code import (
     _fallback_claude_code_paths,
     _probe_cli_auth,
 )
+from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
 
 
 def _posix_path_set(paths: list[str]) -> set[str]:
@@ -494,9 +495,7 @@ def test_auth_hint_uses_claude_auth_login() -> None:
 
 
 def test_detect_uses_claude_code_bin_env(tmp_path: Path) -> None:
-    fake_bin = tmp_path / "my-claude"
-    fake_bin.write_bytes(b"")
-    os.chmod(fake_bin, 0o700)
+    fake_bin = write_fake_runnable_cli_bin(tmp_path, "my-claude")
 
     with (
         patch.dict(

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -34,6 +34,17 @@ def test_classify_auth_api_key_set() -> None:
     assert "ANTHROPIC_API_KEY" in detail
 
 
+def test_classify_auth_auth_token_set() -> None:
+    with patch.dict(
+        os.environ,
+        {"ANTHROPIC_AUTH_TOKEN": "tok-test", "ANTHROPIC_API_KEY": ""},
+        clear=False,
+    ):
+        logged_in, detail = _classify_claude_code_auth()
+    assert logged_in is True
+    assert "ANTHROPIC_AUTH_TOKEN" in detail
+
+
 def test_classify_auth_no_credentials_linux() -> None:
     """On Linux, no env var and no credentials file → definitive False."""
     with (
@@ -353,6 +364,62 @@ def test_detect_not_authenticated(mock_which: MagicMock, mock_run: MagicMock) ->
 
     assert probe.installed is True
     assert probe.logged_in is False
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_not_authenticated_uses_api_key_fallback(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_which.return_value = "/usr/bin/claude"
+    mock_run.side_effect = [_version_proc(), _auth_status_proc(False)]
+
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-fallback"}, clear=False):
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "ANTHROPIC_API_KEY fallback" in probe.detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_not_authenticated_uses_auth_token_fallback(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_which.return_value = "/usr/bin/claude"
+    mock_run.side_effect = [_version_proc(), _auth_status_proc(False)]
+
+    with patch.dict(
+        os.environ,
+        {"ANTHROPIC_AUTH_TOKEN": "tok-fallback", "ANTHROPIC_API_KEY": ""},
+        clear=False,
+    ):
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "ANTHROPIC_AUTH_TOKEN fallback" in probe.detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_unclear_auth_uses_api_key_fallback(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_which.return_value = "/usr/bin/claude"
+    auth_proc = MagicMock()
+    auth_proc.returncode = 1
+    auth_proc.stdout = ""
+    auth_proc.stderr = "unknown command 'auth'"
+    mock_run.side_effect = [_version_proc(), auth_proc]
+
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-fallback"}, clear=False):
+        probe = ClaudeCodeAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "ANTHROPIC_API_KEY fallback" in probe.detail
 
 
 @patch("app.integrations.llm_cli.claude_code._fallback_claude_code_paths", return_value=[])

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -185,14 +185,6 @@ def test_probe_cli_auth_os_error(mock_run: MagicMock) -> None:
     assert "permission denied" in detail
 
 
-@patch("app.integrations.llm_cli.claude_code.importlib.import_module")
-def test_probe_cli_auth_import_error(mock_import_module: MagicMock) -> None:
-    mock_import_module.side_effect = ImportError("runner import failed")
-    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
-    assert logged_in is None
-    assert "prepare claude auth probe environment" in detail
-
-
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 def test_probe_cli_auth_non_json_exit_zero(mock_run: MagicMock) -> None:
     """Older CLI versions that output non-JSON on exit 0 are treated as authenticated."""
@@ -636,23 +628,23 @@ def test_anthropic_key_forwarded_via_build() -> None:
 
 def test_anthropic_key_not_in_blanket_subprocess_env() -> None:
     """ANTHROPIC_API_KEY must NOT be forwarded via the global prefix allowlist (would leak to Codex)."""
-    from app.integrations.llm_cli.runner import _build_subprocess_env
+    from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 
     with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-secret"}, clear=False):
-        env = _build_subprocess_env(None)
+        env = build_cli_subprocess_env(None)
 
     assert "ANTHROPIC_API_KEY" not in env
 
 
 def test_claude_prefix_forwarded_to_subprocess() -> None:
-    from app.integrations.llm_cli.runner import _build_subprocess_env
+    from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 
     with patch.dict(
         os.environ,
         {"CLAUDE_CODE_MODEL": "claude-opus-4-7", "CLAUDE_CODE_BIN": "/usr/bin/claude"},
         clear=False,
     ):
-        env = _build_subprocess_env(None)
+        env = build_cli_subprocess_env(None)
 
     assert env["CLAUDE_CODE_MODEL"] == "claude-opus-4-7"
     assert env["CLAUDE_CODE_BIN"] == "/usr/bin/claude"

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -92,6 +92,32 @@ def test_detect_not_logged_in(mock_which: MagicMock, mock_run: MagicMock) -> Non
 
 @patch("app.integrations.llm_cli.codex.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_not_logged_in_uses_openai_api_key_fallback(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_which.return_value = "/usr/bin/codex"
+
+    def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+        if len(args) >= 2 and args[1] == "--version":
+            return _version_proc()
+        if len(args) >= 3 and args[1] == "login":
+            m = MagicMock()
+            m.returncode = 1
+            m.stdout = ""
+            m.stderr = "Not logged in\n"
+            return m
+        raise AssertionError(args)
+
+    mock_run.side_effect = side_effect
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-fallback"}, clear=False):
+        probe = CodexAdapter().detect()
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "OPENAI_API_KEY fallback" in probe.detail
+
+
+@patch("app.integrations.llm_cli.codex.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
 def test_detect_not_logged_in_exit_zero(mock_which: MagicMock, mock_run: MagicMock) -> None:
     """Some Codex versions may exit 0 while printing 'Not logged in' — must not match 'logged in'."""
     mock_which.return_value = "/usr/bin/codex"
@@ -111,6 +137,32 @@ def test_detect_not_logged_in_exit_zero(mock_which: MagicMock, mock_run: MagicMo
     probe = CodexAdapter().detect()
     assert probe.installed is True
     assert probe.logged_in is False
+
+
+@patch("app.integrations.llm_cli.codex.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_unclear_auth_uses_openai_api_key_fallback(
+    mock_which: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_which.return_value = "/usr/bin/codex"
+
+    def side_effect(args: list[str], **kwargs: object) -> MagicMock:
+        if len(args) >= 2 and args[1] == "--version":
+            return _version_proc()
+        if len(args) >= 3 and args[1] == "login":
+            m = MagicMock()
+            m.returncode = 2
+            m.stdout = ""
+            m.stderr = "network unreachable"
+            return m
+        raise AssertionError(args)
+
+    mock_run.side_effect = side_effect
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-fallback"}, clear=False):
+        probe = CodexAdapter().detect()
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "OPENAI_API_KEY fallback" in probe.detail
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/codex")

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -114,6 +114,38 @@ def test_detect_not_logged_in_exit_zero(mock_which: MagicMock, mock_run: MagicMo
 
 
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/codex")
+def test_build_forwards_openai_platform_env(mock_which: MagicMock) -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-test",
+            "OPENAI_ORG_ID": "org-x",
+            "OPENAI_PROJECT_ID": "proj-y",
+            "OPENAI_BASE_URL": "https://example.invalid/v1",
+        },
+        clear=False,
+    ):
+        inv = CodexAdapter().build(prompt="p", model=None, workspace="")
+
+    mock_which.assert_called()
+    assert inv.env is not None
+    assert inv.env["OPENAI_API_KEY"] == "sk-test"
+    assert inv.env["OPENAI_ORG_ID"] == "org-x"
+    assert inv.env["OPENAI_PROJECT_ID"] == "proj-y"
+    assert inv.env["OPENAI_BASE_URL"] == "https://example.invalid/v1"
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/codex")
+def test_build_omits_env_without_openai_platform_vars(mock_which: MagicMock) -> None:
+    """Strip OPENAI_* so build() does not attach env overrides from the real shell."""
+    base = {k: v for k, v in os.environ.items() if not k.startswith("OPENAI_")}
+    with patch.dict(os.environ, base, clear=True):
+        inv = CodexAdapter().build(prompt="p", model=None, workspace="")
+    mock_which.assert_called()
+    assert inv.env is None
+
+
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which", return_value="/usr/bin/codex")
 def test_build_adds_model_flag_when_not_default(mock_which: MagicMock) -> None:
     inv = CodexAdapter().build(prompt="p", model="o3", workspace="")
     assert inv.stdin == "p"
@@ -172,6 +204,47 @@ def test_cli_backed_client_invoke(mock_run: MagicMock) -> None:
     assert env["CODEX_BIN"] == "/custom/codex"
     assert "ANTHROPIC_API_KEY" not in env
     assert "OPENAI_API_KEY" not in env
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+@patch.object(CodexAdapter, "_probe_binary")
+@patch.object(CodexAdapter, "_resolve_binary", return_value="/usr/bin/codex")
+def test_cli_backed_client_codex_merge_openai_platform_env(
+    _mock_resolve: MagicMock,
+    mock_probe_binary: MagicMock,
+    mock_run: MagicMock,
+) -> None:
+    """Codex invoke merges OPENAI_* from the adapter into the filtered subprocess env."""
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_probe_binary.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/codex",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_run.return_value = MagicMock(returncode=0, stdout="ok\n", stderr="")
+
+    with (
+        patch("app.guardrails.engine.get_guardrail_engine") as gr,
+        patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-from-env",
+                "OPENAI_BASE_URL": "https://proxy.example/v1",
+                "PATH": "/usr/bin",
+            },
+            clear=False,
+        ),
+    ):
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(CodexAdapter(), model=None, max_tokens=256)
+        client.invoke("hello")
+
+    merged = mock_run.call_args.kwargs["env"]
+    assert merged["OPENAI_API_KEY"] == "sk-from-env"
+    assert merged["OPENAI_BASE_URL"] == "https://proxy.example/v1"
+    assert "ANTHROPIC_API_KEY" not in merged
 
 
 @patch("app.integrations.llm_cli.runner.subprocess.run")

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 from app.integrations.llm_cli.binary_resolver import diagnose_binary_path, npm_prefix_bin_dirs
 from app.integrations.llm_cli.codex import CodexAdapter, _fallback_codex_paths
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
+from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_bin
 
 
 def _posix_path_set(paths: list[str]) -> set[str]:
@@ -286,9 +287,7 @@ def test_cli_backed_client_unclear_auth_no_double_period_when_explain_failure_tr
 
 
 def test_detect_uses_codex_bin_env_file(tmp_path) -> None:
-    fake_bin = tmp_path / "my-codex"
-    fake_bin.write_bytes(b"")
-    os.chmod(fake_bin, 0o700)
+    fake_bin = write_fake_runnable_cli_bin(tmp_path, "my-codex")
 
     with (
         patch.dict(os.environ, {"CODEX_BIN": str(fake_bin)}, clear=False),
@@ -460,9 +459,7 @@ def test_diagnose_binary_path_missing_file(tmp_path: Path) -> None:
 
 
 def test_diagnose_binary_path_valid_executable(tmp_path: Path) -> None:
-    exe = tmp_path / "my-bin"
-    exe.write_bytes(b"")
-    os.chmod(exe, 0o700)
+    exe = write_fake_runnable_cli_bin(tmp_path, "my-bin")
     assert diagnose_binary_path(str(exe)) is None
 
 

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -243,6 +243,48 @@ def test_cli_backed_client_failure_mentions_unclear_auth_probe(mock_run: MagicMo
             client.invoke("hello")
 
 
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_unclear_auth_no_double_period_when_explain_failure_trailing_period(
+    mock_run: MagicMock,
+) -> None:
+    """When explain_failure ends with '.', avoid composing '..'."""
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock()
+    mock_adapter.name = "claude-code"
+    mock_adapter.auth_hint = "Run: claude auth login"
+    mock_adapter.binary_env_key = "CLAUDE_CODE_BIN"
+    mock_adapter.install_hint = "npm i -g @anthropic-ai/claude-code"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/claude",
+        logged_in=None,
+        detail="probe unclear",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/claude", "-p"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = "claude -p exited with code 1."
+
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="unauthorized")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="claude-code", max_tokens=256)
+        import pytest
+
+        with pytest.raises(RuntimeError) as exc_info:
+            client.invoke("hello")
+
+    msg = str(exc_info.value)
+    assert ".." not in msg
+    assert "code 1. Auth status could not be verified" in msg
+
+
 def test_detect_uses_codex_bin_env_file(tmp_path) -> None:
     fake_bin = tmp_path / "my-codex"
     fake_bin.write_bytes(b"")

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -283,7 +283,8 @@ def test_cli_backed_client_unclear_auth_no_double_period_when_explain_failure_tr
 
     msg = str(exc_info.value)
     assert ".." not in msg
-    assert "code 1. Auth status could not be verified" in msg
+    assert "code 1." in msg
+    assert "Auth status could not be verified" in msg
 
 
 def test_detect_uses_codex_bin_env_file(tmp_path) -> None:

--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -208,6 +208,41 @@ def test_cli_backed_client_caches_probe_between_invokes(mock_run: MagicMock) -> 
     assert mock_run.call_count == 2
 
 
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_failure_mentions_unclear_auth_probe(mock_run: MagicMock) -> None:
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock()
+    mock_adapter.name = "claude-code"
+    mock_adapter.auth_hint = "Run: claude auth login"
+    mock_adapter.binary_env_key = "CLAUDE_CODE_BIN"
+    mock_adapter.install_hint = "npm i -g @anthropic-ai/claude-code"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/claude",
+        logged_in=None,
+        detail="claude auth status failed: unknown command",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/claude", "-p"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = "claude -p exited with code 1"
+
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="unauthorized")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="claude-code", max_tokens=256)
+        import pytest
+
+        with pytest.raises(RuntimeError, match="Auth status could not be verified"):
+            client.invoke("hello")
+
+
 def test_detect_uses_codex_bin_env_file(tmp_path) -> None:
     fake_bin = tmp_path / "my-codex"
     fake_bin.write_bytes(b"")

--- a/tests/integrations/llm_cli/testing_helpers.py
+++ b/tests/integrations/llm_cli/testing_helpers.py
@@ -1,0 +1,21 @@
+"""Cross-platform helpers for ``llm_cli`` tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def write_fake_runnable_cli_bin(tmp_path: Path, stem: str) -> Path:
+    """Create a minimal file that passes ``is_runnable_binary`` on this OS.
+
+    On Windows, extensionless scripts are rejected unless ``os.access`` claims
+    execute — portable tests use ``.exe`` so resolution matches production rules.
+    """
+    filename = f"{stem}.exe" if sys.platform == "win32" else stem
+    path = tmp_path / filename
+    path.write_bytes(b"")
+    if sys.platform != "win32":
+        os.chmod(path, 0o700)
+    return path

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -157,3 +157,32 @@ def test_minimax_llm_client_temperature_is_set(monkeypatch) -> None:
         temperature=1.0,
     )
     assert client._temperature == 1.0
+
+
+def test_create_llm_client_claude_code_wires_cli_adapter(monkeypatch) -> None:
+    """Investigation uses ``_create_llm_client`` → registry → ``CLIBackedLLMClient``."""
+    monkeypatch.setenv("LLM_PROVIDER", "claude-code")
+    monkeypatch.delenv("CLAUDE_CODE_MODEL", raising=False)
+    llm_client.reset_llm_singletons()
+    try:
+        from app.integrations.llm_cli.claude_code import ClaudeCodeAdapter
+        from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+        client = llm_client._create_llm_client("reasoning")
+
+        assert isinstance(client, CLIBackedLLMClient)
+        assert isinstance(client._adapter, ClaudeCodeAdapter)
+    finally:
+        llm_client.reset_llm_singletons()
+
+
+def test_create_llm_client_claude_code_reads_optional_model_env(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "claude-code")
+    monkeypatch.setenv("CLAUDE_CODE_MODEL", "claude-opus-4-7")
+    llm_client.reset_llm_singletons()
+    try:
+        client = llm_client._create_llm_client("reasoning")
+
+        assert client._model == "claude-opus-4-7"
+    finally:
+        llm_client.reset_llm_singletons()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,3 +96,14 @@ def test_llm_settings_from_env_max_tokens_default(monkeypatch) -> None:
     settings = LLMSettings.from_env()
 
     assert settings.max_tokens == DEFAULT_MAX_TOKENS
+
+
+def test_llm_settings_from_env_claude_code_without_api_key(monkeypatch) -> None:
+    """CLI-backed Claude Code: onboard writes LLM_PROVIDER only; no hosted API key."""
+    monkeypatch.setenv("LLM_PROVIDER", "claude-code")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
+
+    settings = LLMSettings.from_env()
+
+    assert settings.provider == "claude-code"


### PR DESCRIPTION
Fixes #1260

#### Describe the changes you have made in this PR -
- handle claude auth probe bootstrap failures safely by catching runner import failures and returning an unclear-auth probe result instead of crashing
- normalize user-facing Claude auth hints to remove duplicate spacing and keep messaging consistent across adapter paths
- improve interactive shell response extraction to support structured LLM content blocks (`list` / `dict` / `.text` objects)
- add regression tests for probe import failures, auth hint formatting, and structured interactive-shell response rendering

### Demo/Screenshot for feature changes and bug fixes - 
- `uv run pytest tests/integrations/llm_cli/test_claude_code_adapter.py tests/cli/interactive_shell/test_cli_agent.py`
- Result: `60 passed`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- The main failure mode fixed here is an avoidable crash during Claude auth probing when the helper import path is unavailable. The adapter now treats that condition as an unknown auth state, which preserves diagnostic flow and surfaces an actionable message instead of throwing at import time.
- I kept auth messaging centralized by introducing one shared hint constant and using it in all unauthenticated/unclear branches. This avoids drift between probe/classify/runtime errors and removes formatting inconsistencies from user-facing output.
- For interactive shell robustness, response parsing now handles structured content payloads from providers that return block objects instead of plain strings. This preserves intended text output and avoids leaking Python repr-style payloads in terminal responses.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.