### PR TITLE
fix: handle empty test category in interactive picker gracefully (#1566)

### DIFF
--- a/app/cli/tests/interactive.py
+++ b/app/cli/tests/interactive.py
@@ -246,7 +246,8 @@ def choose_interactive_item(
         search = ""
         filtered = catalog.filter(category=category, search=search)
         if not filtered:
-            raise ValueError("No tests matched the selected category.")
+            _console.print("[yellow]No tests matched the selected category. Choose another.[/]")
+            continue
 
         while True:
             try:

--- a/tests/cli/test_interactive.py
+++ b/tests/cli/test_interactive.py
@@ -62,17 +62,28 @@ def test_choose_interactive_item_prompts_when_multiple_matches_exist(monkeypatch
     assert "make:test-cov" in selected_item_ids[0]
 
 
-def test_choose_interactive_item_raises_on_empty_filter(monkeypatch) -> None:
-    catalog = Catalog(items=())
+def test_choose_interactive_item_retries_after_empty_filter(monkeypatch) -> None:
+    catalog = Catalog(
+        items=(
+            CatalogItem(
+                id="make:test-cov",
+                kind="make_target",
+                display_name="Coverage Suite",
+                description="Run the coverage suite.",
+                command=("make", "test-cov"),
+                tags=("ci-safe",),
+            ),
+        )
+    )
 
-    monkeypatch.setattr(interactive, "_choose_category", lambda: "rca")
+    category_choices = iter(["rca", "ci-safe"])
 
-    try:
-        interactive.choose_interactive_item(catalog)
-    except ValueError as exc:
-        assert "No tests matched the selected category." in str(exc)
-    else:
-        raise AssertionError("Expected choose_interactive_item to reject empty categories")
+    monkeypatch.setattr(interactive, "_choose_category", lambda: next(category_choices))
+
+    item, auto_selected = interactive.choose_interactive_item(catalog)
+
+    assert item.id == "make:test-cov"
+    assert auto_selected is True
 
 
 def test_choose_interactive_item_reselects_category_after_escape(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #1566

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
- `app/cli/tests/interactive.py`: In choose_interactive_item(), replaced raise ValueError(...) with a _console.print warning + continue so the user can pick another category instead of crashing.
- `tests/cli/test_interactive.py`: Replaced test_choose_interactive_item_raises_on_empty_filter with test_choose_interactive_item_retries_after_empty_filter, which verifies the function loops back after an empty filter and succeeds on the second category pick.
### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Before (crash)
```
$ opensre tests
? Choose a test category: RCA
ValueError: No tests matched the selected category.
```

After (recovery)
```
$ opensre tests
? Choose a test category: RCA
No tests matched the selected category. Choose another.
? Choose a test category: CI-safe
? Run this test? ...
```
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
- What problem does your code solve? The opensre tests interactive picker crashes with an unhandled ValueError when the user selects a test category that has no matching entries in the catalog. The exception propagates because run_interactive_picker only catches KeyboardInterrupt and commands/tests.py only catches RuntimeError.
- What alternative approaches did you consider? I considered catching the ValueError upstream in run_interactive_picker or commands/tests.py, but that would be a band-aid. The choose_interactive_item function already has a while True outer loop designed for category reselection (the _GoBack exception from the inner loop already breaks to it), so the right fix was to use that existing loop rather than raising.
- Why did you choose this specific implementation? A single-line change from raise ValueError(...) to _console.print(...) + continue is minimal, consistent with the existing [yellow] warning style used elsewhere in the file, and reuses the outer loop that was already there for this purpose.
- What are the key functions/components and what do they do? choose_interactive_item() runs a two-level loop: outer for category selection, inner for item selection. The outer loop was designed to let users try different categories, but the ValueError bypassed it. The fix makes the outer loop functional as intended.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
