### PR TITLE
fix(cli): structured shell execution for interactive REPL (#1372)

### DIFF
--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -18,6 +18,8 @@ from rich.text import Text
 
 from app.cli.interactive_shell.commands import dispatch_slash, switch_llm_provider
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.shell_execution import execute_shell_command
+from app.cli.interactive_shell.shell_policy import evaluate_policy, parse_shell_command
 from app.cli.interactive_shell.terminal_intent import mentioned_integration_services
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
@@ -239,6 +241,8 @@ def _extract_shell_command(clause: PromptClause) -> PlannedAction | None:
         return _shell_action(command, clause.position + explicit_match.start("command"))
 
     command = _normalize_shell_command(clause.text)
+    if command is not None and command.startswith("!") and len(command) > 1:
+        return _shell_action(command, clause.position)
     if command is not None and _looks_like_direct_shell_command(command):
         return _shell_action(command, clause.position)
     return None
@@ -382,8 +386,6 @@ def _print_command_output(console: Console, output: str, *, style: str | None = 
     if not output:
         return
     text = output.rstrip()
-    if len(text) > _MAX_COMMAND_OUTPUT_CHARS:
-        text = text[:_MAX_COMMAND_OUTPUT_CHARS].rstrip() + "\n... output truncated ..."
     console.print(Text(text) if style is None else Text(text, style=style))
 
 
@@ -404,23 +406,35 @@ def _print_planned_actions(console: Console, actions: list[PlannedAction]) -> No
 
 def _run_shell_command(command: str, session: ReplSession, console: Console) -> None:
     console.print(f"[bold]$ {escape(command)}[/bold]")
-    token = _first_command_token(command)
-    if token is not None and token.lower() == "cd":
-        _run_cd_command(command, session, console)
-        return
-    if token is not None and token.lower() == "pwd":
-        _run_pwd_command(command, session, console)
+    parsed = parse_shell_command(command, is_windows=_IS_WINDOWS)
+    decision = evaluate_policy(parsed=parsed)
+    if not decision.allow:
+        console.print(
+            f"[yellow]command blocked:[/yellow] {escape(decision.reason or 'not allowed')}"
+        )
+        if decision.hint:
+            console.print(f"[dim]{escape(decision.hint)}[/dim]")
+        session.record("shell", command, ok=False)
         return
 
+    if parsed.argv is not None and parsed.argv[0].lower() == "cd":
+        _run_cd_command(parsed.command, session, console)
+        return
+    if parsed.argv is not None and parsed.argv[0].lower() == "pwd":
+        _run_pwd_command(parsed.command, session, console)
+        return
+
+    use_shell = parsed.passthrough
+    if use_shell:
+        console.print("[dim]explicit shell passthrough enabled[/dim]")
+
     try:
-        completed = subprocess.run(
-            command,
-            shell=True,
-            executable=os.environ.get("SHELL") or None,
-            capture_output=True,
-            text=True,
-            timeout=_SHELL_COMMAND_TIMEOUT_SECONDS,
-            check=False,
+        result = execute_shell_command(
+            command=parsed.command,
+            argv=parsed.argv,
+            use_shell=use_shell,
+            timeout_seconds=_SHELL_COMMAND_TIMEOUT_SECONDS,
+            max_output_chars=_MAX_COMMAND_OUTPUT_CHARS,
         )
     except subprocess.TimeoutExpired:
         console.print(
@@ -433,12 +447,12 @@ def _run_shell_command(command: str, session: ReplSession, console: Console) -> 
         session.record("shell", command, ok=False)
         return
 
-    _print_command_output(console, completed.stdout)
-    _print_command_output(console, completed.stderr, style="red")
-    ok = completed.returncode == 0
+    _print_command_output(console, result.stdout)
+    _print_command_output(console, result.stderr, style="red")
+    ok = result.exit_code == 0
     if not ok:
-        console.print(f"[red]exit code:[/red] {completed.returncode}")
-    elif not completed.stdout and not completed.stderr:
+        console.print(f"[red]exit code:[/red] {result.exit_code}")
+    elif not result.stdout and not result.stderr:
         console.print("[dim]exit code: 0[/dim]")
     session.record("shell", command, ok=ok)
 

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -417,10 +417,21 @@ def _run_shell_command(command: str, session: ReplSession, console: Console) -> 
         session.record("shell", command, ok=False)
         return
 
-    if parsed.argv is not None and parsed.argv[0].lower() == "cd":
+    argv_builtin = parsed.argv
+    if argv_builtin is None and parsed.passthrough and parsed.command.strip():
+        passthrough_body = parsed.command.strip()
+        try:
+            argv_builtin = shlex.split(passthrough_body, posix=not _IS_WINDOWS)
+        except ValueError:
+            try:
+                argv_builtin = shlex.split(passthrough_body, posix=False)
+            except ValueError:
+                argv_builtin = None
+
+    if argv_builtin is not None and argv_builtin[0].lower() == "cd":
         _run_cd_command(parsed.command, session, console)
         return
-    if parsed.argv is not None and parsed.argv[0].lower() == "pwd":
+    if argv_builtin is not None and argv_builtin[0].lower() == "pwd":
         _run_pwd_command(parsed.command, session, console)
         return
 

--- a/app/cli/interactive_shell/shell_execution.py
+++ b/app/cli/interactive_shell/shell_execution.py
@@ -78,23 +78,4 @@ def execute_shell_command(
     )
 
 
-def timeout_result(
-    *,
-    command: str,
-    argv: list[str] | None,
-    use_shell: bool,
-) -> ShellExecutionResult:
-    """Build a timeout result object without process output."""
-    return ShellExecutionResult(
-        command=command,
-        argv=argv,
-        stdout="",
-        stderr="",
-        exit_code=None,
-        timed_out=True,
-        truncated=False,
-        executed_with_shell=use_shell,
-    )
-
-
-__all__ = ["ShellExecutionResult", "execute_shell_command", "timeout_result"]
+__all__ = ["ShellExecutionResult", "execute_shell_command"]

--- a/app/cli/interactive_shell/shell_execution.py
+++ b/app/cli/interactive_shell/shell_execution.py
@@ -1,0 +1,100 @@
+"""Structured shell command execution helpers for the interactive REPL."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ShellExecutionResult:
+    """Normalized command execution output."""
+
+    command: str
+    argv: list[str] | None
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    timed_out: bool
+    truncated: bool
+    executed_with_shell: bool
+
+
+def _truncate_output(text: str, *, max_chars: int) -> tuple[str, bool]:
+    if len(text) <= max_chars:
+        return text, False
+    return f"{text[:max_chars].rstrip()}\n... output truncated ...", True
+
+
+def execute_shell_command(
+    *,
+    command: str,
+    argv: list[str] | None,
+    use_shell: bool,
+    timeout_seconds: int,
+    max_output_chars: int,
+) -> ShellExecutionResult:
+    """Execute a command and return a structured result object."""
+    if use_shell:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            executable=os.environ.get("SHELL") or None,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    else:
+        if argv is None:
+            raise ValueError("argv is required for shell=False execution.")
+        completed = subprocess.run(
+            argv,
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+
+    stdout, truncated_stdout = _truncate_output(
+        completed.stdout or "",
+        max_chars=max_output_chars,
+    )
+    stderr, truncated_stderr = _truncate_output(
+        completed.stderr or "",
+        max_chars=max_output_chars,
+    )
+    return ShellExecutionResult(
+        command=command,
+        argv=argv,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=completed.returncode,
+        timed_out=False,
+        truncated=truncated_stdout or truncated_stderr,
+        executed_with_shell=use_shell,
+    )
+
+
+def timeout_result(
+    *,
+    command: str,
+    argv: list[str] | None,
+    use_shell: bool,
+) -> ShellExecutionResult:
+    """Build a timeout result object without process output."""
+    return ShellExecutionResult(
+        command=command,
+        argv=argv,
+        stdout="",
+        stderr="",
+        exit_code=None,
+        timed_out=True,
+        truncated=False,
+        executed_with_shell=use_shell,
+    )
+
+
+__all__ = ["ShellExecutionResult", "execute_shell_command", "timeout_result"]

--- a/app/cli/interactive_shell/shell_policy.py
+++ b/app/cli/interactive_shell/shell_policy.py
@@ -1,0 +1,308 @@
+"""Policy helpers for deterministic interactive-shell command safety."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from typing import Literal
+
+CommandClassification = Literal["read_only", "mutating", "restricted", "unknown"]
+
+_EXPLICIT_SHELL_PREFIX = "!"
+_SHELL_OPERATOR_RE = re.compile(r"(^|\s)(\|\||&&|[|;<>]|>>|<<|2>)(\s|$)")
+_INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
+
+_RESTRICTED_COMMANDS = frozenset(
+    {
+        "sudo",
+        "su",
+        "doas",
+        "mount",
+        "umount",
+        "mkfs",
+        "shutdown",
+        "reboot",
+        "poweroff",
+        "init",
+        "systemctl",
+        "service",
+        "passwd",
+        "useradd",
+        "userdel",
+        "usermod",
+        "groupadd",
+        "groupdel",
+        "chown",
+        "chmod",
+        "chgrp",
+        "kill",
+        "killall",
+        "pkill",
+        "iptables",
+        "ufw",
+        "dd",
+    }
+)
+
+_MUTATING_COMMANDS = frozenset(
+    {
+        "rm",
+        "mv",
+        "cp",
+        "mkdir",
+        "rmdir",
+        "touch",
+        "ln",
+        "truncate",
+        "sed",
+        "awk",
+        "tee",
+        "xargs",
+        "make",
+        "pip",
+        "pip3",
+        "poetry",
+        "npm",
+        "pnpm",
+        "yarn",
+        "apt",
+        "apt-get",
+        "apk",
+        "yum",
+        "dnf",
+        "brew",
+        "docker",
+        "kubectl",
+        "helm",
+        "terraform",
+        "ansible",
+        "git",
+    }
+)
+
+_READ_ONLY_COMMANDS = frozenset(
+    {
+        "pwd",
+        "cd",
+        "ls",
+        "dir",
+        "cat",
+        "head",
+        "tail",
+        "wc",
+        "sort",
+        "uniq",
+        "cut",
+        "rg",
+        "grep",
+        "find",
+        "which",
+        "whereis",
+        "echo",
+        "printf",
+        "env",
+        "printenv",
+        "date",
+        "uname",
+        "whoami",
+        "id",
+        "ps",
+        "top",
+        "df",
+        "du",
+        "history",
+        "true",
+        "false",
+    }
+)
+
+_READ_ONLY_GIT_SUBCOMMANDS = frozenset(
+    {"status", "log", "diff", "show", "branch", "remote", "rev-parse"}
+)
+_READ_ONLY_KUBECTL_SUBCOMMANDS = frozenset(
+    {"get", "describe", "logs", "top", "version", "api-resources"}
+)
+_READ_ONLY_HELM_SUBCOMMANDS = frozenset(
+    {"list", "status", "history", "get", "search", "show", "env"}
+)
+
+_READ_ONLY_AWS_PREFIXES = ("get", "list", "describe")
+
+
+@dataclass(frozen=True)
+class ParsedShellCommand:
+    """Structured command parsing result."""
+
+    command: str
+    argv: list[str] | None
+    passthrough: bool
+    parse_error: str | None = None
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Outcome from applying shell command safety policy."""
+
+    allow: bool
+    classification: CommandClassification
+    reason: str | None
+    hint: str | None
+
+
+def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand:
+    """Parse command text and detect explicit passthrough prefix."""
+    stripped = command.strip()
+    if stripped.startswith(_EXPLICIT_SHELL_PREFIX):
+        passthrough_command = stripped[len(_EXPLICIT_SHELL_PREFIX) :].strip()
+        if not passthrough_command:
+            return ParsedShellCommand(
+                command="",
+                argv=None,
+                passthrough=True,
+                parse_error="missing command after passthrough prefix (!).",
+            )
+        return ParsedShellCommand(
+            command=passthrough_command,
+            argv=None,
+            passthrough=True,
+        )
+
+    if (
+        _SHELL_OPERATOR_RE.search(stripped) is not None
+        or _INLINE_SUBSHELL_RE.search(stripped) is not None
+    ):
+        return ParsedShellCommand(
+            command=stripped,
+            argv=None,
+            passthrough=False,
+            parse_error=(
+                "shell operators and command substitution are blocked in safe mode. "
+                "Use !<command> to run this intentionally."
+            ),
+        )
+
+    try:
+        argv = shlex.split(stripped, posix=not is_windows)
+    except ValueError:
+        try:
+            argv = shlex.split(stripped, posix=False)
+        except ValueError as exc:
+            return ParsedShellCommand(
+                command=stripped,
+                argv=None,
+                passthrough=False,
+                parse_error=f"could not parse command: {exc}",
+            )
+
+    if not argv:
+        return ParsedShellCommand(
+            command=stripped,
+            argv=None,
+            passthrough=False,
+            parse_error="empty command.",
+        )
+
+    return ParsedShellCommand(command=stripped, argv=argv, passthrough=False)
+
+
+def classify_command(argv: list[str]) -> CommandClassification:
+    """Classify command into read-only, mutating, restricted, or unknown."""
+    command = argv[0].lower()
+
+    if command in _RESTRICTED_COMMANDS:
+        return "restricted"
+    if command in _READ_ONLY_COMMANDS:
+        return "read_only"
+
+    if command == "git":
+        subcommand = argv[1].lower() if len(argv) > 1 else ""
+        return "read_only" if subcommand in _READ_ONLY_GIT_SUBCOMMANDS else "mutating"
+
+    if command == "kubectl":
+        subcommand = argv[1].lower() if len(argv) > 1 else ""
+        return "read_only" if subcommand in _READ_ONLY_KUBECTL_SUBCOMMANDS else "mutating"
+
+    if command == "helm":
+        subcommand = argv[1].lower() if len(argv) > 1 else ""
+        return "read_only" if subcommand in _READ_ONLY_HELM_SUBCOMMANDS else "mutating"
+
+    if command == "aws":
+        subcommand = argv[1].lower() if len(argv) > 1 else ""
+        return "read_only" if subcommand.startswith(_READ_ONLY_AWS_PREFIXES) else "mutating"
+
+    if command in _MUTATING_COMMANDS:
+        return "mutating"
+
+    return "unknown"
+
+
+def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
+    """Allow read-only commands by default for inferred execution."""
+    if parsed.parse_error is not None:
+        return PolicyDecision(
+            allow=False,
+            classification="unknown",
+            reason=parsed.parse_error,
+            hint="Rewrite as a plain command or use !<command> for explicit shell passthrough.",
+        )
+
+    if parsed.passthrough:
+        return PolicyDecision(
+            allow=True,
+            classification="unknown",
+            reason=None,
+            hint=None,
+        )
+
+    if parsed.argv is None:
+        return PolicyDecision(
+            allow=False,
+            classification="unknown",
+            reason="failed to parse command.",
+            hint="Rewrite as a plain command or use !<command> for explicit shell passthrough.",
+        )
+
+    classification = classify_command(parsed.argv)
+    if classification == "read_only":
+        return PolicyDecision(
+            allow=True,
+            classification=classification,
+            reason=None,
+            hint=None,
+        )
+
+    if classification == "mutating":
+        return PolicyDecision(
+            allow=False,
+            classification=classification,
+            reason="mutating commands are blocked in safe mode.",
+            hint=(
+                "Use a read-only command, or run !<command> to explicitly "
+                "opt into shell passthrough."
+            ),
+        )
+
+    if classification == "restricted":
+        return PolicyDecision(
+            allow=False,
+            classification=classification,
+            reason="restricted command is not allowed from inferred execution.",
+            hint="Run the command directly in your shell if you truly intend it.",
+        )
+
+    return PolicyDecision(
+        allow=False,
+        classification=classification,
+        reason="command is not in the safe read-only allowlist.",
+        hint="Use a known read-only command, or run !<command> for explicit passthrough.",
+    )
+
+
+__all__ = [
+    "ParsedShellCommand",
+    "PolicyDecision",
+    "classify_command",
+    "evaluate_policy",
+    "parse_shell_command",
+]

--- a/app/cli/interactive_shell/shell_policy.py
+++ b/app/cli/interactive_shell/shell_policy.py
@@ -73,13 +73,16 @@ _MUTATING_COMMANDS = frozenset(
         "dnf",
         "brew",
         "docker",
-        "kubectl",
-        "helm",
         "terraform",
         "ansible",
-        "git",
     }
 )
+
+# Commands that can exec arbitrary child processes via flags (e.g. find -exec, env <cmd>).
+# Allowing them defeats the mutating-command policy because the dangerous child process
+# is spawned by the permitted parent — no shell involved, policy never sees it.
+# Users who genuinely need these can prefix with ! for explicit passthrough.
+_EXEC_WRAPPER_COMMANDS = frozenset({"find", "env"})
 
 _READ_ONLY_COMMANDS = frozenset(
     {
@@ -96,12 +99,10 @@ _READ_ONLY_COMMANDS = frozenset(
         "cut",
         "rg",
         "grep",
-        "find",
         "which",
         "whereis",
         "echo",
         "printf",
-        "env",
         "printenv",
         "date",
         "uname",
@@ -212,6 +213,8 @@ def classify_command(argv: list[str]) -> CommandClassification:
 
     if command in _RESTRICTED_COMMANDS:
         return "restricted"
+    if command in _EXEC_WRAPPER_COMMANDS:
+        return "mutating"
     if command in _READ_ONLY_COMMANDS:
         return "read_only"
 
@@ -276,7 +279,10 @@ def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
         return PolicyDecision(
             allow=False,
             classification=classification,
-            reason="mutating commands are blocked in safe mode.",
+            reason=(
+                "mutating commands are blocked in safe mode "
+                "(includes exec-wrapper commands such as find and env)."
+            ),
             hint=(
                 "Use a read-only command, or run !<command> to explicitly "
                 "opt into shell passthrough."

--- a/app/cli/interactive_shell/shell_policy.py
+++ b/app/cli/interactive_shell/shell_policy.py
@@ -81,6 +81,7 @@ _MUTATING_COMMANDS = frozenset(
 # Commands that can exec arbitrary child processes via flags (e.g. find -exec, env <cmd>).
 # Allowing them defeats the mutating-command policy because the dangerous child process
 # is spawned by the permitted parent — no shell involved, policy never sees it.
+# Same risk applies to xargs — it stays in `_MUTATING_COMMANDS` (blocked by name).
 # Users who genuinely need these can prefix with ! for explicit passthrough.
 _EXEC_WRAPPER_COMMANDS = frozenset({"find", "env"})
 
@@ -128,7 +129,89 @@ _READ_ONLY_HELM_SUBCOMMANDS = frozenset(
     {"list", "status", "history", "get", "search", "show", "env"}
 )
 
-_READ_ONLY_AWS_PREFIXES = ("get", "list", "describe")
+# AWS CLI positional args (approximately: drop `-`/`--` tokens and their bundled values).
+_AWS_TWO_ARG_FLAGS = frozenset(
+    {
+        "--region",
+        "--endpoint-url",
+        "--profile",
+        "--ca-bundle",
+        "--cli-read-timeout",
+        "--cli-connect-timeout",
+        "--output",
+        "--query",
+        "--color",
+        "--no-sign-request",
+    }
+)
+
+
+def _aws_token_looks_like_read_operation(tok: str) -> bool:
+    """Match verbs like get-caller-identity / list-tables without false-positive prefixes."""
+    if tok.startswith(
+        ("describe-", "list-", "get-", "batch-get-", "batch-describe-", "history-"),
+    ):
+        return True
+    # Require a hyphen for bare get/list/describe prefix (avoids tokens like getter).
+    if tok.startswith(("describe", "list", "get")):
+        return "-" in tok
+    return False
+
+
+def _aws_cli_positional_args(argv: list[str]) -> list[str]:
+    """Extract likely positional tokens after stripping common global CLI flags."""
+    out: list[str] = []
+    index = 1
+    limit = len(argv)
+    while index < limit:
+        token = argv[index]
+        lower = token.lower()
+        if lower.startswith("--") and "=" in lower:
+            index += 1
+            continue
+        lower_name = lower.split("=", maxsplit=1)[0]
+        if lower_name in _AWS_TWO_ARG_FLAGS or (
+            lower.startswith("--")
+            and "=" not in lower
+            and index + 1 < limit
+            and not argv[index + 1].startswith("-")
+        ):
+            index += 2
+            continue
+        if lower.startswith("-") and lower != "--":
+            skip_value = (
+                len(lower) >= 2
+                and lower[1] != "-"
+                and len(lower) == 2
+                and index + 1 < limit
+                and not argv[index + 1].startswith("-")
+            )
+            index += 2 if skip_value else 1
+            continue
+        out.append(lower)
+        index += 1
+    return out
+
+
+def _aws_cli_argv_is_read_only(argv: list[str]) -> bool:
+    """Treat common read-only AWS CLI calls as allowed (verbs after optional global flags).
+
+    Matches service-scoped invocations (`aws ec2 describe-instances`) as well as
+    shorthand read paths (`aws s3 ls`).
+    """
+    positional = _aws_cli_positional_args(argv)
+    if not positional:
+        return False
+
+    for tok in positional:
+        if _aws_token_looks_like_read_operation(tok):
+            return True
+
+    for index in range(len(positional) - 1):
+        if positional[index] == "s3" and positional[index + 1] in {"ls", "lsf"}:
+            return True
+
+    return False
 
 
 @dataclass(frozen=True)
@@ -231,8 +314,7 @@ def classify_command(argv: list[str]) -> CommandClassification:
         return "read_only" if subcommand in _READ_ONLY_HELM_SUBCOMMANDS else "mutating"
 
     if command == "aws":
-        subcommand = argv[1].lower() if len(argv) > 1 else ""
-        return "read_only" if subcommand.startswith(_READ_ONLY_AWS_PREFIXES) else "mutating"
+        return "read_only" if _aws_cli_argv_is_read_only(argv) else "mutating"
 
     if command in _MUTATING_COMMANDS:
         return "mutating"

--- a/app/cli/interactive_shell/shell_policy.py
+++ b/app/cli/interactive_shell/shell_policy.py
@@ -59,6 +59,7 @@ _MUTATING_COMMANDS = frozenset(
         "awk",
         "tee",
         "xargs",
+        "sort",
         "make",
         "pip",
         "pip3",
@@ -95,7 +96,6 @@ _READ_ONLY_COMMANDS = frozenset(
         "head",
         "tail",
         "wc",
-        "sort",
         "uniq",
         "cut",
         "rg",
@@ -129,7 +129,7 @@ _READ_ONLY_HELM_SUBCOMMANDS = frozenset(
     {"list", "status", "history", "get", "search", "show", "env"}
 )
 
-# AWS CLI positional args (approximately: drop `-`/`--` tokens and their bundled values).
+# AWS CLI: flags that consume the next argv token as a value.
 _AWS_TWO_ARG_FLAGS = frozenset(
     {
         "--region",
@@ -141,7 +141,17 @@ _AWS_TWO_ARG_FLAGS = frozenset(
         "--output",
         "--query",
         "--color",
+    }
+)
+
+# AWS CLI: boolean / no-argument long flags (must not skip a following positional).
+_AWS_BOOLEAN_FLAGS = frozenset(
+    {
         "--no-sign-request",
+        "--no-paginate",
+        "--no-verify-ssl",
+        "--debug",
+        "--no-cli-pager",
     }
 )
 
@@ -170,6 +180,9 @@ def _aws_cli_positional_args(argv: list[str]) -> list[str]:
             index += 1
             continue
         lower_name = lower.split("=", maxsplit=1)[0]
+        if lower_name in _AWS_BOOLEAN_FLAGS:
+            index += 1
+            continue
         if lower_name in _AWS_TWO_ARG_FLAGS or (
             lower.startswith("--")
             and "=" not in lower

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -582,6 +582,49 @@ def test_execute_cli_actions_runs_passthrough_with_shell_true(monkeypatch: objec
     assert "ok" in output
 
 
+def test_execute_cli_actions_routes_bang_cd_through_builtin(monkeypatch: object) -> None:
+    dirs: list[Path] = []
+
+    def _fake_chdir(target: Path) -> None:
+        dirs.append(target)
+
+    def _boom(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+        raise AssertionError("subprocess.run should not be used for !cd builtin routing")
+
+    monkeypatch.setattr(agent_actions.os, "chdir", _fake_chdir)
+    monkeypatch.setattr(agent_actions.subprocess, "run", _boom)
+
+    session = ReplSession()
+    console, buf = _capture()
+
+    message = "run `!cd /tmp`"
+    assert execute_cli_actions(message, session, console) is True
+    assert dirs == [Path("/tmp")]
+    assert session.history[-1] == {"type": "shell", "text": "cd /tmp", "ok": True}
+    captured = buf.getvalue()
+    assert "explicit shell passthrough enabled" not in captured
+
+
+def test_execute_cli_actions_routes_bang_pwd_through_builtin(monkeypatch: object) -> None:
+    def _fake_cwd(_: type[Path]) -> PurePosixPath:
+        return PurePosixPath("/shown")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+        raise AssertionError("subprocess.run should not be used for !pwd builtin routing")
+
+    monkeypatch.setattr(agent_actions.Path, "cwd", classmethod(_fake_cwd))
+    monkeypatch.setattr(agent_actions.subprocess, "run", _boom)
+
+    session = ReplSession()
+    console, buf = _capture()
+
+    assert execute_cli_actions("run `!pwd`", session, console) is True
+    assert session.history[-1] == {"type": "shell", "text": "pwd", "ok": True}
+    captured = buf.getvalue()
+    assert "/shown" in captured
+    assert "explicit shell passthrough enabled" not in captured
+
+
 def test_execute_cli_actions_blocks_mutating_command_by_default() -> None:
     session = ReplSession()
     console, buf = _capture()

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -199,6 +199,7 @@ def test_direct_shell_command_plans_shell_action() -> None:
     assert plan_terminal_tasks("pwd") == ["shell"]
     assert plan_terminal_tasks("cd /tmp") == ["shell"]
     assert plan_terminal_tasks("CD /tmp") == ["shell"]
+    assert plan_terminal_tasks("!ls -la") == ["shell"]
 
 
 def test_sample_alert_launch_plans_sample_alert_action() -> None:
@@ -509,13 +510,15 @@ def test_execute_cli_actions_cd_strips_quotes_on_windows(monkeypatch: object) ->
 
 def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     completed = subprocess.CompletedProcess(
-        args="false",
+        args=["false"],
         returncode=2,
         stdout="",
         stderr="nope\n",
     )
+    calls: list[tuple[list[str], dict[str, object]]] = []
 
-    def _fake_run(command: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
         return completed
 
     monkeypatch.setattr(agent_actions.subprocess, "run", _fake_run)
@@ -524,7 +527,111 @@ def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     console, buf = _capture()
 
     assert execute_cli_actions("execute false", session, console) is True
+    assert calls == [
+        (
+            ["false"],
+            {
+                "shell": False,
+                "capture_output": True,
+                "text": True,
+                "timeout": agent_actions._SHELL_COMMAND_TIMEOUT_SECONDS,
+                "check": False,
+            },
+        )
+    ]
     assert session.history[-1] == {"type": "shell", "text": "false", "ok": False}
     output = buf.getvalue()
     assert "nope" in output
     assert "exit code" in output
+
+
+def test_execute_cli_actions_runs_passthrough_with_shell_true(monkeypatch: object) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def _fake_run(command: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(agent_actions.subprocess, "run", _fake_run)
+
+    session = ReplSession()
+    console, buf = _capture()
+
+    assert execute_cli_actions("run `!echo hello`", session, console) is True
+    assert calls == [
+        (
+            "echo hello",
+            {
+                "shell": True,
+                "executable": agent_actions.os.environ.get("SHELL") or None,
+                "capture_output": True,
+                "text": True,
+                "timeout": agent_actions._SHELL_COMMAND_TIMEOUT_SECONDS,
+                "check": False,
+            },
+        )
+    ]
+    assert session.history[-1] == {"type": "shell", "text": "!echo hello", "ok": True}
+    output = buf.getvalue()
+    assert "explicit shell passthrough enabled" in output
+    assert "ok" in output
+
+
+def test_execute_cli_actions_blocks_mutating_command_by_default() -> None:
+    session = ReplSession()
+    console, buf = _capture()
+
+    assert execute_cli_actions("run `rm -rf /tmp/demo`", session, console) is True
+    assert session.history[-1] == {"type": "shell", "text": "rm -rf /tmp/demo", "ok": False}
+    output = buf.getvalue()
+    assert "command blocked" in output
+    assert "mutating commands are blocked" in output
+    assert "run !<command>" in output
+
+
+def test_execute_cli_actions_blocks_ambiguous_shell_operators() -> None:
+    session = ReplSession()
+    console, buf = _capture()
+
+    assert execute_cli_actions("run `ls | wc -l`", session, console) is True
+    assert session.history[-1] == {"type": "shell", "text": "ls | wc -l", "ok": False}
+    output = buf.getvalue()
+    assert "command blocked" in output
+    assert "shell operators" in output
+
+
+def test_execute_cli_actions_handles_path_with_spaces(monkeypatch: object) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="done\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(agent_actions.subprocess, "run", _fake_run)
+
+    session = ReplSession()
+    console, _ = _capture()
+
+    assert execute_cli_actions('run `cat "/tmp/file with spaces.txt"`', session, console) is True
+    assert calls[0][0] == ["cat", "/tmp/file with spaces.txt"]
+
+
+def test_execute_cli_actions_rejects_malformed_shell_input() -> None:
+    session = ReplSession()
+    console, buf = _capture()
+
+    assert execute_cli_actions('run `cat "unterminated`', session, console) is True
+    assert session.history[-1] == {"type": "shell", "text": 'cat "unterminated', "ok": False}
+    output = buf.getvalue()
+    assert "command blocked" in output
+    assert "could not parse command" in output

--- a/tests/cli/interactive_shell/test_shell_policy.py
+++ b/tests/cli/interactive_shell/test_shell_policy.py
@@ -117,3 +117,19 @@ def test_aws_cli_positional_handles_double_dash_equals_form() -> None:
 
     assert decision.allow is True
     assert decision.classification == "read_only"
+
+
+def test_classify_command_sort_is_mutating_for_file_output_flags() -> None:
+    assert classify_command(["sort", "-o", "/etc/cron.d/out", "in.txt"]) == "mutating"
+
+
+def test_aws_no_sign_request_preserves_s3_ls_positional_pair() -> None:
+    assert classify_command(["aws", "--no-sign-request", "s3", "ls"]) == "read_only"
+
+
+def test_evaluate_policy_blocks_sort_even_without_shell_redirection() -> None:
+    parsed = parse_shell_command("sort -o /tmp/out /tmp/in", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert decision.classification == "mutating"

--- a/tests/cli/interactive_shell/test_shell_policy.py
+++ b/tests/cli/interactive_shell/test_shell_policy.py
@@ -63,3 +63,57 @@ def test_env_exec_wrapper_is_blocked() -> None:
 def test_classify_command_marks_find_and_env_as_mutating() -> None:
     assert classify_command(["find", "/tmp", "-name", "*.log"]) == "mutating"
     assert classify_command(["env", "MY_VAR=1", "echo", "hello"]) == "mutating"
+
+
+def test_evaluate_policy_blocks_restricted_command_sudo() -> None:
+    parsed = parse_shell_command("sudo ls /tmp", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert decision.classification == "restricted"
+    assert decision.reason == "restricted command is not allowed from inferred execution."
+
+
+def test_evaluate_policy_blocks_restricted_command_dd() -> None:
+    parsed = parse_shell_command("dd if=/dev/zero of=/dev/null count=1", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert decision.classification == "restricted"
+    assert "restricted" in (decision.reason or "").lower()
+
+
+def test_classify_command_aws_ec2_describe_instances() -> None:
+    assert classify_command(["aws", "ec2", "describe-instances"]) == "read_only"
+
+
+def test_classify_command_aws_s3_ls() -> None:
+    assert classify_command(["aws", "s3", "ls"]) == "read_only"
+
+
+def test_classify_command_aws_global_flags_then_describe() -> None:
+    assert (
+        classify_command(
+            ["aws", "--region", "us-east-1", "ec2", "describe-instances"],
+        )
+        == "read_only"
+    )
+
+
+def test_classify_command_aws_s3_cp_mutating() -> None:
+    assert classify_command(["aws", "s3", "cp", "s3://b/a", "./a"]) == "mutating"
+
+
+def test_classify_command_aws_configure_is_mutating() -> None:
+    assert classify_command(["aws", "configure"]) == "mutating"
+
+
+def test_aws_cli_positional_handles_double_dash_equals_form() -> None:
+    parsed = parse_shell_command(
+        "aws ec2 describe-instances --output json --query Reservations",
+        is_windows=False,
+    )
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is True
+    assert decision.classification == "read_only"

--- a/tests/cli/interactive_shell/test_shell_policy.py
+++ b/tests/cli/interactive_shell/test_shell_policy.py
@@ -38,3 +38,28 @@ def test_evaluate_policy_blocks_unknown_command_by_default() -> None:
     assert decision.allow is False
     assert decision.classification == "unknown"
     assert "allowlist" in (decision.reason or "")
+
+
+def test_find_exec_wrapper_is_blocked() -> None:
+    """find -exec can spawn arbitrary child processes; must be blocked in safe mode."""
+    parsed = parse_shell_command("find /tmp -exec rm -rf {} +", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert decision.classification == "mutating"
+    assert "exec-wrapper" in (decision.reason or "")
+
+
+def test_env_exec_wrapper_is_blocked() -> None:
+    """env <cmd> execs arbitrary programs; must be blocked in safe mode."""
+    parsed = parse_shell_command("env rm /tmp/foo", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert decision.classification == "mutating"
+    assert "exec-wrapper" in (decision.reason or "")
+
+
+def test_classify_command_marks_find_and_env_as_mutating() -> None:
+    assert classify_command(["find", "/tmp", "-name", "*.log"]) == "mutating"
+    assert classify_command(["env", "MY_VAR=1", "echo", "hello"]) == "mutating"

--- a/tests/cli/interactive_shell/test_shell_policy.py
+++ b/tests/cli/interactive_shell/test_shell_policy.py
@@ -1,0 +1,40 @@
+"""Tests for interactive-shell command safety policy."""
+
+from __future__ import annotations
+
+from app.cli.interactive_shell.shell_policy import (
+    classify_command,
+    evaluate_policy,
+    parse_shell_command,
+)
+
+
+def test_parse_shell_command_detects_passthrough_prefix() -> None:
+    parsed = parse_shell_command("!echo hello", is_windows=False)
+
+    assert parsed.passthrough is True
+    assert parsed.command == "echo hello"
+    assert parsed.argv is None
+    assert parsed.parse_error is None
+
+
+def test_parse_shell_command_rejects_operators_in_safe_mode() -> None:
+    parsed = parse_shell_command("ls | wc -l", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert "shell operators" in (decision.reason or "")
+
+
+def test_classify_command_handles_git_read_only_and_mutating() -> None:
+    assert classify_command(["git", "status"]) == "read_only"
+    assert classify_command(["git", "commit", "-m", "x"]) == "mutating"
+
+
+def test_evaluate_policy_blocks_unknown_command_by_default() -> None:
+    parsed = parse_shell_command("mycustomcmd --check", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    assert decision.allow is False
+    assert decision.classification == "unknown"
+    assert "allowlist" in (decision.reason or "")


### PR DESCRIPTION
Fixes #1372

#### Describe the changes you have made in this PR -

- Replaced implicit `shell=True` for inferred REPL commands with argv parsing and `subprocess.run(argv, shell=False)` by default in `app/cli/interactive_shell/agent_actions.py`.
- Added `app/cli/interactive_shell/shell_policy.py` for passthrough detection (`!` prefix), safe-mode rejection of shell operators / command substitution, and read-only / mutating / restricted classification with user-facing hints.
- Added `app/cli/interactive_shell/shell_execution.py` with `ShellExecutionResult` and centralized execution + stdout/stderr truncation.
- Kept existing `cd` / `pwd` handling; explicit `!command` runs with `shell=True` and prints a visible passthrough notice.
- Extended `tests/cli/interactive_shell/test_agent_actions.py` and added `tests/cli/interactive_shell/test_shell_policy.py` for default path, passthrough, blocking, quoting, and parse failures.

### Demo/Screenshot for feature changes and bug fixes - 

Terminal proof (local run):

```
$ .venv/bin/python -m pytest tests/cli/interactive_shell/test_agent_actions.py tests/cli/interactive_shell/test_shell_policy.py
============================== 35 passed in 0.29s ==============================
```

Also verified: `make lint`, `make format-check`, `make typecheck`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem was natural-language–inferred commands running through the user shell (`shell=True`), which increases injection and surprise-execution risk. The fix splits **parsing** (`parse_shell_command`), **policy** (`evaluate_policy` / `classify_command`), and **execution** (`execute_shell_command`) so the default path is always argv + `shell=False`, with `!` as the only explicit opt-in to full shell semantics. Alternatives included a config flag only or a larger denylist without argv execution; argv-first + visible passthrough matches the issue’s acceptance criteria and keeps behavior testable. Key pieces: `shell_policy` decides allow/reject and hints; `shell_execution` normalizes subprocess output and truncation; `_run_shell_command` wires them and preserves `cd`/`pwd` without regressing Windows path tests.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
