### PR TITLE
ci(good-first-issue): skip auto-assign when author has open PRs

### DIFF
--- a/.github/scripts/good_first_issue_assign.py
+++ b/.github/scripts/good_first_issue_assign.py
@@ -1,7 +1,9 @@
 """Assign and notify **new** contributors on `good first issue` threads.
 
-Here *new* means **zero merged PRs** in this repo authored by the commenter (Search API),
-not GitHub's ``FIRST_TIME_CONTRIBUTOR`` / ``FIRST_TIMER`` flags.
+Here *new* means the commenter has **no merged PRs and no open PRs** in this repo where
+they are the PR author (GitHub Search API). **One or more merged PRs** means they are not
+treated as a first-time contributor for this automation (GitHub's ``FIRST_TIME_CONTRIBUTOR``
+/ ``FIRST_TIMER`` flags are not used).
 
 Also skips repo insiders (OWNER / MEMBER / COLLABORATOR), bots, closed issues,
 comments on **pull request** threads (``issue_comment`` fires for PRs too; those
@@ -23,7 +25,8 @@ from pathlib import Path
 from typing import Any
 
 GOOD_FIRST_LABEL = "good first issue"
-# Do not auto-assign maintainers/collaborators; eligibility is 0 merged PRs + not insider.
+# Do not auto-assign maintainers/collaborators;
+# eligibility is 0 merged + 0 open PRs as author + not insider.
 EXCLUDED_COMMENTER_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 GITHUB_API = "https://api.github.com"
 
@@ -71,13 +74,17 @@ def assign_decision(
     *,
     skip_reason_pre_api: str | None,
     merged_pr_count_for_commenter: int,
+    open_pr_count_for_commenter: int,
 ) -> tuple[bool, str]:
     """Return (should_assign_and_comment, skip_reason_or_empty).
 
-    Eligible "new contributor" means ``merged_pr_count_for_commenter == 0`` (enforced here).
+    Eligible "new contributor" means ``merged_pr_count_for_commenter == 0`` and
+    ``open_pr_count_for_commenter == 0`` (PR author in this repo, via Search API).
     """
     if skip_reason_pre_api is not None:
         return False, skip_reason_pre_api
+    if open_pr_count_for_commenter > 0:
+        return False, "has_open_prs"
     if merged_pr_count_for_commenter > 0:
         return False, "has_merged_prs"
     return True, ""
@@ -97,9 +104,8 @@ def _request_json(url: str, token: str) -> Any:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def fetch_merged_pr_count(owner: str, repo: str, login: str, token: str) -> int:
-    q = f"repo:{owner}/{repo} is:pr is:merged author:{login}"
-    params = urllib.parse.urlencode({"q": q})
+def _search_issue_total_count(query: str, token: str) -> int:
+    params = urllib.parse.urlencode({"q": query})
     url = f"{GITHUB_API}/search/issues?{params}"
     try:
         data = _request_json(url, token)
@@ -110,6 +116,16 @@ def fetch_merged_pr_count(owner: str, repo: str, login: str, token: str) -> int:
     if not isinstance(total, int):
         return 0
     return total
+
+
+def fetch_merged_pr_count(owner: str, repo: str, login: str, token: str) -> int:
+    q = f"repo:{owner}/{repo} is:pr is:merged author:{login}"
+    return _search_issue_total_count(q, token)
+
+
+def fetch_open_pr_count(owner: str, repo: str, login: str, token: str) -> int:
+    q = f"repo:{owner}/{repo} is:pr is:open author:{login}"
+    return _search_issue_total_count(q, token)
 
 
 def build_assign_notice_body(*, assignee_login: str) -> str:
@@ -139,6 +155,7 @@ def main() -> int:
 
     pre = screen_event_without_api(event)
     merged_count = 0
+    open_count = 0
 
     if pre is None:
         owner, _, repo = repository.partition("/")
@@ -149,12 +166,14 @@ def main() -> int:
         c_login = (comment.get("user") or {}).get("login") or ""
         try:
             merged_count = fetch_merged_pr_count(owner, repo, c_login, token)
+            open_count = fetch_open_pr_count(owner, repo, c_login, token)
         except urllib.error.HTTPError:
             return 1
 
     should, reason = assign_decision(
         skip_reason_pre_api=pre,
         merged_pr_count_for_commenter=merged_count,
+        open_pr_count_for_commenter=open_count,
     )
 
     if not should:

--- a/.github/scripts/good_first_issue_assign.py
+++ b/.github/scripts/good_first_issue_assign.py
@@ -109,7 +109,7 @@ def _search_issue_total_count(query: str, token: str) -> int:
     url = f"{GITHUB_API}/search/issues?{params}"
     try:
         data = _request_json(url, token)
-    except urllib.error.HTTPError as exc:
+    except urllib.error.URLError as exc:
         print(f"GitHub search failed: {exc}", file=sys.stderr)
         raise
     total = data.get("total_count")
@@ -167,7 +167,8 @@ def main() -> int:
         try:
             merged_count = fetch_merged_pr_count(owner, repo, c_login, token)
             open_count = fetch_open_pr_count(owner, repo, c_login, token)
-        except urllib.error.HTTPError:
+        except urllib.error.URLError as exc:
+            print(f"GitHub API request failed: {exc}", file=sys.stderr)
             return 1
 
     should, reason = assign_decision(

--- a/.github/workflows/good-first-issue-assign.yml
+++ b/.github/workflows/good-first-issue-assign.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 jobs:
   assign:

--- a/tests/github/test_good_first_issue_assign.py
+++ b/tests/github/test_good_first_issue_assign.py
@@ -74,7 +74,7 @@ def test_screen_skips_repo_insider(gfi, association):
 
 
 def test_screen_allows_contributor_with_zero_merges_checked_later(gfi):
-    """CONTRIBUTOR is allowed here; merged-PR count is enforced in assign_decision."""
+    """CONTRIBUTOR is allowed here; merged/open PR counts are enforced in assign_decision."""
     event = {
         "issue": {
             "state": "open",
@@ -142,15 +142,27 @@ def test_assign_decision_skips_merged_prs(gfi):
     ok, reason = gfi.assign_decision(
         skip_reason_pre_api=None,
         merged_pr_count_for_commenter=1,
+        open_pr_count_for_commenter=0,
     )
     assert ok is False
     assert reason == "has_merged_prs"
+
+
+def test_assign_decision_skips_open_prs_before_merged_check(gfi):
+    ok, reason = gfi.assign_decision(
+        skip_reason_pre_api=None,
+        merged_pr_count_for_commenter=0,
+        open_pr_count_for_commenter=1,
+    )
+    assert ok is False
+    assert reason == "has_open_prs"
 
 
 def test_assign_decision_ok_zero_merges(gfi):
     ok, reason = gfi.assign_decision(
         skip_reason_pre_api=None,
         merged_pr_count_for_commenter=0,
+        open_pr_count_for_commenter=0,
     )
     assert ok is True
     assert reason == ""

--- a/tests/github/test_good_first_issue_assign.py
+++ b/tests/github/test_good_first_issue_assign.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import urllib.parse
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -166,6 +168,38 @@ def test_assign_decision_ok_zero_merges(gfi):
     )
     assert ok is True
     assert reason == ""
+
+
+def test_assign_decision_open_wins_over_merged(gfi):
+    """When both counts are non-zero, open PR check fires first."""
+    ok, reason = gfi.assign_decision(
+        skip_reason_pre_api=None,
+        merged_pr_count_for_commenter=2,
+        open_pr_count_for_commenter=1,
+    )
+    assert ok is False
+    assert reason == "has_open_prs"
+
+
+def test_fetch_open_pr_count_query_string(gfi):
+    """fetch_open_pr_count must search is:pr is:open for the correct author."""
+    captured: list[str] = []
+
+    def fake_request_json(url: str, token: str) -> dict:  # noqa: ARG001
+        captured.append(url)
+        return {"total_count": 0}
+
+    with patch.object(gfi, "_request_json", fake_request_json):
+        result = gfi.fetch_open_pr_count("myorg", "myrepo", "alice", "tok")
+
+    assert result == 0
+    assert len(captured) == 1
+    parsed = urllib.parse.urlparse(captured[0])
+    q = urllib.parse.parse_qs(parsed.query)["q"][0]
+    assert "is:pr" in q
+    assert "is:open" in q
+    assert "author:alice" in q
+    assert "repo:myorg/myrepo" in q
 
 
 def test_build_notice_short(gfi):


### PR DESCRIPTION
## Summary
Good first issue auto-assignment now requires **no open PRs** in the repo where the commenter is the PR author (GitHub Search), in addition to the existing **no merged PRs** rule.

## Changes
- Add `is:pr is:open author:<login>` search alongside merged PR count.
- Factor `_search_issue_total_count` for both queries.
- Document that **one or more merged PRs** excludes someone from first-time eligibility for this workflow.
- Add unit test for `has_open_prs` skip reason.