### PR TITLE
fix: update contributor table layout to 12 columns and adjust avatarsize

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -116,8 +116,8 @@ jobs:
           # Sort by first commit date ascending (earliest contributor first)
           contributors.sort(key=lambda c: c["first_commit"])
 
-          # Build the table HTML (6 columns per row)
-          cols = 6
+          # Build the table HTML (12 columns per row)
+          cols = 12
           rows = [contributors[i:i+cols] for i in range(0, len(contributors), cols)]
           lines = ["<table>", "\t<tbody>"]
           for row in rows:
@@ -125,7 +125,7 @@ jobs:
               for c in row:
                   lines.append(f"""            <td align="center">
                   <a href="{c['html_url']}">
-                      <img src="{c['avatar_url']}" width="100" alt="{c['login']}"/>
+                      <img src="{c['avatar_url']}" width="60" alt="{c['login']}"/>
                       <br />
                       <sub><b>{c['login']}</b></sub>
                   </a>


### PR DESCRIPTION
This pull request updates the contributor table layout in the `.github/workflows/contributors.yml` workflow. The main changes are to the table's column count and the display size of contributor avatars.

**Contributor table layout changes:**

* Increased the number of columns per row in the contributors table from 6 to 12, allowing more contributors to appear per row.
* Reduced the avatar image size from 100px to 60px width for each contributor, making the table more compact.

<img width="978" height="731" alt="Screenshot 2026-05-07 at 2 35 17 PM" src="https://github.com/user-attachments/assets/d24feec4-f91e-4a9e-8312-b00f3d1489a4" />
