### PR TITLE
refactor(interactive-shell): remove legacy implicit shell-execution p…

### DIFF
--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -138,33 +138,24 @@ def run_shell_command(command: str, session: ReplSession, console: Console) -> N
         session.record("shell", command, ok=False)
         return
 
-    argv_builtin = parsed.argv
-    if argv_builtin is None and parsed.passthrough and parsed.command.strip():
-        passthrough_body = parsed.command.strip()
-        try:
-            argv_builtin = shlex.split(passthrough_body, posix=not _intent_parser.IS_WINDOWS)
-        except ValueError:
-            try:
-                argv_builtin = shlex.split(passthrough_body, posix=False)
-            except ValueError:
-                argv_builtin = None
+    argv = parsed.argv
+    if argv is None:
+        # evaluate_policy returns allow=False whenever argv is None, so we never reach here
+        # for a real input. Defensive guard for type-checkers.
+        session.record("shell", command, ok=False)
+        return
 
-    if argv_builtin is not None and argv_builtin[0].lower() == "cd":
+    if argv[0].lower() == "cd":
         run_cd_command(parsed.command, session, console)
         return
-    if argv_builtin is not None and argv_builtin[0].lower() == "pwd":
+    if argv[0].lower() == "pwd":
         run_pwd_command(parsed.command, session, console)
         return
-
-    use_shell = parsed.passthrough
-    if use_shell:
-        console.print("[dim]explicit shell passthrough enabled[/dim]")
 
     try:
         result = execute_shell_command(
             command=parsed.command,
-            argv=parsed.argv,
-            use_shell=use_shell,
+            argv=argv,
             timeout_seconds=SHELL_COMMAND_TIMEOUT_SECONDS,
             max_output_chars=_MAX_COMMAND_OUTPUT_CHARS,
         )

--- a/app/cli/interactive_shell/intent_parser.py
+++ b/app/cli/interactive_shell/intent_parser.py
@@ -209,8 +209,6 @@ def extract_shell_command(clause: PromptClause) -> PlannedAction | None:
         return shell_action(command, clause.position + explicit_match.start("command"))
 
     command = normalize_shell_command(clause.text)
-    if command is not None and command.startswith("!") and len(command) > 1:
-        return shell_action(command, clause.position)
     if command is not None and looks_like_direct_shell_command(command):
         return shell_action(command, clause.position)
     return None

--- a/app/cli/interactive_shell/shell_execution.py
+++ b/app/cli/interactive_shell/shell_execution.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from dataclasses import dataclass
 
@@ -12,13 +11,12 @@ class ShellExecutionResult:
     """Normalized command execution output."""
 
     command: str
-    argv: list[str] | None
+    argv: list[str]
     stdout: str
     stderr: str
     exit_code: int | None
     timed_out: bool
     truncated: bool
-    executed_with_shell: bool
 
 
 def _truncate_output(text: str, *, max_chars: int) -> tuple[str, bool]:
@@ -30,33 +28,19 @@ def _truncate_output(text: str, *, max_chars: int) -> tuple[str, bool]:
 def execute_shell_command(
     *,
     command: str,
-    argv: list[str] | None,
-    use_shell: bool,
+    argv: list[str],
     timeout_seconds: int,
     max_output_chars: int,
 ) -> ShellExecutionResult:
-    """Execute a command and return a structured result object."""
-    if use_shell:
-        completed = subprocess.run(
-            command,
-            shell=True,
-            executable=os.environ.get("SHELL") or None,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
-    else:
-        if argv is None:
-            raise ValueError("argv is required for shell=False execution.")
-        completed = subprocess.run(
-            argv,
-            shell=False,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
+    """Execute ``argv`` with ``shell=False`` and return a structured result."""
+    completed = subprocess.run(  # noqa: S603 - argv is parsed and policy-gated upstream
+        argv,
+        shell=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
 
     stdout, truncated_stdout = _truncate_output(
         completed.stdout or "",
@@ -74,7 +58,6 @@ def execute_shell_command(
         exit_code=completed.returncode,
         timed_out=False,
         truncated=truncated_stdout or truncated_stderr,
-        executed_with_shell=use_shell,
     )
 
 

--- a/app/cli/interactive_shell/shell_policy.py
+++ b/app/cli/interactive_shell/shell_policy.py
@@ -9,7 +9,6 @@ from typing import Literal
 
 CommandClassification = Literal["read_only", "mutating", "restricted", "unknown"]
 
-_EXPLICIT_SHELL_PREFIX = "!"
 _SHELL_OPERATOR_RE = re.compile(r"(^|\s)(\|\||&&|[|;<>]|>>|<<|2>)(\s|$)")
 _INLINE_SUBSHELL_RE = re.compile(r"`|\$\(")
 
@@ -83,7 +82,6 @@ _MUTATING_COMMANDS = frozenset(
 # Allowing them defeats the mutating-command policy because the dangerous child process
 # is spawned by the permitted parent — no shell involved, policy never sees it.
 # Same risk applies to xargs — it stays in `_MUTATING_COMMANDS` (blocked by name).
-# Users who genuinely need these can prefix with ! for explicit passthrough.
 _EXEC_WRAPPER_COMMANDS = frozenset({"find", "env"})
 
 _READ_ONLY_COMMANDS = frozenset(
@@ -233,7 +231,6 @@ class ParsedShellCommand:
 
     command: str
     argv: list[str] | None
-    passthrough: bool
     parse_error: str | None = None
 
 
@@ -248,22 +245,8 @@ class PolicyDecision:
 
 
 def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand:
-    """Parse command text and detect explicit passthrough prefix."""
+    """Parse command text into a structured argv list for shell=False execution."""
     stripped = command.strip()
-    if stripped.startswith(_EXPLICIT_SHELL_PREFIX):
-        passthrough_command = stripped[len(_EXPLICIT_SHELL_PREFIX) :].strip()
-        if not passthrough_command:
-            return ParsedShellCommand(
-                command="",
-                argv=None,
-                passthrough=True,
-                parse_error="missing command after passthrough prefix (!).",
-            )
-        return ParsedShellCommand(
-            command=passthrough_command,
-            argv=None,
-            passthrough=True,
-        )
 
     if (
         _SHELL_OPERATOR_RE.search(stripped) is not None
@@ -272,10 +255,9 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
         return ParsedShellCommand(
             command=stripped,
             argv=None,
-            passthrough=False,
             parse_error=(
-                "shell operators and command substitution are blocked in safe mode. "
-                "Use !<command> to run this intentionally."
+                "shell operators and command substitution are not supported. "
+                "Run individual commands separately."
             ),
         )
 
@@ -288,7 +270,6 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
             return ParsedShellCommand(
                 command=stripped,
                 argv=None,
-                passthrough=False,
                 parse_error=f"could not parse command: {exc}",
             )
 
@@ -296,11 +277,10 @@ def parse_shell_command(command: str, *, is_windows: bool) -> ParsedShellCommand
         return ParsedShellCommand(
             command=stripped,
             argv=None,
-            passthrough=False,
             parse_error="empty command.",
         )
 
-    return ParsedShellCommand(command=stripped, argv=argv, passthrough=False)
+    return ParsedShellCommand(command=stripped, argv=argv)
 
 
 def classify_command(argv: list[str]) -> CommandClassification:
@@ -336,21 +316,13 @@ def classify_command(argv: list[str]) -> CommandClassification:
 
 
 def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
-    """Allow read-only commands by default for inferred execution."""
+    """Allow read-only commands; reject everything else under the structured runner."""
     if parsed.parse_error is not None:
         return PolicyDecision(
             allow=False,
             classification="unknown",
             reason=parsed.parse_error,
-            hint="Rewrite as a plain command or use !<command> for explicit shell passthrough.",
-        )
-
-    if parsed.passthrough:
-        return PolicyDecision(
-            allow=True,
-            classification="unknown",
-            reason=None,
-            hint=None,
+            hint="Rewrite as a plain command without shell operators or substitutions.",
         )
 
     if parsed.argv is None:
@@ -358,7 +330,7 @@ def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
             allow=False,
             classification="unknown",
             reason="failed to parse command.",
-            hint="Rewrite as a plain command or use !<command> for explicit shell passthrough.",
+            hint="Rewrite as a plain command without shell operators or substitutions.",
         )
 
     classification = classify_command(parsed.argv)
@@ -375,20 +347,17 @@ def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
             allow=False,
             classification=classification,
             reason=(
-                "mutating commands are blocked in safe mode "
+                "mutating commands are blocked "
                 "(includes exec-wrapper commands such as find and env)."
             ),
-            hint=(
-                "Use a read-only command, or run !<command> to explicitly "
-                "opt into shell passthrough."
-            ),
+            hint="Run mutating commands directly in your shell if you truly intend them.",
         )
 
     if classification == "restricted":
         return PolicyDecision(
             allow=False,
             classification=classification,
-            reason="restricted command is not allowed from inferred execution.",
+            reason="restricted command is not allowed.",
             hint="Run the command directly in your shell if you truly intend it.",
         )
 
@@ -396,7 +365,7 @@ def evaluate_policy(*, parsed: ParsedShellCommand) -> PolicyDecision:
         allow=False,
         classification=classification,
         reason="command is not in the safe read-only allowlist.",
-        hint="Use a known read-only command, or run !<command> for explicit passthrough.",
+        hint="Use a known read-only command, or run it directly in your shell.",
     )
 
 

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import subprocess
 import tempfile
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock
@@ -10,6 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from rich.console import Console
 
+from app.cli.interactive_shell import action_executor, shell_execution
 from app.cli.interactive_shell.action_executor import (
     read_diag,
     run_cd_command,
@@ -80,13 +82,14 @@ def test_run_cd_command_chdirs_to_target(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    hint = "Run mutating commands directly in your shell if you truly intend them."
     monkeypatch.setattr(
         "app.cli.interactive_shell.action_executor.evaluate_policy",
         lambda **_: PolicyDecision(
             allow=False,
             classification="mutating",
             reason="test block",
-            hint="use ! for passthrough",
+            hint=hint,
         ),
     )
 
@@ -96,9 +99,77 @@ def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.Monkey
 
     run_shell_command("rm -rf /nope", session, console)
 
-    assert "test block" in buf.getvalue()
-    assert "use !" in buf.getvalue().lower() or "passthrough" in buf.getvalue().lower()
+    output = buf.getvalue()
+    assert "test block" in output
+    assert "directly in your shell" in output
     assert session.history[-1] == {"type": "shell", "text": "rm -rf /nope", "ok": False}
+
+
+def test_run_shell_command_uses_structured_argv_no_shell_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structured execution must always pass shell=False with a parsed argv list."""
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(shell_execution.subprocess, "run", _fake_run)
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_shell_command('cat "/tmp/file with spaces.txt"', session, console)
+
+    assert calls == [
+        (
+            ["cat", "/tmp/file with spaces.txt"],
+            {
+                "shell": False,
+                "capture_output": True,
+                "text": True,
+                "timeout": action_executor.SHELL_COMMAND_TIMEOUT_SECONDS,
+                "check": False,
+            },
+        )
+    ]
+    assert session.history[-1]["ok"] is True
+
+
+def test_run_shell_command_records_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd=["echo"], timeout=1)
+
+    monkeypatch.setattr(shell_execution.subprocess, "run", _raise_timeout)
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_shell_command("echo hello", session, console)
+
+    assert "timed out" in buf.getvalue()
+    assert session.history[-1] == {"type": "shell", "text": "echo hello", "ok": False}
+
+
+def test_run_shell_command_rejects_passthrough_prefix() -> None:
+    """`!cmd` no longer escapes structured execution; classification falls through."""
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_shell_command("!echo hi", session, console)
+
+    output = buf.getvalue()
+    assert "command blocked" in output
+    assert session.history[-1] == {"type": "shell", "text": "!echo hi", "ok": False}
 
 
 def test_run_synthetic_test_unknown_suite_records_failure() -> None:

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -204,7 +204,11 @@ def test_direct_shell_command_plans_shell_action() -> None:
     assert plan_terminal_tasks("pwd") == ["shell"]
     assert plan_terminal_tasks("cd /tmp") == ["shell"]
     assert plan_terminal_tasks("CD /tmp") == ["shell"]
-    assert plan_terminal_tasks("!ls -la") == ["shell"]
+
+
+def test_legacy_bang_passthrough_is_not_planned_as_shell_action() -> None:
+    """`!cmd` no longer routes through inferred shell execution."""
+    assert plan_terminal_tasks("!ls -la") == []
 
 
 def test_sample_alert_launch_plans_sample_alert_action() -> None:
@@ -599,86 +603,6 @@ def test_execute_cli_actions_records_shell_failure(monkeypatch: object) -> None:
     assert "exit code" in output
 
 
-def test_execute_cli_actions_runs_passthrough_with_shell_true(monkeypatch: object) -> None:
-    calls: list[tuple[str, dict[str, object]]] = []
-
-    def _fake_run(command: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append((command, kwargs))
-        return subprocess.CompletedProcess(
-            args=command,
-            returncode=0,
-            stdout="ok\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(shell_execution.subprocess, "run", _fake_run)
-
-    session = ReplSession()
-    console, buf = _capture()
-
-    assert execute_cli_actions("run `!echo hello`", session, console) is True
-    assert calls == [
-        (
-            "echo hello",
-            {
-                "shell": True,
-                "executable": shell_execution.os.environ.get("SHELL") or None,
-                "capture_output": True,
-                "text": True,
-                "timeout": action_executor.SHELL_COMMAND_TIMEOUT_SECONDS,
-                "check": False,
-            },
-        )
-    ]
-    assert session.history[-1] == {"type": "shell", "text": "!echo hello", "ok": True}
-    output = buf.getvalue()
-    assert "explicit shell passthrough enabled" in output
-    assert "ok" in output
-
-
-def test_execute_cli_actions_routes_bang_cd_through_builtin(monkeypatch: object) -> None:
-    dirs: list[Path] = []
-
-    def _fake_chdir(target: Path) -> None:
-        dirs.append(target)
-
-    def _boom(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-        raise AssertionError("subprocess.run should not be used for !cd builtin routing")
-
-    monkeypatch.setattr(action_executor.os, "chdir", _fake_chdir)
-    monkeypatch.setattr(shell_execution.subprocess, "run", _boom)
-
-    session = ReplSession()
-    console, buf = _capture()
-
-    message = "run `!cd /tmp`"
-    assert execute_cli_actions(message, session, console) is True
-    assert dirs == [Path("/tmp")]
-    assert session.history[-1] == {"type": "shell", "text": "cd /tmp", "ok": True}
-    captured = buf.getvalue()
-    assert "explicit shell passthrough enabled" not in captured
-
-
-def test_execute_cli_actions_routes_bang_pwd_through_builtin(monkeypatch: object) -> None:
-    def _fake_cwd(_: type[Path]) -> PurePosixPath:
-        return PurePosixPath("/shown")
-
-    def _boom(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
-        raise AssertionError("subprocess.run should not be used for !pwd builtin routing")
-
-    monkeypatch.setattr(action_executor.Path, "cwd", classmethod(_fake_cwd))
-    monkeypatch.setattr(shell_execution.subprocess, "run", _boom)
-
-    session = ReplSession()
-    console, buf = _capture()
-
-    assert execute_cli_actions("run `!pwd`", session, console) is True
-    assert session.history[-1] == {"type": "shell", "text": "pwd", "ok": True}
-    captured = buf.getvalue()
-    assert "/shown" in captured
-    assert "explicit shell passthrough enabled" not in captured
-
-
 def test_execute_cli_actions_blocks_mutating_command_by_default() -> None:
     session = ReplSession()
     console, buf = _capture()
@@ -688,7 +612,7 @@ def test_execute_cli_actions_blocks_mutating_command_by_default() -> None:
     output = buf.getvalue()
     assert "command blocked" in output
     assert "mutating commands are blocked" in output
-    assert "run !<command>" in output
+    assert "directly in your shell" in output
 
 
 def test_execute_cli_actions_blocks_ambiguous_shell_operators() -> None:

--- a/tests/cli/interactive_shell/test_shell_policy.py
+++ b/tests/cli/interactive_shell/test_shell_policy.py
@@ -9,16 +9,25 @@ from app.cli.interactive_shell.shell_policy import (
 )
 
 
-def test_parse_shell_command_detects_passthrough_prefix() -> None:
-    parsed = parse_shell_command("!echo hello", is_windows=False)
+def test_parse_shell_command_returns_argv_for_simple_command() -> None:
+    parsed = parse_shell_command("echo hello", is_windows=False)
 
-    assert parsed.passthrough is True
+    assert parsed.argv == ["echo", "hello"]
     assert parsed.command == "echo hello"
-    assert parsed.argv is None
     assert parsed.parse_error is None
 
 
-def test_parse_shell_command_rejects_operators_in_safe_mode() -> None:
+def test_parse_shell_command_rejects_explicit_shell_prefix() -> None:
+    """The legacy `!` passthrough escape hatch is gone; argv parses literally."""
+    parsed = parse_shell_command("!echo hello", is_windows=False)
+    decision = evaluate_policy(parsed=parsed)
+
+    # `!echo` is parsed as a single token; classification is unknown -> blocked.
+    assert decision.allow is False
+    assert decision.classification == "unknown"
+
+
+def test_parse_shell_command_rejects_operators() -> None:
     parsed = parse_shell_command("ls | wc -l", is_windows=False)
     decision = evaluate_policy(parsed=parsed)
 
@@ -71,7 +80,7 @@ def test_evaluate_policy_blocks_restricted_command_sudo() -> None:
 
     assert decision.allow is False
     assert decision.classification == "restricted"
-    assert decision.reason == "restricted command is not allowed from inferred execution."
+    assert decision.reason == "restricted command is not allowed."
 
 
 def test_evaluate_policy_blocks_restricted_command_dd() -> None:


### PR DESCRIPTION
Fixes #1381

#### Describe the changes you have made in this PR -

Removes the legacy implicit shell-execution path from the interactive-shell action runner. The structured argv runner (`shell=False`) is now the only supported execution model — the `!<command>` passthrough escape hatch and the underlying `shell=True` branch are gone.

**Code removed**
- `shell_execution.py`: dropped the `use_shell` parameter, the `shell=True` branch in `execute_shell_command`, and the `executed_with_shell` field on `ShellExecutionResult`. `argv` is now a required positional input.
- `shell_policy.py`: dropped `_EXPLICIT_SHELL_PREFIX = "!"`, the `passthrough` field on `ParsedShellCommand`, and the passthrough branches in `parse_shell_command` / `evaluate_policy`. Updated reason/hint copy to no longer reference `!<command>`.
- `action_executor.py`: dropped the fallback `shlex.split` parsing that only existed to support `passthrough=True`, the `use_shell = parsed.passthrough` branch, and the "explicit shell passthrough enabled" output. `run_shell_command` now feeds `parsed.argv` directly into the executor.
- `intent_parser.py`: dropped the `command.startswith("!")` branch in `extract_shell_command` so `!cmd` no longer routes through inferred shell execution.

**Tests**
- Removed the three passthrough tests (`runs_passthrough_with_shell_true`, `routes_bang_cd_through_builtin`, `routes_bang_pwd_through_builtin`).
- Added structured-execution coverage in `test_action_executor.py`: quoted-paths-with-spaces argv assertion, timeout handling, and `!cmd` rejection through the policy.
- Added a regression test that `plan_terminal_tasks("!ls -la")` is no longer planned as a shell action.
- Updated the mutating-block hint expectation and the restricted-command reason string.

### Demo/Screenshot for feature changes and bug fixes - 

<img width="915" height="361" alt="Screenshot 2026-05-06 at 11 13 01" src="https://github.com/user-attachments/assets/f5b0e95c-aa8e-4bf2-ae4f-4e16759911a4" />




---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The interactive-shell action runner had two parallel execution paths after #1372 landed structured execution: the new `shell=False` argv runner, and a legacy `shell=True` branch reachable via the `!<command>` passthrough prefix. This issue asked to delete the legacy branch so the structured runner is the only execution model and the trust boundary is single-purpose.

I traced every reference to `passthrough`, `use_shell`, `shell=True`, and `_EXPLICIT_SHELL_PREFIX` across `app/cli/interactive_shell/` and the test suite, then removed them in dependency order: parser → policy → executor → intent extractor → tests. The fallback `shlex.split` block in `action_executor.run_shell_command` only existed because `parse_shell_command` returned `argv=None` for `passthrough=True`; with passthrough gone, `parsed.argv` is always populated when `evaluate_policy` allows the command, and the cd/pwd builtin routing simply reads `argv[0]` directly.

I considered keeping `!<command>` as a thin alias that runs the same structured argv path (so users keep muscle memory), but that would still leave the prefix as a special-case in the parser and contradict the issue's "single execution model" acceptance criterion. The cleaner option was to remove it outright; users who need shell features (pipes, redirection, mutating commands) now get a clear policy hint pointing them to their real shell.

Edge cases covered by the new tests: quoted paths with spaces (argv tokenization is preserved), `subprocess.TimeoutExpired` (recorded as `ok=False` with a "timed out" message), `!cmd` (rejected as `unknown` classification), and the planner no longer treats `!cmd` as a shell action.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

