### PR TITLE
fix: correct e2e deploy helper asset paths

### DIFF
--- a/tests/e2e/deploy/test_e2e_infrastructure_path_resolution.py
+++ b/tests/e2e/deploy/test_e2e_infrastructure_path_resolution.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e.upstream_apache_flink_ecs.infrastructure_sdk import deploy as flink_deploy
+from tests.e2e.upstream_lambda.infrastructure_sdk import deploy as lambda_deploy
+from tests.e2e.upstream_prefect_ecs_fargate.infrastructure_sdk import deploy as prefect_deploy
+
+EXPECTED_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_upstream_lambda_deploy_paths_exist() -> None:
+    assert lambda_deploy.REPO_ROOT == EXPECTED_REPO_ROOT
+    assert lambda_deploy.MOCK_API_CODE_DIR.is_dir()
+    assert lambda_deploy.PIPELINE_CODE_DIR.is_dir()
+
+
+def test_upstream_prefect_deploy_paths_exist() -> None:
+    assert prefect_deploy.REPO_ROOT == EXPECTED_REPO_ROOT
+    assert prefect_deploy.PREFECT_DOCKERFILE.is_file()
+    assert prefect_deploy.ALLOY_CONFIG_DIR.is_dir()
+    assert prefect_deploy.MOCK_API_CODE_DIR.is_dir()
+    assert prefect_deploy.TRIGGER_LAMBDA_CODE_DIR.is_dir()
+
+
+def test_upstream_flink_deploy_paths_exist() -> None:
+    assert flink_deploy.REPO_ROOT == EXPECTED_REPO_ROOT
+    assert flink_deploy.FLINK_DOCKERFILE.is_file()
+    assert flink_deploy.MOCK_API_CODE_DIR.is_dir()
+    assert flink_deploy.TRIGGER_LAMBDA_CODE_DIR.is_dir()

--- a/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
@@ -18,7 +18,13 @@ import time
 import uuid
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+TESTS_DIR = REPO_ROOT / "tests"
+SHARED_TESTS_DIR = TESTS_DIR / "shared"
+E2E_CASE_DIR = TESTS_DIR / "e2e" / "upstream_apache_flink_ecs"
+FLINK_DOCKERFILE = E2E_CASE_DIR / "infrastructure_code" / "flink_image" / "Dockerfile"
+MOCK_API_CODE_DIR = SHARED_TESTS_DIR / "external_vendor_api"
+TRIGGER_LAMBDA_CODE_DIR = E2E_CASE_DIR / "pipeline_code" / "trigger_lambda"
 
 from tests.shared.infrastructure_sdk import save_outputs
 from tests.shared.infrastructure_sdk.resources import (
@@ -150,15 +156,8 @@ def deploy() -> dict:
 
     # Build and push Docker image
     # Build context is project root to include telemetry packages
-    context_dir = project_root
-    dockerfile_path = (
-        project_root
-        / "tests"
-        / "upstream_apache_flink_ecs"
-        / "infrastructure_code"
-        / "flink_image"
-        / "Dockerfile"
-    )
+    context_dir = REPO_ROOT
+    dockerfile_path = FLINK_DOCKERFILE
 
     print("  - Building and pushing Docker image (ARM64)...")
     print(f"    Dockerfile: {dockerfile_path}")
@@ -330,7 +329,7 @@ otelcol.exporter.otlphttp "grafana" {
     print("\n[Phase 6] Creating Lambda functions and API Gateways...")
 
     # Mock API Lambda
-    mock_api_code_dir = project_root / "tests/shared/external_vendor_api"
+    mock_api_code_dir = MOCK_API_CODE_DIR
     print(f"  - Bundling Mock API Lambda from: {mock_api_code_dir}")
     mock_api_code = lambda_.bundle_code(mock_api_code_dir)
 
@@ -360,9 +359,7 @@ otelcol.exporter.otlphttp "grafana" {
     print(f"    Mock API URL: {mock_api['invoke_url']}")
 
     # Trigger Lambda
-    trigger_code_dir = (
-        project_root / "tests/e2e/upstream_apache_flink_ecs/pipeline_code/trigger_lambda"
-    )
+    trigger_code_dir = TRIGGER_LAMBDA_CODE_DIR
     requirements_file = trigger_code_dir / "requirements.txt"
     print(f"  - Bundling Trigger Lambda from: {trigger_code_dir}")
     trigger_code = lambda_.bundle_code(trigger_code_dir, requirements_file)

--- a/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
@@ -27,7 +27,11 @@ from tests.shared.infrastructure_sdk.resources import api_gateway, iam, lambda_,
 from tests.shared.infrastructure_sdk.resources.iam import get_account_id, put_role_policy
 from tests.shared.infrastructure_sdk.resources.secrets import get_secret_value
 
-project_root = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SHARED_TESTS_DIR = REPO_ROOT / "tests" / "shared"
+E2E_CASE_DIR = REPO_ROOT / "tests" / "e2e" / "upstream_lambda"
+MOCK_API_CODE_DIR = SHARED_TESTS_DIR / "external_vendor_api"
+PIPELINE_CODE_DIR = E2E_CASE_DIR / "pipeline_code"
 
 STACK_NAME = "tracer-lambda"
 REGION = "us-east-1"
@@ -185,8 +189,8 @@ def create_lambda_functions(
     print("Creating Lambda functions...")
 
     # Paths
-    shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    shared_dir = MOCK_API_CODE_DIR
+    pipeline_dir = PIPELINE_CODE_DIR
 
     # Bundle code
     print("  Bundling MockApi Lambda code...")
@@ -403,7 +407,7 @@ def deploy() -> dict:
 
     # 3. Create MockApi Lambda and API Gateway first (for URL)
     print("Creating MockApi Lambda...")
-    shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
+    shared_dir = MOCK_API_CODE_DIR
     mock_api_zip = lambda_.bundle_code(shared_dir)
 
     mock_api_lambda = lambda_.create_function(
@@ -431,7 +435,7 @@ def deploy() -> dict:
 
     # 4. Create pipeline Lambdas with correct URLs
     print("Creating pipeline Lambda functions...")
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = PIPELINE_CODE_DIR
 
     print("  Bundling pipeline code (dependencies already vendored)...")
     # Use custom bundling that puts vendored deps at root level

--- a/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
@@ -23,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[4]
 
 from app.utils.config import load_env
 from tests.shared.infrastructure_sdk import save_outputs
@@ -57,19 +57,13 @@ MOCK_API_LAMBDA_NAME = "tracer-prefect-ecs-mock-api"
 TRIGGER_LAMBDA_NAME = "tracer-prefect-ecs-trigger"
 
 # Paths
-TESTS_DIR = project_root / "tests"
-PREFECT_DOCKERFILE = (
-    TESTS_DIR
-    / "upstream_prefect_ecs_fargate"
-    / "infrastructure_code"
-    / "prefect_image"
-    / "Dockerfile"
-)
-ALLOY_CONFIG_DIR = TESTS_DIR / "shared" / "infrastructure_code" / "alloy_config"
-MOCK_API_CODE = TESTS_DIR / "shared" / "external_vendor_api"
-TRIGGER_LAMBDA_CODE = (
-    TESTS_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
-)
+TESTS_DIR = REPO_ROOT / "tests"
+SHARED_TESTS_DIR = TESTS_DIR / "shared"
+E2E_CASE_DIR = TESTS_DIR / "e2e" / "upstream_prefect_ecs_fargate"
+PREFECT_DOCKERFILE = E2E_CASE_DIR / "infrastructure_code" / "prefect_image" / "Dockerfile"
+ALLOY_CONFIG_DIR = SHARED_TESTS_DIR / "infrastructure_code" / "alloy_config"
+MOCK_API_CODE_DIR = SHARED_TESTS_DIR / "external_vendor_api"
+TRIGGER_LAMBDA_CODE_DIR = E2E_CASE_DIR / "pipeline_code" / "trigger_lambda"
 
 GRAFANA_ENV_KEYS = [
     "GCLOUD_HOSTED_METRICS_URL",
@@ -240,7 +234,7 @@ def _build_and_push_prefect_image(repo_uri: str) -> str:
         "-f",
         str(PREFECT_DOCKERFILE),
         "--push",
-        str(project_root),
+        str(REPO_ROOT),
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -289,7 +283,7 @@ def deploy_phase3_ecs(foundation: dict, images: dict) -> dict:
     print_step("Phase 3: ECS Task Definitions & Service")
     results = {}
 
-    grafana_env = _load_grafana_env(project_root / ".env")
+    grafana_env = _load_grafana_env(REPO_ROOT / ".env")
 
     # Build Prefect container definition
     prefect_container = ecs.build_container_definition(
@@ -440,7 +434,7 @@ def deploy_phase4_lambdas(foundation: dict, ecs_resources: dict) -> dict:
     results = {}
 
     # Bundle mock API code
-    mock_api_zip = lambda_.bundle_code(MOCK_API_CODE)
+    mock_api_zip = lambda_.bundle_code(MOCK_API_CODE_DIR)
 
     # Create mock API lambda
     mock_api_lambda = lambda_.create_function(
@@ -513,8 +507,8 @@ def deploy_phase4_lambdas(foundation: dict, ecs_resources: dict) -> dict:
 
     # Bundle trigger lambda code with dependencies
     trigger_zip = lambda_.bundle_code(
-        TRIGGER_LAMBDA_CODE,
-        TRIGGER_LAMBDA_CODE / "requirements.txt",
+        TRIGGER_LAMBDA_CODE_DIR,
+        TRIGGER_LAMBDA_CODE_DIR / "requirements.txt",
     )
 
     # Create trigger lambda


### PR DESCRIPTION
Fixes #1418

#### Describe the changes you have made in this PR -

- Corrected the repo root resolution in the upstream Lambda, Prefect ECS Fargate, and Flink ECS deploy helpers so they no longer resolve from `<repo>/tests`.
- Replaced the broken mixed path construction with explicit shared-vs-E2E asset directory constants for the three deploy helpers.
- Added a regression test covering the resolved repo root plus the key Dockerfile/code directories those helpers depend on.

### Demo/Screenshot for feature changes and bug fixes - 

Terminal verification:

```text
$ uv run pytest tests/e2e/deploy/test_e2e_infrastructure_path_resolution.py -q
3 passed in 0.11s

$ make lint && make format-check && make typecheck && make test-cov
...
5314 passed, 5 skipped, 133 warnings in 70.72s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug came from two related path-resolution problems in the E2E AWS deploy helpers: the files were resolving `project_root` one level too shallow, and some scenario-specific assets were then built from inconsistent `tests/...` vs `tests/e2e/...` paths. I fixed that by introducing explicit repo-root/shared/E2E path constants in each affected helper and then rewiring the bundling/build calls to use those constants. I chose that approach over one-off string fixes because it keeps the shared assets (`tests/shared/...`) and scenario assets (`tests/e2e/...`) obvious and gives the new regression test stable invariants to check.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
