### PR TITLE
fix(claude-code): parse auth status JSON before exit code; use authMethod (#1260)

### DIFF
--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -76,11 +76,63 @@ def _anthropic_auth_env_source() -> str | None:
     return None
 
 
+def _auth_status_from_json_payload(data: dict) -> tuple[bool, str]:
+    """Map `claude auth status` JSON object to (logged_in, user-facing detail).
+
+    The CLI emits ``apiKeySource`` whenever the env contributes an API key,
+    even when the active auth method is the subscription. Use ``authMethod``
+    (``claude.ai`` / ``api_key`` / ``none``) as the authoritative discriminator
+    for the detail string; ``apiKeySource`` and ``email`` are supporting detail
+    and are also used as a legacy fallback for older CLI versions that omit
+    ``authMethod``.
+    """
+    if not data.get("loggedIn"):
+        return False, f"Not authenticated. {_AUTH_HINT}"
+    auth_method = str(data.get("authMethod") or "").lower()
+    email = str(data.get("email") or "")
+    api_key_source = str(data.get("apiKeySource") or "")
+
+    if auth_method == "api_key":
+        source = api_key_source or "ANTHROPIC_API_KEY"
+        return True, f"Authenticated via {source}."
+    if auth_method == "claude.ai":
+        return True, f"Authenticated via Claude subscription{f' ({email})' if email else ''}."
+    # Older CLI versions may omit authMethod — fall back to legacy heuristic.
+    if api_key_source:
+        return True, f"Authenticated via {api_key_source}."
+    if email:
+        return True, f"Authenticated via Claude subscription ({email})."
+    return True, "Authenticated via Claude CLI."
+
+
+def _try_parse_auth_status_stdout(stdout: str) -> tuple[bool, str] | None:
+    """If stdout is a JSON object from ``auth status``, return auth; else None."""
+    raw = (stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return _auth_status_from_json_payload(data)
+
+
 def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     """Check Claude Code auth via `claude auth status` (local, no API call).
 
-    Covers both subscription login and ANTHROPIC_API_KEY; subscription takes
-    priority as reported by the CLI itself.
+    Returns ``(True, …)`` for any working auth (subscription or API key),
+    ``(False, …)`` when the CLI definitively reports the user as not logged
+    in, and ``(None, …)`` only when the probe itself failed (timeout, spawn
+    error, or unparseable output from an older CLI).
+
+    The CLI exits **non-zero** when ``loggedIn`` is false (CLI ≥ 2.x) while
+    still printing valid JSON, so we parse stdout first and only fall back to
+    treating a non-zero exit as an opaque probe failure when the JSON is
+    absent or unparseable. The previous behaviour of returning ``None`` on
+    any non-zero exit hid the real "not logged in" state behind the wizard's
+    "could not verify" branch.
     """
     try:
         proc = subprocess.run(
@@ -98,31 +150,27 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
         )
     except OSError as exc:
         return None, f"Could not spawn claude for auth probe: {exc}"
+
+    parsed = _try_parse_auth_status_stdout(proc.stdout)
+    if parsed is not None:
+        return parsed
+
     if proc.returncode != 0:
         err = (proc.stderr or proc.stdout or "").strip()[:500]
         return None, f"claude auth status failed: {err or 'unknown error'}"
-    try:
-        data = json.loads(proc.stdout)
-        if not data.get("loggedIn"):
-            return False, f"Not authenticated. {_AUTH_HINT}"
-        api_key_source = data.get("apiKeySource", "")
-        if api_key_source:
-            return True, f"Authenticated via {api_key_source}."
-        email = data.get("email", "")
-        return True, f"Authenticated via Claude subscription{f' ({email})' if email else ''}."
-    except (json.JSONDecodeError, AttributeError):
-        # Older CLI versions may not output JSON; classify explicit negative
-        # phrases first to avoid false positives like "Not logged in" (exit 0).
-        plain = (proc.stdout or proc.stderr or "").strip().lower()
-        negative_markers = (
-            "not logged in",
-            "not authenticated",
-            "login required",
-            "unauthenticated",
-        )
-        if any(marker in plain for marker in negative_markers):
-            return False, f"Not authenticated. {_AUTH_HINT}"
-        return True, "Authenticated via Claude CLI."
+
+    # Older CLI versions may not output JSON; classify explicit negative
+    # phrases first to avoid false positives like "Not logged in" (exit 0).
+    plain = (proc.stdout or proc.stderr or "").strip().lower()
+    negative_markers = (
+        "not logged in",
+        "not authenticated",
+        "login required",
+        "unauthenticated",
+    )
+    if any(marker in plain for marker in negative_markers):
+        return False, f"Not authenticated. {_AUTH_HINT}"
+    return True, "Authenticated via Claude CLI."
 
 
 def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | None, str]:

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -97,6 +97,12 @@ def _auth_status_from_json_payload(data: dict) -> tuple[bool, str]:
         return True, f"Authenticated via {source}."
     if auth_method == "claude.ai":
         return True, f"Authenticated via Claude subscription{f' ({email})' if email else ''}."
+    if auth_method:
+        # Unrecognized but non-empty authMethod (e.g. a future "oauth" / "sso"):
+        # surface it verbatim instead of leaning on apiKeySource, which the CLI
+        # also populates for env-supplied API keys regardless of the active
+        # method and would mis-report the source.
+        return True, f"Authenticated via {auth_method}{f' ({email})' if email else ''}."
     # Older CLI versions may omit authMethod — fall back to legacy heuristic.
     if api_key_source:
         return True, f"Authenticated via {api_key_source}."

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -180,7 +180,7 @@ def test_probe_cli_auth_not_logged_in(mock_run: MagicMock) -> None:
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
 def test_probe_cli_auth_nonzero_exit(mock_run: MagicMock) -> None:
-    """Non-zero exit → None (probe failure, not confirmed unauthenticated)."""
+    """Non-zero exit with no parseable JSON → None (probe failure)."""
     m = MagicMock()
     m.returncode = 1
     m.stdout = ""
@@ -189,6 +189,62 @@ def test_probe_cli_auth_nonzero_exit(mock_run: MagicMock) -> None:
     logged_in, detail = _probe_cli_auth("/usr/bin/claude")
     assert logged_in is None
     assert "failed" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_not_logged_in_exits_1(mock_run: MagicMock) -> None:
+    """Real CLI returns exit 1 with valid JSON ``loggedIn=false`` when no auth.
+
+    Regression for #1260. The previous implementation short-circuited on
+    ``returncode != 0`` before parsing JSON and returned ``None``, causing the
+    wizard to show "could not verify" instead of the correct "requires login".
+    """
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = '{"loggedIn": false, "authMethod": "none", "apiProvider": "firstParty"}\n'
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is False
+    assert "Not authenticated" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_subscription_with_env_api_key_reports_subscription(
+    mock_run: MagicMock,
+) -> None:
+    """Subscription auth wins over an env API key in the detail string.
+
+    The CLI emits both ``authMethod="claude.ai"`` and
+    ``apiKeySource="ANTHROPIC_API_KEY"`` when a subscription user also has the
+    env var set, but the active method is the subscription. The detail must
+    reflect that, not the env var. Regression for #1260.
+    """
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = (
+        '{"loggedIn": true, "authMethod": "claude.ai", '
+        '"apiKeySource": "ANTHROPIC_API_KEY", "email": "user@example.com"}\n'
+    )
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is True
+    assert "subscription" in detail
+    assert "user@example.com" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_api_key_only_uses_authmethod(mock_run: MagicMock) -> None:
+    """authMethod=api_key → detail names the env source via apiKeySource."""
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = '{"loggedIn": true, "authMethod": "api_key", "apiKeySource": "ANTHROPIC_API_KEY"}\n'
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is True
+    assert "ANTHROPIC_API_KEY" in detail
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")

--- a/tests/integrations/llm_cli/test_claude_code_adapter.py
+++ b/tests/integrations/llm_cli/test_claude_code_adapter.py
@@ -248,6 +248,53 @@ def test_probe_cli_auth_api_key_only_uses_authmethod(mock_run: MagicMock) -> Non
 
 
 @patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_unrecognized_authmethod_does_not_use_apikeysource(
+    mock_run: MagicMock,
+) -> None:
+    """A future authMethod (e.g. ``oauth``) must not fall through to apiKeySource.
+
+    The CLI populates ``apiKeySource`` whenever the env contributes an API key,
+    so a logged-in subscription/OAuth user with ``ANTHROPIC_API_KEY`` set would
+    otherwise be reported as "Authenticated via ANTHROPIC_API_KEY" — the exact
+    mis-reporting the legacy heuristic produced for ``claude.ai``.
+    """
+    m = MagicMock()
+    m.returncode = 0
+    m.stdout = (
+        '{"loggedIn": true, "authMethod": "oauth", '
+        '"apiKeySource": "ANTHROPIC_API_KEY", "email": "user@example.com"}\n'
+    )
+    m.stderr = ""
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is True
+    assert "ANTHROPIC_API_KEY" not in detail
+    assert "oauth" in detail
+    assert "user@example.com" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
+def test_probe_cli_auth_exit_1_json_on_stderr_only_is_probe_failure(
+    mock_run: MagicMock,
+) -> None:
+    """Exit 1 with JSON only on stderr is treated as an opaque probe failure.
+
+    ``_try_parse_auth_status_stdout`` reads stdout only, so JSON that lands on
+    stderr falls through to the exit-code branch and returns ``(None, "claude
+    auth status failed: …")``. Pinning this contract guards against a future
+    refactor that starts parsing stderr and silently changes the return value.
+    """
+    m = MagicMock()
+    m.returncode = 1
+    m.stdout = ""
+    m.stderr = '{"loggedIn": false, "authMethod": "none"}'
+    mock_run.return_value = m
+    logged_in, detail = _probe_cli_auth("/usr/bin/claude")
+    assert logged_in is None
+    assert "failed" in detail
+
+
+@patch("app.integrations.llm_cli.claude_code.subprocess.run")
 def test_probe_cli_auth_timeout(mock_run: MagicMock) -> None:
     import subprocess
 


### PR DESCRIPTION
Fixes #1260 (follow-up to #1295)

#### Describe the changes you have made in this PR -

Two bugs in `_probe_cli_auth` surfaced by running the live `claude auth status` against every documented auth state. Both still on `main` after #1295 merged.

**1. No auth + no env key — wizard says "could not verify" instead of "requires login"**
The CLI exits **1** with valid JSON `{\"loggedIn\": false, \"authMethod\": \"none\", ...}` when no auth is configured. The probe short-circuited on `returncode != 0` *before* parsing JSON and returned `None`, so the wizard took the `logged_in is None` branch (\"could not verify\") instead of the `False` branch (\"requires login\"). Users had no signal that they needed to run `claude login` — the same `logged_in=None` UX surface that #1199 originally highlighted.

**2. Subscription + `ANTHROPIC_API_KEY` in env — detail string misreports source**
The CLI emits **both** `authMethod: \"claude.ai\"` and `apiKeySource: \"ANTHROPIC_API_KEY\"` when a subscription user also has the env var set, but the active method is the subscription. The prior code branched on `apiKeySource`-presence and reported \"Authenticated via ANTHROPIC_API_KEY\". `authMethod` (`claude.ai` / `api_key` / `none`) is the authoritative discriminator; `apiKeySource` is set whenever the env contributes a key, regardless of which method is active.

#### Implementation

- Extracted `_auth_status_from_json_payload` and `_try_parse_auth_status_stdout` so the JSON path is testable in isolation.
- `_probe_cli_auth` now parses stdout first; the exit-code error path is a fallback only when JSON is absent or unparseable.
- Detail-string branching uses `authMethod` first; falls back to `apiKeySource` / `email` for older CLI versions that omit `authMethod`.

#### Demo / verification

Live against `claude` 2.1.123 across all four auth states:

| State | Before | After |
|---|---|---|
| Subscription only | `(True, \"...subscription (email)\")` | unchanged ✅ |
| API key only | `(True, \"...ANTHROPIC_API_KEY\")` | unchanged ✅ |
| Subscription + env API key | `(True, \"...ANTHROPIC_API_KEY\")` ❌ | `(True, \"...subscription (email)\")` ✅ |
| No auth (fresh HOME) | `(None, \"claude auth status failed: ...\")` ❌ | `(False, \"Not authenticated. ...\")` ✅ |

Reproduce the no-auth case in isolation (doesn't touch your real auth):

\`\`\`bash
env -i HOME=/tmp/empty PATH=\$PATH NO_COLOR=1 claude auth status; echo \"exit: \$?\"
# {\"loggedIn\": false, \"authMethod\": \"none\", \"apiProvider\": \"firstParty\"}
# exit: 1
\`\`\`

#### Tests

- `make lint` ✅
- `make format-check` ✅
- `make typecheck` ✅
- `make test-cov` → 4967 passed
- New regression tests:
  - `test_probe_cli_auth_not_logged_in_exits_1` — exit 1 + valid JSON `loggedIn:false`
  - `test_probe_cli_auth_subscription_with_env_api_key_reports_subscription`
  - `test_probe_cli_auth_api_key_only_uses_authmethod`

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, I used AI assistance

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I found these two bugs by running `claude auth status` directly against the live CLI in each of the four documented auth states (subscription only, API key only, subscription + env key, no auth) and recording the exact JSON shape and exit code in each case. The third row (subscription + env key) showed the CLI emitting `apiKeySource` even when `authMethod` was `claude.ai` — that proves `apiKeySource`-presence is the wrong discriminator. The fourth row showed exit 1 with valid JSON, which the existing probe was treating as an opaque failure.

The fix has two parts. (1) Reorder `_probe_cli_auth` so JSON parsing happens before the exit-code check — the helper `_try_parse_auth_status_stdout` returns `None` only when stdout is genuinely not a JSON object, in which case the exit code becomes the next signal. (2) In the JSON-payload mapper, branch on `authMethod` first; only fall through to the legacy `apiKeySource` / `email` heuristic when `authMethod` is missing, which preserves backward compat with older CLI versions that don't emit it. I extracted the helpers so the JSON path is testable without spinning up a subprocess mock.

Edge cases I checked:
- Older CLI without `auth status` (exit non-zero, non-JSON stderr) → still returns `None` (probe failure).
- Older CLI with non-JSON stdout on exit 0 → existing negative-marker fallback path (\"not logged in\", \"unauthenticated\", etc.) still applies.
- Empty stdout → `_try_parse_auth_status_stdout` returns `None` → exit code path takes over.
- Malformed JSON / non-dict JSON (e.g. `[]`) → `_try_parse_auth_status_stdout` returns `None`, same fallback.
- `loggedIn: true` with no `authMethod` and no `apiKeySource` and no `email` → \"Authenticated via Claude CLI.\" (legacy fallback).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions