### PR TITLE
refactor(interactive-shell): wrap SLASH_COMMANDS in CommandRegistry

### DIFF
--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -38,6 +38,41 @@ class SlashCommand:
     name: str
     help_text: str
     handler: Callable[[ReplSession, Console, list[str]], bool]
+
+
+class CommandRegistry:
+    """Central slash-command registry.
+
+    Wraps the lookup table behind a small interface so handlers can be moved
+    out of this file (one domain module per group) without touching
+    ``dispatch_slash`` or any consumer of ``SLASH_COMMANDS``. The registry's
+    internal dict is exposed as ``SLASH_COMMANDS`` for back-compat with
+    ``loop.py``, ``cli_reference.py``, and tests that iterate it directly.
+    """
+
+    def __init__(self) -> None:
+        self._commands: dict[str, SlashCommand] = {}
+
+    def register(self, command: SlashCommand) -> None:
+        if command.name in self._commands:
+            raise ValueError(f"duplicate slash command: {command.name}")
+        self._commands[command.name] = command
+
+    def get(self, name: str) -> SlashCommand | None:
+        return self._commands.get(name)
+
+    @property
+    def commands(self) -> dict[str, SlashCommand]:
+        return self._commands
+
+    def values(self) -> Iterable[SlashCommand]:
+        return self._commands.values()
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._commands)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._commands
 
 
 def _cmd_help(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
@@ -873,68 +908,105 @@ def _cmd_stop(session: ReplSession, console: Console, args: list[str]) -> bool: 
     return True
 
 
-SLASH_COMMANDS: dict[str, SlashCommand] = {
-    "/help": SlashCommand("/help", "show available commands", _cmd_help),
-    "/?": SlashCommand("/?", "shortcut for /help", _cmd_help),
-    "/exit": SlashCommand("/exit", "exit the interactive shell", _cmd_exit),
-    "/quit": SlashCommand("/quit", "alias for /exit", _cmd_exit),
-    "/clear": SlashCommand("/clear", "clear the screen and re-render the banner", _cmd_clear),
-    "/reset": SlashCommand("/reset", "clear session state (keeps trust mode)", _cmd_reset),
-    "/trust": SlashCommand("/trust", "toggle trust mode ('/trust off' to disable)", _cmd_trust),
-    "/status": SlashCommand("/status", "show session status", _cmd_status),
-    "/list": SlashCommand(
-        "/list",
-        "list integrations, MCP servers, and the active LLM connection "
-        "('/list integrations', '/list models', '/list mcp')",
-        _cmd_list,
-    ),
-    "/integrations": SlashCommand(
-        "/integrations",
-        "manage integrations ('/integrations list', '/integrations verify', '/integrations show <service>')",
-        _cmd_integrations,
-    ),
-    "/mcp": SlashCommand(
-        "/mcp",
-        "manage MCP servers ('/mcp list', '/mcp connect', '/mcp disconnect')",
-        _cmd_mcp,
-    ),
-    "/model": SlashCommand(
-        "/model",
-        "show or set the active LLM ('/model show', "
-        "'/model set <provider> [model] [--toolcall-model <m>]', "
-        "'/model toolcall set <model>')",
-        _cmd_model,
-    ),
-    "/health": SlashCommand("/health", "show integration and agent health", _cmd_health),
-    "/doctor": SlashCommand("/doctor", "run full environment diagnostic", _cmd_doctor),
-    "/version": SlashCommand("/version", "print version, Python and OS info", _cmd_version),
-    "/template": SlashCommand(
-        "/template",
-        "print a starter alert JSON template ('/template generic|datadog|grafana|honeycomb|coralogix')",
-        _cmd_template,
-    ),
-    "/investigate": SlashCommand(
-        "/investigate",
-        "run an RCA investigation from a file ('/investigate <file>')",
-        _cmd_investigate_file,
-    ),
-    "/history": SlashCommand("/history", "show persisted command history", _cmd_history),
-    "/last": SlashCommand("/last", "reprint the most recent investigation report", _cmd_last),
-    "/save": SlashCommand("/save", "save last investigation to a file ('/save <path>')", _cmd_save),
-    "/context": SlashCommand("/context", "show accumulated infra context", _cmd_context),
-    "/cost": SlashCommand("/cost", "show token usage and session cost", _cmd_cost),
-    "/verbose": SlashCommand(
-        "/verbose", "toggle verbose logging ('/verbose off' to disable)", _cmd_verbose
-    ),
-    "/compact": SlashCommand("/compact", "trim old session history to free memory", _cmd_compact),
-    "/tasks": SlashCommand("/tasks", "list recent and in-flight shell tasks", _cmd_tasks),
-    "/cancel": SlashCommand(
-        "/cancel", "cancel a running task by id ('/cancel <task_id>' — see /tasks)", _cmd_cancel
-    ),
-    "/stop": SlashCommand(
-        "/stop", "hints for stopping in-flight investigations and background tasks", _cmd_stop
-    ),
-}
+def _build_default_registry() -> CommandRegistry:
+    registry = CommandRegistry()
+    registry.register(SlashCommand("/help", "show available commands", _cmd_help))
+    registry.register(SlashCommand("/?", "shortcut for /help", _cmd_help))
+    registry.register(SlashCommand("/exit", "exit the interactive shell", _cmd_exit))
+    registry.register(SlashCommand("/quit", "alias for /exit", _cmd_exit))
+    registry.register(
+        SlashCommand("/clear", "clear the screen and re-render the banner", _cmd_clear)
+    )
+    registry.register(SlashCommand("/reset", "clear session state (keeps trust mode)", _cmd_reset))
+    registry.register(
+        SlashCommand("/trust", "toggle trust mode ('/trust off' to disable)", _cmd_trust)
+    )
+    registry.register(SlashCommand("/status", "show session status", _cmd_status))
+    registry.register(
+        SlashCommand(
+            "/list",
+            "list integrations, MCP servers, and the active LLM connection "
+            "('/list integrations', '/list models', '/list mcp')",
+            _cmd_list,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "/integrations",
+            "manage integrations ('/integrations list', '/integrations verify', "
+            "'/integrations show <service>')",
+            _cmd_integrations,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "/mcp",
+            "manage MCP servers ('/mcp list', '/mcp connect', '/mcp disconnect')",
+            _cmd_mcp,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "/model",
+            "show or set the active LLM ('/model show', "
+            "'/model set <provider> [model] [--toolcall-model <m>]', "
+            "'/model toolcall set <model>')",
+            _cmd_model,
+        )
+    )
+    registry.register(SlashCommand("/health", "show integration and agent health", _cmd_health))
+    registry.register(SlashCommand("/doctor", "run full environment diagnostic", _cmd_doctor))
+    registry.register(SlashCommand("/version", "print version, Python and OS info", _cmd_version))
+    registry.register(
+        SlashCommand(
+            "/template",
+            "print a starter alert JSON template "
+            "('/template generic|datadog|grafana|honeycomb|coralogix')",
+            _cmd_template,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "/investigate",
+            "run an RCA investigation from a file ('/investigate <file>')",
+            _cmd_investigate_file,
+        )
+    )
+    registry.register(SlashCommand("/history", "show persisted command history", _cmd_history))
+    registry.register(
+        SlashCommand("/last", "reprint the most recent investigation report", _cmd_last)
+    )
+    registry.register(
+        SlashCommand("/save", "save last investigation to a file ('/save <path>')", _cmd_save)
+    )
+    registry.register(SlashCommand("/context", "show accumulated infra context", _cmd_context))
+    registry.register(SlashCommand("/cost", "show token usage and session cost", _cmd_cost))
+    registry.register(
+        SlashCommand("/verbose", "toggle verbose logging ('/verbose off' to disable)", _cmd_verbose)
+    )
+    registry.register(
+        SlashCommand("/compact", "trim old session history to free memory", _cmd_compact)
+    )
+    registry.register(SlashCommand("/tasks", "list recent and in-flight shell tasks", _cmd_tasks))
+    registry.register(
+        SlashCommand(
+            "/cancel",
+            "cancel a running task by id ('/cancel <task_id>' — see /tasks)",
+            _cmd_cancel,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "/stop",
+            "hints for stopping in-flight investigations and background tasks",
+            _cmd_stop,
+        )
+    )
+    return registry
+
+
+_REGISTRY: CommandRegistry = _build_default_registry()
+SLASH_COMMANDS: dict[str, SlashCommand] = _REGISTRY.commands
 
 
 def dispatch_slash(command_line: str, session: ReplSession, console: Console) -> bool:
@@ -948,7 +1020,7 @@ def dispatch_slash(command_line: str, session: ReplSession, console: Console) ->
         return True
     name = parts[0].lower()
     args = parts[1:]
-    cmd = SLASH_COMMANDS.get(name)
+    cmd = _REGISTRY.get(name)
     if cmd is None:
         console.print()
         console.print(


### PR DESCRIPTION
Fixes #1382

<!-- partial: first of a 4-PR sequence; #1382 fully closed by PR 4 -->

#### Describe the changes you have made in this PR -

Introduce a `CommandRegistry` class inside `app/cli/interactive_shell/commands.py` that wraps the slash-command lookup table. The previous monolithic `SLASH_COMMANDS = {...}` dict literal is replaced with `_build_default_registry()` calling `registry.register(...)` per command.

`SLASH_COMMANDS` is preserved as a back-compat re-export of the registry's internal dict, so every existing consumer (`loop.py`, `cli_reference.py`, `agent_actions.py`, `cli_agent.py`, and the test suite that monkeypatches helpers on the module) keeps working unchanged.

`dispatch_slash` now resolves through `_REGISTRY.get(name)` instead of direct dict lookup. Behavior is identical — same 26 entries, same names, help text, and handler functions; same lookup semantics; same `/help` rendering.

This is step 1 of the migration agreed with @muddlebee on the issue:
1. **This PR** — registry behind `SLASH_COMMANDS`, zero behavior change.
2. PR 2 — split handlers into per-domain modules; add `SlashCommand.aliases`.
3. PR 3 — switch consumers (`loop.py`, `cli_reference.py`, `_cmd_help`) to the registry API.
4. PR 4 — drop `SLASH_COMMANDS` / `dispatch_slash` re-exports; close #1382.

Will rebase on top of @muddlebee's Sprint 1 PRs (#1372, #1373) once they land.

### Demo/Screenshot for feature changes and bug fixes -

Zero behavior change is best demonstrated by the existing test suite — no test changes were needed in this PR.

Slash-command + agent-action suites:

<img width="847" height="294" alt="Screenshot 2026-05-06 at 02 29 15" src="https://github.com/user-attachments/assets/6b65dcfa-5574-457d-92d6-2c41c59c2135" />

Full unit suite:
<img width="1512" height="982" alt="Screenshot 2026-05-06 at 02 31 11" src="https://github.com/user-attachments/assets/6bd1a96b-5482-4128-9fb3-05aa87e113cd" />




I also ran a programmatic invariant check confirming the post-refactor `SLASH_COMMANDS` has the same 26 keys in the same order, with identical `name` / `help_text` / handler function for every entry.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue asks for the monolithic `SLASH_COMMANDS` table to be removed in favor of a modular registry. Doing that in one PR is risky: handlers reference module-level helpers (`_load_verified_integrations`, `_load_llm_settings`) that the existing test suite monkeypatches on the `commands` module directly, so moving handlers into other modules in the same change would silently break those patches.

I broke the work into four small PRs and this is step 1: introduce the registry as a seam without moving any handler. The dict literal becomes a sequence of `register()` calls into a `CommandRegistry` instance; `SLASH_COMMANDS` is rebound to that registry's internal dict so iteration, `in` checks, and module-level monkeypatching all behave identically.

Alternatives considered:
1. Convert `commands.py` to a package and split handlers in this PR — rejected, breaks `monkeypatch.setattr(cmd_module, "_load_verified_integrations", ...)` because the helper lookup happens in whichever module the handler lives in.
2. Add `SlashCommand.aliases` here — rejected for this PR. Aliases would collapse `/quit`, `/?`, `/cancel` into their canonical commands and change `/help` row count, which violates the "zero behavior change" promise. Saved for PR 2 where the help renderer is updated alongside.

Key components:
- `CommandRegistry` — `register()` rejects duplicate names with `ValueError`, `get()` returns the command or `None`, `commands` property exposes the internal dict for back-compat.
- `_build_default_registry()` — constructs the registry; lives where the dict literal used to.
- `_REGISTRY` — module-level singleton; `SLASH_COMMANDS = _REGISTRY.commands`.
- `dispatch_slash` — public surface unchanged; internally calls `_REGISTRY.get(name)`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- Refactor with no behavior change; relies on existing 102-test slash-command suite which all pass unchanged. -->



