### PR TITLE
feat(doctor): add LangGraph compile check

### DIFF
--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -90,6 +91,20 @@ def _check_integrations() -> tuple[bool, str]:
     return True, f"{len(items)} configured: {', '.join(names)}"
 
 
+def _check_langgraph_graph(
+    build_graph_fn: Callable[[], Any] | None = None,
+) -> tuple[bool, str]:
+    try:
+        if build_graph_fn is None:
+            from app.pipeline.graph import build_graph
+
+            build_graph_fn = build_graph
+        build_graph_fn()
+    except Exception as exc:  # noqa: BLE001
+        return False, f"LangGraph graph compile failed: {exc}"
+    return True, "LangGraph agent graph compiles"
+
+
 def _check_version_freshness() -> tuple[bool, str]:
     current = get_version()
     try:
@@ -118,6 +133,7 @@ _CHECKS = [
     ("env_file", _check_env_file),
     ("llm_provider", _check_llm_provider),
     ("integrations", _check_integrations),
+    ("langgraph_graph", _check_langgraph_graph),
     ("version", _check_version_freshness),
     ("network", _check_network),
 ]

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -172,6 +172,37 @@ def test_check_integrations_reports_configured_services(monkeypatch, tmp_path) -
     assert detail == "2 configured: grafana, datadog"
 
 
+def test_check_langgraph_graph_success() -> None:
+    called = False
+
+    def _build_graph() -> object:
+        nonlocal called
+        called = True
+        return object()
+
+    ok, detail = doctor._check_langgraph_graph(_build_graph)
+
+    assert ok is True
+    assert detail == "LangGraph agent graph compiles"
+    assert called is True
+
+
+def test_check_langgraph_graph_compile_failure() -> None:
+    def _build_graph() -> object:
+        raise RuntimeError("unknown node target")
+
+    ok, detail = doctor._check_langgraph_graph(_build_graph)
+
+    assert ok is False
+    assert detail == "LangGraph graph compile failed: unknown node target"
+
+
+def test_doctor_checks_include_langgraph_graph() -> None:
+    check_names = [name for name, _fn in doctor._CHECKS]
+
+    assert "langgraph_graph" in check_names
+
+
 def test_check_version_freshness_up_to_date(monkeypatch) -> None:
     fetch_latest_version = MagicMock(return_value="1.2.3")
     is_update_available = MagicMock(return_value=False)


### PR DESCRIPTION
Fixes #1389

#### Describe the changes you have made in this PR -
- Added a `langgraph_graph` diagnostic to `opensre doctor`.
- The new check imports the existing `app.pipeline.graph.build_graph()` builder and verifies the LangGraph agent graph compiles successfully.
- If graph compilation fails, the doctor output reports a warning with the compile failure detail instead of requiring users to discover it later through `langgraph dev` or deployment.
- Added unit coverage for the success path, compile-failure path, and `_CHECKS` registration.

### Demo/Screenshot for feature changes and bug fixes -
New local check result:

```console
$ .venv/bin/python -c "from app.cli.commands.doctor import _check_langgraph_graph; print(_check_langgraph_graph())"
(True, 'LangGraph agent graph compiles')
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The doctor command already models diagnostics as small functions that return `(ok, detail)` and are registered in `_CHECKS`. I followed that pattern by adding `_check_langgraph_graph`, with an optional injected builder for isolated unit tests. The default path lazily imports `build_graph` so doctor module import remains lightweight, then compiles the graph and reports either a successful compile or a concise warning. This keeps the change focused on a fast local health signal without adding network, Docker, LLM, or external service requirements.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Validation performed:
- `make lint` passed
- `make format-check` passed
- `make typecheck` passed after refreshing the repo's declared dev dependencies with `pip install -e '.[dev]'`
- `.venv/bin/python -m pytest tests/cli/test_doctor.py -q` passed (`20 passed`)
- `make test-cov` ran most of the suite: `5181 passed`, `3 skipped`; 5 unrelated `tests/cli/test_remote.py` cases failed locally because the sandbox could not write `/Users/jeelthummar/.config/opensre` while persisting remote URLs.