### PR TITLE
refactor(cli): remove redundant interactive shell grounding paths

### DIFF
--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Literal
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -21,7 +20,6 @@ from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
 # Cap stored (user, assistant) pairs; list holds 2 entries per turn.
 _MAX_CLI_AGENT_TURNS = 12
-type _GroundingMode = Literal["reference_only", "conversational"]
 
 _TERMINOLOGY_RULE = INTERACTIVE_SHELL_TERMINOLOGY_RULE
 _MARKDOWN_RULE = CLI_ASSISTANT_MARKDOWN_RULE
@@ -62,24 +60,12 @@ def _format_history_for_prompt(session: ReplSession) -> str:
     return "\n".join(lines) if lines else "(no prior messages in this CLI thread)"
 
 
-def _build_system_prompt(grounding: _GroundingMode, reference: str, history: str) -> str:
+def _build_system_prompt(reference: str, history: str) -> str:
     """Build the system prompt for one assistant turn.
 
     Split out so tests can assert on terminology / formatting rules without
     invoking an LLM.
     """
-    if grounding == "reference_only":
-        return (
-            "You are the OpenSRE CLI assistant. The user is in the OpenSRE "
-            "interactive shell (the `opensre` terminal) or asking how to use "
-            "OpenSRE from the shell.\n"
-            "Answer ONLY using the reference below. If the reference does not "
-            "cover their question, say so briefly and suggest `opensre --help` "
-            "or `/help` inside the interactive shell. Prefer copy-pastable "
-            "commands. Keep the answer concise.\n\n"
-            f"{_TERMINOLOGY_RULE}\n{_MARKDOWN_RULE}\n\n"
-            f"--- Reference ---\n{reference}\n"
-        )
     return (
         "You are the OpenSRE terminal assistant. You help with OpenSRE CLI "
         "usage, the interactive shell, and onboarding. Explicit local shell "
@@ -281,13 +267,11 @@ def answer_cli_agent(
     message: str,
     session: ReplSession,
     console: Console,
-    *,
-    grounding: _GroundingMode = "conversational",
 ) -> None:
     """Run one turn of the terminal assistant (no LangGraph / no investigation pipeline).
 
-    Use ``grounding="reference_only"`` for strict procedural CLI Q&A (same as
-    :func:`answer_cli_help`).
+    For documentation-grounded procedural Q&A use :func:`answer_cli_help`, which
+    also pulls relevant ``docs/`` pages into the grounding context.
     """
     try:
         from app.services.llm_client import get_llm_for_reasoning
@@ -298,12 +282,8 @@ def answer_cli_agent(
     reference = build_cli_reference_text()
     log_grounding_cache_diagnostics("cli_agent_grounding")
     history = _format_history_for_prompt(session)
-    system = _build_system_prompt(grounding, reference, history)
-    user_block = (
-        f"--- Question ---\n{message}"
-        if grounding == "reference_only"
-        else f"--- User message ---\n{message}"
-    )
+    system = _build_system_prompt(reference, history)
+    user_block = f"--- User message ---\n{message}"
     prompt = f"{system}\n{user_block}"
 
     try:

--- a/app/cli/interactive_shell/cli_help.py
+++ b/app/cli/interactive_shell/cli_help.py
@@ -118,8 +118,4 @@ def answer_cli_help(question: str, _session: ReplSession, console: Console) -> N
     console.print()
 
 
-__all__ = [
-    "answer_cli_help",
-    "build_cli_reference_text",
-    "build_docs_reference_text",
-]
+__all__ = ["answer_cli_help"]

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -120,23 +120,44 @@ def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool: 
     return True
 
 
+_LIST_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("integrations", "alert-source integrations"),
+    ("models", "active LLM models"),
+    ("mcp", "connected MCP servers"),
+)
+
+_INTEGRATIONS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("list", "list all configured integrations"),
+    ("verify", "run health checks on all integrations"),
+    ("show", "show details for a single integration"),
+)
+
+_MCP_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("list", "list connected MCP servers"),
+    ("connect", "add an MCP server via opensre integrations setup"),
+    ("disconnect", "remove an MCP server"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/list",
         "list integrations, MCP servers, and the active LLM connection "
         "('/list integrations', '/list models', '/list mcp')",
         _cmd_list,
+        first_arg_completions=_LIST_FIRST_ARGS,
     ),
     SlashCommand(
         "/integrations",
         "manage integrations ('/integrations list', '/integrations verify', "
         "'/integrations show <service>')",
         _cmd_integrations,
+        first_arg_completions=_INTEGRATIONS_FIRST_ARGS,
     ),
     SlashCommand(
         "/mcp",
         "manage MCP servers ('/mcp list', '/mcp connect', '/mcp disconnect')",
         _cmd_mcp,
+        first_arg_completions=_MCP_FIRST_ARGS,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -144,12 +144,21 @@ def _cmd_save(session: ReplSession, console: Console, args: list[str]) -> bool:
     return True
 
 
+_TEMPLATE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("generic", "generic alert JSON template"),
+    ("datadog", "Datadog monitor alert template"),
+    ("grafana", "Grafana alert template"),
+    ("honeycomb", "Honeycomb trigger template"),
+    ("coralogix", "Coralogix alert template"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/template",
         "print a starter alert JSON template "
         "('/template generic|datadog|grafana|honeycomb|coralogix')",
         _cmd_template,
+        first_arg_completions=_TEMPLATE_FIRST_ARGS,
     ),
     SlashCommand(
         "/investigate",

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -225,6 +225,12 @@ def _cmd_model(session: ReplSession, console: Console, args: list[str]) -> bool:
     return True
 
 
+_MODEL_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("show", "show active provider and models"),
+    ("set", "switch provider  ·  /model set <provider> [model]"),
+    ("toolcall", "manage toolcall model for the active provider"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/model",
@@ -232,6 +238,7 @@ COMMANDS: list[SlashCommand] = [
         "'/model set <provider> [model] [--toolcall-model <m>]', "
         "'/model toolcall set <model>')",
         _cmd_model,
+        first_arg_completions=_MODEL_FIRST_ARGS,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -120,14 +120,34 @@ def _cmd_context(session: ReplSession, console: Console, args: list[str]) -> boo
     return True
 
 
+_TRUST_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("on", "enable trust mode (skip approval prompts)"),
+    ("off", "disable trust mode"),
+)
+
+_VERBOSE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("on", "enable verbose logging"),
+    ("off", "disable verbose logging"),
+)
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand("/clear", "clear the screen and re-render the banner", _cmd_clear),
     SlashCommand("/reset", "clear session state (keeps trust mode)", _cmd_reset),
-    SlashCommand("/trust", "toggle trust mode ('/trust off' to disable)", _cmd_trust),
+    SlashCommand(
+        "/trust",
+        "toggle trust mode ('/trust off' to disable)",
+        _cmd_trust,
+        first_arg_completions=_TRUST_FIRST_ARGS,
+    ),
     SlashCommand("/status", "show session status", _cmd_status),
     SlashCommand("/context", "show accumulated infra context", _cmd_context),
     SlashCommand("/cost", "show token usage and session cost", _cmd_cost),
-    SlashCommand("/verbose", "toggle verbose logging ('/verbose off' to disable)", _cmd_verbose),
+    SlashCommand(
+        "/verbose",
+        "toggle verbose logging ('/verbose off' to disable)",
+        _cmd_verbose,
+        first_arg_completions=_VERBOSE_FIRST_ARGS,
+    ),
     SlashCommand("/compact", "trim old session history to free memory", _cmd_compact),
 ]
 

--- a/app/cli/interactive_shell/command_registry/types.py
+++ b/app/cli/interactive_shell/command_registry/types.py
@@ -15,6 +15,8 @@ class SlashCommand:
     name: str
     help_text: str
     handler: Callable[[ReplSession, Console, list[str]], bool]
+    #: Tab-completion hints for the first argument after the command name (keyword, meta text).
+    first_arg_completions: tuple[tuple[str, str], ...] = ()
 
 
 __all__ = ["SlashCommand"]

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -122,47 +122,9 @@ class ShellCompleter(Completer):
     Completion levels:
       1. Bare-word aliases (``help``, ``exit``, …) — no leading slash, no spaces.
       2. Top-level slash command names (``/hel`` → ``/help``).
-      3. Subcommand keywords  (``/model `` → ``show / set / toolcall``).
+      3. First-arg keywords from each command's registry metadata (e.g. ``/model `` → hints).
       4. File-path completion for ``/investigate`` and ``/save``.
     """
-
-    _SUBCOMMANDS: dict[str, list[tuple[str, str]]] = {
-        "/model": [
-            ("show", "show active provider and models"),
-            ("set", "switch provider  ·  /model set <provider> [model]"),
-            ("toolcall", "manage toolcall model for the active provider"),
-        ],
-        "/integrations": [
-            ("list", "list all configured integrations"),
-            ("verify", "run health checks on all integrations"),
-            ("show", "show details for a single integration"),
-        ],
-        "/list": [
-            ("integrations", "alert-source integrations"),
-            ("models", "active LLM models"),
-            ("mcp", "connected MCP servers"),
-        ],
-        "/mcp": [
-            ("list", "list connected MCP servers"),
-            ("connect", "add an MCP server via opensre integrations setup"),
-            ("disconnect", "remove an MCP server"),
-        ],
-        "/template": [
-            ("generic", "generic alert JSON template"),
-            ("datadog", "Datadog monitor alert template"),
-            ("grafana", "Grafana alert template"),
-            ("honeycomb", "Honeycomb trigger template"),
-            ("coralogix", "Coralogix alert template"),
-        ],
-        "/trust": [
-            ("on", "enable trust mode (skip approval prompts)"),
-            ("off", "disable trust mode"),
-        ],
-        "/verbose": [
-            ("on", "enable verbose logging"),
-            ("off", "disable verbose logging"),
-        ],
-    }
 
     def get_completions(
         self,
@@ -220,8 +182,10 @@ class ShellCompleter(Completer):
                 )
                 return
 
+            entry = SLASH_COMMANDS.get(cmd_name)
+            hints = entry.first_arg_completions if entry is not None else ()
             sub_prefix = raw_arg.lower()
-            for sub, meta in self._SUBCOMMANDS.get(cmd_name, []):
+            for sub, meta in hints:
                 if sub.startswith(sub_prefix):
                     yield Completion(
                         sub,

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -68,27 +68,20 @@ class TestSystemPromptTerminology:
     """The LLM grounding must steer answers away from the word 'REPL'."""
 
     def test_conversational_prompt_uses_interactive_shell_not_repl(self) -> None:
-        prompt = _build_system_prompt("conversational", reference="(ref)", history="(hist)")
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
         assert "interactive shell" in prompt
         # The prompt must explicitly forbid the "REPL" jargon so the model
         # does not echo it back in answers (#604).
         assert _TERMINOLOGY_RULE in prompt
         assert "Never use the word 'REPL'" in prompt
 
-    def test_reference_only_prompt_uses_interactive_shell_not_repl(self) -> None:
-        prompt = _build_system_prompt("reference_only", reference="(ref)", history="(hist)")
-        assert "interactive shell" in prompt
-        assert _TERMINOLOGY_RULE in prompt
-        assert "Never use the word 'REPL'" in prompt
-
-    def test_both_prompts_request_markdown_formatting(self) -> None:
-        for mode in ("conversational", "reference_only"):
-            prompt = _build_system_prompt(mode, reference="(ref)", history="(hist)")  # type: ignore[arg-type]
-            assert _MARKDOWN_RULE in prompt
-            assert "Markdown" in prompt
+    def test_prompt_requests_markdown_formatting(self) -> None:
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
+        assert _MARKDOWN_RULE in prompt
+        assert "Markdown" in prompt
 
     def test_conversational_prompt_exposes_action_contract(self) -> None:
-        prompt = _build_system_prompt("conversational", reference="(ref)", history="(hist)")
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
 
         assert _ACTION_RULE in prompt
         assert "switch_llm_provider" in prompt

--- a/tests/cli/interactive_shell/test_cli_help.py
+++ b/tests/cli/interactive_shell/test_cli_help.py
@@ -16,7 +16,6 @@ from app.cli.interactive_shell.cli_help import (
     _build_grounded_prompt,
     answer_cli_help,
 )
-from app.cli.interactive_shell.cli_reference import build_cli_reference_text
 from app.cli.interactive_shell.docs_reference import invalidate_docs_cache
 from app.cli.interactive_shell.session import ReplSession
 
@@ -72,12 +71,6 @@ def _seed_docs_root(root: Path) -> None:
         '---\ntitle: "Deployment"\n---\n\nDeploy OpenSRE to Railway, EC2, or LangGraph Cloud.\n',
         encoding="utf-8",
     )
-
-
-def test_legacy_export_still_present() -> None:
-    """The CLI reference helper must remain re-exported for backward compat."""
-    text = build_cli_reference_text()
-    assert "opensre" in text.lower()
 
 
 class TestSystemPromptGrounding:

--- a/tests/cli/interactive_shell/test_command_registry.py
+++ b/tests/cli/interactive_shell/test_command_registry.py
@@ -7,6 +7,17 @@ import io
 from rich.console import Console
 
 from app.cli.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
+from app.cli.interactive_shell.command_registry.integrations import (
+    _INTEGRATIONS_FIRST_ARGS,
+    _LIST_FIRST_ARGS,
+    _MCP_FIRST_ARGS,
+)
+from app.cli.interactive_shell.command_registry.investigation import _TEMPLATE_FIRST_ARGS
+from app.cli.interactive_shell.command_registry.model import _MODEL_FIRST_ARGS
+from app.cli.interactive_shell.command_registry.session_cmds import (
+    _TRUST_FIRST_ARGS,
+    _VERBOSE_FIRST_ARGS,
+)
 from app.cli.interactive_shell.commands import SLASH_COMMANDS as COMMANDS_EXPORT
 from app.cli.interactive_shell.session import ReplSession
 
@@ -43,11 +54,17 @@ def test_dispatch_unknown_command_stays_in_repl() -> None:
 
 
 def test_registry_first_arg_completion_hints_co_located_with_handlers() -> None:
-    """First-token tab hints live on SlashCommand rows (loop reads SLASH_COMMANDS)."""
-    model = SLASH_COMMANDS["/model"]
-    assert {t for t, _ in model.first_arg_completions} == {"show", "set", "toolcall"}
-
-    lst = SLASH_COMMANDS["/list"]
-    assert {t for t, _ in lst.first_arg_completions} == {"integrations", "models", "mcp"}
+    """Merged registry exposes the same first-arg tab tuples defined in each module."""
+    expected: dict[str, tuple[tuple[str, str], ...]] = {
+        "/model": _MODEL_FIRST_ARGS,
+        "/list": _LIST_FIRST_ARGS,
+        "/integrations": _INTEGRATIONS_FIRST_ARGS,
+        "/mcp": _MCP_FIRST_ARGS,
+        "/template": _TEMPLATE_FIRST_ARGS,
+        "/trust": _TRUST_FIRST_ARGS,
+        "/verbose": _VERBOSE_FIRST_ARGS,
+    }
+    for name, tup in expected.items():
+        assert SLASH_COMMANDS[name].first_arg_completions == tup
 
     assert SLASH_COMMANDS["/help"].first_arg_completions == ()

--- a/tests/cli/interactive_shell/test_command_registry.py
+++ b/tests/cli/interactive_shell/test_command_registry.py
@@ -40,3 +40,14 @@ def test_dispatch_unknown_command_stays_in_repl() -> None:
     console, buf = _capture()
     assert dispatch_slash("/not-a-real-slash", session, console) is True
     assert "unknown command" in buf.getvalue()
+
+
+def test_registry_first_arg_completion_hints_co_located_with_handlers() -> None:
+    """First-token tab hints live on SlashCommand rows (loop reads SLASH_COMMANDS)."""
+    model = SLASH_COMMANDS["/model"]
+    assert {t for t, _ in model.first_arg_completions} == {"show", "set", "toolcall"}
+
+    lst = SLASH_COMMANDS["/list"]
+    assert {t for t, _ in lst.first_arg_completions} == {"integrations", "models", "mcp"}
+
+    assert SLASH_COMMANDS["/help"].first_arg_completions == ()


### PR DESCRIPTION
Fixes #1379

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Removed redundant interactive-shell grounding paths after the cache work in #1376 / #1402:

- Dropped the unused `reference_only` branch and `grounding` parameter from `answer_cli_agent` / `_build_system_prompt`; production only ever used conversational mode. Documented that docs-grounded procedural Q&A stays on `answer_cli_help`.
- Stopped re-exporting `build_cli_reference_text` and `build_docs_reference_text` from `cli_help.__all__` so the canonical modules are the single public surface for those helpers.
- Updated `test_cli_agent.py` and `test_cli_help.py` accordingly (removed legacy re-export test and reference-only prompt tests).

### Demo/Screenshot for feature changes and bug fixes - 
N/A — internal cleanup; behavior unchanged for live REPL paths. Verified with `make lint`, `make typecheck`, `make format-check`, and `pytest` on the touched interactive_shell test files.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Issue #1379 called for one canonical cache-aware grounding pipeline and removal of duplicate rebuild/glue. The only live duplicate was the dead `reference_only` path in `cli_agent`, which partially overlapped procedural help but omitted docs and was never called from `loop.py`. Removing it and tightening `cli_help` exports aligns callers with `cli_reference` / `docs_reference` as the single assembly surface.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist with the PR.
