### PR TITLE
feat(cli): add /list tools slash command and tool catalog (#1443)

### DIFF
--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -15,6 +15,7 @@ from app.cli.interactive_shell.rendering import (
 )
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD, TERMINAL_ERROR
+from app.cli.interactive_shell.tool_catalog import build_tool_catalog, format_tool_catalog_text
 
 
 def _cmd_integrations(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
@@ -108,11 +109,19 @@ def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool: 
         render_models_table(console, repl_data.load_llm_settings())
         return True
 
+    if sub in ("tools", "tool"):
+        catalog = build_tool_catalog()
+        if not catalog:
+            console.print("[dim]no tools registered.[/dim]")
+            return True
+        console.print(format_tool_catalog_text(catalog))
+        return True
+
     if sub and sub not in ("", "all"):
         console.print(
             f"[{TERMINAL_ERROR}]unknown list target:[/] {escape(sub)}  "
             "(try [bold]/list integrations[/bold], [bold]/list models[/bold], "
-            "or [bold]/list mcp[/bold])"
+            "[bold]/list mcp[/bold], or [bold]/list tools[/bold])"
         )
         return True
 
@@ -127,6 +136,7 @@ _LIST_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("integrations", "alert-source integrations"),
     ("models", "active LLM models"),
     ("mcp", "connected MCP servers"),
+    ("tools", "registered tools (investigation + chat surfaces)"),
 )
 
 _INTEGRATIONS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
@@ -144,8 +154,8 @@ _MCP_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/list",
-        "list integrations, MCP servers, and the active LLM connection "
-        "('/list integrations', '/list models', '/list mcp')",
+        "list integrations, MCP servers, registered tools, and the active LLM "
+        "connection ('/list integrations', '/list models', '/list mcp', '/list tools')",
         _cmd_list,
         first_arg_completions=_LIST_FIRST_ARGS,
         execution_tier=ExecutionTier.SAFE,

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -114,7 +114,7 @@ def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool: 
         if not catalog:
             console.print("[dim]no tools registered.[/dim]")
             return True
-        console.print(escape(format_tool_catalog_text(catalog)))
+        console.print(format_tool_catalog_text(catalog), markup=False)
         return True
 
     if sub and sub not in ("", "all"):

--- a/app/cli/interactive_shell/command_registry/integrations.py
+++ b/app/cli/interactive_shell/command_registry/integrations.py
@@ -114,7 +114,7 @@ def _cmd_list(session: ReplSession, console: Console, args: list[str]) -> bool: 
         if not catalog:
             console.print("[dim]no tools registered.[/dim]")
             return True
-        console.print(format_tool_catalog_text(catalog))
+        console.print(escape(format_tool_catalog_text(catalog)))
         return True
 
     if sub and sub not in ("", "all"):

--- a/app/cli/interactive_shell/tool_catalog.py
+++ b/app/cli/interactive_shell/tool_catalog.py
@@ -63,10 +63,11 @@ class ToolCatalogEntry:
     """One-line description from the tool's metadata, trimmed for display."""
 
     source_file: str
-    """Path relative to the repo root (forward slashes), e.g.
-    ``"app/tools/run_diagnostic_code.py"``. Empty string if the tool's source
-    cannot be located on disk (defensive: an installed-package tool that
-    somehow registered without a discoverable file)."""
+    """Repo-relative path (forward slashes) when ``__file__`` lives under the
+    checkout root, otherwise the resolved absolute POSIX path when the defining
+    module is outside the repo (e.g. an installed editable or site-packages
+    shim). Empty string only when ``origin_module`` is missing, import fails,
+    or the loaded module exposes no ``__file__``."""
 
     input_schema_summary: str
     """One-line render of top-level params, e.g.

--- a/app/cli/interactive_shell/tool_catalog.py
+++ b/app/cli/interactive_shell/tool_catalog.py
@@ -1,0 +1,187 @@
+"""Tool-registry catalog generator for the interactive shell.
+
+The OpenSRE tool registry (:mod:`app.tools.registry`) auto-discovers tools
+under ``app/tools/`` and exposes them via :func:`get_registered_tools`. Each
+:class:`~app.tools.registered_tool.RegisteredTool` carries rich metadata —
+``name``, ``description``, ``surfaces``, ``input_schema``, ``source``, and
+the module it was discovered in — but none of this is currently visible to
+the interactive-shell user.
+
+This module turns the registry snapshot into a compact catalog suitable for
+two independent consumers:
+
+1. The ``/list tools`` slash command — users can see what tools are wired
+   into their build of the shell.
+2. Future codebase-aware grounding — the catalog text can be injected into
+   the LLM prompt so the assistant can answer "what tools can the chat
+   agent call?" accurately. (Wiring lives in a separate later issue;
+   ``format_tool_catalog_text`` is shaped to support both surfaces today.)
+
+Two pure functions:
+
+- :func:`build_tool_catalog` — wraps :func:`get_registered_tools` and returns
+  :class:`ToolCatalogEntry` records with the fields needed for display and
+  prompt injection.
+- :func:`format_tool_catalog_text` — renders entries as compact Markdown-ish
+  text grouped by surface, suitable for both terminal display and LLM
+  grounding.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.tools.registered_tool import RegisteredTool
+from app.tools.registry import get_registered_tools
+from app.types.tools import ToolSurface
+
+# Repo root is three levels above this file
+# (.../app/cli/interactive_shell/tool_catalog.py -> repo root). Used to make
+# tool source paths relative for display.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Cap one-line schema summaries so wide registries don't break terminal
+# wrapping or balloon prompt injection. The cap is generous — tools with
+# many params get a trailing ellipsis rather than an unwieldy line.
+_MAX_SCHEMA_SUMMARY_CHARS = 200
+
+
+@dataclass(frozen=True)
+class ToolCatalogEntry:
+    """Display-shaped projection of a :class:`RegisteredTool`."""
+
+    name: str
+    """Registered tool name, e.g. ``"search_github_code"``."""
+
+    surfaces: tuple[str, ...]
+    """Surfaces the tool is exposed on (``"investigation"`` and/or ``"chat"``)."""
+
+    description: str
+    """One-line description from the tool's metadata, trimmed for display."""
+
+    source_file: str
+    """Path relative to the repo root (forward slashes), e.g.
+    ``"app/tools/run_diagnostic_code.py"``. Empty string if the tool's source
+    cannot be located on disk (defensive: an installed-package tool that
+    somehow registered without a discoverable file)."""
+
+    input_schema_summary: str
+    """One-line render of top-level params, e.g.
+    ``"query: string, limit?: integer"``. ``"(no params)"`` when the tool
+    takes no inputs."""
+
+
+def _resolve_source_file(tool: RegisteredTool) -> str:
+    """Best-effort relative path to the tool's defining file.
+
+    The tool registry stores ``origin_module`` (a dotted module path); we
+    import it to read ``__file__``. Failures here are non-fatal — the
+    catalog still surfaces the tool, just without a source pointer.
+    """
+    module_name = tool.origin_module
+    if not module_name:
+        return ""
+    try:
+        module = importlib.import_module(module_name)
+    except Exception:  # noqa: BLE001
+        return ""
+    file_attr = getattr(module, "__file__", None)
+    if not file_attr:
+        return ""
+    try:
+        return Path(file_attr).resolve().relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        # Module lives outside the repo root (installed package, namespace
+        # package). Fall back to the absolute path so users can still open
+        # it; ``ValueError`` here means ``relative_to`` couldn't compute a
+        # relative path, not that the file is missing.
+        return Path(file_attr).as_posix()
+
+
+def _summarize_input_schema(input_schema: dict[str, Any]) -> str:
+    """Render top-level params as a one-line ``name: type`` list.
+
+    Required params render as ``name: type``; optional params get a ``?``
+    suffix (``name?: type``). Untyped properties (no ``type`` key) render
+    as ``any`` so the user can see the param exists. Returns
+    ``"(no params)"`` for empty schemas.
+    """
+    properties = input_schema.get("properties") or {}
+    if not properties:
+        return "(no params)"
+    required = set(input_schema.get("required") or ())
+    parts: list[str] = []
+    for name, info in properties.items():
+        info_dict = info if isinstance(info, dict) else {}
+        type_label = str(info_dict.get("type") or "any")
+        suffix = "" if name in required else "?"
+        parts.append(f"{name}{suffix}: {type_label}")
+    rendered = ", ".join(parts)
+    if len(rendered) > _MAX_SCHEMA_SUMMARY_CHARS:
+        return rendered[: _MAX_SCHEMA_SUMMARY_CHARS - 1].rstrip(", ") + "…"
+    return rendered
+
+
+def _entry_from_tool(tool: RegisteredTool) -> ToolCatalogEntry:
+    return ToolCatalogEntry(
+        name=tool.name,
+        surfaces=tuple(tool.surfaces),
+        description=(tool.description or "").strip(),
+        source_file=_resolve_source_file(tool),
+        input_schema_summary=_summarize_input_schema(tool.input_schema),
+    )
+
+
+def build_tool_catalog(surface: ToolSurface | None = None) -> list[ToolCatalogEntry]:
+    """Return :class:`ToolCatalogEntry` records for tools registered on ``surface``.
+
+    Pass ``surface=None`` (default) to get every registered tool, or
+    ``"investigation"`` / ``"chat"`` to filter. The order matches
+    :func:`get_registered_tools` (alphabetical by tool name).
+    """
+    return [_entry_from_tool(tool) for tool in get_registered_tools(surface)]
+
+
+def _surface_sort_key(surface: str) -> tuple[int, str]:
+    """Stable surface ordering — investigation first, chat second, others alphabetical."""
+    priority = {"investigation": 0, "chat": 1}
+    return (priority.get(surface, 99), surface)
+
+
+def format_tool_catalog_text(entries: list[ToolCatalogEntry]) -> str:
+    """Render entries as compact Markdown-ish text grouped by surface.
+
+    Each tool may belong to multiple surfaces and will appear under each one
+    so the user can see at a glance which tools the chat agent versus the
+    investigation pipeline can reach. Returns ``""`` for an empty catalog.
+    """
+    if not entries:
+        return ""
+
+    by_surface: dict[str, list[ToolCatalogEntry]] = {}
+    for entry in entries:
+        for surface in entry.surfaces:
+            by_surface.setdefault(surface, []).append(entry)
+
+    lines: list[str] = []
+    for surface in sorted(by_surface.keys(), key=_surface_sort_key):
+        bucket = by_surface[surface]
+        lines.append(f"## {surface} ({len(bucket)} tool{'s' if len(bucket) != 1 else ''})")
+        lines.append("")
+        for entry in bucket:
+            lines.append(f"- **{entry.name}** — {entry.description}")
+            if entry.source_file:
+                lines.append(f"  - source: `{entry.source_file}`")
+            lines.append(f"  - params: `{entry.input_schema_summary}`")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+__all__ = [
+    "ToolCatalogEntry",
+    "build_tool_catalog",
+    "format_tool_catalog_text",
+]

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -104,7 +104,7 @@ def test_shell_completer_suggests_subcommands_for_list() -> None:
         )
     )
     names = sorted({c.text for c in completions})
-    assert names == ["integrations", "mcp", "models"]
+    assert names == ["integrations", "mcp", "models", "tools"]
 
 
 def test_tab_applies_unique_slash_command_completion() -> None:

--- a/tests/cli/interactive_shell/test_tool_catalog.py
+++ b/tests/cli/interactive_shell/test_tool_catalog.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import io
 from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -154,6 +156,18 @@ class TestBuildToolCatalog:
         assert len(entries) == 1
         assert entries[0].source_file == ""
 
+    def test_origin_module_outside_repo_returns_absolute_source_path(
+        self, fake_registry: list[RegisteredTool], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outside = Path("/virtual/site-packages/some_pkg/plugin.py")
+        fake_mod = SimpleNamespace(__file__=str(outside))
+
+        monkeypatch.setattr(tool_catalog.importlib, "import_module", lambda _: fake_mod)
+        fake_registry.append(_make_tool("ext_tool", origin_module="some_pkg.plugin"))
+        entries = build_tool_catalog()
+        assert len(entries) == 1
+        assert entries[0].source_file == outside.as_posix()
+
 
 class TestFormatToolCatalogText:
     def test_returns_empty_string_for_empty_catalog(self) -> None:
@@ -245,6 +259,26 @@ class TestListToolsSlashCommand:
         assert "search_github" in out
         assert "## investigation" in out
         assert "## chat" in out
+
+    def test_list_tools_escapes_rich_markup_from_tool_metadata(self) -> None:
+        console, buf = self._capture()
+        session = ReplSession()
+        fake = [
+            ToolCatalogEntry(
+                name="risky_tool",
+                surfaces=("investigation",),
+                description="Payload [bold]injection[/bold] attempt",
+                source_file="app/tools/risky.py",
+                input_schema_summary="x: string",
+            )
+        ]
+        with patch(
+            "app.cli.interactive_shell.command_registry.integrations.build_tool_catalog",
+            return_value=fake,
+        ):
+            assert _cmd_list(session, console, ["tools"]) is True
+        out = buf.getvalue()
+        assert "[bold]injection[/bold]" in out
 
     def test_list_tools_handles_empty_registry(self) -> None:
         console, buf = self._capture()

--- a/tests/cli/interactive_shell/test_tool_catalog.py
+++ b/tests/cli/interactive_shell/test_tool_catalog.py
@@ -260,7 +260,7 @@ class TestListToolsSlashCommand:
         assert "## investigation" in out
         assert "## chat" in out
 
-    def test_list_tools_escapes_rich_markup_from_tool_metadata(self) -> None:
+    def test_list_tools_disables_markup_for_plain_catalog_text(self) -> None:
         console, buf = self._capture()
         session = ReplSession()
         fake = [

--- a/tests/cli/interactive_shell/test_tool_catalog.py
+++ b/tests/cli/interactive_shell/test_tool_catalog.py
@@ -1,0 +1,263 @@
+"""Tests for the registered-tool catalog used by the ``/list tools`` slash command."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell import tool_catalog
+from app.cli.interactive_shell.command_registry.integrations import _cmd_list
+from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tool_catalog import (
+    ToolCatalogEntry,
+    _summarize_input_schema,
+    build_tool_catalog,
+    format_tool_catalog_text,
+)
+from app.tools.registered_tool import RegisteredTool
+
+
+def _make_tool(
+    name: str,
+    *,
+    description: str = "Tool description.",
+    surfaces: tuple[str, ...] = ("investigation",),
+    input_schema: dict[str, Any] | None = None,
+    origin_module: str = "app.tools.registry",
+) -> RegisteredTool:
+    """Construct a minimal RegisteredTool stub for catalog rendering tests."""
+    return RegisteredTool(
+        name=name,
+        description=description,
+        input_schema=input_schema or {"type": "object", "properties": {}, "required": []},
+        source="knowledge",
+        run=lambda **_: None,
+        surfaces=surfaces,
+        origin_module=origin_module,
+        origin_name=name,
+    )
+
+
+@pytest.fixture
+def fake_registry(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[RegisteredTool]]:
+    """Replace the live registry with a curated set so tests are deterministic."""
+    tools: list[RegisteredTool] = []
+
+    def _fake_get_registered_tools(surface: str | None = None) -> list[RegisteredTool]:
+        if surface is None:
+            return list(tools)
+        return [t for t in tools if surface in t.surfaces]
+
+    monkeypatch.setattr(tool_catalog, "get_registered_tools", _fake_get_registered_tools)
+    yield tools
+
+
+class TestSummarizeInputSchema:
+    def test_empty_schema_renders_no_params(self) -> None:
+        assert _summarize_input_schema({}) == "(no params)"
+        assert (
+            _summarize_input_schema({"type": "object", "properties": {}, "required": []})
+            == "(no params)"
+        )
+
+    def test_required_params_render_without_question_mark(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}},
+            "required": ["query", "limit"],
+        }
+        assert _summarize_input_schema(schema) == "query: string, limit: integer"
+
+    def test_optional_params_get_question_mark_suffix(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}},
+            "required": ["query"],
+        }
+        assert _summarize_input_schema(schema) == "query: string, limit?: integer"
+
+    def test_untyped_property_renders_as_any(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"cloudops_backend": {}},
+            "required": ["cloudops_backend"],
+        }
+        assert _summarize_input_schema(schema) == "cloudops_backend: any"
+
+    def test_overlong_summary_is_truncated_with_ellipsis(self) -> None:
+        # Build a schema large enough to exceed the 200-char cap.
+        properties = {f"param_{i}": {"type": "string"} for i in range(40)}
+        schema = {
+            "type": "object",
+            "properties": properties,
+            "required": list(properties.keys()),
+        }
+        rendered = _summarize_input_schema(schema)
+        assert len(rendered) <= 200
+        assert rendered.endswith("…")
+
+
+class TestBuildToolCatalog:
+    def test_returns_empty_list_when_no_tools(self, fake_registry: list[RegisteredTool]) -> None:
+        del fake_registry  # unused — registry is empty by default
+        assert build_tool_catalog() == []
+
+    def test_projects_each_tool_into_a_catalog_entry(
+        self, fake_registry: list[RegisteredTool]
+    ) -> None:
+        fake_registry.append(
+            _make_tool(
+                "search_github",
+                description="Search GitHub code.",
+                surfaces=("investigation", "chat"),
+                input_schema={
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            )
+        )
+        entries = build_tool_catalog()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.name == "search_github"
+        assert entry.surfaces == ("investigation", "chat")
+        assert entry.description == "Search GitHub code."
+        assert entry.input_schema_summary == "query: string"
+        # Source file for the registry module resolves to its repo-relative path.
+        assert entry.source_file == "app/tools/registry.py"
+
+    def test_filters_by_surface_when_provided(self, fake_registry: list[RegisteredTool]) -> None:
+        fake_registry.extend(
+            [
+                _make_tool("inv_only", surfaces=("investigation",)),
+                _make_tool("chat_only", surfaces=("chat",)),
+                _make_tool("both", surfaces=("investigation", "chat")),
+            ]
+        )
+        chat_entries = build_tool_catalog(surface="chat")
+        names = {e.name for e in chat_entries}
+        assert names == {"chat_only", "both"}
+
+    def test_unresolvable_origin_module_yields_empty_source_file(
+        self, fake_registry: list[RegisteredTool]
+    ) -> None:
+        # A tool that registered but whose origin module no longer imports
+        # cleanly (e.g. partial uninstall) must still surface in the catalog.
+        fake_registry.append(_make_tool("orphan", origin_module="not.a.real.module"))
+        entries = build_tool_catalog()
+        assert len(entries) == 1
+        assert entries[0].source_file == ""
+
+
+class TestFormatToolCatalogText:
+    def test_returns_empty_string_for_empty_catalog(self) -> None:
+        assert format_tool_catalog_text([]) == ""
+
+    def test_groups_by_surface_with_investigation_first(self) -> None:
+        entries = [
+            ToolCatalogEntry(
+                name="alpha",
+                surfaces=("investigation",),
+                description="alpha desc",
+                source_file="app/tools/alpha.py",
+                input_schema_summary="(no params)",
+            ),
+            ToolCatalogEntry(
+                name="beta",
+                surfaces=("chat",),
+                description="beta desc",
+                source_file="app/tools/beta.py",
+                input_schema_summary="x: string",
+            ),
+        ]
+        text = format_tool_catalog_text(entries)
+        # Investigation header must precede chat header (canonical ordering).
+        inv_pos = text.find("## investigation")
+        chat_pos = text.find("## chat")
+        assert inv_pos != -1 and chat_pos != -1
+        assert inv_pos < chat_pos
+        assert "alpha" in text and "beta" in text
+
+    def test_dual_surface_tool_appears_under_each_surface(self) -> None:
+        entries = [
+            ToolCatalogEntry(
+                name="dual",
+                surfaces=("investigation", "chat"),
+                description="dual desc",
+                source_file="app/tools/dual.py",
+                input_schema_summary="(no params)",
+            )
+        ]
+        text = format_tool_catalog_text(entries)
+        # Dual-surface tools surface in BOTH groups so the user can tell which
+        # tools the chat agent vs the investigation pipeline can reach.
+        assert text.count("**dual**") == 2
+        assert "## investigation (1 tool)" in text
+        assert "## chat (1 tool)" in text
+
+    def test_omits_source_line_when_source_file_unknown(self) -> None:
+        entries = [
+            ToolCatalogEntry(
+                name="orphan",
+                surfaces=("investigation",),
+                description="orphan desc",
+                source_file="",
+                input_schema_summary="(no params)",
+            )
+        ]
+        text = format_tool_catalog_text(entries)
+        assert "**orphan**" in text
+        assert "source:" not in text
+
+
+class TestListToolsSlashCommand:
+    """``/list tools`` reaches the catalog and prints non-empty output."""
+
+    def _capture(self) -> tuple[Console, io.StringIO]:
+        buf = io.StringIO()
+        return Console(file=buf, force_terminal=False, highlight=False), buf
+
+    def test_list_tools_prints_grouped_catalog(self) -> None:
+        console, buf = self._capture()
+        session = ReplSession()
+        # Stub the catalog so the test stays decoupled from registry contents.
+        fake = [
+            ToolCatalogEntry(
+                name="search_github",
+                surfaces=("investigation", "chat"),
+                description="Search GitHub code.",
+                source_file="app/tools/search_github.py",
+                input_schema_summary="query: string",
+            )
+        ]
+        with patch(
+            "app.cli.interactive_shell.command_registry.integrations.build_tool_catalog",
+            return_value=fake,
+        ):
+            assert _cmd_list(session, console, ["tools"]) is True
+        out = buf.getvalue()
+        assert "search_github" in out
+        assert "## investigation" in out
+        assert "## chat" in out
+
+    def test_list_tools_handles_empty_registry(self) -> None:
+        console, buf = self._capture()
+        session = ReplSession()
+        with patch(
+            "app.cli.interactive_shell.command_registry.integrations.build_tool_catalog",
+            return_value=[],
+        ):
+            assert _cmd_list(session, console, ["tools"]) is True
+        assert "no tools registered" in buf.getvalue()
+
+    def test_list_first_args_advertise_tools_for_tab_completion(self) -> None:
+        from app.cli.interactive_shell.command_registry.integrations import _LIST_FIRST_ARGS
+
+        names = {arg for arg, _hint in _LIST_FIRST_ARGS}
+        assert "tools" in names


### PR DESCRIPTION
Fixes #1443

#### Describe the changes you have made in this PR -

The OpenSRE tool registry (`app.tools.registry`) auto-discovers 141 tools and exposes them via `get_registered_tools(surface)`, but none of that metadata is visible to interactive-shell users. `/list integrations`, `/list mcp`, and `/list models` exist; `/list tools` did not. This PR adds it.

**What ships (issue scope (a) — terminal display only; the prompt-grounding wiring is out of scope per the issue):**

- `app/cli/interactive_shell/tool_catalog.py` (new) — two pure functions:
  - `build_tool_catalog(surface)` wraps `get_registered_tools(surface)` and projects each `RegisteredTool` into a `ToolCatalogEntry` with `name`, `surfaces`, `description`, `source_file` (relative to repo root via the tool's `origin_module.__file__`, falling back to `""` for unresolvable modules), and `input_schema_summary` (a one-line `name: type` / `name?: type` render of top-level params, capped at 200 chars with ellipsis).
  - `format_tool_catalog_text(entries)` groups entries by surface (investigation first, chat second; dual-surface tools appear under both), renders compact Markdown-ish text suitable for both terminal display and future prompt injection.
- `app/cli/interactive_shell/command_registry/integrations.py` — adds the `tools` / `tool` subcommand to `_cmd_list`, extends `_LIST_FIRST_ARGS` for tab completion, and updates the unknown-target hint to advertise the new option. Empty-catalog path prints `no tools registered.` instead of an empty block.
- `tests/cli/interactive_shell/test_tool_catalog.py` (new, 16 tests) — covers `_summarize_input_schema` (required vs optional, untyped properties as `any`, ellipsis truncation), `build_tool_catalog` (empty registry, full projection, surface filtering, unresolvable origin module), `format_tool_catalog_text` (empty, surface ordering, dual-surface duplication, missing source line), and the slash-command path (renders catalog, handles empty registry, advertises `tools` for tab completion).
- `tests/cli/interactive_shell/test_loop.py` — updates the pinned subcommand list (`["integrations", "mcp", "models"]` → `["integrations", "mcp", "models", "tools"]`) so the completer regression test matches the new wiring.

### Demo/Screenshot for feature changes and bug fixes -

Smoke test against the live registry (141 tools today):

```
$ uv run python -c "from app.cli.interactive_shell.tool_catalog import build_tool_catalog, format_tool_catalog_text; \
    catalog = build_tool_catalog(); \
    print(f'{len(catalog)} tools'); print(format_tool_catalog_text(catalog)[:600])"

141 tools

## investigation (141 tools)

- **CheckNodeServiceStatus** — Replay Cloud-OpsBench CheckNodeServiceStatus from tool_cache.json.
  - source: `app/tools/CloudOpsBenchK8sTools/__init__.py`
  - params: `cloudops_backend: any, node_name: string, service_name: string`
- **CheckServiceConnectivity** — Replay Cloud-OpsBench CheckServiceConnectivity from tool_cache.json.
  - source: `app/tools/CloudOpsBenchK8sTools/__init__.py`
  - params: `cloudops_backend: any, service_name: string, port: integer, namespace: string`
- **DescribeResource** — Replay Cloud-OpsBench DescribeResource against the case tool_cache.json.
  - source: `app/tools/CloudOpsBenchK8sTools/__init__.py`
  - params: `cloudops_backend: any, resource_type: string, name: string, namespace?: string`
```

Quality gate (run from the checkout):

```
make lint           → All checks passed!
make format-check   → 1151 files already formatted
make typecheck      → Success: no issues found in 494 source files
make test-cov       → 5418 passed, 5 skipped (3 pre-existing gemini_cli auth
                       failures unrelated to this change — same set seen on main)
```

Targeted run:

```
$ uv run pytest tests/cli/interactive_shell/ -q
371 passed in 1.62s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue had two pure-function asks (`build_tool_catalog`, `format_tool_catalog_text`) plus one wiring point (`/list tools`). I held the pure functions purely pure — no Rich tables, no console mutation — so they remain useable for the future prompt-grounding consumer the issue mentions ("can be injected into the LLM prompt") without any refactor.

A few decisions worth flagging for review:

1. **No new Rich table.** I deliberately did not add `render_tool_catalog_table` to `rendering.py` even though `/list integrations`, `/list mcp`, and `/list models` each have one. The issue spec says "compact Markdown-ish text suitable for both terminal display and prompt injection" — a Rich table satisfies neither prompt injection nor a future LLM consumer. Plain text covers both surfaces. If the maintainers prefer table parity with the other `/list` commands for terminal output, I can add a thin wrapper that pretty-prints; happy to follow up.

2. **Source-file resolution is best-effort.** `_resolve_source_file` imports `origin_module` to read `__file__`, then makes it relative to the repo root. For tools whose module resolves outside the repo (installed package, namespace package), `Path.relative_to` raises `ValueError`; the fallback is the absolute path so users can still open the file. For modules that fail to import entirely (the pathological "registered but partially uninstalled" case), it returns `""` and the format function omits the `source:` line — there's a regression test pinning this. I chose `_REPO_ROOT = Path(__file__).resolve().parents[3]` to match the pattern set by `docs_reference.py` and the new `agents_md_reference.py`.

3. **Schema summary is a JSON-Schema view, not a Python-signature view.** The issue example was `query: str, limit: int = 10`, but the registry stores `{"type": "string"}` / `{"type": "integer"}` and does not encode default values in `input_schema`. I rendered as `name: string`, `name?: integer` (`?` for not-in-`required`) to stay faithful to the actual data shape. Untyped properties (e.g. `cloudops_backend: {}`, which several Cloud-OpsBench tools use) render as `name: any` so the param at least appears.

4. **Dual-surface tools appear in both groups.** A `("investigation", "chat")` tool surfaces under `## investigation` AND `## chat`. The use case the issue cites ("what tools can the chat agent call?") needs that — if dual-surface tools were only listed once, the chat-surface answer would be incomplete. The duplication is intentional and tested.

Edge cases under test: empty registry → empty list and empty string; surface filtering; unresolvable origin module → empty `source_file` and omitted source line; overlong schema summary → ellipsis cap at 200 chars; sub-arg `tools` and `tool` both work; the test_loop completer regression is updated for the new tab-completion entry.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions