### PR TITLE
fix(cli): harden REPL against markup injection and handler crashes

### DIFF
--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -136,10 +136,10 @@ def _render_integrations_table(console: Console, results: list[dict[str, str]]) 
     for row in rows:
         status = row.get("status", "unknown")
         table.add_row(
-            row.get("service", "?"),
-            row.get("source", "?"),
-            f"[{_status_style(status)}]{status}[/{_status_style(status)}]",
-            row.get("detail", ""),
+            escape(row.get("service", "?")),
+            escape(row.get("source", "?")),
+            f"[{_status_style(status)}]{escape(status)}[/{_status_style(status)}]",
+            escape(row.get("detail", "")),
         )
     console.print(table)
 
@@ -157,10 +157,10 @@ def _render_mcp_table(console: Console, results: list[dict[str, str]]) -> None:
     for row in rows:
         status = row.get("status", "unknown")
         table.add_row(
-            row.get("service", "?"),
-            row.get("source", "?"),
-            f"[{_status_style(status)}]{status}[/{_status_style(status)}]",
-            row.get("detail", ""),
+            escape(row.get("service", "?")),
+            escape(row.get("source", "?")),
+            f"[{_status_style(status)}]{escape(status)}[/{_status_style(status)}]",
+            escape(row.get("detail", "")),
         )
     console.print(table)
 
@@ -794,7 +794,7 @@ def _cmd_tasks(session: ReplSession, console: Console, args: list[str]) -> bool:
         console.print("[dim]no tasks recorded this session.[/dim]")
         return True
 
-    table = Table(title="Tasks", title_style=TERMINAL_ACCENT_BOLD)
+    table = _repl_table(title="Tasks", title_style=TERMINAL_ACCENT_BOLD)
     table.add_column("id", style="bold")
     table.add_column("kind")
     table.add_column("status")
@@ -825,17 +825,19 @@ def _cmd_tasks(session: ReplSession, console: Console, args: list[str]) -> bool:
 
 def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool:
     if not args:
-        console.print("[red]usage:[/red] /cancel <task_id>  — use [bold]/tasks[/bold] to list ids")
+        console.print(
+            f"[{TERMINAL_ERROR}]usage:[/] /cancel <task_id>  — use [bold]/tasks[/bold] to list ids"
+        )
         return True
 
     needle = args[0]
     candidates = session.task_registry.candidates(needle)
     if not candidates:
-        console.print(f"[red]no task matches id:[/red] {escape(needle)}")
+        console.print(f"[{TERMINAL_ERROR}]no task matches id:[/] {escape(needle)}")
         return True
     if len(candidates) > 1:
         console.print(
-            f"[red]ambiguous id prefix:[/red] {escape(needle)} "
+            f"[{TERMINAL_ERROR}]ambiguous id prefix:[/] {escape(needle)} "
             f"[dim]({len(candidates)} matches — use a longer prefix)[/dim]"
         )
         return True

--- a/app/cli/interactive_shell/follow_up.py
+++ b/app/cli/interactive_shell/follow_up.py
@@ -81,7 +81,7 @@ def answer_follow_up(question: str, session: ReplSession, console: Console) -> N
     try:
         from app.services.llm_client import get_llm_for_reasoning
     except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]LLM client unavailable:[/red] {exc}")
+        console.print(f"[red]LLM client unavailable:[/red] {escape(str(exc))}")
         return
 
     context = _summarize_last_state(session.last_state)

--- a/app/cli/interactive_shell/follow_up.py
+++ b/app/cli/interactive_shell/follow_up.py
@@ -11,7 +11,7 @@ from rich.markup import escape
 
 from app.cli.interactive_shell.loaders import llm_loader
 from app.cli.interactive_shell.session import ReplSession
-from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
+from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD, TERMINAL_ERROR
 
 _logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ def answer_follow_up(question: str, session: ReplSession, console: Console) -> N
             client = get_llm_for_reasoning()
             response = client.invoke(prompt)
     except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]follow-up failed:[/red] {escape(str(exc))}")
+        console.print(f"[{TERMINAL_ERROR}]follow-up failed:[/] {escape(str(exc))}")
         return
 
     text = getattr(response, "content", None) or str(response)

--- a/app/cli/interactive_shell/follow_up.py
+++ b/app/cli/interactive_shell/follow_up.py
@@ -81,7 +81,7 @@ def answer_follow_up(question: str, session: ReplSession, console: Console) -> N
     try:
         from app.services.llm_client import get_llm_for_reasoning
     except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]LLM client unavailable:[/red] {escape(str(exc))}")
+        console.print(f"[{TERMINAL_ERROR}]LLM client unavailable:[/] {escape(str(exc))}")
         return
 
     context = _summarize_last_state(session.last_state)

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -376,7 +376,14 @@ async def _run_one_turn(
         # Rewrite bare-word commands to their slash form before dispatch.
         cmd_text = text if text.startswith("/") else f"/{text}"
         session.record("slash", cmd_text)
-        should_continue = dispatch_slash(cmd_text, session, console)
+        try:
+            should_continue = dispatch_slash(cmd_text, session, console)
+        except Exception as exc:  # noqa: BLE001
+            console.print(
+                f"[{TERMINAL_ERROR}]command error:[/] {escape(str(exc))}"
+                " [dim](the REPL is still running)[/dim]"
+            )
+            should_continue = True
         console.print()
         return should_continue
 

--- a/tests/cli/interactive_shell/test_history.py
+++ b/tests/cli/interactive_shell/test_history.py
@@ -1,0 +1,58 @@
+"""Tests for interactive shell command history helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.cli.interactive_shell.commands import dispatch_slash
+from app.cli.interactive_shell.history import load_command_history_entries
+from app.cli.interactive_shell.session import ReplSession
+
+
+def _capture() -> tuple[object, object]:
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, color_system="truecolor", highlight=False)
+    return console, buf
+
+
+def test_load_command_history_entries_returns_empty_on_mkdir_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_path = MagicMock(spec=Path)
+    mock_parent = MagicMock()
+    mock_path.parent = mock_parent
+    mock_parent.mkdir.side_effect = OSError(13, "Permission denied")
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.history.prompt_history_path",
+        lambda: mock_path,
+    )
+
+    assert load_command_history_entries() == []
+
+
+def test_history_slash_command_does_not_raise_when_history_dir_unwritable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: /history must not crash the REPL when OPENSRE_HOME_DIR is not writable."""
+    mock_path = MagicMock(spec=Path)
+    mock_parent = MagicMock()
+    mock_path.parent = mock_parent
+    mock_parent.mkdir.side_effect = OSError(30, "Read-only file system")
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.history.prompt_history_path",
+        lambda: mock_path,
+    )
+
+    session = ReplSession()
+    console, buf = _capture()
+    assert dispatch_slash("/history", session, console) is True
+    assert "no history yet" in buf.getvalue()


### PR DESCRIPTION
Fixes # (follow-up to #1394)

#### Describe the changes you have made in this PR

Five targeted hardening fixes surfaced during post-merge review of #1394.

**1. Escape integration/MCP table cells (`commands.py`)**
`service`, `source`, and `detail` values come from the integration store or live API verification. Any value containing `[…]` (e.g. `"401 [Unauthorized]"` from a Datadog check) was silently eaten by Rich as a broken markup tag. All three columns now pass through `escape()`.

**2. Escape LLM import error in `follow_up.py`**
The `LLM client unavailable` message printed bare `{exc}`. Exception messages from Python's import machinery routinely contain brackets. Changed to `escape(str(exc))` to match every other error path in the REPL.

**3. Unify error colour in `_cmd_cancel` (`commands.py`)**
`/cancel` used raw `[red]` on its three error lines while every other command uses the `TERMINAL_ERROR` theme constant (`#c99a9a`). Unified.

**4. Use `_repl_table()` for `/tasks` (`commands.py`)**
`_cmd_tasks` was the only command building a bare `Table()`. All other commands go through `_repl_table()` for consistent minimal-border styling. Swapped.

**5. Guard `dispatch_slash` against unhandled handler exceptions (`loop.py`)**
`_run_one_turn` had no `try/except` around `dispatch_slash`. A lazy-import failure or future regression in any slash handler would propagate out of `_repl_main` and terminate the REPL with a traceback. Wrapped in `except Exception` so the REPL stays alive and prints a `TERMINAL_ERROR` message.

**6. `test_history.py` — regression tests for OSError guard**
Added two tests for `load_command_history_entries`:
- `mkdir` raises `OSError` → returns `[]` (no crash).
- `/history` with unwritable home dir shows "no history yet" and returns `True` (REPL stays running).

---

### Demo/Screenshot for feature changes and bug fixes

All changes are defensive hardening — no visible UI change under normal conditions. The `_cmd_tasks` table now uses the same minimal border style as all other REPL command tables.

---

## Code Understanding and AI Usage

- [x] Yes, I used AI assistance (continue below)
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Each fix is a one-to-three line change targeting a specific class of bug:
- `escape()` calls prevent Rich from interpreting external strings as markup.
- `TERMINAL_ERROR` unification ensures consistent error hue across all REPL commands.
- `_repl_table()` ensures all command output shares the same compact table style.
- The `try/except` in `_run_one_turn` is a last-resort safety net — it does not swallow expected errors (those are handled per-handler), only unexpected ones that would otherwise kill the process.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions