### PR TITLE
fix: improve error message when Anthropic model name is invalid

### DIFF
--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -23,5 +23,10 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
                 "CLI tool is not installed or not found.",
                 suggestion=str(exc),
             ) from exc
+        if "was not found" in msg and "model" in msg:
+            raise OpenSREError(
+                str(exc),
+                suggestion="Verify your model name in ANTHROPIC_REASONING_MODEL or ANTHROPIC_TOOLCALL_MODEL environment variables.",
+            ) from exc
 
     raise exc

--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -23,7 +23,7 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
                 "CLI tool is not installed or not found.",
                 suggestion=str(exc),
             ) from exc
-        if "was not found" in msg and "model" in msg:
+        if "anthropic" in msg and "model" in msg and "was not found" in msg:
             raise OpenSREError(
                 str(exc),
                 suggestion="Verify your model name in ANTHROPIC_REASONING_MODEL or ANTHROPIC_TOOLCALL_MODEL environment variables.",

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from app.integrations.llm_cli.registry import CLIProviderRegistration
 
 import boto3
-from anthropic import Anthropic, AnthropicBedrock, AuthenticationError
+from anthropic import Anthropic, AnthropicBedrock, AuthenticationError, NotFoundError
 from openai import AuthenticationError as OpenAIAuthError
 from openai import OpenAI
 from pydantic import BaseModel, ValidationError
@@ -165,6 +165,11 @@ class LLMClient:
                 raise RuntimeError(
                     "Anthropic authentication failed. Check ANTHROPIC_API_KEY in your environment or .env."
                 ) from err
+            except NotFoundError as err:
+                raise RuntimeError(
+                    f"Anthropic model '{self._model}' was not found. "
+                    "Check your configured model name and try again."
+                ) from err
             except GuardrailBlockedError:
                 raise
             except Exception as err:
@@ -205,6 +210,11 @@ class LLMClient:
             except AuthenticationError as err:
                 raise RuntimeError(
                     "Anthropic authentication failed. Check ANTHROPIC_API_KEY in your environment or .env."
+                ) from err
+            except NotFoundError as err:
+                raise RuntimeError(
+                    f"Anthropic model '{self._model}' was not found. "
+                    "Check your configured model name and try again."
                 ) from err
             except GuardrailBlockedError:
                 raise

--- a/tests/cli/test_cli_error_mapping.py
+++ b/tests/cli/test_cli_error_mapping.py
@@ -25,8 +25,7 @@ def test_anthropic_model_not_found_raises_opensre_error() -> None:
 def test_anthropic_model_not_found_suggestion_guides_env_vars() -> None:
     """The suggestion must point at the two env vars users are most likely to misconfigure."""
     exc = RuntimeError(
-        "Anthropic model 'bad-model' was not found. "
-        "Check your configured model name and try again."
+        "Anthropic model 'bad-model' was not found. Check your configured model name and try again."
     )
     with pytest.raises(OpenSREError) as exc_info:
         reraise_cli_runtime_error(exc)

--- a/tests/cli/test_cli_error_mapping.py
+++ b/tests/cli/test_cli_error_mapping.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
+from app.cli.support.errors import OpenSREError
+
+
+def test_anthropic_model_not_found_raises_opensre_error() -> None:
+    """RuntimeError from an invalid Anthropic model name maps to a user-friendly OpenSREError."""
+    exc = RuntimeError(
+        "Anthropic model 'not-a-real-model-xyz' was not found. "
+        "Check your configured model name and try again."
+    )
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(exc)
+
+    err = exc_info.value
+    assert "not-a-real-model-xyz" in str(err)
+    assert err.suggestion is not None
+    assert "ANTHROPIC_REASONING_MODEL" in err.suggestion
+    assert "ANTHROPIC_TOOLCALL_MODEL" in err.suggestion
+
+
+def test_anthropic_model_not_found_suggestion_guides_env_vars() -> None:
+    """The suggestion must point at the two env vars users are most likely to misconfigure."""
+    exc = RuntimeError(
+        "Anthropic model 'bad-model' was not found. "
+        "Check your configured model name and try again."
+    )
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(exc)
+
+    assert exc_info.value.suggestion is not None
+    assert "ANTHROPIC_REASONING_MODEL" in exc_info.value.suggestion
+    assert "ANTHROPIC_TOOLCALL_MODEL" in exc_info.value.suggestion
+
+
+def test_non_anthropic_model_not_found_does_not_match() -> None:
+    """A 'model not found' error from a non-Anthropic provider must not trigger the Anthropic branch."""
+    exc = RuntimeError("OpenAI model 'gpt-99' was not found. Check your configuration.")
+    with pytest.raises(RuntimeError):
+        reraise_cli_runtime_error(exc)
+
+
+def test_cli_not_found_still_maps_correctly() -> None:
+    """Existing CLI-not-found branch must still work after the new branch was added."""
+    exc = RuntimeError("CLI not found on path: codex")
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(exc)
+
+    assert "CLI tool is not installed" in str(exc_info.value)

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -738,3 +738,94 @@ def test_create_llm_client_gemini_cli_reads_optional_model_env(monkeypatch) -> N
         assert client._model == "gemini-2.5-pro"
     finally:
         llm_client.reset_llm_singletons()
+
+
+# ---------------------------------------------------------------------------
+# LLMClient.invoke / invoke_stream — NotFoundError handling
+# ---------------------------------------------------------------------------
+
+
+def _make_not_found_error() -> Exception:
+    """Return a minimal fake that looks like anthropic.NotFoundError."""
+    err = llm_client.NotFoundError.__new__(llm_client.NotFoundError)
+    # NotFoundError is an APIStatusError; bypass its __init__ by setting attrs directly.
+    err.status_code = 404  # type: ignore[attr-defined]
+    err.message = "model_not_found"  # type: ignore[attr-defined]
+    err.body = {}  # type: ignore[attr-defined]
+    err.request = None  # type: ignore[attr-defined]
+    err.response = None  # type: ignore[attr-defined]
+    return err
+
+
+class _NotFoundMessages:
+    """Fake messages object that always raises NotFoundError."""
+
+    def __init__(self, model: str) -> None:
+        self._model = model
+
+    def create(self, **_kwargs) -> None:
+        raise _make_not_found_error()
+
+    def stream(self, **_kwargs):
+        raise _make_not_found_error()
+
+
+class _NotFoundAnthropic:
+    def __init__(self, *, api_key: str, timeout: float) -> None:  # noqa: ARG002
+        self.messages = _NotFoundMessages("not-a-real-model-xyz")
+
+
+def test_anthropic_invoke_not_found_raises_friendly_runtime_error(monkeypatch) -> None:
+    """NotFoundError from the Anthropic API must become a clear RuntimeError."""
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _NotFoundAnthropic)
+
+    client = llm_client.LLMClient(model="not-a-real-model-xyz")
+
+    with pytest.raises(RuntimeError, match="not-a-real-model-xyz") as exc_info:
+        client.invoke("hello")
+
+    msg = str(exc_info.value)
+    assert "was not found" in msg
+    assert "Check your configured model name" in msg
+
+
+def test_anthropic_invoke_not_found_does_not_retry(monkeypatch) -> None:
+    """NotFoundError must never be retried — it is a config error, not transient."""
+    call_count = 0
+
+    class _CountingMessages:
+        def create(self, **_kwargs) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise _make_not_found_error()
+
+    class _CountingAnthropic:
+        def __init__(self, **_kwargs) -> None:
+            self.messages = _CountingMessages()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _CountingAnthropic)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda _: None)
+
+    client = llm_client.LLMClient(model="bad-model")
+
+    with pytest.raises(RuntimeError):
+        client.invoke("hello")
+
+    assert call_count == 1, "NotFoundError must not trigger retries"
+
+
+def test_anthropic_invoke_stream_not_found_raises_friendly_runtime_error(monkeypatch) -> None:
+    """NotFoundError during streaming must also surface a clear message."""
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _NotFoundAnthropic)
+
+    client = llm_client.LLMClient(model="not-a-real-model-xyz")
+
+    with pytest.raises(RuntimeError, match="not-a-real-model-xyz") as exc_info:
+        list(client.invoke_stream("hello"))
+
+    msg = str(exc_info.value)
+    assert "was not found" in msg
+    assert "Check your configured model name" in msg


### PR DESCRIPTION
## Summary                                                                    
  - Catch `NotFoundError` from the Anthropic SDK explicitly in                  
  `LLMClient.invoke()` and `invoke_stream()` — no retries, immediate clear error
  - Error message now includes the configured model name and actionable advice  
  - CLI layer maps the error to `OpenSREError` with a suggestion pointing at the
   relevant env vars                                                            
  - Added 3 unit tests covering both code paths and the CLI mapping             
                                                                                
  ## Before / After                                                             
  **Before:** `Anthropic API request failed after multiple retries:
  NotFoundError`                                                                
  **After:** `Anthropic model 'not-a-real-model-xyz' was not found. Check your  
  configured model name and try again.`                                       
                                                                                
  Closes #1519