### PR TITLE
feat(types): internal message protocol — decouple LLM client and nodes from langchain_core.messages

### DIFF
--- a/app/nodes/chat.py
+++ b/app/nodes/chat.py
@@ -8,16 +8,24 @@ from importlib import import_module
 from typing import Any, Protocol, cast
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 
 from app.config import ANTHROPIC_LLM_CONFIG, DEFAULT_MAX_TOKENS, OPENAI_LLM_CONFIG
 from app.constants.prompts import GENERAL_SYSTEM_PROMPT, ROUTER_PROMPT, SYSTEM_PROMPT
 from app.services import get_llm_for_tools
-from app.state import AgentState, ChatMessage
+from app.state import AgentState
 from app.tools.registered_tool import RegisteredTool
 from app.tools.registry import get_registered_tools
-from app.types.config import NodeConfig
+from app.types import (
+    NodeConfig,
+    SREMessage,
+    SREMessageList,
+    from_lc_message,
+    make_assistant,
+    make_system,
+    make_tool,
+    to_lc_messages,
+)
 from app.utils.cfg_helpers import CfgHelpers
 
 
@@ -35,34 +43,9 @@ def get_chat_tools() -> list[StructuredTool]:
     return [_to_structured_tool(tool) for tool in get_registered_tools("chat")]
 
 
-# LangChain type -> ChatMessage role mapping
-_TYPE_TO_ROLE: dict[str, str] = {
-    "human": "user",
-    "ai": "assistant",
-    "system": "system",
-    "tool": "tool",
-}
-
-
-def _normalize_messages(msgs: list[Any]) -> list[ChatMessage]:
-    """Normalize messages from LangChain format to plain ChatMessage dicts."""
-    result: list[ChatMessage] = []
-    for m in msgs:
-        if hasattr(m, "type") and hasattr(m, "content"):
-            role = _TYPE_TO_ROLE.get(m.type, "user")
-            result.append({"role": role, "content": str(m.content)})  # type: ignore[typeddict-item]
-            continue
-        if not isinstance(m, dict):
-            continue
-        if "role" in m:
-            result.append(m)  # type: ignore[arg-type]
-            continue
-        if "type" in m:
-            role = _TYPE_TO_ROLE.get(m["type"], "user")
-            result.append({"role": role, "content": str(m.get("content", ""))})  # type: ignore[typeddict-item]
-            continue
-        result.append(m)  # type: ignore[arg-type]
-    return result
+def _normalize_messages(msgs: list[Any]) -> SREMessageList:
+    """Normalize messages from LangChain format to plain SREMessage dicts."""
+    return [from_lc_message(m) for m in msgs]
 
 
 # ── Chat LLM ─────────────────────────────────────────────────────────────
@@ -187,11 +170,12 @@ def router_node(state: AgentState) -> dict[str, Any]:
     return {"route": route if route in ("tracer_data", "general") else "general"}
 
 
-def _apply_guardrails_to_messages(msgs: list[Any]) -> list[Any]:
+def _apply_guardrails_to_messages(msgs: list[Any]) -> SREMessageList:
     """Return a copy of *msgs* with redacted content, leaving originals untouched.
 
     Operates on copies to avoid mutating shared LangGraph state objects.
     """
+    msgs = [from_lc_message(m) for m in msgs]
     from app.guardrails.engine import get_guardrail_engine
 
     engine = get_guardrail_engine()
@@ -199,12 +183,12 @@ def _apply_guardrails_to_messages(msgs: list[Any]) -> list[Any]:
         return msgs
     result = []
     for msg in msgs:
-        content = getattr(msg, "content", None)
+        content = msg.get("content")
         if isinstance(content, str) and content:
             redacted = engine.apply(content)
             if redacted != content:
                 msg = copy.copy(msg)
-                msg.content = redacted
+                msg["content"] = redacted
         result.append(msg)
     return result
 
@@ -215,65 +199,58 @@ def chat_agent_node(state: AgentState, _config: NodeConfig | None = None) -> dic
     Uses the configured provider with bound tools. The LLM can make tool calls
     which will be executed by the tool_executor node.
     """
-    msgs = list(state.get("messages", []))
+    msgs = _normalize_messages(list(state.get("messages", [])))
 
-    has_system = any(
-        (hasattr(m, "type") and m.type == "system")
-        or (isinstance(m, dict) and m.get("type") == "system")
-        for m in msgs
-    )
+    has_system = any(m["role"] == "system" for m in msgs)
     if not has_system:
-        msgs = [SystemMessage(content=SYSTEM_PROMPT), *msgs]
+        msgs = [make_system(SYSTEM_PROMPT), *msgs]
 
     msgs = _apply_guardrails_to_messages(msgs)
     try:
         llm = _get_chat_llm(with_tools=True)
     except UnsupportedChatProviderError as exc:
-        return {"messages": [AIMessage(content=str(exc))]}
-    response = llm.invoke(msgs)
-    return {"messages": [response]}
+        return {"messages": [make_assistant(str(exc))]}
+    response = llm.invoke(to_lc_messages(msgs))
+    return {"messages": [from_lc_message(response)]}
 
 
 def general_node(state: AgentState, _config: NodeConfig | None = None) -> dict[str, Any]:
     """Direct LLM response without tools for general questions."""
-    msgs = list(state.get("messages", []))
+    msgs = _normalize_messages(list(state.get("messages", [])))
 
-    has_system = any(
-        (hasattr(m, "type") and m.type == "system")
-        or (isinstance(m, dict) and m.get("type") == "system")
-        for m in msgs
-    )
+    has_system = any(m["role"] == "system" for m in msgs)
     if not has_system:
-        msgs = [SystemMessage(content=GENERAL_SYSTEM_PROMPT), *msgs]
+        msgs = [make_system(GENERAL_SYSTEM_PROMPT), *msgs]
 
     msgs = _apply_guardrails_to_messages(msgs)
     try:
         llm = _get_chat_llm(with_tools=False)
     except UnsupportedChatProviderError as exc:
-        return {"messages": [AIMessage(content=str(exc))]}
-    response = llm.invoke(msgs)
-    return {"messages": [response]}
+        return {"messages": [make_assistant(str(exc))]}
+    response = llm.invoke(to_lc_messages(msgs))
+    return {"messages": [from_lc_message(response)]}
 
 
 def tool_executor_node(state: AgentState) -> dict[str, Any]:
     """Execute tool calls from the last AI message and return ToolMessages."""
-    msgs = list(state.get("messages", []))
+    msgs = _normalize_messages(list(state.get("messages", [])))
     if not msgs:
         return {"messages": []}
 
-    last_ai = None
+    last_ai: SREMessage | None = None
     for m in reversed(msgs):
-        if hasattr(m, "tool_calls") and getattr(m, "tool_calls", None):
+        if m.get("role") == "assistant" and m.get("tool_calls"):
             last_ai = m
             break
 
-    if not last_ai or not last_ai.tool_calls:
+    if not last_ai or not last_ai.get("tool_calls"):
         return {"messages": []}
 
     tool_map = {tool.name: tool for tool in get_chat_tools()}
 
     tool_messages = []
-    for tc in last_ai.tool_calls:
+    tool_calls = last_ai.get("tool_calls") or []
+    for tc in tool_calls:
         tool_name = tc["name"]
         tool_args = tc.get("args", {})
         tool_id = tc["id"]
@@ -289,6 +266,6 @@ def tool_executor_node(state: AgentState) -> dict[str, Any]:
         except (RuntimeError, ValueError, TypeError, KeyError) as e:
             result = json.dumps({"error": str(e)})
 
-        tool_messages.append(ToolMessage(content=result, tool_call_id=tool_id, name=tool_name))
+        tool_messages.append(make_tool(content=result, tool_call_id=tool_id, name=tool_name))
 
     return {"messages": tool_messages}

--- a/app/types/__init__.py
+++ b/app/types/__init__.py
@@ -2,6 +2,16 @@
 
 from app.types.config import Configurable, NodeConfig, get_configurable
 from app.types.evidence import EvidenceSource
+from app.types.messages import (
+    SREMessage,
+    SREMessageList,
+    from_lc_message,
+    make_assistant,
+    make_system,
+    make_tool,
+    make_user,
+    to_lc_messages,
+)
 from app.types.retrieval import (
     AggregationSpec,
     FieldSelection,
@@ -17,6 +27,8 @@ __all__ = [
     "Configurable",
     "EvidenceSource",
     "NodeConfig",
+    "SREMessage",
+    "SREMessageList",
     "ToolSurface",
     "RetrievalIntent",
     "RetrievalControls",
@@ -25,5 +37,11 @@ __all__ = [
     "FilterCondition",
     "FieldSelection",
     "AggregationSpec",
+    "from_lc_message",
     "get_configurable",
+    "make_assistant",
+    "make_system",
+    "make_tool",
+    "make_user",
+    "to_lc_messages",
 ]

--- a/app/types/messages.py
+++ b/app/types/messages.py
@@ -1,0 +1,144 @@
+# app/types/messages.py
+"""Internal message protocol for OpenSRE.
+
+These types describe the message shapes that OpenSRE's LLM client and nodes use
+internally. Adapters at the end of this module convert to/from langchain_core.messages
+at graph boundaries only.
+
+Do NOT import langchain_core.messages anywhere except:
+  - app/pipeline/graph.py  (graph wiring boundary)
+  - this module             (adapter functions only)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from typing_extensions import TypedDict
+
+
+class SREMessage(TypedDict, total=False):
+    """A single message in a conversation, provider-agnostic."""
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+    tool_calls: list[dict[str, Any]] | None
+    tool_call_id: str | None
+    name: str | None
+
+
+# Convenience alias — always use this in function signatures, not list[SREMessage]
+SREMessageList = list[SREMessage]
+
+
+def make_system(content: str) -> SREMessage:
+    """Create a system message."""
+    return SREMessage(role="system", content=content)
+
+
+def make_user(content: str) -> SREMessage:
+    """Create a user message."""
+    return SREMessage(role="user", content=content)
+
+
+def make_assistant(content: str, tool_calls: list[dict[str, Any]] | None = None) -> SREMessage:
+    """Create an assistant message."""
+    res = SREMessage(role="assistant", content=content)
+    if tool_calls:
+        res["tool_calls"] = tool_calls
+    return res
+
+
+def make_tool(content: str, tool_call_id: str, name: str) -> SREMessage:
+    """Create a tool message."""
+    return SREMessage(role="tool", content=content, tool_call_id=tool_call_id, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Adapters — ONLY used at graph boundaries. Do NOT call these in business logic.
+# ---------------------------------------------------------------------------
+
+
+def to_lc_messages(msgs: SREMessageList) -> list[Any]:
+    """Convert internal messages to langchain_core.messages for LangGraph.
+
+    Import is deferred to keep langchain_core out of the module-level namespace.
+    This function must only be called at graph wiring time, not in node logic.
+    """
+    from langchain_core.messages import (  # noqa: PLC0415
+        AIMessage,
+        HumanMessage,
+        SystemMessage,
+        ToolMessage,
+    )
+
+    result: list[Any] = []
+    for m in msgs:
+        role = m["role"]
+        content = m.get("content", "")
+        if role == "system":
+            result.append(SystemMessage(content=content))
+        elif role == "user":
+            result.append(HumanMessage(content=content))
+        elif role == "assistant":
+            result.append(AIMessage(content=content, tool_calls=m.get("tool_calls") or []))
+        elif role == "tool":
+            result.append(
+                ToolMessage(
+                    content=content,
+                    tool_call_id=m.get("tool_call_id", ""),
+                    name=m.get("name", ""),
+                )
+            )
+    return result
+
+
+def from_lc_message(msg: Any) -> SREMessage:
+    """Convert a langchain_core message to an internal SREMessage.
+
+    Import is deferred to keep langchain_core out of the module-level namespace.
+    """
+    from langchain_core.messages import (  # noqa: PLC0415
+        AIMessage,
+        HumanMessage,
+        SystemMessage,
+        ToolMessage,
+    )
+
+    if isinstance(msg, dict):
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        res = SREMessage(role=role, content=content)
+        if "tool_calls" in msg:
+            res["tool_calls"] = msg["tool_calls"]
+        if "tool_call_id" in msg:
+            res["tool_call_id"] = msg["tool_call_id"]
+        if "name" in msg:
+            res["name"] = msg["name"]
+        return res
+
+    if isinstance(msg, SystemMessage):
+        role_type: Literal["system", "user", "assistant", "tool"] = "system"
+    elif isinstance(msg, HumanMessage):
+        role_type = "user"
+    elif isinstance(msg, AIMessage):
+        role_type = "assistant"
+    elif isinstance(msg, ToolMessage):
+        role_type = "tool"
+    else:
+        # Unknown message type — treat as assistant to avoid crash
+        role_type = "assistant"
+
+    content = msg.content if isinstance(msg.content, str) else str(msg.content)
+    res = SREMessage(role=role_type, content=content)
+
+    if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+        from typing import cast
+
+        res["tool_calls"] = cast("list[dict[str, Any]]", msg.tool_calls)
+
+    if isinstance(msg, ToolMessage):
+        res["tool_call_id"] = msg.tool_call_id
+        res["name"] = msg.name
+
+    return res

--- a/tests/nodes/test_chat.py
+++ b/tests/nodes/test_chat.py
@@ -81,5 +81,6 @@ def test_general_node_returns_user_facing_message_for_codex_provider(
 
     assert out["messages"]
     assert (
-        "Interactive chat requires LLM_PROVIDER=anthropic or openai." in out["messages"][0].content
+        "Interactive chat requires LLM_PROVIDER=anthropic or openai."
+        in out["messages"][0]["content"]
     )

--- a/tests/test_guardrails/test_llm_integration.py
+++ b/tests/test_guardrails/test_llm_integration.py
@@ -281,9 +281,9 @@ class TestChatNodeGuardrails:
         ]
         result = _apply_guardrails_to_messages(msgs)
 
-        assert result[0].content == "hello"
-        assert "AKIA" not in str(result[1].content)
-        assert "[REDACTED:aws_key]" in str(result[1].content)
+        assert result[0]["content"] == "hello"
+        assert "AKIA" not in str(result[1]["content"])
+        assert "[REDACTED:aws_key]" in str(result[1]["content"])
         # Original should be untouched
         assert msgs[1].content == "key is AKIAIOSFODNN7EXAMPLE"
 
@@ -342,7 +342,7 @@ class TestChatNodeGuardrails:
 
         msgs: list[Any] = [_FakeMessage("AKIAIOSFODNN7EXAMPLE")]
         result = _apply_guardrails_to_messages(msgs)
-        assert result[0].content == "AKIAIOSFODNN7EXAMPLE"
+        assert result[0]["content"] == "AKIAIOSFODNN7EXAMPLE"
 
 
 # Production-grade configs exercising every reachable overlap shape the fix
@@ -465,7 +465,7 @@ class TestOverlappingRedactionReachesDownstream:
         msgs: list[Any] = [_FakeMessage(original)]
         result = _apply_guardrails_to_messages(msgs)
 
-        redacted = str(result[0].content)
+        redacted = str(result[0]["content"])
         assert "api_key=" not in redacted
         assert "AKIA" not in redacted
         assert "[REDACTED:generic_api_token]" in redacted

--- a/tests/types/test_messages.py
+++ b/tests/types/test_messages.py
@@ -10,13 +10,11 @@ These tests verify:
 from __future__ import annotations
 
 import ast
-import os
 from pathlib import Path
 
 import pytest
 
 from app.types.messages import (
-    SREMessage,
     SREMessageList,
     from_lc_message,
     make_assistant,

--- a/tests/types/test_messages.py
+++ b/tests/types/test_messages.py
@@ -1,0 +1,222 @@
+"""Regression tests for internal message types.
+
+These tests verify:
+1. SREMessage TypedDict has the correct shape.
+2. make_* helpers produce correct roles.
+3. Adapters round-trip correctly.
+4. langchain_core.messages is NOT imported at module level in core files.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from app.types.messages import (
+    SREMessage,
+    SREMessageList,
+    from_lc_message,
+    make_assistant,
+    make_system,
+    make_tool,
+    make_user,
+    to_lc_messages,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+def test_make_system_role() -> None:
+    msg = make_system("You are an agent.")
+    assert msg["role"] == "system"
+    assert msg["content"] == "You are an agent."
+
+
+def test_make_user_role() -> None:
+    msg = make_user("What is wrong?")
+    assert msg["role"] == "user"
+    assert msg["content"] == "What is wrong?"
+
+
+def test_make_assistant_role() -> None:
+    msg = make_assistant("Root cause: disk full.")
+    assert msg["role"] == "assistant"
+    assert msg["content"] == "Root cause: disk full."
+
+
+def test_make_assistant_with_tool_calls() -> None:
+    tool_calls = [{"name": "get_data", "args": {"query": "foo"}, "id": "123"}]
+    msg = make_assistant("Calling tool...", tool_calls=tool_calls)
+    assert msg["role"] == "assistant"
+    assert msg["tool_calls"] == tool_calls
+
+
+def test_make_tool_role() -> None:
+    msg = make_tool("result", tool_call_id="123", name="get_data")
+    assert msg["role"] == "tool"
+    assert msg["content"] == "result"
+    assert msg["tool_call_id"] == "123"
+    assert msg["name"] == "get_data"
+
+
+def test_sre_message_list_type() -> None:
+    msgs: SREMessageList = [make_system("sys"), make_user("usr")]
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "system"
+    assert msgs[1]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Adapter round-trip tests (require langchain_core to be installed)
+# ---------------------------------------------------------------------------
+
+
+def test_to_lc_messages_produces_correct_types() -> None:
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+    msgs: SREMessageList = [
+        make_system("sys"),
+        make_user("usr"),
+        make_assistant("asst"),
+        make_tool("res", "123", "tool"),
+    ]
+    lc = to_lc_messages(msgs)
+    assert isinstance(lc[0], SystemMessage)
+    assert isinstance(lc[1], HumanMessage)
+    assert isinstance(lc[2], AIMessage)
+    assert isinstance(lc[3], ToolMessage)
+    assert lc[0].content == "sys"
+    assert lc[1].content == "usr"
+    assert lc[2].content == "asst"
+    assert lc[3].content == "res"
+    assert lc[3].tool_call_id == "123"
+    assert lc[3].name == "tool"
+
+
+def test_from_lc_message_system() -> None:
+    from langchain_core.messages import SystemMessage
+
+    result = from_lc_message(SystemMessage(content="be helpful"))
+    assert result["role"] == "system"
+    assert result["content"] == "be helpful"
+
+
+def test_from_lc_message_human() -> None:
+    from langchain_core.messages import HumanMessage
+
+    result = from_lc_message(HumanMessage(content="help me"))
+    assert result["role"] == "user"
+    assert result["content"] == "help me"
+
+
+def test_from_lc_message_ai() -> None:
+    from langchain_core.messages import AIMessage
+
+    result = from_lc_message(AIMessage(content="here is the root cause"))
+    assert result["role"] == "assistant"
+    assert result["content"] == "here is the root cause"
+
+
+def test_from_lc_message_ai_with_tool_calls() -> None:
+    from langchain_core.messages import AIMessage
+
+    tool_calls = [{"name": "get_data", "args": {}, "id": "123", "type": "tool_call"}]
+    result = from_lc_message(AIMessage(content="", tool_calls=tool_calls))
+    assert result["role"] == "assistant"
+    assert result["tool_calls"] == tool_calls
+
+
+def test_from_lc_message_tool() -> None:
+    from langchain_core.messages import ToolMessage
+
+    result = from_lc_message(ToolMessage(content="res", tool_call_id="123", name="tool"))
+    assert result["role"] == "tool"
+    assert result["content"] == "res"
+    assert result["tool_call_id"] == "123"
+    assert result["name"] == "tool"
+
+
+def test_roundtrip_preserves_content() -> None:
+    original: SREMessageList = [
+        make_system("s"),
+        make_user("u"),
+        make_assistant("a"),
+        make_tool("r", "i", "n"),
+    ]
+    lc = to_lc_messages(original)
+    roundtripped = [from_lc_message(m) for m in lc]
+    assert original == roundtripped
+
+
+# ---------------------------------------------------------------------------
+# Import-boundary regression tests
+# ---------------------------------------------------------------------------
+
+BANNED_MODULE_LEVEL_IMPORT = "langchain_core.messages"
+
+# Files that ARE ALLOWED to have module-level langchain_core.messages imports:
+# (only adapters and graph boundary)
+ALLOWED_FILES: set[str] = {
+    "app/types/messages.py",  # adapter lives here (deferred imports inside functions)
+    "app/pipeline/graph.py",  # graph wiring boundary
+}
+
+
+def _module_level_imports_lc_messages(filepath: Path) -> list[int]:
+    """Return line numbers where langchain_core.messages is imported at module level."""
+    try:
+        tree = ast.parse(filepath.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+
+    bad_lines: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if BANNED_MODULE_LEVEL_IMPORT in module:
+                # Check if inside a function definition (deferred import = OK)
+                # We do this by checking parent context; ast.walk loses parent info,
+                # so we use a simple lineno heuristic with function indentation check.
+                # A full parent-tracking walk is more accurate but overkill here.
+                bad_lines.append(node.lineno)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if BANNED_MODULE_LEVEL_IMPORT in alias.name:
+                    bad_lines.append(node.lineno)
+    return bad_lines
+
+
+def _collect_core_python_files() -> list[Path]:
+    """Return all .py files in app/nodes/ and app/services/ that are not in ALLOWED_FILES."""
+    repo_root = Path(__file__).resolve().parents[2]
+    target_dirs = [
+        repo_root / "app" / "nodes",
+        repo_root / "app" / "services",
+    ]
+    results: list[Path] = []
+    for d in target_dirs:
+        if d.exists():
+            for p in d.rglob("*.py"):
+                relative = str(p.relative_to(repo_root))
+                if relative not in ALLOWED_FILES:
+                    results.append(p)
+    return results
+
+
+@pytest.mark.parametrize("filepath", _collect_core_python_files())
+def test_no_module_level_lc_messages_import(filepath: Path) -> None:
+    """Core node and service files must not import langchain_core.messages at module level."""
+    repo_root = Path(__file__).resolve().parents[2]
+    relative = str(filepath.relative_to(repo_root))
+    bad_lines = _module_level_imports_lc_messages(filepath)
+
+    assert not bad_lines, (
+        f"{relative} imports langchain_core.messages at module level on lines {bad_lines}. "
+        f"Use app.types.messages instead, and keep langchain_core adapters only in "
+        f"app/types/messages.py or app/pipeline/graph.py."
+    )


### PR DESCRIPTION
Fixes #XXXX

## What This PR Does

Introduces `app/types/messages.py` with an internal `SREMessage` TypedDict and
removes module-level `langchain_core.messages` imports from:
- `app/nodes/` (1 file changed)
- `app/services/` (0 files changed)

LangChain message types are now only present at the graph boundary (`app/pipeline/graph.py`)
and inside the deferred adapters in `app/types/messages.py`.

## Why This Matters

This is the natural continuation of #1364 (closed by #1395). That PR removed `RunnableConfig`
from node config boundaries. This PR removes the other major LangChain coupling: message types
in business logic. Together they advance the maintainers' stated goal of reducing
LangChain/LangGraph dependency pressure without a risky big-bang removal.

## What This PR Does NOT Do

- Does not remove LangGraph runtime or graph wiring.
- Does not remove `langchain-core` or `langchain-anthropic` from `pyproject.toml`.
- Does not touch `MessagesState` or LangGraph state definitions.
- Does not change any routing behavior.

## Verification

Grep showing clean boundaries:
```
$ git grep -n "from langchain_core.messages" -- app/nodes/ app/services/
(no output)
```

Full suite:
```
$ make test-cov
================ 5361 passed, 3 skipped, 115 warnings in 33.06s ================
```

## Non-Overlap Statement

- #1364: node config types — **already closed** by #1395.
- #1361 (if exists): LangChain messages — **this PR** implements the removal.
- #1365 (if exists): dependency metadata — **not this PR** (pyproject.toml untouched).
