### PR TITLE
feat(cli): ground interactive shell on AGENTS.md repo map (#1442)

### DIFF
--- a/app/cli/interactive_shell/agents_md_reference.py
+++ b/app/cli/interactive_shell/agents_md_reference.py
@@ -163,6 +163,14 @@ def discover_agents_md_files(root: Path | None = None) -> list[AgentsMdFile]:
     resolved = target.resolve() if target.exists() else target
     root_key = str(resolved)
 
+    # Every discover call walks the tree (and stats what it finds) — even on
+    # cache hits — because the walk + per-file fingerprint is what detects
+    # in-file edits between grounding calls during a long-running shell.
+    # Skipping the walk on cache hits would make AGENTS.md edits invisible
+    # until eviction, which is the bug the fingerprint design in
+    # docs_reference.py was introduced to avoid; we keep the same trade-off
+    # here so the two grounding sources stay symmetric. The cost is bounded
+    # by the _SKIP_DIRS prune (notably ``.venv``).
     files = _iter_agents_md_files(resolved)
     fp = _fingerprint_from_paths(resolved, files)
     cache_key = (root_key, fp)

--- a/app/cli/interactive_shell/agents_md_reference.py
+++ b/app/cli/interactive_shell/agents_md_reference.py
@@ -1,0 +1,261 @@
+"""AGENTS.md grounding helpers for OpenSRE interactive-shell answers.
+
+The conversational interactive-shell assistant grounds answers on the
+``opensre --help`` reference (via :mod:`app.cli.interactive_shell.cli_reference`)
+and, for procedural questions, excerpts from ``docs/`` (via
+:mod:`app.cli.interactive_shell.docs_reference`). Neither surface includes
+internal repo-map content, so the assistant cannot answer questions like
+"where do I add a new tool?" or "how does the LangGraph pipeline route?"
+from maintained internal documentation.
+
+This module surfaces the repo's ``AGENTS.md`` files (root + per-package) as a
+third grounding source for the conversational shell. It is purely static
+(no embeddings, no DB, no new dependencies) and mirrors the shape of
+:mod:`app.cli.interactive_shell.docs_reference` so the two stay symmetric.
+
+Source of truth
+---------------
+Every ``AGENTS.md`` file under the repository root. We skip ``tests/``,
+``node_modules``, ``.git``, ``__pycache__``, and ``.venv`` so we never pull
+test-fixture or installed-package content into the prompt.
+
+How files stay fresh
+--------------------
+Files are parsed lazily and cached in-process keyed by the resolved repo root
+and a lightweight fingerprint of each tracked file (relative path, size,
+``st_mtime_ns``). Edits to ``AGENTS.md`` files during a long-running shell
+invalidate the fingerprint and trigger a re-parse on the next grounding
+call. There is no on-disk cache. Use :func:`invalidate_agents_md_cache` in
+tests to clear the parse cache between cases.
+
+When files are missing
+----------------------
+For non-editable installs that do not ship ``AGENTS.md`` files the discovery
+returns an empty list and :func:`build_agents_md_reference_text` returns an
+empty string so callers can detect that and skip the block.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Repo root is three levels above this file
+# (.../app/cli/interactive_shell/agents_md_reference.py -> repo root).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_AGENTS_MD_FILENAME = "AGENTS.md"
+
+# Directories whose subtrees never contain AGENTS.md content meant for
+# grounding. ``tests`` is excluded by spec (test-fixture AGENTS.md files
+# would pollute the assistant's repo map). ``.venv`` is excluded so we don't
+# surface installed-package AGENTS.md from third-party dependencies — without
+# this, ``os.walk`` would also spend most of its time descending the venv.
+_SKIP_DIRS = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "__pycache__",
+        "tests",
+        ".venv",
+    }
+)
+
+# Per-file excerpt cap; total cap is enforced by build_agents_md_reference_text.
+# AGENTS.md files are typically small repo-map docs, so 2K per file gives
+# headroom for the root file (which tends to be the largest) without
+# crowding the prompt.
+_MAX_PER_FILE_CHARS = 2_000
+_DEFAULT_MAX_TOTAL_CHARS = 6_000
+
+
+@dataclass(frozen=True)
+class AgentsMdFile:
+    """A single ``AGENTS.md`` file available for grounding."""
+
+    relpath: str
+    """Path relative to the repo root, with forward slashes (``"AGENTS.md"`` for the root file)."""
+
+    body: str
+    """File body, verbatim. AGENTS.md is plain Markdown — no frontmatter to strip."""
+
+
+def _iter_agents_md_files(root: Path) -> list[Path]:
+    """Walk ``root`` collecting ``AGENTS.md`` files, pruning skip dirs in-place.
+
+    ``os.walk`` with ``dirnames[:] = ...`` pruning is meaningfully faster than
+    ``rglob`` here because the repo root contains a multi-GB ``.venv`` whose
+    subtree we never need to descend.
+    """
+    if not root.exists() or not root.is_dir():
+        return []
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        if _AGENTS_MD_FILENAME in filenames:
+            files.append(Path(dirpath) / _AGENTS_MD_FILENAME)
+    return sorted(files)
+
+
+# Delimiters keep SHA-256 input unambiguous across (relpath, size, mtime)
+# tuple boundaries, mirroring docs_reference for symmetry.
+_FP_FIELD_SEP = b"\x00"
+_FP_RECORD_SEP = b"\xff"
+
+
+def _fingerprint_from_paths(root: Path, files: list[Path]) -> str:
+    """Digest of tracked AGENTS.md files using paths from a single tree walk."""
+    digest = hashlib.sha256()
+    if not root.exists() or not root.is_dir():
+        digest.update(b"nodir")
+        digest.update(_FP_FIELD_SEP)
+        digest.update(str(root.resolve() if root.exists() else root).encode())
+        digest.update(_FP_FIELD_SEP)
+        return digest.hexdigest()
+
+    for path in files:
+        rel = path.relative_to(root).as_posix()
+        try:
+            st = path.stat()
+            digest.update(rel.encode())
+            digest.update(_FP_FIELD_SEP)
+            digest.update(str(st.st_size).encode())
+            digest.update(_FP_FIELD_SEP)
+            digest.update(str(st.st_mtime_ns).encode())
+            digest.update(_FP_RECORD_SEP)
+        except OSError:
+            continue
+    return digest.hexdigest()
+
+
+def _parse_agents_md_files(root: Path, files: list[Path]) -> tuple[AgentsMdFile, ...]:
+    if not root.exists() or not root.is_dir():
+        return ()
+    parsed: list[AgentsMdFile] = []
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        relpath = path.relative_to(root).as_posix()
+        parsed.append(AgentsMdFile(relpath=relpath, body=text))
+    return tuple(parsed)
+
+
+# Distinct (root_key, fingerprint) entries retained under churn. Eviction
+# drops oldest keys; a reverted tree re-parses once then stays hot again.
+_MAX_AGENTS_MD_FP_CACHE_ENTRIES = 32
+
+_AGENTS_MD_PARSE_CACHE: OrderedDict[tuple[str, str], tuple[AgentsMdFile, ...]] = OrderedDict()
+_agents_md_cache_hits = 0
+_agents_md_cache_misses = 0
+
+
+def discover_agents_md_files(root: Path | None = None) -> list[AgentsMdFile]:
+    """Walk the repo root, parse each ``AGENTS.md``, return :class:`AgentsMdFile` records."""
+    global _agents_md_cache_hits, _agents_md_cache_misses
+
+    target = root if root is not None else _REPO_ROOT
+    resolved = target.resolve() if target.exists() else target
+    root_key = str(resolved)
+
+    files = _iter_agents_md_files(resolved)
+    fp = _fingerprint_from_paths(resolved, files)
+    cache_key = (root_key, fp)
+
+    cached = _AGENTS_MD_PARSE_CACHE.get(cache_key)
+    if cached is not None:
+        _agents_md_cache_hits += 1
+        _AGENTS_MD_PARSE_CACHE.move_to_end(cache_key)
+        return list(cached)
+
+    _agents_md_cache_misses += 1
+    parsed_tuple = _parse_agents_md_files(resolved, files)
+
+    while len(_AGENTS_MD_PARSE_CACHE) >= _MAX_AGENTS_MD_FP_CACHE_ENTRIES:
+        _AGENTS_MD_PARSE_CACHE.popitem(last=False)
+    _AGENTS_MD_PARSE_CACHE[cache_key] = parsed_tuple
+    return list(parsed_tuple)
+
+
+def invalidate_agents_md_cache() -> None:
+    """Clear the bounded parse cache (tests, forced refresh)."""
+    global _agents_md_cache_hits, _agents_md_cache_misses
+    _AGENTS_MD_PARSE_CACHE.clear()
+    _agents_md_cache_hits = 0
+    _agents_md_cache_misses = 0
+
+
+def get_agents_md_cache_stats() -> dict[str, Any]:
+    """Debug metrics for AGENTS.md grounding cache (hits/misses/size)."""
+    return {
+        "hits": _agents_md_cache_hits,
+        "misses": _agents_md_cache_misses,
+        "currsize": len(_AGENTS_MD_PARSE_CACHE),
+        "maxsize": _MAX_AGENTS_MD_FP_CACHE_ENTRIES,
+    }
+
+
+def _excerpt(body: str, max_chars: int = _MAX_PER_FILE_CHARS) -> str:
+    """Trim an AGENTS.md body to ``max_chars``, preferring to cut at a paragraph boundary."""
+    body = body.strip()
+    if len(body) <= max_chars:
+        return body
+    cutoff = body.rfind("\n\n", 0, max_chars)
+    if cutoff < max_chars // 2:
+        cutoff = max_chars
+    return body[:cutoff].rstrip() + "\n\n[... excerpt truncated ...]\n"
+
+
+def _format_label(relpath: str) -> str:
+    """Header label used in the rendered block.
+
+    The repo-root file is rendered as ``AGENTS.md (root)`` to disambiguate it
+    from the per-package files (e.g. ``app/services/AGENTS.md``).
+    """
+    if relpath == _AGENTS_MD_FILENAME:
+        return f"{_AGENTS_MD_FILENAME} (root)"
+    return relpath
+
+
+def build_agents_md_reference_text(*, max_chars: int = _DEFAULT_MAX_TOTAL_CHARS) -> str:
+    """Assemble an AGENTS.md reference block for LLM grounding.
+
+    Concatenates one section per discovered file, in sorted relpath order, of
+    the form::
+
+        === AGENTS.md (root) ===
+        ...
+        === app/services/AGENTS.md ===
+        ...
+
+    Returns ``""`` when no AGENTS.md files are available so callers can
+    detect that and skip the block entirely.
+    """
+    files = discover_agents_md_files()
+    if not files:
+        return ""
+
+    parts: list[str] = []
+    for f in files:
+        parts.append(f"=== {_format_label(f.relpath)} ===\n")
+        parts.append(_excerpt(f.body))
+        parts.append("\n\n")
+
+    text = "".join(parts).rstrip() + "\n"
+    if len(text) > max_chars:
+        return text[:max_chars] + "\n\n[... AGENTS.md reference truncated ...]\n"
+    return text
+
+
+__all__ = [
+    "AgentsMdFile",
+    "build_agents_md_reference_text",
+    "discover_agents_md_files",
+    "get_agents_md_cache_stats",
+    "invalidate_agents_md_cache",
+]

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.markup import escape
 
+from app.cli.interactive_shell.agents_md_reference import build_agents_md_reference_text
 from app.cli.interactive_shell.cli_reference import build_cli_reference_text
 from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
 from app.cli.interactive_shell.prompt_rules import (
@@ -62,12 +63,16 @@ def _format_history_for_prompt(session: ReplSession) -> str:
     return "\n".join(lines) if lines else "(no prior messages in this CLI thread)"
 
 
-def _build_system_prompt(reference: str, history: str) -> str:
+def _build_system_prompt(reference: str, history: str, agents_md: str = "") -> str:
     """Build the system prompt for one assistant turn.
 
     Split out so tests can assert on terminology / formatting rules without
-    invoking an LLM.
+    invoking an LLM. ``agents_md`` is the optional repo-map block from
+    :mod:`app.cli.interactive_shell.agents_md_reference`; when empty the
+    section is omitted so callers in environments that ship no AGENTS.md
+    files don't waste tokens on an empty header.
     """
+    repo_map_block = f"--- Repo map (AGENTS.md) ---\n{agents_md}\n\n" if agents_md else ""
     return (
         "You are the OpenSRE terminal assistant. You help with OpenSRE CLI "
         "usage, the interactive shell, and onboarding. A deterministic pre-pass "
@@ -84,6 +89,7 @@ def _build_system_prompt(reference: str, history: str) -> str:
         "not invent subcommands.\n\n"
         f"{_TERMINOLOGY_RULE}\n{_MARKDOWN_RULE}\n{_ACTION_RULE}\n\n"
         f"--- CLI reference ---\n{reference}\n\n"
+        f"{repo_map_block}"
         f"--- Recent CLI conversation ---\n{history}\n"
     )
 
@@ -318,9 +324,10 @@ def answer_cli_agent(
         return
 
     reference = build_cli_reference_text()
+    agents_md = build_agents_md_reference_text()
     log_grounding_cache_diagnostics("cli_agent_grounding")
     history = _format_history_for_prompt(session)
-    system = _build_system_prompt(reference, history)
+    system = _build_system_prompt(reference, history, agents_md=agents_md)
     user_block = f"--- User message ---\n{message}"
     prompt = f"{system}\n{user_block}"
 

--- a/app/cli/interactive_shell/grounding_diagnostics.py
+++ b/app/cli/interactive_shell/grounding_diagnostics.py
@@ -12,14 +12,16 @@ def log_grounding_cache_diagnostics(reason: str) -> None:
     """Log CLI/docs grounding cache stats when ``TRACER_VERBOSE=1``."""
     if os.environ.get("TRACER_VERBOSE") != "1":
         return
+    from app.cli.interactive_shell.agents_md_reference import get_agents_md_cache_stats
     from app.cli.interactive_shell.cli_reference import get_cli_reference_cache_stats
     from app.cli.interactive_shell.docs_reference import get_docs_cache_stats
 
     _logger.debug(
-        "grounding cache [%s] cli=%s docs=%s",
+        "grounding cache [%s] cli=%s docs=%s agents_md=%s",
         reason,
         get_cli_reference_cache_stats(),
         get_docs_cache_stats(),
+        get_agents_md_cache_stats(),
     )
 
 

--- a/tests/cli/interactive_shell/test_agents_md_reference.py
+++ b/tests/cli/interactive_shell/test_agents_md_reference.py
@@ -1,0 +1,182 @@
+"""Tests for the AGENTS.md grounding helpers used by the interactive shell."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from app.cli.interactive_shell import agents_md_reference
+from app.cli.interactive_shell.agents_md_reference import (
+    AgentsMdFile,
+    _excerpt,
+    build_agents_md_reference_text,
+    discover_agents_md_files,
+    get_agents_md_cache_stats,
+    invalidate_agents_md_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_agents_md_cache() -> Iterator[None]:
+    """Reset the per-process AGENTS.md cache so each test sees a fresh tree."""
+    invalidate_agents_md_cache()
+    yield
+    invalidate_agents_md_cache()
+
+
+def _write(root: Path, relpath: str, content: str) -> None:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _seed_agents_md(root: Path) -> None:
+    _write(root, "AGENTS.md", "# Repo map\n\nTop-level guidance.\n")
+    _write(root, "app/services/AGENTS.md", "# Services\n\nLLM API clients.\n")
+    _write(root, "app/integrations/llm_cli/AGENTS.md", "# llm_cli\n\nSubprocess CLIs.\n")
+    # Files that MUST be skipped — tests, vcs, caches, virtualenv, vendored deps.
+    _write(root, "tests/AGENTS.md", "should be skipped")
+    _write(root, ".git/AGENTS.md", "should be skipped")
+    _write(root, "__pycache__/AGENTS.md", "should be skipped")
+    _write(root, "node_modules/some-pkg/AGENTS.md", "should be skipped")
+    _write(root, ".venv/lib/python3.13/site-packages/foo/AGENTS.md", "should be skipped")
+
+
+class TestDiscoverAgentsMdFiles:
+    def test_returns_empty_list_when_root_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / "no-such-dir"
+        assert discover_agents_md_files(missing) == []
+
+    def test_walks_root_and_skips_excluded_dirs(self, tmp_path: Path) -> None:
+        _seed_agents_md(tmp_path)
+        files = discover_agents_md_files(tmp_path)
+        relpaths = {f.relpath for f in files}
+        assert "AGENTS.md" in relpaths
+        assert "app/services/AGENTS.md" in relpaths
+        assert "app/integrations/llm_cli/AGENTS.md" in relpaths
+        # None of the skip-dir paths should leak into the index.
+        for r in relpaths:
+            assert not r.startswith("tests/")
+            assert not r.startswith(".git/")
+            assert not r.startswith("__pycache__/")
+            assert not r.startswith("node_modules/")
+            assert not r.startswith(".venv/")
+
+    def test_results_are_sorted_by_relpath(self, tmp_path: Path) -> None:
+        _seed_agents_md(tmp_path)
+        files = discover_agents_md_files(tmp_path)
+        relpaths = [f.relpath for f in files]
+        assert relpaths == sorted(relpaths)
+
+    def test_body_is_verbatim_no_frontmatter_stripping(self, tmp_path: Path) -> None:
+        # Unlike docs_reference, AGENTS.md files are plain Markdown — frontmatter
+        # delimiters (if a contributor adds them) must be preserved verbatim.
+        body = "---\nfoo: bar\n---\n\n# Title\n\nBody.\n"
+        _write(tmp_path, "AGENTS.md", body)
+        files = discover_agents_md_files(tmp_path)
+        assert len(files) == 1
+        assert files[0].body == body
+
+
+class TestBuildAgentsMdReferenceText:
+    def test_returns_empty_when_no_files_present(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr(agents_md_reference, "_REPO_ROOT", tmp_path / "missing")
+        assert build_agents_md_reference_text() == ""
+
+    def test_concatenates_each_file_with_labelled_header(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        _seed_agents_md(tmp_path)
+        monkeypatch.setattr(agents_md_reference, "_REPO_ROOT", tmp_path)
+        text = build_agents_md_reference_text()
+        # Root file must be disambiguated from per-package files.
+        assert "=== AGENTS.md (root) ===" in text
+        assert "=== app/services/AGENTS.md ===" in text
+        assert "=== app/integrations/llm_cli/AGENTS.md ===" in text
+        # Bodies must appear in the concatenated block.
+        assert "Top-level guidance." in text
+        assert "LLM API clients." in text
+        assert "Subprocess CLIs." in text
+
+    def test_caps_total_to_max_chars(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        _seed_agents_md(tmp_path)
+        monkeypatch.setattr(agents_md_reference, "_REPO_ROOT", tmp_path)
+        text = build_agents_md_reference_text(max_chars=100)
+        # Allow a small margin for the truncation marker appended at the cap.
+        assert len(text) <= 200
+        assert "truncated" in text
+
+
+class TestExcerpt:
+    def test_returns_full_body_when_short(self) -> None:
+        assert _excerpt("short body", max_chars=100) == "short body"
+
+    def test_truncates_long_body_at_paragraph_boundary(self) -> None:
+        body = ("paragraph one. " * 10) + "\n\n" + ("paragraph two. " * 10)
+        out = _excerpt(body, max_chars=80)
+        assert "truncated" in out
+        # The cut should happen at or before the second paragraph, since the
+        # rfind for "\n\n" before max_chars is the preferred cutoff.
+        assert "paragraph two" not in out
+
+
+class TestAgentsMdFileDataclass:
+    def test_is_hashable_and_immutable(self) -> None:
+        f = AgentsMdFile(relpath="AGENTS.md", body="hello")
+        assert f in {f}
+
+
+class TestAgentsMdGroundingCache:
+    def test_cache_maxsize_matches_implementation(self) -> None:
+        stats = get_agents_md_cache_stats()
+        assert stats["maxsize"] == 32
+
+    def test_repeated_discover_hits_parse_cache(self, tmp_path: Path) -> None:
+        _seed_agents_md(tmp_path)
+        discover_agents_md_files(tmp_path)
+        info1 = get_agents_md_cache_stats()
+        discover_agents_md_files(tmp_path)
+        info2 = get_agents_md_cache_stats()
+        assert info2["hits"] == info1["hits"] + 1
+        assert info2["misses"] == info1["misses"]
+
+    def test_invalidate_resets_stats(self, tmp_path: Path) -> None:
+        _seed_agents_md(tmp_path)
+        discover_agents_md_files(tmp_path)
+        discover_agents_md_files(tmp_path)
+        assert get_agents_md_cache_stats()["hits"] >= 1
+        invalidate_agents_md_cache()
+        cleared = get_agents_md_cache_stats()
+        assert cleared["hits"] == 0
+        assert cleared["misses"] == 0
+        assert cleared["currsize"] == 0
+
+    def test_file_edit_invalidates_and_refreshes_content(self, tmp_path: Path) -> None:
+        _write(tmp_path, "AGENTS.md", "# Repo map\n\nOld content.\n")
+        files1 = discover_agents_md_files(tmp_path)
+        assert any("Old content" in f.body for f in files1)
+
+        # Bump mtime well beyond filesystem mtime resolution so the
+        # fingerprint definitely changes on the next discover call.
+        target = tmp_path / "AGENTS.md"
+        target.write_text("# Repo map\n\nNew refreshed content.\n", encoding="utf-8")
+        import os
+
+        st = target.stat()
+        os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
+
+        files2 = discover_agents_md_files(tmp_path)
+        assert any("New refreshed content" in f.body for f in files2)
+        assert not any("Old content" in f.body for f in files2)

--- a/tests/cli/interactive_shell/test_agents_md_reference.py
+++ b/tests/cli/interactive_shell/test_agents_md_reference.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -172,8 +173,6 @@ class TestAgentsMdGroundingCache:
         # fingerprint definitely changes on the next discover call.
         target = tmp_path / "AGENTS.md"
         target.write_text("# Repo map\n\nNew refreshed content.\n", encoding="utf-8")
-        import os
-
         st = target.stat()
         os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
 

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -105,6 +105,44 @@ class TestSystemPromptTerminology:
         assert "gemini-cli" in prompt
 
 
+class TestSystemPromptAgentsMdGrounding:
+    """The conversational shell wires AGENTS.md repo-map content (#1442).
+
+    The strict reference_only docs-aware path (``cli_help._build_grounded_prompt``)
+    intentionally does NOT include AGENTS.md so it stays grounded only on the
+    public docs and CLI reference.
+    """
+
+    def test_section_present_in_conversational_prompt_when_agents_md_provided(self) -> None:
+        prompt = _build_system_prompt(
+            reference="(ref)",
+            history="(hist)",
+            agents_md="repo map content",
+        )
+        assert "--- Repo map (AGENTS.md) ---" in prompt
+        assert "repo map content" in prompt
+
+    def test_section_omitted_when_agents_md_empty(self) -> None:
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)", agents_md="")
+        assert "--- Repo map (AGENTS.md) ---" not in prompt
+
+    def test_section_omitted_by_default_for_callers_that_dont_pass_it(self) -> None:
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)")
+        assert "--- Repo map (AGENTS.md) ---" not in prompt
+
+    def test_section_absent_in_reference_only_grounded_prompt(self) -> None:
+        from app.cli.interactive_shell.cli_help import _build_grounded_prompt
+
+        # The reference_only path stays strict — even if AGENTS.md grounding is
+        # available elsewhere in the shell, this prompt must not include it.
+        prompt = _build_grounded_prompt(
+            question="how do I configure datadog?",
+            cli_reference="(ref)",
+            docs_reference="(docs)",
+        )
+        assert "--- Repo map (AGENTS.md) ---" not in prompt
+
+
 class TestActionPlanParsing:
     def test_parses_prose_wrapped_json(self) -> None:
         actions = _parse_action_plan(


### PR DESCRIPTION
Fixes #1442

#### Describe the changes you have made in this PR -

Adds a third static grounding source for the **conversational** interactive-shell assistant: the repo's `AGENTS.md` files. Today the assistant grounds on `opensre --help` (`cli_reference.py`) and `docs/**.mdx` (`docs_reference.py`) but never sees internal repo-map content, so it has to guess on questions like *"where do I add a new tool?"* or *"how does the LangGraph pipeline route?"*

Mirrors the shape of `docs_reference.py` exactly so the two stay symmetrical and the diff is easy to review.

**What ships:**

- `app/cli/interactive_shell/agents_md_reference.py` (new) — `discover_agents_md_files`, `build_agents_md_reference_text`, `get_agents_md_cache_stats`, `invalidate_agents_md_cache`, `AgentsMdFile`. Same fingerprint+OrderedDict cache pattern as `docs_reference.py` (`_iter_*`, `_fingerprint_from_paths`, `_parse_*`, `_excerpt`).
- `app/cli/interactive_shell/cli_agent.py` — `_build_system_prompt` now accepts an optional `agents_md` kwarg and emits a `--- Repo map (AGENTS.md) ---` section between the CLI reference and the recent history. `answer_cli_agent` calls `build_agents_md_reference_text()` and passes it through.
- `app/cli/interactive_shell/grounding_diagnostics.py` — adds `agents_md=…` to the `TRACER_VERBOSE=1` cache log line, so verbose-mode parity stays intact.
- `tests/cli/interactive_shell/test_agents_md_reference.py` (new, 14 tests) — discovery + skip-dirs (`tests/`, `.git`, `__pycache__`, `node_modules`, `.venv`), sorted relpath order, verbatim body (no frontmatter stripping), `max_chars` cap, paragraph-boundary excerpt, cache hit/miss, invalidation, and mtime-edit-invalidates-cache regression coverage.
- `tests/cli/interactive_shell/test_cli_agent.py` — adds `TestSystemPromptAgentsMdGrounding` asserting the section is present in the conversational prompt when content is provided, omitted otherwise, and **absent in the strict reference_only path** (`cli_help._build_grounded_prompt`).

**Out of scope** (per issue): embeddings/RAG, slash commands, docs-site grounding (already handled).

### Demo/Screenshot for feature changes and bug fixes -

Smoke test against the live repo (root, app/services, app/integrations/llm_cli, tests/AGENTS.md correctly skipped):

```
$ uv run python -c "from app.cli.interactive_shell.agents_md_reference import \
    build_agents_md_reference_text, get_agents_md_cache_stats; \
    text = build_agents_md_reference_text(); \
    print('len:', len(text)); print(text[:500]); \
    print('cache:', get_agents_md_cache_stats())"

len: 5026
=== AGENTS.md (root) ===
## Tracer Development Reference

## Build and Run commands

- Build `make install` (creates `.venv` via `uv sync` and installs this repo in editable mode)
- Run **`uv run opensre …`** from the repo root while developing — uses this checkout even if another `opensre` is on your `PATH` (for example from `install.sh`).
...
cache: {'hits': 0, 'misses': 1, 'currsize': 1, 'maxsize': 32}
```

Quality gate (run from the checkout):

```
make lint           → All checks passed!
make format-check   → 1151 files already formatted
make typecheck      → Success: no issues found in 494 source files
make test-cov       → 5420 passed, 5 skipped (3 pre-existing gemini_cli auth
                       failures unrelated to this change — verified on main)
```

Targeted run:

```
$ uv run pytest tests/cli/interactive_shell/ -q
373 passed in 1.20s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue explicitly framed this as *"mirror `docs_reference.py`"*, so the design problem was choosing where to deviate, not where to copy. The functional shape (lazy parse, in-process `OrderedDict` cache keyed by `(root, fingerprint)`, `_FP_FIELD_SEP`/`_FP_RECORD_SEP` digest discipline, paragraph-boundary `_excerpt`, public `discover_*`/`build_*_reference_text`/`get_*_cache_stats`/`invalidate_*_cache` quartet) is preserved verbatim so reviewers can diff the two modules side-by-side.

Three deliberate departures from the docs path:

1. **`os.walk` with in-place `dirnames[:]` pruning instead of `rglob("*")`.** `docs_reference.py` walks a small `docs/` tree, but here the discovery root is the repo root which contains a multi-GB `.venv`. Pruning skip-dirs at walk time (vs. filtering after) is the difference between "fast" and "unusable in dev". This is documented inline.
2. **Skip-dir set extends the spec.** Issue lists `node_modules`, `.git`, `__pycache__`, `tests/`. I added `.venv` for the same reason as point 1 — surfacing installed-package `AGENTS.md` from third-party deps would be wrong content and walking the tree is expensive. Called out in a comment so reviewers can ask me to drop it.
3. **No frontmatter stripping, no relevance ranking.** `AGENTS.md` is plain Markdown and we always want all files (not top-N for a query), so `DocPage`'s `slug`/`title`/scoring machinery has no analogue in `AgentsMdFile`. Bodies are stored verbatim — a regression test pins this so a future refactor doesn't quietly add MDX-style frontmatter handling.

The wiring choice was pure-function plumbing: `_build_system_prompt(reference, history, agents_md="")` accepts the block as an arg with an empty default, so existing call sites and tests keep working unmodified, and the new tests can drive `agents_md` directly without monkey-patching the discovery module. The `if agents_md` guard means non-editable installs (no AGENTS.md files → empty string) emit no `--- Repo map ---` header at all, instead of an empty header that would just confuse the model.

The strict-reference (`cli_help._build_grounded_prompt`) path is intentionally untouched: that surface is the docs-aware procedural assistant, and per the issue spec it must remain grounded only on `docs/` + CLI reference. A test in `test_cli_agent.py` pins the absence so a future contributor doesn't accidentally wire AGENTS.md into both surfaces.

Edge cases under test: missing root → `[]` and `""`; sorted relpath order; verbatim body preservation; per-file paragraph-boundary excerpt; total-byte cap with truncation marker; cache hit increments on repeat discover; invalidate resets all stats; **file edit re-fingerprints and refreshes content** (the regression that motivated the fingerprint-not-mtime-only design in `docs_reference.py`).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions