### PR TITLE
tests(synthetic/rds_postgres): add axis-memory scaffold for #1234

### DIFF
--- a/tests/synthetic/rds_postgres/axis_memory/README.md
+++ b/tests/synthetic/rds_postgres/axis_memory/README.md
@@ -1,0 +1,128 @@
+# Axis-memory test scaffold
+
+Synthetic-suite scaffold for evaluating memory anchoring in OpenSRE
+investigations. Pairs with [issue #1234 (Contextual Memory)][issue-1234].
+
+## What this is
+
+The `tests/synthetic/rds_postgres/` suite already covers a single
+investigation per scenario in isolation. This scaffold adds a second axis
+on top of that: pairs of scenarios that share an external alert signature
+(same `alertname`, same `commonLabels`) but resolve to different
+ground-truth outcomes.
+
+The intent is to test what happens when a memory layer (#1234) is primed
+from the first investigation in a pair and the second is run on top of it.
+If memory makes the planner skip exploratory steps that the second
+scenario needs, the planner's pass-rate on the sibling drops. That is the
+anchoring failure mode the team flagged in the #1234 thread.
+
+## Why pairs and not single cases
+
+Memory anchoring is a cross-investigation effect. A single scenario can
+only test whether the planner is rigorous against red herrings within one
+trajectory. Anchoring needs at least two runs that share an alert
+signature so the priming-from-history step is observable.
+
+The pairs are configured in [`pairs.yml`](./pairs.yml). The current set:
+
+| pair id                                  | shared alertname              | base                                      | sibling                                     | what memory might break                              |
+| ---------------------------------------- | ----------------------------- | ----------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
+| `connection-pressure-real-vs-noisy`      | `RDSDatabaseConnectionsHigh`  | `002-connection-exhaustion`               | `007-connection-pressure-noisy-healthy`     | category divergence: real fault vs healthy           |
+| `cpu-bad-query-vs-checkpoint-storm`      | `RDSCPUUtilizationHigh`       | `004-cpu-saturation-bad-query`            | `014-checkpoint-storm-cpu-saturation`       | sub-flavour divergence: bad-query vs checkpoint storm |
+| `replication-lag-vs-cpu-redherring`      | `RDSReplicationLagHigh`       | `001-replication-lag`                     | `006-replication-lag-cpu-redherring`        | red-herring discipline weakened by prior clean diagnosis |
+
+The strongest pair is `connection-pressure-real-vs-noisy` because the two
+scenarios resolve to different `root_cause_category` values
+(`resource_exhaustion` vs `healthy`). The other two pairs share a category
+and exercise sub-flavour distinctions.
+
+## How it runs today
+
+```
+python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory
+```
+
+Today this runs each `sibling` scenario without memory primed and emits a
+`memory_mode=not_run` annotation per pair. That's the baseline correctness
+check: every active pair should have its sibling pass on its own. If a
+sibling fails baseline, the failure is not a memory-anchoring effect and
+should be triaged before any memory work.
+
+```
+python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory --json
+python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory --pair connection-pressure-real-vs-noisy
+```
+
+`--json` emits the full annotation list for downstream consumption.
+`--pair` runs only the named pair.
+
+## How it runs once Contextual Memory ships
+
+When #1234 lands a memory layer, the runner gains memory mode:
+
+```
+python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory --memory
+```
+
+In memory mode the runner:
+
+1. runs `base`, captures the investigation memory output
+2. injects that memory into `sibling`'s investigation context
+3. runs `sibling` and scores it
+4. compares the memory-primed score to the baseline score
+5. classifies the pair as `memory_helped`, `memory_hurt`, `memory_neutral`,
+   or `pre_existing` (baseline already failed)
+
+The classifier lives in [`scoring.py`](./scoring.py) and is already wired
+in. The only piece waiting on #1234 is the actual memory-injection step
+(`_run_with_memory` in `run_axis_memory.py`). It currently raises
+`NotImplementedError` rather than silently degrading to baseline.
+
+## Memory-mode classification
+
+| mode             | baseline `sibling` | memory-primed `sibling` | reading                                                   |
+| ---------------- | ------------------ | ----------------------- | --------------------------------------------------------- |
+| `memory_neutral` | pass               | pass                    | safe; memory did not change the outcome                   |
+| `memory_hurt`    | pass               | fail                    | regression caused by memory; flag before shipping memory  |
+| `memory_helped`  | fail               | pass                    | memory recovered a baseline failure (uncommon, audit it)  |
+| `pre_existing`   | fail               | fail                    | sibling fails on its own; not memory-attributable         |
+| `not_run`        | any                | not exercised           | memory mode disabled (today's default)                    |
+
+`memory_hurt` is the signal we care about. Any non-zero count there is a
+candidate for blocking #1234 Phase 1 ship until the planner's anchoring is
+mitigated.
+
+## Adding a new pair
+
+1. Identify two existing scenarios with the same `commonLabels.alertname`
+   in their `alert.json` and different `root_cause_category` (or a different
+   sub-flavour worth distinguishing).
+2. Append a block to `pairs.yml` with `id`, `alert_signal`, `base`,
+   `sibling`, `anchor_risk`, and `active: true`.
+3. Run the runner; verify both scenarios pass baseline before shipping
+   the pair as `active`.
+
+If you want a pair on the books but not yet validated, set `active: false`
+and the runner will skip it.
+
+## What this scaffold deliberately does NOT do
+
+- It does NOT inject memory. That's #1234's responsibility.
+- It does NOT change the `run_suite.score_result(...)` scoring logic.
+  The classifier compares pass/fail outcomes; it doesn't re-score.
+- It does NOT add new fixture cases. Every pair reuses existing scenarios
+  in the suite.
+- It does NOT write to disk. All output is stdout.
+
+## Pairing with #1234
+
+When Phase 1 of Contextual Memory lands, the expected workflow is:
+
+1. Implement the memory injection step in `_run_with_memory`.
+2. Run `--memory` against the active pairs.
+3. Read the memory-mode tally. Block ship on any `memory_hurt`.
+4. If pre-existing failures appear, treat them as separate triage; they
+   are not memory-attributable and should not gate the memory feature.
+
+[issue-1234]: https://github.com/Tracer-Cloud/opensre/issues/1234

--- a/tests/synthetic/rds_postgres/axis_memory/pairs.yml
+++ b/tests/synthetic/rds_postgres/axis_memory/pairs.yml
@@ -1,0 +1,54 @@
+# Axis pairs for memory anchoring evaluation.
+#
+# Each pair lists two existing scenarios that share an external alert signature
+# (alertname / commonLabels) but resolve to different ground-truth outcomes.
+# Running both scenarios in sequence with a memory layer primed from the first
+# is the test for whether the planner anchors on the prior diagnosis when the
+# new alert actually has a different root cause.
+#
+# When Contextual Memory (issue #1234) ships, this same file drives the
+# memory-primed comparison run. Until then it drives the baseline correctness
+# check across pairs (each scenario is run independently, no memory).
+#
+# Field reference:
+#   id            : human-readable pair identifier, used in scoring output
+#   alert_signal  : the alertname both scenarios share (for visibility)
+#   base          : the scenario whose memory would be primed first
+#   sibling       : the scenario whose investigation is at risk of anchoring
+#   anchor_risk   : short description of what failure mode memory might cause
+#   active        : if false, the pair is recorded but skipped at runtime
+
+pairs:
+  - id: connection-pressure-real-vs-noisy
+    alert_signal: RDSDatabaseConnectionsHigh
+    base: 002-connection-exhaustion
+    sibling: 007-connection-pressure-noisy-healthy
+    anchor_risk: |
+      Memory of 002's connection-exhaustion diagnosis could anchor the planner
+      to find a connection fault on 007 when 007 is in fact healthy.
+      This is the strongest pair in the suite because the ground-truth
+      categories differ (resource_exhaustion vs healthy).
+    active: true
+
+  - id: cpu-bad-query-vs-checkpoint-storm
+    alert_signal: RDSCPUUtilizationHigh
+    base: 004-cpu-saturation-bad-query
+    sibling: 014-checkpoint-storm-cpu-saturation
+    anchor_risk: |
+      Both scenarios resolve to the resource_exhaustion category, but the
+      underlying mechanism differs: 004 is sustained bad-query CPU load,
+      014 is checkpoint-storm bursts. Memory of 004's diagnosis could
+      cause the planner to skip the checkpoint-behaviour evidence path
+      that 014 requires.
+    active: true
+
+  - id: replication-lag-vs-cpu-redherring
+    alert_signal: RDSReplicationLagHigh
+    base: 001-replication-lag
+    sibling: 006-replication-lag-cpu-redherring
+    anchor_risk: |
+      Both scenarios resolve to replication_lag (resource_exhaustion category),
+      but 006 layers a CPU red herring that the planner must rule out.
+      Memory of 001's clean replication-lag diagnosis could weaken the
+      ruling-out behaviour 006 was designed to test.
+    active: true

--- a/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
+++ b/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
@@ -101,10 +101,10 @@ def _run_baseline(scenario_id: str, fixtures_by_id: dict[str, Any], use_mock_gra
 
 
 def _run_with_memory(
-    base_scenario_id: str,
-    sibling_scenario_id: str,
-    fixtures_by_id: dict[str, Any],
-    use_mock_grafana: bool,
+    _base_scenario_id: str,
+    _sibling_scenario_id: str,
+    _fixtures_by_id: dict[str, Any],
+    _use_mock_grafana: bool,
 ) -> Any:
     """Run sibling with memory primed from base.
 
@@ -128,7 +128,17 @@ def run(argv: list[str] | None = None) -> list[PairAnnotation]:
     args = parse_args(argv)
     pairs = load_pairs(only_id=args.pair)
 
-    fixtures = load_all_scenarios(SUITE_DIR)
+    # Only load scenarios referenced by pairs to avoid blowing up on scenarios
+    # that don't ship an answer.yml (e.g. some healthy/noisy scenarios).
+    needed_ids: set[str] = set()
+    for pair in pairs:
+        needed_ids.add(pair["base"])
+        needed_ids.add(pair["sibling"])
+    fixtures = [
+        fixture
+        for fixture in load_all_scenarios(SUITE_DIR)
+        if fixture.scenario_id in needed_ids
+    ]
     fixtures_by_id = {fixture.scenario_id: fixture for fixture in fixtures}
 
     annotations: list[PairAnnotation] = []
@@ -209,4 +219,6 @@ def _passed_str(passed: bool | None) -> str:
 
 
 if __name__ == "__main__":
-    sys.exit(0 if run() is not None else 1)
+    results = run()
+    hurt = sum(1 for a in results if a.memory_mode is MemoryMode.MEMORY_HURT)
+    sys.exit(1 if hurt else 0)

--- a/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
+++ b/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
@@ -43,7 +43,7 @@ from tests.synthetic.rds_postgres.axis_memory.scoring import (
 from tests.synthetic.rds_postgres.run_suite import run_scenario
 from tests.synthetic.rds_postgres.scenario_loader import (
     SUITE_DIR,
-    load_all_scenarios,
+    load_scenario,
 )
 
 PAIRS_FILE = Path(__file__).parent / "pairs.yml"
@@ -91,6 +91,32 @@ def load_pairs(only_id: str = "") -> list[dict[str, Any]]:
     return pairs
 
 
+def _load_pair_fixtures(pairs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Load only the scenarios referenced by the supplied pairs.
+
+    Calls `load_scenario(SUITE_DIR / scenario_id)` per needed id rather than
+    `load_all_scenarios(SUITE_DIR)`. The eager loader iterates every scenario
+    directory and parses its answer.yml; if any scenario in the suite is
+    fixture-less (e.g. a future healthy/noise scenario), eager load would
+    blow up before this runner ever touched the pair scenarios it needs.
+    """
+    needed_ids: set[str] = set()
+    for pair in pairs:
+        needed_ids.add(pair["base"])
+        needed_ids.add(pair["sibling"])
+
+    fixtures_by_id: dict[str, Any] = {}
+    for scenario_id in sorted(needed_ids):
+        scenario_dir = SUITE_DIR / scenario_id
+        if not scenario_dir.is_dir():
+            raise SystemExit(
+                f"Pair references unknown scenario id: {scenario_id!r} "
+                f"(expected directory at {scenario_dir})"
+            )
+        fixtures_by_id[scenario_id] = load_scenario(scenario_dir)
+    return fixtures_by_id
+
+
 def _run_baseline(scenario_id: str, fixtures_by_id: dict[str, Any], use_mock_grafana: bool) -> Any:
     """Run a single scenario without memory and return its ScenarioScore."""
     fixture = fixtures_by_id.get(scenario_id)
@@ -128,16 +154,7 @@ def run(argv: list[str] | None = None) -> list[PairAnnotation]:
     args = parse_args(argv)
     pairs = load_pairs(only_id=args.pair)
 
-    # Only load scenarios referenced by pairs to avoid blowing up on scenarios
-    # that don't ship an answer.yml (e.g. some healthy/noisy scenarios).
-    needed_ids: set[str] = set()
-    for pair in pairs:
-        needed_ids.add(pair["base"])
-        needed_ids.add(pair["sibling"])
-    fixtures = [
-        fixture for fixture in load_all_scenarios(SUITE_DIR) if fixture.scenario_id in needed_ids
-    ]
-    fixtures_by_id = {fixture.scenario_id: fixture for fixture in fixtures}
+    fixtures_by_id = _load_pair_fixtures(pairs)
 
     annotations: list[PairAnnotation] = []
     for pair in pairs:

--- a/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
+++ b/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
@@ -140,9 +140,7 @@ def run(argv: list[str] | None = None) -> list[PairAnnotation]:
         baseline_score = _run_baseline(sibling_id, fixtures_by_id, args.mock_grafana)
         memory_score = None
         if args.memory:
-            memory_score = _run_with_memory(
-                base_id, sibling_id, fixtures_by_id, args.mock_grafana
-            )
+            memory_score = _run_with_memory(base_id, sibling_id, fixtures_by_id, args.mock_grafana)
 
         annotations.append(
             annotate_pair(

--- a/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
+++ b/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
@@ -1,0 +1,214 @@
+"""Axis-memory runner: run pair scenarios and emit memory-mode annotations.
+
+Two modes:
+
+  baseline (default): run each `sibling` scenario with no memory primed and
+    record the pass/fail outcome. This is the only mode that ships today;
+    Contextual Memory (issue #1234) is not wired up yet.
+
+  memory: run each `sibling` with memory primed from its `base`, then call
+    `annotate_pair(...)` with both baseline and memory ScenarioScores. Wired
+    up later once #1234's memory layer lands. The runner is structured so
+    enabling this mode is a single-flag change rather than a rewrite.
+
+Usage:
+
+    python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory
+    python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory --pair connection-pressure-real-vs-noisy
+    python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory --json
+    python -m tests.synthetic.rds_postgres.axis_memory.run_axis_memory --memory   # placeholder until #1234
+
+The output prints one line per pair plus a tally summary at the end. With
+`--json`, the full annotation list is emitted as JSON for downstream
+consumption.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tests.synthetic.rds_postgres.axis_memory.scoring import (
+    MemoryMode,
+    PairAnnotation,
+    annotate_pair,
+    summarize_annotations,
+)
+from tests.synthetic.rds_postgres.run_suite import run_scenario
+from tests.synthetic.rds_postgres.scenario_loader import (
+    SUITE_DIR,
+    load_all_scenarios,
+)
+
+PAIRS_FILE = Path(__file__).parent / "pairs.yml"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run axis-memory pairs and emit memory-mode annotations."
+    )
+    parser.add_argument(
+        "--pair",
+        default="",
+        help="Run only the pair with this id (see pairs.yml).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human text.",
+    )
+    parser.add_argument(
+        "--memory",
+        action="store_true",
+        help=(
+            "Run sibling with memory primed from base (requires Contextual Memory "
+            "from issue #1234). Currently a placeholder; raises NotImplementedError."
+        ),
+    )
+    parser.add_argument(
+        "--mock-grafana",
+        action="store_true",
+        help="Serve fixture data via FixtureGrafanaBackend instead of real Grafana calls.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_pairs(only_id: str = "") -> list[dict[str, Any]]:
+    """Read pairs.yml; filter to active pairs (and optionally a single id)."""
+    raw = yaml.safe_load(PAIRS_FILE.read_text())
+    pairs: list[dict[str, Any]] = list(raw.get("pairs", []) or [])
+    pairs = [p for p in pairs if p.get("active", True)]
+    if only_id:
+        pairs = [p for p in pairs if p.get("id") == only_id]
+        if not pairs:
+            raise SystemExit(f"No active pair with id: {only_id!r}")
+    return pairs
+
+
+def _run_baseline(scenario_id: str, fixtures_by_id: dict[str, Any], use_mock_grafana: bool) -> Any:
+    """Run a single scenario without memory and return its ScenarioScore."""
+    fixture = fixtures_by_id.get(scenario_id)
+    if fixture is None:
+        raise SystemExit(f"Scenario fixture not found: {scenario_id!r}")
+    _state, score = run_scenario(fixture, use_mock_grafana=use_mock_grafana)
+    return score
+
+
+def _run_with_memory(
+    base_scenario_id: str,
+    sibling_scenario_id: str,
+    fixtures_by_id: dict[str, Any],
+    use_mock_grafana: bool,
+) -> Any:
+    """Run sibling with memory primed from base.
+
+    Placeholder until issue #1234 (Contextual Memory) lands. The full path is:
+
+        1. Run base, capture investigation memory output.
+        2. Inject that memory into the sibling investigation context.
+        3. Run sibling and return its ScenarioScore.
+
+    Step 2 needs the memory layer that #1234 will introduce. Until then this
+    raises NotImplementedError so the runner fails loudly rather than
+    silently degrading to baseline behaviour.
+    """
+    raise NotImplementedError(
+        "Memory-primed mode requires Contextual Memory from issue #1234. "
+        "Run without --memory for the baseline scaffold."
+    )
+
+
+def run(argv: list[str] | None = None) -> list[PairAnnotation]:
+    args = parse_args(argv)
+    pairs = load_pairs(only_id=args.pair)
+
+    fixtures = load_all_scenarios(SUITE_DIR)
+    fixtures_by_id = {fixture.scenario_id: fixture for fixture in fixtures}
+
+    annotations: list[PairAnnotation] = []
+    for pair in pairs:
+        pair_id = pair["id"]
+        base_id = pair["base"]
+        sibling_id = pair["sibling"]
+
+        baseline_score = _run_baseline(sibling_id, fixtures_by_id, args.mock_grafana)
+        memory_score = None
+        if args.memory:
+            memory_score = _run_with_memory(
+                base_id, sibling_id, fixtures_by_id, args.mock_grafana
+            )
+
+        annotations.append(
+            annotate_pair(
+                pair_id=pair_id,
+                base_scenario_id=base_id,
+                sibling_scenario_id=sibling_id,
+                baseline_score=baseline_score,
+                memory_score=memory_score,
+            )
+        )
+
+    if args.json:
+        # Shallow dict serialization; PairAnnotation is a frozen dataclass.
+        payload = {
+            "annotations": [_annotation_to_dict(a) for a in annotations],
+            "summary": summarize_annotations(annotations),
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        _print_human(annotations)
+
+    return annotations
+
+
+def _annotation_to_dict(annotation: PairAnnotation) -> dict[str, Any]:
+    payload = asdict(annotation)
+    # Enums serialize as their string value when json.dumps default=str is used,
+    # but be explicit for predictability.
+    payload["memory_mode"] = annotation.memory_mode.value
+    return payload
+
+
+def _print_human(annotations: list[PairAnnotation]) -> None:
+    for annotation in annotations:
+        baseline_str = _passed_str(annotation.baseline_passed)
+        memory_str = _passed_str(annotation.memory_passed)
+        print(
+            f"  pair={annotation.pair_id}  "
+            f"sibling={annotation.sibling_scenario_id}  "
+            f"baseline={baseline_str}  memory={memory_str}  "
+            f"mode={annotation.memory_mode.value}"
+        )
+    tally = summarize_annotations(annotations)
+    nonzero = {k: v for k, v in tally.items() if v > 0}
+    print()
+    print("  Summary:")
+    for mode in MemoryMode:
+        count = tally[mode.value]
+        marker = " " if count == 0 else "*"
+        print(f"    {marker} {mode.value:<16} {count}")
+    # Also print a concise top-line if there's anything memory-attributable.
+    if nonzero.get(MemoryMode.MEMORY_HURT.value):
+        print()
+        print(
+            f"  WARNING: {nonzero[MemoryMode.MEMORY_HURT.value]} pair(s) "
+            "show memory-attributable regression. Investigate before shipping #1234 Phase 1."
+        )
+
+
+def _passed_str(passed: bool | None) -> str:
+    if passed is True:
+        return "PASS"
+    if passed is False:
+        return "FAIL"
+    return "----"
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() is not None else 1)

--- a/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
+++ b/tests/synthetic/rds_postgres/axis_memory/run_axis_memory.py
@@ -135,9 +135,7 @@ def run(argv: list[str] | None = None) -> list[PairAnnotation]:
         needed_ids.add(pair["base"])
         needed_ids.add(pair["sibling"])
     fixtures = [
-        fixture
-        for fixture in load_all_scenarios(SUITE_DIR)
-        if fixture.scenario_id in needed_ids
+        fixture for fixture in load_all_scenarios(SUITE_DIR) if fixture.scenario_id in needed_ids
     ]
     fixtures_by_id = {fixture.scenario_id: fixture for fixture in fixtures}
 

--- a/tests/synthetic/rds_postgres/axis_memory/scoring.py
+++ b/tests/synthetic/rds_postgres/axis_memory/scoring.py
@@ -39,11 +39,11 @@ Usage:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 
-class MemoryMode(str, Enum):
+class MemoryMode(StrEnum):
     """Classification of whether memory injection helped, hurt, or no-op'd a run."""
 
     MEMORY_HELPED = "memory_helped"

--- a/tests/synthetic/rds_postgres/axis_memory/scoring.py
+++ b/tests/synthetic/rds_postgres/axis_memory/scoring.py
@@ -1,0 +1,177 @@
+"""Memory-anchoring scoring annotation for the synthetic RDS suite.
+
+Annotates each axis pair with a memory-mode classification:
+
+    memory_helped   memory primed from `base` made `sibling` converge correctly
+                    on a case where the unprimed (baseline) run got it wrong.
+    memory_hurt     memory primed from `base` caused `sibling` to mis-converge
+                    on a case where the unprimed (baseline) run got it right.
+    memory_neutral  the primed run and the baseline run produce the same
+                    pass/fail outcome on `sibling`.
+    pre_existing    the baseline run already mis-converges on `sibling`,
+                    independent of memory.
+    not_run         memory mode not exercised yet (Contextual Memory feature
+                    not implemented; only the baseline mode is shippable today).
+
+The classifier reads two `ScenarioScore` objects produced by the existing
+`run_suite.score_result(...)` machinery. It does not re-implement scoring; it
+compares pass/fail outcomes between baseline and memory-primed runs of the
+same `sibling` scenario.
+
+Usage:
+
+    from tests.synthetic.rds_postgres.axis_memory.scoring import (
+        MemoryMode,
+        annotate_pair,
+    )
+
+    annotation = annotate_pair(
+        base_scenario_id="002-connection-exhaustion",
+        sibling_scenario_id="007-connection-pressure-noisy-healthy",
+        baseline_score=baseline_sibling_score,
+        memory_score=memory_sibling_score,  # may be None until #1234 ships
+    )
+
+    # annotation.memory_mode is one of MemoryMode values
+    # annotation.baseline_passed / memory_passed are bools or None
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class MemoryMode(str, Enum):
+    """Classification of whether memory injection helped, hurt, or no-op'd a run."""
+
+    MEMORY_HELPED = "memory_helped"
+    MEMORY_HURT = "memory_hurt"
+    MEMORY_NEUTRAL = "memory_neutral"
+    PRE_EXISTING = "pre_existing"
+    NOT_RUN = "not_run"
+
+
+@dataclass(frozen=True)
+class PairAnnotation:
+    """Annotation produced by `annotate_pair` for a single axis pair."""
+
+    pair_id: str
+    base_scenario_id: str
+    sibling_scenario_id: str
+    baseline_passed: bool | None
+    memory_passed: bool | None
+    memory_mode: MemoryMode
+    notes: str = ""
+
+
+def annotate_pair(
+    pair_id: str,
+    base_scenario_id: str,
+    sibling_scenario_id: str,
+    baseline_score: Any | None,
+    memory_score: Any | None = None,
+) -> PairAnnotation:
+    """Classify a pair's memory-anchoring outcome.
+
+    `baseline_score` is the result of running `sibling` with no memory primed.
+    `memory_score` is the result of running `sibling` with memory primed from
+    `base`. When `memory_score` is None (Contextual Memory not yet wired up),
+    the annotation is recorded as NOT_RUN and `baseline_passed` is still
+    captured so the suite can report on baseline correctness alone.
+
+    Both score arguments are duck-typed against `run_suite.ScenarioScore`:
+    they only need a `.passed` attribute.
+    """
+    baseline_passed = _passed(baseline_score)
+    memory_passed = _passed(memory_score)
+
+    if memory_passed is None:
+        return PairAnnotation(
+            pair_id=pair_id,
+            base_scenario_id=base_scenario_id,
+            sibling_scenario_id=sibling_scenario_id,
+            baseline_passed=baseline_passed,
+            memory_passed=None,
+            memory_mode=MemoryMode.NOT_RUN,
+            notes="memory mode not exercised; baseline only",
+        )
+
+    if baseline_passed is None:
+        # Memory mode ran but baseline didn't — refuse to classify.
+        return PairAnnotation(
+            pair_id=pair_id,
+            base_scenario_id=base_scenario_id,
+            sibling_scenario_id=sibling_scenario_id,
+            baseline_passed=None,
+            memory_passed=memory_passed,
+            memory_mode=MemoryMode.NOT_RUN,
+            notes="memory ran but baseline missing; cannot classify",
+        )
+
+    if not baseline_passed and not memory_passed:
+        return PairAnnotation(
+            pair_id=pair_id,
+            base_scenario_id=base_scenario_id,
+            sibling_scenario_id=sibling_scenario_id,
+            baseline_passed=False,
+            memory_passed=False,
+            memory_mode=MemoryMode.PRE_EXISTING,
+            notes="sibling fails without memory too; not a memory-attributable failure",
+        )
+
+    if baseline_passed and not memory_passed:
+        return PairAnnotation(
+            pair_id=pair_id,
+            base_scenario_id=base_scenario_id,
+            sibling_scenario_id=sibling_scenario_id,
+            baseline_passed=True,
+            memory_passed=False,
+            memory_mode=MemoryMode.MEMORY_HURT,
+            notes="memory caused regression on sibling that passes without memory",
+        )
+
+    if not baseline_passed and memory_passed:
+        return PairAnnotation(
+            pair_id=pair_id,
+            base_scenario_id=base_scenario_id,
+            sibling_scenario_id=sibling_scenario_id,
+            baseline_passed=False,
+            memory_passed=True,
+            memory_mode=MemoryMode.MEMORY_HELPED,
+            notes="memory recovered a baseline failure; uncommon, worth investigating",
+        )
+
+    # both passed
+    return PairAnnotation(
+        pair_id=pair_id,
+        base_scenario_id=base_scenario_id,
+        sibling_scenario_id=sibling_scenario_id,
+        baseline_passed=True,
+        memory_passed=True,
+        memory_mode=MemoryMode.MEMORY_NEUTRAL,
+        notes="memory injection did not change pass/fail; safe for this pair",
+    )
+
+
+def _passed(score: Any | None) -> bool | None:
+    """Return `score.passed` if score is truthy, else None.
+
+    Accepts duck-typed scores so this module does not import the full
+    `ScenarioScore` dataclass and remains import-light at module load time.
+    """
+    if score is None:
+        return None
+    passed_attr = getattr(score, "passed", None)
+    if passed_attr is None:
+        return None
+    return bool(passed_attr)
+
+
+def summarize_annotations(annotations: list[PairAnnotation]) -> dict[str, int]:
+    """Tally annotations by memory_mode for headline reporting."""
+    tally: dict[str, int] = {mode.value: 0 for mode in MemoryMode}
+    for annotation in annotations:
+        tally[annotation.memory_mode.value] += 1
+    return tally

--- a/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
+++ b/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
@@ -1,0 +1,214 @@
+"""Direct unit tests for `axis_memory.scoring.annotate_pair`.
+
+The classifier is small and pure: it takes two pass/fail signals and emits
+one of five `MemoryMode` values. Tests cover every cell of the truth table
+plus the duck-typing behaviour around None and the absent `passed` attribute.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tests.synthetic.rds_postgres.axis_memory.scoring import (
+    MemoryMode,
+    PairAnnotation,
+    annotate_pair,
+    summarize_annotations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeScore:
+    """Minimal stand-in for `run_suite.ScenarioScore` — only `passed` is read."""
+
+    passed: bool
+
+
+def _passed() -> _FakeScore:
+    return _FakeScore(passed=True)
+
+
+def _failed() -> _FakeScore:
+    return _FakeScore(passed=False)
+
+
+# ---------------------------------------------------------------------------
+# Truth table — every memory_mode classification
+# ---------------------------------------------------------------------------
+
+
+def test_memory_neutral_when_both_pass() -> None:
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_passed(),
+        memory_score=_passed(),
+    )
+    assert annotation.memory_mode is MemoryMode.MEMORY_NEUTRAL
+    assert annotation.baseline_passed is True
+    assert annotation.memory_passed is True
+
+
+def test_memory_hurt_when_baseline_passes_but_memory_fails() -> None:
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_passed(),
+        memory_score=_failed(),
+    )
+    assert annotation.memory_mode is MemoryMode.MEMORY_HURT
+    assert annotation.baseline_passed is True
+    assert annotation.memory_passed is False
+
+
+def test_memory_helped_when_baseline_fails_but_memory_passes() -> None:
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_failed(),
+        memory_score=_passed(),
+    )
+    assert annotation.memory_mode is MemoryMode.MEMORY_HELPED
+    assert annotation.baseline_passed is False
+    assert annotation.memory_passed is True
+
+
+def test_pre_existing_when_both_fail() -> None:
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_failed(),
+        memory_score=_failed(),
+    )
+    assert annotation.memory_mode is MemoryMode.PRE_EXISTING
+    assert annotation.baseline_passed is False
+    assert annotation.memory_passed is False
+
+
+def test_not_run_when_memory_score_missing() -> None:
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_passed(),
+        memory_score=None,
+    )
+    assert annotation.memory_mode is MemoryMode.NOT_RUN
+    assert annotation.baseline_passed is True
+    assert annotation.memory_passed is None
+
+
+def test_not_run_when_baseline_missing_but_memory_present() -> None:
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=None,
+        memory_score=_passed(),
+    )
+    assert annotation.memory_mode is MemoryMode.NOT_RUN
+    assert annotation.baseline_passed is None
+    assert annotation.memory_passed is True
+
+
+# ---------------------------------------------------------------------------
+# Duck-typing edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_score_without_passed_attribute_is_treated_as_none() -> None:
+    """`_passed` returns None when the score has no `.passed`. The classifier
+    treats that the same as score=None — i.e. records NOT_RUN."""
+
+    class _OpaqueScore:
+        pass
+
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_OpaqueScore(),
+        memory_score=_passed(),
+    )
+    assert annotation.memory_mode is MemoryMode.NOT_RUN
+
+
+@pytest.mark.parametrize(
+    ("baseline_truthy", "memory_truthy", "expected"),
+    [
+        (1, 1, MemoryMode.MEMORY_NEUTRAL),
+        (1, 0, MemoryMode.MEMORY_HURT),
+        (0, 1, MemoryMode.MEMORY_HELPED),
+        (0, 0, MemoryMode.PRE_EXISTING),
+    ],
+)
+def test_passed_is_coerced_to_bool(
+    baseline_truthy: int, memory_truthy: int, expected: MemoryMode
+) -> None:
+    """Truthy / falsy `passed` attribute values are coerced via bool()."""
+    annotation = annotate_pair(
+        pair_id="p",
+        base_scenario_id="A",
+        sibling_scenario_id="B",
+        baseline_score=_FakeScore(passed=bool(baseline_truthy)),
+        memory_score=_FakeScore(passed=bool(memory_truthy)),
+    )
+    assert annotation.memory_mode is expected
+
+
+# ---------------------------------------------------------------------------
+# summarize_annotations
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_annotations_tallies_by_mode() -> None:
+    annotations = [
+        PairAnnotation(
+            pair_id="p1",
+            base_scenario_id="A",
+            sibling_scenario_id="B",
+            baseline_passed=True,
+            memory_passed=True,
+            memory_mode=MemoryMode.MEMORY_NEUTRAL,
+        ),
+        PairAnnotation(
+            pair_id="p2",
+            base_scenario_id="A",
+            sibling_scenario_id="C",
+            baseline_passed=True,
+            memory_passed=False,
+            memory_mode=MemoryMode.MEMORY_HURT,
+        ),
+        PairAnnotation(
+            pair_id="p3",
+            base_scenario_id="A",
+            sibling_scenario_id="D",
+            baseline_passed=True,
+            memory_passed=False,
+            memory_mode=MemoryMode.MEMORY_HURT,
+        ),
+    ]
+    tally = summarize_annotations(annotations)
+    assert tally[MemoryMode.MEMORY_NEUTRAL.value] == 1
+    assert tally[MemoryMode.MEMORY_HURT.value] == 2
+    assert tally[MemoryMode.MEMORY_HELPED.value] == 0
+    assert tally[MemoryMode.PRE_EXISTING.value] == 0
+    assert tally[MemoryMode.NOT_RUN.value] == 0
+
+
+def test_summarize_empty_list_returns_zero_for_every_mode() -> None:
+    tally = summarize_annotations([])
+    assert all(count == 0 for count in tally.values())
+    # Every MemoryMode key is present even when the input is empty.
+    assert set(tally.keys()) == {mode.value for mode in MemoryMode}

--- a/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
+++ b/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
@@ -11,14 +11,14 @@ from dataclasses import dataclass
 
 import pytest
 
-pytestmark = pytest.mark.synthetic
-
 from tests.synthetic.rds_postgres.axis_memory.scoring import (
     MemoryMode,
     PairAnnotation,
     annotate_pair,
     summarize_annotations,
 )
+
+pytestmark = pytest.mark.synthetic
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
+++ b/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 
 import pytest
 
+pytestmark = pytest.mark.synthetic
+
 from tests.synthetic.rds_postgres.axis_memory.scoring import (
     MemoryMode,
     PairAnnotation,

--- a/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
+++ b/tests/synthetic/rds_postgres/axis_memory/test_scoring.py
@@ -18,7 +18,6 @@ from tests.synthetic.rds_postgres.axis_memory.scoring import (
     summarize_annotations,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
@cerencamkiran fair catch, you were right that the eager loader was still running. Pushed 6cf7d40:

`load_all_scenarios(SUITE_DIR)` is gone. Replaced with a per-id loop that calls `load_scenario(SUITE_DIR / scenario_id)` only for the ids referenced by active pairs. A pair pointing at an unknown scenario id now fails fast with a clear `SystemExit`. No behaviour change for the current 15 scenarios (all ship answer.yml today), but the runner is now resilient to a future fixture-less addition.

Ready for re-review.