### PR TITLE
chore(sentry): capture all events without downsampling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,8 +175,8 @@ GITHUB_MCP_TOOLSETS=repos,issues,pull_requests,actions,search
 # Runtime error monitoring for OpenSRE itself uses the project Sentry DSN constant.
 # Optional: override for operator-side DSN rotation without rebuilding.
 # OPENSRE_SENTRY_DSN=
-SENTRY_ERROR_SAMPLE_RATE=0.2
-SENTRY_TRACES_SAMPLE_RATE=0.2
+SENTRY_ERROR_SAMPLE_RATE=1.0
+SENTRY_TRACES_SAMPLE_RATE=1.0
 OPENSRE_SENTRY_DISABLED=0
 
 # Sentry investigation integration

--- a/app/constants/sentry.py
+++ b/app/constants/sentry.py
@@ -8,5 +8,5 @@ SENTRY_DSN: Final[str] = (
     "https://06d6b2b739eb2267864d12c6cad34e70"
     "@o4509281671380992.ingest.us.sentry.io/4511150863482880"
 )
-SENTRY_ERROR_SAMPLE_RATE: Final[float] = 0.2
-SENTRY_TRACES_SAMPLE_RATE: Final[float] = 0.2
+SENTRY_ERROR_SAMPLE_RATE: Final[float] = 1.0
+SENTRY_TRACES_SAMPLE_RATE: Final[float] = 1.0


### PR DESCRIPTION
## Summary

- Raise the default `SENTRY_ERROR_SAMPLE_RATE` and `SENTRY_TRACES_SAMPLE_RATE` from `0.2` to `1.0` so Sentry captures every error and trace instead of downsampling to 20%.
- Update `.env.example` to match the new defaults.

Operators can still tune sampling on their side via the `SENTRY_ERROR_SAMPLE_RATE` / `SENTRY_TRACES_SAMPLE_RATE` env vars (already wired through `app/utils/sentry_sdk.py`).

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] `mypy app/constants/sentry.py`
- [x] `pytest tests/test_sentry_init.py` (16 passed)


Made with [Cursor](https://cursor.com)