### PR TITLE
revert(ci): skip coverage artifact upload on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
           -m "${{ matrix.os == 'windows-latest' && 'not synthetic and not integration' || 'not synthetic' }}"
 
       - name: Upload coverage
-        if: always() && matrix.os == 'ubuntu-latest'
+        if: >-
+          always() && matrix.os == 'ubuntu-latest' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.os }}


### PR DESCRIPTION
## Summary

Reverts the widening of the **Upload coverage** step from #1291 so fork PRs no longer upload `htmlcov/` and `.coverage` as Actions artifacts.

## Behavior

- **Push to main / PR from same repo**: unchanged — coverage artifacts still uploaded for Ubuntu.
- **PR from a fork**: tests still run with `--cov` and terminal/html reports in the job log; only the artifact upload is skipped (reduces storage/noise for fork workflows).

## Related

Follow-up to #1291 coverage-upload change.