### PR TITLE
refactor(nodes): decouple node config typing from LangChain

### DIFF
--- a/app/nodes/adapt_window/node.py
+++ b/app/nodes/adapt_window/node.py
@@ -10,14 +10,13 @@ be tested in isolation against plain dicts.
 """
 
 import logging
-from typing import Optional
 
-from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.nodes.adapt_window.rules import adapt_incident_window
 from app.output import debug_print
 from app.state import InvestigationState
+from app.types.config import NodeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +24,7 @@ logger = logging.getLogger(__name__)
 @traceable(name="node_adapt_window")
 def node_adapt_window(
     state: InvestigationState,
-    config: Optional[RunnableConfig] = None,  # noqa: ARG001,UP007,UP045
+    config: NodeConfig | None = None,  # noqa: ARG001
 ) -> dict:
     """Apply the adaptive-window rules and return a state delta.
 

--- a/app/nodes/auth.py
+++ b/app/nodes/auth.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from langchain_core.runnables import RunnableConfig
-
 from app.state import AgentState
+from app.types.config import NodeConfig, get_configurable
 
 
-def _extract_auth(state: AgentState, config: RunnableConfig) -> dict[str, str]:
+def _extract_auth(state: AgentState, config: NodeConfig | None) -> dict[str, str]:
     """Extract auth context and LangGraph metadata from config."""
-    configurable = config.get("configurable", {})
+    configurable = get_configurable(config)
     auth = configurable.get("langgraph_auth_user", {})
 
     thread_id = configurable.get("thread_id", "") or state.get("thread_id", "")
@@ -28,6 +27,6 @@ def _extract_auth(state: AgentState, config: RunnableConfig) -> dict[str, str]:
     }
 
 
-def inject_auth_node(state: AgentState, config: RunnableConfig) -> dict[str, Any]:
+def inject_auth_node(state: AgentState, config: NodeConfig | None = None) -> dict[str, Any]:
     """Extract auth context from JWT and inject into state."""
     return _extract_auth(state, config)

--- a/app/nodes/chat.py
+++ b/app/nodes/chat.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import copy
 import json
 from importlib import import_module
-from typing import Any, TypeAlias, cast
+from typing import Any, Protocol, cast
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
-from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 
 from app.config import ANTHROPIC_LLM_CONFIG, DEFAULT_MAX_TOKENS, OPENAI_LLM_CONFIG
@@ -18,6 +17,7 @@ from app.services import get_llm_for_tools
 from app.state import AgentState, ChatMessage
 from app.tools.registered_tool import RegisteredTool
 from app.tools.registry import get_registered_tools
+from app.types.config import NodeConfig
 from app.utils.cfg_helpers import CfgHelpers
 
 
@@ -67,7 +67,10 @@ def _normalize_messages(msgs: list[Any]) -> list[ChatMessage]:
 
 # ── Chat LLM ─────────────────────────────────────────────────────────────
 
-ToolEnabledChatModel: TypeAlias = Runnable[object, object]  # noqa: UP040
+
+class ToolEnabledChatModel(Protocol):
+    def invoke(self, input: object, **kwargs: Any) -> object: ...
+
 
 _chat_llm_cache: dict[str, BaseChatModel] = {}
 _chat_llm_with_tools_cache: dict[str, ToolEnabledChatModel] = {}
@@ -205,7 +208,7 @@ def _apply_guardrails_to_messages(msgs: list[Any]) -> list[Any]:
     return result
 
 
-def chat_agent_node(state: AgentState, _config: RunnableConfig) -> dict[str, Any]:
+def chat_agent_node(state: AgentState, _config: NodeConfig | None = None) -> dict[str, Any]:
     """Chat agent with tools for Tracer data queries.
 
     Uses the configured provider with bound tools. The LLM can make tool calls
@@ -230,7 +233,7 @@ def chat_agent_node(state: AgentState, _config: RunnableConfig) -> dict[str, Any
     return {"messages": [response]}
 
 
-def general_node(state: AgentState, _config: RunnableConfig) -> dict[str, Any]:
+def general_node(state: AgentState, _config: NodeConfig | None = None) -> dict[str, Any]:
     """Direct LLM response without tools for general questions."""
     msgs = list(state.get("messages", []))
 

--- a/app/nodes/chat.py
+++ b/app/nodes/chat.py
@@ -69,7 +69,8 @@ def _normalize_messages(msgs: list[Any]) -> list[ChatMessage]:
 
 
 class ToolEnabledChatModel(Protocol):
-    def invoke(self, input: object, **kwargs: Any) -> object: ...
+    def invoke(self, input: object, **kwargs: Any) -> object:
+        pass
 
 
 _chat_llm_cache: dict[str, BaseChatModel] = {}

--- a/app/nodes/extract_alert/extract_node.py
+++ b/app/nodes/extract_alert/extract_node.py
@@ -3,9 +3,8 @@
 import json
 import logging
 import time
-from typing import Any, Optional
+from typing import Any
 
-from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.incident_window import resolve_incident_window
@@ -13,6 +12,7 @@ from app.nodes.extract_alert.extract import _CANONICAL_ALERT_SOURCES, extract_al
 from app.nodes.extract_alert.models import AlertDetails
 from app.output import debug_print, get_tracker, render_investigation_header
 from app.state import InvestigationState
+from app.types.config import NodeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ def _enrich_raw_alert(raw_alert: Any, details: AlertDetails) -> Any:
 
 
 @traceable(name="node_extract_alert")
-def node_extract_alert(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP007,UP045
+def node_extract_alert(state: InvestigationState, config: NodeConfig | None = None) -> dict:  # noqa: ARG001
     """Classify and extract alert details from raw input (single LLM call)."""
     tracker = get_tracker()
     tracker.start("extract_alert", "Classifying and extracting alert details")

--- a/app/nodes/plan_actions/node.py
+++ b/app/nodes/plan_actions/node.py
@@ -1,8 +1,7 @@
 """Plan actions node - planning only."""
 
-from typing import Optional, cast
+from typing import cast
 
-from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 from pydantic import BaseModel, Field
 
@@ -11,6 +10,7 @@ from app.nodes.investigate.types import PlanAudit
 from app.nodes.plan_actions.plan_actions import plan_actions as build_plan_actions
 from app.output import debug_print, get_tracker
 from app.state import InvestigationState
+from app.types.config import NodeConfig
 from app.types.retrieval import RetrievalControlsMap, RetrievalIntent
 
 
@@ -39,7 +39,7 @@ class InvestigationPlan(BaseModel):
 
 
 @traceable(name="node_plan_actions")
-def node_plan_actions(state: InvestigationState, config: Optional[RunnableConfig] = None) -> dict:  # noqa: ARG001,UP007,UP045
+def node_plan_actions(state: InvestigationState, config: NodeConfig | None = None) -> dict:  # noqa: ARG001
     """Plan investigation actions and write plan outputs to state.
 
     Supports rerouting when new evidence changes the likely source family,

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -1,9 +1,7 @@
 """Main orchestration node for report generation and publishing."""
 
 import logging
-from typing import Optional
 
-from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.masking import MaskingContext
@@ -13,6 +11,7 @@ from app.nodes.publish_findings.renderers.editor import open_in_editor
 from app.nodes.publish_findings.renderers.terminal import render_report
 from app.nodes.publish_findings.report_context import build_report_context
 from app.state import InvestigationState
+from app.types.config import NodeConfig
 from app.utils.ingest_delivery import create_investigation_and_attach_url
 
 logger = logging.getLogger(__name__)
@@ -164,7 +163,7 @@ def generate_report(state: InvestigationState) -> dict:
 @traceable(name="node_publish_findings")
 def node_publish_findings(
     state: InvestigationState,
-    config: Optional[RunnableConfig] = None,  # noqa: ARG001,UP007,UP045
+    config: NodeConfig | None = None,  # noqa: ARG001
 ) -> dict:
     """LangGraph node wrapper with LangSmith tracking."""
     return generate_report(state)

--- a/app/nodes/resolve_integrations/node.py
+++ b/app/nodes/resolve_integrations/node.py
@@ -9,9 +9,8 @@ import base64
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
-from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.integrations.catalog import (
@@ -28,6 +27,7 @@ from app.integrations.catalog import (
 )
 from app.output import get_tracker
 from app.state import InvestigationState
+from app.types.config import NodeConfig, get_configurable
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def _strip_bearer(token: str) -> str:
 @traceable(name="node_resolve_integrations")
 def node_resolve_integrations(
     state: InvestigationState,
-    config: Optional[RunnableConfig] = None,  # noqa: UP007,UP045
+    config: NodeConfig | None = None,
 ) -> dict:
     """Fetch all org integrations and classify them by service.
 
@@ -68,7 +68,7 @@ def node_resolve_integrations(
     tracker.start("resolve_integrations", "Fetching org integrations")
     org_id = state.get("org_id", "")
 
-    configurable = (config or {}).get("configurable", {})
+    configurable = get_configurable(config)
     auth_user = configurable.get("langgraph_auth_user", {})
     webhook_token = _strip_bearer(
         (auth_user.get("token", "") or state.get("_auth_token", "")).strip()

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -1,9 +1,7 @@
 """Root cause diagnosis node - orchestration and entry point."""
 
 import os
-from typing import Optional
 
-from langchain_core.runnables import RunnableConfig
 from langsmith import traceable
 
 from app.investigation_constants import MAX_INVESTIGATION_LOOPS
@@ -11,6 +9,7 @@ from app.masking import MaskingContext
 from app.output import debug_print, get_tracker
 from app.services import get_llm_for_reasoning, parse_root_cause
 from app.state import InvestigationState
+from app.types.config import NodeConfig
 
 from .claim_validator import calculate_validity_score, validate_and_categorize_claims
 from .evidence_checker import (
@@ -229,7 +228,7 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
 @traceable(name="node_diagnose_root_cause")
 def node_diagnose_root_cause(
     state: InvestigationState,
-    config: Optional[RunnableConfig] = None,  # noqa: ARG001,UP007,UP045
+    config: NodeConfig | None = None,  # noqa: ARG001
 ) -> dict:
     """LangGraph node wrapper with LangSmith tracking."""
     return diagnose_root_cause(state)

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -42,7 +43,6 @@ NodeWithConfig = Callable[[AgentState, NodeConfig | None], dict[str, Any]]
 
 def _accept_langgraph_config(func: NodeWithConfig) -> Callable[..., dict[str, Any]]:
     """Expose an unannotated config kwarg for LangGraph runtime injection."""
-    import functools
 
     @functools.wraps(func)
     def _wrapped(state: AgentState, config=None) -> dict[str, Any]:

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -42,11 +42,12 @@ NodeWithConfig = Callable[[AgentState, NodeConfig | None], dict[str, Any]]
 
 def _accept_langgraph_config(func: NodeWithConfig) -> Callable[..., dict[str, Any]]:
     """Expose an unannotated config kwarg for LangGraph runtime injection."""
+    import functools
 
+    @functools.wraps(func)
     def _wrapped(state: AgentState, config=None) -> dict[str, Any]:
         return func(state, cast(NodeConfig | None, config))
 
-    _wrapped.__name__ = func.__name__
     return _wrapped
 
 

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any, cast
+
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
@@ -32,6 +35,19 @@ from app.pipeline.routing import (
     should_call_tools,
 )
 from app.state import AgentState
+from app.types.config import NodeConfig
+
+NodeWithConfig = Callable[[AgentState, NodeConfig | None], dict[str, Any]]
+
+
+def _accept_langgraph_config(func: NodeWithConfig) -> Callable[..., dict[str, Any]]:
+    """Expose an unannotated config kwarg for LangGraph runtime injection."""
+
+    def _wrapped(state: AgentState, config=None) -> dict[str, Any]:
+        return func(state, cast(NodeConfig | None, config))
+
+    _wrapped.__name__ = func.__name__
+    return _wrapped
 
 
 def build_graph(config: None = None) -> CompiledStateGraph:
@@ -39,22 +55,22 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     _ = config
     graph = StateGraph(AgentState)
 
-    graph.add_node("inject_auth", inject_auth_node)
+    graph.add_node("inject_auth", _accept_langgraph_config(inject_auth_node))
 
     graph.add_node("router", router_node)
-    graph.add_node("chat_agent", chat_agent_node)  # type: ignore[arg-type]
-    graph.add_node("general", general_node)  # type: ignore[arg-type]
+    graph.add_node("chat_agent", _accept_langgraph_config(chat_agent_node))
+    graph.add_node("general", _accept_langgraph_config(general_node))
     graph.add_node("tool_executor", tool_executor_node)
 
-    graph.add_node("extract_alert", node_extract_alert)
-    graph.add_node("resolve_integrations", node_resolve_integrations)
-    graph.add_node("plan_actions", node_plan_actions)
+    graph.add_node("extract_alert", _accept_langgraph_config(node_extract_alert))
+    graph.add_node("resolve_integrations", _accept_langgraph_config(node_resolve_integrations))
+    graph.add_node("plan_actions", _accept_langgraph_config(node_plan_actions))
     graph.add_node("investigate_hypothesis", node_investigate_hypothesis)
     graph.add_node("merge_hypothesis_results", merge_hypothesis_results)
-    graph.add_node("diagnose", node_diagnose_root_cause)
-    graph.add_node("adapt_window", node_adapt_window)
+    graph.add_node("diagnose", _accept_langgraph_config(node_diagnose_root_cause))
+    graph.add_node("adapt_window", _accept_langgraph_config(node_adapt_window))
     graph.add_node("opensre_eval", node_opensre_llm_eval)
-    graph.add_node("publish", node_publish_findings)
+    graph.add_node("publish", _accept_langgraph_config(node_publish_findings))
 
     graph.set_entry_point("inject_auth")
 

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -6,11 +6,10 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, cast
 
-from langchain_core.runnables import RunnableConfig
-
 from app.nodes.chat import chat_agent_node, general_node, router_node
 from app.remote.stream import StreamEvent
 from app.state import AgentState, make_initial_state
+from app.types.config import NodeConfig
 from app.utils.sentry_sdk import capture_exception, init_sentry
 
 
@@ -27,7 +26,7 @@ def _merge_state(state: AgentState, updates: dict[str, Any]) -> None:
         state_any[key] = value
 
 
-def run_chat(state: AgentState, config: RunnableConfig | None = None) -> AgentState:
+def run_chat(state: AgentState, config: NodeConfig | None = None) -> AgentState:
     """Run chat routing + response without LangGraph (for testing)."""
     init_sentry()
     cfg = config or {"configurable": {}}
@@ -138,13 +137,13 @@ def _map_langgraph_event(event: dict[str, Any]) -> StreamEvent:
 
 @dataclass
 class SimpleAgent:
-    def invoke(self, state: AgentState, config: RunnableConfig | None = None) -> AgentState:
+    def invoke(self, state: AgentState, config: NodeConfig | None = None) -> AgentState:
         init_sentry()
         from app.pipeline.graph import graph as compiled_graph  # lazy to avoid circular import
 
         cfg = config or {"configurable": {}}
         try:
-            return cast(AgentState, compiled_graph.invoke(state, cfg))
+            return cast(AgentState, compiled_graph.invoke(state, cast(Any, cfg)))
         except Exception as exc:
             capture_exception(exc)
             raise

--- a/app/types/__init__.py
+++ b/app/types/__init__.py
@@ -1,5 +1,6 @@
 """Shared domain types — decoupled from any single module."""
 
+from app.types.config import Configurable, NodeConfig, get_configurable
 from app.types.evidence import EvidenceSource
 from app.types.retrieval import (
     AggregationSpec,
@@ -13,7 +14,9 @@ from app.types.retrieval import (
 from app.types.tools import ToolSurface
 
 __all__ = [
+    "Configurable",
     "EvidenceSource",
+    "NodeConfig",
     "ToolSurface",
     "RetrievalIntent",
     "RetrievalControls",
@@ -22,4 +25,5 @@ __all__ = [
     "FilterCondition",
     "FieldSelection",
     "AggregationSpec",
+    "get_configurable",
 ]

--- a/app/types/config.py
+++ b/app/types/config.py
@@ -1,0 +1,29 @@
+"""Project-owned node execution config types."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+Configurable = dict[str, Any]
+
+
+class NodeConfig(TypedDict, total=False):
+    """Config shape consumed by OpenSRE nodes.
+
+    LangGraph may pass a richer runtime config, but core nodes only depend on
+    these project-owned fields.
+    """
+
+    configurable: Configurable
+    metadata: dict[str, Any]
+    tags: list[str]
+    run_name: str
+    run_id: str
+
+
+def get_configurable(config: NodeConfig | None) -> Configurable:
+    """Return the configurable payload from a node config."""
+    if not config:
+        return {}
+    configurable = config.get("configurable", {})
+    return configurable if isinstance(configurable, dict) else {}

--- a/tests/benchmarks/toolcall_model_benchmark/pipeline_benchmark.py
+++ b/tests/benchmarks/toolcall_model_benchmark/pipeline_benchmark.py
@@ -14,11 +14,10 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
-from langchain_core.runnables import RunnableConfig
-
 from app.pipeline import graph as graph_pipeline
 from app.services import llm_client as llm_mod
 from app.state import AgentState, make_initial_state
+from app.types.config import NodeConfig
 from tests.benchmarks.toolcall_model_benchmark.pricing import estimate_run_cost_usd
 from tests.synthetic.rds_postgres.run_suite import _build_resolved_integrations
 from tests.synthetic.rds_postgres.scenario_loader import (
@@ -240,7 +239,7 @@ def run_langgraph_investigation_bench(
     llm_calls: list[LLMCallRecord] = []
     initial = make_investigation_state(fixture)
     run_id = uuid.uuid4().hex[:8]
-    config: RunnableConfig = {
+    config: NodeConfig = {
         "configurable": {
             "thread_id": f"bench-{run_id}",
             "run_id": run_id,

--- a/tests/nodes/adapt_window/test_node.py
+++ b/tests/nodes/adapt_window/test_node.py
@@ -113,6 +113,6 @@ def test_node_does_not_log_at_info_on_no_op(caplog: Any) -> None:
 
 
 def test_node_accepts_config_kwarg() -> None:
-    # LangGraph passes a RunnableConfig; the node must accept and ignore it.
+    # LangGraph passes a config dict; the node must accept and ignore it.
     delta = node_adapt_window(_firing_state(), config={"configurable": {}})  # type: ignore[arg-type]
     assert "incident_window" in delta

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from app.nodes.auth import _extract_auth, inject_auth_node
+from app.types.config import NodeConfig
 
 
 def _make_config(
     configurable: dict | None = None,
-) -> dict:
-    """Build a minimal RunnableConfig dict."""
+) -> NodeConfig:
+    """Build a minimal node config dict."""
     return {"configurable": configurable or {}}
 
 

--- a/tests/types/test_config.py
+++ b/tests/types/test_config.py
@@ -20,7 +20,11 @@ def test_get_configurable_tolerates_missing_or_invalid_configurable() -> None:
 
 def test_core_nodes_do_not_import_runnable_config() -> None:
     repo_root = Path(__file__).resolve().parents[2]
-    targets = [repo_root / "app" / "nodes", repo_root / "app" / "pipeline" / "runners.py"]
+    targets = [
+        repo_root / "app" / "nodes",
+        repo_root / "app" / "pipeline" / "runners.py",
+        repo_root / "app" / "pipeline" / "graph.py",
+    ]
     banned = ("RunnableConfig", "langchain_core.runnables")
     offenders: list[str] = []
 

--- a/tests/types/test_config.py
+++ b/tests/types/test_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from app.types.config import NodeConfig, get_configurable
+
+
+def test_get_configurable_returns_payload() -> None:
+    config: NodeConfig = {"configurable": {"thread_id": "thread-1"}}
+
+    assert get_configurable(config) == {"thread_id": "thread-1"}
+
+
+def test_get_configurable_tolerates_missing_or_invalid_configurable() -> None:
+    assert get_configurable(None) == {}
+    assert get_configurable({}) == {}
+    assert get_configurable(cast(NodeConfig, {"configurable": None})) == {}
+
+
+def test_core_nodes_do_not_import_runnable_config() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    targets = [repo_root / "app" / "nodes", repo_root / "app" / "pipeline" / "runners.py"]
+    banned = ("RunnableConfig", "langchain_core.runnables")
+    offenders: list[str] = []
+
+    for target in targets:
+        files = target.rglob("*.py") if target.is_dir() else [target]
+        for path in files:
+            text = path.read_text(encoding="utf-8")
+            if any(pattern in text for pattern in banned):
+                offenders.append(str(path.relative_to(repo_root)))
+
+    assert offenders == []


### PR DESCRIPTION
Fixes #1364

#### Describe the changes you have made in this PR -

This PR decouples OpenSRE's core node signatures from LangChain's `RunnableConfig`. 
- Introduced an internal `NodeConfig` TypedDict in `app/types/config.py`.
- Replaced `RunnableConfig` imports and type hints in all core nodes and runners.
- Added a `get_configurable` helper to safely extract configuration dictionaries.
- Added a regression test in `tests/types/test_config.py` to prevent future coupling.

### Demo/Screenshot for feature changes and bug fixes - 

Grep verification showing no matches for banned imports in core paths:
$ grep -rE "RunnableConfig|langchain_core\.runnables" app/nodes app/pipeline/runners.py
(no output)

Full test suite passed:
$ make test-cov
...
=========== 5245 passed, 3 skipped, 17 warnings in 78.56s (0:01:18) ============

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The goal was to remove framework coupling from business logic boundaries. By introducing `NodeConfig`, we allow LangGraph to pass its runtime config while nodes only depend on a project-defined shape. This makes the architecture more resilient to future dependency changes (e.g., migrating away from LangChain internals).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
