### PR TITLE
fix(cli): allow opensre update when sentry sdk is missing

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -182,14 +182,23 @@ def _install_sigint_handler() -> None:
     signal.signal(signal.SIGINT, _handler)
 
 
+def _is_update_invocation(argv: list[str]) -> bool:
+    command_parts = _resolve_command_parts(cli, argv)
+    return bool(command_parts) and command_parts[0] == "update"
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``opensre`` console script."""
     load_dotenv(override=False)
-    init_sentry()
+    cli_argv = list(sys.argv[1:] if argv is None else argv)
+    try:
+        init_sentry()
+    except ModuleNotFoundError as exc:
+        if exc.name != "sentry_sdk" or not _is_update_invocation(cli_argv):
+            raise
     install_questionary_escape_cancel()
     install_questionary_ctrl_c_double_exit()
     _install_sigint_handler()
-    cli_argv = list(sys.argv[1:] if argv is None else argv)
 
     try:
         cli(

--- a/packaging/opensre.spec
+++ b/packaging/opensre.spec
@@ -17,6 +17,7 @@ def _is_runtime_submodule(module_name: str) -> bool:
 
 
 hiddenimports = collect_submodules("app", filter=_is_runtime_submodule)
+hiddenimports += collect_submodules("sentry_sdk")
 datas = collect_data_files("app")
 
 block_cipher = None

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -73,6 +73,36 @@ def test_main_runs_health_command(monkeypatch) -> None:
     assert exit_code == 0
 
 
+def test_main_allows_update_when_sentry_sdk_missing(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+
+    def _raise_missing_sentry() -> None:
+        raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
+
+    monkeypatch.setattr("app.cli.__main__.init_sentry", _raise_missing_sentry)
+    monkeypatch.setattr("app.cli.support.update._fetch_latest_version", lambda: "9999.0.0")
+    monkeypatch.setattr("app.cli.support.update._is_update_available", lambda _c, _l: False)
+
+    exit_code = main(["update", "--check"])
+
+    assert exit_code == 0
+    assert "already up to date" in capsys.readouterr().out
+
+
+def test_main_non_update_still_raises_when_sentry_sdk_missing(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+
+    def _raise_missing_sentry() -> None:
+        raise ModuleNotFoundError("No module named 'sentry_sdk'", name="sentry_sdk")
+
+    monkeypatch.setattr("app.cli.__main__.init_sentry", _raise_missing_sentry)
+
+    with pytest.raises(ModuleNotFoundError):
+        main(["version"])
+
+
 def test_main_does_not_capture_analytics_for_help(monkeypatch, capsys) -> None:
     captured: list[str] = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- allow `opensre update` to continue when Sentry initialization fails specifically because `sentry_sdk` is missing
- keep strict startup behavior for all other commands (non-update commands still raise)
- include `sentry_sdk` submodules in the PyInstaller spec hidden imports so packaged builds include the SDK

## Test plan
- [x] `pytest tests/cli/test_main.py tests/test_sentry_init.py`
- [x] verify new tests cover update-vs-non-update behavior when `sentry_sdk` is missing

Made with [Cursor](https://cursor.com)