### PR TITLE
feat(agents): add AgentRecord dataclass and AgentRegistry with JSONL persistence

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Local agent fleet monitoring: registry, probes, meters, and status heuristics."""
+
+from app.agents.registry import AgentRecord, AgentRegistry
+
+__all__ = ["AgentRecord", "AgentRegistry"]

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -1,0 +1,105 @@
+"""Agent record storage and JSONL-backed registry for tracked local processes."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.constants import OPENSRE_HOME_DIR
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REGISTRY_PATH = OPENSRE_HOME_DIR / "agents.jsonl"
+
+
+@dataclass(frozen=True)
+class AgentRecord:
+    """Immutable snapshot of a registered local AI agent process."""
+
+    name: str
+    pid: int
+    command: str
+    registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AgentRecord:
+        raw_pid = data["pid"]
+        pid = int(str(raw_pid))
+        return cls(
+            name=str(data["name"]),
+            pid=pid,
+            command=str(data["command"]),
+            registered_at=str(data.get("registered_at", datetime.now(UTC).isoformat())),
+        )
+
+
+class AgentRegistry:
+    """JSONL-backed registry of locally running AI agent processes.
+
+    Persists to ``~/.config/opensre/agents.jsonl`` by default.  The file is
+    append-only for ``register`` and fully rewritten on ``forget`` / ``flush``.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _DEFAULT_REGISTRY_PATH
+        self._records: dict[int, AgentRecord] = {}
+        self._load_from_disk()
+
+    def register(self, record: AgentRecord) -> None:
+        self._records[record.pid] = record
+        self._append(record)
+
+    def forget(self, pid: int) -> AgentRecord | None:
+        removed = self._records.pop(pid, None)
+        if removed is not None:
+            self._rewrite()
+        return removed
+
+    def list(self) -> list[AgentRecord]:
+        return list(self._records.values())
+
+    def get(self, pid: int) -> AgentRecord | None:
+        return self._records.get(pid)
+
+    def clear(self) -> None:
+        self._records.clear()
+        self._rewrite()
+
+    def _load_from_disk(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            lines = self._path.read_text(encoding="utf-8").strip().splitlines()
+        except OSError:
+            logger.warning("Failed to read agent registry from %s", self._path)
+            return
+        for line in lines:
+            try:
+                data = json.loads(line)
+                record = AgentRecord.from_dict(data)
+                self._records[record.pid] = record
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                logger.warning("Skipping corrupt agent registry line: %s", line[:80])
+
+    def _append(self, record: AgentRecord) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record.to_dict()) + "\n")
+        except OSError:
+            logger.warning("Failed to append to agent registry at %s", self._path)
+
+    def _rewrite(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("w", encoding="utf-8") as fh:
+                for record in self._records.values():
+                    fh.write(json.dumps(record.to_dict()) + "\n")
+        except OSError:
+            logger.warning("Failed to rewrite agent registry at %s", self._path)

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -1,0 +1,137 @@
+"""Tests for agent record storage and JSONL-backed registry."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.agents.registry import AgentRecord, AgentRegistry
+
+
+@pytest.fixture
+def registry(tmp_path):
+    return AgentRegistry(path=tmp_path / "agents.jsonl")
+
+
+@pytest.fixture
+def sample_record():
+    return AgentRecord(
+        name="claude-code",
+        pid=8421,
+        command="claude --dangerously-skip-permissions",
+        registered_at="2026-05-07T12:00:00+00:00",
+    )
+
+
+class TestAgentRecord:
+    def test_frozen(self, sample_record):
+        with pytest.raises(AttributeError):
+            sample_record.name = "aider"  # type: ignore[misc]
+
+    def test_round_trip_dict(self, sample_record):
+        restored = AgentRecord.from_dict(sample_record.to_dict())
+        assert restored == sample_record
+
+    def test_from_dict_missing_registered_at(self):
+        record = AgentRecord.from_dict({"name": "aider", "pid": 1234, "command": "aider"})
+        assert record.name == "aider"
+        assert record.registered_at  # auto-populated
+
+    def test_from_dict_coerces_types(self):
+        record = AgentRecord.from_dict({"name": "codex", "pid": "9999", "command": "codex"})
+        assert record.pid == 9999
+        assert isinstance(record.pid, int)
+
+
+class TestAgentRegistry:
+    def test_register_and_list(self, registry, sample_record):
+        registry.register(sample_record)
+        records = registry.list()
+        assert len(records) == 1
+        assert records[0] == sample_record
+
+    def test_register_overwrites_same_pid(self, registry, sample_record):
+        registry.register(sample_record)
+        updated = AgentRecord(
+            name="claude-code-v2",
+            pid=8421,
+            command="claude",
+            registered_at="2026-05-07T13:00:00+00:00",
+        )
+        registry.register(updated)
+        assert len(registry.list()) == 1
+        assert registry.get(8421).name == "claude-code-v2"
+
+    def test_get_returns_none_for_missing(self, registry):
+        assert registry.get(99999) is None
+
+    def test_forget_removes_record(self, registry, sample_record):
+        registry.register(sample_record)
+        removed = registry.forget(8421)
+        assert removed == sample_record
+        assert registry.list() == []
+
+    def test_forget_missing_returns_none(self, registry):
+        assert registry.forget(99999) is None
+
+    def test_clear_empties_registry(self, registry, sample_record):
+        registry.register(sample_record)
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider"))
+        registry.clear()
+        assert registry.list() == []
+
+    def test_persistence_round_trip(self, tmp_path, sample_record):
+        path = tmp_path / "agents.jsonl"
+        reg1 = AgentRegistry(path=path)
+        reg1.register(sample_record)
+        reg1.register(AgentRecord(name="aider", pid=7702, command="aider"))
+
+        reg2 = AgentRegistry(path=path)
+        assert len(reg2.list()) == 2
+        assert reg2.get(8421) == sample_record
+
+    def test_forget_updates_disk(self, tmp_path, sample_record):
+        path = tmp_path / "agents.jsonl"
+        reg1 = AgentRegistry(path=path)
+        reg1.register(sample_record)
+        reg1.register(AgentRecord(name="aider", pid=7702, command="aider"))
+        reg1.forget(8421)
+
+        reg2 = AgentRegistry(path=path)
+        assert len(reg2.list()) == 1
+        assert reg2.get(8421) is None
+        assert reg2.get(7702) is not None
+
+    def test_corrupt_line_skipped(self, tmp_path):
+        path = tmp_path / "agents.jsonl"
+        path.write_text(
+            '{"name":"claude-code","pid":8421,"command":"claude","registered_at":"2026-05-07T12:00:00+00:00"}\n'
+            "this is not json\n"
+            '{"name":"aider","pid":7702,"command":"aider","registered_at":"2026-05-07T12:00:00+00:00"}\n',
+            encoding="utf-8",
+        )
+        reg = AgentRegistry(path=path)
+        assert len(reg.list()) == 2
+
+    def test_empty_file(self, tmp_path):
+        path = tmp_path / "agents.jsonl"
+        path.write_text("", encoding="utf-8")
+        reg = AgentRegistry(path=path)
+        assert reg.list() == []
+
+    def test_nonexistent_file(self, tmp_path):
+        path = tmp_path / "does_not_exist.jsonl"
+        reg = AgentRegistry(path=path)
+        assert reg.list() == []
+
+    def test_jsonl_file_format(self, tmp_path, sample_record):
+        path = tmp_path / "agents.jsonl"
+        reg = AgentRegistry(path=path)
+        reg.register(sample_record)
+
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["name"] == "claude-code"
+        assert parsed["pid"] == 8421


### PR DESCRIPTION
## Summary
- Add `app/agents/` package with `AgentRecord` frozen dataclass and `AgentRegistry` backed by JSONL at `~/.config/opensre/agents.jsonl`
- Registry supports register, forget, list, get, clear with append-only writes and full rewrite on forget/clear
- Graceful handling of corrupt JSONL lines on disk load (skip + log warning)
- Follows the JSONL append pattern from `app/guardrails/audit.py`

## Test plan
- 16 tests covering record immutability, dict round-trip, type coercion, register/forget/list/get/clear, persistence round-trip, disk update on forget, corrupt line handling, empty file, nonexistent file, JSONL format validation
- All tests use `tmp_path` fixture to avoid touching real home directory
- `make lint`, `make format-check`, and `make typecheck` all pass

Resolves #1487