### PR TITLE
refactor(cli): remove /stop placeholder; /tasks + /cancel canonical

### DIFF
--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -1,4 +1,4 @@
-"""Slash commands: /history, /tasks, /cancel, /stop."""
+"""Slash commands: /history, /tasks, /cancel."""
 
 from __future__ import annotations
 
@@ -127,15 +127,6 @@ def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool
     return True
 
 
-def _cmd_stop(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    console.print(
-        "[dim]in-flight work: press[/dim] [bold]Ctrl+C[/bold] "
-        "[dim]during a streaming investigation, or run[/dim] [bold]/tasks[/bold] "
-        "[dim]then[/dim] [bold]/cancel <id>[/bold] [dim]for background tasks.[/dim]"
-    )
-    return True
-
-
 COMMANDS: list[SlashCommand] = [
     SlashCommand("/history", "show persisted command history", _cmd_history),
     SlashCommand("/tasks", "list recent and in-flight shell tasks", _cmd_tasks),
@@ -143,11 +134,6 @@ COMMANDS: list[SlashCommand] = [
         "/cancel",
         "cancel a running task by id ('/cancel <task_id>' — see /tasks)",
         _cmd_cancel,
-    ),
-    SlashCommand(
-        "/stop",
-        "hints for stopping in-flight investigations and background tasks",
-        _cmd_stop,
     ),
 ]
 

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -891,16 +891,6 @@ class TestCompactCommand:
         assert "compacted" in buf.getvalue()
 
 
-class TestStopCommand:
-    def test_prints_stop_hints(self) -> None:
-        console, buf = _capture()
-        dispatch_slash("/stop", ReplSession(), console)
-        out = buf.getvalue()
-        assert "Ctrl+C" in out
-        assert "/tasks" in out
-        assert "/cancel" in out
-
-
 class TestCancelCommand:
     def test_usage_without_task_id(self) -> None:
         console, buf = _capture()

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -144,6 +144,21 @@ class TestSlashTaskCommands:
         assert "cancellation" in out.lower()
         assert "Ctrl+C" in out
 
+    def test_cancel_running_synthetic_signals_and_terminates_process(self) -> None:
+        session = ReplSession()
+        t = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+        t.mark_running()
+        proc = MagicMock()
+        proc.poll.return_value = None
+        t.attach_process(proc)
+        console, buf = _capture()
+        dispatch_slash(f"/cancel {t.task_id}", session, console)
+        assert t.cancel_requested.is_set()
+        proc.terminate.assert_called_once()
+        out = buf.getvalue()
+        assert "stop requested" in out.lower()
+        assert t.task_id in out
+
 
 class _ImmediateThread:
     """Run ``target`` synchronously inside ``start()`` (for deterministic tests)."""


### PR DESCRIPTION
Fixes #1380 

#### Describe the changes you have made in this PR -

Removes the `/stop` slash command - a placeholder UX path that printed help text but never operated on the task model. After this change, `/tasks` and `/cancel` are the only canonical control primitives, matching the lifecycle established by `TaskRegistry` and `TaskRecord`.

- Deleted `_cmd_stop` and its `SlashCommand` registration in app/cli/interactive_shell/command_registry/tasks_cmds.py
- Deleted `TestStopCommand` from tests/cli/interactive_shell/test_commands.py
- Added `test_cancel_running_synthetic_signals_and_terminates_process` in tests/cli/interactive_shell/test_tasks.py - validates that `/cancel` on a `SYNTHETIC_TEST` task signals cancellation and terminates the bound subprocess, giving symmetric dispatcher-boundary coverage alongside the existing investigation test

A broad audit of the codebase confirmed no other legacy in-memory control paths exist (no session counters, no global cancellation flags, no parallel cancel paths) - all four execution sites already create tasks and propagate `cancel_requested` events through the canonical task model.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue called for removing obsolete in-memory-only control paths now that `/tasks` and `/cancel` are established. After auditing the codebase, the only matching artifact was the `/stop` slash command - a leftover placeholder that printed Ctrl+C/`/cancel` hints but never touched `TaskRegistry`. There were no session counters, global flags, or parallel cancel paths to remove; the task model in app/cli/interactive_shell/tasks.py is already the single source of truth used by all four execution sites (free-text loop, `/investigate`, sample alert, synthetic test).

I considered preserving `/stop`'s discoverability hint by relocating the Ctrl+C text into `/cancel`'s no-arg usage, but rejected that as out of scope, the issue explicitly says to *remove* placeholder stop/cancel UX, not relocate it.

For testing, the existing `TaskRecord`-level state transition coverage is comprehensive. The one gap was a dispatcher-boundary test for synthetic-task `/cancel`: existing tests covered investigation kind through `dispatch_slash`, and synthetic kind only at the `TaskRecord` level. The new test closes that gap by asserting both the signal (`cancel_requested.is_set()`) and the cancellation outcome (`proc.terminate` called).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
