### PR TITLE
improvement(install.sh): add colors and visual formatting to installer output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,22 +17,95 @@ INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-release}"
 BIN_NAME="opensre"
 INSTALL_WITH_SUDO=0
 requested_version="${OPENSRE_VERSION:-}"
+STDOUT_COLORS_ENABLED=0
+STDERR_COLORS_ENABLED=0
+ANSI_RESET=""
+ANSI_BOLD=""
+ANSI_GREEN=""
+ANSI_YELLOW=""
+ANSI_RED=""
+ANSI_CYAN=""
 
 [ -n "$INSTALL_DIR" ] && INSTALL_DIR_OVERRIDE=1
 requested_version="${requested_version#v}"
+
+init_output_styles() {
+  if [ "${TERM:-}" != "dumb" ] && [ -t 1 ]; then
+    STDOUT_COLORS_ENABLED=1
+  fi
+
+  if [ "${TERM:-}" != "dumb" ] && [ -t 2 ]; then
+    STDERR_COLORS_ENABLED=1
+  fi
+
+  if [ "$STDOUT_COLORS_ENABLED" -eq 1 ] || [ "$STDERR_COLORS_ENABLED" -eq 1 ]; then
+    ANSI_RESET="$(printf '\033[0m')"
+    ANSI_BOLD="$(printf '\033[1m')"
+    ANSI_GREEN="$(printf '\033[32m')"
+    ANSI_YELLOW="$(printf '\033[33m')"
+    ANSI_RED="$(printf '\033[31m')"
+    ANSI_CYAN="$(printf '\033[36m')"
+  fi
+}
+
+stdout_line() {
+  local style="$1"
+  shift
+  local message="$*"
+  local colors_enabled="${STDOUT_COLORS_ENABLED:-0}"
+
+  if [ "$colors_enabled" -eq 1 ] && [ -n "$style" ]; then
+    printf '%s%s%s\n' "$style" "$message" "$ANSI_RESET"
+  else
+    printf '%s\n' "$message"
+  fi
+}
+
+stderr_line() {
+  local style="$1"
+  shift
+  local message="$*"
+  local colors_enabled="${STDERR_COLORS_ENABLED:-0}"
+
+  if [ "$colors_enabled" -eq 1 ] && [ -n "$style" ]; then
+    printf '%s%s%s\n' "$style" "$message" "$ANSI_RESET" >&2
+  else
+    printf '%s\n' "$message" >&2
+  fi
+}
 
 log() {
   printf '%s\n' "$*"
 }
 
+log_step() {
+  local step="$1"
+  shift
+  stdout_line "${ANSI_CYAN}${ANSI_BOLD}" "[${step}] $*"
+}
+
+log_success() {
+  stdout_line "${ANSI_GREEN}${ANSI_BOLD}" "$*"
+}
+
+log_highlight() {
+  stdout_line "${ANSI_BOLD}" "$*"
+}
+
+print_separator() {
+  stdout_line "${ANSI_CYAN}" "----------------------------------------"
+}
+
 warn() {
-  printf 'Warning: %s\n' "$*" >&2
+  stderr_line "${ANSI_YELLOW}${ANSI_BOLD}" "Warning: $*"
 }
 
 die() {
-  printf 'Error: %s\n' "$*" >&2
+  stderr_line "${ANSI_RED}${ANSI_BOLD}" "Error: $*"
   exit 1
 }
+
+init_output_styles
 
 usage() {
   cat <<'EOF'
@@ -549,25 +622,18 @@ print_success_screen() {
   local version="$1"
   local sep="────────────────────────────────────────────"
 
-  if [ ! -t 1 ]; then
-    sep="--------------------------------------------"
-  fi
-
   log ""
-  log "$sep"
+  print_separator
   if [ "$version" = "main" ]; then
-    log "  opensre (main build) installed successfully"
+    log_success "OpenSRE main build installed successfully."
   else
-    log "  opensre v${version} installed successfully"
+    log_success "OpenSRE v${version} installed successfully."
   fi
-  log "$sep"
-  log ""
-  log "Next steps:"
-  log "  1. Run:  opensre onboard"
-  log "  2. Then: opensre investigate -i <alert.json>"
-  log ""
+  log_highlight "Next steps:"
+  log "  1. Run 'opensre onboard' to complete setup."
+  log "  2. Then run 'opensre investigate -i <alert.json>' with a real alert."
   log "Docs: https://www.opensre.com/docs"
-  log ""
+  print_separator
 }
 
 os="$(uname -s)"
@@ -608,9 +674,9 @@ version="$requested_version"
 release_tag=""
 
 if [ "$INSTALL_CHANNEL" = "main" ]; then
-  log "Fetching latest main build metadata..."
+  log_step "1/4" "Fetching latest main build metadata..."
 elif [ -z "$version" ]; then
-  log "Fetching latest release version..."
+  log_step "1/4" "Fetching latest release version..."
 fi
 
 release_json="$(fetch_release_json "$version")" || {
@@ -662,14 +728,14 @@ checksum_asset="${archive}.sha256"
 checksum_url="${download_url}.sha256"
 
 if [ "$INSTALL_CHANNEL" = "main" ]; then
-  log "Installing opensre main build (${platform}/${target_arch})..."
+  log_step "2/4" "Installing opensre main build (${platform}/${target_arch})..."
 else
-  log "Installing opensre v${version} (${platform}/${target_arch})..."
+  log_step "2/4" "Installing opensre v${version} (${platform}/${target_arch})..."
 fi
 if [ "$asset_arch" != "$target_arch" ]; then
   log "Using release asset built for ${platform}/${asset_arch}."
 fi
-log "Downloading ${download_url}"
+log_step "3/4" "Downloading ${download_url}"
 
 need_cmd mktemp
 tmp_dir="$(mktemp -d)"
@@ -714,12 +780,12 @@ install_binary "$binary_path" "${INSTALL_DIR}/${BIN_NAME}"
 
 if [ "$INSTALL_CHANNEL" = "main" ]; then
   if [ "$installed_version" = "main" ]; then
-    log "Installed ${BIN_NAME} main build to ${INSTALL_DIR}/${BIN_NAME}"
+    log_step "4/4" "Installed ${BIN_NAME} main build to ${INSTALL_DIR}/${BIN_NAME}"
   else
-    log "Installed ${BIN_NAME} main build (${installed_version}) to ${INSTALL_DIR}/${BIN_NAME}"
+    log_step "4/4" "Installed ${BIN_NAME} main build (${installed_version}) to ${INSTALL_DIR}/${BIN_NAME}"
   fi
 else
-  log "Installed ${BIN_NAME} v${installed_version} to ${INSTALL_DIR}/${BIN_NAME}"
+  log_step "4/4" "Installed ${BIN_NAME} v${installed_version} to ${INSTALL_DIR}/${BIN_NAME}"
 fi
 
 configure_path

--- a/tests/cli/test_install_sh_formatting.py
+++ b/tests/cli/test_install_sh_formatting.py
@@ -30,5 +30,7 @@ def test_install_sh_success_block_lists_next_steps() -> None:
     assert 'log_success "OpenSRE v${version} installed successfully."' in source
     assert 'log_highlight "Next steps:"' in source
     assert "log \"  1. Run 'opensre onboard' to complete setup.\"" in source
-    assert "log \"  2. Then run 'opensre investigate -i <alert.json>' with a real alert.\"" in source
+    assert (
+        "log \"  2. Then run 'opensre investigate -i <alert.json>' with a real alert.\"" in source
+    )
     assert 'log "Docs: https://www.opensre.com/docs"' in source

--- a/tests/cli/test_install_sh_formatting.py
+++ b/tests/cli/test_install_sh_formatting.py
@@ -1,0 +1,34 @@
+"""Source-level contract tests for install.sh output formatting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+INSTALL_SH = Path(__file__).parents[2] / "install.sh"
+
+
+def test_install_sh_enables_colors_only_for_tty_output() -> None:
+    source = INSTALL_SH.read_text()
+    assert '[ "${TERM:-}" != "dumb" ] && [ -t 1 ]' in source
+    assert '[ "${TERM:-}" != "dumb" ] && [ -t 2 ]' in source
+
+
+def test_install_sh_defines_styled_output_helpers() -> None:
+    source = INSTALL_SH.read_text()
+    assert "log_step()" in source
+    assert "log_success()" in source
+    assert "log_highlight()" in source
+    assert "print_separator()" in source
+    assert 'stderr_line "${ANSI_YELLOW}${ANSI_BOLD}" "Warning: $*"' in source
+    assert 'stderr_line "${ANSI_RED}${ANSI_BOLD}" "Error: $*"' in source
+
+
+def test_install_sh_success_block_lists_next_steps() -> None:
+    source = INSTALL_SH.read_text()
+    assert 'log_step "4/4"' in source
+    assert 'log_success "OpenSRE main build installed successfully."' in source
+    assert 'log_success "OpenSRE v${version} installed successfully."' in source
+    assert 'log_highlight "Next steps:"' in source
+    assert "log \"  1. Run 'opensre onboard' to complete setup.\"" in source
+    assert "log \"  2. Then run 'opensre investigate -i <alert.json>' with a real alert.\"" in source
+    assert 'log "Docs: https://www.opensre.com/docs"' in source

--- a/tests/cli/test_install_sh_path.py
+++ b/tests/cli/test_install_sh_path.py
@@ -38,7 +38,7 @@ def _run(
     idir = install_dir if install_dir is not None else str(fake_home / _LOCAL_BIN)
 
     script = textwrap.dedent(f"""\
-        __fn=$(awk 'p&&/^}}$/{{print;exit}} /^configure_path\\(\\)/{{p=1}} p{{print}}' {INSTALL_SH})
+        __fn=$(awk 'p&&/^}}$/{{print;exit}} /^(function[[:space:]]+)?configure_path[[:space:]]*\\(\\)[[:space:]]*\\{{/{{p=1}} p{{print}}' {INSTALL_SH})
         if [ -z "$__fn" ]; then
             echo "configure_path not found in install.sh" >&2
             exit 1
@@ -47,6 +47,46 @@ def _run(
         warn() {{ printf 'Warning: %s\\n' "$*" >&2; }}
         eval "$__fn"
         INSTALL_DIR="{idir}" platform="{platform}" HOME="{fake_home}" SHELL="{shell}" configure_path
+    """)
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def _run_output_helpers(
+    *,
+    stdout_colors_enabled: int | None,
+    stderr_colors_enabled: int | None,
+) -> subprocess.CompletedProcess[str]:
+    stdout_setup = (
+        f"STDOUT_COLORS_ENABLED={stdout_colors_enabled}"
+        if stdout_colors_enabled is not None
+        else ""
+    )
+    stderr_setup = (
+        f"STDERR_COLORS_ENABLED={stderr_colors_enabled}"
+        if stderr_colors_enabled is not None
+        else ""
+    )
+
+    script = textwrap.dedent(f"""\
+        eval "$(awk '
+            /^(function[[:space:]]+)?[a-z_][a-z_]*[[:space:]]*\\(\\)[[:space:]]*\\{{/ {{ in_fn=1 }}
+            in_fn {{ print }}
+            in_fn && /^\\}}$/ {{ in_fn=0 }}
+        ' {INSTALL_SH})"
+
+        {stdout_setup}
+        {stderr_setup}
+        ANSI_RESET='[reset]'
+        ANSI_BOLD='[bold]'
+        ANSI_GREEN='[green]'
+        ANSI_YELLOW='[yellow]'
+        ANSI_RED='[red]'
+        ANSI_CYAN='[cyan]'
+
+        log_step "1/4" "Fetching latest release version..."
+        log_success "OpenSRE install complete."
+        print_separator
+        warn "Using fallback asset."
     """)
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 
@@ -124,6 +164,37 @@ def test_marker_comment_present(tmp_path: Path) -> None:
     _run(tmp_path, shell="/bin/zsh")
     content = (tmp_path / "home" / ".zshrc").read_text()
     assert "# Added by opensre installer" in content
+
+
+def test_output_helpers_fall_back_to_plain_text_without_color() -> None:
+    result = _run_output_helpers(stdout_colors_enabled=0, stderr_colors_enabled=0)
+    assert result.returncode == 0, result.stderr
+    assert "[1/4] Fetching latest release version..." in result.stdout
+    assert "OpenSRE install complete." in result.stdout
+    assert "----------------------------------------" in result.stdout
+    assert "Warning: Using fallback asset." in result.stderr
+    assert "[cyan]" not in result.stdout
+    assert "[green]" not in result.stdout
+    assert "[yellow]" not in result.stderr
+
+
+def test_output_helpers_default_to_plain_text_when_flags_are_unset() -> None:
+    result = _run_output_helpers(stdout_colors_enabled=None, stderr_colors_enabled=None)
+    assert result.returncode == 0, result.stderr
+    assert "[1/4] Fetching latest release version..." in result.stdout
+    assert "OpenSRE install complete." in result.stdout
+    assert "Warning: Using fallback asset." in result.stderr
+    assert "[reset]" not in result.stdout
+    assert "[reset]" not in result.stderr
+
+
+def test_output_helpers_emit_styled_output_when_color_enabled() -> None:
+    result = _run_output_helpers(stdout_colors_enabled=1, stderr_colors_enabled=1)
+    assert result.returncode == 0, result.stderr
+    assert "[cyan][bold][1/4] Fetching latest release version...[reset]" in result.stdout
+    assert "[green][bold]OpenSRE install complete.[reset]" in result.stdout
+    assert "[cyan]----------------------------------------[reset]" in result.stdout
+    assert "[yellow][bold]Warning: Using fallback asset.[reset]" in result.stderr
 
 
 def test_post_install_message_mentions_source(tmp_path: Path) -> None:
@@ -213,7 +284,7 @@ def _run_post_install(
     script = textwrap.dedent(f"""\
         # 1. Load every function definition from install.sh
         eval "$(awk '
-            /^[a-z_][a-z_]*\\(\\)/ {{ in_fn=1 }}
+            /^(function[[:space:]]+)?[a-z_][a-z_]*[[:space:]]*\\(\\)[[:space:]]*\\{{/ {{ in_fn=1 }}
             in_fn {{ print }}
             in_fn && /^\\}}$/ {{ in_fn=0 }}
         ' {INSTALL_SH})"
@@ -318,3 +389,16 @@ def test_onboarding_hint_appears_after_version_line(tmp_path: Path) -> None:
     assert onboard_pos > installed_pos, (
         "Onboarding hint must come after the install confirmation line"
     )
+
+
+def test_post_install_success_block_includes_next_steps(tmp_path: Path) -> None:
+    result = _run_post_install(tmp_path, shell="/bin/zsh", installed_version="2026.4.1")
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert "[4/4] Installed opensre v2026.4.1" in output
+    assert "OpenSRE v2026.4.1 installed successfully." in output
+    assert "Next steps:" in output
+    assert "opensre onboard" in output
+    assert "opensre investigate -i <alert.json>" in output
+    assert "Docs: https://www.opensre.com/docs" in output
+    assert output.count("----------------------------------------") == 2


### PR DESCRIPTION
Fixes #1316

## What changed
- add TTY-aware output styling helpers to `install.sh` so progress steps, warnings, errors, and the final success block are easier to scan
- keep plain-text fallback when stdout/stderr are not attached to a TTY or when `TERM=dumb`
- format the install flow as numbered steps and expand the success footer with clear next steps
- add installer tests that cover the styling helpers, the plain-text fallback, and the post-install success block

## Why
The installer previously printed every line in the same plain format, which made warnings and next steps easy to miss. This keeps non-interactive installs clean while making interactive runs more readable.

## Validation
- `python -m pytest -q tests/cli/test_install_sh_formatting.py tests/cli/test_install_sh_path.py tests/cli/test_install_sh_resolution.py`
- `python -m ruff check tests/cli/test_install_sh_formatting.py tests/cli/test_install_sh_path.py`
- `python -m ruff format --check tests/cli/test_install_sh_formatting.py tests/cli/test_install_sh_path.py`
- `python -m mypy app`
- `bash -n install.sh`
- manual Git Bash sanity check for the styled helper output and post-install footer