### PR TITLE
feat(cli): REPL task lifecycle, /tasks and /cancel

### DIFF
--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -163,6 +164,8 @@ _SHELL_COMMAND_TIMEOUT_SECONDS = 120
 _SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
 _SYNTHETIC_POLL_SECONDS = 0.25
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
+_SYNTHETIC_DIAG_CHARS = 2_000  # max stderr bytes captured from a failing synthetic run
+_SIGTERM_GRACE_SECONDS = 10  # wait for clean exit after SIGTERM before escalating to SIGKILL
 _IS_WINDOWS = os.name == "nt"
 
 
@@ -416,17 +419,21 @@ def _terminate_child_process(proc: subprocess.Popen[Any]) -> None:
     """Best-effort SIGTERM → wait → SIGKILL → wait without blocking forever."""
     if proc.poll() is not None:
         return
-    _grace_s = 45
-    _post_kill_wait_s = 5
     with contextlib.suppress(OSError):
         proc.terminate()
     try:
-        proc.wait(timeout=_grace_s)
+        proc.wait(timeout=_SIGTERM_GRACE_SECONDS)
     except subprocess.TimeoutExpired:
         with contextlib.suppress(OSError):
             proc.kill()
         with contextlib.suppress(subprocess.TimeoutExpired):
-            proc.wait(timeout=_post_kill_wait_s)
+            proc.wait(timeout=5)
+
+
+def _read_diag(buf: tempfile.SpooledTemporaryFile[bytes]) -> str:  # type: ignore[type-arg]
+    """Read up to ``_SYNTHETIC_DIAG_CHARS`` bytes from a captured stderr buffer."""
+    buf.seek(0)
+    return buf.read(_SYNTHETIC_DIAG_CHARS).decode("utf-8", errors="replace").strip()
 
 
 def _watch_synthetic_subprocess(
@@ -434,6 +441,7 @@ def _watch_synthetic_subprocess(
     proc: subprocess.Popen[Any],
     session: ReplSession,
     suite_name: str,
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
 ) -> None:
     def _history_text() -> str:
         return f"{suite_name} task:{task.task_id}"
@@ -448,39 +456,53 @@ def _watch_synthetic_subprocess(
     def _run() -> None:
         started = time.monotonic()
         timed_out = False
+        # Track whether *we* explicitly terminated the process so we can
+        # distinguish a cancel-driven exit from a natural exit that happened
+        # to race with a concurrent /cancel.
+        terminated_by_watcher = False
         while proc.poll() is None:
             if time.monotonic() - started > _SYNTHETIC_TEST_TIMEOUT_SECONDS:
                 timed_out = True
                 task.request_cancel()
                 _terminate_child_process(proc)
+                terminated_by_watcher = True
                 break
             if task.cancel_requested.is_set():
                 _terminate_child_process(proc)
+                terminated_by_watcher = True
                 break
             time.sleep(_SYNTHETIC_POLL_SECONDS)
 
-        if timed_out:
-            task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
-            _record_synthetic_if_current_session(ok=False)
-            return
+        try:
+            if timed_out:
+                task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
+                _record_synthetic_if_current_session(ok=False)
+                return
 
-        code = proc.returncode
-        if code is None:
-            task.mark_failed("subprocess did not report exit code")
-            _record_synthetic_if_current_session(ok=False)
-            return
+            code = proc.returncode
+            if code is None:
+                task.mark_failed("subprocess did not report exit code")
+                _record_synthetic_if_current_session(ok=False)
+                return
 
-        if task.cancel_requested.is_set():
-            task.mark_cancelled()
-            _record_synthetic_if_current_session(ok=False)
-            return
+            # Honour the real exit code when the process exited on its own.
+            # Only treat as CANCELLED when *we* killed it after a cancel request;
+            # a natural exit that races with /cancel should be recorded by its code.
+            if terminated_by_watcher and task.cancel_requested.is_set():
+                task.mark_cancelled()
+                _record_synthetic_if_current_session(ok=False)
+                return
 
-        if code == 0:
-            task.mark_completed(result="ok")
-            _record_synthetic_if_current_session(ok=True)
-        else:
-            task.mark_failed(f"exit code {code}")
-            _record_synthetic_if_current_session(ok=False)
+            if code == 0:
+                task.mark_completed(result="ok")
+                _record_synthetic_if_current_session(ok=True)
+            else:
+                diag = _read_diag(stderr_buf)
+                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+                task.mark_failed(error_msg)
+                _record_synthetic_if_current_session(ok=False)
+        finally:
+            stderr_buf.close()
 
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
 
@@ -645,20 +667,25 @@ def _run_synthetic_test(suite_name: str, session: ReplSession, console: Console)
     console.print(f"[bold]$ {display_command}[/bold]")
     task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
     task.mark_running()
+    # Lifetime managed by the watcher thread's finally block. noqa: SIM115
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+        max_size=_SYNTHETIC_DIAG_CHARS * 2
+    )
     try:
         proc = subprocess.Popen(  # noqa: S603 - argv is trusted interpreter path + module
             [sys.executable, "-m", "app.cli", "tests", "synthetic"],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=stderr_buf,
         )
     except Exception as exc:  # noqa: BLE001
+        stderr_buf.close()
         task.mark_failed(str(exc))
         console.print(f"[red]synthetic test failed to start:[/red] {escape(str(exc))}")
         session.record("synthetic_test", suite_name, ok=False)
         return
 
     task.attach_process(proc)
-    _watch_synthetic_subprocess(task, proc, session, suite_name)
+    _watch_synthetic_subprocess(task, proc, session, suite_name, stderr_buf)
     console.print(
         f"[dim]synthetic test started — task[/dim] [bold]{escape(task.task_id)}[/bold]. "
         f"[dim]/tasks[/dim] [dim]to monitor,[/dim] [bold]/cancel {escape(task.task_id)}[/bold] "

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -433,6 +433,13 @@ def _watch_synthetic_subprocess(
     def _history_text() -> str:
         return f"{suite_name} task:{task.task_id}"
 
+    history_gen_when_watch_started = session.history_generation
+
+    def _record_synthetic_if_current_session(ok: bool) -> None:
+        if session.history_generation != history_gen_when_watch_started:
+            return
+        session.record("synthetic_test", _history_text(), ok=ok)
+
     def _run() -> None:
         started = time.monotonic()
         timed_out = False
@@ -449,26 +456,26 @@ def _watch_synthetic_subprocess(
 
         if timed_out:
             task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
-            session.record("synthetic_test", _history_text(), ok=False)
+            _record_synthetic_if_current_session(ok=False)
             return
 
         code = proc.returncode
         if code is None:
             task.mark_failed("subprocess did not report exit code")
-            session.record("synthetic_test", _history_text(), ok=False)
+            _record_synthetic_if_current_session(ok=False)
             return
 
         if task.cancel_requested.is_set():
             task.mark_cancelled()
-            session.record("synthetic_test", _history_text(), ok=False)
+            _record_synthetic_if_current_session(ok=False)
             return
 
         if code == 0:
             task.mark_completed(result="ok")
-            session.record("synthetic_test", _history_text(), ok=True)
+            _record_synthetic_if_current_session(ok=True)
         else:
             task.mark_failed(f"exit code {code}")
-            session.record("synthetic_test", _history_text(), ok=False)
+            _record_synthetic_if_current_session(ok=False)
 
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
 

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 import shlex
 import shutil
 import subprocess
 import sys
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from rich.console import Console
 from rich.markup import escape
@@ -18,6 +21,7 @@ from rich.text import Text
 
 from app.cli.interactive_shell.commands import dispatch_slash, switch_llm_provider
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind, TaskRecord
 from app.cli.interactive_shell.terminal_intent import mentioned_integration_services
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
@@ -152,6 +156,7 @@ _NON_COMMAND_STARTS = frozenset(
 _SHELL_BUILTINS = frozenset({"cd", "pwd"})
 _SHELL_COMMAND_TIMEOUT_SECONDS = 120
 _SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
+_SYNTHETIC_POLL_SECONDS = 0.25
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
 _IS_WINDOWS = os.name == "nt"
 
@@ -402,6 +407,58 @@ def _print_planned_actions(console: Console, actions: list[PlannedAction]) -> No
         )
 
 
+def _terminate_child_process(proc: subprocess.Popen[Any]) -> None:
+    """Best-effort SIGTERM → wait → SIGKILL → wait without blocking forever."""
+    if proc.poll() is not None:
+        return
+    _grace_s = 45
+    with contextlib.suppress(OSError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=_grace_s)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(OSError):
+            proc.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=_grace_s)
+
+
+def _watch_synthetic_subprocess(task: TaskRecord, proc: subprocess.Popen[Any]) -> None:
+    def _run() -> None:
+        started = time.monotonic()
+        timed_out = False
+        while proc.poll() is None:
+            if time.monotonic() - started > _SYNTHETIC_TEST_TIMEOUT_SECONDS:
+                timed_out = True
+                task.request_cancel()
+                _terminate_child_process(proc)
+                break
+            if task.cancel_requested.is_set():
+                _terminate_child_process(proc)
+                break
+            time.sleep(_SYNTHETIC_POLL_SECONDS)
+
+        if timed_out:
+            task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
+            return
+
+        code = proc.returncode
+        if code is None:
+            task.mark_failed("subprocess did not report exit code")
+            return
+
+        if task.cancel_requested.is_set():
+            task.mark_cancelled()
+            return
+
+        if code == 0:
+            task.mark_completed(result="ok")
+        else:
+            task.mark_failed(f"exit code {code}")
+
+    threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
+
+
 def _run_shell_command(command: str, session: ReplSession, console: Console) -> None:
     console.print(f"[bold]$ {escape(command)}[/bold]")
     token = _first_command_token(command)
@@ -496,20 +553,27 @@ def _run_sample_alert(template_name: str, session: ReplSession, console: Console
     from app.cli.investigation import run_sample_alert_for_session
 
     console.print(f"[bold]sample alert:[/bold] {escape(template_name)}")
+    task = session.task_registry.create(TaskKind.INVESTIGATION)
+    task.mark_running()
     try:
         final_state = run_sample_alert_for_session(
             template_name=template_name,
             context_overrides=session.accumulated_context or None,
+            cancel_requested=task.cancel_requested,
         )
     except KeyboardInterrupt:
+        task.mark_cancelled()
         console.print("[yellow]investigation cancelled.[/yellow]")
         session.record("alert", f"sample:{template_name}", ok=False)
         return
     except Exception as exc:  # noqa: BLE001
+        task.mark_failed(str(exc))
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         session.record("alert", f"sample:{template_name}", ok=False)
         return
 
+    root = final_state.get("root_cause")
+    task.mark_completed(result=str(root) if root is not None else "")
     session.last_state = final_state
     session.accumulate_from_state(final_state)
     session.record("alert", f"sample:{template_name}")
@@ -523,27 +587,28 @@ def _run_synthetic_test(suite_name: str, session: ReplSession, console: Console)
 
     display_command = "opensre tests synthetic"
     console.print(f"[bold]$ {display_command}[/bold]")
+    task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+    task.mark_running()
     try:
-        completed = subprocess.run(
+        proc = subprocess.Popen(  # noqa: S603 - argv is trusted interpreter path + module
             [sys.executable, "-m", "app.cli", "tests", "synthetic"],
-            timeout=_SYNTHETIC_TEST_TIMEOUT_SECONDS,
-            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
-    except subprocess.TimeoutExpired:
-        console.print(
-            f"[red]synthetic test timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS} seconds[/red]"
-        )
-        session.record("synthetic_test", suite_name, ok=False)
-        return
     except Exception as exc:  # noqa: BLE001
+        task.mark_failed(str(exc))
         console.print(f"[red]synthetic test failed to start:[/red] {escape(str(exc))}")
         session.record("synthetic_test", suite_name, ok=False)
         return
 
-    ok = completed.returncode == 0
-    if not ok:
-        console.print(f"[red]exit code:[/red] {completed.returncode}")
-    session.record("synthetic_test", suite_name, ok=ok)
+    task.attach_process(proc)
+    _watch_synthetic_subprocess(task, proc)
+    console.print(
+        f"[dim]synthetic test started — task[/dim] [bold]{escape(task.task_id)}[/bold]. "
+        f"[dim]/tasks[/dim] [dim]to monitor,[/dim] [bold]/cancel {escape(task.task_id)}[/bold] "
+        f"[dim]to stop.[/dim]"
+    )
+    session.record("synthetic_test", f"{suite_name} task:{task.task_id}")
 
 
 def execute_cli_actions(message: str, session: ReplSession, console: Console) -> bool:

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -616,6 +616,7 @@ def _run_sample_alert(template_name: str, session: ReplSession, console: Console
         session.record("alert", f"sample:{template_name}", ok=False)
         return
     except OpenSREError as exc:
+        task.mark_failed(str(exc))
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         if exc.suggestion:
             console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -412,6 +412,7 @@ def _terminate_child_process(proc: subprocess.Popen[Any]) -> None:
     if proc.poll() is not None:
         return
     _grace_s = 45
+    _post_kill_wait_s = 5
     with contextlib.suppress(OSError):
         proc.terminate()
     try:
@@ -420,10 +421,18 @@ def _terminate_child_process(proc: subprocess.Popen[Any]) -> None:
         with contextlib.suppress(OSError):
             proc.kill()
         with contextlib.suppress(subprocess.TimeoutExpired):
-            proc.wait(timeout=_grace_s)
+            proc.wait(timeout=_post_kill_wait_s)
 
 
-def _watch_synthetic_subprocess(task: TaskRecord, proc: subprocess.Popen[Any]) -> None:
+def _watch_synthetic_subprocess(
+    task: TaskRecord,
+    proc: subprocess.Popen[Any],
+    session: ReplSession,
+    suite_name: str,
+) -> None:
+    def _history_text() -> str:
+        return f"{suite_name} task:{task.task_id}"
+
     def _run() -> None:
         started = time.monotonic()
         timed_out = False
@@ -440,21 +449,26 @@ def _watch_synthetic_subprocess(task: TaskRecord, proc: subprocess.Popen[Any]) -
 
         if timed_out:
             task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
+            session.record("synthetic_test", _history_text(), ok=False)
             return
 
         code = proc.returncode
         if code is None:
             task.mark_failed("subprocess did not report exit code")
+            session.record("synthetic_test", _history_text(), ok=False)
             return
 
         if task.cancel_requested.is_set():
             task.mark_cancelled()
+            session.record("synthetic_test", _history_text(), ok=False)
             return
 
         if code == 0:
             task.mark_completed(result="ok")
+            session.record("synthetic_test", _history_text(), ok=True)
         else:
             task.mark_failed(f"exit code {code}")
+            session.record("synthetic_test", _history_text(), ok=False)
 
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
 
@@ -602,13 +616,12 @@ def _run_synthetic_test(suite_name: str, session: ReplSession, console: Console)
         return
 
     task.attach_process(proc)
-    _watch_synthetic_subprocess(task, proc)
+    _watch_synthetic_subprocess(task, proc, session, suite_name)
     console.print(
         f"[dim]synthetic test started — task[/dim] [bold]{escape(task.task_id)}[/bold]. "
         f"[dim]/tasks[/dim] [dim]to monitor,[/dim] [bold]/cancel {escape(task.task_id)}[/bold] "
         f"[dim]to stop.[/dim]"
     )
-    session.record("synthetic_test", f"{suite_name} task:{task.task_id}")
 
 
 def execute_cli_actions(message: str, session: ReplSession, console: Console) -> bool:

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from rich.console import Console
@@ -744,7 +744,7 @@ def _cmd_compact(session: ReplSession, console: Console, args: list[str]) -> boo
 
 
 def _task_started_label(task: TaskRecord) -> str:
-    return datetime.fromtimestamp(task.started_at).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.fromtimestamp(task.started_at, tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _task_duration_label(task: TaskRecord) -> str:

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from rich.console import Console
@@ -14,6 +15,7 @@ from rich.table import Table
 from app.cli.interactive_shell.banner import render_banner, resolve_provider_models
 from app.cli.interactive_shell.history import load_command_history_entries
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind, TaskRecord, TaskStatus
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 from app.utils.sentry_sdk import capture_exception
 
@@ -558,21 +560,28 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
         console.print(f"[red]cannot read file:[/red] {escape(str(exc))}")
         return True
 
+    task = session.task_registry.create(TaskKind.INVESTIGATION)
+    task.mark_running()
     try:
         final_state = run_investigation_for_session(
             alert_text=text,
             context_overrides=session.accumulated_context or None,
+            cancel_requested=task.cancel_requested,
         )
     except KeyboardInterrupt:
+        task.mark_cancelled()
         console.print("[yellow]investigation cancelled.[/yellow]")
         session.record("alert", args[0], ok=False)
         return True
     except Exception as exc:  # noqa: BLE001
+        task.mark_failed(str(exc))
         capture_exception(exc)
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         session.record("alert", args[0], ok=False)
         return True
 
+    root = final_state.get("root_cause")
+    task.mark_completed(result=str(root) if root is not None else "")
     session.last_state = final_state
     # Match `_run_new_alert` in loop.py: inherit service / cluster / region
     # across subsequent investigations in the same REPL session.  Without
@@ -734,8 +743,107 @@ def _cmd_compact(session: ReplSession, console: Console, args: list[str]) -> boo
     return True
 
 
+def _task_started_label(task: TaskRecord) -> str:
+    return datetime.fromtimestamp(task.started_at).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _task_duration_label(task: TaskRecord) -> str:
+    duration = task.duration_seconds()
+    if duration is None:
+        return "—"
+    return f"{duration:.1f}s"
+
+
+def _task_detail_label(task: TaskRecord) -> str:
+    if task.error:
+        return str(task.error)
+    if task.result:
+        return str(task.result)
+    return "—"
+
+
+def _cmd_tasks(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    # ``list_recent(n)`` respects ``n`; default in the helper is smaller—use 50 here so
+    # /tasks spans most of what the registry can hold (~100 slots).
+    tasks = session.task_registry.list_recent(n=50)
+    if not tasks:
+        console.print("[dim]no tasks recorded this session.[/dim]")
+        return True
+
+    table = Table(title="Tasks", title_style=TERMINAL_ACCENT_BOLD)
+    table.add_column("id", style="bold")
+    table.add_column("kind")
+    table.add_column("status")
+    table.add_column("started", style="dim")
+    table.add_column("duration", style="dim", justify="right")
+    table.add_column("detail", style="dim", overflow="fold")
+
+    status_style = {
+        TaskStatus.RUNNING: "yellow",
+        TaskStatus.COMPLETED: "green",
+        TaskStatus.CANCELLED: "yellow",
+        TaskStatus.FAILED: "red",
+        TaskStatus.PENDING: "dim",
+    }
+    for task in tasks:
+        st = status_style.get(task.status, "dim")
+        table.add_row(
+            task.task_id,
+            task.kind.value,
+            f"[{st}]{task.status.value}[/{st}]",
+            _task_started_label(task),
+            _task_duration_label(task),
+            escape(_task_detail_label(task)),
+        )
+    console.print(table)
+    return True
+
+
+def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool:
+    if not args:
+        console.print("[red]usage:[/red] /cancel <task_id>  — use [bold]/tasks[/bold] to list ids")
+        return True
+
+    needle = args[0]
+    candidates = session.task_registry.candidates(needle)
+    if not candidates:
+        console.print(f"[red]no task matches id:[/red] {escape(needle)}")
+        return True
+    if len(candidates) > 1:
+        console.print(
+            f"[red]ambiguous id prefix:[/red] {escape(needle)} "
+            f"[dim]({len(candidates)} matches — use a longer prefix)[/dim]"
+        )
+        return True
+
+    task = candidates[0]
+    if task.status != TaskStatus.RUNNING:
+        console.print(
+            f"[dim]task {escape(task.task_id)} already finished "
+            f"(status: {task.status.value}).[/dim]"
+        )
+        return True
+
+    task.request_cancel()
+    if task.kind == TaskKind.INVESTIGATION:
+        console.print(
+            "[yellow]cancellation signaled.[/yellow] "
+            "[dim]if the investigation is still streaming, press[/dim] [bold]Ctrl+C[/bold] "
+            "[dim]to interrupt the current run.[/dim]"
+        )
+    else:
+        console.print(
+            f"[green]stop requested[/green] [dim]for synthetic test {escape(task.task_id)}.[/dim] "
+            "[dim]use[/dim] [bold]/tasks[/bold] [dim]to confirm status.[/dim]"
+        )
+    return True
+
+
 def _cmd_stop(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    console.print("[dim]press [bold]Ctrl+C[/bold] to cancel an in-flight investigation.[/dim]")
+    console.print(
+        "[dim]in-flight work: press[/dim] [bold]Ctrl+C[/bold] [dim]during a streaming investigation, "
+        "or run[/dim] [bold]/tasks[/bold] [dim]then[/dim] [bold]/cancel <id>[/bold] [dim]for background tasks."
+    )
     return True
 
 
@@ -793,10 +901,13 @@ SLASH_COMMANDS: dict[str, SlashCommand] = {
         "/verbose", "toggle verbose logging ('/verbose off' to disable)", _cmd_verbose
     ),
     "/compact": SlashCommand("/compact", "trim old session history to free memory", _cmd_compact),
-    "/stop": SlashCommand(
-        "/stop", "reminder: press Ctrl+C to cancel an in-flight investigation", _cmd_stop
+    "/tasks": SlashCommand("/tasks", "list recent and in-flight shell tasks", _cmd_tasks),
+    "/cancel": SlashCommand(
+        "/cancel", "cancel a running task by id ('/cancel <task_id>' — see /tasks)", _cmd_cancel
     ),
-    "/cancel": SlashCommand("/cancel", "alias for /stop", _cmd_stop),
+    "/stop": SlashCommand(
+        "/stop", "hints for stopping in-flight investigations and background tasks", _cmd_stop
+    ),
 }
 
 

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -575,6 +575,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
         session.record("alert", args[0], ok=False)
         return True
     except OpenSREError as exc:
+        task.mark_failed(str(exc))
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         if exc.suggestion:
             console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -118,6 +118,7 @@ def _run_new_alert(text: str, session: ReplSession, console: Console) -> None:
         session.record("alert", text, ok=False)
         return
     except OpenSREError as exc:
+        task.mark_failed(str(exc))
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         if exc.suggestion:
             console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -100,24 +100,32 @@ def _build_prompt_style() -> Style:
 
 def _run_new_alert(text: str, session: ReplSession, console: Console) -> None:
     """Dispatch a free-text alert description to the streaming pipeline."""
+    from app.cli.interactive_shell.tasks import TaskKind
     from app.cli.investigation import run_investigation_for_session
 
+    task = session.task_registry.create(TaskKind.INVESTIGATION)
+    task.mark_running()
     try:
         final_state = run_investigation_for_session(
             alert_text=text,
             context_overrides=session.accumulated_context or None,
+            cancel_requested=task.cancel_requested,
         )
     except KeyboardInterrupt:
+        task.mark_cancelled()
         console.print("[yellow]investigation cancelled.[/yellow]")
         session.record("alert", text, ok=False)
         return
     except Exception as exc:  # noqa: BLE001
+        task.mark_failed(str(exc))
         # Exception repr may contain brackets (stack frame refs, config
         # dicts) that Rich would eat as markup tags — escape before printing.
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
         session.record("alert", text, ok=False)
         return
 
+    root = final_state.get("root_cause")
+    task.mark_completed(result=str(root) if root is not None else "")
     session.last_state = final_state
     session.accumulate_from_state(final_state)
     session.record("alert", text)

--- a/app/cli/interactive_shell/session.py
+++ b/app/cli/interactive_shell/session.py
@@ -41,6 +41,9 @@ class ReplSession:
     task_registry: TaskRegistry = field(default_factory=TaskRegistry)
     """Recent in-flight and completed shell tasks for /tasks and /cancel."""
 
+    history_generation: int = 0
+    """Incremented on /reset so background synthetic watchers can skip stale history writes."""
+
     # Keys from a completed AgentState that carry reusable infra context into
     # the next investigation.  Kept as a class-level tuple so any caller that
     # wants to know "what counts as accumulated context" has a single source.
@@ -73,6 +76,7 @@ class ReplSession:
 
     def clear(self) -> None:
         """Reset the session to a fresh state (used by /reset)."""
+        self.history_generation += 1
         self.history.clear()
         self.last_state = None
         self.accumulated_context.clear()

--- a/app/cli/interactive_shell/session.py
+++ b/app/cli/interactive_shell/session.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.cli.interactive_shell.tasks import TaskRegistry
+
 
 @dataclass
 class ReplSession:
@@ -35,6 +37,9 @@ class ReplSession:
 
     cli_agent_messages: list[tuple[str, str]] = field(default_factory=list)
     """LangGraph-free terminal assistant history: alternating (\"user\"|\"assistant\", text)."""
+
+    task_registry: TaskRegistry = field(default_factory=TaskRegistry)
+    """Recent in-flight and completed shell tasks for /tasks and /cancel."""
 
     # Keys from a completed AgentState that carry reusable infra context into
     # the next investigation.  Kept as a class-level tuple so any caller that
@@ -73,4 +78,5 @@ class ReplSession:
         self.accumulated_context.clear()
         self.token_usage.clear()
         self.cli_agent_messages.clear()
+        self.task_registry = TaskRegistry()
         # trust_mode is intentionally preserved across /reset

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -1,0 +1,148 @@
+"""In-flight task bookkeeping for the interactive shell (REPL tasks + cancellation)."""
+
+from __future__ import annotations
+
+import contextlib
+import secrets
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from enum import StrEnum
+from subprocess import Popen
+from typing import Any
+
+_TASK_ID_BYTES = 4
+_MAX_REGISTRY = 100
+
+
+class TaskStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class TaskKind(StrEnum):
+    INVESTIGATION = "investigation"
+    SYNTHETIC_TEST = "synthetic_test"
+
+
+@dataclass
+class TaskRecord:
+    """One shell task (investigation pipeline run or subprocess-backed suite)."""
+
+    task_id: str
+    kind: TaskKind
+    status: TaskStatus = TaskStatus.PENDING
+    started_at: float = field(default_factory=time.time)
+    ended_at: float | None = None
+    result: str | None = None
+    error: str | None = None
+    _cancel_requested: threading.Event = field(
+        default_factory=threading.Event, repr=False, init=False
+    )
+    _process: Popen[Any] | None = field(default=None, repr=False, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, init=False)
+
+    @property
+    def cancel_requested(self) -> threading.Event:
+        """Set by :meth:`request_cancel`; polled by cooperative cancellation paths."""
+        return self._cancel_requested
+
+    def attach_process(self, proc: Popen[Any]) -> None:
+        """Bind a child process so :meth:`request_cancel` can terminate it."""
+        with self._lock:
+            self._process = proc
+
+    def mark_running(self) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.RUNNING
+
+    def mark_completed(self, *, result: str | None = None) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.COMPLETED
+            self.result = result
+            self.ended_at = time.time()
+
+    def mark_cancelled(self) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.CANCELLED
+            self.ended_at = time.time()
+
+    def mark_failed(self, message: str) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.FAILED
+            self.error = message
+            self.ended_at = time.time()
+
+    def request_cancel(self) -> bool:
+        """Signal cancellation and kill a bound subprocess. Returns True if task was running."""
+        with self._lock:
+            was_active = self.status == TaskStatus.RUNNING
+            self._cancel_requested.set()
+            proc = self._process
+        if proc is not None and proc.poll() is None:
+            with contextlib.suppress(OSError):
+                proc.terminate()
+        return was_active
+
+    def duration_seconds(self) -> float | None:
+        if self.ended_at is None:
+            return None
+        return self.ended_at - self.started_at
+
+
+class TaskRegistry:
+    """Recent tasks for /tasks and /cancel (ring buffer, in-process only)."""
+
+    def __init__(self, *, max_tasks: int = _MAX_REGISTRY) -> None:
+        self._tasks: deque[TaskRecord] = deque(maxlen=max_tasks)
+        self._lock = threading.Lock()
+
+    def create(self, kind: TaskKind) -> TaskRecord:
+        task_id = secrets.token_hex(_TASK_ID_BYTES)
+        record = TaskRecord(task_id=task_id, kind=kind)
+        with self._lock:
+            self._tasks.append(record)
+        return record
+
+    def candidates(self, task_id_prefix: str) -> list[TaskRecord]:
+        needle = task_id_prefix.strip().lower()
+        if not needle:
+            return []
+        with self._lock:
+            items = list(self._tasks)
+        return [t for t in items if t.task_id.lower().startswith(needle)]
+
+    def get(self, task_id_prefix: str) -> TaskRecord | None:
+        matches = self.candidates(task_id_prefix)
+        if len(matches) != 1:
+            return None
+        return matches[0]
+
+    def list_recent(self, n: int = 20) -> list[TaskRecord]:
+        """Return up to ``n`` tasks, newer tasks first (FIFO buffer end is newest)."""
+        with self._lock:
+            items = list(self._tasks)
+        return list(reversed(items[-n:]))
+
+    def __contains__(self, task_id: str) -> bool:
+        return self.get(task_id) is not None
+
+
+__all__ = [
+    "TaskKind",
+    "TaskRecord",
+    "TaskRegistry",
+    "TaskStatus",
+]

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -214,14 +215,17 @@ def run_investigation_cli_streaming(
     }
 
 
+_SESSION_EVENT_POLL_S = 0.25
+
+
 def _run_session_alert_payload(
     *,
     raw_alert: dict[str, Any],
     context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
 ) -> dict[str, Any]:
     """Run a streaming investigation from an already-structured session alert."""
     import queue
-    import threading
 
     from app.pipeline.runners import astream_investigation
     from app.remote.renderer import StreamRenderer
@@ -280,7 +284,13 @@ def _run_session_alert_payload(
     def _events() -> Iterator[StreamEvent]:
         try:
             while True:
-                item = event_queue.get()
+                if cancel_requested is not None and cancel_requested.is_set():
+                    _cancel_pump()
+                    raise KeyboardInterrupt
+                try:
+                    item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+                except queue.Empty:
+                    continue
                 if isinstance(item, BaseException):
                     _reraise_investigation_failure(item)
                 if item is None:
@@ -312,6 +322,7 @@ def run_investigation_for_session(
     *,
     alert_text: str,
     context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
 ) -> dict[str, Any]:
     """Run a streaming investigation from a free-text alert description.
 
@@ -322,15 +333,27 @@ def run_investigation_for_session(
     KeyboardInterrupt in the main thread is forwarded to the background
     asyncio loop as a task cancel, so Ctrl+C unwinds the in-flight LangGraph
     run cleanly instead of leaving it orphaned.
+
+    When ``cancel_requested`` is set, the streaming loop polls it and cancels
+    the pump the same way (used by the interactive shell task table).
+
+    While this function runs, the synchronous REPL cannot process ``/cancel`` —
+    Ctrl+C remains the interactive cancel path; the event wiring exists for a
+    future non-blocking investigation driver or tooling that sets the flag.
     """
     raw_alert: dict[str, Any] = {"alert_name": "Interactive session", "message": alert_text}
-    return _run_session_alert_payload(raw_alert=raw_alert, context_overrides=context_overrides)
+    return _run_session_alert_payload(
+        raw_alert=raw_alert,
+        context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
+    )
 
 
 def run_sample_alert_for_session(
     *,
     template_name: str = "generic",
     context_overrides: dict[str, Any] | None = None,
+    cancel_requested: threading.Event | None = None,
 ) -> dict[str, Any]:
     """Run a streaming investigation for a built-in sample alert."""
     from app.cli.investigation.alert_templates import build_alert_template
@@ -338,4 +361,5 @@ def run_sample_alert_for_session(
     return _run_session_alert_payload(
         raw_alert=build_alert_template(template_name),
         context_overrides=context_overrides,
+        cancel_requested=cancel_requested,
     )

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -371,11 +371,6 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
         },
         {"type": "slash", "text": "/list integrations", "ok": True},
     ]
-    synthetic_entry = session.history[-1]
-    assert synthetic_entry["type"] == "synthetic_test"
-    assert synthetic_entry["ok"] is True
-    assert "rds_postgres" in synthetic_entry["text"]
-    assert "task:" in synthetic_entry["text"]
 
     for _ in range(100):
         recent = session.task_registry.list_recent(1)
@@ -384,6 +379,12 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
         time.sleep(0.01)
     finished = session.task_registry.list_recent(1)[0]
     assert finished.status == TaskStatus.COMPLETED
+
+    synthetic_entry = session.history[-1]
+    assert synthetic_entry["type"] == "synthetic_test"
+    assert synthetic_entry["ok"] is True
+    assert "rds_postgres" in synthetic_entry["text"]
+    assert "task:" in synthetic_entry["text"]
 
     output = buf.getvalue()
     assert output.index("1.") < output.index("$ /list integrations")

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -323,6 +323,34 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
     assert "generic" in output
 
 
+def test_execute_cli_actions_sample_alert_opensre_error_marks_task_failed(
+    monkeypatch: object,
+) -> None:
+    from app.cli.support.errors import OpenSREError
+
+    def _raise(
+        *,
+        template_name: str = "generic",
+        context_overrides: dict[str, object] | None = None,
+        cancel_requested: object | None = None,
+    ) -> dict[str, object]:
+        raise OpenSREError("sample pipeline blocked")
+
+    import app.cli.investigation as investigation_module
+
+    monkeypatch.setattr(investigation_module, "run_sample_alert_for_session", _raise)
+
+    session = ReplSession()
+    console, _ = _capture()
+    assert execute_cli_actions("okay launch a simple alert", session, console) is True
+    inv_tasks = [
+        t for t in session.task_registry.list_recent(10) if t.kind == TaskKind.INVESTIGATION
+    ]
+    assert len(inv_tasks) == 1
+    assert inv_tasks[0].status == TaskStatus.FAILED
+    assert inv_tasks[0].error == "sample pipeline blocked"
+
+
 def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch: object) -> None:
     dispatched: list[str] = []
     popen_calls: list[tuple[list[str], dict[str, object]]] = []

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import io
 import subprocess
+import time
 from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock
 
 from rich.console import Console
 
@@ -15,6 +17,7 @@ from app.cli.interactive_shell.agent_actions import (
     plan_terminal_tasks,
 )
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
 
 
 def _capture() -> tuple[Console, io.StringIO]:
@@ -279,6 +282,7 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
         *,
         template_name: str = "generic",
         context_overrides: dict[str, object] | None = None,
+        cancel_requested: object | None = None,
     ) -> dict[str, object]:
         calls.append(template_name)
         assert context_overrides is None
@@ -307,6 +311,12 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
         "is_noise": False,
     }
     assert session.history[-1] == {"type": "alert", "text": "sample:generic", "ok": True}
+    inv_tasks = [
+        t for t in session.task_registry.list_recent(10) if t.kind == TaskKind.INVESTIGATION
+    ]
+    assert len(inv_tasks) == 1
+    assert inv_tasks[0].status == TaskStatus.COMPLETED
+    assert inv_tasks[0].result == "sample failure"
     output = buf.getvalue()
     assert "sample alert" in output
     assert "generic" in output
@@ -314,22 +324,22 @@ def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:
 
 def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch: object) -> None:
     dispatched: list[str] = []
-    synthetic_calls: list[tuple[list[str], dict[str, object]]] = []
+    popen_calls: list[tuple[list[str], dict[str, object]]] = []
 
     def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
         dispatched.append(command)
         console.print(f"ran {command}")
         return True
 
-    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        synthetic_calls.append((command, kwargs))
-        return subprocess.CompletedProcess(
-            args=command,
-            returncode=0,
-        )
+    def _fake_popen(command: list[str], **kwargs: object) -> MagicMock:
+        popen_calls.append((command, kwargs))
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        return proc
 
     monkeypatch.setattr(agent_actions, "dispatch_slash", _fake_dispatch)  # type: ignore[attr-defined]
-    monkeypatch.setattr(agent_actions.subprocess, "run", _fake_run)
+    monkeypatch.setattr(agent_actions.subprocess, "Popen", _fake_popen)
 
     session = ReplSession()
     console, buf = _capture()
@@ -341,16 +351,16 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
 
     assert handled is True
     assert dispatched == ["/list integrations"]
-    assert synthetic_calls == [
-        (
-            [agent_actions.sys.executable, "-m", "app.cli", "tests", "synthetic"],
-            {
-                "timeout": agent_actions._SYNTHETIC_TEST_TIMEOUT_SECONDS,
-                "check": False,
-            },
-        )
+    assert len(popen_calls) == 1
+    assert popen_calls[0][0] == [
+        agent_actions.sys.executable,
+        "-m",
+        "app.cli",
+        "tests",
+        "synthetic",
     ]
-    assert session.history == [
+
+    assert session.history[:2] == [
         {
             "type": "cli_agent",
             "text": (
@@ -360,8 +370,21 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
             "ok": True,
         },
         {"type": "slash", "text": "/list integrations", "ok": True},
-        {"type": "synthetic_test", "text": "rds_postgres", "ok": True},
     ]
+    synthetic_entry = session.history[-1]
+    assert synthetic_entry["type"] == "synthetic_test"
+    assert synthetic_entry["ok"] is True
+    assert "rds_postgres" in synthetic_entry["text"]
+    assert "task:" in synthetic_entry["text"]
+
+    for _ in range(100):
+        recent = session.task_registry.list_recent(1)
+        if recent and recent[0].status != TaskStatus.RUNNING:
+            break
+        time.sleep(0.01)
+    finished = session.task_registry.list_recent(1)[0]
+    assert finished.status == TaskStatus.COMPLETED
+
     output = buf.getvalue()
     assert output.index("1.") < output.index("$ /list integrations")
     assert output.index("2.") < output.index("$ /list integrations")

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -630,7 +630,11 @@ class TestInvestigateFileCommand:
 
         captured: list[str] = []
 
-        def _fake(alert_text: str, context_overrides: object = None) -> dict:
+        def _fake(
+            alert_text: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict:
             captured.append(alert_text)
             return {"root_cause": "test cause"}
 
@@ -653,7 +657,11 @@ class TestInvestigateFileCommand:
         alert_file = tmp_path / "alert.json"  # type: ignore[operator]
         alert_file.write_text('{"alert_name": "test"}', encoding="utf-8")  # type: ignore[union-attr]
 
-        def _fake(alert_text: str, context_overrides: object = None) -> dict:
+        def _fake(
+            alert_text: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict:
             return {
                 "root_cause": "disk full",
                 "service": "orders-api",
@@ -873,12 +881,18 @@ class TestCompactCommand:
 
 
 class TestStopCommand:
-    def test_prints_ctrl_c_hint(self) -> None:
+    def test_prints_stop_hints(self) -> None:
         console, buf = _capture()
         dispatch_slash("/stop", ReplSession(), console)
-        assert "Ctrl+C" in buf.getvalue()
+        out = buf.getvalue()
+        assert "Ctrl+C" in out
+        assert "/tasks" in out
+        assert "/cancel" in out
 
-    def test_cancel_alias_same_as_stop(self) -> None:
+
+class TestCancelCommand:
+    def test_usage_without_task_id(self) -> None:
         console, buf = _capture()
         dispatch_slash("/cancel", ReplSession(), console)
-        assert "Ctrl+C" in buf.getvalue()
+        assert "usage" in buf.getvalue().lower()
+        assert "/tasks" in buf.getvalue()

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
 
 
 def _capture() -> tuple[Console, io.StringIO]:
@@ -682,8 +683,33 @@ class TestInvestigateFileCommand:
             "region": "us-east-1",
         }
 
+    def test_investigate_opensre_error_marks_task_failed(
+        self, tmp_path: object, monkeypatch: object
+    ) -> None:
+        from app.cli.support.errors import OpenSREError
 
-# ---------------------------------------------------------------------------
+        alert_file = tmp_path / "alert.json"  # type: ignore[operator]
+        alert_file.write_text('{"alert_name": "test"}', encoding="utf-8")  # type: ignore[union-attr]
+
+        def _raise(
+            alert_text: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict[str, object]:
+            raise OpenSREError("bad config")
+
+        monkeypatch.setattr("app.cli.investigation.run_investigation_for_session", _raise)
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash(f"/investigate {alert_file}", session, console)
+        inv_tasks = [
+            t for t in session.task_registry.list_recent(10) if t.kind == TaskKind.INVESTIGATION
+        ]
+        assert len(inv_tasks) == 1
+        assert inv_tasks[0].status == TaskStatus.FAILED
+        assert inv_tasks[0].error == "bad config"
+
+
 # Task 4 — Session-state commands
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pytest
@@ -103,3 +104,29 @@ def test_completion_menu_current_item_uses_subtle_highlight() -> None:
     assert attrs.bgcolor == "241913"
     assert attrs.reverse is False
     assert attrs.bold is False
+
+
+def test_run_new_alert_marks_task_failed_on_opensre_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from rich.console import Console
+
+    from app.cli.interactive_shell.session import ReplSession
+    from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
+    from app.cli.support.errors import OpenSREError
+
+    def _raise(
+        alert_text: str,
+        context_overrides: object = None,
+        cancel_requested: object = None,
+    ) -> dict[str, object]:
+        raise OpenSREError("integration misconfigured", suggestion="run /doctor")
+
+    monkeypatch.setattr("app.cli.investigation.run_investigation_for_session", _raise)
+    session = ReplSession()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    loop._run_new_alert("High CPU alert", session, console)
+    inv_tasks = [
+        t for t in session.task_registry.list_recent(10) if t.kind == TaskKind.INVESTIGATION
+    ]
+    assert len(inv_tasks) == 1
+    assert inv_tasks[0].status == TaskStatus.FAILED
+    assert inv_tasks[0].error == "integration misconfigured"

--- a/tests/cli/interactive_shell/test_session.py
+++ b/tests/cli/interactive_shell/test_session.py
@@ -12,6 +12,7 @@ class TestReplSession:
         assert session.last_state is None
         assert session.accumulated_context == {}
         assert session.trust_mode is False
+        assert session.task_registry.list_recent() == []
 
     def test_record_appends_entry(self) -> None:
         session = ReplSession()
@@ -36,6 +37,7 @@ class TestReplSession:
         assert session.last_state is None
         assert session.accumulated_context == {}
         assert session.cli_agent_messages == []
+        assert session.task_registry.list_recent() == []
         assert session.trust_mode is True  # preserved intentionally
 
     def test_accumulate_from_state_extracts_known_keys(self) -> None:

--- a/tests/cli/interactive_shell/test_session.py
+++ b/tests/cli/interactive_shell/test_session.py
@@ -31,7 +31,9 @@ class TestReplSession:
         session.last_state = {"foo": "bar"}
         session.cli_agent_messages.append(("user", "hey"))
 
+        assert session.history_generation == 0
         session.clear()
+        assert session.history_generation == 1
 
         assert session.history == []
         assert session.last_state is None

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -182,8 +182,12 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        aa._watch_synthetic_subprocess(task, proc)
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
         assert task.status == TaskStatus.COMPLETED
+        hist = session.history[-1]
+        assert hist["type"] == "synthetic_test"
+        assert hist["ok"] is True
+        assert "task:" in hist["text"]
 
     def test_watch_marks_cancelled_when_requested(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """First poll waits; synthetic sleep fires cancel_request; poll then returns exit code."""
@@ -212,6 +216,9 @@ class TestSyntheticSubprocessWatcher:
             pending[0] = 0
 
         monkeypatch.setattr(aa.time, "sleep", _fake_sleep)
-        aa._watch_synthetic_subprocess(task, proc)
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
         assert task.status == TaskStatus.CANCELLED
         assert sleeps
+        hist = session.history[-1]
+        assert hist["type"] == "synthetic_test"
+        assert hist["ok"] is False

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -247,7 +247,9 @@ class TestSyntheticSubprocessWatcher:
         assert hist["type"] == "synthetic_test"
         assert hist["ok"] is False
 
-    def test_watch_skips_synthetic_history_after_reset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_watch_skips_synthetic_history_after_reset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import app.cli.interactive_shell.agent_actions as aa
 
         _DeferredSyntheticThread.pending.clear()

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -1,0 +1,217 @@
+"""Tests for REPL task registry and /tasks · /cancel."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.commands import dispatch_slash
+from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind, TaskRegistry, TaskStatus
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, force_terminal=False, highlight=False), buf
+
+
+class TestTaskRecord:
+    def test_lifecycle_completed(self) -> None:
+        reg = TaskRegistry()
+        t = reg.create(TaskKind.INVESTIGATION)
+        assert t.status == TaskStatus.PENDING
+        t.mark_running()
+        assert t.status == TaskStatus.RUNNING
+        t.mark_completed(result="done")
+        assert t.status == TaskStatus.COMPLETED
+        assert t.result == "done"
+        assert t.ended_at is not None
+        t.mark_failed("x")
+        assert t.status == TaskStatus.COMPLETED
+
+    def test_mark_cancelled_idempotent_after_terminal(self) -> None:
+        reg = TaskRegistry()
+        t = reg.create(TaskKind.INVESTIGATION)
+        t.mark_running()
+        t.mark_cancelled()
+        assert t.status == TaskStatus.CANCELLED
+        t.mark_completed(result="nope")
+        assert t.status == TaskStatus.CANCELLED
+
+    def test_request_cancel_sets_event_even_when_pending(self) -> None:
+        reg = TaskRegistry()
+        t = reg.create(TaskKind.INVESTIGATION)
+        assert t.request_cancel() is False
+        assert t.cancel_requested.is_set()
+        assert t.status == TaskStatus.PENDING
+
+    def test_request_cancel_sets_event_and_terminates_process(self) -> None:
+        reg = TaskRegistry()
+        t = reg.create(TaskKind.SYNTHETIC_TEST)
+        t.mark_running()
+        proc = MagicMock()
+        proc.poll.return_value = None
+        t.attach_process(proc)
+        assert t.request_cancel() is True
+        proc.terminate.assert_called_once()
+        assert t.cancel_requested.is_set()
+
+
+class TestTaskRegistry:
+    def test_get_single_prefix_match(self) -> None:
+        reg = TaskRegistry()
+        t = reg.create(TaskKind.INVESTIGATION)
+        assert reg.get(t.task_id[:4]) == t
+        assert reg.get("") is None
+
+    def test_candidates_ambiguous_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ids = iter(["11111111", "11112222"])
+
+        def _fake_hex(_nbytes: int) -> str:
+            return next(_ids)
+
+        monkeypatch.setattr("app.cli.interactive_shell.tasks.secrets.token_hex", _fake_hex)
+        session = ReplSession()
+        session.task_registry.create(TaskKind.INVESTIGATION)
+        session.task_registry.create(TaskKind.INVESTIGATION)
+        console, buf = _capture()
+        dispatch_slash("/cancel 1111", session, console)
+        assert "ambiguous" in buf.getvalue().lower()
+
+    def test_ring_buffer_drops_oldest(self) -> None:
+        reg = TaskRegistry(max_tasks=3)
+        first = reg.create(TaskKind.INVESTIGATION)
+        reg.create(TaskKind.INVESTIGATION)
+        reg.create(TaskKind.INVESTIGATION)
+        reg.create(TaskKind.INVESTIGATION)
+        recent_ids = [t.task_id for t in reg.list_recent(10)]
+        assert first.task_id not in recent_ids
+        assert len(recent_ids) == 3
+
+
+class TestSlashTaskCommands:
+    def test_tasks_empty_message(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        dispatch_slash("/tasks", session, console)
+        assert "no tasks" in buf.getvalue().lower()
+
+    def test_tasks_shows_recent_rows(self) -> None:
+        session = ReplSession()
+        t = session.task_registry.create(TaskKind.INVESTIGATION)
+        t.mark_running()
+        t.mark_completed(result="rc")
+        console, buf = _capture()
+        dispatch_slash("/tasks", session, console)
+        out = buf.getvalue()
+        assert t.task_id in out
+        assert "investigation" in out
+        assert "completed" in out
+
+    def test_cancel_usage_without_id(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        dispatch_slash("/cancel", session, console)
+        assert "usage" in buf.getvalue().lower()
+
+    def test_cancel_unknown_id(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        dispatch_slash("/cancel deadbeef", session, console)
+        assert "no task" in buf.getvalue().lower()
+
+    def test_cancel_completed_task_message(self) -> None:
+        session = ReplSession()
+        t = session.task_registry.create(TaskKind.INVESTIGATION)
+        t.mark_running()
+        t.mark_completed(result="x")
+        console, buf = _capture()
+        dispatch_slash(f"/cancel {t.task_id}", session, console)
+        assert "already finished" in buf.getvalue().lower()
+
+    def test_cancel_running_investigation_signals(self) -> None:
+        session = ReplSession()
+        t = session.task_registry.create(TaskKind.INVESTIGATION)
+        t.mark_running()
+        console, buf = _capture()
+        dispatch_slash(f"/cancel {t.task_id}", session, console)
+        out = buf.getvalue()
+        assert "cancellation" in out.lower()
+        assert "Ctrl+C" in out
+
+
+class _ImmediateThread:
+    """Run ``target`` synchronously inside ``start()`` (for deterministic tests)."""
+
+    def __init__(
+        self,
+        group: object = None,
+        target: Callable[[], None] | None = None,
+        name: object = None,
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+        *,
+        daemon: object = None,
+    ) -> None:  # noqa: ARG002 - mimic threading.Thread ctor
+        del group, args, kwargs, daemon, name  # threaded API baggage
+        if target is None:
+            raise TypeError("target required")
+        self._target = target
+
+    def start(self) -> None:
+        self._target()
+
+
+class TestSyntheticSubprocessWatcher:
+    def test_watch_marks_completed_when_process_already_done(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import app.cli.interactive_shell.agent_actions as aa
+
+        monkeypatch.setattr(aa.threading, "Thread", _ImmediateThread)
+
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        task.attach_process(proc)
+        aa._watch_synthetic_subprocess(task, proc)
+        assert task.status == TaskStatus.COMPLETED
+
+    def test_watch_marks_cancelled_when_requested(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """First poll waits; synthetic sleep fires cancel_request; poll then returns exit code."""
+        import app.cli.interactive_shell.agent_actions as aa
+
+        monkeypatch.setattr(aa.threading, "Thread", _ImmediateThread)
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        proc = MagicMock()
+
+        pending: list[int | None] = [None]
+
+        def _poll_side() -> int | None:
+            return pending[0] if task.cancel_requested.is_set() else None
+
+        proc.poll.side_effect = _poll_side
+        proc.returncode = 0
+
+        sleeps: list[float] = []
+
+        def _fake_sleep(_secs: float) -> None:
+            sleeps.append(_secs)
+            task.cancel_requested.set()
+            pending[0] = 0
+
+        monkeypatch.setattr(aa.time, "sleep", _fake_sleep)
+        aa._watch_synthetic_subprocess(task, proc)
+        assert task.status == TaskStatus.CANCELLED
+        assert sleeps

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -166,6 +166,30 @@ class _ImmediateThread:
         self._target()
 
 
+class _DeferredSyntheticThread:
+    """Queue ``target`` via ``start()``; tests invoke queued callables explicitly."""
+
+    pending: list[Callable[[], None]] = []
+
+    def __init__(
+        self,
+        group: object = None,
+        target: Callable[[], None] | None = None,
+        name: object = None,
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+        *,
+        daemon: object = None,
+    ) -> None:  # noqa: ARG002 - mimic threading.Thread ctor
+        del group, args, kwargs, daemon, name
+        if target is None:
+            raise TypeError("target required")
+        self._target = target
+
+    def start(self) -> None:
+        _DeferredSyntheticThread.pending.append(self._target)
+
+
 class TestSyntheticSubprocessWatcher:
     def test_watch_marks_completed_when_process_already_done(
         self, monkeypatch: pytest.MonkeyPatch
@@ -222,3 +246,45 @@ class TestSyntheticSubprocessWatcher:
         hist = session.history[-1]
         assert hist["type"] == "synthetic_test"
         assert hist["ok"] is False
+
+    def test_watch_skips_synthetic_history_after_reset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import app.cli.interactive_shell.agent_actions as aa
+
+        _DeferredSyntheticThread.pending.clear()
+        monkeypatch.setattr(aa.threading, "Thread", _DeferredSyntheticThread)
+
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        task.attach_process(proc)
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
+        assert len(_DeferredSyntheticThread.pending) == 1
+        session.clear()
+        _DeferredSyntheticThread.pending[0]()
+        assert session.history == []
+        _DeferredSyntheticThread.pending.clear()
+
+    def test_deferred_watcher_writes_history_when_no_reset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import app.cli.interactive_shell.agent_actions as aa
+
+        _DeferredSyntheticThread.pending.clear()
+        monkeypatch.setattr(aa.threading, "Thread", _DeferredSyntheticThread)
+
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        task.attach_process(proc)
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
+        _DeferredSyntheticThread.pending[0]()
+        assert session.history[-1]["type"] == "synthetic_test"
+        _DeferredSyntheticThread.pending.clear()

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import tempfile
 from collections.abc import Callable
 from unittest.mock import MagicMock
 
@@ -206,15 +207,23 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert task.status == TaskStatus.COMPLETED
         hist = session.history[-1]
         assert hist["type"] == "synthetic_test"
         assert hist["ok"] is True
         assert "task:" in hist["text"]
 
-    def test_watch_marks_cancelled_when_requested(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """First poll waits; synthetic sleep fires cancel_request; poll then returns exit code."""
+    def test_watch_honours_exit_code_when_cancel_races_loop_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Process exits naturally (code 0) in the same poll tick that /cancel fires.
+
+        The poll loop exits because proc.poll() returns non-None *before* the
+        cancel_requested branch runs, so terminated_by_watcher stays False.
+        The task must be COMPLETED, not CANCELLED — the process succeeded.
+        """
         import app.cli.interactive_shell.agent_actions as aa
 
         monkeypatch.setattr(aa.threading, "Thread", _ImmediateThread)
@@ -224,10 +233,12 @@ class TestSyntheticSubprocessWatcher:
         task.mark_running()
         proc = MagicMock()
 
+        # poll() returns None once (enter loop body), then cancel fires via
+        # sleep, which also makes poll return 0 — loop exits via while condition.
         pending: list[int | None] = [None]
 
         def _poll_side() -> int | None:
-            return pending[0] if task.cancel_requested.is_set() else None
+            return pending[0]
 
         proc.poll.side_effect = _poll_side
         proc.returncode = 0
@@ -237,15 +248,92 @@ class TestSyntheticSubprocessWatcher:
         def _fake_sleep(_secs: float) -> None:
             sleeps.append(_secs)
             task.cancel_requested.set()
-            pending[0] = 0
+            pending[0] = 0  # process finishes naturally in the same window
 
         monkeypatch.setattr(aa.time, "sleep", _fake_sleep)
-        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
-        assert task.status == TaskStatus.CANCELLED
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
+        # terminated_by_watcher is False → honour exit code 0 → COMPLETED
+        assert task.status == TaskStatus.COMPLETED
         assert sleeps
+
+    def test_watch_marks_cancelled_when_watcher_kills_process(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cancel_requested is set while proc is still running; watcher terminates it."""
+        import app.cli.interactive_shell.agent_actions as aa
+
+        monkeypatch.setattr(aa.threading, "Thread", _ImmediateThread)
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        proc = MagicMock()
+
+        # poll() always returns None so the watcher's cancel branch runs and
+        # calls _terminate_child_process; returncode is set after that.
+        proc.poll.return_value = None
+        proc.returncode = -15
+
+        task.cancel_requested.set()  # cancel already set before first loop check
+
+        # Skip the sleep so the loop iterates immediately to the cancel branch.
+        monkeypatch.setattr(aa.time, "sleep", lambda _: None)
+
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
+        assert task.status == TaskStatus.CANCELLED
         hist = session.history[-1]
         assert hist["type"] == "synthetic_test"
         assert hist["ok"] is False
+
+    def test_watch_honours_exit_code_when_cancel_races_natural_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Process exits naturally (code 0) while /cancel fires concurrently.
+
+        The watcher should mark the task COMPLETED, not CANCELLED, because we
+        never called _terminate_child_process — the process was already gone.
+        """
+        import app.cli.interactive_shell.agent_actions as aa
+
+        monkeypatch.setattr(aa.threading, "Thread", _ImmediateThread)
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        proc = MagicMock()
+        # Process already finished; poll returns non-None immediately so the
+        # while-loop body never executes — terminated_by_watcher stays False.
+        proc.poll.return_value = 0
+        proc.returncode = 0
+
+        # Simulate /cancel arriving just as the watcher reads poll()
+        task.cancel_requested.set()
+
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
+        assert task.status == TaskStatus.COMPLETED
+
+    def test_watch_captures_stderr_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Diagnostic stderr output is included in mark_failed message."""
+        import app.cli.interactive_shell.agent_actions as aa
+
+        monkeypatch.setattr(aa.threading, "Thread", _ImmediateThread)
+
+        session = ReplSession()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        task.mark_running()
+        proc = MagicMock()
+        proc.poll.return_value = 1
+        proc.returncode = 1
+
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        stderr_buf.write(b"ConnectionError: database unreachable\n")
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
+        assert task.status == TaskStatus.FAILED
+        assert "exit code 1" in (task.error or "")
+        assert "ConnectionError" in (task.error or "")
 
     def test_watch_skips_synthetic_history_after_reset(
         self, monkeypatch: pytest.MonkeyPatch
@@ -263,7 +351,8 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert len(_DeferredSyntheticThread.pending) == 1
         session.clear()
         _DeferredSyntheticThread.pending[0]()
@@ -286,7 +375,8 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres")
+        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
+        aa._watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         _DeferredSyntheticThread.pending[0]()
         assert session.history[-1]["type"] == "synthetic_test"
         _DeferredSyntheticThread.pending.clear()


### PR DESCRIPTION
Fixes #1373

#### Describe the changes you have made in this PR -

- Add in-process `TaskRegistry` / `TaskRecord` with stable task ids, statuses, and cooperative `threading.Event` cancellation.
- Slash commands: **`/tasks`** lists recent tasks; **`/cancel <id>`** signals cancel (subprocess terminate for background synthetic tests); **`/stop`** messaging updated.
- Wire free-text and `/investigate` investigations plus sample alerts through task records; pass `cancel_requested` into streaming session payload (polled between queue reads).
- Synthetic RDS suite: non-blocking `Popen` + watcher thread; session history records `task:<id>`.
- Tests: task transitions, registry prefix/ambiguity, watcher, sample-alert registry, session clear, command updates.

### Demo/Screenshot for feature changes and bug fixes -

**Prompt**: 
```
show me which services are connected and after that run a synthetic test RDS database
```

```
/tasks                         # RUNNING synthetic_test
/cancel <paste-full-task-id>
/tasks                         # CANCELLED or FAILED shortly after watcher finishes
/stop                          # reminders for Ctrl+C vs /cancel
```

<img width="829" height="826" alt="image" src="https://github.com/user-attachments/assets/879a0e18-01b1-4e24-a8ad-3afcc69d7a39" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Task table is an in-memory ring buffer on `ReplSession` (cleared by `/reset`). Investigations reuse the existing streaming pipeline; cancellation for that path polls a shared event so external callers can cooperate without process-wide SIGINT-only behavior. Synthetic tests move to background `Popen` so `/cancel` can terminate the child. Follow-up improvement (out of scope here): truly non-blocking investigations so `/cancel` is usable mid-stream without Ctrl+C.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
