### PR TITLE
feat(synthetic/rds_postgres): add memory_mode field + helper for #1234

### DIFF
--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import re
 from dataclasses import asdict, dataclass, replace
-from typing import Any
+from typing import Any, Literal, get_args
 
 from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
@@ -49,6 +49,17 @@ class ReasoningScore:
     reasoning_score: float
 
 
+# The five canonical memory-anchoring modes. Set on ScenarioScore.memory_mode
+# by the axis-memory runner (tests/synthetic/rds_postgres/axis_memory/, #1234).
+MemoryMode = Literal[
+    "memory_helped",
+    "memory_hurt",
+    "memory_neutral",
+    "pre_existing",
+    "not_run",
+]
+
+
 @dataclass(frozen=True)
 class ScenarioScore:
     scenario_id: str
@@ -67,17 +78,24 @@ class ScenarioScore:
     # scenario is run as part of an axis pair. One of: "memory_helped",
     # "memory_hurt", "memory_neutral", "pre_existing", "not_run". None when
     # the scenario was not run via the axis-memory runner.
-    memory_mode: str | None = None
+    memory_mode: MemoryMode | None = None
 
 
-def annotate_with_memory_mode(score: ScenarioScore, memory_mode: str) -> ScenarioScore:
+def annotate_with_memory_mode(score: ScenarioScore, memory_mode: MemoryMode) -> ScenarioScore:
     """Return a new ScenarioScore with memory_mode set.
 
     ScenarioScore is frozen, so this uses dataclasses.replace to produce a new
     instance. Used by the axis-memory runner to tag sibling scenario scores
     with the memory-anchoring classification produced by
     axis_memory.scoring.annotate_pair (see issue #1234).
+
+    Raises ValueError if memory_mode is not one of the five canonical values.
     """
+    if memory_mode not in get_args(MemoryMode):
+        raise ValueError(
+            f"unknown memory_mode: {memory_mode!r} "
+            f"(expected one of {get_args(MemoryMode)})"
+        )
     return replace(score, memory_mode=memory_mode)
 
 

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import Any
 
 from app.pipeline.runners import run_investigation
@@ -62,6 +62,23 @@ class ScenarioScore:
     failure_reason: str = ""
     trajectory: TrajectoryScore | None = None
     reasoning: ReasoningScore | None = None
+    # Optional axis-memory annotation set by the axis-memory runner
+    # (tests/synthetic/rds_postgres/axis_memory/, issue #1234) when a sibling
+    # scenario is run as part of an axis pair. One of: "memory_helped",
+    # "memory_hurt", "memory_neutral", "pre_existing", "not_run". None when
+    # the scenario was not run via the axis-memory runner.
+    memory_mode: str | None = None
+
+
+def annotate_with_memory_mode(score: ScenarioScore, memory_mode: str) -> ScenarioScore:
+    """Return a new ScenarioScore with memory_mode set.
+
+    ScenarioScore is frozen, so this uses dataclasses.replace to produce a new
+    instance. Used by the axis-memory runner to tag sibling scenario scores
+    with the memory-anchoring classification produced by
+    axis_memory.scoring.annotate_pair (see issue #1234).
+    """
+    return replace(score, memory_mode=memory_mode)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -514,6 +531,8 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
                 if result.failure_reason
                 else f"category={result.actual_category}"
             )
+            if result.memory_mode is not None:
+                detail = f"{detail} memory_mode={result.memory_mode}"
             print(f"{status} {result.scenario_id} {detail}")
 
         passed_count = sum(1 for result in results if result.passed)

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -93,8 +93,7 @@ def annotate_with_memory_mode(score: ScenarioScore, memory_mode: MemoryMode) -> 
     """
     if memory_mode not in get_args(MemoryMode):
         raise ValueError(
-            f"unknown memory_mode: {memory_mode!r} "
-            f"(expected one of {get_args(MemoryMode)})"
+            f"unknown memory_mode: {memory_mode!r} (expected one of {get_args(MemoryMode)})"
         )
     return replace(score, memory_mode=memory_mode)
 

--- a/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
@@ -11,6 +11,8 @@ from dataclasses import asdict
 
 import pytest
 
+pytestmark = pytest.mark.synthetic
+
 from tests.synthetic.rds_postgres.run_suite import (
     ScenarioScore,
     annotate_with_memory_mode,
@@ -84,3 +86,13 @@ def test_asdict_serialises_none_memory_mode() -> None:
     payload = asdict(_make_score())
     assert "memory_mode" in payload
     assert payload["memory_mode"] is None
+
+
+@pytest.mark.parametrize(
+    "bad_mode",
+    ["", "neutral", "memory_HELPED", "MEMORY_NEUTRAL", "garbage", "helped"],
+)
+def test_annotate_rejects_unknown_mode(bad_mode: str) -> None:
+    """An unknown memory_mode string raises ValueError rather than silently storing."""
+    with pytest.raises(ValueError, match="unknown memory_mode"):
+        annotate_with_memory_mode(_make_score(), bad_mode)  # type: ignore[arg-type]

--- a/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
@@ -1,0 +1,86 @@
+"""Direct unit tests for the memory_mode annotation on ScenarioScore.
+
+Covers the dataclass field default, the annotate_with_memory_mode helper, and
+that asdict serialises the field for the --json output path. Pairs with the
+axis-memory scaffold landed for issue #1234.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+
+from tests.synthetic.rds_postgres.run_suite import (
+    ScenarioScore,
+    annotate_with_memory_mode,
+)
+
+
+def _make_score(memory_mode: str | None = None) -> ScenarioScore:
+    return ScenarioScore(
+        scenario_id="002-connection-exhaustion",
+        passed=True,
+        root_cause_present=True,
+        expected_category="resource_exhaustion",
+        actual_category="resource_exhaustion",
+        missing_keywords=[],
+        matched_keywords=["connection", "max_connections"],
+        root_cause="connection exhaustion",
+        memory_mode=memory_mode,
+    )
+
+
+def test_memory_mode_defaults_to_none() -> None:
+    """An unannotated ScenarioScore has memory_mode=None."""
+    score = _make_score()
+    assert score.memory_mode is None
+
+
+def test_memory_mode_can_be_constructed_directly() -> None:
+    """memory_mode can be set at construction time as a string."""
+    score = _make_score(memory_mode="memory_neutral")
+    assert score.memory_mode == "memory_neutral"
+
+
+def test_annotate_with_memory_mode_returns_new_instance() -> None:
+    """The helper returns a new ScenarioScore (frozen dataclass)."""
+    original = _make_score()
+    annotated = annotate_with_memory_mode(original, "memory_hurt")
+    assert annotated.memory_mode == "memory_hurt"
+    # Original is unchanged because the dataclass is frozen.
+    assert original.memory_mode is None
+    # All other fields are preserved.
+    assert annotated.scenario_id == original.scenario_id
+    assert annotated.passed == original.passed
+    assert annotated.matched_keywords == original.matched_keywords
+
+
+@pytest.mark.parametrize(
+    "memory_mode",
+    [
+        "memory_helped",
+        "memory_hurt",
+        "memory_neutral",
+        "pre_existing",
+        "not_run",
+    ],
+)
+def test_annotate_accepts_every_documented_mode(memory_mode: str) -> None:
+    """Every memory mode documented in the dataclass docstring round-trips."""
+    score = annotate_with_memory_mode(_make_score(), memory_mode)
+    assert score.memory_mode == memory_mode
+
+
+def test_asdict_serialises_memory_mode() -> None:
+    """asdict (used by the --json output path) emits memory_mode."""
+    score = _make_score(memory_mode="memory_neutral")
+    payload = asdict(score)
+    assert payload["memory_mode"] == "memory_neutral"
+
+
+def test_asdict_serialises_none_memory_mode() -> None:
+    """The default None case is also emitted, not skipped."""
+    payload = asdict(_make_score())
+    assert "memory_mode" in payload
+    assert payload["memory_mode"] is None

--- a/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
@@ -11,12 +11,12 @@ from dataclasses import asdict
 
 import pytest
 
-pytestmark = pytest.mark.synthetic
-
 from tests.synthetic.rds_postgres.run_suite import (
     ScenarioScore,
     annotate_with_memory_mode,
 )
+
+pytestmark = pytest.mark.synthetic
 
 
 def _make_score(memory_mode: str | None = None) -> ScenarioScore:

--- a/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_memory_mode.py
@@ -12,6 +12,7 @@ from dataclasses import asdict
 import pytest
 
 from tests.synthetic.rds_postgres.run_suite import (
+    MemoryMode,
     ScenarioScore,
     annotate_with_memory_mode,
 )
@@ -19,7 +20,7 @@ from tests.synthetic.rds_postgres.run_suite import (
 pytestmark = pytest.mark.synthetic
 
 
-def _make_score(memory_mode: str | None = None) -> ScenarioScore:
+def _make_score(memory_mode: MemoryMode | None = None) -> ScenarioScore:
     return ScenarioScore(
         scenario_id="002-connection-exhaustion",
         passed=True,


### PR DESCRIPTION
Pairs with #1234 (Contextual Memory). Adds an optional `memory_mode` field to the existing `ScenarioScore` dataclass in `tests/synthetic/rds_postgres/run_suite.py` plus a small `annotate_with_memory_mode` helper, so the axis-memory runner landed in #1410 can attach memory-anchoring classifications to per-scenario scores and the published report can split metrics by memory mode.

This is piece 3 of the three pieces I sketched in https://github.com/Tracer-Cloud/opensre/issues/1234#issuecomment-4383654309 following @davincios's invite to take the eval-side instrumentation.

#### Describe the changes you have made in this PR -

Three small changes in `tests/synthetic/rds_postgres/run_suite.py`:

1. `ScenarioScore` gains `memory_mode: str | None = None` (optional, default None). Backwards-compatible.
2. New `annotate_with_memory_mode(score, memory_mode) -> ScenarioScore` helper using `dataclasses.replace` since the dataclass is frozen. Lets the axis-memory runner attach a classification without re-implementing scoring.
3. The text-output loop in `run_suite(...)` includes `memory_mode=<value>` in the per-scenario detail when the field is set. JSON output gets it for free via the existing `asdict(...)` path.

Plus a new `tests/synthetic/rds_postgres/test_run_suite_memory_mode.py` with 6 unit tests covering the field default, the helper, every documented mode (`memory_helped`, `memory_hurt`, `memory_neutral`, `pre_existing`, `not_run`), and the `asdict` serialisation path.

### Demo/Screenshot for feature changes and bug fixes - 

Local validation:

- `ruff check` on both files: All checks passed!
- `ruff format --check` on both files: already formatted
- `ast.parse` on `run_suite.py`: clean
- structural verification: ScenarioScore now has 12 fields including `memory_mode`, `annotate_with_memory_mode` exists at lines 73-81, the print loop has the `memory_mode` branch
- direct exercise of every assertion in `test_run_suite_memory_mode.py` against the helper API: all pass

The full pytest run requires the opensre dependency tree (langgraph, opentelemetry); tests will run in CI on developer machines that have it.

## Independence from #1410

This PR only modifies `run_suite.py` and adds one test file. It does NOT depend on `tests/synthetic/rds_postgres/axis_memory/` (which lives on PR #1410). The `memory_mode` field is no-op None until something writes to it. Once both #1410 and this land, the axis-memory runner can call `annotate_with_memory_mode(score, mode.value)` to wire them together. Until then, the field is invisible.

## JSON output shape change

`asdict()` (used by the `--json` output path) now emits `"memory_mode": null` in every existing scenario result, since the field is added unconditionally to `ScenarioScore` with a default of `None`. Any downstream consumer doing strict-key-equality on the JSON output (golden fixture comparison, schema validation, snapshot harnesses) should expect the new key. The new `test_asdict_serialises_none_memory_mode` test guards against accidentally dropping the field again.


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The simplest possible shape: extend an existing frozen dataclass with one optional field, add one tiny helper, integrate the field into the existing text-output path. No re-scoring logic, no scenario re-run logic, no new module.

Considered alternatives:
- Wrapper dataclass in axis_memory that wraps ScenarioScore + adds memory_mode (rejected: the run_suite report would never see the field, defeating the point)
- New "annotated_results" output mode (rejected: adds surface area unnecessarily; the existing JSON path already works once the field exists)
- Mutating the score in place (rejected: ScenarioScore is frozen, and frozen is the right default for a scoring dataclass)

The chosen shape costs 19 lines of source + 86 lines of tests and lets the axis-memory runner from #1410 attach classifications with one function call.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the project's style guidelines and conventions

cc @davincios @muddlebee