### PR TITLE
fix(synthetic/rds_postgres): harden 002-connection-exhaustion answer key + add QA_VALIDATION (#598)

### DIFF
--- a/tests/synthetic/rds_postgres/002-connection-exhaustion/QA_VALIDATION.md
+++ b/tests/synthetic/rds_postgres/002-connection-exhaustion/QA_VALIDATION.md
@@ -1,0 +1,55 @@
+# Scenario 002 - Connection Pool Leak
+
+## Overview
+
+This scenario validates that the agent identifies connection exhaustion caused by a client-side pool leak, and treats the concurrent CPU elevation as a secondary symptom rather than an independent failure.
+
+The trap is the 35-50% CPU rise: it is a real signal, but it is a downstream effect of accumulated idle sessions making periodic lightweight queries. The agent must not classify the incident as `cpu_saturation`.
+
+## Correct Diagnosis
+
+| Field | Expected |
+|---|---|
+| Root cause category | `resource_exhaustion` |
+| Root cause | Client-side connection pool leak exhausted `max_connections` |
+| Affected component | Primary RDS instance with leaked client sessions |
+| Primary symptom | New connection attempts rejected as `max_connections` is reached |
+| Secondary symptom | CPUUtilization 35-50% from idle session housekeeping queries |
+| Non-root cause | CPU saturation, slow query, or bad SQL plan |
+
+## Required Reasoning
+
+A correct answer should include the full causal chain:
+
+1. A client-side pool leak holds open sessions instead of returning them.
+2. Idle sessions accumulate; `DatabaseConnections` climbs to ~490 of 500.
+3. Idle sessions issue periodic lightweight queries, lifting CPUUtilization to 35-50% as a side effect.
+4. New application requests fail to connect; the alert fires on `max_connections` exhaustion.
+5. Performance Insights shows `Client:ClientRead` as the dominant wait event, confirming idle-session pressure rather than query workload.
+
+## Evidence Expectations
+
+The agent should cite evidence such as:
+
+- `aws_cloudwatch_metrics`: `DatabaseConnections` near 490/500, CPUUtilization 35-50%
+- `aws_performance_insights`: `Client:ClientRead` as the dominant wait event, no expensive SQL dominating db_load
+
+## Pass Criteria
+
+The answer is considered correct if it:
+
+- Identifies connection exhaustion as the root cause
+- References `max_connections` and the near-cap connection count
+- Explains that the CPU elevation is a secondary effect of idle sessions, not an independent CPU saturation
+- Cites Performance Insights `ClientRead` waits as the discriminating signal
+- Uses both metric-level and query-level evidence
+
+## Common Failure Modes
+
+The answer should be considered incorrect if it:
+
+- Diagnoses `cpu_saturation` based on the 35-50% CPU rise
+- Says "connection exhaustion" without explaining the idle-session leak pattern
+- Treats CPU and connections as two independent problems instead of one causal chain
+- Blames a slow query or missing index without checking Performance Insights wait events
+- Omits Performance Insights from the evidence chain

--- a/tests/synthetic/rds_postgres/002-connection-exhaustion/answer.yml
+++ b/tests/synthetic/rds_postgres/002-connection-exhaustion/answer.yml
@@ -4,6 +4,12 @@ required_keywords:
   - max_connections
   - idle
   - client sessions
+  - clientread
+required_evidence_sources:
+  - aws_cloudwatch_metrics
+  - aws_performance_insights
+ruling_out_keywords:
+  - cpu
 forbidden_categories:
   - cpu_saturation
 optimal_trajectory:
@@ -12,11 +18,11 @@ optimal_trajectory:
   - query_grafana_alert_rules
 max_investigation_loops: 4
 model_response: |
-  ROOT_CAUSE: The database hit connection exhaustion because leaked client sessions consumed nearly all available max_connections. The outage came from session pressure, not a compute bottleneck. CPUUtilization showed mild elevation (~35-50%) from minute 4 onward, but this is a symptom of accumulated idle client sessions making periodic lightweight queries — not an independent CPU saturation event.
+  ROOT_CAUSE: The database hit connection exhaustion because leaked client sessions consumed nearly all available max_connections. The outage came from session pressure, not a compute bottleneck. CPUUtilization showed mild elevation (~35-50%) from minute 4 onward, but this is a symptom of accumulated idle client sessions making periodic lightweight queries, not an independent CPU saturation event. Performance Insights confirms Client:ClientRead as the dominant wait event, ruling out CPU saturation and bad-query patterns.
   ROOT_CAUSE_CATEGORY: resource_exhaustion
   VALIDATED_CLAIMS:
   - DatabaseConnections stayed near 490 out of 500 allowed sessions. [evidence: aws_cloudwatch_metrics]
-  - CPUUtilization rose to 35-50% beginning at minute 4, correlated with — and caused by — the growth in idle client sessions. This is not independent CPU saturation; Performance Insights confirms Client:ClientRead as the dominant wait event. [evidence: aws_cloudwatch_metrics, aws_performance_insights]
+  - CPUUtilization rose to 35-50% beginning at minute 4, correlated with and caused by the growth in idle client sessions. This is not independent CPU saturation; Performance Insights confirms Client:ClientRead as the dominant wait event. [evidence: aws_cloudwatch_metrics, aws_performance_insights]
   - Performance Insights points to idle client sessions waiting on ClientRead rather than an expensive SQL statement. [evidence: aws_performance_insights]
   NON_VALIDATED_CLAIMS:
   - Tightening pool limits or terminating leaked sessions would likely restore service quickly.

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -333,6 +333,7 @@ def score_result(
             "aas",
             "db load",
             "walwrite",
+            "clientread",
         )
 
         for source_key in answer_key.required_evidence_sources:


### PR DESCRIPTION
Closes #598. Mirrors the same shape @cerencamkiran used for 001 in #1214 (now merged).

#### Describe the changes you have made in this PR -

`answer.yml` additions in `tests/synthetic/rds_postgres/002-connection-exhaustion/`:

- `required_evidence_sources`: `aws_cloudwatch_metrics` + `aws_performance_insights`. Without this the scenario passes Axis 1 but never enforces the evidence path. Closes the same Axis 1 / Axis 2 gap that 001 closed.
- `ruling_out_keywords: [cpu]`. Mirrors what cerencamkiran did for 001. Forces the agent to demonstrate it considered and rejected CPU rather than just not picking it.
- `clientread` added to `required_keywords`. Confirms the agent surfaces the dominant Performance Insights wait event in its output.
- `model_response` lightly extended so all the new keywords appear in the canonical answer (`Client:ClientRead`, ruling-out language, `[evidence: aws_performance_insights]` tags).

`forbidden_categories: [cpu_saturation]` was already present and is unchanged.

Plus a new `QA_VALIDATION.md` in the same directory, same structure as 001 and 005. Documents the validation paths, ruling-out logic, and the discriminating PI signal (`Client:ClientRead`).

### Demo/Screenshot for feature changes and bug fixes - 

Local validation:

- `answer.yml` parses as valid YAML
- all `required_keywords` (including new `clientread`) appear in the new `model_response` text after lowercase-normalize
- `ruling_out_keywords: [cpu]` appears in `model_response`
- both `required_evidence_sources` cited as `[evidence: <source>]` tags in `model_response`
- `forbidden_categories: [cpu_saturation]` does not collide with the actual category (`resource_exhaustion`) in `model_response`

The full per-source `aws_performance_insights` validation path now exists in `run_suite.py` thanks to #1214 (just merged).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Same shape cerencamkiran used for 001 in #1214: tighten the answer key with explicit evidence sources and ruling-out keywords so the scenario enforces both Axis 1 (does the agent name the right cause) and Axis 2 (does the agent rule out the obvious wrong cause). `Client:ClientRead` is the discriminating Performance Insights wait event for connection exhaustion vs CPU saturation — the agent has to surface it to demonstrate it actually queried PI rather than guessing from CloudWatch metrics alone.

`QA_VALIDATION.md` follows the existing convention from 001 and 005 (header, validation paths, invariants).

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [ ] I have performed a self-review of my code
- [ ] **I can explain the purpose of every function, class, and logic block I added**
- [ ] I understand why my changes work and have tested them thoroughly
- [ ] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the project's style guidelines and conventions

cc @muddlebee @cerencamkiran