### PR TITLE
fix(cli): treat onboard abort as clean cancel

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -219,6 +219,11 @@ def main(argv: list[str] | None = None) -> int:
         # exit quietly — Click's "Aborted!" message is intentionally suppressed.
         print(flush=True)
         return 0
+    except click.Abort:
+        # Click raises Abort for some prompt-level cancel paths. Treat it as a
+        # clean user cancel, not as an unexpected CLI failure.
+        print(flush=True)
+        return 0
     except click.ClickException as exc:
         if _should_capture_cli_exception(exc):
             report_exception(exc, context="cli.main")

--- a/app/cli/support/exception_reporting.py
+++ b/app/cli/support/exception_reporting.py
@@ -15,7 +15,7 @@ def should_report_exception(exc: BaseException, *, expected: bool = False) -> bo
     """Return whether a caught exception should be reported to Sentry."""
     if expected:
         return False
-    if isinstance(exc, (KeyboardInterrupt, EOFError, OpenSREError)):
+    if isinstance(exc, (KeyboardInterrupt, EOFError, OpenSREError, click.Abort)):
         return False
     if isinstance(exc, click.UsageError):
         return str(exc).startswith("No such command ")

--- a/app/cli/wizard/__main__.py
+++ b/app/cli/wizard/__main__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import click
 from dotenv import load_dotenv
 
 from app.analytics.cli import build_cli_invoked_properties, capture_cli_invoked
@@ -28,6 +29,12 @@ def main() -> int:
 
     try:
         return int(run_wizard())
+    except KeyboardInterrupt:
+        print(flush=True)
+        return 0
+    except click.Abort:
+        print(flush=True)
+        return 0
     finally:
         shutdown_analytics(flush=True)
 

--- a/tests/cli/test_exception_reporting.py
+++ b/tests/cli/test_exception_reporting.py
@@ -15,6 +15,7 @@ def test_should_not_report_expected_cli_errors() -> None:
     assert should_report_exception(click.UsageError("No such option: --bogus")) is False
     assert should_report_exception(OpenSREError("missing integration")) is False
     assert should_report_exception(KeyboardInterrupt()) is False
+    assert should_report_exception(click.Abort()) is False
     assert should_report_exception(ValueError("user input"), expected=True) is False
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -91,6 +91,23 @@ def test_main_does_not_capture_expected_usage_errors_to_sentry(
     assert captured == []
 
 
+def test_main_treats_onboard_abort_as_clean_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("app.cli.__main__.init_sentry", lambda: None)
+    monkeypatch.setattr(
+        "app.cli.wizard.run_wizard",
+        lambda: (_ for _ in ()).throw(click.Abort()),
+    )
+
+    exit_code = main(["onboard"])
+
+    assert exit_code == 0
+
+
 def test_main_allows_update_when_sentry_sdk_missing(monkeypatch, capsys) -> None:
     monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
     monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)

--- a/tests/cli/test_wizard_main.py
+++ b/tests/cli/test_wizard_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import click
 import pytest
 
 from app.cli.wizard import __main__ as wizard_main
@@ -63,4 +64,30 @@ def test_main_flushes_analytics_even_when_wizard_raises(
     with pytest.raises(RuntimeError):
         wizard_main.main()
 
+    assert flush_calls == [True]
+
+
+def test_main_treats_abort_as_clean_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flush_calls: list[bool] = []
+
+    monkeypatch.setattr(wizard_main, "init_sentry", lambda: None)
+    monkeypatch.setattr(wizard_main, "capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr(wizard_main, "capture_cli_invoked", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        wizard_main,
+        "shutdown_analytics",
+        lambda **kw: flush_calls.append(bool(kw.get("flush"))),
+    )
+    monkeypatch.setattr(wizard_main, "install_questionary_escape_cancel", lambda: None)
+    monkeypatch.setattr(
+        wizard_main,
+        "run_wizard",
+        lambda: (_ for _ in ()).throw(click.Abort()),
+    )
+
+    exit_code = wizard_main.main()
+
+    assert exit_code == 0
     assert flush_calls == [True]

--- a/tests/cli/test_wizard_main.py
+++ b/tests/cli/test_wizard_main.py
@@ -91,3 +91,29 @@ def test_main_treats_abort_as_clean_cancel(
 
     assert exit_code == 0
     assert flush_calls == [True]
+
+
+def test_main_treats_keyboard_interrupt_as_clean_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flush_calls: list[bool] = []
+
+    monkeypatch.setattr(wizard_main, "init_sentry", lambda: None)
+    monkeypatch.setattr(wizard_main, "capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr(wizard_main, "capture_cli_invoked", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        wizard_main,
+        "shutdown_analytics",
+        lambda **kw: flush_calls.append(bool(kw.get("flush"))),
+    )
+    monkeypatch.setattr(wizard_main, "install_questionary_escape_cancel", lambda: None)
+    monkeypatch.setattr(
+        wizard_main,
+        "run_wizard",
+        lambda: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    exit_code = wizard_main.main()
+
+    assert exit_code == 0
+    assert flush_calls == [True]


### PR DESCRIPTION
Fixes #1540

#### Describe the changes you have made in this PR -

This PR fixes the onboarding cancel path so user-initiated aborts do not surface as CLI errors.

I first verified that issue #1540 was valid. The failure was reproducible when the onboarding flow exited through `click.Abort`, which caused the CLI to return an error path instead of treating the
action as a normal user cancellation.

Changes made:
- updated `app/cli/__main__.py` to treat `click.Abort` the same way as `KeyboardInterrupt`, returning exit code `0`
- updated `app/cli/wizard/__main__.py` to treat standalone wizard aborts as clean cancels
- updated `app/cli/support/exception_reporting.py` so `click.Abort` is not reported as an unexpected exception
- added regression tests for both main entrypoints and exception-reporting behavior

### Demo/Screenshot for feature changes and bug fixes -

Reproduction before fix:
- onboarding abort through `click.Abort` bubbled as an error path and could be surfaced to Sentry

Behavior after fix:
- `main(["onboard"])` returns `0` for `click.Abort`
- onboarding cancel is treated as a clean user exit

Validation run:
- `.venv/bin/pytest -q tests/cli/test_main.py tests/cli/test_wizard_main.py tests/cli/test_exception_reporting.py`
- `make lint`
- `make format-check`
- `make typecheck`

Result:
- targeted tests passed
- lint passed
- format-check passed
- typecheck passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I started by checking whether the Sentry issue was a real product bug or just noise from a normal Ctrl+C path. The key finding was that the problematic path was not a plain `KeyboardInterrupt`; it was
a `click.Abort` coming out of onboarding prompt cancellation.

The main CLI already handled `KeyboardInterrupt` as a quiet user cancel, but `click.Abort` was still escaping as a failure path. I chose the minimal fix: treat `click.Abort` as the same class of
expected user action in both the main CLI entrypoint and the standalone wizard entrypoint.

I also updated the shared exception-reporting policy so `click.Abort` is not considered reportable. That keeps cancellation behavior consistent across exit handling and telemetry/error reporting.

Finally, I added regression tests that assert:
- `main(["onboard"])` returns `0` when onboarding aborts
- the standalone wizard entrypoint also returns `0` on abort
- `click.Abort` is excluded from unexpected exception reporting

This approach keeps the fix tightly scoped to cancellation semantics and avoids changing the onboarding wizard flow itself.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---