### PR TITLE
test(airflow-routing): require connection_verified on openclaw fixture

### DIFF
--- a/tests/nodes/plan_actions/test_airflow_routing.py
+++ b/tests/nodes/plan_actions/test_airflow_routing.py
@@ -19,7 +19,7 @@ def test_seed_action_names_for_sources_includes_airflow_tools() -> None:
 def test_seed_action_names_for_sources_keeps_existing_seed_sources() -> None:
     available_sources = {
         "s3_audit": {"bucket": "example-bucket", "key": "audit.json"},
-        "openclaw": {"url": "http://localhost:8081"},
+        "openclaw": {"url": "http://localhost:8081", "connection_verified": True},
         "airflow": {
             "base_url": "http://localhost:8080/api/v1",
             "username": "admin",


### PR DESCRIPTION
## Summary
- `_seed_action_names_for_sources` was tightened in #141193c6 (openclaw runtime validation) to only seed `search_openclaw_conversations` / `list_openclaw_tools` when `available_sources["openclaw"]["connection_verified"]` is truthy.
- The companion test in `test_airflow_routing.py` was missed in that PR's fixture updates and still passed `{"url": ...}` only, so CI started failing with `assert 'search_openclaw_conversations' in ['get_s3_object', 'get_recent_airflow_failures', 'get_airflow_dag_runs']`.
- Adds `"connection_verified": True` to the openclaw fixture so the test reflects the current contract.

## Test plan
- [x] `python -m pytest tests/nodes/plan_actions/test_airflow_routing.py -v` — all 3 pass
- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`