### PR TITLE
fix(cli): fall back to .env when LLM keyring unavailable

### DIFF
--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -86,6 +86,7 @@ def sync_provider_env(
     provider: ProviderOption,
     model: str,
     env_path: Path | None = None,
+    llm_api_key_plaintext: str | None = None,
 ) -> Path:
     """Write non-secret provider settings into the project .env.
 
@@ -93,6 +94,10 @@ def sync_provider_env(
     is in the keyring, or when switching LLM provider. If the user still has
     the active provider's key only in ``.env`` (same ``LLM_PROVIDER``), that
     line is kept until they save to the keyring.
+
+    When *llm_api_key_plaintext* is set (no working keychain, e.g. headless
+    Linux), the active provider's API key is written to ``.env`` and is not
+    stripped by the cleanup pass.
     """
     from app.cli.wizard.config import SUPPORTED_PROVIDERS
 
@@ -125,11 +130,16 @@ def sync_provider_env(
     ):
         keys_to_remove.discard(provider.api_key_env)
 
+    if llm_api_key_plaintext and provider.api_key_env:
+        keys_to_remove.discard(provider.api_key_env)
+
     lines = _remove_keys(existing, keys_to_remove)
 
     values: dict[str, str] = {"LLM_PROVIDER": provider.value, provider.model_env: model}
     if provider.legacy_model_env:
         values[provider.legacy_model_env] = model
+    if llm_api_key_plaintext and provider.api_key_env:
+        values[provider.api_key_env] = llm_api_key_plaintext.strip()
 
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -325,7 +325,7 @@ def _prompt_value(
         _console.print("[red]Required.[/]")
 
 
-def _persist_llm_api_key(env_var: str, value: str) -> bool:
+def _persist_llm_api_key(env_var: str, value: str) -> Literal["keychain", "env"] | None:
     try:
         save_llm_api_key(env_var, value)
     except RuntimeError as exc:
@@ -335,8 +335,19 @@ def _persist_llm_api_key(env_var: str, value: str) -> bool:
         )
         for line in get_keyring_setup_instructions(env_var):
             _console.print(f"[dim]{line}[/]")
-        return False
-    return True
+
+        if sys.stdin.isatty() and not _confirm(
+            "Save the API key to your project .env file instead? "
+            "[dim](Common on SSH / headless servers; use chmod 600 on .env)[/]",
+            default=True,
+        ):
+            return None
+        _console.print(
+            "[yellow]Storing API key in .env. Restrict access: "
+            "[bold]chmod 600 .env[/] (or move the key to a keychain later).[/]"
+        )
+        return "env"
+    return "keychain"
 
 
 def _parse_csv_values(raw_value: str) -> list[str]:
@@ -1608,9 +1619,13 @@ def _render_next_steps() -> None:
     )
 
 
-def _credential_line_for_saved_summary(provider: ProviderOption) -> str:
+def _credential_line_for_saved_summary(
+    provider: ProviderOption, *, llm_key_in_env_file: bool = False
+) -> str:
     """One-line credential description for the post-wizard saved summary."""
     if provider.credential_kind != "cli":
+        if llm_key_in_env_file and provider.api_key_env:
+            return f"project .env ({provider.api_key_env})"
         return "system keychain"
     if provider.adapter_factory is None:
         return f"{provider.label} (CLI)"
@@ -1752,6 +1767,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
     force_repick = False
     provider: ProviderOption
     model: str
+    llm_api_key_plaintext_for_env: str | None = None
     while True:
         _step("LLM Provider")
         saved_provider = (
@@ -1792,8 +1808,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 except KeyboardInterrupt:
                     _console.print("\n[yellow]Setup cancelled.[/]")
                     return 1
-                if not _persist_llm_api_key(provider.api_key_env, api_key):
+                persist_kind = _persist_llm_api_key(provider.api_key_env, api_key)
+                if persist_kind is None:
                     return 1
+                if persist_kind == "env":
+                    llm_api_key_plaintext_for_env = api_key
         else:
             assert saved_provider is not None
             provider = saved_provider
@@ -1802,8 +1821,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 has_api_key = bool(defaults["has_api_key"])
                 legacy_api_key = str(defaults["legacy_api_key"] or "").strip()
                 if not has_api_key and legacy_api_key:
-                    if not _persist_llm_api_key(provider.api_key_env, legacy_api_key):
+                    persist_kind = _persist_llm_api_key(provider.api_key_env, legacy_api_key)
+                    if persist_kind is None:
                         return 1
+                    if persist_kind == "env":
+                        llm_api_key_plaintext_for_env = legacy_api_key
                     has_api_key = True
                 if not has_api_key:
                     _step(provider.credential_label.title())
@@ -1816,8 +1838,11 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                     except KeyboardInterrupt:
                         _console.print("\n[yellow]Setup cancelled.[/]")
                         return 1
-                    if not _persist_llm_api_key(provider.api_key_env, api_key):
+                    persist_kind = _persist_llm_api_key(provider.api_key_env, api_key)
+                    if persist_kind is None:
                         return 1
+                    if persist_kind == "env":
+                        llm_api_key_plaintext_for_env = api_key
 
         if provider.credential_kind == "cli":
             cli_out = _run_cli_llm_onboarding(provider)
@@ -1840,7 +1865,13 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         model_env=provider.model_env,
         probes=probes,
     )
-    env_path = sync_provider_env(provider=provider, model=model)
+    env_path = sync_provider_env(
+        provider=provider,
+        model=model,
+        llm_api_key_plaintext=llm_api_key_plaintext_for_env,
+    )
+    if llm_api_key_plaintext_for_env and provider.api_key_env:
+        os.environ[provider.api_key_env] = llm_api_key_plaintext_for_env.strip()
 
     _step("Integrations")
     try:
@@ -1858,7 +1889,9 @@ def run_wizard(_argv: list[str] | None = None) -> int:
         saved_path=str(saved_path),
         env_path=summary_env_path,
         configured_integrations=configured_integrations,
-        credential_line=_credential_line_for_saved_summary(provider),
+        credential_line=_credential_line_for_saved_summary(
+            provider, llm_key_in_env_file=llm_api_key_plaintext_for_env is not None
+        ),
     )
     _render_next_steps()
     return 0

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -65,6 +65,21 @@ def test_sync_provider_env_codex_writes_codex_model(tmp_path) -> None:
     assert "CODEX_MODEL=\n" in content
 
 
+def test_sync_provider_env_writes_llm_api_key_when_plaintext_passed(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_PROVIDER=openai\nOPENAI_API_KEY=old\n", encoding="utf-8")
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["anthropic"],
+        model=PROVIDER_BY_VALUE["anthropic"].default_model,
+        env_path=env_path,
+        llm_api_key_plaintext="sk-in-env",
+    )
+    content = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=anthropic\n" in content
+    assert "ANTHROPIC_API_KEY=sk-in-env\n" in content
+    assert "OPENAI_API_KEY=" not in content
+
+
 def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -129,6 +129,8 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
             "Start a D-Bus shell: dbus-run-session -- sh",
         ),
     )
+    monkeypatch.setattr(flow.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(flow, "_confirm", lambda *_a, **_k: False)
 
     exit_code = flow.run_wizard()
 
@@ -138,6 +140,48 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
     assert "Install it first: sudo apt update && sudo apt install -y gnome-keyring" in output
     assert "dbus-user-session" in output
     assert "Start a D-Bus shell: dbus-run-session -- sh" in output
+
+
+def test_run_wizard_saves_llm_key_to_env_when_keyring_unavailable(monkeypatch, tmp_path) -> None:
+    """Headless Linux (e.g. EC2): keychain missing — user can persist API key in .env."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    select_responses = iter(["quickstart", "anthropic", "skip"])
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = "sk-env-fallback"
+        return m
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(
+        flow,
+        "save_llm_api_key",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("Secure local credential storage is unavailable on this machine.")
+        ),
+    )
+    monkeypatch.setattr(flow, "_confirm", lambda *_a, **_k: True)
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(
+        flow,
+        "sync_provider_env",
+        lambda **kwargs: sync_provider_env(env_path=env_path, **kwargs),
+    )
+
+    exit_code = flow.run_wizard()
+    assert exit_code == 0
+    text = env_path.read_text(encoding="utf-8")
+    assert "ANTHROPIC_API_KEY=sk-env-fallback\n" in text
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-env-fallback"
 
 
 def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, capsys) -> None:
@@ -982,6 +1026,15 @@ def test_credential_line_for_saved_summary_anthropic() -> None:
 
     anthropic = next(p for p in wizard_config.SUPPORTED_PROVIDERS if p.value == "anthropic")
     assert flow._credential_line_for_saved_summary(anthropic) == "system keychain"
+
+
+def test_credential_line_for_saved_summary_anthropic_env_file() -> None:
+    from app.cli.wizard import config as wizard_config
+
+    anthropic = next(p for p in wizard_config.SUPPORTED_PROVIDERS if p.value == "anthropic")
+    assert flow._credential_line_for_saved_summary(anthropic, llm_key_in_env_file=True) == (
+        "project .env (ANTHROPIC_API_KEY)"
+    )
 
 
 def test_credential_line_for_saved_summary_cli_without_factory() -> None:


### PR DESCRIPTION
No linked issue (repro: `opensre onboard` on fresh Ubuntu 22.04 EC2 / headless Linux when Python `keyring` has no backend — onboarding exited after API key entry).

#### Describe the changes you have made in this PR -

- **Wizard (`flow.py`):** When saving the LLM API key to the system keychain fails, the flow still prints existing keyring setup hints, then offers to store the secret in the **project `.env`** instead. On a **TTY**, the user is prompted (default yes); when **stdin is not a TTY**, `.env` is used automatically so scripted installs do not hang.
- **`sync_provider_env`:** New optional `llm_api_key_plaintext` writes the active provider’s API key into `.env` and excludes that key from the “strip API keys from .env” cleanup so it is not deleted on the next sync.
- **Summary copy:** Post-wizard credential line can show `project .env (ANTHROPIC_API_KEY)` (etc.) when that path was used.
- **Tests:** Cover declining `.env` (exit 1), accepting `.env` (key written, `make` passes), `sync_provider_env` with plaintext, and credential summary line. **Tests run:** `pytest tests/cli/wizard/test_flow.py tests/cli/wizard/test_env_sync.py`; `make lint` and `make typecheck` pass.

### Demo/Screenshot for feature changes and bug fixes - 

**Before:** After entering an API key, users saw _“Secure local credential storage is unavailable on this machine.”_ and the wizard exited without finishing Quickstart.

**After (TTY):** Same error text plus keyring install hints, then a confirm step: save to `.env` instead; on success, onboarding continues. **Non-TTY:** Automatically persists to `.env` and continues.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Headless Linux (e.g. EC2) often has no working keyring backend, so `save_llm_api_key` raises. The previous behavior aborted onboarding. Alternatives considered: (1) only document `export ANTHROPIC_API_KEY` / install `gnome-keyring` — poor first-run UX; (2) always write secrets to `.env` — weaker on desktops where keyring is available. The chosen approach keeps **keyring-first** behavior and adds an **explicit `.env` fallback** after failure, with a TTY prompt (default yes) and non-TTY auto path. `sync_provider_env` gained `llm_api_key_plaintext` so the normal sync pass does not remove the key we just wrote. Trade-off: `.env` secrets rely on file permissions; the wizard reminds users to use `chmod 600 .env`.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


Note: Please check **Allow edits from maintainers** if you would like us to assist with the PR.
