### PR TITLE
feat(cli): add REPL execution policy gate

### DIFF
--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -110,6 +110,10 @@ def capture_cli_invoked(properties: Properties | None = None) -> None:
     _capture(Event.CLI_INVOKED, properties)
 
 
+def capture_repl_execution_policy_decision(properties: Properties | None = None) -> None:
+    _capture(Event.REPL_EXECUTION_POLICY_DECISION, properties)
+
+
 def capture_onboard_started() -> None:
     _capture(Event.ONBOARD_STARTED)
 

--- a/app/analytics/events.py
+++ b/app/analytics/events.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 class Event(StrEnum):
     # Lifecycle
     CLI_INVOKED = "cli_invoked"
+    REPL_EXECUTION_POLICY_DECISION = "repl_execution_policy_decision"
     INSTALL_DETECTED = "install_detected"
     USER_ID_LOAD_FAILED = "user_id_load_failed"
     SENTRY_INIT_SKIPPED = "sentry_init_skipped"

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -30,6 +30,7 @@ from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.shell_execution import execute_shell_command
 from app.cli.interactive_shell.shell_policy import parse_shell_command
 from app.cli.interactive_shell.tasks import TaskKind, TaskRecord
+from app.cli.interactive_shell.theme import TERMINAL_ERROR
 from app.cli.support.errors import OpenSREError
 
 SHELL_COMMAND_TIMEOUT_SECONDS = 120
@@ -199,10 +200,14 @@ def run_shell_command(
     print_command_output(console, result.stdout)
     print_command_output(console, result.stderr, style="red")
     ok = result.exit_code == 0
-    if not ok:
-        console.print(f"[red]exit code:[/red] {result.exit_code}")
-    elif not result.stdout and not result.stderr:
-        console.print("[dim]exit code: 0[/dim]")
+    had_stdout = bool((result.stdout or "").strip())
+    had_stderr = bool((result.stderr or "").strip())
+    if ok:
+        if not had_stdout and not had_stderr:
+            console.print("[dim]✓[/dim]")
+    else:
+        code = result.exit_code if result.exit_code is not None else "?"
+        console.print(f"[{TERMINAL_ERROR}]✗[/] exit {code}")
     session.record("shell", command, ok=ok)
 
 

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -139,6 +139,7 @@ def run_shell_command(
     *,
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
+    action_already_listed: bool = False,
 ) -> None:
     parsed = parse_shell_command(command, is_windows=_intent_parser.IS_WINDOWS)
     policy = evaluate_shell_from_parsed(parsed)
@@ -149,6 +150,7 @@ def run_shell_command(
         action_summary=f"$ {command}",
         confirm_fn=confirm_fn,
         is_tty=is_tty,
+        action_already_listed=action_already_listed,
     ):
         session.record("shell", command, ok=False)
         return
@@ -260,6 +262,7 @@ def run_sample_alert(
     *,
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
+    action_already_listed: bool = False,
 ) -> None:
     from app.cli.investigation import run_sample_alert_for_session
 
@@ -271,6 +274,7 @@ def run_sample_alert(
         action_summary=f"sample alert investigation ({template_name})",
         confirm_fn=confirm_fn,
         is_tty=is_tty,
+        action_already_listed=action_already_listed,
     ):
         session.record("alert", f"sample:{template_name}", ok=False)
         return
@@ -316,6 +320,7 @@ def run_synthetic_test(
     *,
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
+    action_already_listed: bool = False,
 ) -> None:
     if suite_name != "rds_postgres":
         console.print(f"[red]unknown synthetic suite:[/red] {escape(suite_name)}")
@@ -330,6 +335,7 @@ def run_synthetic_test(
         action_summary="opensre tests synthetic",
         confirm_fn=confirm_fn,
         is_tty=is_tty,
+        action_already_listed=action_already_listed,
     ):
         session.record("synthetic_test", suite_name, ok=False)
         return

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -18,10 +19,16 @@ from rich.markup import escape
 from rich.text import Text
 
 import app.cli.interactive_shell.intent_parser as _intent_parser
+from app.cli.interactive_shell.execution_policy import (
+    evaluate_investigation_launch,
+    evaluate_shell_from_parsed,
+    evaluate_synthetic_test_launch,
+    execution_allowed,
+)
 from app.cli.interactive_shell.rendering import print_command_output
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.shell_execution import execute_shell_command
-from app.cli.interactive_shell.shell_policy import evaluate_policy, parse_shell_command
+from app.cli.interactive_shell.shell_policy import parse_shell_command
 from app.cli.interactive_shell.tasks import TaskKind, TaskRecord
 from app.cli.support.errors import OpenSREError
 
@@ -125,18 +132,28 @@ def watch_synthetic_subprocess(
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
 
 
-def run_shell_command(command: str, session: ReplSession, console: Console) -> None:
-    console.print(f"[bold]$ {escape(command)}[/bold]")
+def run_shell_command(
+    command: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> None:
     parsed = parse_shell_command(command, is_windows=_intent_parser.IS_WINDOWS)
-    decision = evaluate_policy(parsed=parsed)
-    if not decision.allow:
-        console.print(
-            f"[yellow]command blocked:[/yellow] {escape(decision.reason or 'not allowed')}"
-        )
-        if decision.hint:
-            console.print(f"[dim]{escape(decision.hint)}[/dim]")
+    policy = evaluate_shell_from_parsed(parsed)
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"$ {command}",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    ):
         session.record("shell", command, ok=False)
         return
+
+    console.print(f"[bold]$ {escape(command)}[/bold]")
 
     argv_builtin = parsed.argv
     if argv_builtin is None and parsed.passthrough and parsed.command.strip():
@@ -236,8 +253,27 @@ def run_pwd_command(command: str, session: ReplSession, console: Console) -> Non
     session.record("shell", command)
 
 
-def run_sample_alert(template_name: str, session: ReplSession, console: Console) -> None:
+def run_sample_alert(
+    template_name: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> None:
     from app.cli.investigation import run_sample_alert_for_session
+
+    policy = evaluate_investigation_launch(action_type="sample_alert")
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"sample alert investigation ({template_name})",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    ):
+        session.record("alert", f"sample:{template_name}", ok=False)
+        return
 
     console.print(f"[bold]sample alert:[/bold] {escape(template_name)}")
     task = session.task_registry.create(TaskKind.INVESTIGATION)
@@ -273,9 +309,28 @@ def run_sample_alert(template_name: str, session: ReplSession, console: Console)
     session.record("alert", f"sample:{template_name}")
 
 
-def run_synthetic_test(suite_name: str, session: ReplSession, console: Console) -> None:
+def run_synthetic_test(
+    suite_name: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> None:
     if suite_name != "rds_postgres":
         console.print(f"[red]unknown synthetic suite:[/red] {escape(suite_name)}")
+        session.record("synthetic_test", suite_name, ok=False)
+        return
+
+    policy = evaluate_synthetic_test_launch()
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary="opensre tests synthetic",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    ):
         session.record("synthetic_test", suite_name, ok=False)
         return
 

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -17,10 +17,16 @@ from app.cli.interactive_shell.action_planner import (
     plan_cli_actions,
     plan_terminal_tasks,
 )
-from app.cli.interactive_shell.command_registry import dispatch_slash, switch_llm_provider
+from app.cli.interactive_shell.command_registry import (
+    SLASH_COMMANDS,
+    dispatch_slash,
+    switch_llm_provider,
+)
 from app.cli.interactive_shell.execution_policy import (
     evaluate_llm_runtime_switch,
+    evaluate_slash_tier,
     execution_allowed,
+    resolve_slash_execution_tier,
 )
 from app.cli.interactive_shell.rendering import print_planned_actions
 from app.cli.interactive_shell.session import ReplSession
@@ -55,6 +61,43 @@ def execute_cli_actions(
     for action in actions:
         console.print()
         if action.kind == "slash":
+            stripped = action.content.strip()
+            parts = stripped.split()
+            if stripped == "/" or not parts:
+                if not dispatch_slash(
+                    action.content,
+                    session,
+                    console,
+                    confirm_fn=confirm_fn,
+                    is_tty=is_tty,
+                ):
+                    return True
+                continue
+            name = parts[0].lower()
+            args = parts[1:]
+            cmd = SLASH_COMMANDS.get(name)
+            if cmd is None:
+                if not dispatch_slash(
+                    action.content,
+                    session,
+                    console,
+                    confirm_fn=confirm_fn,
+                    is_tty=is_tty,
+                ):
+                    return True
+                continue
+            tier = resolve_slash_execution_tier(name, args, cmd.execution_tier)
+            policy = evaluate_slash_tier(tier)
+            if not execution_allowed(
+                policy,
+                session=session,
+                console=console,
+                action_summary=stripped,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            ):
+                session.record("slash", stripped, ok=False)
+                continue
             console.print(f"[bold]$ {escape(action.content)}[/bold]")
             if not dispatch_slash(
                 action.content,
@@ -62,10 +105,10 @@ def execute_cli_actions(
                 console,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                policy_precleared=True,
             ):
                 return True
         elif action.kind == "llm_provider":
-            console.print(f"[bold]$ /model set {escape(action.content)}[/bold]")
             pol = evaluate_llm_runtime_switch(action_type="switch_llm_provider")
             if not execution_allowed(
                 pol,
@@ -76,6 +119,7 @@ def execute_cli_actions(
                 is_tty=is_tty,
             ):
                 continue
+            console.print(f"[bold]$ /model set {escape(action.content)}[/bold]")
             switch_llm_provider(action.content, console)
             session.record("slash", f"/model set {action.content}")
         elif action.kind == "shell":

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from rich.console import Console
 from rich.markup import escape
 
@@ -16,12 +18,23 @@ from app.cli.interactive_shell.action_planner import (
     plan_terminal_tasks,
 )
 from app.cli.interactive_shell.command_registry import dispatch_slash, switch_llm_provider
+from app.cli.interactive_shell.execution_policy import (
+    evaluate_llm_runtime_switch,
+    execution_allowed,
+)
 from app.cli.interactive_shell.rendering import print_planned_actions
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
 
-def execute_cli_actions(message: str, session: ReplSession, console: Console) -> bool:
+def execute_cli_actions(
+    message: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> bool:
     """Execute inferred CLI and shell actions.
 
     Returns True when the message was handled. Unknown or ambiguous requests fall
@@ -42,20 +55,53 @@ def execute_cli_actions(message: str, session: ReplSession, console: Console) ->
     for action in actions:
         console.print()
         if action.kind == "slash":
-            session.record("slash", action.content)
             console.print(f"[bold]$ {escape(action.content)}[/bold]")
-            if not dispatch_slash(action.content, session, console):
+            if not dispatch_slash(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            ):
                 return True
         elif action.kind == "llm_provider":
             console.print(f"[bold]$ /model set {escape(action.content)}[/bold]")
+            pol = evaluate_llm_runtime_switch(action_type="switch_llm_provider")
+            if not execution_allowed(
+                pol,
+                session=session,
+                console=console,
+                action_summary=f"/model set {action.content}",
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            ):
+                continue
             switch_llm_provider(action.content, console)
             session.record("slash", f"/model set {action.content}")
         elif action.kind == "shell":
-            run_shell_command(action.content, session, console)
+            run_shell_command(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            )
         elif action.kind == "sample_alert":
-            run_sample_alert(action.content, session, console)
+            run_sample_alert(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            )
         else:
-            run_synthetic_test(action.content, session, console)
+            run_synthetic_test(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            )
 
     console.print()
     return not has_unhandled_clause

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -53,8 +53,6 @@ def execute_cli_actions(
     console.print()
     console.print(f"[{TERMINAL_ACCENT_BOLD}]assistant:[/]")
     print_planned_actions(console, actions)
-    console.print()
-    console.print("[dim]Running requested actions:[/dim]")
     if not has_unhandled_clause:
         session.record("cli_agent", message)
 
@@ -95,6 +93,7 @@ def execute_cli_actions(
                 action_summary=stripped,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             ):
                 session.record("slash", stripped, ok=False)
                 continue
@@ -117,6 +116,7 @@ def execute_cli_actions(
                 action_summary=f"/model set {action.content}",
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             ):
                 continue
             console.print(f"[bold]$ /model set {escape(action.content)}[/bold]")
@@ -129,6 +129,7 @@ def execute_cli_actions(
                 console,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             )
         elif action.kind == "sample_alert":
             run_sample_alert(
@@ -137,6 +138,7 @@ def execute_cli_actions(
                 console,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             )
         else:
             run_synthetic_test(
@@ -145,6 +147,7 @@ def execute_cli_actions(
                 console,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             )
 
     console.print()

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -177,13 +177,16 @@ def _execute_action_plan(
         return False
 
     from app.cli.interactive_shell.commands import (
+        SLASH_COMMANDS,
         dispatch_slash,
         switch_llm_provider,
         switch_toolcall_model,
     )
     from app.cli.interactive_shell.execution_policy import (
         evaluate_llm_runtime_switch,
+        evaluate_slash_tier,
         execution_allowed,
+        resolve_slash_execution_tier,
     )
 
     console.print()
@@ -228,7 +231,6 @@ def _execute_action_plan(
                 slash_label += f" {requested_model}"
             if requested_toolcall:
                 slash_label += f" --toolcall-model {requested_toolcall}"
-            console.print(f"[bold]$ {escape(slash_label)}[/bold]")
             pol = evaluate_llm_runtime_switch(action_type="switch_llm_provider")
             if not execution_allowed(
                 pol,
@@ -239,6 +241,7 @@ def _execute_action_plan(
                 is_tty=is_tty,
             ):
                 continue
+            console.print(f"[bold]$ {escape(slash_label)}[/bold]")
             switch_llm_provider(
                 provider,
                 console,
@@ -253,7 +256,6 @@ def _execute_action_plan(
             if not requested_model:
                 console.print("[red]missing model for switch_toolcall_model action[/red]")
                 continue
-            console.print(f"[bold]$ /model toolcall set {escape(requested_model)}[/bold]")
             pol = evaluate_llm_runtime_switch(action_type="switch_toolcall_model")
             if not execution_allowed(
                 pol,
@@ -264,6 +266,7 @@ def _execute_action_plan(
                 is_tty=is_tty,
             ):
                 continue
+            console.print(f"[bold]$ /model toolcall set {escape(requested_model)}[/bold]")
             switch_toolcall_model(requested_model, console)
             session.record("slash", f"/model toolcall set {requested_model}")
             continue
@@ -273,6 +276,32 @@ def _execute_action_plan(
             if command not in _ALLOWED_SLASH_ACTIONS:
                 console.print(f"[red]unsupported action command:[/red] {escape(command)}")
                 continue
+            stripped = command.strip()
+            parts = stripped.split()
+            name = parts[0].lower()
+            args = parts[1:]
+            cmd_slash = SLASH_COMMANDS.get(name)
+            if cmd_slash is None:
+                dispatch_slash(
+                    command,
+                    session,
+                    console,
+                    confirm_fn=confirm_fn,
+                    is_tty=is_tty,
+                )
+                continue
+            tier = resolve_slash_execution_tier(name, args, cmd_slash.execution_tier)
+            policy = evaluate_slash_tier(tier)
+            if not execution_allowed(
+                policy,
+                session=session,
+                console=console,
+                action_summary=stripped,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            ):
+                session.record("slash", stripped, ok=False)
+                continue
             console.print(f"[bold]$ {escape(command)}[/bold]")
             dispatch_slash(
                 command,
@@ -280,6 +309,7 @@ def _execute_action_plan(
                 console,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                policy_precleared=True,
             )
             continue
 

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -168,6 +169,9 @@ def _execute_action_plan(
     actions: list[dict[str, object]],
     session: ReplSession,
     console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
 ) -> bool:
     if not actions:
         return False
@@ -176,6 +180,10 @@ def _execute_action_plan(
         dispatch_slash,
         switch_llm_provider,
         switch_toolcall_model,
+    )
+    from app.cli.interactive_shell.execution_policy import (
+        evaluate_llm_runtime_switch,
+        execution_allowed,
     )
 
     console.print()
@@ -221,6 +229,16 @@ def _execute_action_plan(
             if requested_toolcall:
                 slash_label += f" --toolcall-model {requested_toolcall}"
             console.print(f"[bold]$ {escape(slash_label)}[/bold]")
+            pol = evaluate_llm_runtime_switch(action_type="switch_llm_provider")
+            if not execution_allowed(
+                pol,
+                session=session,
+                console=console,
+                action_summary=slash_label,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            ):
+                continue
             switch_llm_provider(
                 provider,
                 console,
@@ -236,6 +254,16 @@ def _execute_action_plan(
                 console.print("[red]missing model for switch_toolcall_model action[/red]")
                 continue
             console.print(f"[bold]$ /model toolcall set {escape(requested_model)}[/bold]")
+            pol = evaluate_llm_runtime_switch(action_type="switch_toolcall_model")
+            if not execution_allowed(
+                pol,
+                session=session,
+                console=console,
+                action_summary=f"/model toolcall set {requested_model}",
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            ):
+                continue
             switch_toolcall_model(requested_model, console)
             session.record("slash", f"/model toolcall set {requested_model}")
             continue
@@ -245,9 +273,14 @@ def _execute_action_plan(
             if command not in _ALLOWED_SLASH_ACTIONS:
                 console.print(f"[red]unsupported action command:[/red] {escape(command)}")
                 continue
-            session.record("slash", command)
             console.print(f"[bold]$ {escape(command)}[/bold]")
-            dispatch_slash(command, session, console)
+            dispatch_slash(
+                command,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            )
             continue
 
         console.print(f"[red]unsupported action:[/red] {escape(kind or '?')}")

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -215,7 +215,6 @@ def _execute_action_plan(
         console.print(f"[dim]{index}.[/dim] [{TERMINAL_ACCENT_BOLD}]{escape(label)}[/]")
 
     console.print()
-    console.print("[dim]Running requested actions:[/dim]")
     for action in actions:
         kind = str(action.get("action", "")).strip()
         console.print()
@@ -239,6 +238,7 @@ def _execute_action_plan(
                 action_summary=slash_label,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             ):
                 continue
             console.print(f"[bold]$ {escape(slash_label)}[/bold]")
@@ -264,6 +264,7 @@ def _execute_action_plan(
                 action_summary=f"/model toolcall set {requested_model}",
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             ):
                 continue
             console.print(f"[bold]$ /model toolcall set {escape(requested_model)}[/bold]")
@@ -299,6 +300,7 @@ def _execute_action_plan(
                 action_summary=stripped,
                 confirm_fn=confirm_fn,
                 is_tty=is_tty,
+                action_already_listed=True,
             ):
                 session.record("slash", stripped, ok=False)
                 continue

--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -58,11 +58,22 @@ def dispatch_slash(
     *,
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
+    policy_precleared: bool = False,
 ) -> bool:
-    """Dispatch a slash command line. Returns False iff the REPL should exit."""
+    """Dispatch a slash command line. Returns False iff the REPL should exit.
+
+    When ``policy_precleared`` is True, skip the execution gate (caller already ran
+    :func:`execution_allowed`) and run the handler directly. Only valid for lines
+    the registry resolves to a known command, or bare ``/`` after an equivalent
+    gate for help.
+    """
     stripped = command_line.strip()
     if stripped == "/":
         from app.cli.interactive_shell.command_registry.help import _cmd_help
+
+        if policy_precleared:
+            session.record("slash", stripped, ok=True)
+            return _cmd_help(session, console, [])
 
         help_cmd = SLASH_COMMANDS["/help"]
         gate = evaluate_slash_tier(
@@ -94,6 +105,9 @@ def dispatch_slash(
             f"[{TERMINAL_ERROR}]unknown command:[/] {escape(name)}  (type [bold]/help[/bold])"
         )
         return True
+    if policy_precleared:
+        session.record("slash", stripped, ok=True)
+        return cmd.handler(session, console, args)
     tier = resolve_slash_execution_tier(name, args, cmd.execution_tier)
     policy = evaluate_slash_tier(tier)
     if not execution_allowed(

--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from itertools import chain
 
 from rich.console import Console
@@ -27,6 +28,11 @@ from app.cli.interactive_shell.command_registry.session_cmds import COMMANDS as 
 from app.cli.interactive_shell.command_registry.system import COMMANDS as SYSTEM_COMMANDS
 from app.cli.interactive_shell.command_registry.tasks_cmds import COMMANDS as TASK_COMMANDS
 from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.execution_policy import (
+    evaluate_slash_tier,
+    execution_allowed,
+    resolve_slash_execution_tier,
+)
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ERROR
 
@@ -45,12 +51,34 @@ _MERGED_SEQUENCE = tuple(
 SLASH_COMMANDS: dict[str, SlashCommand] = {cmd.name: cmd for cmd in _MERGED_SEQUENCE}
 
 
-def dispatch_slash(command_line: str, session: ReplSession, console: Console) -> bool:
+def dispatch_slash(
+    command_line: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> bool:
     """Dispatch a slash command line. Returns False iff the REPL should exit."""
     stripped = command_line.strip()
     if stripped == "/":
         from app.cli.interactive_shell.command_registry.help import _cmd_help
 
+        help_cmd = SLASH_COMMANDS["/help"]
+        gate = evaluate_slash_tier(
+            resolve_slash_execution_tier("/help", [], help_cmd.execution_tier)
+        )
+        if not execution_allowed(
+            gate,
+            session=session,
+            console=console,
+            action_summary=stripped,
+            confirm_fn=confirm_fn,
+            is_tty=is_tty,
+        ):
+            session.record("slash", stripped, ok=False)
+            return True
+        session.record("slash", stripped, ok=True)
         return _cmd_help(session, console, [])
 
     parts = stripped.split()
@@ -60,11 +88,25 @@ def dispatch_slash(command_line: str, session: ReplSession, console: Console) ->
     args = parts[1:]
     cmd = SLASH_COMMANDS.get(name)
     if cmd is None:
+        session.record("slash", stripped, ok=False)
         console.print()
         console.print(
             f"[{TERMINAL_ERROR}]unknown command:[/] {escape(name)}  (type [bold]/help[/bold])"
         )
         return True
+    tier = resolve_slash_execution_tier(name, args, cmd.execution_tier)
+    policy = evaluate_slash_tier(tier)
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=stripped,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    ):
+        session.record("slash", stripped, ok=False)
+        return True
+    session.record("slash", stripped, ok=True)
     return cmd.handler(session, console, args)
 
 

--- a/app/cli/interactive_shell/command_registry/help.py
+++ b/app/cli/interactive_shell/command_registry/help.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from rich.console import Console
 
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.rendering import repl_table
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
@@ -24,8 +24,10 @@ def _cmd_help(session: ReplSession, console: Console, args: list[str]) -> bool: 
 
 
 COMMANDS: list[SlashCommand] = [
-    SlashCommand("/help", "show available commands", _cmd_help),
-    SlashCommand("/?", "shortcut for /help", _cmd_help),
+    SlashCommand(
+        "/help", "show available commands", _cmd_help, execution_tier=ExecutionTier.EXEMPT
+    ),
+    SlashCommand("/?", "shortcut for /help", _cmd_help, execution_tier=ExecutionTier.EXEMPT),
 ]
 
 __all__ = ["COMMANDS"]

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.command_registry import repl_data
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.rendering import (
     render_integrations_table,
     render_mcp_table,
@@ -145,6 +145,7 @@ COMMANDS: list[SlashCommand] = [
         "('/list integrations', '/list models', '/list mcp')",
         _cmd_list,
         first_arg_completions=_LIST_FIRST_ARGS,
+        execution_tier=ExecutionTier.SAFE,
     ),
     SlashCommand(
         "/integrations",
@@ -152,12 +153,14 @@ COMMANDS: list[SlashCommand] = [
         "'/integrations show <service>')",
         _cmd_integrations,
         first_arg_completions=_INTEGRATIONS_FIRST_ARGS,
+        execution_tier=ExecutionTier.SAFE,
     ),
     SlashCommand(
         "/mcp",
         "manage MCP servers ('/mcp list', '/mcp connect', '/mcp disconnect')",
         _cmd_mcp,
         first_arg_completions=_MCP_FIRST_ARGS,
+        execution_tier=ExecutionTier.SAFE,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.markup import escape
 
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.tasks import TaskKind
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD, TERMINAL_ERROR
@@ -159,14 +159,26 @@ COMMANDS: list[SlashCommand] = [
         "('/template generic|datadog|grafana|honeycomb|coralogix')",
         _cmd_template,
         first_arg_completions=_TEMPLATE_FIRST_ARGS,
+        execution_tier=ExecutionTier.SAFE,
     ),
     SlashCommand(
         "/investigate",
         "run an RCA investigation from a file ('/investigate <file>')",
         _cmd_investigate_file,
+        execution_tier=ExecutionTier.ELEVATED,
     ),
-    SlashCommand("/last", "reprint the most recent investigation report", _cmd_last),
-    SlashCommand("/save", "save last investigation to a file ('/save <path>')", _cmd_save),
+    SlashCommand(
+        "/last",
+        "reprint the most recent investigation report",
+        _cmd_last,
+        execution_tier=ExecutionTier.SAFE,
+    ),
+    SlashCommand(
+        "/save",
+        "save last investigation to a file ('/save <path>')",
+        _cmd_save,
+        execution_tier=ExecutionTier.ELEVATED,
+    ),
 ]
 
 __all__ = ["COMMANDS"]

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.command_registry import repl_data
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.rendering import render_models_table
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ERROR
@@ -239,6 +239,7 @@ COMMANDS: list[SlashCommand] = [
         "'/model toolcall set <model>')",
         _cmd_model,
         first_arg_completions=_MODEL_FIRST_ARGS,
+        execution_tier=ExecutionTier.SAFE,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.banner import render_banner
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.rendering import repl_table
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
@@ -138,6 +138,7 @@ COMMANDS: list[SlashCommand] = [
         "toggle trust mode ('/trust off' to disable)",
         _cmd_trust,
         first_arg_completions=_TRUST_FIRST_ARGS,
+        execution_tier=ExecutionTier.EXEMPT,
     ),
     SlashCommand("/status", "show session status", _cmd_status),
     SlashCommand("/context", "show accumulated infra context", _cmd_context),

--- a/app/cli/interactive_shell/command_registry/system.py
+++ b/app/cli/interactive_shell/command_registry/system.py
@@ -6,7 +6,7 @@ import platform
 
 from rich.console import Console
 
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.rendering import repl_table
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
@@ -74,8 +74,10 @@ def _cmd_version(session: ReplSession, console: Console, args: list[str]) -> boo
 
 
 COMMANDS: list[SlashCommand] = [
-    SlashCommand("/exit", "exit the interactive shell", _cmd_exit),
-    SlashCommand("/quit", "alias for /exit", _cmd_exit),
+    SlashCommand(
+        "/exit", "exit the interactive shell", _cmd_exit, execution_tier=ExecutionTier.EXEMPT
+    ),
+    SlashCommand("/quit", "alias for /exit", _cmd_exit, execution_tier=ExecutionTier.EXEMPT),
     SlashCommand("/health", "show integration and agent health", _cmd_health),
     SlashCommand("/doctor", "run full environment diagnostic", _cmd_doctor),
     SlashCommand("/version", "print version, Python and OS info", _cmd_version),

--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from rich.console import Console
 from rich.markup import escape
 
-from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.history import load_command_history_entries
 from app.cli.interactive_shell.rendering import repl_table
 from app.cli.interactive_shell.session import ReplSession
@@ -134,6 +134,7 @@ COMMANDS: list[SlashCommand] = [
         "/cancel",
         "cancel a running task by id ('/cancel <task_id>' — see /tasks)",
         _cmd_cancel,
+        execution_tier=ExecutionTier.ELEVATED,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/types.py
+++ b/app/cli/interactive_shell/command_registry/types.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from rich.console import Console
 
+from app.cli.interactive_shell.execution_tier import ExecutionTier
 from app.cli.interactive_shell.session import ReplSession
 
 
@@ -17,6 +18,7 @@ class SlashCommand:
     handler: Callable[[ReplSession, Console, list[str]], bool]
     #: Tab-completion hints for the first argument after the command name (keyword, meta text).
     first_arg_completions: tuple[tuple[str, str], ...] = ()
+    execution_tier: ExecutionTier = ExecutionTier.SAFE
 
 
-__all__ = ["SlashCommand"]
+__all__ = ["ExecutionTier", "SlashCommand"]

--- a/app/cli/interactive_shell/execution_policy.py
+++ b/app/cli/interactive_shell/execution_policy.py
@@ -1,0 +1,299 @@
+"""Central execution policy (allow / ask / deny) for interactive REPL actions."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from rich.console import Console
+from rich.markup import escape
+
+import app.cli.interactive_shell.intent_parser as _intent_parser
+from app.analytics.cli import capture_repl_execution_policy_decision
+from app.cli.interactive_shell.execution_tier import ExecutionTier
+from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.shell_policy import (
+    ParsedShellCommand,
+    evaluate_policy,
+    parse_shell_command,
+)
+
+ExecutionVerdict = Literal["allow", "ask", "deny"]
+
+
+@dataclass(frozen=True)
+class ExecutionPolicyResult:
+    """Result of evaluating whether an action may run."""
+
+    verdict: ExecutionVerdict
+    action_type: str
+    reason: str | None
+    hint: str | None = None
+    shell_classification: str | None = None
+
+
+def _default_confirm_fn(prompt: str) -> str:
+    return input(prompt)
+
+
+DEFAULT_CONFIRM_FN: Callable[[str], str] = _default_confirm_fn
+
+
+def resolve_slash_execution_tier(
+    command_name: str, args: list[str], registered: ExecutionTier
+) -> ExecutionTier:
+    """Refine tier using subcommands where the registry defaults are too coarse."""
+    if registered == ExecutionTier.EXEMPT:
+        return ExecutionTier.EXEMPT
+    key = command_name.lower()
+    if key == "/model":
+        sub = (args[0].lower() if args else "show").strip()
+        if sub in {"show"}:
+            return ExecutionTier.SAFE
+        if sub == "toolcall":
+            if len(args) >= 2 and args[1].lower() in {"set", "use", "switch"}:
+                return ExecutionTier.ELEVATED
+            return ExecutionTier.SAFE
+        if sub in {"set", "use", "switch"}:
+            return ExecutionTier.ELEVATED
+        return ExecutionTier.SAFE
+    if key == "/integrations":
+        sub = (args[0].lower() if args else "list").strip()
+        if sub == "verify":
+            return ExecutionTier.ELEVATED
+        return ExecutionTier.SAFE
+    return registered
+
+
+def _emit_decision(
+    *,
+    action_type: str,
+    policy_verdict: ExecutionVerdict,
+    outcome: str,
+    trust_mode: bool,
+    reason: str | None,
+) -> None:
+    props: dict[str, str | bool] = {
+        "action_type": action_type,
+        "policy_verdict": policy_verdict,
+        "outcome": outcome,
+        "trust_mode": trust_mode,
+    }
+    if reason:
+        props["reason"] = reason[:240]
+    capture_repl_execution_policy_decision(props)
+
+
+def execution_allowed(
+    result: ExecutionPolicyResult,
+    *,
+    session: ReplSession,
+    console: Console,
+    action_summary: str,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> bool:
+    """Print policy UX, emit analytics, and return whether execution should proceed."""
+    trust_mode = session.trust_mode
+    tty = sys.stdin.isatty() if is_tty is None else is_tty
+    confirm = confirm_fn or DEFAULT_CONFIRM_FN
+
+    if result.verdict == "deny":
+        _emit_decision(
+            action_type=result.action_type,
+            policy_verdict="deny",
+            outcome="blocked",
+            trust_mode=trust_mode,
+            reason=result.reason,
+        )
+        console.print(f"[yellow]action blocked:[/yellow] {escape(result.reason or 'not allowed')}")
+        if result.hint:
+            console.print(f"[dim]{escape(result.hint)}[/dim]")
+        return False
+
+    if result.verdict == "allow":
+        _emit_decision(
+            action_type=result.action_type,
+            policy_verdict="allow",
+            outcome="allowed",
+            trust_mode=trust_mode,
+            reason=result.reason,
+        )
+        return True
+
+    # ask
+    if trust_mode:
+        _emit_decision(
+            action_type=result.action_type,
+            policy_verdict="ask",
+            outcome="allowed",
+            trust_mode=trust_mode,
+            reason="trust_mode_skipped_prompt",
+        )
+        return True
+
+    if not tty:
+        _emit_decision(
+            action_type=result.action_type,
+            policy_verdict="ask",
+            outcome="blocked",
+            trust_mode=trust_mode,
+            reason="non_interactive_stdin",
+        )
+        console.print(
+            "[yellow]confirmation required but stdin is not a TTY; "
+            "enable trust mode with[/yellow] [bold]/trust[/bold] [yellow]or rerun in a terminal.[/yellow]"
+        )
+        console.print(f"[dim]{escape(action_summary)}[/dim]")
+        return False
+
+    console.print(
+        f"[yellow]Confirm:[/yellow] {escape(result.reason or 'this action')} "
+        f"[dim](reply y or yes)[/dim]"
+    )
+    console.print(f"[dim]{escape(action_summary)}[/dim]")
+    _emit_decision(
+        action_type=result.action_type,
+        policy_verdict="ask",
+        outcome="prompted",
+        trust_mode=trust_mode,
+        reason=result.reason,
+    )
+    answer = confirm("Proceed? [y/N] ").strip().lower()
+    if answer not in {"y", "yes"}:
+        _emit_decision(
+            action_type=result.action_type,
+            policy_verdict="ask",
+            outcome="aborted",
+            trust_mode=trust_mode,
+            reason="user_declined",
+        )
+        console.print("[dim]cancelled.[/dim]")
+        return False
+
+    _emit_decision(
+        action_type=result.action_type,
+        policy_verdict="ask",
+        outcome="allowed",
+        trust_mode=trust_mode,
+        reason="user_confirmed",
+    )
+    return True
+
+
+def evaluate_shell_from_parsed(parsed: ParsedShellCommand) -> ExecutionPolicyResult:
+    """Like :func:`evaluate_shell_command` but reuses an existing parse result."""
+    d = evaluate_policy(parsed=parsed)
+
+    if parsed.parse_error is not None:
+        return ExecutionPolicyResult(
+            verdict="deny",
+            action_type="shell",
+            reason=d.reason,
+            hint=d.hint,
+            shell_classification=d.classification,
+        )
+
+    if parsed.passthrough:
+        return ExecutionPolicyResult(
+            verdict="ask",
+            action_type="shell",
+            reason="explicit shell passthrough (!) runs your full user shell",
+            hint=d.hint,
+            shell_classification=d.classification,
+        )
+
+    if d.allow:
+        return ExecutionPolicyResult(
+            verdict="allow",
+            action_type="shell",
+            reason=None,
+            shell_classification=d.classification,
+        )
+
+    if d.classification == "restricted":
+        return ExecutionPolicyResult(
+            verdict="deny",
+            action_type="shell",
+            reason=d.reason,
+            hint=d.hint,
+            shell_classification=d.classification,
+        )
+
+    if parsed.argv is None:
+        return ExecutionPolicyResult(
+            verdict="deny",
+            action_type="shell",
+            reason=d.reason or "failed to parse command.",
+            hint=d.hint,
+            shell_classification=d.classification,
+        )
+
+    return ExecutionPolicyResult(
+        verdict="ask",
+        action_type="shell",
+        reason=d.reason,
+        hint=d.hint,
+        shell_classification=d.classification,
+    )
+
+
+def evaluate_shell_command(command: str) -> ExecutionPolicyResult:
+    """Map shell policy + passthrough rules into allow/ask/deny."""
+    parsed = parse_shell_command(command, is_windows=_intent_parser.IS_WINDOWS)
+    return evaluate_shell_from_parsed(parsed)
+
+
+def evaluate_slash_tier(tier: ExecutionTier) -> ExecutionPolicyResult:
+    """Turn a resolved slash tier into an execution verdict."""
+    if tier == ExecutionTier.EXEMPT or tier == ExecutionTier.SAFE:
+        return ExecutionPolicyResult(verdict="allow", action_type="slash", reason=None)
+    return ExecutionPolicyResult(
+        verdict="ask",
+        action_type="slash",
+        reason="this command may change configuration or run heavy work",
+    )
+
+
+def evaluate_investigation_launch(
+    *, action_type: Literal["investigation", "sample_alert"]
+) -> ExecutionPolicyResult:
+    """Policy for starting an RCA / LangGraph investigation from the REPL."""
+    return ExecutionPolicyResult(
+        verdict="ask",
+        action_type=action_type,
+        reason="investigations call external tools and consume LLM quota",
+    )
+
+
+def evaluate_synthetic_test_launch() -> ExecutionPolicyResult:
+    return ExecutionPolicyResult(
+        verdict="ask",
+        action_type="synthetic_test",
+        reason="synthetic tests spawn a long-running subprocess",
+    )
+
+
+def evaluate_llm_runtime_switch(*, action_type: str) -> ExecutionPolicyResult:
+    return ExecutionPolicyResult(
+        verdict="ask",
+        action_type=action_type,
+        reason="this updates LLM provider / model environment configuration",
+    )
+
+
+__all__ = [
+    "DEFAULT_CONFIRM_FN",
+    "ExecutionPolicyResult",
+    "ExecutionVerdict",
+    "evaluate_investigation_launch",
+    "evaluate_llm_runtime_switch",
+    "evaluate_shell_command",
+    "evaluate_shell_from_parsed",
+    "evaluate_slash_tier",
+    "evaluate_synthetic_test_launch",
+    "execution_allowed",
+    "resolve_slash_execution_tier",
+]

--- a/app/cli/interactive_shell/execution_policy.py
+++ b/app/cli/interactive_shell/execution_policy.py
@@ -97,8 +97,13 @@ def execution_allowed(
     action_summary: str,
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
+    action_already_listed: bool = False,
 ) -> bool:
-    """Print policy UX, emit analytics, and return whether execution should proceed."""
+    """Print policy UX, emit analytics, and return whether execution should proceed.
+
+    When ``action_already_listed`` is True (e.g. assistant printed a numbered action plan),
+    the TTY prompt omits repeating ``action_summary`` and shows only the policy reason.
+    """
     trust_mode = session.trust_mode
     tty = sys.stdin.isatty() if is_tty is None else is_tty
     confirm = confirm_fn or DEFAULT_CONFIRM_FN
@@ -111,7 +116,7 @@ def execution_allowed(
             trust_mode=trust_mode,
             reason=result.reason,
         )
-        console.print(f"[yellow]action blocked:[/yellow] {escape(result.reason or 'not allowed')}")
+        console.print(f"[yellow]Action blocked:[/yellow] {escape(result.reason or 'not allowed')}")
         if result.hint:
             console.print(f"[dim]{escape(result.hint)}[/dim]")
         return False
@@ -152,10 +157,16 @@ def execution_allowed(
         console.print(f"[dim]{escape(action_summary)}[/dim]")
         return False
 
-    console.print(
-        f"[yellow]Confirm:[/yellow] {escape(result.reason or 'this action')} "
-        f"[dim](reply y or yes)[/dim]"
-    )
+    reason = (result.reason or "this action").strip()
+    summary = action_summary.strip()
+    if action_already_listed:
+        console.print(f"[yellow]Confirm:[/yellow] [dim]{escape(reason)}[/dim]")
+    elif summary:
+        console.print(
+            f"[yellow]Confirm[/yellow] [bold]{escape(summary)}[/bold] [dim]— {escape(reason)}[/dim]"
+        )
+    else:
+        console.print(f"[yellow]Confirm:[/yellow] [dim]{escape(reason)}[/dim]")
     answer = confirm("Proceed? [y/N] ").strip().lower()
     if answer not in {"y", "yes"}:
         _emit_decision(

--- a/app/cli/interactive_shell/execution_policy.py
+++ b/app/cli/interactive_shell/execution_policy.py
@@ -74,6 +74,7 @@ def _emit_decision(
     outcome: str,
     trust_mode: bool,
     reason: str | None,
+    user_prompted: bool = False,
 ) -> None:
     props: dict[str, str | bool] = {
         "action_type": action_type,
@@ -83,6 +84,8 @@ def _emit_decision(
     }
     if reason:
         props["reason"] = reason[:240]
+    if user_prompted:
+        props["user_prompted"] = True
     capture_repl_execution_policy_decision(props)
 
 
@@ -153,14 +156,6 @@ def execution_allowed(
         f"[yellow]Confirm:[/yellow] {escape(result.reason or 'this action')} "
         f"[dim](reply y or yes)[/dim]"
     )
-    console.print(f"[dim]{escape(action_summary)}[/dim]")
-    _emit_decision(
-        action_type=result.action_type,
-        policy_verdict="ask",
-        outcome="prompted",
-        trust_mode=trust_mode,
-        reason=result.reason,
-    )
     answer = confirm("Proceed? [y/N] ").strip().lower()
     if answer not in {"y", "yes"}:
         _emit_decision(
@@ -169,6 +164,7 @@ def execution_allowed(
             outcome="aborted",
             trust_mode=trust_mode,
             reason="user_declined",
+            user_prompted=True,
         )
         console.print("[dim]cancelled.[/dim]")
         return False
@@ -179,6 +175,7 @@ def execution_allowed(
         outcome="allowed",
         trust_mode=trust_mode,
         reason="user_confirmed",
+        user_prompted=True,
     )
     return True
 

--- a/app/cli/interactive_shell/execution_tier.py
+++ b/app/cli/interactive_shell/execution_tier.py
@@ -1,0 +1,21 @@
+"""Execution tiers for interactive REPL policy (imported without loading the full command registry)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ExecutionTier(StrEnum):
+    """How aggressively the execution policy gate treats a slash command."""
+
+    EXEMPT = "exempt"
+    """Meta commands that must not prompt (e.g. /trust, /exit)."""
+
+    SAFE = "safe"
+    """Read-only or informational; always allowed without confirmation."""
+
+    ELEVATED = "elevated"
+    """Mutating, expensive, or stops work; may require confirmation."""
+
+
+__all__ = ["ExecutionTier"]

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -279,10 +279,33 @@ def _build_prompt_style() -> Style:
     )
 
 
-def _run_new_alert(text: str, session: ReplSession, console: Console) -> None:
+def _run_new_alert(
+    text: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> None:
     """Dispatch a free-text alert description to the streaming pipeline."""
+    from app.cli.interactive_shell.execution_policy import (
+        evaluate_investigation_launch,
+        execution_allowed,
+    )
     from app.cli.interactive_shell.tasks import TaskKind
     from app.cli.investigation import run_investigation_for_session
+
+    policy = evaluate_investigation_launch(action_type="investigation")
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary="run RCA investigation from pasted alert text",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    ):
+        session.record("alert", text, ok=False)
+        return
 
     task = session.task_registry.create(TaskKind.INVESTIGATION)
     task.mark_running()
@@ -339,7 +362,6 @@ async def _run_one_turn(
     if kind == "slash":
         # Rewrite bare-word commands to their slash form before dispatch.
         cmd_text = text if text.startswith("/") else f"/{text}"
-        session.record("slash", cmd_text)
         try:
             should_continue = dispatch_slash(cmd_text, session, console)
         except Exception as exc:  # noqa: BLE001
@@ -397,7 +419,6 @@ async def _repl_main(initial_input: str | None = None, config: ReplConfig | None
             kind = classify_input(stripped, session)
             if kind == "slash":
                 cmd_text = stripped if stripped.startswith("/") else f"/{stripped}"
-                session.record("slash", cmd_text)
                 if not dispatch_slash(cmd_text, session, console):
                     return 0
                 console.print()

--- a/app/cli/interactive_shell/session.py
+++ b/app/cli/interactive_shell/session.py
@@ -29,8 +29,7 @@ class ReplSession:
     earlier investigations that should seed future ones."""
 
     trust_mode: bool = False
-    """If True, skip any future [Y/n] confirmation prompts for read-only tools.
-    (No destructive tools exist today; reserved for forward compatibility.)"""
+    """When True, confirmation prompts for elevated REPL actions are skipped."""
 
     token_usage: dict[str, int] = field(default_factory=dict)
     """Accumulated token counts: {"input": N, "output": N}. Populated when available."""

--- a/app/cli/interactive_shell/shell_policy.py
+++ b/app/cli/interactive_shell/shell_policy.py
@@ -374,10 +374,7 @@ def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
         return PolicyDecision(
             allow=False,
             classification=classification,
-            reason=(
-                "mutating commands are blocked in safe mode "
-                "(includes exec-wrapper commands such as find and env)."
-            ),
+            reason="mutating commands are blocked in safe mode.",
             hint=(
                 "Use a read-only command, or run !<command> to explicitly "
                 "opt into shell passthrough."
@@ -388,8 +385,8 @@ def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
         return PolicyDecision(
             allow=False,
             classification=classification,
-            reason="restricted command is not allowed from inferred execution.",
-            hint="Run the command directly in your shell if you truly intend it.",
+            reason="Not allowed for assistant-run shell.",
+            hint="Run it in your terminal if needed.",
         )
 
     return PolicyDecision(

--- a/tests/cli/interactive_shell/conftest.py
+++ b/tests/cli/interactive_shell/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for interactive-shell tests."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _repl_execution_policy_auto_yes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Elevated REPL actions prompt for confirmation; stdin is non-TTY under pytest."""
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.execution_policy.DEFAULT_CONFIRM_FN",
+        lambda _prompt: "y",
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -81,7 +81,7 @@ def test_run_cd_command_chdirs_to_target(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        "app.cli.interactive_shell.action_executor.evaluate_policy",
+        "app.cli.interactive_shell.execution_policy.evaluate_policy",
         lambda **_: PolicyDecision(
             allow=False,
             classification="mutating",
@@ -94,10 +94,16 @@ def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.Monkey
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False)
 
-    run_shell_command("rm -rf /nope", session, console)
+    run_shell_command(
+        "rm -rf /nope",
+        session,
+        console,
+        confirm_fn=lambda _p: "n",
+        is_tty=True,
+    )
 
     assert "test block" in buf.getvalue()
-    assert "use !" in buf.getvalue().lower() or "passthrough" in buf.getvalue().lower()
+    assert "cancelled" in buf.getvalue().lower()
     assert session.history[-1] == {"type": "shell", "text": "rm -rf /nope", "ok": False}
 
 

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -19,6 +19,7 @@ from app.cli.interactive_shell.action_executor import (
     terminate_child_process,
 )
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.shell_execution import ShellExecutionResult
 from app.cli.interactive_shell.shell_policy import PolicyDecision
 
 
@@ -105,6 +106,62 @@ def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.Monkey
     assert "test block" in buf.getvalue()
     assert "cancelled" in buf.getvalue().lower()
     assert session.history[-1] == {"type": "shell", "text": "rm -rf /nope", "ok": False}
+
+
+def test_run_shell_command_silent_success_prints_checkmark(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
+        return ShellExecutionResult(
+            command="true",
+            argv=["true"],
+            stdout="",
+            stderr="",
+            exit_code=0,
+            timed_out=False,
+            truncated=False,
+            executed_with_shell=False,
+        )
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.execute_shell_command",
+        _fake_execute,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_shell_command("true", session, console)
+    assert "✓" in buf.getvalue()
+    assert session.history[-1] == {"type": "shell", "text": "true", "ok": True}
+
+
+def test_run_shell_command_failure_prints_exit_line(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
+        return ShellExecutionResult(
+            command="false",
+            argv=["false"],
+            stdout="",
+            stderr="",
+            exit_code=7,
+            timed_out=False,
+            truncated=False,
+            executed_with_shell=False,
+        )
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.execute_shell_command",
+        _fake_execute,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_shell_command("false", session, console)
+    out = buf.getvalue()
+    assert "✗" in out
+    assert "exit 7" in out
+    assert session.history[-1] == {"type": "shell", "text": "false", "ok": False}
 
 
 def test_run_synthetic_test_unknown_suite_records_failure() -> None:

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell import action_executor, agent_actions, shell_execution
@@ -56,8 +57,14 @@ def test_integration_prompt_plans_datadog_lookup_only() -> None:
 def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) -> None:
     dispatched: list[str] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -94,8 +101,14 @@ def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) ->
 def test_execute_cli_actions_falls_through_for_local_llama_request(monkeypatch: object) -> None:
     dispatched: list[str] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -149,8 +162,14 @@ def test_execute_cli_actions_answers_discord_then_dispatches_datadog(
 ) -> None:
     dispatched: list[str] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -224,8 +243,14 @@ def test_compound_services_and_synthetic_rds_plans_all_actions() -> None:
 def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> None:
     dispatched: list[str] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -253,8 +278,14 @@ def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> No
 def test_services_version_deploy_prompt_executes_in_order(monkeypatch: object) -> None:
     dispatched: list[str] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -357,8 +388,14 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
     dispatched: list[str] = []
     popen_calls: list[tuple[list[str], dict[str, object]]] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -427,8 +464,14 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
 def test_partial_match_reports_unhandled_clause(monkeypatch: object) -> None:
     dispatched: list[str] = []
 
-    def _fake_dispatch(command: str, _session: ReplSession, console: Console) -> bool:
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
         dispatched.append(command)
+        session.record("slash", command, ok=True)
         console.print(f"ran {command}")
         return True
 
@@ -679,16 +722,21 @@ def test_execute_cli_actions_routes_bang_pwd_through_builtin(monkeypatch: object
     assert "explicit shell passthrough enabled" not in captured
 
 
-def test_execute_cli_actions_blocks_mutating_command_by_default() -> None:
+def test_execute_cli_actions_declines_mutating_shell_when_user_rejects_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.execution_policy.DEFAULT_CONFIRM_FN",
+        lambda _p: "n",
+    )
     session = ReplSession()
     console, buf = _capture()
 
     assert execute_cli_actions("run `rm -rf /tmp/demo`", session, console) is True
     assert session.history[-1] == {"type": "shell", "text": "rm -rf /tmp/demo", "ok": False}
     output = buf.getvalue()
-    assert "command blocked" in output
-    assert "mutating commands are blocked" in output
-    assert "run !<command>" in output
+    assert "cancelled" in output.lower()
+    assert "mutating commands are blocked" in output.lower() or "confirm" in output.lower()
 
 
 def test_execute_cli_actions_blocks_ambiguous_shell_operators() -> None:
@@ -698,7 +746,7 @@ def test_execute_cli_actions_blocks_ambiguous_shell_operators() -> None:
     assert execute_cli_actions("run `ls | wc -l`", session, console) is True
     assert session.history[-1] == {"type": "shell", "text": "ls | wc -l", "ok": False}
     output = buf.getvalue()
-    assert "command blocked" in output
+    assert "action blocked" in output
     assert "shell operators" in output
 
 
@@ -730,5 +778,5 @@ def test_execute_cli_actions_rejects_malformed_shell_input() -> None:
     assert execute_cli_actions('run `cat "unterminated`', session, console) is True
     assert session.history[-1] == {"type": "shell", "text": 'cat "unterminated', "ok": False}
     output = buf.getvalue()
-    assert "command blocked" in output
+    assert "action blocked" in output
     assert "could not parse command" in output

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -93,7 +93,6 @@ def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) ->
     assert output.index("Requested actions") < output.index("$ /health")
     assert output.index("1.") < output.index("$ /health")
     assert output.index("2.") < output.index("$ /health")
-    assert "Running requested actions" in output
     assert "ran /health" in output
     assert "ran /list integrations" in output
 
@@ -512,7 +511,6 @@ def test_execute_cli_actions_runs_shell_command(monkeypatch: object) -> None:
         {"type": "shell", "text": "pwd", "ok": True},
     ]
     output = buf.getvalue()
-    assert "Running requested actions" in output
     assert "$ pwd" in output
     assert "/tmp/project" in output
 
@@ -746,7 +744,7 @@ def test_execute_cli_actions_blocks_ambiguous_shell_operators() -> None:
     assert execute_cli_actions("run `ls | wc -l`", session, console) is True
     assert session.history[-1] == {"type": "shell", "text": "ls | wc -l", "ok": False}
     output = buf.getvalue()
-    assert "action blocked" in output
+    assert "action blocked" in output.lower()
     assert "shell operators" in output
 
 
@@ -778,5 +776,5 @@ def test_execute_cli_actions_rejects_malformed_shell_input() -> None:
     assert execute_cli_actions('run `cat "unterminated`', session, console) is True
     assert session.history[-1] == {"type": "shell", "text": 'cat "unterminated', "ok": False}
     output = buf.getvalue()
-    assert "action blocked" in output
+    assert "action blocked" in output.lower()
     assert "could not parse command" in output

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -637,7 +637,7 @@ def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     assert session.history[-1] == {"type": "shell", "text": "false", "ok": False}
     output = buf.getvalue()
     assert "nope" in output
-    assert "exit code" in output
+    assert "exit 2" in output
 
 
 def test_execute_cli_actions_runs_passthrough_with_shell_true(monkeypatch: object) -> None:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -881,7 +881,8 @@ class TestCompactCommand:
         console, buf = _capture()
         dispatch_slash("/compact", session, console)
         assert "nothing to compact" in buf.getvalue()
-        assert len(session.history) == 5
+        assert len(session.history) == 6
+        assert session.history[-1]["text"] == "/compact"
 
     def test_trims_to_20_when_over_limit(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_execution_policy.py
+++ b/tests/cli/interactive_shell/test_execution_policy.py
@@ -1,0 +1,108 @@
+"""Unit tests for REPL execution policy composition."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from app.cli.interactive_shell.execution_policy import (
+    evaluate_investigation_launch,
+    evaluate_shell_command,
+    evaluate_slash_tier,
+    evaluate_synthetic_test_launch,
+    execution_allowed,
+    resolve_slash_execution_tier,
+)
+from app.cli.interactive_shell.execution_tier import ExecutionTier
+from app.cli.interactive_shell.session import ReplSession
+
+
+def test_read_only_shell_is_allow() -> None:
+    r = evaluate_shell_command("pwd")
+    assert r.verdict == "allow"
+    assert r.action_type == "shell"
+
+
+def test_restricted_shell_is_deny() -> None:
+    r = evaluate_shell_command("sudo ls /")
+    assert r.verdict == "deny"
+
+
+def test_mutating_shell_is_ask() -> None:
+    r = evaluate_shell_command("rm -rf /tmp/x")
+    assert r.verdict == "ask"
+    assert r.shell_classification == "mutating"
+
+
+def test_passthrough_shell_is_ask() -> None:
+    r = evaluate_shell_command("!echo hi")
+    assert r.verdict == "ask"
+
+
+def test_slash_exempt_is_allow() -> None:
+    r = evaluate_slash_tier(ExecutionTier.EXEMPT)
+    assert r.verdict == "allow"
+
+
+def test_slash_elevated_is_ask() -> None:
+    r = evaluate_slash_tier(ExecutionTier.ELEVATED)
+    assert r.verdict == "ask"
+
+
+def test_model_show_resolves_safe() -> None:
+    tier = resolve_slash_execution_tier("/model", [], ExecutionTier.SAFE)
+    assert tier == ExecutionTier.SAFE
+
+
+def test_model_set_resolves_elevated() -> None:
+    tier = resolve_slash_execution_tier("/model", ["set", "anthropic"], ExecutionTier.SAFE)
+    assert tier == ExecutionTier.ELEVATED
+
+
+def test_integrations_verify_resolves_elevated() -> None:
+    tier = resolve_slash_execution_tier("/integrations", ["verify"], ExecutionTier.SAFE)
+    assert tier == ExecutionTier.ELEVATED
+
+
+def test_investigation_launch_is_ask() -> None:
+    r = evaluate_investigation_launch(action_type="investigation")
+    assert r.verdict == "ask"
+    assert r.action_type == "investigation"
+
+
+def test_synthetic_is_ask() -> None:
+    r = evaluate_synthetic_test_launch()
+    assert r.verdict == "ask"
+
+
+def test_trust_mode_skips_ask() -> None:
+    session = ReplSession()
+    session.trust_mode = True
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    r = evaluate_slash_tier(ExecutionTier.ELEVATED)
+    assert execution_allowed(
+        r,
+        session=session,
+        console=console,
+        action_summary="/investigate x",
+        confirm_fn=lambda _: "n",
+        is_tty=True,
+    )
+
+
+def test_non_tty_blocks_ask() -> None:
+    session = ReplSession()
+    session.trust_mode = False
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    r = evaluate_slash_tier(ExecutionTier.ELEVATED)
+    assert not execution_allowed(
+        r,
+        session=session,
+        console=console,
+        action_summary="/save out.md",
+        is_tty=False,
+    )
+    assert "not a TTY" in buf.getvalue()

--- a/tests/cli/interactive_shell/test_execution_policy.py
+++ b/tests/cli/interactive_shell/test_execution_policy.py
@@ -106,3 +106,43 @@ def test_non_tty_blocks_ask() -> None:
         is_tty=False,
     )
     assert "not a TTY" in buf.getvalue()
+
+
+def test_tty_ask_combines_summary_and_reason_on_one_line() -> None:
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    r = evaluate_slash_tier(ExecutionTier.ELEVATED)
+    assert not execution_allowed(
+        r,
+        session=session,
+        console=console,
+        action_summary="/integrations verify foo",
+        confirm_fn=lambda _: "n",
+        is_tty=True,
+    )
+    out = buf.getvalue()
+    assert "Action:" not in out
+    assert "/integrations verify foo" in out
+    assert "Confirm" in out
+    assert "configuration" in out
+
+
+def test_tty_ask_when_action_already_listed_omits_repeat_of_summary() -> None:
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    r = evaluate_slash_tier(ExecutionTier.ELEVATED)
+    assert not execution_allowed(
+        r,
+        session=session,
+        console=console,
+        action_summary="/integrations verify foo",
+        confirm_fn=lambda _: "n",
+        is_tty=True,
+        action_already_listed=True,
+    )
+    out = buf.getvalue()
+    assert "/integrations verify foo" not in out
+    assert "Confirm:" in out
+    assert "configuration" in out

--- a/tests/cli/interactive_shell/test_shell_policy.py
+++ b/tests/cli/interactive_shell/test_shell_policy.py
@@ -47,7 +47,7 @@ def test_find_exec_wrapper_is_blocked() -> None:
 
     assert decision.allow is False
     assert decision.classification == "mutating"
-    assert "exec-wrapper" in (decision.reason or "")
+    assert decision.reason == "mutating commands are blocked in safe mode."
 
 
 def test_env_exec_wrapper_is_blocked() -> None:
@@ -57,7 +57,7 @@ def test_env_exec_wrapper_is_blocked() -> None:
 
     assert decision.allow is False
     assert decision.classification == "mutating"
-    assert "exec-wrapper" in (decision.reason or "")
+    assert decision.reason == "mutating commands are blocked in safe mode."
 
 
 def test_classify_command_marks_find_and_env_as_mutating() -> None:
@@ -71,7 +71,7 @@ def test_evaluate_policy_blocks_restricted_command_sudo() -> None:
 
     assert decision.allow is False
     assert decision.classification == "restricted"
-    assert decision.reason == "restricted command is not allowed from inferred execution."
+    assert decision.reason == "Not allowed for assistant-run shell."
 
 
 def test_evaluate_policy_blocks_restricted_command_dd() -> None:
@@ -80,7 +80,7 @@ def test_evaluate_policy_blocks_restricted_command_dd() -> None:
 
     assert decision.allow is False
     assert decision.classification == "restricted"
-    assert "restricted" in (decision.reason or "").lower()
+    assert decision.reason == "Not allowed for assistant-run shell."
 
 
 def test_classify_command_aws_ec2_describe_instances() -> None:


### PR DESCRIPTION
Fixes #1370

#### Describe the changes you have made in this PR -

- Add central REPL execution policy (`allow` / `ask` / `deny`) composing existing shell safety rules with slash tiers, investigations, synthetic runs, and LLM runtime switches.
- Extend `SlashCommand` with `execution_tier` and refine `/model` and `/integrations` subcommands; gate all slash dispatch from one place with session history recording.
- Wire `trust_mode` to skip confirmation prompts; block `ask` when stdin is not a TTY with a clear message.
- Emit `repl_execution_policy_decision` analytics with verdict, outcome, action type, and short reason.
- Add `tests/cli/interactive_shell/conftest.py` autoconfirm for pytest; new `test_execution_policy.py`; update related tests.

### Demo/Screenshot for feature changes and bug fixes -

<img width="803" height="425" alt="image" src="https://github.com/user-attachments/assets/983c8ba3-c67b-4cbd-81ad-dd7f6f423ae5" />

<img width="888" height="387" alt="image" src="https://github.com/user-attachments/assets/f7deb499-25bc-4076-a158-ac92d1d64bb9" />


```text
$ make lint && make format-check && make typecheck
(all pass)

$ .venv/bin/python -m pytest tests/cli/interactive_shell/ -q
322 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Central `execution_policy` composes `shell_policy` (parse/restrict deny; read-only allow; mutating/unknown ask; `!` passthrough ask) with slash `ExecutionTier` and dedicated evaluators for investigations and synthetic tests. `execution_allowed()` handles deny UX, trust short-circuit, non-TTY block, and Y/n confirmation, and emits one analytics payload per outcome. `dispatch_slash` records slash history once to avoid duplicate entries with the main loop.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist with this PR.
