### PR TITLE
feat(interactive-shell): run_cli_command supports full opensre subcommand surface

### DIFF
--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -226,9 +226,9 @@ def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -
         console.print(f"[red]Cannot run `opensre {first_token}`: subcommand is blocked.[/red]")
         return False
 
-    command = [sys.executable, "-m", "app.cli"] + tokens
-    full_command = " ".join(command)
-    _run_shell_command(full_command, session, console)
+    command_list = [sys.executable, "-m", "app.cli"] + tokens
+    full_command = " ".join(command_list)
+    _run_shell_command(full_command, session, console, argv=command_list)
     session.record("cli_command", full_command)
     return True
 
@@ -475,99 +475,13 @@ def _print_planned_actions(console: Console, actions: list[PlannedAction]) -> No
         )
 
 
-def _terminate_child_process(proc: subprocess.Popen[Any]) -> None:
-    """Best-effort SIGTERM → wait → SIGKILL → wait without blocking forever."""
-    if proc.poll() is not None:
-        return
-    with contextlib.suppress(OSError):
-        proc.terminate()
-    try:
-        proc.wait(timeout=_SIGTERM_GRACE_SECONDS)
-    except subprocess.TimeoutExpired:
-        with contextlib.suppress(OSError):
-            proc.kill()
-        with contextlib.suppress(subprocess.TimeoutExpired):
-            proc.wait(timeout=5)
-
-
-def _read_diag(buf: tempfile.SpooledTemporaryFile[bytes]) -> str:  # type: ignore[type-arg]
-    """Read up to ``_SYNTHETIC_DIAG_CHARS`` bytes from a captured stderr buffer."""
-    buf.seek(0)
-    return buf.read(_SYNTHETIC_DIAG_CHARS).decode("utf-8", errors="replace").strip()
-
-
-def _watch_synthetic_subprocess(
-    task: TaskRecord,
-    proc: subprocess.Popen[Any],
+def _run_shell_command(
+    command: str,
     session: ReplSession,
-    suite_name: str,
-    stderr_buf: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+    console: Console,
+    *,
+    argv: list[str] | None = None,
 ) -> None:
-    def _history_text() -> str:
-        return f"{suite_name} task:{task.task_id}"
-
-    history_gen_when_watch_started = session.history_generation
-
-    def _record_synthetic_if_current_session(ok: bool) -> None:
-        if session.history_generation != history_gen_when_watch_started:
-            return
-        session.record("synthetic_test", _history_text(), ok=ok)
-
-    def _run() -> None:
-        started = time.monotonic()
-        timed_out = False
-        # Track whether *we* explicitly terminated the process so we can
-        # distinguish a cancel-driven exit from a natural exit that happened
-        # to race with a concurrent /cancel.
-        terminated_by_watcher = False
-        while proc.poll() is None:
-            if time.monotonic() - started > _SYNTHETIC_TEST_TIMEOUT_SECONDS:
-                timed_out = True
-                task.request_cancel()
-                _terminate_child_process(proc)
-                terminated_by_watcher = True
-                break
-            if task.cancel_requested.is_set():
-                _terminate_child_process(proc)
-                terminated_by_watcher = True
-                break
-            time.sleep(_SYNTHETIC_POLL_SECONDS)
-
-        try:
-            if timed_out:
-                task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
-                _record_synthetic_if_current_session(ok=False)
-                return
-
-            code = proc.returncode
-            if code is None:
-                task.mark_failed("subprocess did not report exit code")
-                _record_synthetic_if_current_session(ok=False)
-                return
-
-            # Honour the real exit code when the process exited on its own.
-            # Only treat as CANCELLED when *we* killed it after a cancel request;
-            # a natural exit that races with /cancel should be recorded by its code.
-            if terminated_by_watcher and task.cancel_requested.is_set():
-                task.mark_cancelled()
-                _record_synthetic_if_current_session(ok=False)
-                return
-
-            if code == 0:
-                task.mark_completed(result="ok")
-                _record_synthetic_if_current_session(ok=True)
-            else:
-                diag = _read_diag(stderr_buf)
-                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
-                task.mark_failed(error_msg)
-                _record_synthetic_if_current_session(ok=False)
-        finally:
-            stderr_buf.close()
-
-    threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
-
-
-def _run_shell_command(command: str, session: ReplSession, console: Console) -> None:
     console.print(f"[bold]$ {escape(command)}[/bold]")
     parsed = parse_shell_command(command, is_windows=_IS_WINDOWS)
     decision = evaluate_policy(parsed=parsed)
@@ -602,10 +516,13 @@ def _run_shell_command(command: str, session: ReplSession, console: Console) -> 
     if use_shell:
         console.print("[dim]explicit shell passthrough enabled[/dim]")
 
+    # Use provided argv if passed directly (bypasses shell injection risk)
+    exec_argv = argv if argv is not None else parsed.argv
+
     try:
         result = execute_shell_command(
             command=parsed.command,
-            argv=parsed.argv,
+            argv=exec_argv,
             use_shell=use_shell,
             timeout_seconds=_SHELL_COMMAND_TIMEOUT_SECONDS,
             max_output_chars=_MAX_COMMAND_OUTPUT_CHARS,

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -29,12 +29,21 @@ from app.cli.interactive_shell.terminal_intent import mentioned_integration_serv
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 from app.cli.support.errors import OpenSREError
 
+_OPENSRE_BLOCKED_SUBCOMMANDS = frozenset({"agent"})
+
 
 @dataclass(frozen=True)
 class PlannedAction:
     """A deterministic action inferred from a natural-language terminal request."""
 
-    kind: Literal["llm_provider", "slash", "shell", "sample_alert", "synthetic_test"]
+    kind: Literal[
+        "llm_provider",
+        "slash",
+        "shell",
+        "sample_alert",
+        "synthetic_test",
+        "cli_command",
+    ]
     content: str
     position: int
 
@@ -74,6 +83,15 @@ _ACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
             re.IGNORECASE,
         ),
         "/version",
+    ),
+    (
+        re.compile(
+            r"\b(?:deploy|guardrails|remote|doctor|onboard|update|uninstall)\b"
+            r"|"
+            r"\bopensre\s+(?P<subcmd>[a-z][a-z0-9-]*)\b",
+            re.IGNORECASE,
+        ),
+        "cli_command",
     ),
 )
 
@@ -189,6 +207,27 @@ def _llm_provider_action(provider: str, position: int) -> PlannedAction:
     return PlannedAction(kind="llm_provider", content=provider, position=position)
 
 
+def _cli_command_action(args: str, position: int) -> PlannedAction:
+    return PlannedAction(kind="cli_command", content=args, position=position)
+
+
+def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -> bool:
+    """Run an opensre subcommand (not agent) and return False on success."""
+    tokens = args.split()
+    if not tokens:
+        return False
+
+    first_token = tokens[0].lower()
+    if first_token in _OPENSRE_BLOCKED_SUBCOMMANDS:
+        console.print(f"[red]Cannot run `opensre {first_token}`: subcommand is blocked.[/red]")
+        return False
+
+    command = [sys.executable, "-m", "app.cli"] + tokens
+    full_command = " ".join(command)
+    _run_shell_command(full_command, session, console)
+    return True
+
+
 def _strip_wrapping_quotes(command: str) -> str:
     stripped = command.strip()
     if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"`", "'", '"'}:
@@ -288,7 +327,18 @@ def _plan_clause_actions(
 
     for pattern, command in _ACTION_PATTERNS:
         match = pattern.search(clause.text)
-        if match is None or command in seen_slash:
+        if match is None:
+            continue
+
+        # Handle cli_command pattern (captures subcommand name)
+        if command == "cli_command":
+            # Try to get named group "subcmd" first, fallback to matching the full pattern
+            subcmd = match.group("subcmd") if match.lastgroup == "subcmd" else match.group(0)
+            if subcmd and subcmd.lower() not in _OPENSRE_BLOCKED_SUBCOMMANDS:
+                planned.append(_cli_command_action(subcmd, clause.position + match.start()))
+            continue
+
+        if command in seen_slash:
             continue
         if command == "/list integrations" and mentioned_services:
             continue
@@ -384,8 +434,12 @@ def _plan_actions(message: str) -> list[PlannedAction]:
 
 
 def plan_cli_actions(message: str) -> list[str]:
-    """Return safe read-only slash commands requested by a natural-language turn."""
-    return [action.content for action in _plan_actions(message) if action.kind == "slash"]
+    """Return safe read-only slash commands and CLI commands requested by a natural-language turn."""
+    return [
+        action.content
+        for action in _plan_actions(message)
+        if action.kind in ("slash", "cli_command")
+    ]
 
 
 def plan_terminal_tasks(message: str) -> list[str]:
@@ -409,6 +463,7 @@ def _print_planned_actions(console: Console, actions: list[PlannedAction]) -> No
             "shell": "shell",
             "slash": "command",
             "synthetic_test": "synthetic test",
+            "cli_command": "opensre",
         }[action.kind]
         console.print(
             f"[dim]{index}.[/dim] [{TERMINAL_ACCENT_BOLD}]{label}[/] {escape(action.content)}"
@@ -726,6 +781,9 @@ def execute_cli_actions(message: str, session: ReplSession, console: Console) ->
             _run_shell_command(action.content, session, console)
         elif action.kind == "sample_alert":
             _run_sample_alert(action.content, session, console)
+        elif action.kind == "cli_command":
+            if not run_opensre_cli_command(action.content, session, console):
+                return True
         else:
             _run_synthetic_test(action.content, session, console)
 

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -86,7 +86,7 @@ _ACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(
-            r"\b(?:deploy|guardrails|remote|doctor|onboard|update|uninstall)\b"
+            r"\b(?:deploy|guardrails|remote|doctor|onboard|uninstall)\b"
             r"|"
             r"\bopensre\s+(?P<subcmd>[a-z][a-z0-9-]*)\b",
             re.IGNORECASE,
@@ -212,7 +212,11 @@ def _cli_command_action(args: str, position: int) -> PlannedAction:
 
 
 def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -> bool:
-    """Run an opensre subcommand (not agent) and return False on success."""
+    """Run an opensre subcommand (not agent).
+
+    Returns True if the command was attempted (regardless of success),
+    False if the subcommand is blocked or args are empty.
+    """
     tokens = args.split()
     if not tokens:
         return False
@@ -225,6 +229,7 @@ def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -
     command = [sys.executable, "-m", "app.cli"] + tokens
     full_command = " ".join(command)
     _run_shell_command(full_command, session, console)
+    session.record("cli_command", full_command)
     return True
 
 

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -475,6 +475,92 @@ def _print_planned_actions(console: Console, actions: list[PlannedAction]) -> No
         )
 
 
+def _terminate_child_process(proc: subprocess.Popen[Any]) -> None:
+    """Best-effort SIGTERM → wait → SIGKILL → wait without blocking forever."""
+    if proc.poll() is not None:
+        return
+    with contextlib.suppress(OSError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=_SIGTERM_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(OSError):
+            proc.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+
+def _read_diag(buf: tempfile.SpooledTemporaryFile[bytes]) -> str:
+    """Read up to ``_SYNTHETIC_DIAG_CHARS`` bytes from a captured stderr buffer."""
+    buf.seek(0)
+    return buf.read(_SYNTHETIC_DIAG_CHARS).decode("utf-8", errors="replace").strip()
+
+
+def _watch_synthetic_subprocess(
+    task: TaskRecord,
+    proc: subprocess.Popen[Any],
+    session: ReplSession,
+    suite_name: str,
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes],
+) -> None:
+    def _history_text() -> str:
+        return f"{suite_name} task:{task.task_id}"
+
+    history_gen_when_watch_started = session.history_generation
+
+    def _record_synthetic_if_current_session(ok: bool) -> None:
+        if session.history_generation != history_gen_when_watch_started:
+            return
+        session.record("synthetic_test", _history_text(), ok=ok)
+
+    def _run() -> None:
+        started = time.monotonic()
+        timed_out = False
+        terminated_by_watcher = False
+        while proc.poll() is None:
+            if time.monotonic() - started > _SYNTHETIC_TEST_TIMEOUT_SECONDS:
+                timed_out = True
+                task.request_cancel()
+                _terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            if task.cancel_requested.is_set():
+                _terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            time.sleep(_SYNTHETIC_POLL_SECONDS)
+
+        try:
+            if timed_out:
+                task.mark_failed(f"timed out after {_SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
+                _record_synthetic_if_current_session(ok=False)
+                return
+
+            code = proc.returncode
+            if code is None:
+                task.mark_failed("subprocess did not report exit code")
+                _record_synthetic_if_current_session(ok=False)
+                return
+
+            if terminated_by_watcher and task.cancel_requested.is_set():
+                task.mark_cancelled()
+                _record_synthetic_if_current_session(ok=False)
+                return
+
+            if code == 0:
+                task.mark_completed(result="ok")
+                _record_synthetic_if_current_session(ok=True)
+            else:
+                diag = _read_diag(stderr_buf)
+                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+                task.mark_failed(error_msg)
+                _record_synthetic_if_current_session(ok=False)
+        finally:
+            stderr_buf.close()
+
+    threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
+
+
 def _run_shell_command(
     command: str,
     session: ReplSession,

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -43,9 +43,9 @@ _ACTION_RULE = (
     "ollama, codex, claude-code, gemini-cli; both `model` (reasoning) and `toolcall_model` are optional; "
     '`{"action":"switch_toolcall_model","model":"claude-opus-4-7"}` '
     "to change ONLY the toolcall model on the currently active provider; "
-    '`{"action":"slash","command":"/model show"}` where command is one of '
-    "/model show, /list models, /health, /doctor, /version. For ordinary "
-    "questions, return normal Markdown."
+    '`{"action":"run_cli_command","args":"<subcommand> <flags>"}` '
+    "to run any opensre subcommand (see CLI reference below for all subcommands; "
+    "agent is blocked). For ordinary questions, return normal Markdown."
 )
 
 _ALLOWED_SLASH_ACTIONS = frozenset(
@@ -269,6 +269,17 @@ def _execute_action_plan(
             session.record("slash", command)
             console.print(f"[bold]$ {escape(command)}[/bold]")
             dispatch_slash(command, session, console)
+            continue
+
+        if kind == "run_cli_command":
+            args = str(action.get("args", "")).strip()
+            if not args:
+                console.print("[red]missing args for run_cli_command action[/red]")
+                continue
+            console.print(f"[bold]$ opensre {escape(args)}[/bold]")
+            from app.cli.interactive_shell.agent_actions import run_opensre_cli_command
+
+            run_opensre_cli_command(args, session, console)
             continue
 
         console.print(f"[red]unsupported action:[/red] {escape(kind or '?')}")

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -220,6 +220,8 @@ def _execute_action_plan(
             )
         elif kind == "slash":
             label = str(action.get("command", "")).strip()
+        elif kind == "run_cli_command":
+            label = f"opensre {str(action.get('args', '')).strip()}"
         else:
             label = f"unsupported action: {kind or '?'}"
         console.print(f"[dim]{index}.[/dim] [{TERMINAL_ACCENT_BOLD}]{escape(label)}[/]")
@@ -276,7 +278,6 @@ def _execute_action_plan(
             if not args:
                 console.print("[red]missing args for run_cli_command action[/red]")
                 continue
-            console.print(f"[bold]$ opensre {escape(args)}[/bold]")
             from app.cli.interactive_shell.agent_actions import run_opensre_cli_command
 
             run_opensre_cli_command(args, session, console)

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -178,8 +178,8 @@ def test_compound_prompt_plans_chat_list_and_blocked_deploy() -> None:
         "AND then deploy OpenSRE to EC2"
     )
 
-    assert plan_terminal_tasks(message) == ["slash"]
-    assert plan_cli_actions(message) == ["/list integrations"]
+    assert plan_terminal_tasks(message) == ["slash", "cli_command"]
+    assert plan_cli_actions(message) == ["/list integrations", "deploy"]
 
 
 def test_services_version_deploy_prompt_plans_all_actions() -> None:
@@ -188,8 +188,8 @@ def test_services_version_deploy_prompt_plans_all_actions() -> None:
         "AND then deploy to EC2 within 90 seconds"
     )
 
-    assert plan_terminal_tasks(message) == ["slash", "slash"]
-    assert plan_cli_actions(message) == ["/list integrations", "/version"]
+    assert plan_terminal_tasks(message) == ["slash", "slash", "cli_command"]
+    assert plan_cli_actions(message) == ["/list integrations", "/version", "deploy"]
 
 
 def test_explicit_shell_command_plans_shell_action() -> None:
@@ -221,13 +221,20 @@ def test_compound_services_and_synthetic_rds_plans_all_actions() -> None:
 
 def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> None:
     dispatched: list[str] = []
+    cli_commands: list[str] = []
 
     def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
         dispatched.append(command)
         console.print(f"ran {command}")
         return True
 
+    def _fake_run_cli_command(args: str, _session: ReplSession, console: Console) -> bool:
+        cli_commands.append(args)
+        console.print(f"ran cli_command {args}")
+        return True
+
     monkeypatch.setattr(agent_actions, "dispatch_slash", _fake_dispatch)  # type: ignore[attr-defined]
+    monkeypatch.setattr(agent_actions, "run_opensre_cli_command", _fake_run_cli_command)  # type: ignore[attr-defined]
 
     session = ReplSession()
     console, buf = _capture()
@@ -242,21 +249,29 @@ def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> No
 
     assert handled is False
     assert dispatched == ["/list integrations"]
+    assert cli_commands == ["deploy"]
     output = buf.getvalue()
     assert "I'm doing fine" not in output
-    assert "EC2 deployment creates AWS" not in output
     assert "ran /list integrations" in output
+    assert "ran cli_command deploy" in output
 
 
 def test_services_version_deploy_prompt_executes_in_order(monkeypatch: object) -> None:
     dispatched: list[str] = []
+    cli_commands: list[str] = []
 
     def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
         dispatched.append(command)
         console.print(f"ran {command}")
         return True
 
+    def _fake_run_cli_command(args: str, _session: ReplSession, console: Console) -> bool:
+        cli_commands.append(args)
+        console.print(f"ran cli_command {args}")
+        return True
+
     monkeypatch.setattr(agent_actions, "dispatch_slash", _fake_dispatch)  # type: ignore[attr-defined]
+    monkeypatch.setattr(agent_actions, "run_opensre_cli_command", _fake_run_cli_command)  # type: ignore[attr-defined]
 
     session = ReplSession()
     console, buf = _capture()
@@ -269,11 +284,11 @@ def test_services_version_deploy_prompt_executes_in_order(monkeypatch: object) -
         console,
     )
 
-    assert handled is False
+    assert handled is True  # All actions handled, message fully processed
     assert dispatched == ["/list integrations", "/version"]
+    assert cli_commands == ["deploy"]
     output = buf.getvalue()
     assert output.index("ran /list integrations") < output.index("ran /version")
-    assert "EC2 deployment creates AWS" not in output
 
 
 def test_execute_cli_actions_runs_sample_alert(monkeypatch: object) -> None:


### PR DESCRIPTION
Fixes #1346

## Description

This PR adds support for running **any** `opensre` subcommand (not just hardcoded examples) through the interactive shell's `run_cli_command` action.

Previously, `_ACTION_RULE` in `cli_agent.py` listed only a small set of hardcoded examples (`tests`, `list`, `health`, `doctor`, etc.), which created a contradiction — the contract said "any subcommand" but the examples implied a closed list.

## Changes

- **Added `_OPENSRE_BLOCKED_SUBCOMMANDS`** — A single source of truth for blocked subcommands (currently only `agent`)
- **Added `cli_command` action kind** — New planned action type in `PlannedAction` dataclass
- **Added `run_opensre_cli_command()`** — Function that executes subcommands via `python -m app.cli`
- **Added regex patterns** — Detects natural language requests for subcommands like `deploy`, `guardrails`, `remote`, `doctor`, `onboard`, `update`, `uninstall`, or any `opensre <subcommand>` pattern
- **Updated `_ACTION_RULE`** — Now references the CLI reference section instead of listing hardcoded examples (`health`, `doctor`, `version`)
- **Updated tests** — Modified test expectations to include `cli_command` actions for deployment-related phrases

## Screenshot

<img width="922" height="161" alt="image" src="https://github.com/user-attachments/assets/5ac55920-1c50-4e8f-8231-4f9a64355b94" />


## Implementation Approach

The root cause was that `_ACTION_RULE` implied a closed list via hardcoded examples, contradicting the intended open subcommand surface.

**Solution:**
1. Added `_OPENSRE_BLOCKED_SUBCOMMANDS` as a single source of truth for blocked subcommands
2. Added regex patterns that detect natural language requests for known subcommands (`deploy`, `guardrails`, `remote`, etc.) or any `opensre <subcommand>` pattern
3. The blocker check is enforced both at planning time (regex filter) and at execution time (`run_opensre_cli_command`)

---

