### PR TITLE
fix(integrations): mkdir store parent before file lock

### DIFF
--- a/app/integrations/store.py
+++ b/app/integrations/store.py
@@ -129,6 +129,7 @@ def _lock_path() -> Path:
 
 def _acquire_lock() -> FileLock:
     """Create and return a FileLock for the current STORE_PATH."""
+    STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
     return FileLock(str(_lock_path()), timeout=_LOCK_TIMEOUT_SECONDS)
 
 


### PR DESCRIPTION
Fixes #

<!-- Follow-up to review on #1301: explicit config-dir bootstrap before filelock -->

#### Describe the changes you have made in this PR -

Call `STORE_PATH.parent.mkdir(parents=True, exist_ok=True)` at the start of `_acquire_lock()` so every locked path (`_save`, `_locked_update`, legacy/v2 migration under lock) creates the integrations config directory before the lock file is opened. Makes fresh-install behavior explicit in our code rather than relying only on filelock’s internal `ensure_directory_exists`.

### Demo/Screenshot for feature changes and bug fixes - 

N/A — no UI. Existing integration store tests (`tests/integrations/test_store*.py`) cover save and concurrency.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The lock file lives next to `STORE_PATH`, so ensuring `STORE_PATH.parent` exists before `FileLock` matches the previous “mkdir before touching the store” contract. Centralizing this in `_acquire_lock()` updates all call sites in one place.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
