### PR TITLE
feat(rca): populate remediation_steps with LLM-grounded actions

### DIFF
--- a/app/nodes/publish_findings/formatters/report.py
+++ b/app/nodes/publish_findings/formatters/report.py
@@ -294,6 +294,15 @@ def format_slack_message(ctx: ReportContext) -> str:
             "\n*Provenance:*\n" + _sanitize_for_slack("\n".join(provenance_lines)) + "\n"
         )
 
+    remediation_steps = ctx.get("remediation_steps", [])
+    remediation_block = ""
+    if remediation_steps:
+        remediation_block = (
+            "\n## Recommended Actions\n"
+            + "\n".join(f"• {_sanitize_for_slack(s)}" for s in remediation_steps)
+            + "\n"
+        )
+
     trace_steps = build_investigation_trace(ctx)
     trace_block = (
         "\n## Investigation Trace\n" + "\n".join(trace_steps) + "\n" if trace_steps else ""
@@ -311,7 +320,7 @@ def format_slack_message(ctx: ReportContext) -> str:
     # Do not prefix with a separate [RCA] title line; the consumer can render
     # section headings (Root Cause text, Findings, Investigation Trace) with
     # larger fonts as needed.
-    return f"""{conclusion_block}{provenance_block}{trace_block}
+    return f"""{conclusion_block}{provenance_block}{remediation_block}{trace_block}
 {cited_section}
 {cloudwatch_link}{meta_block}
 """
@@ -390,6 +399,18 @@ def build_slack_blocks(ctx: ReportContext) -> list[dict]:
             }
         )
         _add(_mrkdwn_section("\n".join(provenance_lines)))
+
+    # ── Recommended Actions ──
+    remediation_steps = ctx.get("remediation_steps", [])
+    if remediation_steps:
+        blocks.append({"type": "divider"})
+        blocks.append(
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "Recommended Actions"},
+            }
+        )
+        _add(_mrkdwn_section("\n".join(f"• {_sanitize_for_slack(s)}" for s in remediation_steps)))
 
     # ── Investigation Trace ──
     trace_steps = build_investigation_trace(ctx)

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -402,7 +402,7 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
         ],
         "validity_score": 0.0,
         "investigation_recommendations": recommendations,
-        "remediation_steps": get_template_steps("unknown", {}),
+        "remediation_steps": get_template_steps("unknown", state.get("available_sources", {})),
         "investigation_loop_count": next_loop_count,
     }
 

--- a/app/nodes/root_cause_diagnosis/node.py
+++ b/app/nodes/root_cause_diagnosis/node.py
@@ -22,6 +22,7 @@ from .evidence_checker import (
     is_clearly_healthy,
 )
 from .prompt_builder import build_diagnosis_prompt
+from .remediation_templates import get_template_steps
 
 
 def _is_healthy_claim_key(key: str, value: object) -> bool:
@@ -293,6 +294,10 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
     # Unmask any placeholders the LLM passed through so state carries real
     # identifiers for user-facing display. No-op when masking is disabled.
     masking_ctx = MaskingContext.from_state(dict(state))
+    _available_sources = state.get("available_sources", {})
+    _remediation = result.remediation_steps or get_template_steps(
+        result.root_cause_category, _available_sources
+    )
     return {
         "root_cause": masking_ctx.unmask(result.root_cause),
         "root_cause_category": result.root_cause_category,
@@ -301,7 +306,7 @@ def diagnose_root_cause(state: InvestigationState) -> dict:
         "non_validated_claims": masking_ctx.unmask_value(non_validated_claims_list),
         "validity_score": validity_score,
         "investigation_recommendations": [masking_ctx.unmask(rec) for rec in recommendations],
-        "remediation_steps": [],
+        "remediation_steps": [masking_ctx.unmask(s) for s in _remediation],
         "investigation_loop_count": next_loop_count,
     }
 
@@ -397,7 +402,7 @@ def _handle_insufficient_evidence(state: InvestigationState, tracker) -> dict:
         ],
         "validity_score": 0.0,
         "investigation_recommendations": recommendations,
-        "remediation_steps": [],
+        "remediation_steps": get_template_steps("unknown", {}),
         "investigation_loop_count": next_loop_count,
     }
 

--- a/app/nodes/root_cause_diagnosis/prompt_builder.py
+++ b/app/nodes/root_cause_diagnosis/prompt_builder.py
@@ -141,6 +141,12 @@ CAUSAL_CHAIN:
 - <step 2: how the fault propagated>
 - <step N: the observable symptom or alert>
 (Trace from root cause to the alert. Each step should be one sentence backed by evidence where possible.)
+
+REMEDIATION_STEPS:
+- <step 1: most urgent concrete action — reference the specific service, pod, or resource identified above>
+- <step 2>
+- <step 3>
+(3–5 steps. Ground each in the evidence. Only suggest steps using tools or resources confirmed in the investigation. No generic advice.)
 """
 
     return prompt

--- a/app/nodes/root_cause_diagnosis/remediation_templates.py
+++ b/app/nodes/root_cause_diagnosis/remediation_templates.py
@@ -1,6 +1,8 @@
 """Deterministic remediation step fallbacks keyed on root_cause_category."""
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 _TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
     "resource_exhaustion": [
         ("Identify the saturated resource (memory, CPU, connections, storage) from the evidence", None),
@@ -45,7 +47,7 @@ _TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
 }
 
 
-def get_template_steps(category: str, available_sources: dict[str, object]) -> list[str]:
+def get_template_steps(category: str, available_sources: Mapping[str, object]) -> list[str]:
     """Return filtered remediation steps for the given root_cause_category."""
     entries = _TEMPLATES.get(category, _TEMPLATES["unknown"])
     return [

--- a/app/nodes/root_cause_diagnosis/remediation_templates.py
+++ b/app/nodes/root_cause_diagnosis/remediation_templates.py
@@ -45,7 +45,7 @@ _TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
 }
 
 
-def get_template_steps(category: str, available_sources: dict) -> list[str]:
+def get_template_steps(category: str, available_sources: dict[str, object]) -> list[str]:
     """Return filtered remediation steps for the given root_cause_category."""
     entries = _TEMPLATES.get(category, _TEMPLATES["unknown"])
     return [

--- a/app/nodes/root_cause_diagnosis/remediation_templates.py
+++ b/app/nodes/root_cause_diagnosis/remediation_templates.py
@@ -1,0 +1,55 @@
+"""Deterministic remediation step fallbacks keyed on root_cause_category."""
+from __future__ import annotations
+
+_TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
+    "resource_exhaustion": [
+        ("Identify the saturated resource (memory, CPU, connections, storage) from the evidence", None),
+        ("Scale up or right-size the affected workload or database", None),
+        ("Set resource limits and alerts at 80% to catch saturation early", None),
+        ("Review Grafana dashboards for resource trend leading up to the incident", "grafana"),
+        ("Check Datadog monitors for threshold breaches on the affected resource", "datadog"),
+        ("List EKS pods and confirm OOMKill events with kubectl describe", "eks"),
+    ],
+    "dependency_failure": [
+        ("Identify the failing upstream service or dependency from error logs", None),
+        ("Check upstream service health page and recent deployments", None),
+        ("Enable circuit breaker or retry with exponential backoff if not active", None),
+        ("Review Grafana logs for connection errors or timeouts to the dependency", "grafana"),
+        ("Check Datadog monitors for upstream SLO breach", "datadog"),
+    ],
+    "configuration_error": [
+        ("Diff the configuration deployed before the incident against the last known-good config", None),
+        ("Roll back the configuration change that introduced the mismatch", None),
+        ("Add validation checks to CI/CD pipeline for configuration values", None),
+    ],
+    "code_defect": [
+        ("Identify the commit introducing the defect using git history or recent deploy timestamps", None),
+        ("Roll back or hot-fix the affected service", None),
+        ("Add a regression test covering the failing code path before re-deploying", None),
+    ],
+    "data_quality": [
+        ("Quarantine or skip the malformed records to unblock the pipeline", None),
+        ("Add schema validation at the ingestion boundary", None),
+        ("Trace the upstream source of the bad data and notify the owner", None),
+    ],
+    "infrastructure": [
+        ("Check cloud provider status page and recent AWS service events for the region", None),
+        ("Verify IAM roles, VPC security groups, and networking rules are unchanged", None),
+        ("Trigger failover to standby if the primary zone is degraded", None),
+    ],
+    "unknown": [
+        ("Enable debug logging and re-run the failing workload to gather more signal", None),
+        ("Escalate to the owning team with the investigation trace and causal chain attached", None),
+    ],
+    "healthy": [],
+}
+
+
+def get_template_steps(category: str, available_sources: dict) -> list[str]:
+    """Return filtered remediation steps for the given root_cause_category."""
+    entries = _TEMPLATES.get(category, _TEMPLATES["unknown"])
+    return [
+        step
+        for step, required_source in entries
+        if required_source is None or required_source in available_sources
+    ]

--- a/app/nodes/root_cause_diagnosis/remediation_templates.py
+++ b/app/nodes/root_cause_diagnosis/remediation_templates.py
@@ -1,11 +1,15 @@
 """Deterministic remediation step fallbacks keyed on root_cause_category."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
 
 _TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
     "resource_exhaustion": [
-        ("Identify the saturated resource (memory, CPU, connections, storage) from the evidence", None),
+        (
+            "Identify the saturated resource (memory, CPU, connections, storage) from the evidence",
+            None,
+        ),
         ("Scale up or right-size the affected workload or database", None),
         ("Set resource limits and alerts at 80% to catch saturation early", None),
         ("Review Grafana dashboards for resource trend leading up to the incident", "grafana"),
@@ -20,12 +24,18 @@ _TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
         ("Check Datadog monitors for upstream SLO breach", "datadog"),
     ],
     "configuration_error": [
-        ("Diff the configuration deployed before the incident against the last known-good config", None),
+        (
+            "Diff the configuration deployed before the incident against the last known-good config",
+            None,
+        ),
         ("Roll back the configuration change that introduced the mismatch", None),
         ("Add validation checks to CI/CD pipeline for configuration values", None),
     ],
     "code_defect": [
-        ("Identify the commit introducing the defect using git history or recent deploy timestamps", None),
+        (
+            "Identify the commit introducing the defect using git history or recent deploy timestamps",
+            None,
+        ),
         ("Roll back or hot-fix the affected service", None),
         ("Add a regression test covering the failing code path before re-deploying", None),
     ],
@@ -41,7 +51,10 @@ _TEMPLATES: dict[str, list[tuple[str, str | None]]] = {
     ],
     "unknown": [
         ("Enable debug logging and re-run the failing workload to gather more signal", None),
-        ("Escalate to the owning team with the investigation trace and causal chain attached", None),
+        (
+            "Escalate to the owning team with the investigation trace and causal chain attached",
+            None,
+        ),
     ],
     "healthy": [],
 }

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -972,7 +972,11 @@ def parse_root_cause(response: str) -> RootCauseResult:
             # Extract non-validated claims
             if "NON_VALIDATED_CLAIMS:" in after:
                 non_validated_section = after.split("NON_VALIDATED_CLAIMS:", 1)[1]
-                for delimiter in ("ALTERNATIVE_HYPOTHESES_CONSIDERED:", "CAUSAL_CHAIN:"):
+                for delimiter in (
+                    "ALTERNATIVE_HYPOTHESES_CONSIDERED:",
+                    "CAUSAL_CHAIN:",
+                    "REMEDIATION_STEPS:",
+                ):
                     if delimiter in non_validated_section:
                         non_validated_text = non_validated_section.split(delimiter, 1)[0]
                         break
@@ -985,6 +989,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
                         line
                         and not line.startswith("CAUSAL_CHAIN")
                         and not line.startswith("ALTERNATIVE")
+                        and not line.startswith("REMEDIATION_STEPS")
                     ):
                         non_validated_claims.append(line)
 

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1014,6 +1014,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
                             "NON_VALIDATED",
                             "CAUSAL",
                             "ALTERNATIVE",
+                            "REMEDIATION_STEPS",
                         )
                     ):
                         break

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -941,6 +941,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
                 "VALIDATED_CLAIMS:",
                 "NON_VALIDATED_CLAIMS:",
                 "CAUSAL_CHAIN:",
+                "REMEDIATION_STEPS:",
             ):
                 if delimiter in after:
                     root_cause = after.split(delimiter, 1)[0].strip()
@@ -951,10 +952,14 @@ def parse_root_cause(response: str) -> RootCauseResult:
             # Extract validated claims
             if "VALIDATED_CLAIMS:" in after:
                 validated_section = after.split("VALIDATED_CLAIMS:", 1)[1]
-                if "NON_VALIDATED_CLAIMS:" in validated_section:
-                    validated_text = validated_section.split("NON_VALIDATED_CLAIMS:", 1)[0]
-                elif "CAUSAL_CHAIN:" in validated_section:
-                    validated_text = validated_section.split("CAUSAL_CHAIN:", 1)[0]
+                for delimiter in (
+                    "NON_VALIDATED_CLAIMS:",
+                    "CAUSAL_CHAIN:",
+                    "REMEDIATION_STEPS:",
+                ):
+                    if delimiter in validated_section:
+                        validated_text = validated_section.split(delimiter, 1)[0]
+                        break
                 else:
                     validated_text = validated_section
 
@@ -966,6 +971,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
                         and not line.startswith("CAUSAL_CHAIN")
                         and not line.startswith("CONFIDENCE")
                         and not line.startswith("ROOT_CAUSE")
+                        and not line.startswith("REMEDIATION_STEPS")
                     ):
                         validated_claims.append(line)
 

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -83,6 +83,7 @@ class RootCauseResult:
     validated_claims: list[str]
     non_validated_claims: list[str]
     causal_chain: list[str]
+    remediation_steps: list[str]
 
 
 @dataclass(frozen=True)
@@ -918,6 +919,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
     validated_claims: list[str] = []
     non_validated_claims: list[str] = []
     causal_chain: list[str] = []
+    remediation_steps: list[str] = []
 
     if "ROOT_CAUSE_CATEGORY:" in response:
         parts = response.split("ROOT_CAUSE_CATEGORY:", 1)
@@ -989,6 +991,8 @@ def parse_root_cause(response: str) -> RootCauseResult:
             # Extract causal chain
             if "CAUSAL_CHAIN:" in after:
                 causal_section = after.split("CAUSAL_CHAIN:", 1)[1]
+                if "REMEDIATION_STEPS:" in causal_section:
+                    causal_section = causal_section.split("REMEDIATION_STEPS:", 1)[0]
                 causal_text = causal_section
 
                 for line in causal_text.strip().split("\n"):
@@ -996,10 +1000,30 @@ def parse_root_cause(response: str) -> RootCauseResult:
                     if line and not line.startswith("ALTERNATIVE"):
                         causal_chain.append(line)
 
+            if "REMEDIATION_STEPS:" in after:
+                rem_section = after.split("REMEDIATION_STEPS:", 1)[1]
+                for line in rem_section.strip().split("\n"):
+                    line = line.strip().lstrip("*-•( ").strip()
+                    if not line:
+                        continue
+                    if any(
+                        line.startswith(h)
+                        for h in (
+                            "ROOT_CAUSE",
+                            "VALIDATED",
+                            "NON_VALIDATED",
+                            "CAUSAL",
+                            "ALTERNATIVE",
+                        )
+                    ):
+                        break
+                    remediation_steps.append(line)
+
     return RootCauseResult(
         root_cause=root_cause,
         root_cause_category=root_cause_category,
         validated_claims=validated_claims,
         non_validated_claims=non_validated_claims,
         causal_chain=causal_chain,
+        remediation_steps=remediation_steps,
     )

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1004,7 +1004,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
                 rem_section = after.split("REMEDIATION_STEPS:", 1)[1]
                 for line in rem_section.strip().split("\n"):
                     line = line.strip().lstrip("*-•( ").strip()
-                    if not line:
+                    if not line or line.startswith("("):
                         continue
                     if any(
                         line.startswith(h)

--- a/tests/nodes/publish_findings/test_report_provenance.py
+++ b/tests/nodes/publish_findings/test_report_provenance.py
@@ -162,14 +162,9 @@ def test_build_slack_blocks_shows_recommended_actions() -> None:
     blocks = build_slack_blocks(ctx)
 
     block_texts = [
-        b.get("text", {}).get("text", "") if isinstance(b.get("text"), dict) else ""
-        for b in blocks
+        b.get("text", {}).get("text", "") if isinstance(b.get("text"), dict) else "" for b in blocks
     ]
-    header_texts = [
-        b.get("text", {}).get("text", "")
-        for b in blocks
-        if b.get("type") == "header"
-    ]
+    header_texts = [b.get("text", {}).get("text", "") for b in blocks if b.get("type") == "header"]
     assert any("Recommended Actions" in t for t in header_texts)
     assert any("Increase memory limit" in t for t in block_texts)
     assert any(b.get("type") == "divider" for b in blocks)
@@ -179,9 +174,5 @@ def test_build_slack_blocks_omits_recommended_actions_when_empty() -> None:
     ctx = build_report_context(_make_state())  # remediation_steps=[] by default
     blocks = build_slack_blocks(ctx)
 
-    header_texts = [
-        b.get("text", {}).get("text", "")
-        for b in blocks
-        if b.get("type") == "header"
-    ]
+    header_texts = [b.get("text", {}).get("text", "") for b in blocks if b.get("type") == "header"]
     assert not any("Recommended Actions" in t for t in header_texts)

--- a/tests/nodes/publish_findings/test_report_provenance.py
+++ b/tests/nodes/publish_findings/test_report_provenance.py
@@ -58,6 +58,27 @@ def test_format_slack_message_shows_provenance() -> None:
     assert "*Provenance:*" in message
     assert "Grafana: instance=myorg.grafana.net" in message
     assert "AWS EKS: cluster=prod-cluster, namespace=payments, region=us-east-1" in message
+
+
+def test_format_slack_message_shows_recommended_actions() -> None:
+    state = _make_state()
+    state["remediation_steps"] = [
+        "Increase memory limit for payments-api deployment",
+        "Add Datadog monitor for memory usage at 80% threshold",
+    ]
+    ctx = build_report_context(state)
+    message = format_slack_message(ctx)
+
+    assert "## Recommended Actions" in message
+    assert "• Increase memory limit for payments-api deployment" in message
+    assert "• Add Datadog monitor for memory usage at 80% threshold" in message
+
+
+def test_format_slack_message_omits_recommended_actions_when_empty() -> None:
+    ctx = build_report_context(_make_state())  # remediation_steps=[] by default
+    message = format_slack_message(ctx)
+
+    assert "## Recommended Actions" not in message
     assert (
         "provenance: instance=myorg.grafana.net, service=checkout-api, pipeline=checkout-service"
         in message

--- a/tests/nodes/publish_findings/test_report_provenance.py
+++ b/tests/nodes/publish_findings/test_report_provenance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.nodes.publish_findings.formatters.report import format_slack_message
+from app.nodes.publish_findings.formatters.report import build_slack_blocks, format_slack_message
 from app.nodes.publish_findings.report_context import build_report_context
 
 
@@ -150,3 +150,38 @@ def test_format_slack_message_sanitizes_provenance_content() -> None:
 
     assert "service=*checkout-api*" in message
     assert "service=**checkout-api**" not in message
+
+
+def test_build_slack_blocks_shows_recommended_actions() -> None:
+    state = _make_state()
+    state["remediation_steps"] = [
+        "Increase memory limit for payments-api deployment",
+        "Add Datadog monitor for memory usage at 80% threshold",
+    ]
+    ctx = build_report_context(state)
+    blocks = build_slack_blocks(ctx)
+
+    block_texts = [
+        b.get("text", {}).get("text", "") if isinstance(b.get("text"), dict) else ""
+        for b in blocks
+    ]
+    header_texts = [
+        b.get("text", {}).get("text", "")
+        for b in blocks
+        if b.get("type") == "header"
+    ]
+    assert any("Recommended Actions" in t for t in header_texts)
+    assert any("Increase memory limit" in t for t in block_texts)
+    assert any(b.get("type") == "divider" for b in blocks)
+
+
+def test_build_slack_blocks_omits_recommended_actions_when_empty() -> None:
+    ctx = build_report_context(_make_state())  # remediation_steps=[] by default
+    blocks = build_slack_blocks(ctx)
+
+    header_texts = [
+        b.get("text", {}).get("text", "")
+        for b in blocks
+        if b.get("type") == "header"
+    ]
+    assert not any("Recommended Actions" in t for t in header_texts)

--- a/tests/nodes/root_cause_diagnosis/test_masking_integration.py
+++ b/tests/nodes/root_cause_diagnosis/test_masking_integration.py
@@ -52,6 +52,7 @@ def _mock_parse_result(root_cause: str) -> object:
         {"claim": "<POD_0> entered CrashLoopBackOff", "validation_status": "validated"}
     ]
     result.non_validated_claims = []
+    result.remediation_steps = []
     return result
 
 

--- a/tests/nodes/root_cause_diagnosis/test_remediation.py
+++ b/tests/nodes/root_cause_diagnosis/test_remediation.py
@@ -1,0 +1,92 @@
+"""Tests for remediation_templates and parse_root_cause REMEDIATION_STEPS parsing."""
+from app.nodes.root_cause_diagnosis.remediation_templates import get_template_steps
+from app.services.llm_client import parse_root_cause
+
+
+class TestGetTemplateSteps:
+    def test_resource_exhaustion_no_sources(self):
+        steps = get_template_steps("resource_exhaustion", {})
+        assert len(steps) >= 3
+        assert all(isinstance(s, str) for s in steps)
+        # source-gated steps excluded
+        assert not any("Grafana" in s for s in steps)
+        assert not any("Datadog" in s for s in steps)
+        assert not any("EKS" in s for s in steps)
+
+    def test_resource_exhaustion_with_grafana_and_eks(self):
+        steps = get_template_steps("resource_exhaustion", {"grafana": {}, "eks": {}})
+        assert any("Grafana" in s for s in steps)
+        assert any("EKS" in s for s in steps)
+        assert not any("Datadog" in s for s in steps)
+
+    def test_healthy_returns_empty(self):
+        assert get_template_steps("healthy", {}) == []
+
+    def test_unknown_category_falls_back_to_unknown(self):
+        steps = get_template_steps("nonexistent_category", {})
+        unknown_steps = get_template_steps("unknown", {})
+        assert steps == unknown_steps
+        assert len(steps) > 0
+
+
+class TestParseRootCauseRemediationSteps:
+    def test_remediation_steps_parsed(self):
+        response = """ROOT_CAUSE:
+Memory limit exceeded.
+
+ROOT_CAUSE_CATEGORY:
+resource_exhaustion
+
+VALIDATED_CLAIMS:
+- Pod exited with code 137 [evidence: eks]
+
+NON_VALIDATED_CLAIMS:
+- Traffic spike may have caused burst
+
+CAUSAL_CHAIN:
+- Memory usage grew past limit
+- Kubelet sent SIGKILL
+
+REMEDIATION_STEPS:
+- Increase memory limit for payments-api deployment
+- Add Datadog monitor for memory usage at 80% threshold
+- Review recent traffic patterns for load spikes
+"""
+        result = parse_root_cause(response)
+        assert len(result.remediation_steps) == 3
+        assert "payments-api" in result.remediation_steps[0]
+
+    def test_no_remediation_section_returns_empty(self):
+        response = """ROOT_CAUSE:
+OOM kill detected.
+
+ROOT_CAUSE_CATEGORY:
+resource_exhaustion
+
+CAUSAL_CHAIN:
+- Memory exceeded limit
+"""
+        result = parse_root_cause(response)
+        assert result.remediation_steps == []
+
+    def test_causal_chain_does_not_swallow_remediation_steps(self):
+        response = """ROOT_CAUSE:
+Config error.
+
+ROOT_CAUSE_CATEGORY:
+configuration_error
+
+CAUSAL_CHAIN:
+- Bad env var set
+- Service failed to start
+
+REMEDIATION_STEPS:
+- Roll back the config change
+- Validate env vars in CI
+"""
+        result = parse_root_cause(response)
+        # causal chain must not include remediation lines
+        assert not any("Roll back" in step for step in result.causal_chain)
+        assert not any("Validate env" in step for step in result.causal_chain)
+        assert len(result.causal_chain) == 2
+        assert len(result.remediation_steps) == 2

--- a/tests/nodes/root_cause_diagnosis/test_remediation.py
+++ b/tests/nodes/root_cause_diagnosis/test_remediation.py
@@ -91,3 +91,27 @@ REMEDIATION_STEPS:
         assert not any("Validate env" in step for step in result.causal_chain)
         assert len(result.causal_chain) == 2
         assert len(result.remediation_steps) == 2
+
+    def test_non_validated_claims_does_not_swallow_remediation_steps(self):
+        """Weak model skips CAUSAL_CHAIN — REMEDIATION_STEPS must still be parsed."""
+        response = """ROOT_CAUSE:
+OOM kill detected.
+
+ROOT_CAUSE_CATEGORY:
+resource_exhaustion
+
+VALIDATED_CLAIMS:
+- Pod exited with code 137
+
+NON_VALIDATED_CLAIMS:
+- Memory limit may be too low
+
+REMEDIATION_STEPS:
+- Increase memory limit for payments-api
+- Add memory alert at 80% threshold
+"""
+        result = parse_root_cause(response)
+        assert not any("Increase memory" in c for c in result.non_validated_claims)
+        assert not any("Add memory alert" in c for c in result.non_validated_claims)
+        assert len(result.remediation_steps) == 2
+        assert "payments-api" in result.remediation_steps[0]

--- a/tests/nodes/root_cause_diagnosis/test_remediation.py
+++ b/tests/nodes/root_cause_diagnosis/test_remediation.py
@@ -1,4 +1,5 @@
 """Tests for remediation_templates and parse_root_cause REMEDIATION_STEPS parsing."""
+
 from app.nodes.root_cause_diagnosis.remediation_templates import get_template_steps
 from app.services.llm_client import parse_root_cause
 

--- a/tests/nodes/root_cause_diagnosis/test_remediation.py
+++ b/tests/nodes/root_cause_diagnosis/test_remediation.py
@@ -92,6 +92,26 @@ REMEDIATION_STEPS:
         assert len(result.causal_chain) == 2
         assert len(result.remediation_steps) == 2
 
+    def test_validated_claims_does_not_swallow_remediation_steps(self):
+        """Weak model skips NON_VALIDATED_CLAIMS and CAUSAL_CHAIN — REMEDIATION_STEPS must not leak into validated_claims."""
+        response = """ROOT_CAUSE:
+OOM kill detected.
+
+ROOT_CAUSE_CATEGORY:
+resource_exhaustion
+
+VALIDATED_CLAIMS:
+- Pod exited with code 137
+
+REMEDIATION_STEPS:
+- Increase memory limit for payments-api
+- Add memory alert at 80% threshold
+"""
+        result = parse_root_cause(response)
+        assert not any("Increase memory" in c for c in result.validated_claims)
+        assert not any("Add memory alert" in c for c in result.validated_claims)
+        assert len(result.remediation_steps) == 2
+
     def test_non_validated_claims_does_not_swallow_remediation_steps(self):
         """Weak model skips CAUSAL_CHAIN — REMEDIATION_STEPS must still be parsed."""
         response = """ROOT_CAUSE:


### PR DESCRIPTION
Part of #1073

#### Describe the changes you have made in this PR

Every investigation report previously ended with an empty `remediation_steps: []`. This PR wires up actionable remediation steps in every report.

- The diagnosis prompt now asks the LLM to emit a `REMEDIATION_STEPS:` section grounded in the evidence gathered (specific pod names, namespaces, time windows).
- If the LLM returns no steps, `remediation_templates.py` provides deterministic fallback steps keyed on `root_cause_category`, filtered by which integrations are active.
- Both the Slack text formatter and Block Kit renderer now include a `## Recommended Actions` section when steps are present.
- The `CAUSAL_CHAIN:` parser had no end delimiter and would have consumed `REMEDIATION_STEPS:` lines — fixed.
- The `healthy` path intentionally returns `[]` — informational alerts need no actions.

---

### Demo/Screenshot

**Before:**
```
=== remediation_steps ===
count: 0
```

**After** — scenario `001-oomkilled-crashloop` (synthetic, mock backends):

<img width="1935" height="1299" alt="image" src="https://github.com/user-attachments/assets/5d862474-2ccd-4d39-babc-7ac802578479" />

Investigation output shows `Recommended Actions` with 4 LLM-grounded steps specific to the OOM incident, `remediation_steps` count: 4, and `## Recommended Actions` rendered in the report section.

---

## Code Understanding and AI Usage

- [x] Yes, I used AI assistance (continue below)
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`remediation_steps` was already declared in `AgentState`, `ReportContext`, and `build_report_context` — it just was never populated. The fix is two-layered: LLM steps are incident-specific but unreliable on weak models; deterministic templates are always available but generic. The `or` fallback in `node.py` prefers LLM steps and silently falls back to templates.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions