### PR TITLE
fix: replace bare print() with logger.warning() for action failures

### DIFF
--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -6,11 +6,11 @@ import re
 from collections.abc import Callable
 from datetime import UTC, datetime
 
-logger = logging.getLogger(__name__)
-
 from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
 from app.nodes.investigate.types import ExecutedHypothesis, FailedAction, PlanAudit
 from app.tools.utils.metric_summary import summarize_prometheus_metrics
+
+logger = logging.getLogger(__name__)
 
 MAX_RETRYABLE_ACTION_FAILURES = 2
 _NON_RETRYABLE_FAILURE_INDICATORS = (

--- a/app/nodes/investigate/processing/post_process.py
+++ b/app/nodes/investigate/processing/post_process.py
@@ -1,9 +1,12 @@
 """Post-processing: merge evidence and track hypotheses."""
 
 import json
+import logging
 import re
 from collections.abc import Callable
 from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
 
 from app.nodes.investigate.execution.execute_actions import ActionExecutionResult
 from app.nodes.investigate.types import ExecutedHypothesis, FailedAction, PlanAudit
@@ -920,7 +923,7 @@ def build_evidence_summary(execution_results: dict[str, ActionExecutionResult]) 
             # Log action failures for debugging
             error_msg = f"{action_name}:FAILED({result.error[:50] if result.error else 'unknown'})"
             errors.append(error_msg)
-            print(f"[WARNING] Action failed: {error_msg}")
+            logger.warning("Action failed: %s", error_msg)
 
     if errors:
         summary = ", ".join(summary_parts) if summary_parts else "No evidence collected"


### PR DESCRIPTION
## Summary
- Replaced stray `print()` call at line 923 in `post_process.py` with `logger.warning()`
- Added `import logging` and `logger = logging.getLogger(__name__)` to the module

## Problem
The bare `print()` bypassed the project's logging system — no log level, no timestamp, no filtering capability. Every other warning in the codebase uses the proper logging path.

Fixes #1319

## Test plan
- [ ] `make lint` passes
- [ ] `make typecheck` passes
- [ ] `make test-cov` passes
- [ ] Verified no other bare `print()` calls exist in the file