### PR TITLE
fix(synthetic-tests): skip E2E tests gracefully when LLM credentials are missing

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ These are public endpoints and issuer URLs, not secrets.
 import os
 from difflib import get_close_matches
 from enum import Enum
-from typing import Final, Literal
+from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
 
@@ -135,31 +135,6 @@ LLMProvider = Literal[
     "kimi",
 ]
 
-# ollama: local; bedrock: IAM; CLI providers: auth outside OPENAI-style env keys.
-LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV: Final[frozenset[str]] = frozenset(
-    {
-        "ollama",
-        "bedrock",
-        "codex",
-        "cursor",
-        "claude-code",
-        "gemini-cli",
-        "opencode",
-        "kimi",
-    }
-)
-
-# Hosted / API-key providers: env var names must stay aligned with from_env() and resolve_llm_api_key.
-LLM_PROVIDER_KEY_ENV: Final[dict[str, str]] = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "openai": "OPENAI_API_KEY",
-    "openrouter": "OPENROUTER_API_KEY",
-    "requesty": "REQUESTY_API_KEY",
-    "gemini": "GEMINI_API_KEY",
-    "nvidia": "NVIDIA_API_KEY",
-    "minimax": "MINIMAX_API_KEY",
-}
-
 
 class LLMSettings(StrictConfigModel):
     """Strict runtime configuration for selecting and authenticating an LLM provider."""
@@ -226,8 +201,17 @@ class LLMSettings(StrictConfigModel):
 
     @model_validator(mode="after")
     def _require_api_key_for_selected_provider(self) -> "LLMSettings":
-        if self.provider in LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV:
-            return self
+        if self.provider in (
+            "ollama",
+            "bedrock",
+            "codex",
+            "cursor",
+            "claude-code",
+            "gemini-cli",
+            "opencode",
+            "kimi",
+        ):
+            return self  # ollama: local; bedrock: IAM; CLI providers: vendor auth
         provider_to_key = {
             "anthropic": self.anthropic_api_key,
             "openai": self.openai_api_key,
@@ -240,7 +224,15 @@ class LLMSettings(StrictConfigModel):
         if provider_to_key[self.provider]:
             return self
 
-        env_var = LLM_PROVIDER_KEY_ENV[self.provider]
+        env_var = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "openrouter": "OPENROUTER_API_KEY",
+            "requesty": "REQUESTY_API_KEY",
+            "gemini": "GEMINI_API_KEY",
+            "nvidia": "NVIDIA_API_KEY",
+            "minimax": "MINIMAX_API_KEY",
+        }[self.provider]
         raise ValueError(f"LLM provider '{self.provider}' requires {env_var} to be set.")
 
     @classmethod

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ from difflib import get_close_matches
 from enum import Enum
 from typing import Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 
 from app.llm_credentials import resolve_llm_api_key
 from app.strict_config import StrictConfigModel
@@ -329,6 +329,42 @@ class LLMSettings(StrictConfigModel):
                 "max_tokens": os.getenv("LLM_MAX_TOKENS", str(DEFAULT_MAX_TOKENS)),
             }
         )
+
+
+def _is_only_missing_llm_api_key_validation(exc: ValidationError) -> bool:
+    """True when the only failure is LLMSettings' missing-key model validator."""
+    errors = exc.errors()
+    if len(errors) != 1:
+        return False
+    err = errors[0]
+    if err.get("type") != "value_error":
+        return False
+    if err.get("loc") != ():
+        return False
+    msg = str(err.get("msg", ""))
+    return (
+        "LLM provider" in msg
+        and "requires" in msg
+        and "API_KEY" in msg
+        and "to be set" in msg
+    )
+
+
+def has_credentials_for_active_llm_provider() -> bool:
+    """Return True when :meth:`LLMSettings.from_env` succeeds.
+
+    Runs full LLM env validation (provider, model names, ``LLM_MAX_TOKENS``, keys via
+    :func:`resolve_llm_api_key`, etc.). Callers such as synthetic tests skip only when
+    validation fails *solely* because the active provider's API key is absent; any other
+    misconfiguration is re-raised so the run fails loudly.
+    """
+    try:
+        LLMSettings.from_env()
+        return True
+    except ValidationError as exc:
+        if _is_only_missing_llm_api_key_validation(exc):
+            return False
+        raise
 
 
 # LLM Provider Configs

--- a/app/config.py
+++ b/app/config.py
@@ -342,12 +342,7 @@ def _is_only_missing_llm_api_key_validation(exc: ValidationError) -> bool:
     if err.get("loc") != ():
         return False
     msg = str(err.get("msg", ""))
-    return (
-        "LLM provider" in msg
-        and "requires" in msg
-        and "API_KEY" in msg
-        and "to be set" in msg
-    )
+    return "LLM provider" in msg and "requires" in msg and "API_KEY" in msg and "to be set" in msg
 
 
 def has_credentials_for_active_llm_provider() -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ These are public endpoints and issuer URLs, not secrets.
 import os
 from difflib import get_close_matches
 from enum import Enum
-from typing import Literal
+from typing import Final, Literal
 
 from pydantic import Field, field_validator, model_validator
 
@@ -135,6 +135,31 @@ LLMProvider = Literal[
     "kimi",
 ]
 
+# ollama: local; bedrock: IAM; CLI providers: auth outside OPENAI-style env keys.
+LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV: Final[frozenset[str]] = frozenset(
+    {
+        "ollama",
+        "bedrock",
+        "codex",
+        "cursor",
+        "claude-code",
+        "gemini-cli",
+        "opencode",
+        "kimi",
+    }
+)
+
+# Hosted / API-key providers: env var names must stay aligned with from_env() and resolve_llm_api_key.
+LLM_PROVIDER_KEY_ENV: Final[dict[str, str]] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "requesty": "REQUESTY_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "nvidia": "NVIDIA_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
+}
+
 
 class LLMSettings(StrictConfigModel):
     """Strict runtime configuration for selecting and authenticating an LLM provider."""
@@ -201,17 +226,8 @@ class LLMSettings(StrictConfigModel):
 
     @model_validator(mode="after")
     def _require_api_key_for_selected_provider(self) -> "LLMSettings":
-        if self.provider in (
-            "ollama",
-            "bedrock",
-            "codex",
-            "cursor",
-            "claude-code",
-            "gemini-cli",
-            "opencode",
-            "kimi",
-        ):
-            return self  # ollama: local; bedrock: IAM; CLI providers: vendor auth
+        if self.provider in LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV:
+            return self
         provider_to_key = {
             "anthropic": self.anthropic_api_key,
             "openai": self.openai_api_key,
@@ -224,15 +240,7 @@ class LLMSettings(StrictConfigModel):
         if provider_to_key[self.provider]:
             return self
 
-        env_var = {
-            "anthropic": "ANTHROPIC_API_KEY",
-            "openai": "OPENAI_API_KEY",
-            "openrouter": "OPENROUTER_API_KEY",
-            "requesty": "REQUESTY_API_KEY",
-            "gemini": "GEMINI_API_KEY",
-            "nvidia": "NVIDIA_API_KEY",
-            "minimax": "MINIMAX_API_KEY",
-        }[self.provider]
+        env_var = LLM_PROVIDER_KEY_ENV[self.provider]
         raise ValueError(f"LLM provider '{self.provider}' requires {env_var} to be set.")
 
     @classmethod

--- a/app/llm_credentials.py
+++ b/app/llm_credentials.py
@@ -9,7 +9,6 @@ from typing import Final
 
 import keyring  # type: ignore[import-not-found,import-untyped]
 import keyring.errors  # type: ignore[import-not-found,import-untyped]
-from pydantic import ValidationError
 
 _KEYRING_SERVICE: Final = "opensre.llm"
 _DISABLED_VALUES: Final = frozenset({"1", "true", "yes", "on"})
@@ -35,39 +34,6 @@ def resolve_llm_api_key(env_var: str) -> str:
 def has_llm_api_key(env_var: str) -> bool:
     """Return True when an API key is available from env or secure local storage."""
     return bool(resolve_llm_api_key(env_var))
-
-
-def _is_only_missing_llm_api_key_validation(exc: ValidationError) -> bool:
-    """True when the only failure is LLMSettings' missing-key model validator."""
-    errors = exc.errors()
-    if len(errors) != 1:
-        return False
-    err = errors[0]
-    if err.get("type") != "value_error":
-        return False
-    if err.get("loc") != ():
-        return False
-    msg = str(err.get("msg", ""))
-    return "LLM provider" in msg and "requires" in msg and "API_KEY" in msg and "to be set" in msg
-
-
-def has_credentials_for_active_llm_provider() -> bool:
-    """Return True when :meth:`app.config.LLMSettings.from_env` succeeds.
-
-    Runs full LLM env validation (provider, model names, ``LLM_MAX_TOKENS``, keys via
-    :func:`resolve_llm_api_key`, etc.). Callers such as synthetic tests skip only when
-    validation fails *solely* because the active provider's API key is absent; any other
-    misconfiguration is re-raised so the run fails loudly.
-    """
-    from app.config import LLMSettings
-
-    try:
-        LLMSettings.from_env()
-        return True
-    except ValidationError as exc:
-        if _is_only_missing_llm_api_key_validation(exc):
-            return False
-        raise
 
 
 def _keyring_backend_name() -> str:

--- a/app/llm_credentials.py
+++ b/app/llm_credentials.py
@@ -9,6 +9,7 @@ from typing import Final
 
 import keyring  # type: ignore[import-not-found,import-untyped]
 import keyring.errors  # type: ignore[import-not-found,import-untyped]
+from pydantic import ValidationError
 
 _KEYRING_SERVICE: Final = "opensre.llm"
 _DISABLED_VALUES: Final = frozenset({"1", "true", "yes", "on"})
@@ -34,6 +35,39 @@ def resolve_llm_api_key(env_var: str) -> str:
 def has_llm_api_key(env_var: str) -> bool:
     """Return True when an API key is available from env or secure local storage."""
     return bool(resolve_llm_api_key(env_var))
+
+
+def _is_only_missing_llm_api_key_validation(exc: ValidationError) -> bool:
+    """True when the only failure is LLMSettings' missing-key model validator."""
+    errors = exc.errors()
+    if len(errors) != 1:
+        return False
+    err = errors[0]
+    if err.get("type") != "value_error":
+        return False
+    if err.get("loc") != ():
+        return False
+    msg = str(err.get("msg", ""))
+    return "LLM provider" in msg and "requires" in msg and "API_KEY" in msg and "to be set" in msg
+
+
+def has_credentials_for_active_llm_provider() -> bool:
+    """Return True when :meth:`app.config.LLMSettings.from_env` succeeds.
+
+    Runs full LLM env validation (provider, model names, ``LLM_MAX_TOKENS``, keys via
+    :func:`resolve_llm_api_key`, etc.). Callers such as synthetic tests skip only when
+    validation fails *solely* because the active provider's API key is absent; any other
+    misconfiguration is re-raised so the run fails loudly.
+    """
+    from app.config import LLMSettings
+
+    try:
+        LLMSettings.from_env()
+        return True
+    except ValidationError as exc:
+        if _is_only_missing_llm_api_key_validation(exc):
+            return False
+        raise
 
 
 def _keyring_backend_name() -> str:

--- a/tests/synthetic/eks/test_suite.py
+++ b/tests/synthetic/eks/test_suite.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.llm_credentials import has_llm_api_key
+from app.llm_credentials import has_credentials_for_active_llm_provider
 from app.nodes.plan_actions.node import InvestigationPlan
 from tests.synthetic.eks.run_suite import run_scenario, score_result
 from tests.synthetic.eks.scenario_loader import (
@@ -19,48 +19,12 @@ from tests.synthetic.k8s_schemas import VALID_K8S_EVIDENCE_SOURCES
 from tests.synthetic.mock_datadog_backend.backend import FixtureDatadogBackend
 from tests.synthetic.mock_eks_backend.backend import FixtureEKSBackend
 
-# Providers that authenticate via local/IAM mechanisms and don't need an API key env var.
-# Must match the no-key providers in LLMSettings._require_api_key_for_selected_provider().
-_NO_KEY_PROVIDERS = frozenset(
-    {"ollama", "bedrock", "codex", "cursor", "claude-code", "gemini-cli", "opencode", "kimi"}
+# Synthetic E2E uses fixture EKS/Datadog backends; many tool "calls" hit mocks, not real APIs.
+# This gate only reflects whether the *LLM* can authenticate (the reason we skip when keys are absent).
+_SYNTHETIC_SKIP_LLM = (
+    "SKIPPED: missing API key for LLM_PROVIDER "
+    "(suite uses mock EKS/Datadog backends; configure the key for your selected provider)"
 )
-
-# Maps cloud-based providers to the env var they require.
-# Must match the provider_to_key mapping in LLMSettings._require_api_key_for_selected_provider().
-_PROVIDER_KEY_ENV_VAR: dict[str, str] = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "openai": "OPENAI_API_KEY",
-    "openrouter": "OPENROUTER_API_KEY",
-    "requesty": "REQUESTY_API_KEY",
-    "gemini": "GEMINI_API_KEY",
-    "nvidia": "NVIDIA_API_KEY",
-    "minimax": "MINIMAX_API_KEY",
-}
-
-
-def _llm_credentials_available() -> bool:
-    """Return True when the active LLM provider's credentials are configured.
-
-    Only returns False (triggering a skip) when the provider is recognized and
-    its required API key is genuinely absent.  Invalid provider names or other
-    config errors are *not* caught here so they still surface as hard failures.
-    """
-    import os
-
-    provider = (os.getenv("LLM_PROVIDER") or "anthropic").strip().lower() or "anthropic"
-
-    if provider in _NO_KEY_PROVIDERS:
-        return True
-
-    env_var = _PROVIDER_KEY_ENV_VAR.get(provider)
-    if env_var is None:
-        # Unknown provider — let the test run and fail loudly with a real error.
-        return True
-
-    return has_llm_api_key(env_var)
-
-
-_SKIP_REASON = "SKIPPED: Requires LLM provider credentials"
 
 # ---------------------------------------------------------------------------
 # Loader and fixture validation
@@ -388,8 +352,8 @@ def _should_assert_trajectory(fixture, actual_category: str) -> bool:
 
 def _run_scenario_test(fixture) -> None:
     """Run scenario with real LLM and mock backends, then assert scoring."""
-    if not _llm_credentials_available():
-        pytest.skip(_SKIP_REASON)
+    if not has_credentials_for_active_llm_provider():
+        pytest.skip(_SYNTHETIC_SKIP_LLM)
 
     failures: list[str] = []
     for attempt in range(1, _LLM_ATTEMPTS + 1):

--- a/tests/synthetic/eks/test_suite.py
+++ b/tests/synthetic/eks/test_suite.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.llm_credentials import has_credentials_for_active_llm_provider
+from app.config import has_credentials_for_active_llm_provider
 from app.nodes.plan_actions.node import InvestigationPlan
 from tests.synthetic.eks.run_suite import run_scenario, score_result
 from tests.synthetic.eks.scenario_loader import (

--- a/tests/synthetic/eks/test_suite.py
+++ b/tests/synthetic/eks/test_suite.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from app.llm_credentials import has_llm_api_key
 from app.nodes.plan_actions.node import InvestigationPlan
 from tests.synthetic.eks.run_suite import run_scenario, score_result
 from tests.synthetic.eks.scenario_loader import (
@@ -17,6 +18,49 @@ from tests.synthetic.eks.scenario_loader import (
 from tests.synthetic.k8s_schemas import VALID_K8S_EVIDENCE_SOURCES
 from tests.synthetic.mock_datadog_backend.backend import FixtureDatadogBackend
 from tests.synthetic.mock_eks_backend.backend import FixtureEKSBackend
+
+# Providers that authenticate via local/IAM mechanisms and don't need an API key env var.
+# Must match the no-key providers in LLMSettings._require_api_key_for_selected_provider().
+_NO_KEY_PROVIDERS = frozenset(
+    {"ollama", "bedrock", "codex", "cursor", "claude-code", "gemini-cli", "opencode", "kimi"}
+)
+
+# Maps cloud-based providers to the env var they require.
+# Must match the provider_to_key mapping in LLMSettings._require_api_key_for_selected_provider().
+_PROVIDER_KEY_ENV_VAR: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "requesty": "REQUESTY_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "nvidia": "NVIDIA_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
+}
+
+
+def _llm_credentials_available() -> bool:
+    """Return True when the active LLM provider's credentials are configured.
+
+    Only returns False (triggering a skip) when the provider is recognized and
+    its required API key is genuinely absent.  Invalid provider names or other
+    config errors are *not* caught here so they still surface as hard failures.
+    """
+    import os
+
+    provider = (os.getenv("LLM_PROVIDER") or "anthropic").strip().lower() or "anthropic"
+
+    if provider in _NO_KEY_PROVIDERS:
+        return True
+
+    env_var = _PROVIDER_KEY_ENV_VAR.get(provider)
+    if env_var is None:
+        # Unknown provider — let the test run and fail loudly with a real error.
+        return True
+
+    return has_llm_api_key(env_var)
+
+
+_SKIP_REASON = "SKIPPED: Requires LLM provider credentials"
 
 # ---------------------------------------------------------------------------
 # Loader and fixture validation
@@ -269,6 +313,7 @@ class TestHarnessEndToEnd:
         # environment.  A dummy value is enough here because every LLM call in
         # the pipeline is either mocked (plan_actions) or bypassed entirely by
         # the healthy short-circuit (diagnose_root_cause).
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-dummy")
         monkeypatch.setenv("HEALTHY_SHORT_CIRCUIT", "true")
 
@@ -343,6 +388,9 @@ def _should_assert_trajectory(fixture, actual_category: str) -> bool:
 
 def _run_scenario_test(fixture) -> None:
     """Run scenario with real LLM and mock backends, then assert scoring."""
+    if not _llm_credentials_available():
+        pytest.skip(_SKIP_REASON)
+
     failures: list[str] = []
     for attempt in range(1, _LLM_ATTEMPTS + 1):
         final_state, score = run_scenario(fixture, use_mock_backends=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-from typing import get_args
-
 import pytest
 from pydantic import ValidationError
 
-from app.config import (
-    LLM_PROVIDER_KEY_ENV,
-    LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV,
-    LLMProvider,
-    LLMSettings,
-)
+from app.config import LLMSettings
 from app.llm_credentials import has_credentials_for_active_llm_provider
 
 
@@ -126,12 +119,6 @@ def test_llm_settings_from_env_gemini_cli_without_api_key(monkeypatch) -> None:
     settings = LLMSettings.from_env()
 
     assert settings.provider == "gemini-cli"
-
-
-def test_llm_provider_key_registry_is_exhaustive() -> None:
-    all_providers = frozenset(get_args(LLMProvider))
-    assert not (frozenset(LLM_PROVIDER_KEY_ENV) & LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV)
-    assert frozenset(LLM_PROVIDER_KEY_ENV) | LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV == all_providers
 
 
 def test_has_credentials_for_active_llm_provider_missing_key(monkeypatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import pytest
 from pydantic import ValidationError
 
-from app.config import LLMSettings
+from app.config import (
+    LLM_PROVIDER_KEY_ENV,
+    LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV,
+    LLMProvider,
+    LLMSettings,
+)
+from app.llm_credentials import has_credentials_for_active_llm_provider
 
 
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:
@@ -118,3 +126,56 @@ def test_llm_settings_from_env_gemini_cli_without_api_key(monkeypatch) -> None:
     settings = LLMSettings.from_env()
 
     assert settings.provider == "gemini-cli"
+
+
+def test_llm_provider_key_registry_is_exhaustive() -> None:
+    all_providers = frozenset(get_args(LLMProvider))
+    assert not (frozenset(LLM_PROVIDER_KEY_ENV) & LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV)
+    assert frozenset(LLM_PROVIDER_KEY_ENV) | LLM_PROVIDERS_WITHOUT_REQUIRED_KEY_ENV == all_providers
+
+
+def test_has_credentials_for_active_llm_provider_missing_key(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
+
+    assert has_credentials_for_active_llm_provider() is False
+
+
+def test_has_credentials_for_active_llm_provider_with_key(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "sk-x" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    assert has_credentials_for_active_llm_provider() is True
+
+
+def test_has_credentials_for_active_llm_provider_ollama_never_requires_key(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
+
+    assert has_credentials_for_active_llm_provider() is True
+
+
+def test_has_credentials_for_active_llm_provider_re_raises_non_key_validation_errors(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "0")
+    monkeypatch.setattr(
+        "app.config.resolve_llm_api_key",
+        lambda env_var: "sk" if env_var == "OPENAI_API_KEY" else "",
+    )
+
+    with pytest.raises(ValidationError, match="greater than 0"):
+        has_credentials_for_active_llm_provider()
+
+
+def test_has_credentials_for_active_llm_provider_re_raises_invalid_provider(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _: "")
+
+    with pytest.raises(ValidationError, match="Unsupported LLM provider"):
+        has_credentials_for_active_llm_provider()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from app.config import LLMSettings
-from app.llm_credentials import has_credentials_for_active_llm_provider
+from app.config import LLMSettings, has_credentials_for_active_llm_provider
 
 
 def test_llm_settings_reject_provider_typos_with_suggestion() -> None:


### PR DESCRIPTION
Fixes #1349

#### Describe the changes

Skip E2E synthetic tests gracefully when LLM credentials are not configured, rather than crashing with a `ValidationError`.

- Add `_llm_credentials_available()` helper that detects missing API keys
- Skip parametrized level tests with a clear skip message instead of failing
- Fix `TestHarnessEndToEnd` to explicitly set `LLM_PROVIDER=anthropic` so it works regardless of `.env` contents


## Before
Tests crash with a raw ValidationError when LLM keys are missing:
<paste the error traceback from the issue>

## After
Tests skip gracefully with a clear message:
<screenshot of the terminal output above>

### What was changed
- Added `_llm_credentials_available()` check that detects missing API keys upfront
- Parametrized level tests now `pytest.skip()` with a descriptive reason
- Fixed `TestHarnessEndToEnd` to explicitly set `LLM_PROVIDER` so it works regardless of `.env` contents

### Screenshot 
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/5d3e7f82-b47a-4e61-b20f-45a28f26e452" />

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/ff195739-4204-420f-81bb-66fd345d240f" />




---

