### PR TITLE
refactor(cli): remove redundant interactive shell grounding paths

### DIFF
--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Literal
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -21,7 +20,6 @@ from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
 # Cap stored (user, assistant) pairs; list holds 2 entries per turn.
 _MAX_CLI_AGENT_TURNS = 12
-type _GroundingMode = Literal["reference_only", "conversational"]
 
 _TERMINOLOGY_RULE = INTERACTIVE_SHELL_TERMINOLOGY_RULE
 _MARKDOWN_RULE = CLI_ASSISTANT_MARKDOWN_RULE
@@ -62,24 +60,12 @@ def _format_history_for_prompt(session: ReplSession) -> str:
     return "\n".join(lines) if lines else "(no prior messages in this CLI thread)"
 
 
-def _build_system_prompt(grounding: _GroundingMode, reference: str, history: str) -> str:
+def _build_system_prompt(reference: str, history: str) -> str:
     """Build the system prompt for one assistant turn.
 
     Split out so tests can assert on terminology / formatting rules without
     invoking an LLM.
     """
-    if grounding == "reference_only":
-        return (
-            "You are the OpenSRE CLI assistant. The user is in the OpenSRE "
-            "interactive shell (the `opensre` terminal) or asking how to use "
-            "OpenSRE from the shell.\n"
-            "Answer ONLY using the reference below. If the reference does not "
-            "cover their question, say so briefly and suggest `opensre --help` "
-            "or `/help` inside the interactive shell. Prefer copy-pastable "
-            "commands. Keep the answer concise.\n\n"
-            f"{_TERMINOLOGY_RULE}\n{_MARKDOWN_RULE}\n\n"
-            f"--- Reference ---\n{reference}\n"
-        )
     return (
         "You are the OpenSRE terminal assistant. You help with OpenSRE CLI "
         "usage, the interactive shell, and onboarding. Explicit local shell "
@@ -281,13 +267,11 @@ def answer_cli_agent(
     message: str,
     session: ReplSession,
     console: Console,
-    *,
-    grounding: _GroundingMode = "conversational",
 ) -> None:
     """Run one turn of the terminal assistant (no LangGraph / no investigation pipeline).
 
-    Use ``grounding="reference_only"`` for strict procedural CLI Q&A (same as
-    :func:`answer_cli_help`).
+    For documentation-grounded procedural Q&A use :func:`answer_cli_help`, which
+    also pulls relevant ``docs/`` pages into the grounding context.
     """
     try:
         from app.services.llm_client import get_llm_for_reasoning
@@ -298,12 +282,8 @@ def answer_cli_agent(
     reference = build_cli_reference_text()
     log_grounding_cache_diagnostics("cli_agent_grounding")
     history = _format_history_for_prompt(session)
-    system = _build_system_prompt(grounding, reference, history)
-    user_block = (
-        f"--- Question ---\n{message}"
-        if grounding == "reference_only"
-        else f"--- User message ---\n{message}"
-    )
+    system = _build_system_prompt(reference, history)
+    user_block = f"--- User message ---\n{message}"
     prompt = f"{system}\n{user_block}"
 
     try:

--- a/app/cli/interactive_shell/cli_help.py
+++ b/app/cli/interactive_shell/cli_help.py
@@ -118,8 +118,4 @@ def answer_cli_help(question: str, _session: ReplSession, console: Console) -> N
     console.print()
 
 
-__all__ = [
-    "answer_cli_help",
-    "build_cli_reference_text",
-    "build_docs_reference_text",
-]
+__all__ = ["answer_cli_help"]

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -68,27 +68,20 @@ class TestSystemPromptTerminology:
     """The LLM grounding must steer answers away from the word 'REPL'."""
 
     def test_conversational_prompt_uses_interactive_shell_not_repl(self) -> None:
-        prompt = _build_system_prompt("conversational", reference="(ref)", history="(hist)")
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
         assert "interactive shell" in prompt
         # The prompt must explicitly forbid the "REPL" jargon so the model
         # does not echo it back in answers (#604).
         assert _TERMINOLOGY_RULE in prompt
         assert "Never use the word 'REPL'" in prompt
 
-    def test_reference_only_prompt_uses_interactive_shell_not_repl(self) -> None:
-        prompt = _build_system_prompt("reference_only", reference="(ref)", history="(hist)")
-        assert "interactive shell" in prompt
-        assert _TERMINOLOGY_RULE in prompt
-        assert "Never use the word 'REPL'" in prompt
-
-    def test_both_prompts_request_markdown_formatting(self) -> None:
-        for mode in ("conversational", "reference_only"):
-            prompt = _build_system_prompt(mode, reference="(ref)", history="(hist)")  # type: ignore[arg-type]
-            assert _MARKDOWN_RULE in prompt
-            assert "Markdown" in prompt
+    def test_prompt_requests_markdown_formatting(self) -> None:
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
+        assert _MARKDOWN_RULE in prompt
+        assert "Markdown" in prompt
 
     def test_conversational_prompt_exposes_action_contract(self) -> None:
-        prompt = _build_system_prompt("conversational", reference="(ref)", history="(hist)")
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
 
         assert _ACTION_RULE in prompt
         assert "switch_llm_provider" in prompt

--- a/tests/cli/interactive_shell/test_cli_help.py
+++ b/tests/cli/interactive_shell/test_cli_help.py
@@ -16,7 +16,6 @@ from app.cli.interactive_shell.cli_help import (
     _build_grounded_prompt,
     answer_cli_help,
 )
-from app.cli.interactive_shell.cli_reference import build_cli_reference_text
 from app.cli.interactive_shell.docs_reference import invalidate_docs_cache
 from app.cli.interactive_shell.session import ReplSession
 
@@ -72,12 +71,6 @@ def _seed_docs_root(root: Path) -> None:
         '---\ntitle: "Deployment"\n---\n\nDeploy OpenSRE to Railway, EC2, or LangGraph Cloud.\n',
         encoding="utf-8",
     )
-
-
-def test_legacy_export_still_present() -> None:
-    """The CLI reference helper must remain re-exported for backward compat."""
-    text = build_cli_reference_text()
-    assert "opensre" in text.lower()
 
 
 class TestSystemPromptGrounding:


### PR DESCRIPTION
Fixes #1379

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR contains **only** the interactive-shell grounding cleanup for #1379 (no other feature commits).

After the grounding cache landed (#1376 / #1402), redundant paths remained:

- Removed the unused `reference_only` mode and `grounding` parameter from `answer_cli_agent` / `_build_system_prompt` (never called from `loop.py`; differed from `answer_cli_help` by omitting docs). Documented that procedural, docs-aware Q&A stays on `answer_cli_help`.
- Stopped re-exporting `build_cli_reference_text` and `build_docs_reference_text` from `cli_help.__all__`; canonical imports remain `cli_reference` and `docs_reference`.
- Adjusted `test_cli_agent.py` and `test_cli_help.py`.

**Note:** An earlier PR from branch `refactor/cli-slash-first-arg-registry-hints` incorrectly bundled this change with unrelated slash-completion work. This branch is cut from current `main` with a single cherry-picked commit for #1379 only.

### Demo/Screenshot for feature changes and bug fixes - 
N/A — behavioral cleanup; paths unchanged for the live REPL. Verified with `make lint`, `make typecheck`, `make format-check`, and targeted `pytest` on the modified interactive_shell tests.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Single canonical cache-aware assembly via `build_cli_reference_text()` / `build_docs_reference_text()`; remove dead `reference_only` glue and duplicate export surface so #1379 acceptance criteria (one pipeline, no redundant rebuild branches at the call site) are met.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist with the PR.
