### PR TITLE
fix: handle asyncio/selector failures in interactive prompt gracefully

### DIFF
--- a/app/cli/support/prompt_support.py
+++ b/app/cli/support/prompt_support.py
@@ -130,6 +130,17 @@ def _with_ctrl_c_double_exit(
                 print("\n(Press Ctrl+C again to exit)", flush=True)
                 # Loop: re-run the same application (Application.run() is
                 # safe to call again after a clean exit or KeyboardInterrupt).
+            except (OSError, KeyError, RuntimeError):
+                # The event loop / selector can fail on platforms where
+                # epoll or select cannot handle terminal file descriptors
+                # (e.g. WSL).  Bail out with a clear message instead of a
+                # cryptic traceback.
+                print(
+                    "\nThe interactive prompt could not be displayed due to a "
+                    "terminal I/O error on this platform.",
+                    flush=True,
+                )
+                sys.exit(1)
 
     question.ask = _patched_ask  # type: ignore[method-assign]
     return question

--- a/app/cli/support/prompt_support.py
+++ b/app/cli/support/prompt_support.py
@@ -130,11 +130,16 @@ def _with_ctrl_c_double_exit(
                 print("\n(Press Ctrl+C again to exit)", flush=True)
                 # Loop: re-run the same application (Application.run() is
                 # safe to call again after a clean exit or KeyboardInterrupt).
-            except (OSError, KeyError, RuntimeError):
+            except (OSError, KeyError) as exc:
                 # The event loop / selector can fail on platforms where
-                # epoll or select cannot handle terminal file descriptors
-                # (e.g. WSL).  Bail out with a clear message instead of a
-                # cryptic traceback.
+                # epoll or select cannot handle terminal file descriptors.
+                # Bail out with a clear message instead of a cryptic
+                # traceback.
+                import logging
+
+                logging.getLogger(__name__).debug(
+                    "interactive prompt selector error: %s", exc, exc_info=True
+                )
                 print(
                     "\nThe interactive prompt could not be displayed due to a "
                     "terminal I/O error on this platform.",


### PR DESCRIPTION
Fixes #1569

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
`app/cli/support/prompt_support.py`: In _patched_ask(), added except (OSError, KeyError, RuntimeError) to catch asyncio/selector failures when prompt_toolkit registers stdin (fd 0) in the event loop. Prints a clear message and calls sys.exit(1) so the process exits cleanly instead of crashing with a cryptic traceback
### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->
Before (crash):

```
$ opensre onboard
? How do you want to get started?
KeyError: '0 is not registered'
  File "asyncio/selector_events.py", line 282, in _add_reader
    key = self._selector.get_key(fd)
  File "selectors.py", line 192, in get_key
    raise KeyError("{!r} is not registered".format(fileobj)) from None

OSError: [Errno 22] Invalid argument
```

After (clean exit):
```

$ opensre onboard
? How do you want to get started?

The interactive prompt could not be displayed due to a terminal I/O error on this platform.
```
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
- What problem does your code solve? When prompt_toolkit's asyncio event loop tries to register stdin (fd 0) via epoll_ctl or select, the syscall can fail on some platforms, raising OSError or KeyError. These propagate unhandled because _patched_ask only catches KeyboardInterrupt, and main() only catches SystemExit/ClickException — so the user sees a full crash traceback.
- What alternative approaches did you consider? I considered setting an asyncio event loop policy (e.g. SelectSelector fallback) but that's fragile and platform-specific. I also considered adding a general except Exception to main(), but that would suppress legitimate bugs elsewhere. The targeted catch at the failure site is the most minimal and safe.
- Why did you choose this specific implementation? The _patched_ask closure is the exact point where the asyncio failure occurs. Catching (OSError, KeyError, RuntimeError) there and calling sys.exit(1) gives the user a clear message. SystemExit(1) propagates untouched through Exception handlers (it inherits from BaseException) and is cleanly caught by main()'s existing except SystemExit handler.
- What are the key functions/components and what do they do? _patched_ask() is a closure that wraps questionary's unsafe_ask() in a retry loop for Ctrl+C double-exit handling. It's installed globally by install_questionary_ctrl_c_double_exit() onto every questionary prompt type (select, text, confirm, etc.). The new catch block covers the selector failure path without interfering with the existing Ctrl+C and Escape handling.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
