### PR TITLE
test(wizard): fix Claude Code flow test after demo step removal

### DIFF
--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -670,11 +670,6 @@ def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
     monkeypatch.setattr(flow, "_run_cli_llm_onboarding", _cli_onboarding)
     monkeypatch.setattr(
         flow,
-        "build_demo_action_response",
-        lambda: {"success": True, "topics": [], "guidance": []},
-    )
-    monkeypatch.setattr(
-        flow,
         "save_local_config",
         lambda **kwargs: wizard_store.save_local_config(path=store_path, **kwargs),
     )


### PR DESCRIPTION
## Summary
Upstream `run_wizard` no longer calls `build_demo_action_response()` (see `_render_saved_summary` → `_render_next_steps`). `test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding` was the only test still monkeypatching `flow.build_demo_action_response`, which no longer exists on `flow`, causing `AttributeError` in CI.

## Changes
- Remove the obsolete monkeypatch from the Claude Code wizard test.

## Testing
- `uv run pytest tests/cli/wizard/test_flow.py -q` (26 passed)
