### PR TITLE
fix(config): correct stale OpenAI comment and remove retired Codex CLI models (#1201)

### DIFF
--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -72,6 +72,7 @@ ANTHROPIC_MODELS = (
 )
 
 OPENAI_MODELS = (
+    ModelOption(value="gpt-5.5", label="GPT-5.5 — frontier, released 2026-04-23"),
     ModelOption(value=OPENAI_REASONING_MODEL, label="GPT-5.4"),
     ModelOption(value="gpt-5.4-mini", label="GPT-5.4 mini"),
     ModelOption(value="gpt-5.4-nano", label="GPT-5.4 nano"),
@@ -80,6 +81,7 @@ OPENAI_MODELS = (
 
 OPENROUTER_MODELS = (
     ModelOption(value=OPENROUTER_REASONING_MODEL, label="OpenRouter Auto (smart routing)"),
+    ModelOption(value="openai/gpt-5.5", label="GPT-5.5 (via OpenRouter)"),
     ModelOption(value="openai/gpt-5.2", label="GPT-5.2 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-opus-4.6", label="Claude Opus 4.6 (via OpenRouter)"),
     ModelOption(value="anthropic/claude-sonnet-4.5", label="Claude Sonnet 4.5 (via OpenRouter)"),
@@ -165,21 +167,18 @@ CLAUDE_CODE_MODELS = (
 )
 
 # Empty value means "no -m" so the Codex CLI uses its configured default/current model.
+# gpt-5.2-codex, gpt-5.1-codex-max, and gpt-5.1-codex-mini were retired from the
+# Codex CLI on 2026-04-14 and have been removed from this list.
 CODEX_MODELS = (
     ModelOption(
         value="",
         label="CLI default (no -m; use Codex configured model)",
     ),
+    ModelOption(value="gpt-5.5", label="gpt-5.5 — frontier, recommended default since 2026-04-23"),
     ModelOption(value="gpt-5.4", label="gpt-5.4 — strong default for everyday coding"),
-    ModelOption(value="gpt-5.2-codex", label="gpt-5.2-codex — frontier agentic coding"),
-    ModelOption(
-        value="gpt-5.1-codex-max",
-        label="gpt-5.1-codex-max — deep / fast reasoning",
-    ),
     ModelOption(value="gpt-5.4-mini", label="gpt-5.4-mini — fast, cost-efficient"),
     ModelOption(value="gpt-5.3-codex", label="gpt-5.3-codex — coding-optimized"),
     ModelOption(value="gpt-5.2", label="gpt-5.2 — long-running agents"),
-    ModelOption(value="gpt-5.1-codex-mini", label="gpt-5.1-codex-mini"),
 )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -73,8 +73,9 @@ ANTHROPIC_REASONING_MODEL = "claude-sonnet-4-6"
 ANTHROPIC_TOOLCALL_MODEL = "claude-haiku-4-5-20251001"
 
 # OpenAI model constants
-# UNVERIFIED PLACEHOLDER — gpt-5.4 / gpt-5.4-mini do not exist as of 2026-04.
-# Update to a real model ID once OpenAI releases it, or override via OPENAI_REASONING_MODEL env var.
+# gpt-5.4 (released 2026-03-05) and gpt-5.4-mini are the current defaults.
+# gpt-5.5 (released 2026-04-23) is available for users who want the latest frontier model.
+# Override via OPENAI_REASONING_MODEL / OPENAI_TOOLCALL_MODEL env vars if needed.
 OPENAI_REASONING_MODEL = "gpt-5.4"
 OPENAI_TOOLCALL_MODEL = "gpt-5.4-mini"
 


### PR DESCRIPTION
## Summary

Addresses #1201 — but with a correction: the model names (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`) are **valid and real** OpenAI models released on 2026-03-05. The bug report incorrectly suggested replacing them with `gpt-4.1`. This PR fixes what actually needed fixing, and adds `gpt-5.5` support.

### Changes

**`app/config.py`**
- Removes the incorrect comment claiming `gpt-5.4`/`gpt-5.4-mini` are "UNVERIFIED PLACEHOLDERS". They were released 2026-03-05 and are confirmed valid.
- Adds a note that `gpt-5.5` (released 2026-04-23) is also available for users who want the latest frontier model.

**`app/cli/wizard/config.py`**
- Removes `gpt-5.2-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini` from `CODEX_MODELS` — these were retired from the Codex CLI on 2026-04-14.
- Adds `gpt-5.5` to `OPENAI_MODELS` (direct OpenAI API provider).
- Adds `openai/gpt-5.5` to `OPENROUTER_MODELS` (via OpenRouter).
- Adds `gpt-5.5` to `CODEX_MODELS` — it is the new recommended default in the Codex CLI since its launch on 2026-04-23.

### Verification

- `gpt-5.4` and `gpt-5.4-mini` confirmed valid: https://developers.openai.com/api/docs/models/gpt-5.4
- `gpt-5.5` confirmed released 2026-04-23 and available in the API and Codex CLI: https://developers.openai.com/api/docs/models/gpt-5.5
- `gpt-5.3-codex` confirmed valid: https://developers.openai.com/api/docs/models/gpt-5.3-codex
- Retired models confirmed: https://codex.danielvaughan.com/2026/04/16/codex-cli-model-deprecation-wave-april-2026-migration-guide/
- `ruff check` and `ruff format --check` pass on both changed files