### PR TITLE
docs: fix contributing guide links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,8 @@ Welcome to OpenSRE
 ## Quick Links
 
 - **GitHub:** [https://github.com/Tracer-Cloud/opensre](https://github.com/Tracer-Cloud/opensre)
-- **Vision:** `[VISION.md](VISION.md)`
 - **Discord:** [https://discord.gg/opensre](https://discord.gg/opensre)
-- **X/Twitter:** §[@open_sre](https://x.com/open_sre)
+- **X/Twitter:** [@open_sre](https://x.com/open_sre)
 
 ## How to Contribute
 
@@ -32,7 +31,7 @@ See **[SETUP.md](SETUP.md)** for detailed setup instructions including Windows-s
 3. Run checks: `make lint && make format-check && make typecheck && make test-cov`
 4. Build release artifacts when needed: `make build`
 
-If you prefer VS Code, you can use the repo's devcontainer at `[.devcontainer/devcontainer.json](.devcontainer/devcontainer.json)` instead of setting up Python manually.
+If you prefer VS Code, you can use the repo's devcontainer at [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json) instead of setting up Python manually.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove a Quick Links entry that pointed to missing VISION.md
- fix the rendered X/Twitter link text
- render the devcontainer path as a normal Markdown link

## Verification
- git diff --check
- targeted Python assertion over CONTRIBUTING.md link cleanup