### PR TITLE
fix(cli): propagate CLI auth & setup errors across all runtime surfaces

### DIFF
--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -20,6 +20,7 @@ from app.cli.interactive_shell.commands import dispatch_slash, switch_llm_provid
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.terminal_intent import mentioned_integration_services
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
+from app.cli.support.errors import OpenSREError
 
 
 @dataclass(frozen=True)
@@ -464,6 +465,12 @@ def _run_sample_alert(template_name: str, session: ReplSession, console: Console
         )
     except KeyboardInterrupt:
         console.print("[yellow]investigation cancelled.[/yellow]")
+        session.record("alert", f"sample:{template_name}", ok=False)
+        return
+    except OpenSREError as exc:
+        console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
+        if exc.suggestion:
+            console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")
         session.record("alert", f"sample:{template_name}", ok=False)
         return
     except Exception as exc:  # noqa: BLE001

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -15,6 +15,7 @@ from app.cli.interactive_shell.banner import render_banner, resolve_provider_mod
 from app.cli.interactive_shell.history import load_command_history_entries
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
+from app.cli.support.errors import OpenSREError
 
 
 @dataclass(frozen=True)
@@ -564,6 +565,12 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
         )
     except KeyboardInterrupt:
         console.print("[yellow]investigation cancelled.[/yellow]")
+        session.record("alert", args[0], ok=False)
+        return True
+    except OpenSREError as exc:
+        console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
+        if exc.suggestion:
+            console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")
         session.record("alert", args[0], ok=False)
         return True
     except Exception as exc:  # noqa: BLE001

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -32,6 +32,7 @@ from app.cli.interactive_shell.theme import (
     OPENCLAW_ORANGE,
     PROMPT_ACCENT_ANSI,
 )
+from app.cli.support.errors import OpenSREError
 
 
 class SlashCommandCompleter(Completer):
@@ -111,9 +112,13 @@ def _run_new_alert(text: str, session: ReplSession, console: Console) -> None:
         console.print("[yellow]investigation cancelled.[/yellow]")
         session.record("alert", text, ok=False)
         return
+    except OpenSREError as exc:
+        console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
+        if exc.suggestion:
+            console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")
+        session.record("alert", text, ok=False)
+        return
     except Exception as exc:  # noqa: BLE001
-        # Exception repr may contain brackets (stack frame refs, config
-        # dicts) that Rich would eat as markup tags — escape before printing.
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         session.record("alert", text, ok=False)
         return

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 
 from langsmith import traceable
 
+from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
 from app.config import LLMSettings
 
 if TYPE_CHECKING:
@@ -19,16 +20,8 @@ _logger = logging.getLogger(__name__)
 
 
 def _reraise_investigation_failure(exc: BaseException) -> NoReturn:
-    """Map CLI auth probe failures to structured CLI errors; re-raise anything else."""
-    from app.cli.support.errors import OpenSREError
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
-
-    if isinstance(exc, CLIAuthenticationRequired):
-        raise OpenSREError(
-            f"{exc.provider} CLI is not authenticated.",
-            suggestion=f"{exc.auth_hint} ({exc.detail})",
-        ) from exc
-    raise exc
+    """Map investigation runtime failures to structured CLI errors."""
+    reraise_cli_runtime_error(exc)
 
 
 def _call_run_investigation(

--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -1,0 +1,27 @@
+"""Map low-level CLI runtime errors to user-facing CLI errors."""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+
+def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
+    """Convert CLI auth/setup failures to structured CLI UX errors."""
+    from app.cli.support.errors import OpenSREError
+    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
+
+    if isinstance(exc, CLIAuthenticationRequired):
+        raise OpenSREError(
+            f"{exc.provider} CLI is not authenticated.",
+            suggestion=f"{exc.auth_hint} ({exc.detail})",
+        ) from exc
+
+    if isinstance(exc, RuntimeError):
+        msg = str(exc).lower()
+        if "cli not found" in msg or "not found on path" in msg:
+            raise OpenSREError(
+                "CLI tool is not installed or not found.",
+                suggestion=str(exc),
+            ) from exc
+
+    raise exc

--- a/app/cli/support/errors.py
+++ b/app/cli/support/errors.py
@@ -40,4 +40,7 @@ class OpenSREError(click.ClickException):
     def show(self, file: t.IO[t.Any] | None = None) -> None:
         if file is None:
             file = sys.stderr
-        click.echo(click.style("Error: ", fg="red", bold=True) + self.format_message(), file=file)
+        click.echo(
+            "\n" + click.style("Error: ", fg="red", bold=True) + self.format_message(),
+            file=file,
+        )

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field, ValidationError
 
 from app.cli.investigation import run_investigation_cli
+from app.cli.support.errors import OpenSREError
 
 
 class RunRCAInput(BaseModel):
@@ -20,6 +21,7 @@ class RunRCAOutput(BaseModel):
     result: dict[str, Any] | None = None
     error: str | None = None
     error_type: str | None = None
+    suggestion: str | None = None
 
 
 mcp = FastMCP("opensre")
@@ -85,9 +87,26 @@ def run_rca(
 
         return RunRCAOutput(ok=True, result=result).model_dump()
     except ValidationError as err:
-        return RunRCAOutput(ok=False, error=str(err), error_type=type(err).__name__).model_dump()
+        return RunRCAOutput(
+            ok=False,
+            error=str(err),
+            error_type=type(err).__name__,
+        ).model_dump()
+
+    except OpenSREError as err:
+        return RunRCAOutput(
+            ok=False,
+            error=str(err),
+            error_type=type(err).__name__,
+            suggestion=err.suggestion,
+        ).model_dump()
+
     except Exception as err:  # noqa: BLE001
-        return RunRCAOutput(ok=False, error=str(err), error_type=type(err).__name__).model_dump()
+        return RunRCAOutput(
+            ok=False,
+            error=str(err),
+            error_type=type(err).__name__,
+        ).model_dump()
 
 
 def main() -> None:

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -351,7 +351,7 @@ def investigate(req: InvestigateRequest) -> InvestigateResponse:
         detail = str(exc)
         if exc.suggestion:
             detail = f"{detail} Suggestion: {exc.suggestion}"
-        raise HTTPException(status_code=400, detail=detail) from exc
+        raise HTTPException(status_code=503, detail=detail) from exc
     except Exception as exc:
         logger.exception("Investigation failed")
         raise HTTPException(status_code=500, detail=f"{type(exc).__name__}: {exc}") from exc

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -44,6 +44,7 @@ from nacl.signing import VerifyKey
 from pydantic import BaseModel
 from starlette.responses import JSONResponse, StreamingResponse
 
+from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
 from app.cli.support.errors import OpenSREError
 from app.remote.vercel_poller import (
     VercelInvestigationCandidate,
@@ -421,13 +422,24 @@ async def investigate_stream(req: InvestigateRequest) -> Response:
                 payload = _json.dumps(event.data, default=str)
                 yield f"event: {event.event_type}\ndata: {payload}\n\n"
             yield "event: end\ndata: {}\n\n"
-        except OpenSREError as exc:
-            logger.warning("Streaming investigation failed due to CLI runtime error: %s", exc)
-            error_payload = {"detail": str(exc), "suggestion": exc.suggestion}
-            yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
-        except Exception:
-            logger.exception("Streaming investigation failed")
-            yield 'event: error\ndata: {"detail": "internal error"}\n\n'
+        except Exception as exc:
+            try:
+                reraise_cli_runtime_error(exc)
+            except OpenSREError as mapped:
+                logger.warning(
+                    "Streaming investigation failed due to CLI runtime error: %s",
+                    mapped,
+                )
+                error_payload = {
+                    "detail": str(mapped),
+                    "suggestion": mapped.suggestion,
+                }
+                yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
+                return
+            except Exception:
+                logger.exception("Streaming investigation failed")
+                yield 'event: error\ndata: {"detail": "internal error"}\n\n'
+                return
         finally:
             _persist_streamed_result(
                 alert_name=alert_name,

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -44,6 +44,7 @@ from nacl.signing import VerifyKey
 from pydantic import BaseModel
 from starlette.responses import JSONResponse, StreamingResponse
 
+from app.cli.support.errors import OpenSREError
 from app.remote.vercel_poller import (
     VercelInvestigationCandidate,
     VercelPoller,
@@ -345,6 +346,12 @@ def investigate(req: InvestigateRequest) -> InvestigateResponse:
         )
     except VercelResolutionError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except OpenSREError as exc:
+        logger.warning("Investigation failed due to CLI runtime error: %s", exc)
+        detail = str(exc)
+        if exc.suggestion:
+            detail = f"{detail} Suggestion: {exc.suggestion}"
+        raise HTTPException(status_code=400, detail=detail) from exc
     except Exception as exc:
         logger.exception("Investigation failed")
         raise HTTPException(status_code=500, detail=f"{type(exc).__name__}: {exc}") from exc
@@ -414,6 +421,10 @@ async def investigate_stream(req: InvestigateRequest) -> Response:
                 payload = _json.dumps(event.data, default=str)
                 yield f"event: {event.event_type}\ndata: {payload}\n\n"
             yield "event: end\ndata: {}\n\n"
+        except OpenSREError as exc:
+            logger.warning("Streaming investigation failed due to CLI runtime error: %s", exc)
+            payload = {"detail": str(exc), "suggestion": exc.suggestion}
+            yield f"event: error\ndata: {_json.dumps(payload)}\n\n"
         except Exception:
             logger.exception("Streaming investigation failed")
             yield 'event: error\ndata: {"detail": "internal error"}\n\n'

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -423,8 +423,8 @@ async def investigate_stream(req: InvestigateRequest) -> Response:
             yield "event: end\ndata: {}\n\n"
         except OpenSREError as exc:
             logger.warning("Streaming investigation failed due to CLI runtime error: %s", exc)
-            payload = {"detail": str(exc), "suggestion": exc.suggestion}
-            yield f"event: error\ndata: {_json.dumps(payload)}\n\n"
+            error_payload = {"detail": str(exc), "suggestion": exc.suggestion}
+            yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
         except Exception:
             logger.exception("Streaming investigation failed")
             yield 'event: error\ndata: {"detail": "internal error"}\n\n'

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -192,3 +192,23 @@ def test_stream_investigation_cli_maps_cli_auth_to_opensre_error(
     assert next(events).event_type == "metadata"
     with pytest.raises(OpenSREError, match="not authenticated"):
         next(events)
+
+
+def test_reraise_cli_runtime_error_maps_cli_auth() -> None:
+    import pytest
+
+    from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
+    from app.cli.support.errors import OpenSREError
+    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
+
+    exc = CLIAuthenticationRequired(
+        provider="opencode",
+        auth_hint="Run: opencode auth login",
+        detail="not logged in",
+    )
+
+    with pytest.raises(OpenSREError) as raised:
+        reraise_cli_runtime_error(exc)
+
+    assert str(raised.value) == "opencode CLI is not authenticated."
+    assert raised.value.suggestion == "Run: opencode auth login (not logged in)"

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -212,3 +212,18 @@ def test_reraise_cli_runtime_error_maps_cli_auth() -> None:
 
     assert str(raised.value) == "opencode CLI is not authenticated."
     assert raised.value.suggestion == "Run: opencode auth login (not logged in)"
+
+
+def test_reraise_cli_runtime_error_maps_cli_not_found() -> None:
+    import pytest
+
+    from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
+    from app.cli.support.errors import OpenSREError
+
+    exc = RuntimeError("codex CLI not found on PATH")
+
+    with pytest.raises(OpenSREError) as raised:
+        reraise_cli_runtime_error(exc)
+
+    assert str(raised.value) == "CLI tool is not installed or not found."
+    assert raised.value.suggestion == "codex CLI not found on PATH"

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -10,6 +10,9 @@ from app.cli.investigation import (
     run_investigation_cli,
     stream_investigation_cli,
 )
+from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
+from app.cli.support.errors import OpenSREError
+from app.integrations.llm_cli.errors import CLIAuthenticationRequired
 from app.remote.stream import StreamEvent
 
 
@@ -149,9 +152,6 @@ def test_stream_investigation_cli_raises_queued_exception_immediately(
 def test_run_investigation_cli_maps_cli_auth_to_opensre_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.cli.support.errors import OpenSREError
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
-
     def boom(*_args: object, **_kwargs: object) -> NoReturn:
         raise CLIAuthenticationRequired(
             provider="cursor",
@@ -171,9 +171,6 @@ def test_run_investigation_cli_maps_cli_auth_to_opensre_error(
 def test_stream_investigation_cli_maps_cli_auth_to_opensre_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.cli.support.errors import OpenSREError
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
-
     async def fake_astream_investigation(*args: object, **kwargs: object):
         yield StreamEvent("metadata", data={"run_id": "run-123"})
         raise CLIAuthenticationRequired(
@@ -195,12 +192,6 @@ def test_stream_investigation_cli_maps_cli_auth_to_opensre_error(
 
 
 def test_reraise_cli_runtime_error_maps_cli_auth() -> None:
-    import pytest
-
-    from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
-    from app.cli.support.errors import OpenSREError
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired
-
     exc = CLIAuthenticationRequired(
         provider="opencode",
         auth_hint="Run: opencode auth login",
@@ -215,11 +206,6 @@ def test_reraise_cli_runtime_error_maps_cli_auth() -> None:
 
 
 def test_reraise_cli_runtime_error_maps_cli_not_found() -> None:
-    import pytest
-
-    from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
-    from app.cli.support.errors import OpenSREError
-
     exc = RuntimeError("codex CLI not found on PATH")
 
     with pytest.raises(OpenSREError) as raised:
@@ -227,3 +213,10 @@ def test_reraise_cli_runtime_error_maps_cli_not_found() -> None:
 
     assert str(raised.value) == "CLI tool is not installed or not found."
     assert raised.value.suggestion == "codex CLI not found on PATH"
+
+
+def test_reraise_cli_runtime_error_reraises_unknown_runtime_error() -> None:
+    exc = RuntimeError("some unrelated runtime failure")
+
+    with pytest.raises(RuntimeError, match="some unrelated runtime failure"):
+        reraise_cli_runtime_error(exc)


### PR DESCRIPTION
Extends CLI error handling beyond the investigate path to ensure consistent, user-friendly error reporting across all runtime surfaces (#1309).

## Context

Previously, `CLIAuthenticationRequired` was only mapped to `OpenSREError` inside `investigate.py`.  
This meant that REPL paths, streaming flows, remote/server endpoints, and MCP entrypoints could still surface raw exceptions or tracebacks, especially for CLI-backed providers (Codex, Claude Code, OpenCode).

Additionally, CLI setup failures (e.g. missing binaries) were not handled and resulted in unstructured `RuntimeError` outputs.

---

## What this PR does

### 1. Centralized error mapping

- Introduces `cli_error_mapping.py` with `reraise_cli_runtime_error`
- Handles:
  - `CLIAuthenticationRequired` → structured auth error
  - CLI setup failures (`RuntimeError: CLI not found`) → structured setup error
- Establishes a single source of truth for CLI error handling

### 2. Propagates structured errors across all runtime surfaces

Applies consistent `OpenSREError` handling to:

- CLI investigate flow (`investigate.py`)
- REPL:
  - `loop.py`
  - `commands.py`
  - `agent_actions.py`
- Remote server:
  - blocking `/investigate`
  - streaming `/investigate/stream`
- MCP entrypoint (`mcp.py`)

All now:
- avoid raw tracebacks
- preserve `suggestion`
- surface actionable messages consistently

---

## UX Improvement

Before:
Traceback ...
RuntimeError: codex CLI not found ...

After:
Error: CLI tool is not installed or not found.
Suggestion: codex CLI not found. npm i -g @openai/codex ...

---

## Testing

Automated:
- `python -m pytest tests/cli/test_investigate.py -q` → all passing

Lint / format:
- `python -m ruff check ...`
- `python -m ruff format --check ...` → clean

Manual:
- Tested with missing CLI binaries:
  - `LLM_PROVIDER=codex`
  - `LLM_PROVIDER=claude-code`
  - `LLM_PROVIDER=opencode`
- All now return structured error + suggestion (no traceback)

---

## Result

CLI-backed providers now consistently surface structured, actionable errors across all entrypoints (CLI, REPL, streaming, remote, MCP), replacing raw exceptions with a unified and user-friendly UX.

<img width="1762" height="599" alt="Ekran görüntüsü 2026-05-05 215702" src="https://github.com/user-attachments/assets/b516da06-6955-4842-b275-37b513ace2a5" />
