### PR TITLE
Remove dead noqa directives and fix mechanical lint warnings

### DIFF
--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -175,7 +175,7 @@ def _investigation_started_properties(
 def _capture(event: Event, properties: Properties | None = None) -> None:
     try:
         get_analytics().capture(event, properties)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         capture_exception(exc)
 
 

--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -18,7 +18,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Final, TypeAlias
+from typing import Final
 
 import httpx
 
@@ -66,8 +66,8 @@ _CI_FINGERPRINT_ENV_KEYS: Final[tuple[str, ...]] = (
     "JOB_NAME",
 )
 
-PropertyValue: TypeAlias = str | bool | int | float  # noqa: UP040
-Properties: TypeAlias = dict[str, PropertyValue]  # noqa: UP040
+type PropertyValue = str | bool | int | float
+type Properties = dict[str, PropertyValue]
 
 
 @dataclass(frozen=True, slots=True)
@@ -323,7 +323,7 @@ def _compute_anonymous_identity() -> _AnonymousIdentity:
 
 
 def _get_or_create_anonymous_id() -> str:
-    global _cached_anonymous_id, _cached_identity_persistence  # noqa: PLW0603
+    global _cached_anonymous_id, _cached_identity_persistence
     if _cached_anonymous_id is not None:
         return _cached_anonymous_id
     with _anonymous_id_lock:
@@ -345,7 +345,7 @@ def _event_insert_id(event: str, distinct_id: str) -> str | None:
 
 
 def _touch_once(path: Path) -> bool:
-    global _first_run_marker_created_this_process  # noqa: PLW0603
+    global _first_run_marker_created_this_process
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("x", encoding="utf-8") as fh:
@@ -605,7 +605,7 @@ def _log_failure(stage: str, error: BaseException, **extra: object) -> None:
         _write_failure_line(primary_path, line)
     except OSError:
         primary_failed = True
-    except Exception:  # noqa: BLE001
+    except Exception:
         # Defensive: an unexpected exception in our diagnostics path must not
         # propagate. Treat it the same as an OSError and try the fallback.
         primary_failed = True
@@ -624,7 +624,7 @@ def _capture_sentry_failure(error: BaseException) -> None:
     """Report telemetry failures without making analytics depend on Sentry imports."""
     try:
         from app.utils.sentry_sdk import capture_exception
-    except Exception:  # noqa: BLE001
+    except Exception:
         return
     capture_exception(error)
 
@@ -726,7 +726,7 @@ class Analytics:
             error = _QueueOverflow(f"queue overflow at size={_QUEUE_SIZE}")
             _log_failure("queue_full", error, event=event.value)
             _capture_sentry_failure(error)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             if pending_registered:
                 self._mark_done()
             _log_failure("capture", exc, event=event.value)
@@ -739,7 +739,7 @@ class Analytics:
         if self._worker_alive:
             try:
                 self._ensure_worker()
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 _log_failure("worker_start", exc)
                 _capture_sentry_failure(exc)
                 self._worker_alive = False
@@ -798,7 +798,7 @@ class Analytics:
         }
         try:
             client.post(f"{POSTHOG_HOST}/capture/", json=payload).raise_for_status()
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             _log_failure("posthog_send", exc, event=item.event)
             _capture_sentry_failure(exc)
 
@@ -813,7 +813,7 @@ _instance: Analytics | None = None
 
 
 def get_analytics() -> Analytics:
-    global _instance  # noqa: PLW0603
+    global _instance
     if _instance is None:
         _instance = Analytics()
     return _instance

--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -64,38 +64,43 @@ async def on_thread_create(ctx: Auth.types.AuthContext, value: dict[str, Any]) -
 
 @auth.on.threads.read
 async def on_thread_read(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
+    ctx: Auth.types.AuthContext,
+    value: Any,
 ) -> None:
+    del ctx, value
     return None
 
 
 @auth.on.threads.update
 async def on_thread_update(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
+    ctx: Auth.types.AuthContext,
+    value: Any,
 ) -> None:
+    del ctx, value
     return None
 
 
 @auth.on.threads.delete
 async def on_thread_delete(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
+    ctx: Auth.types.AuthContext,
+    value: Any,
 ) -> None:
+    del ctx, value
     return None
 
 
 @auth.on.threads.search
-async def on_thread_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_thread_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.threads.create_run
 async def on_thread_create_run(
-    ctx: Auth.types.AuthContext,  # noqa: ARG001
-    value: Any,  # noqa: ARG001
+    ctx: Auth.types.AuthContext,
+    value: Any,
 ) -> None:
+    del ctx, value
     return None
 
 
@@ -108,22 +113,26 @@ async def on_assistant_create(ctx: Auth.types.AuthContext, value: dict[str, Any]
 
 
 @auth.on.assistants.read
-async def on_assistant_read(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_assistant_read(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.assistants.update
-async def on_assistant_update(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_assistant_update(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.assistants.delete
-async def on_assistant_delete(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_assistant_delete(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.assistants.search
-async def on_assistant_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_assistant_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
@@ -136,20 +145,24 @@ async def on_cron_create(ctx: Auth.types.AuthContext, value: dict[str, Any]) -> 
 
 
 @auth.on.crons.read
-async def on_cron_read(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_cron_read(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.crons.update
-async def on_cron_update(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_cron_update(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.crons.delete
-async def on_cron_delete(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_cron_delete(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}
 
 
 @auth.on.crons.search
-async def on_cron_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:  # noqa: ARG001
+async def on_cron_search(ctx: Auth.types.AuthContext, value: Any) -> dict[str, str]:
+    del value
     return {"org_id": _get_org_id(ctx)}

--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -48,7 +48,7 @@ def _get_deployment_status() -> dict[str, str]:
             "instance_id": outputs.get("InstanceId", ""),
             "port": outputs.get("ServerPort", "8080"),
         }
-    except (FileNotFoundError, Exception):  # noqa: BLE001
+    except (FileNotFoundError, Exception):
         return {}
 
 
@@ -271,7 +271,7 @@ def _check_deploy_health(status: dict[str, str], console: Any) -> None:
         )
     except TimeoutError:
         console.print(f"  [red]Timeout[/red]  could not reach {ip}:{port}")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"  [red]Unhealthy[/red]  {exc}")
 
 

--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -21,7 +21,7 @@ def _check(name: str, fn: Any) -> dict[str, str]:
     try:
         ok, detail = fn()
         return {"check": name, "status": "ok" if ok else "warn", "detail": detail}
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return {"check": name, "status": "error", "detail": str(exc)}
 
 
@@ -107,7 +107,7 @@ def _check_version_freshness() -> tuple[bool, str]:
         if _is_update_available(current, latest):
             return False, f"current={current}, latest={latest} — run 'opensre update'"
         return True, f"{current} (up to date)"
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return True, f"{current} (could not check: {exc})"
 
 

--- a/app/cli/commands/remote.py
+++ b/app/cli/commands/remote.py
@@ -87,7 +87,7 @@ def _browse_investigations(ctx: click.Context, style: Any, questionary: Any, con
             f"Connection timed out: {exc}",
             suggestion="Check network connectivity and verify the remote agent is running.",
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise OpenSREError(
             f"Failed to list investigations: {exc}",
             suggestion="Run 'opensre remote health' to verify the remote agent.",
@@ -126,7 +126,7 @@ def _browse_investigations(ctx: click.Context, style: Any, questionary: Any, con
 
         try:
             content = client.get_investigation(selected)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             console.print(f"  [red]Failed to load: {exc}[/red]")
             continue
 
@@ -643,7 +643,7 @@ def _run_streamed_investigation(ctx: click.Context, raw_alert: dict[str, Any]) -
             f"Connection timed out reaching {client.base_url}.",
             suggestion="Check network connectivity and verify the remote agent is running.",
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise OpenSREError(
             f"Remote investigation failed: {exc}",
             suggestion="Run 'opensre remote health' to verify the remote agent.",
@@ -728,7 +728,7 @@ def _run_langgraph_investigation(ctx: click.Context, raw_alert: dict[str, Any]) 
             f"Connection timed out reaching {client.base_url}.",
             suggestion="Check network connectivity and verify the remote agent is running.",
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise OpenSREError(
             f"Remote investigation failed: {exc}",
             suggestion="Run 'opensre remote health' to verify the remote agent.",
@@ -926,7 +926,7 @@ def remote_trigger(ctx: click.Context, alert_json: str | None, detach: bool) -> 
             f"Connection timed out reaching {client.base_url}.",
             suggestion="Check network connectivity and verify the remote agent is running.",
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise OpenSREError(
             f"Remote investigation failed: {exc}",
             suggestion="Run 'opensre remote health' to verify the remote agent.",
@@ -990,7 +990,7 @@ def _run_blocking_investigation(ctx: click.Context, raw_alert: dict[str, Any]) -
             f"Connection timed out: {exc}",
             suggestion="The remote agent may be overloaded. Try again or check 'opensre remote health'.",
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise OpenSREError(
             f"Remote investigation failed: {exc}",
             suggestion="Run 'opensre remote health' to verify the remote agent.",
@@ -1028,7 +1028,7 @@ def remote_pull(ctx: click.Context, latest: bool, pull_all: bool, output_dir: st
             f"Connection timed out: {exc}",
             suggestion="Check network connectivity and verify the remote agent is running.",
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise OpenSREError(
             f"Failed to list investigations: {exc}",
             suggestion="Run 'opensre remote health' to verify the remote agent.",
@@ -1055,5 +1055,5 @@ def remote_pull(ctx: click.Context, latest: bool, pull_all: bool, output_dir: st
             destination = output_path / f"{investigation_id}.md"
             destination.write_text(content, encoding="utf-8")
             click.echo(f"  Downloaded: {destination}")
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             click.echo(f"  Failed to download {investigation_id}: {exc}", err=True)

--- a/app/cli/commands/remote_health.py
+++ b/app/cli/commands/remote_health.py
@@ -148,5 +148,5 @@ def run_remote_health_check(
             "SSH into the instance and check: `systemctl status opensre` and "
             "`cat /var/log/opensre-remote.log`."
         ) from exc
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise click.ClickException(f"Health check failed: {exc}") from exc

--- a/app/cli/commands/tests.py
+++ b/app/cli/commands/tests.py
@@ -30,9 +30,9 @@ class _TestIdType(click.ParamType):
 
     def shell_complete(
         self,
-        ctx: click.Context,  # noqa: ARG002
-        param: click.Parameter,  # noqa: ARG002
-        incomplete: str,  # noqa: ARG002
+        _ctx: click.Context,
+        _param: click.Parameter,
+        incomplete: str,
     ) -> list[click.shell_completion.CompletionItem]:
         try:
             from app.cli.tests.discover import load_test_catalog
@@ -43,7 +43,7 @@ class _TestIdType(click.ParamType):
                 for item in catalog.all_items()
                 if item.id.startswith(incomplete) and item.is_runnable
             ]
-        except Exception:  # noqa: BLE001
+        except Exception:
             return []
 
 

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -185,7 +185,7 @@ def run_shell_command(
             timeout_seconds=SHELL_COMMAND_TIMEOUT_SECONDS,
             max_output_chars=_MAX_COMMAND_OUTPUT_CHARS,
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.shell_command.start")
         console.print(f"[red]command failed to start:[/red] {escape(str(exc))}")
         session.record("shell", command, ok=False)
@@ -232,7 +232,7 @@ def run_cd_command(command: str, session: ReplSession, console: Console) -> None
     target = Path(tokens[1]).expanduser() if len(tokens) == 2 else Path.home()
     try:
         os.chdir(target)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"[red]cd failed:[/red] {escape(str(exc))}")
         session.record("shell", command, ok=False)
         return
@@ -303,7 +303,7 @@ def run_sample_alert(
             console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")
         session.record("alert", f"sample:{template_name}", ok=False)
         return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         task.mark_failed(str(exc))
         report_exception(exc, context="interactive_shell.sample_alert")
         console.print(f"[red]investigation failed:[/red] {escape(str(exc))}")
@@ -353,12 +353,12 @@ def run_synthetic_test(
         max_size=_SYNTHETIC_DIAG_CHARS * 2
     )
     try:
-        proc = subprocess.Popen(  # noqa: S603 - argv is trusted interpreter path + module
+        proc = subprocess.Popen(
             [sys.executable, "-m", "app.cli", "tests", "synthetic"],
             stdout=subprocess.DEVNULL,
             stderr=stderr_buf,
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         stderr_buf.close()
         task.mark_failed(str(exc))
         report_exception(exc, context="interactive_shell.synthetic_test.start")

--- a/app/cli/interactive_shell/banner.py
+++ b/app/cli/interactive_shell/banner.py
@@ -42,7 +42,7 @@ def detect_provider_model() -> tuple[str, str]:
     """Return a human-readable (provider, model) for the active LLM config."""
     try:
         settings = LLMSettings.from_env()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return ("unknown", "unknown")
 
     provider = settings.provider or os.getenv("LLM_PROVIDER", "anthropic")

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -312,7 +312,7 @@ def answer_cli_agent(
     """
     try:
         from app.services.llm_client import get_llm_for_reasoning
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.cli_agent.import")
         console.print(f"[red]LLM client unavailable:[/red] {escape(str(exc))}")
         return
@@ -338,7 +338,7 @@ def answer_cli_agent(
     except KeyboardInterrupt:
         console.print("[dim]· cancelled[/dim]")
         return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.cli_agent.stream")
         console.print(f"[red]assistant failed:[/red] {escape(str(exc))}")
         return

--- a/app/cli/interactive_shell/cli_help.py
+++ b/app/cli/interactive_shell/cli_help.py
@@ -88,7 +88,7 @@ def answer_cli_help(question: str, _session: ReplSession, console: Console) -> N
     """
     try:
         from app.services.llm_client import get_llm_for_reasoning
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.cli_help.import")
         console.print(f"[red]LLM client unavailable:[/red] {escape(str(exc))}")
         return
@@ -108,7 +108,7 @@ def answer_cli_help(question: str, _session: ReplSession, console: Console) -> N
     except KeyboardInterrupt:
         console.print("[dim]· cancelled[/dim]")
         return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.cli_help.stream")
         console.print(f"[red]assistant failed:[/red] {escape(str(exc))}")
         return

--- a/app/cli/interactive_shell/command_registry/help.py
+++ b/app/cli/interactive_shell/command_registry/help.py
@@ -10,7 +10,7 @@ from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
 
-def _cmd_help(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_help(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     # Import after the registry is fully assembled (avoids circular import at module load).
     from app.cli.interactive_shell.command_registry import SLASH_COMMANDS
 

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -17,7 +17,7 @@ from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD, TERMINAL_ERROR
 
 
-def _cmd_integrations(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_integrations(session: ReplSession, console: Console, args: list[str]) -> bool:
     sub = (args[0].lower() if args else "list").strip()
 
     if sub in ("list", "ls"):
@@ -67,7 +67,7 @@ def _cmd_integrations(session: ReplSession, console: Console, args: list[str]) -
     return True
 
 
-def _cmd_mcp(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_mcp(_session: ReplSession, console: Console, args: list[str]) -> bool:
     sub = (args[0].lower() if args else "list").strip()
 
     if sub in ("list", "ls"):
@@ -93,7 +93,7 @@ def _cmd_mcp(session: ReplSession, console: Console, args: list[str]) -> bool:  
     return True
 
 
-def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_list(_session: ReplSession, console: Console, args: list[str]) -> bool:
     sub = (args[0].lower() if args else "").strip()
 
     if sub in ("integrations", "integration", "int"):

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -16,7 +16,7 @@ from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
 
 
-def _cmd_template(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_template(_session: ReplSession, console: Console, args: list[str]) -> bool:
     from app.cli.investigation.alert_templates import build_alert_template
     from app.cli.support.constants import ALERT_TEMPLATE_CHOICES
 
@@ -56,7 +56,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
 
     try:
         text = path.read_text(encoding="utf-8")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"[{TERMINAL_ERROR}]cannot read file:[/] {escape(str(exc))}")
         session.mark_latest(ok=False, kind="slash")
         return True
@@ -83,7 +83,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
         session.record("alert", args[0], ok=False)
         session.mark_latest(ok=False, kind="slash")
         return True
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         task.mark_failed(str(exc))
         report_exception(exc, context="interactive_shell.investigate_file")
         console.print(f"[{TERMINAL_ERROR}]investigation failed:[/] {escape(str(exc))}")
@@ -101,7 +101,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
     return True
 
 
-def _cmd_last(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_last(session: ReplSession, console: Console, _args: list[str]) -> bool:
     if session.last_state is None:
         console.print("[dim]no investigation in this session yet.[/dim]")
         return True
@@ -145,7 +145,7 @@ def _cmd_save(session: ReplSession, console: Console, args: list[str]) -> bool:
                 lines.append(f"## Report\n\n{report}\n")
             dest.write_text("\n".join(lines) or "(no report content)", encoding="utf-8")
         console.print(f"[green]saved:[/green] {escape(str(dest))}")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         console.print(f"[{TERMINAL_ERROR}]save failed:[/] {escape(str(exc))}")
     return True
 

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -225,7 +225,7 @@ def parse_model_set_args(args: list[str]) -> tuple[str, str | None, str | None]:
     return provider, reasoning_model, toolcall_model
 
 
-def _cmd_model(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_model(session: ReplSession, console: Console, args: list[str]) -> bool:
     sub = (args[0].lower() if args else "show").strip()
 
     if sub == "show":

--- a/app/cli/interactive_shell/command_registry/repl_data.py
+++ b/app/cli/interactive_shell/command_registry/repl_data.py
@@ -18,7 +18,7 @@ def load_llm_settings() -> Any | None:
         from app.config import LLMSettings
 
         return LLMSettings.from_env()
-    except Exception:  # noqa: BLE001 — env/config errors are expected here
+    except Exception:
         return None
 
 

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -14,13 +14,13 @@ from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
 
-def _cmd_clear(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_clear(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     console.clear()
     render_banner(console)
     return True
 
 
-def _cmd_reset(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_reset(session: ReplSession, console: Console, _args: list[str]) -> bool:
     session.clear()
     console.print("[dim]session state cleared.[/dim]")
     return True
@@ -36,7 +36,7 @@ def _cmd_trust(session: ReplSession, console: Console, args: list[str]) -> bool:
     return True
 
 
-def _cmd_status(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_status(session: ReplSession, console: Console, _args: list[str]) -> bool:
     from app.cli.interactive_shell.cli_reference import get_cli_reference_cache_stats
     from app.cli.interactive_shell.docs_reference import get_docs_cache_stats
 
@@ -66,7 +66,7 @@ def _cmd_status(session: ReplSession, console: Console, args: list[str]) -> bool
     return True
 
 
-def _cmd_cost(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_cost(session: ReplSession, console: Console, _args: list[str]) -> bool:
     table = repl_table(title="Session cost", title_style=TERMINAL_ACCENT_BOLD, show_header=False)
     table.add_column("key", style="bold")
     table.add_column("value")
@@ -84,7 +84,7 @@ def _cmd_cost(session: ReplSession, console: Console, args: list[str]) -> bool: 
     return True
 
 
-def _cmd_verbose(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_verbose(_session: ReplSession, console: Console, args: list[str]) -> bool:
     if args and args[0].lower() in ("off", "false", "0", "disable"):
         os.environ.pop("TRACER_VERBOSE", None)
         console.print("[dim]verbose logging off[/dim]")
@@ -94,7 +94,7 @@ def _cmd_verbose(session: ReplSession, console: Console, args: list[str]) -> boo
     return True
 
 
-def _cmd_compact(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_compact(session: ReplSession, console: Console, _args: list[str]) -> bool:
     before = len(session.history)
     if before > 20:
         session.history = session.history[-20:]
@@ -104,7 +104,7 @@ def _cmd_compact(session: ReplSession, console: Console, args: list[str]) -> boo
     return True
 
 
-def _cmd_context(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_context(session: ReplSession, console: Console, _args: list[str]) -> bool:
     if not session.accumulated_context:
         console.print("[dim]no infra context accumulated yet.[/dim]")
         return True

--- a/app/cli/interactive_shell/command_registry/system.py
+++ b/app/cli/interactive_shell/command_registry/system.py
@@ -12,12 +12,12 @@ from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 
 
-def _cmd_exit(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_exit(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     console.print("[dim]goodbye.[/dim]")
     return False
 
 
-def _cmd_health(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_health(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     from app.cli.support.health_view import render_health_report
     from app.config import get_environment
     from app.integrations.store import STORE_PATH
@@ -34,7 +34,7 @@ def _cmd_health(session: ReplSession, console: Console, args: list[str]) -> bool
     return True
 
 
-def _cmd_doctor(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_doctor(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     from app.cli.commands.doctor import _CHECKS, _check
 
     status_styles: dict[str, str] = {"ok": "green", "warn": "yellow", "error": "red"}
@@ -60,7 +60,7 @@ def _cmd_doctor(session: ReplSession, console: Console, args: list[str]) -> bool
     return True
 
 
-def _cmd_version(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_version(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     from app.version import get_version
 
     table = repl_table(title="Version info", title_style=TERMINAL_ACCENT_BOLD, show_header=False)

--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -34,7 +34,7 @@ def _task_detail_label(task: TaskRecord) -> str:
     return "—"
 
 
-def _cmd_history(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_history(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     entries = load_command_history_entries()
     if not entries:
         console.print("[dim]no history yet.[/dim]")
@@ -50,7 +50,7 @@ def _cmd_history(session: ReplSession, console: Console, args: list[str]) -> boo
     return True
 
 
-def _cmd_tasks(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _cmd_tasks(session: ReplSession, console: Console, _args: list[str]) -> bool:
     tasks = session.task_registry.list_recent(n=50)
     if not tasks:
         console.print("[dim]no tasks recorded this session.[/dim]")

--- a/app/cli/interactive_shell/config.py
+++ b/app/cli/interactive_shell/config.py
@@ -33,7 +33,7 @@ def _read_config_file() -> dict[str, Any]:
             return {}
 
         return interactive
-    except Exception:  # noqa: BLE001
+    except Exception:
         return {}
 
 

--- a/app/cli/interactive_shell/follow_up.py
+++ b/app/cli/interactive_shell/follow_up.py
@@ -81,7 +81,7 @@ def answer_follow_up(question: str, session: ReplSession, console: Console) -> N
 
     try:
         from app.services.llm_client import get_llm_for_reasoning
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.follow_up.import")
         console.print(f"[{TERMINAL_ERROR}]LLM client unavailable:[/] {escape(str(exc))}")
         return
@@ -106,7 +106,7 @@ def answer_follow_up(question: str, session: ReplSession, console: Console) -> N
     except KeyboardInterrupt:
         console.print("[dim]· cancelled[/dim]")
         return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         report_exception(exc, context="interactive_shell.follow_up.stream")
         console.print(f"[{TERMINAL_ERROR}]follow-up failed:[/] {escape(str(exc))}")
         return

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -132,7 +132,7 @@ class ShellCompleter(Completer):
     def get_completions(
         self,
         document: Document,
-        complete_event: CompleteEvent,  # noqa: ARG002 - required by prompt_toolkit protocol
+        complete_event: CompleteEvent,
     ) -> Iterable[Completion]:
         text = document.text_before_cursor
         if not text:
@@ -330,7 +330,7 @@ def _run_new_alert(
             console.print(f"[yellow]suggestion:[/yellow] {escape(exc.suggestion)}")
         session.record("alert", text, ok=False)
         return
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         task.mark_failed(str(exc))
         report_exception(exc, context="interactive_shell.new_alert")
         # Exception repr may contain brackets (stack frame refs, config
@@ -376,7 +376,7 @@ async def _run_one_turn(
         cmd_text = text if text.startswith("/") else f"/{text}"
         try:
             should_continue = dispatch_slash(cmd_text, session, console)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             report_exception(exc, context="interactive_shell.slash_dispatch")
             console.print(
                 f"[{TERMINAL_ERROR}]command error:[/] {escape(str(exc))}"
@@ -429,7 +429,7 @@ async def _run_one_turn(
     return True
 
 
-async def _repl_main(initial_input: str | None = None, config: ReplConfig | None = None) -> int:  # noqa: ARG001
+async def _repl_main(initial_input: str | None = None, _config: ReplConfig | None = None) -> int:
     # force_terminal + truecolor so Rich always emits full ANSI, even after
     # prompt_toolkit has claimed and released stdout for input handling.
     # Without this, slash-command output after the first prompt renders as
@@ -504,7 +504,7 @@ def run_repl(initial_input: str | None = None, config: ReplConfig | None = None)
         return 0
 
     try:
-        return asyncio.run(_repl_main(initial_input=initial_input, config=cfg))
+        return asyncio.run(_repl_main(initial_input=initial_input, _config=cfg))
     except (EOFError, KeyboardInterrupt):
         return 0
 

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -258,7 +258,7 @@ def _run_session_alert_payload(
                 loop.run_until_complete(task)
             except asyncio.CancelledError:
                 event_queue.put(KeyboardInterrupt("investigation cancelled"))
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             event_queue.put(exc)
         finally:
             event_queue.put(None)

--- a/app/cli/local_llm/hardware.py
+++ b/app/cli/local_llm/hardware.py
@@ -46,7 +46,7 @@ def _get_total_ram_gb() -> float:
                 for line in f:
                     if line.startswith("MemTotal:"):
                         return int(line.split()[1]) / (1024**2)
-    except Exception:  # noqa: BLE001 — safe fallback: any detection failure uses conservative default
+    except Exception:
         return _FALLBACK_RAM_GB
     return _FALLBACK_RAM_GB
 
@@ -61,7 +61,7 @@ def _get_available_ram_gb(total_ram_gb: float) -> float:
                 for line in f:
                     if line.startswith("MemAvailable:"):
                         return int(line.split()[1]) / (1024**2)
-    except Exception:  # noqa: BLE001 — safe fallback: any detection failure uses conservative default
+    except Exception:
         return total_ram_gb * 0.5
     return total_ram_gb * 0.5
 

--- a/app/cli/local_llm/ollama.py
+++ b/app/cli/local_llm/ollama.py
@@ -41,7 +41,7 @@ def install(console: Console) -> bool:
         console.print(f"Will run: [bold]{cmd}[/bold]")
         if not questionary.confirm("Proceed?", default=True).ask():
             return False
-        result = subprocess.run(cmd, shell=True, check=False)  # noqa: S602
+        result = subprocess.run(cmd, shell=True, check=False)
         return result.returncode == 0
 
     elif sys.platform == "win32":
@@ -59,7 +59,7 @@ def is_server_running(host: str = DEFAULT_OLLAMA_HOST) -> bool:
 
 
 def start_server() -> subprocess.Popen:  # type: ignore[type-arg]
-    return subprocess.Popen(  # noqa: S603, S607
+    return subprocess.Popen(
         ["ollama", "serve"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -99,5 +99,5 @@ def pull_model(model: str, console: Console, host: str = DEFAULT_OLLAMA_HOST) ->
     with console.status(
         f"Downloading [bold]{model}[/bold] (this may take a few minutes)...", spinner="dots"
     ):
-        result = subprocess.run(["ollama", "pull", model], check=False)  # noqa: S603, S607
+        result = subprocess.run(["ollama", "pull", model], check=False)
     return result.returncode == 0

--- a/app/cli/tests/discover.py
+++ b/app/cli/tests/discover.py
@@ -350,7 +350,7 @@ def _discover_rds_synthetic_scenarios() -> list[TestCatalogItem]:
                 failure_mode = meta.get("failure_mode", "")
                 if failure_mode:
                     display_name = f"{scenario_id}  [{failure_mode}]"
-            except Exception:  # noqa: BLE001 — best-effort enrichment; malformed YAML is fine
+            except Exception:
                 display_name = scenario_id
         items.append(
             TestCatalogItem(

--- a/app/cli/wizard/integration_validators/client_validators.py
+++ b/app/cli/wizard/integration_validators/client_validators.py
@@ -328,7 +328,7 @@ def validate_betterstack_integration(
                 "sources": list(sources or []),
             }
         )
-    except Exception as err:  # noqa: BLE001 -- config errors should surface to the user verbatim
+    except Exception as err:
         return IntegrationHealthResult(ok=False, detail=f"Better Stack config invalid: {err}")
     result = validate_betterstack_config(config)
     return IntegrationHealthResult(ok=result.ok, detail=result.detail)

--- a/app/deployment/methods/langsmith.py
+++ b/app/deployment/methods/langsmith.py
@@ -27,7 +27,7 @@ def _run_command(
 ) -> subprocess.CompletedProcess[str]:
     """Run a command and return the completed process."""
     try:
-        return subprocess.run(  # noqa: S603
+        return subprocess.run(
             cmd,
             capture_output=True,
             text=True,

--- a/app/deployment/methods/railway.py
+++ b/app/deployment/methods/railway.py
@@ -57,7 +57,7 @@ def _run_command(
         kwargs["timeout"] = timeout
 
     try:
-        result: subprocess.CompletedProcess[str] = subprocess.run(cmd, **kwargs)  # noqa: S603
+        result: subprocess.CompletedProcess[str] = subprocess.run(cmd, **kwargs)
         return result
     except FileNotFoundError:
         # Command not found - CLI not installed
@@ -254,7 +254,7 @@ def deploy_to_railway(
                     logs.append("Health check passed!")
                     health_ok = True
                     break
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logs.append(f"Health check pending... ({type(exc).__name__})")
 
             time.sleep(health_interval)

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -106,7 +106,7 @@ def run_rca(
             suggestion=err.suggestion,
         ).model_dump()
 
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         capture_exception(err)
         return RunRCAOutput(
             ok=False,

--- a/app/guardrails/engine.py
+++ b/app/guardrails/engine.py
@@ -216,7 +216,7 @@ _engine: GuardrailEngine | None = None
 
 def get_guardrail_engine() -> GuardrailEngine:
     """Return the module-level singleton engine, loading rules from default path."""
-    global _engine  # noqa: PLW0603
+    global _engine
     if _engine is None:
         rules = load_rules(get_default_rules_path())
         _engine = GuardrailEngine(rules, audit_logger=AuditLogger())
@@ -225,5 +225,5 @@ def get_guardrail_engine() -> GuardrailEngine:
 
 def reset_guardrail_engine() -> None:
     """Clear the singleton (for tests and config reload)."""
-    global _engine  # noqa: PLW0603
+    global _engine
     _engine = None

--- a/app/incident_window.py
+++ b/app/incident_window.py
@@ -428,7 +428,7 @@ def _extract_anchor(payload: dict[str, Any]) -> tuple[datetime, str] | None:
     for parser in _ANCHOR_PARSERS:
         try:
             result = parser(payload)
-        except Exception:  # noqa: BLE001 - defensive isolation
+        except Exception:
             logger.debug("incident_window: anchor parser %s raised", parser.__name__, exc_info=True)
             continue
         if result is not None:

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1109,6 +1109,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 }
             )
         except Exception:
+            # invalid env-derived config: skip ArgoCD entry rather than fail discovery
             pass
         else:
             integrations.append(

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -172,7 +172,7 @@ def _verify_grafana(source: str, config: dict[str, Any]) -> dict[str, str]:
         )
         response.raise_for_status()
         payload = response.json()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return result("grafana", source, "failed", f"Datasource discovery failed: {exc}")
 
     datasources = payload if isinstance(payload, list) else []
@@ -204,7 +204,7 @@ def _verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         sts_client, region, mode = _build_sts_client(config)
         identity = sts_client.get_caller_identity()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return result("aws", source, "failed", f"AWS STS check failed: {exc}")
 
     account = str(identity.get("Account", "")).strip()
@@ -246,7 +246,7 @@ def _verify_slack(
     try:
         response = httpx.post(webhook_url, json=payload, timeout=10.0)
         response.raise_for_status()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return result("slack", source, "failed", f"Webhook delivery failed: {exc}")
     return result("slack", source, "passed", "Webhook delivered test message successfully.")
 
@@ -299,7 +299,7 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
         client.run(bot_token)
     except discord.LoginFailure as err:
         return result("discord", source, "failed", f"Discord login failed: {err}")
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         detail = str(err)
         if "run() cannot be called from a running event loop" in detail:
             return result("discord", source, "passed", "Discord bot token accepted.")
@@ -316,7 +316,7 @@ def _verify_telegram(source: str, config: dict[str, Any]) -> dict[str, str]:
         response = requests.get(f"https://api.telegram.org/bot{bot_token}/getMe", timeout=10)
         response.raise_for_status()
         payload = response.json()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return result("telegram", source, "failed", f"Telegram API check failed: {exc}")
 
     if not payload.get("ok"):

--- a/app/integrations/airflow.py
+++ b/app/integrations/airflow.py
@@ -146,7 +146,7 @@ def validate_airflow_config(config: AirflowConfig) -> AirflowValidationResult:
     except httpx.HTTPStatusError as err:
         detail = err.response.text.strip() or str(err)
         return AirflowValidationResult(ok=False, detail=f"Airflow validation failed: {detail}")
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return AirflowValidationResult(ok=False, detail=f"Airflow validation failed: {err}")
 
 

--- a/app/integrations/azure_sql.py
+++ b/app/integrations/azure_sql.py
@@ -160,7 +160,10 @@ def _get_connection(config: AzureSQLConfig) -> Any:
     import pyodbc
 
     encrypt_value = "yes" if config.encrypt else "no"
-    _esc = lambda v: str(v).replace("}", "}}")  # noqa: E731
+
+    def _esc(v: object) -> str:
+        return str(v).replace("}", "}}")
+
     conn_str = (
         f"DRIVER={{{config.driver}}};"
         f"SERVER={config.server},{config.port};"
@@ -199,7 +202,7 @@ def validate_azure_sql_config(config: AzureSQLConfig) -> AzureSQLValidationResul
             )
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("Azure SQL validate_config failed", exc_info=True)
         return AzureSQLValidationResult(ok=False, detail=f"Azure SQL connection failed: {err}")
 
@@ -328,7 +331,7 @@ def get_server_status(config: AzureSQLConfig) -> dict[str, Any]:
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("Azure SQL get_server_status failed", exc_info=True)
         return {"source": "azure_sql", "available": False, "error": str(err)}
 
@@ -406,7 +409,7 @@ def get_current_queries(
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("Azure SQL get_current_queries failed", exc_info=True)
         return {"source": "azure_sql", "available": False, "error": str(err)}
 
@@ -488,7 +491,7 @@ def get_resource_stats(
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("Azure SQL get_resource_stats failed", exc_info=True)
         return {"source": "azure_sql", "available": False, "error": str(err)}
 
@@ -561,7 +564,7 @@ def get_slow_queries(
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("Azure SQL get_slow_queries failed", exc_info=True)
         return {"source": "azure_sql", "available": False, "error": str(err)}
 
@@ -617,6 +620,6 @@ def get_wait_stats(config: AzureSQLConfig) -> dict[str, Any]:
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("Azure SQL get_wait_stats failed", exc_info=True)
         return {"source": "azure_sql", "available": False, "error": str(err)}

--- a/app/integrations/betterstack.py
+++ b/app/integrations/betterstack.py
@@ -209,7 +209,7 @@ def validate_betterstack_config(
     try:
         with _sql_client(config) as client:
             response, err = _post_sql(client, config.query_endpoint, _VALIDATION_PROBE_SQL)
-    except Exception as err:  # noqa: BLE001 — final-resort guard around transport setup
+    except Exception as err:
         logger.debug("Better Stack validate_config failed", exc_info=True)
         return BetterStackValidationResult(
             ok=False, detail=f"Better Stack connection failed: {err}"
@@ -217,7 +217,7 @@ def validate_betterstack_config(
 
     if err is not None:
         return BetterStackValidationResult(ok=False, detail=err)
-    assert response is not None  # noqa: S101 — narrow for mypy; _post_sql contract guarantees non-None on err=None
+    assert response is not None
 
     status = response.status_code
     if status == 200:
@@ -395,7 +395,7 @@ def query_logs(
     try:
         with _sql_client(config) as client:
             response, err = _post_sql(client, config.query_endpoint, sql)
-    except Exception as err:  # noqa: BLE001 — final-resort guard around transport setup
+    except Exception as err:
         logger.debug("Better Stack query_logs failed", exc_info=True)
         return _error_evidence(f"Better Stack connection failed: {err}", source=safe_source)
 

--- a/app/integrations/bitbucket.py
+++ b/app/integrations/bitbucket.py
@@ -109,7 +109,7 @@ def validate_bitbucket_config(
             )
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return BitbucketValidationResult(ok=False, detail=f"Bitbucket connection failed: {err}")
 
 
@@ -156,7 +156,7 @@ def list_commits(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "bitbucket", "available": False, "error": str(err)}
 
 
@@ -192,7 +192,7 @@ def get_file_contents(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "bitbucket", "available": False, "error": str(err)}
 
 
@@ -242,5 +242,5 @@ def search_code(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "bitbucket", "available": False, "error": str(err)}

--- a/app/integrations/clickhouse.py
+++ b/app/integrations/clickhouse.py
@@ -145,7 +145,7 @@ def validate_clickhouse_config(config: ClickHouseConfig) -> ClickHouseValidation
             )
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return ClickHouseValidationResult(ok=False, detail=f"ClickHouse connection failed: {err}")
 
 
@@ -205,7 +205,7 @@ def get_query_activity(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "clickhouse", "available": False, "error": str(err)}
 
 
@@ -247,7 +247,7 @@ def get_system_health(config: ClickHouseConfig) -> dict[str, Any]:
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "clickhouse", "available": False, "error": str(err)}
 
 
@@ -305,5 +305,5 @@ def get_table_stats(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "clickhouse", "available": False, "error": str(err)}

--- a/app/integrations/github_mcp.py
+++ b/app/integrations/github_mcp.py
@@ -1047,7 +1047,7 @@ def validate_github_mcp_config(
             profile_public_repos=profile_pub,
             profile_private_repos=profile_priv,
         )
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return GitHubMCPValidationResult(
             ok=False,
             detail=_connectivity_failure_detail(err),

--- a/app/integrations/gitlab.py
+++ b/app/integrations/gitlab.py
@@ -103,7 +103,7 @@ def validate_gitlab_config(config: GitlabConfig) -> GitlabValidationResult:
     except httpx.HTTPStatusError as err:
         detail = err.response.text.strip() or str(err)
         return GitlabValidationResult(ok=False, detail=f"Gitlab validation failed: {detail}")
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return GitlabValidationResult(ok=False, detail=f"Gitlab validation failed: {err}")
 
 

--- a/app/integrations/kafka.py
+++ b/app/integrations/kafka.py
@@ -160,7 +160,7 @@ def validate_kafka_config(config: KafkaConfig) -> KafkaValidationResult:
                 f"and {topic_count} topic(s)."
             ),
         )
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return KafkaValidationResult(ok=False, detail=f"Kafka connection failed: {err}")
 
 
@@ -217,7 +217,7 @@ def get_topic_health(
             "cluster_topic_count": len(metadata.topics),
             "topics": topics,
         }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "kafka", "available": False, "error": str(err)}
 
 
@@ -281,5 +281,5 @@ def get_consumer_group_lag(
             }
         finally:
             consumer.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "kafka", "available": False, "error": str(err)}

--- a/app/integrations/mariadb.py
+++ b/app/integrations/mariadb.py
@@ -130,7 +130,7 @@ def validate_mariadb_config(config: MariaDBConfig) -> MariaDBValidationResult:
                 )
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("MariaDB validate_config failed", exc_info=True)
         return MariaDBValidationResult(ok=False, detail=f"MariaDB connection failed: {err}")
 
@@ -204,7 +204,7 @@ def get_process_list(
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("MariaDB get_process_list failed", exc_info=True)
         return {"source": "mariadb", "available": False, "error": str(err)}
 
@@ -255,7 +255,7 @@ def get_global_status(config: MariaDBConfig) -> dict[str, Any]:
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("MariaDB get_global_status failed", exc_info=True)
         return {"source": "mariadb", "available": False, "error": str(err)}
 
@@ -287,7 +287,7 @@ def get_innodb_status(config: MariaDBConfig) -> dict[str, Any]:
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("MariaDB get_innodb_status failed", exc_info=True)
         return {"source": "mariadb", "available": False, "error": str(err)}
 
@@ -354,7 +354,7 @@ def get_slow_queries(
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("MariaDB get_slow_queries failed", exc_info=True)
         return {"source": "mariadb", "available": False, "error": str(err)}
 
@@ -383,7 +383,7 @@ def get_replication_status(config: MariaDBConfig) -> dict[str, Any]:
                         if cur.description:
                             columns = [d[0] for d in cur.description]
                         break
-                    except Exception as stmt_err:  # noqa: BLE001
+                    except Exception as stmt_err:
                         import pymysql as _pymysql
 
                         if isinstance(stmt_err, _pymysql.err.ProgrammingError):
@@ -423,6 +423,6 @@ def get_replication_status(config: MariaDBConfig) -> dict[str, Any]:
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("MariaDB get_replication_status failed", exc_info=True)
         return {"source": "mariadb", "available": False, "error": str(err)}

--- a/app/integrations/mongodb.py
+++ b/app/integrations/mongodb.py
@@ -118,7 +118,7 @@ def validate_mongodb_config(config: MongoDBConfig) -> MongoDBValidationResult:
             )
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return MongoDBValidationResult(ok=False, detail=f"MongoDB connection failed: {err}")
 
 
@@ -182,7 +182,7 @@ def get_server_status(config: MongoDBConfig) -> dict[str, Any]:
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb", "available": False, "error": str(err)}
 
 
@@ -231,7 +231,7 @@ def get_current_ops(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb", "available": False, "error": str(err)}
 
 
@@ -271,7 +271,7 @@ def get_rs_status(config: MongoDBConfig) -> dict[str, Any]:
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         error_str = str(err)
         # Not a replica set is not an error per se
         if "not running with --replSet" in error_str or "NotYetInitialized" in error_str:
@@ -357,7 +357,7 @@ def get_profiler_data(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb", "available": False, "error": str(err)}
 
 
@@ -403,5 +403,5 @@ def get_collection_stats(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb", "available": False, "error": str(err)}

--- a/app/integrations/mongodb_atlas.py
+++ b/app/integrations/mongodb_atlas.py
@@ -132,7 +132,7 @@ def validate_mongodb_atlas_config(
             ok=False,
             detail=f"Atlas API returned {err.response.status_code}: {err.response.text[:200]}",
         )
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return MongoDBAtlasValidationResult(ok=False, detail=f"Atlas connection failed: {err}")
 
 
@@ -198,7 +198,7 @@ def get_clusters(config: MongoDBAtlasConfig) -> dict[str, Any]:
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb_atlas", "available": False, "error": str(err)}
 
 
@@ -246,7 +246,7 @@ def get_alerts(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb_atlas", "available": False, "error": str(err)}
 
 
@@ -382,7 +382,7 @@ def get_cluster_metrics(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb_atlas", "available": False, "error": str(err)}
 
 
@@ -465,7 +465,7 @@ def get_performance_advisor(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb_atlas", "available": False, "error": str(err)}
 
 
@@ -517,5 +517,5 @@ def get_cluster_events(
             }
         finally:
             client.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mongodb_atlas", "available": False, "error": str(err)}

--- a/app/integrations/mysql.py
+++ b/app/integrations/mysql.py
@@ -176,7 +176,7 @@ def validate_mysql_config(config: MySQLConfig) -> MySQLValidationResult:
                 )
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return MySQLValidationResult(ok=False, detail=f"MySQL connection failed: {err}")
 
 
@@ -290,7 +290,7 @@ def get_server_status(config: MySQLConfig) -> dict[str, Any]:
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mysql", "available": False, "error": str(err)}
 
 
@@ -346,7 +346,7 @@ def get_current_processes(
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mysql", "available": False, "error": str(err)}
 
 
@@ -392,7 +392,7 @@ def get_replication_status(config: MySQLConfig) -> dict[str, Any]:
                         cur.execute(stmt)
                         rows = list(cur.fetchall())
                         break
-                    except Exception as stmt_err:  # noqa: BLE001
+                    except Exception as stmt_err:
                         import pymysql as _pymysql
 
                         if isinstance(stmt_err, _pymysql.err.ProgrammingError):
@@ -420,7 +420,7 @@ def get_replication_status(config: MySQLConfig) -> dict[str, Any]:
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mysql", "available": False, "error": str(err)}
 
 
@@ -517,7 +517,7 @@ def get_slow_queries(
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mysql", "available": False, "error": str(err)}
 
 
@@ -592,5 +592,5 @@ def get_table_stats(
                 }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "mysql", "available": False, "error": str(err)}

--- a/app/integrations/openclaw.py
+++ b/app/integrations/openclaw.py
@@ -504,7 +504,7 @@ def validate_openclaw_config(config: OpenClawConfig) -> OpenClawValidationResult
             ),
             tool_names=tool_names,
         )
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return OpenClawValidationResult(
             ok=False,
             detail=f"OpenClaw MCP validation failed: {describe_openclaw_error(err, config)}",

--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -158,7 +158,7 @@ def validate_postgresql_config(config: PostgreSQLConfig) -> PostgreSQLValidation
             )
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return PostgreSQLValidationResult(ok=False, detail=f"PostgreSQL connection failed: {err}")
 
 
@@ -267,7 +267,7 @@ def get_server_status(config: PostgreSQLConfig) -> dict[str, Any]:
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "postgresql", "available": False, "error": str(err)}
 
 
@@ -339,7 +339,7 @@ def get_current_queries(
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "postgresql", "available": False, "error": str(err)}
 
 
@@ -438,7 +438,7 @@ def get_replication_status(config: PostgreSQLConfig) -> dict[str, Any]:
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         error_str = str(err)
         # Check if this might be a replica server
         if "recovery" in error_str.lower() or "read-only" in error_str.lower():
@@ -541,7 +541,7 @@ def get_slow_queries(
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "postgresql", "available": False, "error": str(err)}
 
 
@@ -642,5 +642,5 @@ def get_table_stats(
             }
         finally:
             conn.close()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "postgresql", "available": False, "error": str(err)}

--- a/app/integrations/posthog.py
+++ b/app/integrations/posthog.py
@@ -163,7 +163,7 @@ def validate_posthog_config(config: PostHogConfig) -> PostHogValidationResult:
             else f"HTTP {err.response.status_code}"
         )
         return PostHogValidationResult(ok=False, detail=detail)
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return PostHogValidationResult(ok=False, detail=str(err))
 
 

--- a/app/integrations/rabbitmq.py
+++ b/app/integrations/rabbitmq.py
@@ -194,7 +194,7 @@ def validate_rabbitmq_config(config: RabbitMQConfig) -> RabbitMQValidationResult
                     f"Connected to RabbitMQ {version} (cluster: {cluster}, vhost: {config.vhost})."
                 ),
             )
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("RabbitMQ validate_config failed", exc_info=True)
         return RabbitMQValidationResult(ok=False, detail=f"RabbitMQ connection failed: {err}")
 
@@ -275,7 +275,7 @@ def get_queue_backlog(
                 "returned": len(truncated),
                 "queues": truncated,
             }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("RabbitMQ get_queue_backlog failed", exc_info=True)
         return _error_evidence(str(err))
 
@@ -321,7 +321,7 @@ def get_consumer_health(
                 "returned": len(consumers),
                 "consumers": consumers,
             }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("RabbitMQ get_consumer_health failed", exc_info=True)
         return _error_evidence(str(err))
 
@@ -394,7 +394,7 @@ def get_broker_overview(config: RabbitMQConfig) -> dict[str, Any]:
                 "channels": object_totals.get("channels", 0),
                 "alarms": alarm_payload,
             }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("RabbitMQ get_broker_overview failed", exc_info=True)
         return _error_evidence(str(err))
 
@@ -441,7 +441,7 @@ def get_node_health(config: RabbitMQConfig) -> dict[str, Any]:
                 "any_partitioned": any_partitioned,
                 "nodes": nodes,
             }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("RabbitMQ get_node_health failed", exc_info=True)
         return _error_evidence(str(err))
 
@@ -495,7 +495,7 @@ def get_connection_stats(
                 "returned": len(truncated),
                 "connections": truncated,
             }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         logger.debug("RabbitMQ get_connection_stats failed", exc_info=True)
         return _error_evidence(str(err))
 

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -144,7 +144,7 @@ def validate_sentry_config(config: SentryConfig) -> SentryValidationResult:
     except httpx.HTTPStatusError as err:
         detail = err.response.text.strip() or str(err)
         return SentryValidationResult(ok=False, detail=f"Sentry validation failed: {detail}")
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return SentryValidationResult(ok=False, detail=f"Sentry validation failed: {err}")
 
 

--- a/app/integrations/trello.py
+++ b/app/integrations/trello.py
@@ -114,7 +114,7 @@ def validate_trello_config(config: TrelloConfig) -> TrelloValidationResult:
     except httpx.HTTPStatusError as err:
         detail = err.response.text.strip() or str(err)
         return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {detail}")
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return TrelloValidationResult(ok=False, detail=f"Trello validation failed: {err}")
 
 

--- a/app/nodes/publish_findings/gitlab_writeback.py
+++ b/app/nodes/publish_findings/gitlab_writeback.py
@@ -50,5 +50,5 @@ def post_gitlab_mr_writeback(state: InvestigationState, report: str) -> None:
             body=_build_mr_note(report),
         )
         logger.info("[publish] GitLab MR note posted: project=%s mr_iid=%s", project_id, mr_iid)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.warning("[publish] GitLab MR write-back failed: %s", exc)

--- a/app/output.py
+++ b/app/output.py
@@ -329,7 +329,7 @@ def _is_verbose() -> bool:
         from app.cli.support.context import is_debug, is_verbose
 
         return is_verbose() or is_debug()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
 

--- a/app/remote/client.py
+++ b/app/remote/client.py
@@ -154,7 +154,7 @@ class RemoteAgentClient:
                 if parsed:
                     remote_version = parsed
                     version_source = "/version"
-        except Exception:  # noqa: BLE001
+        except Exception:
             return remote_version, version_source
         return remote_version, version_source
 
@@ -183,7 +183,7 @@ class RemoteAgentClient:
                         "detail": detail,
                     }
                 )
-        except Exception:  # noqa: BLE001
+        except Exception:
             return []
         return checks
 
@@ -201,7 +201,7 @@ class RemoteAgentClient:
         url = f"{self.base_url}{path}"
         try:
             response = client.get(url, headers=self._headers)
-        except Exception:  # noqa: BLE001
+        except Exception:
             return False
         return response.status_code != 404
 
@@ -268,7 +268,7 @@ class RemoteAgentClient:
         except httpx.HTTPStatusError as exc:
             code = exc.response.status_code
             return PreflightResult(ok=False, error=f"HTTP {code}")
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return PreflightResult(ok=False, error=str(exc) or "unknown error")
 
     def probe_health(

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -110,7 +110,7 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
         if poller_task is not None:
             poller_task.cancel()
             with suppress(asyncio.CancelledError):
-                await poller_task  # noqa: B018  -- intentional await for clean shutdown
+                await poller_task
 
 
 app = FastAPI(
@@ -631,7 +631,7 @@ def _check_llm_connectivity() -> DeepHealthCheck:
             status="passed",
             detail=f"Connected to Bedrock in {region}.",
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return DeepHealthCheck(
             name="Bedrock connectivity",
             status="failed",

--- a/app/remote/system_metrics.py
+++ b/app/remote/system_metrics.py
@@ -90,7 +90,7 @@ def _collect_memory() -> dict[str, Any] | None:
             return _memory_linux()
         if sys.platform == "darwin":
             return _memory_darwin()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None
     return None
 
@@ -123,16 +123,8 @@ def _memory_linux() -> dict[str, Any] | None:
 
 
 def _memory_darwin() -> dict[str, Any] | None:
-    total_bytes = int(
-        subprocess.check_output(  # noqa: S603, S607
-            ["sysctl", "-n", "hw.memsize"], text=True
-        ).strip()
-    )
-    user_bytes = int(
-        subprocess.check_output(  # noqa: S603, S607
-            ["sysctl", "-n", "hw.usermem"], text=True
-        ).strip()
-    )
+    total_bytes = int(subprocess.check_output(["sysctl", "-n", "hw.memsize"], text=True).strip())
+    user_bytes = int(subprocess.check_output(["sysctl", "-n", "hw.usermem"], text=True).strip())
     total_gb = round(total_bytes / (1024**3), 1)
     available_gb = round(user_bytes / (1024**3), 1)
     used_gb = round((total_bytes - user_bytes) / (1024**3), 1)
@@ -179,7 +171,7 @@ def _collect_uptime() -> dict[str, Any] | None:
             return _uptime_linux()
         if sys.platform == "darwin":
             return _uptime_darwin()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None
     return None
 
@@ -191,9 +183,7 @@ def _uptime_linux() -> dict[str, Any] | None:
 
 
 def _uptime_darwin() -> dict[str, Any] | None:
-    raw = subprocess.check_output(  # noqa: S603, S607
-        ["sysctl", "-n", "kern.boottime"], text=True
-    ).strip()
+    raw = subprocess.check_output(["sysctl", "-n", "kern.boottime"], text=True).strip()
     # Format: "{ sec = 1712345678, usec = 123456 } ..."
     sec_part = raw.split("sec =")[1].split(",")[0].strip()
     boot_ts = int(sec_part)
@@ -254,5 +244,5 @@ def _collect_process() -> dict[str, Any] | None:
             result["open_fds"] = len(list(fd_dir.iterdir()))
 
         return result
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -218,7 +218,7 @@ class ArgoCDClient:
                 _normalize_application(item) for item in items if isinstance(item, dict)
             ]
             return {"success": True, "applications": applications, "total": len(applications)}
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning("[argocd] list_applications failed type=%s", type(exc).__name__)
             return self._error_result("list applications failed", exc)
 
@@ -251,7 +251,7 @@ class ArgoCDClient:
                 "application": app,
                 "recent_history": _recent_history(payload),
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(
                 "[argocd] get_application_summary failed type=%s app=%r",
                 type(exc).__name__,
@@ -301,7 +301,7 @@ class ArgoCDClient:
                 "diffs": diffs,
                 "diff_count": len(diffs),
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(
                 "[argocd] get_application_diff failed type=%s app=%r",
                 type(exc).__name__,

--- a/app/services/coralogix/client.py
+++ b/app/services/coralogix/client.py
@@ -217,7 +217,7 @@ class CoralogixClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
 
         parsed = self._parse_ndjson(response.text)

--- a/app/services/honeycomb/client.py
+++ b/app/services/honeycomb/client.py
@@ -87,7 +87,7 @@ class HoneycombClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
 
         environment = payload.get("environment", {}) if isinstance(payload, dict) else {}
@@ -110,7 +110,7 @@ class HoneycombClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
 
         query_id = str(payload.get("id", "")).strip() if isinstance(payload, dict) else ""
@@ -139,7 +139,7 @@ class HoneycombClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
 
         return {"success": True, "result": result}
@@ -157,7 +157,7 @@ class HoneycombClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
         return {"success": True, "result": payload}
 

--- a/app/services/splunk/client.py
+++ b/app/services/splunk/client.py
@@ -105,7 +105,7 @@ class SplunkClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
 
         logs = self._parse_export_response(response.text)
@@ -170,7 +170,7 @@ class SplunkClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return {"success": False, "error": str(exc)}
 
     def probe_access(self) -> ProbeResult:

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -147,7 +147,7 @@ class VictoriaLogsClient:
                 "success": False,
                 "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
             }
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning("[victoria_logs] Query error: %s", e)
             return {"success": False, "error": str(e)}
 

--- a/app/tools/AzureMonitorLogsTool/__init__.py
+++ b/app/tools/AzureMonitorLogsTool/__init__.py
@@ -112,7 +112,7 @@ def query_azure_monitor_logs(
         response = httpx.post(url, headers=headers, json=payload, timeout=max(1.0, timeout_seconds))
         response.raise_for_status()
         body = response.json()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "azure", "available": False, "error": str(err), "rows": []}
 
     tables = body.get("tables", []) if isinstance(body, dict) else []

--- a/app/tools/OpenClawMCPTool/__init__.py
+++ b/app/tools/OpenClawMCPTool/__init__.py
@@ -181,7 +181,7 @@ def list_openclaw_bridge_tools(
 
     try:
         tools = list_openclaw_mcp_tools(config)
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         payload = _openclaw_unavailable_response(describe_openclaw_error(err, config))
         payload["tools"] = []
         return payload
@@ -259,7 +259,7 @@ def search_openclaw_conversations(
 
     try:
         result = invoke_openclaw_mcp_tool(config, "conversations_list", arguments)
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         payload = _openclaw_unavailable_response(describe_openclaw_error(err, config))
         payload["conversations"] = []
         return payload
@@ -338,7 +338,7 @@ def call_openclaw_bridge_tool(
 
     try:
         result = invoke_openclaw_mcp_tool(config, normalized_tool_name, arguments or {})
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return _openclaw_unavailable_response(
             describe_openclaw_error(err, config),
             tool_name=normalized_tool_name,

--- a/app/tools/OpenObserveLogsTool/__init__.py
+++ b/app/tools/OpenObserveLogsTool/__init__.py
@@ -167,7 +167,7 @@ def query_openobserve_logs(
         )
         response.raise_for_status()
         body = response.json()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "openobserve", "available": False, "error": str(err), "records": []}
 
     records = _extract_records(body if isinstance(body, dict) else {})[:effective_limit]

--- a/app/tools/SnowflakeQueryHistoryTool/__init__.py
+++ b/app/tools/SnowflakeQueryHistoryTool/__init__.py
@@ -178,7 +178,7 @@ def query_snowflake_history(
         )
         response.raise_for_status()
         body = response.json()
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:
         return {"source": "snowflake", "available": False, "error": str(err), "rows": []}
 
     rows = _normalize_rows(body)[:effective_limit]

--- a/app/tools/tool_decorator.py
+++ b/app/tools/tool_decorator.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TypeVar, cast, overload
+from typing import Any, cast, overload
 
 from app.tools.base import BaseTool
 from app.tools.registered_tool import REGISTERED_TOOL_ATTR, CostTier, RegisteredTool
 from app.types.evidence import EvidenceSource
 from app.types.retrieval import RetrievalControls
-
-F = TypeVar("F", bound=Callable[..., Any])
 
 
 @overload
@@ -36,7 +34,7 @@ def tool(
 
 
 @overload
-def tool(  # noqa: UP047
+def tool[F: Callable[..., Any]](
     func: F,
     *,
     name: str | None = None,
@@ -58,7 +56,7 @@ def tool(  # noqa: UP047
 
 
 @overload
-def tool(  # noqa: UP047
+def tool[F: Callable[..., Any]](
     func: None = None,
     *,
     name: str | None = None,
@@ -79,7 +77,7 @@ def tool(  # noqa: UP047
     pass
 
 
-def tool(  # noqa: UP047
+def tool[F: Callable[..., Any]](
     func: F | BaseTool | None = None,
     *,
     name: str | None = None,

--- a/app/tools/utils/compaction.py
+++ b/app/tools/utils/compaction.py
@@ -7,7 +7,7 @@ within regression limits on noisy fixtures.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, TypeVar
+from typing import Any
 
 # Default limits for high-volume tools
 DEFAULT_LOG_LIMIT = 50
@@ -17,10 +17,7 @@ DEFAULT_METRICS_LIMIT = 50
 DEFAULT_MESSAGE_CHARS = 1000  # Max characters per log message
 
 
-T = TypeVar("T")
-
-
-def truncate_list(  # noqa: UP047
+def truncate_list[T](
     items: Sequence[T],
     limit: int | None = None,
     default_limit: int = DEFAULT_LOG_LIMIT,

--- a/app/tools/utils/sql_wrapper.py
+++ b/app/tools/utils/sql_wrapper.py
@@ -10,14 +10,12 @@ Centralizes the common pattern of:
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
 
 from app.tools.utils.db_warnings import default_db_warning
 
-T = TypeVar("T")
 
-
-def call_db_tool_with_default_db_warning(  # noqa: UP047
+def call_db_tool_with_default_db_warning[T](
     database: str | None,
     default_db_name: str,
     config_resolver: Callable[..., T],

--- a/app/utils/delivery_transport.py
+++ b/app/utils/delivery_transport.py
@@ -123,6 +123,7 @@ def post_json(
         if isinstance(parsed, dict):
             data = parsed
     except Exception:
+        # non-JSON body is permitted; fall through with empty data
         pass
 
     return DeliveryResponse(

--- a/app/utils/delivery_transport.py
+++ b/app/utils/delivery_transport.py
@@ -113,7 +113,7 @@ def post_json(
             timeout=timeout,
             follow_redirects=follow_redirects,
         )
-    except Exception as exc:  # noqa: BLE001 — transport never re-raises
+    except Exception as exc:
         return DeliveryResponse(ok=False, error=str(exc), exc_type=type(exc).__name__)
 
     text = response.text
@@ -122,7 +122,7 @@ def post_json(
         parsed = response.json()
         if isinstance(parsed, dict):
             data = parsed
-    except Exception:  # noqa: BLE001 — non-JSON body is permitted
+    except Exception:
         pass
 
     return DeliveryResponse(

--- a/app/utils/ingest_delivery.py
+++ b/app/utils/ingest_delivery.py
@@ -132,7 +132,7 @@ def send_ingest(state: InvestigationState) -> str | None:
             investigation_id,
         )
         return investigation_id
-    except httpx.HTTPStatusError as exc:  # noqa: BLE001
+    except httpx.HTTPStatusError as exc:
         detail = exc.response.text[:200] if exc.response is not None else str(exc)
         logger.warning(
             "[ingest] Delivery HTTP failure status=%s thread_id=%s url=%s response_snippet=%s",
@@ -141,7 +141,7 @@ def send_ingest(state: InvestigationState) -> str | None:
             api_url,
             detail,
         )
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.warning("[ingest] Delivery failed: %s", exc)
     return None
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -120,7 +120,7 @@ def _before_send(event: Any, _hint: dict[str, Any]) -> Any:
         return event
     try:
         _scrub_event_in_place(event)
-    except Exception:  # noqa: BLE001
+    except Exception:
         # The hook must never raise — Sentry will swallow the event silently.
         return event
     return event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "opensre"
 version = "2026.4.5"
 description = "Open-source SRE agent for automated incident investigation and root cause analysis. Automatically analyzes alerts from Slack, Grafana, Datadog, and other tooling."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [
   { name = "OpenSRE", email = "support@opensre.com" },

--- a/tests/benchmarks/cloudopsbench/run_suite.py
+++ b/tests/benchmarks/cloudopsbench/run_suite.py
@@ -211,7 +211,7 @@ def _run_cases(
             case = future_to_case[future]
             try:
                 _, score = future.result()
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 raise RuntimeError(f"{case.case_id}: run failed") from exc
             scores.append(score)
     return sorted(scores, key=lambda item: item.case_id)

--- a/tests/benchmarks/interactive_shell/grounding_benchmark.py
+++ b/tests/benchmarks/interactive_shell/grounding_benchmark.py
@@ -28,7 +28,7 @@ def _timed(label: str, fn: Callable[[], object]) -> tuple[float, object]:
     t0 = time.perf_counter()
     result = fn()
     elapsed = time.perf_counter() - t0
-    print(f"{label}: {elapsed * 1000:.2f} ms")  # noqa: T201
+    print(f"{label}: {elapsed * 1000:.2f} ms")
     return elapsed, result
 
 
@@ -52,19 +52,19 @@ def main() -> None:
             lambda: build_docs_reference_text("configure Datadog integration"),
         )
     else:
-        print("[skip] docs/ not present — docs parse timings omitted")  # noqa: T201
+        print("[skip] docs/ not present — docs parse timings omitted")
 
     docs_stats = get_docs_cache_stats()
 
-    print(  # noqa: T201
+    print(
         f"\nSummary: CLI speedup ~{cold_cli / warm_cli:.1f}x (warm vs cold reference build)"
         if warm_cli > 0
         else "\nSummary: CLI warm path too fast to ratio"
     )
     if docs_root.is_dir() and warm_docs > 0:
-        print(f"Docs parse speedup ~{cold_docs / warm_docs:.1f}x")  # noqa: T201
-    print(f"CLI cache stats: {cli_stats}")  # noqa: T201
-    print(f"Docs cache stats: {docs_stats}")  # noqa: T201
+        print(f"Docs parse speedup ~{cold_docs / warm_docs:.1f}x")
+    print(f"CLI cache stats: {cli_stats}")
+    print(f"Docs cache stats: {docs_stats}")
 
 
 if __name__ == "__main__":

--- a/tests/chaos_engineering/paths.py
+++ b/tests/chaos_engineering/paths.py
@@ -84,7 +84,7 @@ def infer_chaos_kind(chaos_yaml: Path) -> str | None:
         for doc in yaml.safe_load_all(text):
             if isinstance(doc, dict) and doc.get("kind"):
                 return str(doc["kind"])
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None
     return None
 

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -209,7 +209,7 @@ class TestAssistantOutputRendering:
         captured_errors: list[BaseException] = []
 
         class _Boom:
-            def invoke_stream(self, prompt: str) -> Iterator[str]:  # noqa: ARG002
+            def invoke_stream(self, _prompt: str) -> Iterator[str]:
                 raise RuntimeError("upstream 503")
                 yield  # pragma: no cover  -- generator marker
 
@@ -322,11 +322,11 @@ class TestStreamingMigration:
         calls: list[str] = []
 
         class _Recording:
-            def invoke(self, prompt: str) -> Any:  # noqa: ARG002
+            def invoke(self, _prompt: str) -> Any:
                 calls.append("invoke")
                 raise AssertionError("cli_agent must not call invoke after streaming migration")
 
-            def invoke_stream(self, prompt: str) -> Iterator[str]:  # noqa: ARG002
+            def invoke_stream(self, _prompt: str) -> Iterator[str]:
                 calls.append("invoke_stream")
                 yield "ok"
 

--- a/tests/cli/interactive_shell/test_cli_help.py
+++ b/tests/cli/interactive_shell/test_cli_help.py
@@ -173,7 +173,7 @@ class TestAnswerCliHelp:
         captured_errors: list[BaseException] = []
 
         class _Boom:
-            def invoke_stream(self, prompt: str) -> Iterator[str]:  # noqa: ARG002
+            def invoke_stream(self, _prompt: str) -> Iterator[str]:
                 raise RuntimeError("upstream 503")
                 yield  # pragma: no cover  -- generator marker
 
@@ -205,11 +205,11 @@ class TestAnswerCliHelp:
         calls: list[str] = []
 
         class _Recording:
-            def invoke(self, prompt: str) -> Any:  # noqa: ARG002
+            def invoke(self, _prompt: str) -> Any:
                 calls.append("invoke")
                 raise AssertionError("cli_help must not call invoke after streaming migration")
 
-            def invoke_stream(self, prompt: str) -> Iterator[str]:  # noqa: ARG002
+            def invoke_stream(self, _prompt: str) -> Iterator[str]:
                 calls.append("invoke_stream")
                 yield "ok"
 

--- a/tests/cli/interactive_shell/test_follow_up.py
+++ b/tests/cli/interactive_shell/test_follow_up.py
@@ -22,7 +22,7 @@ class _StreamingClient:
     def __init__(self, content: str) -> None:
         self._content = content
 
-    def invoke_stream(self, prompt: str) -> Iterator[str]:  # noqa: ARG002
+    def invoke_stream(self, _prompt: str) -> Iterator[str]:
         yield self._content
 
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -295,7 +295,7 @@ def test_run_one_turn_reports_slash_dispatch_error(monkeypatch: pytest.MonkeyPat
     from app.cli.interactive_shell.session import ReplSession
 
     class _Prompt:
-        async def prompt_async(self, prompt: object) -> str:  # noqa: ARG002
+        async def prompt_async(self, _prompt: object) -> str:
             return "/boom"
 
     captured_errors: list[BaseException] = []

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -172,7 +172,7 @@ class _ImmediateThread:
         kwargs: dict[str, object] | None = None,
         *,
         daemon: object = None,
-    ) -> None:  # noqa: ARG002 - mimic threading.Thread ctor
+    ) -> None:
         del group, args, kwargs, daemon, name  # threaded API baggage
         if target is None:
             raise TypeError("target required")
@@ -196,7 +196,7 @@ class _DeferredSyntheticThread:
         kwargs: dict[str, object] | None = None,
         *,
         daemon: object = None,
-    ) -> None:  # noqa: ARG002 - mimic threading.Thread ctor
+    ) -> None:
         del group, args, kwargs, daemon, name
         if target is None:
             raise TypeError("target required")

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -169,7 +169,7 @@ class TestIsRailwayCliInstalled:
     """Tests for is_railway_cli_installed function."""
 
     def test_returns_true_when_cli_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def mock_run(*args, **kwargs):  # noqa: ARG001
+        def mock_run(*args, **kwargs):
             class Result:
                 returncode = 0
 
@@ -179,7 +179,7 @@ class TestIsRailwayCliInstalled:
         assert is_railway_cli_installed() is True
 
     def test_returns_false_when_cli_not_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def mock_run(*args, **kwargs):  # noqa: ARG001
+        def mock_run(*args, **kwargs):
             class Result:
                 returncode = 127
 
@@ -193,7 +193,7 @@ class TestGetRailwayAuthStatus:
     """Tests for get_railway_auth_status function."""
 
     def test_authenticated_when_whoami_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def mock_run(*args, **kwargs):  # noqa: ARG001
+        def mock_run(*args, **kwargs):
             class Result:
                 returncode = 0
                 stdout = "user@example.com"
@@ -207,7 +207,7 @@ class TestGetRailwayAuthStatus:
         assert result["detail"] == "user@example.com"
 
     def test_not_authenticated_when_whoami_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def mock_run(*args, **kwargs):  # noqa: ARG001
+        def mock_run(*args, **kwargs):
             class Result:
                 returncode = 1
                 stdout = ""
@@ -272,7 +272,7 @@ class TestDeployToRailway:
         assert "dry-run" in result["logs"][0].lower()
 
     def test_failed_deploy_includes_database_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             class Result:
                 returncode = 1
                 stdout = ""
@@ -299,7 +299,7 @@ class TestDeployToRailway:
 
         commands_run: list[list[str]] = []
 
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             commands_run.append(cmd)
 
             class Result:
@@ -330,7 +330,7 @@ class TestDeployToRailway:
             lambda: {"authenticated": True, "detail": "user@example.com"},
         )
 
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             class Result:
                 returncode = 0
                 stdout = "https://myapp.up.railway.app"
@@ -362,7 +362,7 @@ class TestDeployToRailway:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             class Result:
                 returncode = 0
                 stdout = "https://myapp.up.railway.app"
@@ -403,7 +403,7 @@ class TestDeployToRailway:
 
         command_calls = {"count": 0}
 
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             command_calls["count"] += 1
 
             class Result:
@@ -432,7 +432,7 @@ class TestDeployToRailway:
             lambda: pytest.fail("Auth check should be skipped"),
         )
 
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             class Result:
                 returncode = 0
                 stdout = "https://myapp.up.railway.app"
@@ -459,7 +459,7 @@ class TestDeployToRailway:
             lambda: pytest.fail("Auth check should be skipped"),
         )
 
-        def mock_run_command(cmd: list[str], **kwargs: object) -> object:  # noqa: ARG001
+        def mock_run_command(cmd: list[str], **kwargs: object) -> object:
             class Result:
                 returncode = 0
                 stdout = "https://myapp.up.railway.app"

--- a/tests/cli/test_interactive.py
+++ b/tests/cli/test_interactive.py
@@ -277,7 +277,7 @@ def test_run_interactive_picker_returns_zero_on_escape(monkeypatch) -> None:
         interactive,
         "choose_interactive_item",
         lambda _catalog: (_ for _ in ()).throw(KeyboardInterrupt()),
-    )  # noqa: E501
+    )
 
     assert interactive.run_interactive_picker(catalog) == 0
 

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -334,7 +334,7 @@ def _run_cli_pty(
 
 
 class _ReleaseHandler(BaseHTTPRequestHandler):
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         payload = json.dumps({"tag_name": "v9999.0.0"}).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def _disable_system_keyring(monkeypatch) -> None:
     monkeypatch.setenv("OPENSRE_DISABLE_KEYRING", "1")
 
 
-def pytest_configure(config):  # noqa: ARG001
+def pytest_configure(config):
     """Pytest hook — keep env available for collection and execution."""
     _load_env()
     _disable_sentry()

--- a/tests/deployment/ec2/hello_world/server.py
+++ b/tests/deployment/ec2/hello_world/server.py
@@ -21,7 +21,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
-    def log_message(self, format: str, *args: object) -> None:  # noqa: A002, ARG002
+    def log_message(self, _format: str, *args: object) -> None:
         print(f"[hello-world] {args[0]} {args[1]} {args[2]}")
 
 

--- a/tests/e2e/crashloop/test_local.py
+++ b/tests/e2e/crashloop/test_local.py
@@ -34,11 +34,11 @@ load_dotenv()
 
 from pathlib import Path
 
-from tests.e2e.kubernetes.infrastructure_sdk.local import (  # noqa: E402
+from tests.e2e.kubernetes.infrastructure_sdk.local import (
     create_or_update_monitor,
     load_monitor_definitions,
 )
-from tests.utils.conftest import get_test_config  # noqa: E402
+from tests.utils.conftest import get_test_config
 
 BASE_DIR = Path(__file__).parent
 MONITOR_DEFS = str(BASE_DIR / "datadog-monitor.yaml")

--- a/tests/e2e/datadog/test_local.py
+++ b/tests/e2e/datadog/test_local.py
@@ -38,11 +38,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from tests.e2e.kubernetes.infrastructure_sdk.local import (  # noqa: E402
+from tests.e2e.kubernetes.infrastructure_sdk.local import (
     create_or_update_monitor,
     load_monitor_definitions,
 )
-from tests.utils.conftest import get_test_config  # noqa: E402
+from tests.utils.conftest import get_test_config
 
 BASE_DIR = Path(__file__).parent
 PIPELINE_DIR = BASE_DIR / "pipeline_code"

--- a/tests/github/test_good_first_issue_assign.py
+++ b/tests/github/test_good_first_issue_assign.py
@@ -200,7 +200,7 @@ def test_fetch_open_pr_count_query_string(gfi):
     """fetch_open_pr_count must search is:pr is:open for the correct author."""
     captured: list[str] = []
 
-    def fake_request_json(url: str, token: str) -> dict:  # noqa: ARG001
+    def fake_request_json(url: str, token: str) -> dict:
         captured.append(url)
         return {"total_count": 0}
 
@@ -220,7 +220,7 @@ def test_fetch_open_pr_count_query_string(gfi):
 def test_fetch_open_assigned_issue_count_query_string(gfi):
     captured: list[str] = []
 
-    def fake_request_json(url: str, token: str) -> dict:  # noqa: ARG001
+    def fake_request_json(url: str, token: str) -> dict:
         captured.append(url)
         return {"total_count": 0}
 

--- a/tests/integrations/test_github_mcp_validation.py
+++ b/tests/integrations/test_github_mcp_validation.py
@@ -457,7 +457,7 @@ def test_connectivity_failure_detail_unwraps_taskgroup_exception_group() -> None
     """TaskGroup often wraps the real error; users should see the inner exception."""
     inner = ConnectionError("Connection refused")
     group = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [inner])
-    msg = github_mcp_module._connectivity_failure_detail(group)  # noqa: SLF001
+    msg = github_mcp_module._connectivity_failure_detail(group)
     assert "ConnectionError" in msg
     assert "Connection refused" in msg
     assert "Check: outbound HTTPS" in msg

--- a/tests/integrations/test_gitlab.py
+++ b/tests/integrations/test_gitlab.py
@@ -166,9 +166,13 @@ def test_validate_gitlab_config_fails_when_token_missing() -> None:
 def test_validate_gitlab_config_returns_ok_on_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def _ok(*, config: GitlabConfig) -> dict[str, str]:
+        del config
+        return {"username": "gl-user"}
+
     monkeypatch.setattr(
         "app.integrations.gitlab.validate_gitlab_connection",
-        lambda *, config: {"username": "gl-user"},  # noqa: ARG005
+        _ok,
     )
 
     result = validate_gitlab_config(_make_config())
@@ -200,9 +204,13 @@ def test_validate_gitlab_config_handles_http_error(
 def test_validate_gitlab_config_handles_generic_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def _boom(*, config: GitlabConfig) -> dict[str, str]:
+        del config
+        raise RuntimeError("connection refused")
+
     monkeypatch.setattr(
         "app.integrations.gitlab.validate_gitlab_connection",
-        lambda *, config: (_ for _ in ()).throw(RuntimeError("connection refused")),  # noqa: ARG005
+        _boom,
     )
 
     result = validate_gitlab_config(_make_config())

--- a/tests/integrations/test_trello.py
+++ b/tests/integrations/test_trello.py
@@ -11,8 +11,8 @@ from app.integrations.trello import (
     validate_trello_connection,
 )
 
-_TEST_API_KEY = "test-trello-api-key"  # noqa: S105
-_TEST_TOKEN = "test-trello-token"  # noqa: S105
+_TEST_API_KEY = "test-trello-api-key"
+_TEST_TOKEN = "test-trello-token"
 _TEST_BOARD_ID = "board123"
 _TEST_LIST_ID = "list123"
 
@@ -117,7 +117,7 @@ def test_validate_trello_config_success(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_validate_trello_config_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
-    config = _make_config(api_key="bad_key", token="bad_token")  # noqa: S106
+    config = _make_config(api_key="bad_key", token="bad_token")
 
     request = httpx.Request("GET", "https://api.trello.com/1/members/me")
     response = httpx.Response(401, request=request, text="unauthorized")

--- a/tests/pipeline/test_graph_adapt_window_wiring.py
+++ b/tests/pipeline/test_graph_adapt_window_wiring.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from app.pipeline.graph import build_graph
 
 
-def _builder():  # noqa: ANN202 - internal LangGraph type, type-stub varies
+def _builder():
     return build_graph().builder
 
 

--- a/tests/remote/test_discord_interactions.py
+++ b/tests/remote/test_discord_interactions.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 from nacl.signing import SigningKey
 
-_INTERACTION_TOKEN = "test-interaction-token"  # noqa: S105
+_INTERACTION_TOKEN = "test-interaction-token"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/remote/test_ops.py
+++ b/tests/remote/test_ops.py
@@ -47,7 +47,7 @@ def test_railway_provider_scopes_with_link_when_project_provided() -> None:
     provider = RailwayRemoteOpsProvider()
     scope = RemoteServiceScope(provider="railway", project="proj-a", service="svc-a")
 
-    def _fake_run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _fake_run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
 
         if cmd[:2] == ["railway", "link"]:
@@ -72,7 +72,7 @@ def test_railway_provider_logs() -> None:
 
     captured: list[list[str]] = []
 
-    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
         captured.append(list(cmd))
         if cmd[:2] == ["railway", "link"]:
@@ -94,7 +94,7 @@ def test_railway_provider_fetch_logs() -> None:
     provider = RailwayRemoteOpsProvider()
     scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
 
-    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
         if cmd[:2] == ["railway", "link"]:
             return _Result(0, stdout="{}")
@@ -116,7 +116,7 @@ def test_railway_provider_fetch_logs_stderr_only() -> None:
     provider = RailwayRemoteOpsProvider()
     scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
 
-    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
         if cmd[:2] == ["railway", "link"]:
             return _Result(0, stdout="{}")
@@ -137,7 +137,7 @@ def test_railway_provider_restart() -> None:
     provider = RailwayRemoteOpsProvider()
     scope = RemoteServiceScope(provider="railway", project="proj", service="svc")
 
-    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
         if cmd[:2] == ["railway", "link"]:
             return _Result(0, stdout="{}")

--- a/tests/remote/test_ops_fetch_logs.py
+++ b/tests/remote/test_ops_fetch_logs.py
@@ -17,7 +17,7 @@ class _Result:
 
 
 def _make_run(log_output: str = "", log_returncode: int = 0, log_stderr: str = ""):
-    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
         if cmd[:2] == ["railway", "link"]:
             return _Result(0, stdout="{}")
@@ -137,7 +137,7 @@ def test_fetch_logs_passes_tail_argument() -> None:
 
     captured: list[list[str]] = []
 
-    def _run(cmd, check, text, capture_output):  # noqa: ANN001
+    def _run(cmd, check, text, capture_output):
         _ = (check, text, capture_output)
         captured.append(list(cmd))
         if cmd[:2] == ["railway", "link"]:

--- a/tests/services/test_grafana_tempo.py
+++ b/tests/services/test_grafana_tempo.py
@@ -18,7 +18,8 @@ class FakeGrafanaClient(TempoMixin):
     def _build_datasource_url(self, uid: str, path: str) -> str:
         return f"https://grafana.fake/api/datasources/uid/{uid}{path}"
 
-    def _make_request(self, url: str, params: dict | None = None) -> dict:  # noqa: ARG002
+    def _make_request(self, url: str, params: dict | None = None) -> dict:
+        del url, params
         # To be mocked in tests
         return {}
 

--- a/tests/shared/tracer_ingest/__init__.py
+++ b/tests/shared/tracer_ingest/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import requests
@@ -36,11 +36,7 @@ def _redact_token(token: str) -> str:
 
 def _utc_now_iso() -> str:
     """UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
-    return (
-        datetime.now(timezone.utc)  # noqa: UP017 - use timezone.utc for broad compatibility
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _tracer_context_metadata() -> dict[str, Any]:

--- a/tests/test_elasticsearch_client.py
+++ b/tests/test_elasticsearch_client.py
@@ -303,7 +303,7 @@ class TestGetClusterHealth:
 
 
 def test_package_exports() -> None:
-    from app.services.elasticsearch import ElasticsearchClient as C  # noqa: F401
+    from app.services.elasticsearch import ElasticsearchClient as C
     from app.services.elasticsearch import ElasticsearchConfig as Cfg
 
     assert C is not None

--- a/tests/tools/test_git_deploy_timeline_tool.py
+++ b/tests/tools/test_git_deploy_timeline_tool.py
@@ -110,7 +110,7 @@ def test_run_passes_time_window_and_branch_to_mcp() -> None:
     mock_config = MagicMock()
     captured: dict[str, object] = {}
 
-    def _fake_call(config, name, arguments):  # noqa: ARG001
+    def _fake_call(config, name, arguments):
         captured["name"] = name
         captured["arguments"] = arguments
         return {"is_error": False, "text": "", "structured_content": [], "content": []}
@@ -202,7 +202,7 @@ def test_run_passes_per_page_to_mcp() -> None:
     mock_config = MagicMock()
     captured: dict[str, object] = {}
 
-    def _fake_call(config, name, arguments):  # noqa: ARG001
+    def _fake_call(config, name, arguments):
         captured["arguments"] = arguments
         return {"is_error": False, "text": "", "structured_content": [], "content": []}
 
@@ -231,7 +231,7 @@ def test_run_clamps_per_page_to_api_maximum() -> None:
     mock_config = MagicMock()
     captured: dict[str, object] = {}
 
-    def _fake_call(config, name, arguments):  # noqa: ARG001
+    def _fake_call(config, name, arguments):
         captured["arguments"] = arguments
         return {"is_error": False, "text": "", "structured_content": [], "content": []}
 
@@ -356,7 +356,7 @@ def _run_with_shared_window(
     """Helper: run the tool with a stubbed MCP and return (kwargs_to_mcp, payload)."""
     captured: dict = {}
 
-    def _fake_call(config, name, arguments):  # noqa: ARG001
+    def _fake_call(config, name, arguments):
         captured["arguments"] = arguments
         return {"is_error": False, "text": "", "structured_content": [], "content": []}
 


### PR DESCRIPTION
Fixes #1401 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
PR-1 of 3 to remove all # noqa lint suppressions from the codebase.

Most of the 288 # noqa directives were dead — pointing at rules not in the project's Ruff select list. Used RUF100 auto-fix to drop those, then fixed the small remainder by hand:

Renamed unused framework-callback args with _ prefix.
Used del ctx, value for LangGraph auth handlers (keyword-name protocol matching).
Migrated TypeAlias and TypeVar generics to PEP 695 syntax.
Lambda → def, timezone.utc → datetime.UTC.
Result: 288 → 19 noqas. The remaining 19 need structural refactors and are deferred to upcoming PRs.

### Demo/Screenshot for feature changes and bug fixes - 

<img width="916" height="233" alt="image" src="https://github.com/user-attachments/assets/2bdfabe8-8a98-4e75-8956-65aaedd78120" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The repo had 200+ # noqa suppressions. Before refactoring, I checked which were actually doing work, most were protecting against rules not enforced by the project's Ruff config, so they could just be deleted. Ruff's RUF100 rule found and auto-removed them.

The small remainder needed real fixes: renames, PEP 695 syntax, and a lambda-to-def. One subtle case, LangGraph's auth Protocol matches handlers by keyword-arg name, so renaming ctx/value broke mypy. Used del ctx, value instead to satisfy the linter without breaking the framework contract.

Split into 4 PRs so each kind of change gets focused review. This PR only touches mechanical/low-risk changes; structural refactors are in later PRs.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
