### PR TITLE
feat(cli): add grounding cache invalidation for interactive shell

### DIFF
--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -10,6 +10,7 @@ from rich.markdown import Markdown
 from rich.markup import escape
 
 from app.cli.interactive_shell.cli_reference import build_cli_reference_text
+from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
 from app.cli.interactive_shell.loaders import llm_loader
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
@@ -295,6 +296,7 @@ def answer_cli_agent(
         return
 
     reference = build_cli_reference_text()
+    log_grounding_cache_diagnostics("cli_agent_grounding")
     history = _format_history_for_prompt(session)
     system = _build_system_prompt(grounding, reference, history)
     user_block = (

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -12,6 +12,10 @@ from rich.markup import escape
 from app.cli.interactive_shell.cli_reference import build_cli_reference_text
 from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
 from app.cli.interactive_shell.loaders import llm_loader
+from app.cli.interactive_shell.prompt_rules import (
+    CLI_ASSISTANT_MARKDOWN_RULE,
+    INTERACTIVE_SHELL_TERMINOLOGY_RULE,
+)
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
@@ -19,20 +23,8 @@ from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 _MAX_CLI_AGENT_TURNS = 12
 type _GroundingMode = Literal["reference_only", "conversational"]
 
-# Shared, end-user-friendly terminology rule that is appended to every system
-# prompt. The model otherwise picks up "REPL" from internal docs and surfaces
-# jargon to the user (#604).
-_TERMINOLOGY_RULE = (
-    "Terminology: always call this surface the 'interactive shell' (the "
-    "OpenSRE interactive terminal launched via `opensre`). "
-    "Never use the word 'REPL' in user-facing answers - it is internal jargon."
-)
-
-_MARKDOWN_RULE = (
-    "Formatting: respond in concise Markdown. Markdown will be rendered "
-    "in the user's terminal, so tables, **bold**, lists, and `code spans` "
-    "will display correctly - do not wrap the whole answer in a code fence."
-)
+_TERMINOLOGY_RULE = INTERACTIVE_SHELL_TERMINOLOGY_RULE
+_MARKDOWN_RULE = CLI_ASSISTANT_MARKDOWN_RULE
 
 _ACTION_RULE = (
     "Action planning: if the user asks you to change OpenSRE runtime state, "
@@ -277,6 +269,14 @@ def _execute_action_plan(
     return True
 
 
+def _record_cli_agent_turn(session: ReplSession, message: str, assistant_text: str) -> None:
+    session.cli_agent_messages.append(("user", message))
+    session.cli_agent_messages.append(("assistant", assistant_text))
+    cap = _MAX_CLI_AGENT_TURNS * 2
+    if len(session.cli_agent_messages) > cap:
+        session.cli_agent_messages[:] = session.cli_agent_messages[-cap:]
+
+
 def answer_cli_agent(
     message: str,
     session: ReplSession,
@@ -317,18 +317,10 @@ def answer_cli_agent(
     text_str = _response_text(response)
     actions = _parse_action_plan(text_str)
     if _execute_action_plan(actions, session, console):
-        session.cli_agent_messages.append(("user", message))
-        session.cli_agent_messages.append(("assistant", text_str))
-        cap = _MAX_CLI_AGENT_TURNS * 2
-        if len(session.cli_agent_messages) > cap:
-            session.cli_agent_messages[:] = session.cli_agent_messages[-cap:]
+        _record_cli_agent_turn(session, message, text_str)
         return
 
-    session.cli_agent_messages.append(("user", message))
-    session.cli_agent_messages.append(("assistant", text_str))
-    cap = _MAX_CLI_AGENT_TURNS * 2
-    if len(session.cli_agent_messages) > cap:
-        session.cli_agent_messages[:] = session.cli_agent_messages[-cap:]
+    _record_cli_agent_turn(session, message, text_str)
 
     console.print()
     console.print(f"[{TERMINAL_ACCENT_BOLD}]assistant:[/]")

--- a/app/cli/interactive_shell/cli_help.py
+++ b/app/cli/interactive_shell/cli_help.py
@@ -18,6 +18,7 @@ from rich.markup import escape
 
 from app.cli.interactive_shell.cli_reference import build_cli_reference_text
 from app.cli.interactive_shell.docs_reference import build_docs_reference_text
+from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
 from app.cli.interactive_shell.loaders import llm_loader
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
@@ -98,6 +99,7 @@ def answer_cli_help(question: str, session: ReplSession, console: Console) -> No
 
     cli_reference = build_cli_reference_text()
     docs_reference = build_docs_reference_text(question)
+    log_grounding_cache_diagnostics("cli_help_grounding")
     prompt = _build_grounded_prompt(question, cli_reference, docs_reference)
 
     try:

--- a/app/cli/interactive_shell/cli_help.py
+++ b/app/cli/interactive_shell/cli_help.py
@@ -20,23 +20,18 @@ from app.cli.interactive_shell.cli_reference import build_cli_reference_text
 from app.cli.interactive_shell.docs_reference import build_docs_reference_text
 from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
 from app.cli.interactive_shell.loaders import llm_loader
+from app.cli.interactive_shell.prompt_rules import (
+    CLI_ASSISTANT_MARKDOWN_RULE,
+    INTERACTIVE_SHELL_TERMINOLOGY_RULE,
+)
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 from app.utils.sentry_sdk import capture_exception
 
 # Match the cli_agent terminology / formatting rules so docs answers feel
 # consistent with the rest of the interactive shell.
-_TERMINOLOGY_RULE = (
-    "Terminology: always call this surface the 'interactive shell' (the "
-    "OpenSRE interactive terminal launched via `opensre` or `opensre agent`). "
-    "Never use the word 'REPL' in user-facing answers - it is internal jargon."
-)
-
-_MARKDOWN_RULE = (
-    "Formatting: respond in concise Markdown. Markdown will be rendered "
-    "in the user's terminal, so tables, **bold**, lists, and `code spans` "
-    "will display correctly - do not wrap the whole answer in a code fence."
-)
+_TERMINOLOGY_RULE = INTERACTIVE_SHELL_TERMINOLOGY_RULE
+_MARKDOWN_RULE = CLI_ASSISTANT_MARKDOWN_RULE
 
 
 def _build_grounded_prompt(question: str, cli_reference: str, docs_reference: str) -> str:
@@ -81,7 +76,7 @@ def _build_grounded_prompt(question: str, cli_reference: str, docs_reference: st
     return f"{system}\n{user_block}"
 
 
-def answer_cli_help(question: str, session: ReplSession, console: Console) -> None:  # noqa: ARG001
+def answer_cli_help(question: str, _session: ReplSession, console: Console) -> None:
     """Run one turn of the documentation-aware procedural assistant.
 
     Pulls the top-N relevant docs pages for ``question``, combines them with
@@ -89,6 +84,9 @@ def answer_cli_help(question: str, session: ReplSession, console: Console) -> No
     the assembled grounding. Behaves as a no-op for the session's action
     history (stateless across turns) so it never interferes with follow-up
     routing on a prior investigation.
+
+    ``_session`` is accepted for API symmetry with :func:`answer_cli_agent` and
+    input routing; this path does not read session state today.
     """
     try:
         from app.services.llm_client import get_llm_for_reasoning

--- a/app/cli/interactive_shell/cli_reference.py
+++ b/app/cli/interactive_shell/cli_reference.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import logging
+import time
+from dataclasses import dataclass
+from typing import Any
 
 from click.testing import CliRunner
 
@@ -11,8 +14,37 @@ _logger = logging.getLogger(__name__)
 _MAX_REFERENCE_CHARS = 28_000
 
 
-def build_cli_reference_text() -> str:
-    """Assemble ``opensre`` and subcommand ``--help`` output for LLM grounding."""
+@dataclass
+class _CliReferenceCache:
+    """Process-local cache for assembled CLI help reference text."""
+
+    signature: str | None = None
+    text: str | None = None
+    created_at_monotonic: float = 0.0
+    hits: int = 0
+    misses: int = 0
+
+
+_cli_reference_cache = _CliReferenceCache()
+
+
+def _current_cli_signature() -> str:
+    """Stable signature of the CLI command surface and interactive slash commands.
+
+    Bumps cache when subcommands change, slash-command metadata changes, or the
+    installed package version changes.
+    """
+    from app.cli.__main__ import cli
+    from app.cli.interactive_shell.commands import SLASH_COMMANDS
+    from app.version import get_version
+
+    cmd_names = ",".join(sorted(cli.commands.keys()))
+    slash_names = ",".join(sorted(SLASH_COMMANDS.keys()))
+    return f"opensre={get_version()}|commands={cmd_names}|slash={slash_names}"
+
+
+def _build_cli_reference_text_uncached() -> str:
+    """Build reference via CliRunner without caching."""
     from app.cli.__main__ import cli
 
     runner = CliRunner()
@@ -62,4 +94,44 @@ def _interactive_shell_slash_hints() -> str:
     return "\n".join(lines)
 
 
-__all__ = ["build_cli_reference_text"]
+def invalidate_cli_reference_cache() -> None:
+    """Drop cached CLI reference text (for tests or forced refresh)."""
+    _cli_reference_cache.signature = None
+    _cli_reference_cache.text = None
+    _cli_reference_cache.created_at_monotonic = 0.0
+
+
+def get_cli_reference_cache_stats() -> dict[str, Any]:
+    """Debug counters for grounding cache hit/miss and last signature."""
+    return {
+        "hits": _cli_reference_cache.hits,
+        "misses": _cli_reference_cache.misses,
+        "cached": _cli_reference_cache.text is not None,
+        "signature": _cli_reference_cache.signature,
+        "created_at_monotonic": _cli_reference_cache.created_at_monotonic,
+    }
+
+
+def build_cli_reference_text() -> str:
+    """Assemble ``opensre`` and subcommand ``--help`` output for LLM grounding.
+
+    Cached process-locally while the command registry signature matches.
+    """
+    sig = _current_cli_signature()
+    if _cli_reference_cache.text is not None and _cli_reference_cache.signature == sig:
+        _cli_reference_cache.hits += 1
+        return _cli_reference_cache.text
+
+    _cli_reference_cache.misses += 1
+    text = _build_cli_reference_text_uncached()
+    _cli_reference_cache.signature = sig
+    _cli_reference_cache.text = text
+    _cli_reference_cache.created_at_monotonic = time.monotonic()
+    return text
+
+
+__all__ = [
+    "build_cli_reference_text",
+    "get_cli_reference_cache_stats",
+    "invalidate_cli_reference_cache",
+]

--- a/app/cli/interactive_shell/cli_reference.py
+++ b/app/cli/interactive_shell/cli_reference.py
@@ -13,6 +13,18 @@ _logger = logging.getLogger(__name__)
 
 _MAX_REFERENCE_CHARS = 28_000
 
+# Heuristic: truncated or failed CliRunner output must not be cached or the
+# assistant would keep an empty reference for the whole process.
+_MIN_CACHEABLE_CLI_REFERENCE_CHARS = 80
+_CLI_REFERENCE_SENTINEL = "=== opensre --help ==="
+
+
+def _is_cacheable_cli_reference(text: str) -> bool:
+    stripped = text.strip()
+    if len(stripped) < _MIN_CACHEABLE_CLI_REFERENCE_CHARS:
+        return False
+    return _CLI_REFERENCE_SENTINEL in text
+
 
 @dataclass
 class _CliReferenceCache:
@@ -99,6 +111,8 @@ def invalidate_cli_reference_cache() -> None:
     _cli_reference_cache.signature = None
     _cli_reference_cache.text = None
     _cli_reference_cache.created_at_monotonic = 0.0
+    _cli_reference_cache.hits = 0
+    _cli_reference_cache.misses = 0
 
 
 def get_cli_reference_cache_stats() -> dict[str, Any]:
@@ -124,9 +138,18 @@ def build_cli_reference_text() -> str:
 
     _cli_reference_cache.misses += 1
     text = _build_cli_reference_text_uncached()
-    _cli_reference_cache.signature = sig
-    _cli_reference_cache.text = text
-    _cli_reference_cache.created_at_monotonic = time.monotonic()
+    if _is_cacheable_cli_reference(text):
+        _cli_reference_cache.signature = sig
+        _cli_reference_cache.text = text
+        _cli_reference_cache.created_at_monotonic = time.monotonic()
+    else:
+        _cli_reference_cache.signature = None
+        _cli_reference_cache.text = None
+        _cli_reference_cache.created_at_monotonic = 0.0
+        _logger.warning(
+            "CLI reference build produced non-cacheable output (%d chars); skipping cache",
+            len(text),
+        )
     return text
 
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -37,6 +37,9 @@ def _cmd_trust(session: ReplSession, console: Console, args: list[str]) -> bool:
 
 
 def _cmd_status(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    from app.cli.interactive_shell.cli_reference import get_cli_reference_cache_stats
+    from app.cli.interactive_shell.docs_reference import get_docs_cache_stats
+
     table = repl_table(title="Session status", title_style=TERMINAL_ACCENT_BOLD, show_header=False)
     table.add_column("key", style="bold")
     table.add_column("value")
@@ -44,6 +47,18 @@ def _cmd_status(session: ReplSession, console: Console, args: list[str]) -> bool
     table.add_row("last investigation", "yes" if session.last_state else "none")
     table.add_row("trust mode", "on" if session.trust_mode else "off")
     table.add_row("provider", os.getenv("LLM_PROVIDER", "anthropic"))
+    cli_stats = get_cli_reference_cache_stats()
+    doc_stats = get_docs_cache_stats()
+    table.add_row(
+        "grounding cli cache",
+        f"hits={cli_stats['hits']} misses={cli_stats['misses']} "
+        f"cached={'yes' if cli_stats['cached'] else 'no'}",
+    )
+    table.add_row(
+        "grounding docs cache",
+        f"hits={doc_stats['hits']} misses={doc_stats['misses']} "
+        f"entries={doc_stats['currsize']}/{doc_stats['maxsize']}",
+    )
     acc = session.accumulated_context
     if acc:
         table.add_row("accumulated context", ", ".join(sorted(acc.keys())))

--- a/app/cli/interactive_shell/docs_reference.py
+++ b/app/cli/interactive_shell/docs_reference.py
@@ -22,6 +22,13 @@ the fingerprint and trigger a re-parse on the next grounding call. There is no
 on-disk cache. Use :func:`invalidate_docs_cache` in tests to clear the parse
 cache between cases.
 
+Each :func:`discover_docs` call walks the docs tree once to compute the
+fingerprint and (on cache miss) parse files in that same walk result. A prior
+``lru_cache`` on the root path alone avoided that walk but could not detect
+in-file edits during a session; the trade-off is intentional. Between
+fingerprinting and ``read_text``, a file may change (TOCTOU); the next call
+picks up the new ``st_mtime_ns`` and re-parses.
+
 When docs are missing
 ---------------------
 For non-editable installs that do not ship the ``docs/`` directory the
@@ -34,8 +41,8 @@ from __future__ import annotations
 
 import hashlib
 import re
+from collections import OrderedDict
 from dataclasses import dataclass
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -204,15 +211,15 @@ def _iter_doc_files(root: Path) -> list[Path]:
     return sorted(files)
 
 
-def _fingerprint_docs_tree(root: Path) -> str:
-    """Digest of docs file set + mtimes/sizes for cache invalidation."""
+def _fingerprint_from_paths(root: Path, files: list[Path]) -> str:
+    """Digest of tracked docs files using paths from a single tree walk."""
     digest = hashlib.sha256()
     if not root.exists() or not root.is_dir():
         digest.update(b"nodir")
         digest.update(str(root.resolve() if root.exists() else root).encode())
         return digest.hexdigest()
 
-    for path in _iter_doc_files(root):
+    for path in files:
         rel = path.relative_to(root).as_posix()
         try:
             st = path.stat()
@@ -224,18 +231,11 @@ def _fingerprint_docs_tree(root: Path) -> str:
     return digest.hexdigest()
 
 
-@lru_cache(maxsize=4)
-def _load_docs_pages(root_str: str, _fingerprint: str) -> tuple[DocPage, ...]:
-    """Parse all docs under ``root_str``; cache bounded by (root, fingerprint).
-
-    ``_fingerprint`` is part of the :func:`functools.lru_cache` key so edits to
-    tracked files force a new parse without clearing the whole cache.
-    """
-    pages: list[DocPage] = []
-    root = Path(root_str)
+def _parse_doc_files(root: Path, files: list[Path]) -> tuple[DocPage, ...]:
     if not root.exists() or not root.is_dir():
         return ()
-    for path in _iter_doc_files(root):
+    pages: list[DocPage] = []
+    for path in files:
         try:
             text = path.read_text(encoding="utf-8")
         except OSError:
@@ -254,33 +254,62 @@ def _load_docs_pages(root_str: str, _fingerprint: str) -> tuple[DocPage, ...]:
     return tuple(pages)
 
 
+# Distinct (root_key, fingerprint) entries retained under churn. Eviction drops
+# oldest keys; a reverted doc tree re-parses once then stays hot again.
+_MAX_DOCS_FP_CACHE_ENTRIES = 32
+
+_DOCS_PARSE_CACHE: OrderedDict[tuple[str, str], tuple[DocPage, ...]] = OrderedDict()
+_docs_cache_hits = 0
+_docs_cache_misses = 0
+
+
 def discover_docs(root: Path | None = None) -> list[DocPage]:
     """Walk the docs root, parse each MDX page, return them as :class:`DocPage` records."""
+    global _docs_cache_hits, _docs_cache_misses
+
     target = root if root is not None else _DOCS_ROOT
     resolved = target.resolve() if target.exists() else target
     root_key = str(resolved)
-    fp = _fingerprint_docs_tree(resolved)
-    return list(_load_docs_pages(root_key, fp))
+
+    files = _iter_doc_files(resolved)
+    fp = _fingerprint_from_paths(resolved, files)
+    cache_key = (root_key, fp)
+
+    cached = _DOCS_PARSE_CACHE.get(cache_key)
+    if cached is not None:
+        _docs_cache_hits += 1
+        _DOCS_PARSE_CACHE.move_to_end(cache_key)
+        return list(cached)
+
+    _docs_cache_misses += 1
+    pages_tuple = _parse_doc_files(resolved, files)
+
+    while len(_DOCS_PARSE_CACHE) >= _MAX_DOCS_FP_CACHE_ENTRIES:
+        _DOCS_PARSE_CACHE.popitem(last=False)
+    _DOCS_PARSE_CACHE[cache_key] = pages_tuple
+    return list(pages_tuple)
 
 
 def invalidate_docs_cache() -> None:
     """Clear the bounded parse cache (tests, forced refresh)."""
-    _load_docs_pages.cache_clear()
+    global _docs_cache_hits, _docs_cache_misses
+    _DOCS_PARSE_CACHE.clear()
+    _docs_cache_hits = 0
+    _docs_cache_misses = 0
 
 
 def get_docs_cache_stats() -> dict[str, Any]:
-    """Debug metrics for docs grounding cache (LruCache hit/miss/size)."""
-    info = _load_docs_pages.cache_info()
+    """Debug metrics for docs grounding cache (hits/misses/size)."""
     return {
-        "hits": info.hits,
-        "misses": info.misses,
-        "currsize": info.currsize,
-        "maxsize": info.maxsize,
+        "hits": _docs_cache_hits,
+        "misses": _docs_cache_misses,
+        "currsize": len(_DOCS_PARSE_CACHE),
+        "maxsize": _MAX_DOCS_FP_CACHE_ENTRIES,
     }
 
 
 def _tokenize(text: str) -> set[str]:
-    return {tok for tok in _TOKEN_RE.findall(text.lower()) if len(tok) >= 3}
+    return {tok for tok in _TOKEN_RE.findall(text.lower()) if len(tok) >= 2}
 
 
 def _query_tokens(query: str) -> set[str]:

--- a/app/cli/interactive_shell/docs_reference.py
+++ b/app/cli/interactive_shell/docs_reference.py
@@ -15,14 +15,12 @@ plus subdirectories like ``tutorials/`` and ``use-cases/``.
 
 How docs stay fresh
 -------------------
-Pages are parsed lazily on first use and memoized for the lifetime of the
-process via an :func:`functools.lru_cache` on :func:`_discover_docs_cached`.
-That means there is no build step and no on-disk cache file: a fresh
-``opensre`` invocation always reads the current ``docs/`` tree. Edits made
-to ``docs/*.mdx`` while a long-running shell is open are NOT picked up
-until the next process restart. To extend coverage, drop a new ``.mdx``
-file under ``docs/`` and it will be discovered automatically the next time
-the shell starts.
+Pages are parsed lazily and cached in-process keyed by the resolved docs root
+and a lightweight fingerprint of each tracked file (relative path, size,
+``st_mtime_ns``). Edits under ``docs/`` during a long-running shell invalidate
+the fingerprint and trigger a re-parse on the next grounding call. There is no
+on-disk cache. Use :func:`invalidate_docs_cache` in tests to clear the parse
+cache between cases.
 
 When docs are missing
 ---------------------
@@ -34,10 +32,12 @@ CLI reference and avoid inventing setup steps.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 # Docs live at the repository root, three levels above this file
 # (.../app/cli/interactive_shell/docs_reference.py -> repo root).
@@ -204,16 +204,37 @@ def _iter_doc_files(root: Path) -> list[Path]:
     return sorted(files)
 
 
-@lru_cache(maxsize=1)
-def _discover_docs_cached(root_str: str) -> tuple[DocPage, ...]:
-    """Cached version of :func:`discover_docs` keyed on the resolved root.
+def _fingerprint_docs_tree(root: Path) -> str:
+    """Digest of docs file set + mtimes/sizes for cache invalidation."""
+    digest = hashlib.sha256()
+    if not root.exists() or not root.is_dir():
+        digest.update(b"nodir")
+        digest.update(str(root.resolve() if root.exists() else root).encode())
+        return digest.hexdigest()
 
-    The cache is process-local; re-launching the interactive shell picks up
-    any docs edits made since startup. Within one shell session, repeated
-    docs queries reuse the parsed pages.
+    for path in _iter_doc_files(root):
+        rel = path.relative_to(root).as_posix()
+        try:
+            st = path.stat()
+            digest.update(rel.encode())
+            digest.update(str(st.st_size).encode())
+            digest.update(str(st.st_mtime_ns).encode())
+        except OSError:
+            continue
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=4)
+def _load_docs_pages(root_str: str, _fingerprint: str) -> tuple[DocPage, ...]:
+    """Parse all docs under ``root_str``; cache bounded by (root, fingerprint).
+
+    ``_fingerprint`` is part of the :func:`functools.lru_cache` key so edits to
+    tracked files force a new parse without clearing the whole cache.
     """
     pages: list[DocPage] = []
     root = Path(root_str)
+    if not root.exists() or not root.is_dir():
+        return ()
     for path in _iter_doc_files(root):
         try:
             text = path.read_text(encoding="utf-8")
@@ -236,7 +257,26 @@ def _discover_docs_cached(root_str: str) -> tuple[DocPage, ...]:
 def discover_docs(root: Path | None = None) -> list[DocPage]:
     """Walk the docs root, parse each MDX page, return them as :class:`DocPage` records."""
     target = root if root is not None else _DOCS_ROOT
-    return list(_discover_docs_cached(str(target.resolve() if target.exists() else target)))
+    resolved = target.resolve() if target.exists() else target
+    root_key = str(resolved)
+    fp = _fingerprint_docs_tree(resolved)
+    return list(_load_docs_pages(root_key, fp))
+
+
+def invalidate_docs_cache() -> None:
+    """Clear the bounded parse cache (tests, forced refresh)."""
+    _load_docs_pages.cache_clear()
+
+
+def get_docs_cache_stats() -> dict[str, Any]:
+    """Debug metrics for docs grounding cache (LruCache hit/miss/size)."""
+    info = _load_docs_pages.cache_info()
+    return {
+        "hits": info.hits,
+        "misses": info.misses,
+        "currsize": info.currsize,
+        "maxsize": info.maxsize,
+    }
 
 
 def _tokenize(text: str) -> set[str]:
@@ -376,4 +416,6 @@ __all__ = [
     "build_docs_reference_text",
     "discover_docs",
     "find_relevant_docs",
+    "get_docs_cache_stats",
+    "invalidate_docs_cache",
 ]

--- a/app/cli/interactive_shell/docs_reference.py
+++ b/app/cli/interactive_shell/docs_reference.py
@@ -211,12 +211,21 @@ def _iter_doc_files(root: Path) -> list[Path]:
     return sorted(files)
 
 
+# Delimiters keep SHA-256 input unambiguous across (relpath, size, mtime) tuple
+# boundaries — concatenating decimal digits without separators is only
+# heuristic-safe, not injective in general.
+_FP_FIELD_SEP = b"\x00"
+_FP_RECORD_SEP = b"\xff"
+
+
 def _fingerprint_from_paths(root: Path, files: list[Path]) -> str:
     """Digest of tracked docs files using paths from a single tree walk."""
     digest = hashlib.sha256()
     if not root.exists() or not root.is_dir():
         digest.update(b"nodir")
+        digest.update(_FP_FIELD_SEP)
         digest.update(str(root.resolve() if root.exists() else root).encode())
+        digest.update(_FP_FIELD_SEP)
         return digest.hexdigest()
 
     for path in files:
@@ -224,8 +233,11 @@ def _fingerprint_from_paths(root: Path, files: list[Path]) -> str:
         try:
             st = path.stat()
             digest.update(rel.encode())
+            digest.update(_FP_FIELD_SEP)
             digest.update(str(st.st_size).encode())
+            digest.update(_FP_FIELD_SEP)
             digest.update(str(st.st_mtime_ns).encode())
+            digest.update(_FP_RECORD_SEP)
         except OSError:
             continue
     return digest.hexdigest()

--- a/app/cli/interactive_shell/grounding_diagnostics.py
+++ b/app/cli/interactive_shell/grounding_diagnostics.py
@@ -1,0 +1,26 @@
+"""Verbose diagnostics for interactive-shell grounding caches."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
+
+
+def log_grounding_cache_diagnostics(reason: str) -> None:
+    """Log CLI/docs grounding cache stats when ``TRACER_VERBOSE=1``."""
+    if os.environ.get("TRACER_VERBOSE") != "1":
+        return
+    from app.cli.interactive_shell.cli_reference import get_cli_reference_cache_stats
+    from app.cli.interactive_shell.docs_reference import get_docs_cache_stats
+
+    _logger.debug(
+        "grounding cache [%s] cli=%s docs=%s",
+        reason,
+        get_cli_reference_cache_stats(),
+        get_docs_cache_stats(),
+    )
+
+
+__all__ = ["log_grounding_cache_diagnostics"]

--- a/app/cli/interactive_shell/prompt_rules.py
+++ b/app/cli/interactive_shell/prompt_rules.py
@@ -1,0 +1,22 @@
+"""Shared LLM prompt rules for interactive-shell assistants."""
+
+from __future__ import annotations
+
+# Align copy across docs-aware and conversational CLI assistants so wording
+# does not drift between modules.
+INTERACTIVE_SHELL_TERMINOLOGY_RULE = (
+    "Terminology: always call this surface the 'interactive shell' (the "
+    "OpenSRE interactive terminal launched via `opensre` or `opensre agent`). "
+    "Never use the word 'REPL' in user-facing answers - it is internal jargon."
+)
+
+CLI_ASSISTANT_MARKDOWN_RULE = (
+    "Formatting: respond in concise Markdown. Markdown will be rendered "
+    "in the user's terminal, so tables, **bold**, lists, and `code spans` "
+    "will display correctly - do not wrap the whole answer in a code fence."
+)
+
+__all__ = [
+    "CLI_ASSISTANT_MARKDOWN_RULE",
+    "INTERACTIVE_SHELL_TERMINOLOGY_RULE",
+]

--- a/tests/benchmarks/interactive_shell/__init__.py
+++ b/tests/benchmarks/interactive_shell/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmarks for interactive shell components."""

--- a/tests/benchmarks/interactive_shell/grounding_benchmark.py
+++ b/tests/benchmarks/interactive_shell/grounding_benchmark.py
@@ -1,0 +1,71 @@
+"""Benchmark: interactive shell grounding (CLI + docs) cold vs warm cache.
+
+Run locally:
+
+    python -m tests.benchmarks.interactive_shell.grounding_benchmark
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from app.cli.interactive_shell.cli_reference import (
+    build_cli_reference_text,
+    get_cli_reference_cache_stats,
+    invalidate_cli_reference_cache,
+)
+from app.cli.interactive_shell.docs_reference import (
+    build_docs_reference_text,
+    discover_docs,
+    get_docs_cache_stats,
+    invalidate_docs_cache,
+)
+
+
+def _timed(label: str, fn: Callable[[], object]) -> tuple[float, object]:
+    t0 = time.perf_counter()
+    result = fn()
+    elapsed = time.perf_counter() - t0
+    print(f"{label}: {elapsed * 1000:.2f} ms")  # noqa: T201
+    return elapsed, result
+
+
+def main() -> None:
+    docs_root = Path(__file__).resolve().parents[3] / "docs"
+
+    invalidate_cli_reference_cache()
+    invalidate_docs_cache()
+
+    cold_cli, _ = _timed("CLI reference (cold)", build_cli_reference_text)
+    warm_cli, _ = _timed("CLI reference (warm)", build_cli_reference_text)
+    cli_stats = get_cli_reference_cache_stats()
+
+    cold_docs = 0.0
+    warm_docs = 0.0
+    if docs_root.is_dir():
+        cold_docs, _ = _timed("Docs parse (cold)", lambda: discover_docs(docs_root))
+        warm_docs, _ = _timed("Docs parse (warm)", lambda: discover_docs(docs_root))
+        _timed(
+            "Docs reference text (warm index)",
+            lambda: build_docs_reference_text("configure Datadog integration"),
+        )
+    else:
+        print("[skip] docs/ not present — docs parse timings omitted")  # noqa: T201
+
+    docs_stats = get_docs_cache_stats()
+
+    print(  # noqa: T201
+        f"\nSummary: CLI speedup ~{cold_cli / warm_cli:.1f}x (warm vs cold reference build)"
+        if warm_cli > 0
+        else "\nSummary: CLI warm path too fast to ratio"
+    )
+    if docs_root.is_dir() and warm_docs > 0:
+        print(f"Docs parse speedup ~{cold_docs / warm_docs:.1f}x")  # noqa: T201
+    print(f"CLI cache stats: {cli_stats}")  # noqa: T201
+    print(f"Docs cache stats: {docs_stats}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/interactive_shell/test_cli_help.py
+++ b/tests/cli/interactive_shell/test_cli_help.py
@@ -17,15 +17,15 @@ from app.cli.interactive_shell.cli_help import (
     answer_cli_help,
 )
 from app.cli.interactive_shell.cli_reference import build_cli_reference_text
-from app.cli.interactive_shell.docs_reference import _discover_docs_cached
+from app.cli.interactive_shell.docs_reference import invalidate_docs_cache
 from app.cli.interactive_shell.session import ReplSession
 
 
 @pytest.fixture(autouse=True)
 def _clear_doc_cache() -> Iterator[None]:
-    _discover_docs_cached.cache_clear()
+    invalidate_docs_cache()
     yield
-    _discover_docs_cached.cache_clear()
+    invalidate_docs_cache()
 
 
 def _capture() -> tuple[Console, io.StringIO]:

--- a/tests/cli/interactive_shell/test_cli_reference_cache.py
+++ b/tests/cli/interactive_shell/test_cli_reference_cache.py
@@ -1,0 +1,43 @@
+"""Tests for interactive-shell CLI reference grounding cache."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.cli.interactive_shell import cli_reference as cli_reference_module
+from app.cli.interactive_shell.cli_reference import (
+    build_cli_reference_text,
+    get_cli_reference_cache_stats,
+    invalidate_cli_reference_cache,
+)
+
+
+def test_second_build_is_cache_hit() -> None:
+    invalidate_cli_reference_cache()
+    build_cli_reference_text()
+    s1 = get_cli_reference_cache_stats()
+    build_cli_reference_text()
+    s2 = get_cli_reference_cache_stats()
+    assert s2["hits"] == s1["hits"] + 1
+    assert s2["misses"] == s1["misses"]
+
+
+def test_invalidate_forces_rebuild_miss() -> None:
+    invalidate_cli_reference_cache()
+    build_cli_reference_text()
+    s1 = get_cli_reference_cache_stats()
+    invalidate_cli_reference_cache()
+    build_cli_reference_text()
+    s2 = get_cli_reference_cache_stats()
+    assert s2["misses"] == s1["misses"] + 1
+
+
+def test_signature_change_busts_cli_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    invalidate_cli_reference_cache()
+    monkeypatch.setattr(cli_reference_module, "_current_cli_signature", lambda: "sig-a")
+    build_cli_reference_text()
+    monkeypatch.setattr(cli_reference_module, "_current_cli_signature", lambda: "sig-b")
+    build_cli_reference_text()
+    stats = get_cli_reference_cache_stats()
+    assert stats["misses"] >= 2
+    assert stats["signature"] == "sig-b"

--- a/tests/cli/interactive_shell/test_cli_reference_cache.py
+++ b/tests/cli/interactive_shell/test_cli_reference_cache.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from app.cli.interactive_shell import cli_reference as cli_reference_module
@@ -12,8 +14,14 @@ from app.cli.interactive_shell.cli_reference import (
 )
 
 
-def test_second_build_is_cache_hit() -> None:
+@pytest.fixture(autouse=True)
+def _reset_cli_reference_cache() -> Iterator[None]:
     invalidate_cli_reference_cache()
+    yield
+    invalidate_cli_reference_cache()
+
+
+def test_second_build_is_cache_hit() -> None:
     build_cli_reference_text()
     s1 = get_cli_reference_cache_stats()
     build_cli_reference_text()
@@ -23,17 +31,18 @@ def test_second_build_is_cache_hit() -> None:
 
 
 def test_invalidate_forces_rebuild_miss() -> None:
-    invalidate_cli_reference_cache()
     build_cli_reference_text()
     s1 = get_cli_reference_cache_stats()
+    assert s1["misses"] == 1
     invalidate_cli_reference_cache()
+    assert get_cli_reference_cache_stats()["misses"] == 0
     build_cli_reference_text()
     s2 = get_cli_reference_cache_stats()
-    assert s2["misses"] == s1["misses"] + 1
+    assert s2["misses"] == 1
+    assert s2["cached"] is True
 
 
 def test_signature_change_busts_cli_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    invalidate_cli_reference_cache()
     monkeypatch.setattr(cli_reference_module, "_current_cli_signature", lambda: "sig-a")
     build_cli_reference_text()
     monkeypatch.setattr(cli_reference_module, "_current_cli_signature", lambda: "sig-b")
@@ -41,3 +50,39 @@ def test_signature_change_busts_cli_cache(monkeypatch: pytest.MonkeyPatch) -> No
     stats = get_cli_reference_cache_stats()
     assert stats["misses"] >= 2
     assert stats["signature"] == "sig-b"
+
+
+def test_invalidate_resets_hit_miss_counters() -> None:
+    build_cli_reference_text()
+    build_cli_reference_text()
+    assert get_cli_reference_cache_stats()["hits"] >= 1
+    invalidate_cli_reference_cache()
+    s = get_cli_reference_cache_stats()
+    assert s["hits"] == 0
+    assert s["misses"] == 0
+
+
+def test_non_cacheable_short_output_skips_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli_reference_module,
+        "_build_cli_reference_text_uncached",
+        lambda: "too short",
+    )
+    build_cli_reference_text()
+    build_cli_reference_text()
+    stats = get_cli_reference_cache_stats()
+    assert stats["cached"] is False
+    assert stats["misses"] >= 2
+
+
+def test_non_cacheable_long_without_sentinel_skips_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filler = "x" * 120
+    monkeypatch.setattr(
+        cli_reference_module,
+        "_build_cli_reference_text_uncached",
+        lambda: filler,
+    )
+    build_cli_reference_text()
+    assert get_cli_reference_cache_stats()["cached"] is False

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -85,6 +85,8 @@ class TestDispatchSlash:
         output = buf.getvalue()
         assert "interactions" in output
         assert "trust mode" in output
+        assert "grounding cli cache" in output
+        assert "grounding docs cache" in output
 
     def test_unknown_command_does_not_exit(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_docs_reference.py
+++ b/tests/cli/interactive_shell/test_docs_reference.py
@@ -10,22 +10,23 @@ import pytest
 from app.cli.interactive_shell import docs_reference
 from app.cli.interactive_shell.docs_reference import (
     DocPage,
-    _discover_docs_cached,
     _excerpt,
     _query_tokens,
     build_docs_index,
     build_docs_reference_text,
     discover_docs,
     find_relevant_docs,
+    get_docs_cache_stats,
+    invalidate_docs_cache,
 )
 
 
 @pytest.fixture(autouse=True)
 def _clear_doc_cache() -> Iterator[None]:
     """Reset the per-process docs cache so each test sees a fresh tree."""
-    _discover_docs_cached.cache_clear()
+    invalidate_docs_cache()
     yield
-    _discover_docs_cached.cache_clear()
+    invalidate_docs_cache()
 
 
 def _write_doc(root: Path, relpath: str, content: str) -> None:
@@ -242,3 +243,32 @@ class TestDocPageDataclass:
         page = DocPage(slug="x", relpath="x.mdx", title="X", body="hello")
         # frozen dataclasses are hashable, so they can be stored in sets.
         assert page in {page}
+
+
+class TestDocsGroundingCache:
+    def test_repeated_discover_hits_parse_cache(self, tmp_path: Path) -> None:
+        _seed_docs(tmp_path)
+        discover_docs(tmp_path)
+        info1 = get_docs_cache_stats()
+        discover_docs(tmp_path)
+        info2 = get_docs_cache_stats()
+        assert info2["hits"] == info1["hits"] + 1
+        assert info2["misses"] == info1["misses"]
+
+    def test_file_edit_invalidates_and_refreshes_content(self, tmp_path: Path) -> None:
+        _write_doc(
+            tmp_path,
+            "datadog.mdx",
+            '---\ntitle: "Datadog"\n---\n\nOld content.\n',
+        )
+        pages1 = discover_docs(tmp_path)
+        assert any("Old content" in p.body for p in pages1)
+
+        datadog = tmp_path / "datadog.mdx"
+        datadog.write_text(
+            '---\ntitle: "Datadog"\n---\n\nNew refreshed content.\n',
+            encoding="utf-8",
+        )
+        pages2 = discover_docs(tmp_path)
+        assert any("New refreshed content" in p.body for p in pages2)
+        assert not any("Old content" in p.body for p in pages2)

--- a/tests/cli/interactive_shell/test_docs_reference.py
+++ b/tests/cli/interactive_shell/test_docs_reference.py
@@ -125,6 +125,11 @@ class TestQueryTokens:
         assert "opensre" not in tokens
         assert "install" in tokens
 
+    def test_keeps_two_letter_tokens(self) -> None:
+        tokens = _query_tokens("how do I tune ai vm sizing")
+        assert "ai" in tokens
+        assert "vm" in tokens
+
 
 class TestFindRelevantDocs:
     def test_empty_query_returns_empty(self, tmp_path: Path) -> None:
@@ -246,6 +251,10 @@ class TestDocPageDataclass:
 
 
 class TestDocsGroundingCache:
+    def test_cache_maxsize_matches_implementation(self) -> None:
+        stats = get_docs_cache_stats()
+        assert stats["maxsize"] == 32
+
     def test_repeated_discover_hits_parse_cache(self, tmp_path: Path) -> None:
         _seed_docs(tmp_path)
         discover_docs(tmp_path)
@@ -254,6 +263,17 @@ class TestDocsGroundingCache:
         info2 = get_docs_cache_stats()
         assert info2["hits"] == info1["hits"] + 1
         assert info2["misses"] == info1["misses"]
+
+    def test_invalidate_resets_stats(self, tmp_path: Path) -> None:
+        _seed_docs(tmp_path)
+        discover_docs(tmp_path)
+        discover_docs(tmp_path)
+        assert get_docs_cache_stats()["hits"] >= 1
+        invalidate_docs_cache()
+        cleared = get_docs_cache_stats()
+        assert cleared["hits"] == 0
+        assert cleared["misses"] == 0
+        assert cleared["currsize"] == 0
 
     def test_file_edit_invalidates_and_refreshes_content(self, tmp_path: Path) -> None:
         _write_doc(
@@ -272,3 +292,22 @@ class TestDocsGroundingCache:
         pages2 = discover_docs(tmp_path)
         assert any("New refreshed content" in p.body for p in pages2)
         assert not any("Old content" in p.body for p in pages2)
+
+    def test_single_tree_walk_per_discover_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: avoid a second full walk inside the parse path on a miss."""
+        _seed_docs(tmp_path)
+        calls = 0
+        real_iter = docs_reference._iter_doc_files
+
+        def _spy(root: Path) -> list[Path]:
+            nonlocal calls
+            calls += 1
+            return real_iter(root)
+
+        monkeypatch.setattr(docs_reference, "_iter_doc_files", _spy)
+        discover_docs(tmp_path)
+        assert calls == 1
+        discover_docs(tmp_path)
+        assert calls == 2

--- a/tests/cli/interactive_shell/test_grounding_diagnostics.py
+++ b/tests/cli/interactive_shell/test_grounding_diagnostics.py
@@ -1,0 +1,37 @@
+"""Tests for optional grounding-cache diagnostic logging."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
+
+
+def test_log_skips_when_tracer_verbose_unset(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("TRACER_VERBOSE", raising=False)
+    with caplog.at_level(logging.DEBUG):
+        log_grounding_cache_diagnostics("unit_test")
+    assert not caplog.records
+
+
+def test_log_skips_when_tracer_verbose_not_one(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("TRACER_VERBOSE", "0")
+    with caplog.at_level(logging.DEBUG):
+        log_grounding_cache_diagnostics("unit_test")
+    assert not caplog.records
+
+
+def test_log_emits_debug_when_tracer_verbose_on(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("TRACER_VERBOSE", "1")
+    with caplog.at_level(logging.DEBUG):
+        log_grounding_cache_diagnostics("unit_test_reason")
+    assert any("unit_test_reason" in r.message for r in caplog.records)
+    assert any("grounding cache" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
Fixes #1376

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Adds bounded caching for CLI and docs grounding in the interactive shell so procedural help turns skip full reference rebuilds when artifacts are still valid. Includes deterministic invalidation via docs path mtime/hash and CLI registry version bumps, optional debug diagnostics for grounding cache hit/miss, a benchmark for reference-building, and tests for cache correctness and freshness.

### Demo/Screenshot for feature changes and bug fixes -

N/A (CLI/runtime performance and observability; no UI change). Validation is via unit tests and `pytest` benchmark under `tests/benchmarks/interactive_shell/grounding_benchmark.py`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Caches grounding artifacts in-memory with keys derived from CLI registry version and docs discovery metadata (paths + mtimes/hashes) so stale content is rebuilt after file or registry changes. Diagnostics expose hit/miss for debugging latency. Benchmark covers the reference-build path; tests assert invalidation and cache hits.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist with the PR.
