### PR TITLE
refactor(interactive-shell): registry-backed first-arg tab hints

### DIFF
--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -120,23 +120,44 @@ def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool: 
     return True
 
 
+_LIST_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("integrations", "alert-source integrations"),
+    ("models", "active LLM models"),
+    ("mcp", "connected MCP servers"),
+)
+
+_INTEGRATIONS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("list", "list all configured integrations"),
+    ("verify", "run health checks on all integrations"),
+    ("show", "show details for a single integration"),
+)
+
+_MCP_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("list", "list connected MCP servers"),
+    ("connect", "add an MCP server via opensre integrations setup"),
+    ("disconnect", "remove an MCP server"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/list",
         "list integrations, MCP servers, and the active LLM connection "
         "('/list integrations', '/list models', '/list mcp')",
         _cmd_list,
+        first_arg_completions=_LIST_FIRST_ARGS,
     ),
     SlashCommand(
         "/integrations",
         "manage integrations ('/integrations list', '/integrations verify', "
         "'/integrations show <service>')",
         _cmd_integrations,
+        first_arg_completions=_INTEGRATIONS_FIRST_ARGS,
     ),
     SlashCommand(
         "/mcp",
         "manage MCP servers ('/mcp list', '/mcp connect', '/mcp disconnect')",
         _cmd_mcp,
+        first_arg_completions=_MCP_FIRST_ARGS,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -144,12 +144,21 @@ def _cmd_save(session: ReplSession, console: Console, args: list[str]) -> bool:
     return True
 
 
+_TEMPLATE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("generic", "generic alert JSON template"),
+    ("datadog", "Datadog monitor alert template"),
+    ("grafana", "Grafana alert template"),
+    ("honeycomb", "Honeycomb trigger template"),
+    ("coralogix", "Coralogix alert template"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/template",
         "print a starter alert JSON template "
         "('/template generic|datadog|grafana|honeycomb|coralogix')",
         _cmd_template,
+        first_arg_completions=_TEMPLATE_FIRST_ARGS,
     ),
     SlashCommand(
         "/investigate",

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -225,6 +225,12 @@ def _cmd_model(session: ReplSession, console: Console, args: list[str]) -> bool:
     return True
 
 
+_MODEL_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("show", "show active provider and models"),
+    ("set", "switch provider  ·  /model set <provider> [model]"),
+    ("toolcall", "manage toolcall model for the active provider"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/model",
@@ -232,6 +238,7 @@ COMMANDS: list[SlashCommand] = [
         "'/model set <provider> [model] [--toolcall-model <m>]', "
         "'/model toolcall set <model>')",
         _cmd_model,
+        first_arg_completions=_MODEL_FIRST_ARGS,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -120,14 +120,34 @@ def _cmd_context(session: ReplSession, console: Console, args: list[str]) -> boo
     return True
 
 
+_TRUST_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("on", "enable trust mode (skip approval prompts)"),
+    ("off", "disable trust mode"),
+)
+
+_VERBOSE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("on", "enable verbose logging"),
+    ("off", "disable verbose logging"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand("/clear", "clear the screen and re-render the banner", _cmd_clear),
     SlashCommand("/reset", "clear session state (keeps trust mode)", _cmd_reset),
-    SlashCommand("/trust", "toggle trust mode ('/trust off' to disable)", _cmd_trust),
+    SlashCommand(
+        "/trust",
+        "toggle trust mode ('/trust off' to disable)",
+        _cmd_trust,
+        first_arg_completions=_TRUST_FIRST_ARGS,
+    ),
     SlashCommand("/status", "show session status", _cmd_status),
     SlashCommand("/context", "show accumulated infra context", _cmd_context),
     SlashCommand("/cost", "show token usage and session cost", _cmd_cost),
-    SlashCommand("/verbose", "toggle verbose logging ('/verbose off' to disable)", _cmd_verbose),
+    SlashCommand(
+        "/verbose",
+        "toggle verbose logging ('/verbose off' to disable)",
+        _cmd_verbose,
+        first_arg_completions=_VERBOSE_FIRST_ARGS,
+    ),
     SlashCommand("/compact", "trim old session history to free memory", _cmd_compact),
 ]
 

--- a/app/cli/interactive_shell/command_registry/types.py
+++ b/app/cli/interactive_shell/command_registry/types.py
@@ -15,6 +15,8 @@ class SlashCommand:
     name: str
     help_text: str
     handler: Callable[[ReplSession, Console, list[str]], bool]
+    #: Tab-completion hints for the first argument after the command name (keyword, meta text).
+    first_arg_completions: tuple[tuple[str, str], ...] = ()
 
 
 __all__ = ["SlashCommand"]

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -122,47 +122,9 @@ class ShellCompleter(Completer):
     Completion levels:
       1. Bare-word aliases (``help``, ``exit``, …) — no leading slash, no spaces.
       2. Top-level slash command names (``/hel`` → ``/help``).
-      3. Subcommand keywords  (``/model `` → ``show / set / toolcall``).
+      3. First-arg keywords from each command's registry metadata (e.g. ``/model `` → hints).
       4. File-path completion for ``/investigate`` and ``/save``.
     """
-
-    _SUBCOMMANDS: dict[str, list[tuple[str, str]]] = {
-        "/model": [
-            ("show", "show active provider and models"),
-            ("set", "switch provider  ·  /model set <provider> [model]"),
-            ("toolcall", "manage toolcall model for the active provider"),
-        ],
-        "/integrations": [
-            ("list", "list all configured integrations"),
-            ("verify", "run health checks on all integrations"),
-            ("show", "show details for a single integration"),
-        ],
-        "/list": [
-            ("integrations", "alert-source integrations"),
-            ("models", "active LLM models"),
-            ("mcp", "connected MCP servers"),
-        ],
-        "/mcp": [
-            ("list", "list connected MCP servers"),
-            ("connect", "add an MCP server via opensre integrations setup"),
-            ("disconnect", "remove an MCP server"),
-        ],
-        "/template": [
-            ("generic", "generic alert JSON template"),
-            ("datadog", "Datadog monitor alert template"),
-            ("grafana", "Grafana alert template"),
-            ("honeycomb", "Honeycomb trigger template"),
-            ("coralogix", "Coralogix alert template"),
-        ],
-        "/trust": [
-            ("on", "enable trust mode (skip approval prompts)"),
-            ("off", "disable trust mode"),
-        ],
-        "/verbose": [
-            ("on", "enable verbose logging"),
-            ("off", "disable verbose logging"),
-        ],
-    }
 
     def get_completions(
         self,
@@ -220,8 +182,10 @@ class ShellCompleter(Completer):
                 )
                 return
 
+            entry = SLASH_COMMANDS.get(cmd_name)
+            hints = entry.first_arg_completions if entry is not None else ()
             sub_prefix = raw_arg.lower()
-            for sub, meta in self._SUBCOMMANDS.get(cmd_name, []):
+            for sub, meta in hints:
                 if sub.startswith(sub_prefix):
                     yield Completion(
                         sub,

--- a/tests/cli/interactive_shell/test_command_registry.py
+++ b/tests/cli/interactive_shell/test_command_registry.py
@@ -7,6 +7,17 @@ import io
 from rich.console import Console
 
 from app.cli.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
+from app.cli.interactive_shell.command_registry.integrations import (
+    _INTEGRATIONS_FIRST_ARGS,
+    _LIST_FIRST_ARGS,
+    _MCP_FIRST_ARGS,
+)
+from app.cli.interactive_shell.command_registry.investigation import _TEMPLATE_FIRST_ARGS
+from app.cli.interactive_shell.command_registry.model import _MODEL_FIRST_ARGS
+from app.cli.interactive_shell.command_registry.session_cmds import (
+    _TRUST_FIRST_ARGS,
+    _VERBOSE_FIRST_ARGS,
+)
 from app.cli.interactive_shell.commands import SLASH_COMMANDS as COMMANDS_EXPORT
 from app.cli.interactive_shell.session import ReplSession
 
@@ -43,11 +54,17 @@ def test_dispatch_unknown_command_stays_in_repl() -> None:
 
 
 def test_registry_first_arg_completion_hints_co_located_with_handlers() -> None:
-    """First-token tab hints live on SlashCommand rows (loop reads SLASH_COMMANDS)."""
-    model = SLASH_COMMANDS["/model"]
-    assert {t for t, _ in model.first_arg_completions} == {"show", "set", "toolcall"}
-
-    lst = SLASH_COMMANDS["/list"]
-    assert {t for t, _ in lst.first_arg_completions} == {"integrations", "models", "mcp"}
+    """Merged registry exposes the same first-arg tab tuples defined in each module."""
+    expected: dict[str, tuple[tuple[str, str], ...]] = {
+        "/model": _MODEL_FIRST_ARGS,
+        "/list": _LIST_FIRST_ARGS,
+        "/integrations": _INTEGRATIONS_FIRST_ARGS,
+        "/mcp": _MCP_FIRST_ARGS,
+        "/template": _TEMPLATE_FIRST_ARGS,
+        "/trust": _TRUST_FIRST_ARGS,
+        "/verbose": _VERBOSE_FIRST_ARGS,
+    }
+    for name, tup in expected.items():
+        assert SLASH_COMMANDS[name].first_arg_completions == tup
 
     assert SLASH_COMMANDS["/help"].first_arg_completions == ()

--- a/tests/cli/interactive_shell/test_command_registry.py
+++ b/tests/cli/interactive_shell/test_command_registry.py
@@ -40,3 +40,14 @@ def test_dispatch_unknown_command_stays_in_repl() -> None:
     console, buf = _capture()
     assert dispatch_slash("/not-a-real-slash", session, console) is True
     assert "unknown command" in buf.getvalue()
+
+
+def test_registry_first_arg_completion_hints_co_located_with_handlers() -> None:
+    """First-token tab hints live on SlashCommand rows (loop reads SLASH_COMMANDS)."""
+    model = SLASH_COMMANDS["/model"]
+    assert {t for t, _ in model.first_arg_completions} == {"show", "set", "toolcall"}
+
+    lst = SLASH_COMMANDS["/list"]
+    assert {t for t, _ in lst.first_arg_completions} == {"integrations", "models", "mcp"}
+
+    assert SLASH_COMMANDS["/help"].first_arg_completions == ()


### PR DESCRIPTION
Fixes #1382

#### Describe the changes you have made in this PR -

Follow-up to the modular slash registry (#1400): nested first-token tab completion no longer uses a duplicated `_SUBCOMMANDS` map in `loop.py`.

- Extended `SlashCommand` with an optional `first_arg_completions` tuple (keyword + meta text).
- Defined those hints beside the handlers for `/model`, `/list`, `/integrations`, `/mcp`, `/template`, `/trust`, and `/verbose`.
- `ShellCompleter` now reads `SLASH_COMMANDS[name].first_arg_completions` so `/help`, dispatch, and first-arg completion share one metadata source.

Unit tests: extended `test_command_registry`; existing `test_loop` completion tests unchanged in behavior.

### Demo/Screenshot for feature changes and bug fixes -

No UI change; behavior parity covered by `tests/cli/interactive_shell/test_loop.py` and `test_command_registry.py`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Issue #1382 asked for autocomplete driven from registry metadata; top-level `/…` completion already used `SLASH_COMMANDS`, but first-argument hints lived only in `ShellCompleter._SUBCOMMANDS`. Attaching a small frozen tuple to each `SlashCommand` keeps hints next to the handler implementation and removes the parallel dictionary.

Alternatives considered: a separate merged `FIRST_ARG_COMPLETIONS` dict in `command_registry/__init__.py` (extra merge step), or keyword-only sub-registry modules (more files). The chosen shape minimizes indirection while keeping `SlashCommand` the single row type.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist with the PR.