### PR TITLE
fix: validate interactive /model set names before persisting to .env

### DIFF
--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -21,10 +21,14 @@ def _format_supported_models(provider_models: tuple[object, ...]) -> str:
     return ", ".join(visible) if visible else "provider default"
 
 
-def _is_reasoning_model_plausible(provider_value: str, model: str) -> bool:
-    if provider_value == "anthropic":
-        return model.startswith("claude-")
-    return True
+def _is_model_supported(
+    provider_value: str, model: str, provider_models: tuple[object, ...]
+) -> bool:
+    if provider_value == "ollama":
+        # Ollama supports any local model name the daemon exposes.
+        return bool(model)
+    supported_values = {str(getattr(option, "value", "")) for option in provider_models}
+    return model in supported_values
 
 
 def _reset_runtime_llm_caches() -> None:
@@ -84,7 +88,7 @@ def switch_llm_provider(
         return False
 
     selected_model = model.strip() if model else provider.default_model
-    if selected_model and not _is_reasoning_model_plausible(provider.value, selected_model):
+    if selected_model and not _is_model_supported(provider.value, selected_model, provider.models):
         console.print(
             f"[{TERMINAL_ERROR}]unknown model for {provider.value}:[/] {escape(selected_model)}"
         )
@@ -108,6 +112,16 @@ def switch_llm_provider(
         else:
             selected_toolcall = toolcall_model.strip()
             if selected_toolcall:
+                if not _is_model_supported(provider.value, selected_toolcall, provider.models):
+                    console.print(
+                        f"[{TERMINAL_ERROR}]unknown model for {provider.value}:[/] "
+                        f"{escape(selected_toolcall)}"
+                    )
+                    console.print(
+                        "[dim]known toolcall models:[/dim] "
+                        f"{escape(_format_supported_models(provider.models))}"
+                    )
+                    return False
                 values[provider.toolcall_model_env] = selected_toolcall
 
     env_path = sync_env_values(values)

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -474,6 +474,52 @@ class TestModelCommand:
         assert not env_path.exists()
         assert session.history[-1]["ok"] is False
 
+    def test_set_unknown_reasoning_model_is_rejected_for_openai(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        console, buf = _capture()
+        dispatch_slash("/model set openai not-a-real-model-xyz", ReplSession(), console)
+
+        output = buf.getvalue()
+        assert "unknown model for openai" in output
+        assert "not-a-real-model-xyz" in output
+        assert "switched LLM provider" not in output
+        assert not env_path.exists()
+
+    def test_set_unknown_toolcall_model_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._patch_llm(monkeypatch)
+        import app.cli.wizard.env_sync as env_sync
+
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(env_sync, "PROJECT_ENV_PATH", env_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        console, buf = _capture()
+        dispatch_slash(
+            "/model set anthropic claude-opus-4-7 --toolcall-model not-a-real-model-xyz",
+            ReplSession(),
+            console,
+        )
+
+        output = buf.getvalue()
+        assert "unknown model for anthropic" in output
+        assert "not-a-real-model-xyz" in output
+        assert "switched LLM provider" not in output
+        assert not env_path.exists()
+
     def test_set_with_toolcall_flag_writes_both_env_vars(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Fixes #1518 

#### Describe the changes you have made in this PR - Fix validate interactive /model set names

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
I checked model name in provider.models.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
