### PR TITLE
fix(installer): glibc precheck + preserve binary on smoke-test failure (#1284)

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -4,6 +4,18 @@ slug: "quickstart"
 ---
 
 <Steps>
+  <Step title="Requirements">
+    OpenSRE runs on macOS, Linux, and Windows. The Linux release currently requires **glibc 2.38 or newer**.
+
+    | Platform | Supported |
+    |---|---|
+    | macOS | Any recent version |
+    | Linux | Ubuntu 24.04+, Fedora 39+, Amazon Linux 2023+, Arch / rolling distros (recent) |
+    | Windows | Windows 10+ |
+
+    On older Linux (Ubuntu 22.04, Debian 11/12, RHEL/CentOS 8, Amazon Linux 2), the curl one-liner will print the supported-OS list and exit cleanly. Track [issue #1284](https://github.com/Tracer-Cloud/opensre/issues/1284) for the planned `manylinux_2_28` rebuild that lowers this floor.
+  </Step>
+
   <Step title="Install OpenSRE">
     <Tabs>
       <Tab title="macOS / Linux">

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,8 @@ INSTALL_DIR_OVERRIDE=0
 INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-release}"
 BIN_NAME="opensre"
 INSTALL_WITH_SUDO=0
+SMOKE_TEST_FAILED=0
+PRESERVED_BINARY_PATH=""
 requested_version="${OPENSRE_VERSION:-}"
 
 [ -n "$INSTALL_DIR" ] && INSTALL_DIR_OVERRIDE=1
@@ -481,6 +483,14 @@ verify_binary_version() {
   local actual_version
 
   if ! version_output="$("$binary_path" --version 2>&1)"; then
+    SMOKE_TEST_FAILED=1
+    PRESERVED_BINARY_PATH="${HOME}/.opensre/failed-install/${BIN_NAME}"
+    if mkdir -p "${PRESERVED_BINARY_PATH%/*}" 2>/dev/null && cp "$binary_path" "$PRESERVED_BINARY_PATH" 2>/dev/null; then
+      die "Failed to execute '${binary_path##*/} --version': ${version_output}
+The downloaded binary has been preserved at ${PRESERVED_BINARY_PATH} for debugging.
+On Linux, run 'ldd ${PRESERVED_BINARY_PATH}' to inspect missing libraries.
+See https://github.com/${REPO}/issues/1284 for the most common cause (glibc < 2.38)."
+    fi
     die "Failed to execute '${binary_path##*/} --version': ${version_output}"
   fi
 
@@ -508,6 +518,54 @@ verify_binary_version() {
       printf '%s\n' "$actual_version"
       ;;
   esac
+}
+
+check_glibc_floor() {
+  # Linux-only: verify glibc version is at or above the published floor.
+  # Returns silently if check is not applicable or passes; dies with a clear
+  # message and supported-OS list if the floor is not met.
+  [ "${platform:-}" = "linux" ] || return 0
+  command -v ldd >/dev/null 2>&1 || return 0
+
+  local ldd_output detected_version detected_major detected_minor
+  local required_major=2 required_minor=38
+
+  ldd_output="$(ldd --version 2>&1 | head -n 1 || true)"
+  detected_version="$(printf '%s\n' "$ldd_output" | sed -n 's/.*[^0-9.]\([0-9]\+\.[0-9]\+\).*/\1/p' | head -n 1)"
+  [ -n "$detected_version" ] || return 0
+
+  detected_major="${detected_version%.*}"
+  detected_minor="${detected_version#*.}"
+
+  # Pass if detected >= required
+  if [ "$detected_major" -gt "$required_major" ]; then
+    return 0
+  fi
+  if [ "$detected_major" -eq "$required_major" ] && [ "$detected_minor" -ge "$required_minor" ]; then
+    return 0
+  fi
+
+  cat >&2 <<EOF
+Error: detected glibc ${detected_version}, but the OpenSRE Linux release requires glibc ${required_major}.${required_minor} or newer.
+
+Supported Linux distributions (glibc >= 2.38):
+  - Ubuntu 24.04+
+  - Fedora 39+
+  - Amazon Linux 2023
+  - Arch / rolling distros (recent)
+
+Affected distributions (glibc < 2.38):
+  - Ubuntu 22.04 / 20.04
+  - Debian 11 / 12
+  - RHEL / CentOS 8 family
+  - Amazon Linux 2
+
+Workarounds:
+  1. Upgrade to a supported distribution.
+  2. Install from source. see https://github.com/${REPO}/blob/main/docs/development.md
+  3. Track https://github.com/${REPO}/issues/1284 for the manylinux_2_28 rebuild that lowers this floor.
+EOF
+  exit 1
 }
 
 configure_path() {
@@ -636,6 +694,8 @@ case "$arch" in
     ;;
 esac
 
+check_glibc_floor
+
 resolve_install_dir
 
 version="$requested_version"
@@ -712,6 +772,9 @@ need_cmd mktemp
 tmp_dir="$(mktemp -d)"
 
 cleanup() {
+  if [ "$SMOKE_TEST_FAILED" -eq 1 ] && [ -n "$PRESERVED_BINARY_PATH" ] && [ -e "$PRESERVED_BINARY_PATH" ]; then
+    printf 'Smoke test failed. Binary preserved at: %s\n' "$PRESERVED_BINARY_PATH" >&2
+  fi
   if [ -n "${tmp_dir:-}" ] && [ -d "$tmp_dir" ]; then
     rm -rf "$tmp_dir"
   fi

--- a/install.sh
+++ b/install.sh
@@ -482,8 +482,12 @@ verify_binary_version() {
   local actual_version
 
   if ! version_output="$("$binary_path" --version 2>&1)"; then
-    PRESERVED_BINARY_PATH="${HOME}/.opensre/failed-install/${BIN_NAME}"
-    if mkdir -p "${PRESERVED_BINARY_PATH%/*}" 2>/dev/null && cp "$binary_path" "$PRESERVED_BINARY_PATH" 2>/dev/null; then
+    # Stage the target path locally; only promote to the global
+    # PRESERVED_BINARY_PATH after the copy actually succeeds, so callers don't
+    # see a path pointing to a file that was never written.
+    local _preserve_target="${HOME}/.opensre/failed-install/${BIN_NAME}"
+    if mkdir -p "${_preserve_target%/*}" 2>/dev/null && cp "$binary_path" "$_preserve_target" 2>/dev/null; then
+      PRESERVED_BINARY_PATH="$_preserve_target"
       die "Failed to execute '${binary_path##*/} --version': ${version_output}
 The downloaded binary has been preserved at ${PRESERVED_BINARY_PATH} for debugging.
 On Linux, run 'ldd ${PRESERVED_BINARY_PATH}' to inspect missing libraries.
@@ -518,6 +522,39 @@ See https://github.com/${REPO}/issues/1284 for the most common cause (glibc < 2.
   esac
 }
 
+print_success_screen() {
+  local version="$1"
+  local sep="────────────────────────────────────────────"
+
+  if [ ! -t 1 ]; then
+    sep="--------------------------------------------"
+  fi
+
+  log ""
+  log "$sep"
+  success "Welcome to OpenSRE"
+  if [ "$version" = "main" ]; then
+    log "  ${COLOR_BOLD:-}opensre (main build) installed successfully${COLOR_RESET:-}"
+  else
+    log "  ${COLOR_BOLD:-}opensre v${version} installed successfully${COLOR_RESET:-}"
+  fi
+  log "$sep"
+  log ""
+  log "Next steps:"
+  log "  1. Run  ${BIN_NAME:-opensre} onboard"
+  log "     Set up your LLM provider and add your observability integrations."
+  log ""
+  log "  2. Run  ${BIN_NAME:-opensre}  (no subcommand)"
+  log "     From a normal interactive terminal this starts the interactive shell — type a"
+  log "     prompt or incident description at the prompt to investigate."
+  log ""
+  log "  3. Optional — one-shot RCA from a file:"
+  log "     ${BIN_NAME:-opensre} investigate -i path/to/alert.json"
+  log ""
+  log "Docs: https://www.opensre.com/docs"
+  log ""
+}
+
 check_glibc_floor() {
   # Linux-only: verify glibc version is at or above the published floor.
   # Returns silently if check is not applicable or passes; dies with a clear
@@ -529,6 +566,16 @@ check_glibc_floor() {
   local required_major=2 required_minor=38
 
   ldd_output="$(ldd --version 2>&1 | head -n 1 || true)"
+
+  # Skip the check on musl-based systems (e.g. Alpine ships ldd as a musl
+  # symlink that emits "musl libc ... Version 1.2.4"). The greedy version
+  # extract below would otherwise pull "2.4" from "1.2.4" and fail with a
+  # misleading glibc-version error. A glibc-built binary won't run on musl
+  # anyway, but that's a separate failure mode the binary itself surfaces.
+  case "$ldd_output" in
+    *musl*|*MUSL*) return 0 ;;
+  esac
+
   detected_version="$(printf '%s\n' "$ldd_output" | sed -n 's/.*[^0-9.]\([0-9]\+\.[0-9]\+\).*/\1/p' | head -n 1)"
   [ -n "$detected_version" ] || return 0
 
@@ -825,6 +872,4 @@ else
 fi
 
 configure_path
-
-log ""
-log "Next: run 'opensre onboard' to complete setup."
+print_success_screen "$installed_version"

--- a/install.sh
+++ b/install.sh
@@ -708,8 +708,6 @@ print_success_screen() {
   log ""
 }
 
-=======
->>>>>>> 9739c266 (address greptile feedback: drop duplicate preserved-path message + dead SMOKE_TEST_FAILED)
 os="$(uname -s)"
 arch="$(uname -m)"
 

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,6 @@ INSTALL_DIR_OVERRIDE=0
 INSTALL_CHANNEL="${OPENSRE_INSTALL_CHANNEL:-release}"
 BIN_NAME="opensre"
 INSTALL_WITH_SUDO=0
-SMOKE_TEST_FAILED=0
 PRESERVED_BINARY_PATH=""
 requested_version="${OPENSRE_VERSION:-}"
 
@@ -483,7 +482,6 @@ verify_binary_version() {
   local actual_version
 
   if ! version_output="$("$binary_path" --version 2>&1)"; then
-    SMOKE_TEST_FAILED=1
     PRESERVED_BINARY_PATH="${HOME}/.opensre/failed-install/${BIN_NAME}"
     if mkdir -p "${PRESERVED_BINARY_PATH%/*}" 2>/dev/null && cp "$binary_path" "$PRESERVED_BINARY_PATH" 2>/dev/null; then
       die "Failed to execute '${binary_path##*/} --version': ${version_output}
@@ -629,6 +627,7 @@ configure_path() {
   log "Or open a new terminal."
 }
 
+<<<<<<< HEAD
 print_success_screen() {
   local version="$1"
   local sep="────────────────────────────────────────────"
@@ -662,6 +661,8 @@ print_success_screen() {
   log ""
 }
 
+=======
+>>>>>>> 9739c266 (address greptile feedback: drop duplicate preserved-path message + dead SMOKE_TEST_FAILED)
 os="$(uname -s)"
 arch="$(uname -m)"
 
@@ -772,9 +773,9 @@ need_cmd mktemp
 tmp_dir="$(mktemp -d)"
 
 cleanup() {
-  if [ "$SMOKE_TEST_FAILED" -eq 1 ] && [ -n "$PRESERVED_BINARY_PATH" ] && [ -e "$PRESERVED_BINARY_PATH" ]; then
-    printf 'Smoke test failed. Binary preserved at: %s\n' "$PRESERVED_BINARY_PATH" >&2
-  fi
+  # Note: when verify_binary_version dies after a successful preserve copy, its
+  # die() call already names the preserved path in the user-facing error, so we
+  # do not re-print it here (greptile flagged the duplicate on PR #1408).
   if [ -n "${tmp_dir:-}" ] && [ -d "$tmp_dir" ]; then
     rm -rf "$tmp_dir"
   fi
@@ -824,4 +825,6 @@ else
 fi
 
 configure_path
-print_success_screen "$installed_version"
+
+log ""
+log "Next: run 'opensre onboard' to complete setup."


### PR DESCRIPTION
Closes #1284 (sub-fixes #2, #3, #4 from the issue body).

#### Describe the changes you have made in this PR -

Sub-fixes #2 and #3 land in `install.sh`:
- new `check_glibc_floor()` runs after platform detection, before download. Linux-only. Reads `ldd --version`, exits cleanly with the supported-OS list if glibc < 2.38. Returns silently if `ldd` is missing so this never breaks a working install.
- `verify_binary_version` preserves the binary at `~/.opensre/failed-install/opensre` on smoke-test failure and points the user at it plus a `ldd` debug hint. The `cleanup` trap logs the preserved path before removing the temp dir.

Sub-fix #4 lands in `docs/quickstart.mdx`:
- new Requirements step before Install OpenSRE, lists supported platforms in a table, links to #1284 for the planned manylinux rebuild.

Sub-fix #1 (rebuild release in `manylinux_2_28`) is intentionally out of scope here. it needs CI/release-pipeline access. Flagged separately in the issue.

### Demo/Screenshot for feature changes and bug fixes - 

Local validation:
- `bash -n install.sh`: clean
- `check_glibc_floor` extracted and run on Ubuntu 22.04 (glibc 2.35): produces the expected supported/affected OS list and exits 1
- the smoke-test preserve path is exercised via the existing `--version` die path, no new call sites

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The fix is three small additions to install.sh and one new docs section:

1. Two new globals at the top (`SMOKE_TEST_FAILED`, `PRESERVED_BINARY_PATH`) used by the smoke-test preserve and cleanup paths.
2. A new `check_glibc_floor` function called after platform/arch detection. Linux-only, reads `ldd --version`, parses major.minor, compares to required 2.38, prints supported/affected OS list and exits 1 if below. Returns silently when `ldd` isn't available so non-glibc systems aren't broken.
3. The existing `verify_binary_version` `die` path is augmented to copy the binary to `~/.opensre/failed-install/` before dying, and the user-facing error message now includes the preserved path plus a `ldd` debug hint.
4. The `cleanup` trap reads `SMOKE_TEST_FAILED` and prints the preserved path before removing the temp dir.

Considered alternatives: detect glibc by parsing `/lib/x86_64-linux-gnu/libc.so.6` directly (more brittle), or skip the floor check entirely and let pyinstaller fail (worse UX). The `ldd --version` approach matches what the binary already needs and what's available on every relevant distro.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

cc @VaibhavUpreti @muddlebee