### PR TITLE
feat(synthetic/rds_postgres): add TP/FP/TN/FN classification + accura…

### DIFF
--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import re
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, Literal
 
 from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
@@ -66,14 +66,14 @@ class ScenarioScore:
     # One of: "TP" (real fault correctly identified), "FP" (healthy scenario
     # mis-classified as a fault), "TN" (healthy scenario correctly identified),
     # "FN" (real fault missed or mis-categorised). Set by score_result().
-    outcome_class: str | None = None
+    outcome_class: Literal["TP", "FP", "TN", "FN"] | None = None
 
 
 def classify_outcome(
     actual_category: str,
     expected_category: str,
     root_cause_present: bool,
-) -> str:
+) -> Literal["TP", "FP", "TN", "FN"]:
     """Classify a scored scenario into TP/FP/TN/FN.
 
     A scenario is HEALTHY when expected_category == "healthy" — the alert is

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -62,6 +62,75 @@ class ScenarioScore:
     failure_reason: str = ""
     trajectory: TrajectoryScore | None = None
     reasoning: ReasoningScore | None = None
+    # Classification of the scenario outcome against the expected ground truth.
+    # One of: "TP" (real fault correctly identified), "FP" (healthy scenario
+    # mis-classified as a fault), "TN" (healthy scenario correctly identified),
+    # "FN" (real fault missed or mis-categorised). Set by score_result().
+    outcome_class: str | None = None
+
+
+def classify_outcome(
+    actual_category: str,
+    expected_category: str,
+    root_cause_present: bool,
+) -> str:
+    """Classify a scored scenario into TP/FP/TN/FN.
+
+    A scenario is HEALTHY when expected_category == "healthy" — the alert is
+    expected to be noise and the agent should report no fault. Otherwise the
+    scenario has a real fault that the agent should identify by category.
+
+    Returns one of: "TP", "FP", "TN", "FN".
+    """
+    is_healthy_ground_truth = expected_category == "healthy"
+    actual_says_healthy = (not root_cause_present) or actual_category == "healthy"
+
+    if is_healthy_ground_truth:
+        return "TN" if actual_says_healthy else "FP"
+
+    # Real-fault scenario from here on.
+    if not root_cause_present:
+        return "FN"
+    if actual_category == expected_category:
+        return "TP"
+    return "FN"
+
+
+def compute_classification_stats(results: list[ScenarioScore]) -> dict[str, Any]:
+    """Aggregate TP/FP/TN/FN counts and derived metrics across scenarios.
+
+    Returns a dict with the four raw counts plus total, accuracy, precision,
+    recall, and F1. Divisions return 0.0 when the denominator is zero rather
+    than raising, so the function is safe on empty or all-skipped result sets.
+    """
+    counts: dict[str, int] = {"TP": 0, "FP": 0, "TN": 0, "FN": 0}
+    for result in results:
+        cls = result.outcome_class
+        if cls in counts:
+            counts[cls] += 1
+
+    tp = counts["TP"]
+    fp = counts["FP"]
+    tn = counts["TN"]
+    fn = counts["FN"]
+    total = tp + fp + tn + fn
+
+    accuracy = (tp + tn) / total if total else 0.0
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    return {
+        "TP": tp,
+        "FP": fp,
+        "TN": tn,
+        "FN": fn,
+        "total": total,
+        "accuracy": accuracy,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -404,6 +473,12 @@ def score_result(
     passed = not failure_reason
     trajectory = score_trajectory(fixture, final_state)
     reasoning = score_reasoning(fixture, final_state, queried_metrics)
+    outcome_class = classify_outcome(
+        actual_category=actual_category,
+        expected_category=fixture.answer_key.root_cause_category,
+        root_cause_present=root_cause_present,
+    )
+
     return ScenarioScore(
         scenario_id=fixture.scenario_id,
         passed=passed,
@@ -416,6 +491,7 @@ def score_result(
         failure_reason=failure_reason,
         trajectory=trajectory,
         reasoning=reasoning,
+        outcome_class=outcome_class,
     )
 
 
@@ -518,6 +594,18 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
 
         passed_count = sum(1 for result in results if result.passed)
         print(f"\nResults: {passed_count}/{len(results)} passed")
+
+        stats = compute_classification_stats(results)
+        print(
+            f"Classification: TP={stats['TP']}  FP={stats['FP']}  "
+            f"TN={stats['TN']}  FN={stats['FN']}  (total {stats['total']})"
+        )
+        print(
+            f"Accuracy={stats['accuracy']:.0%}  "
+            f"Precision={stats['precision']:.0%}  "
+            f"Recall={stats['recall']:.0%}  "
+            f"F1={stats['f1']:.0%}"
+        )
 
     return results
 

--- a/tests/synthetic/rds_postgres/test_run_suite_classification.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_classification.py
@@ -1,0 +1,181 @@
+"""Direct unit tests for the TP / FP / TN / FN classifier and aggregation.
+
+The classifier (`classify_outcome`) maps an agent outcome against ground truth
+into one of four cells. The aggregator (`compute_classification_stats`) tallies
+counts and computes accuracy / precision / recall / F1 across a result set.
+Both are pure and have no dependency on the rest of the suite, so the tests
+exercise them directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tests.synthetic.rds_postgres.run_suite import (
+    ScenarioScore,
+    classify_outcome,
+    compute_classification_stats,
+)
+
+# ---------------------------------------------------------------------------
+# classify_outcome — truth table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("actual", "expected", "present", "want"),
+    [
+        # Real-fault scenario, agent identifies the right category.
+        ("resource_exhaustion", "resource_exhaustion", True, "TP"),
+        ("infrastructure", "infrastructure", True, "TP"),
+        # Real-fault scenario, agent says "healthy" or has no root cause.
+        ("healthy", "resource_exhaustion", True, "FN"),
+        ("unknown", "resource_exhaustion", False, "FN"),
+        # Real-fault scenario, agent says wrong non-healthy category.
+        ("infrastructure", "resource_exhaustion", True, "FN"),
+        ("cpu_saturation", "resource_exhaustion", True, "FN"),
+        # Healthy scenario, agent correctly says healthy or has no root cause.
+        ("healthy", "healthy", True, "TN"),
+        ("unknown", "healthy", False, "TN"),
+        # Healthy scenario, agent claims a fault.
+        ("resource_exhaustion", "healthy", True, "FP"),
+        ("infrastructure", "healthy", True, "FP"),
+    ],
+)
+def test_classify_outcome_truth_table(actual: str, expected: str, present: bool, want: str) -> None:
+    assert classify_outcome(actual, expected, present) == want
+
+
+def test_classify_outcome_returns_one_of_four_classes() -> None:
+    """Sanity: every output is one of TP / FP / TN / FN, never None."""
+    for actual in ("healthy", "resource_exhaustion", "unknown"):
+        for expected in ("healthy", "resource_exhaustion"):
+            for present in (True, False):
+                got = classify_outcome(actual, expected, present)
+                assert got in {"TP", "FP", "TN", "FN"}
+
+
+# ---------------------------------------------------------------------------
+# compute_classification_stats — aggregation + derived metrics
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockScore:
+    """Minimal stand-in for ScenarioScore — only `outcome_class` is read."""
+
+    outcome_class: str | None
+
+
+def _scores(*classes: str | None) -> list[_MockScore]:
+    return [_MockScore(outcome_class=c) for c in classes]
+
+
+def test_compute_stats_empty_input_returns_zeros() -> None:
+    stats = compute_classification_stats([])
+    assert stats["TP"] == 0
+    assert stats["FP"] == 0
+    assert stats["TN"] == 0
+    assert stats["FN"] == 0
+    assert stats["total"] == 0
+    assert stats["accuracy"] == 0.0
+    assert stats["precision"] == 0.0
+    assert stats["recall"] == 0.0
+    assert stats["f1"] == 0.0
+
+
+def test_compute_stats_counts_each_class() -> None:
+    stats = compute_classification_stats(_scores("TP", "TP", "FP", "TN", "FN", "FN"))
+    assert stats["TP"] == 2
+    assert stats["FP"] == 1
+    assert stats["TN"] == 1
+    assert stats["FN"] == 2
+    assert stats["total"] == 6
+
+
+def test_compute_stats_accuracy_precision_recall_f1_math() -> None:
+    """Spot-check the arithmetic against hand-computed values.
+
+    With TP=2, FP=1, TN=1, FN=2:
+      accuracy = (2+1)/6 = 0.5
+      precision = 2/(2+1) = 2/3
+      recall = 2/(2+2) = 0.5
+      F1 = 2 * P * R / (P + R) = 2 * (2/3) * (1/2) / (2/3 + 1/2) = 4/7
+    """
+    stats = compute_classification_stats(_scores("TP", "TP", "FP", "TN", "FN", "FN"))
+    assert stats["accuracy"] == pytest.approx(0.5)
+    assert stats["precision"] == pytest.approx(2 / 3)
+    assert stats["recall"] == pytest.approx(0.5)
+    assert stats["f1"] == pytest.approx(4 / 7)
+
+
+def test_compute_stats_all_correct_yields_one_one_one() -> None:
+    """An all-passing run is the upper bound: all metrics = 1.0."""
+    stats = compute_classification_stats(_scores("TP", "TP", "TN"))
+    assert stats["accuracy"] == 1.0
+    assert stats["precision"] == 1.0
+    assert stats["recall"] == 1.0
+    assert stats["f1"] == 1.0
+
+
+def test_compute_stats_all_failing_yields_zero_accuracy() -> None:
+    stats = compute_classification_stats(_scores("FP", "FN", "FN"))
+    assert stats["accuracy"] == 0.0
+    # precision = 0 / (0 + 1) = 0; recall = 0 / (0 + 2) = 0; F1 = 0.
+    assert stats["precision"] == 0.0
+    assert stats["recall"] == 0.0
+    assert stats["f1"] == 0.0
+
+
+def test_compute_stats_skips_unknown_outcome_class() -> None:
+    """Unknown / None outcome_class is treated as not classified, not counted."""
+    stats = compute_classification_stats(_scores("TP", None, "garbage", "TN"))
+    assert stats["TP"] == 1
+    assert stats["TN"] == 1
+    assert stats["total"] == 2  # only two classified
+
+
+def test_compute_stats_division_by_zero_does_not_raise() -> None:
+    """All-TN result set: TP+FP=0 (precision denom) and TP+FN=0 (recall denom).
+    Both must short-circuit to 0.0 rather than ZeroDivisionError."""
+    stats = compute_classification_stats(_scores("TN", "TN"))
+    assert stats["accuracy"] == 1.0
+    assert stats["precision"] == 0.0
+    assert stats["recall"] == 0.0
+    assert stats["f1"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# ScenarioScore field is wired
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_score_outcome_class_defaults_to_none() -> None:
+    score = ScenarioScore(
+        scenario_id="000-healthy",
+        passed=True,
+        root_cause_present=False,
+        expected_category="healthy",
+        actual_category="healthy",
+        missing_keywords=[],
+        matched_keywords=[],
+        root_cause="",
+    )
+    assert score.outcome_class is None
+
+
+def test_scenario_score_outcome_class_can_be_set() -> None:
+    score = ScenarioScore(
+        scenario_id="002-connection-exhaustion",
+        passed=True,
+        root_cause_present=True,
+        expected_category="resource_exhaustion",
+        actual_category="resource_exhaustion",
+        missing_keywords=[],
+        matched_keywords=["connection"],
+        root_cause="connection exhaustion",
+        outcome_class="TP",
+    )
+    assert score.outcome_class == "TP"

--- a/tests/synthetic/rds_postgres/test_run_suite_classification.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_classification.py
@@ -13,13 +13,13 @@ from dataclasses import dataclass
 
 import pytest
 
-pytestmark = pytest.mark.synthetic
-
 from tests.synthetic.rds_postgres.run_suite import (
     ScenarioScore,
     classify_outcome,
     compute_classification_stats,
 )
+
+pytestmark = pytest.mark.synthetic
 
 # ---------------------------------------------------------------------------
 # classify_outcome — truth table

--- a/tests/synthetic/rds_postgres/test_run_suite_classification.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_classification.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 
 import pytest
 
+pytestmark = pytest.mark.synthetic
+
 from tests.synthetic.rds_postgres.run_suite import (
     ScenarioScore,
     classify_outcome,


### PR DESCRIPTION
Closes the first of the two README-flagged gaps from the May-1 outreach (Accuracy / FP / FN aren't measured in the benchmark). @VaibhavUpreti green-lit this in DM today.

Three additions in tests/synthetic/rds_postgres/run_suite.py:

- new optional ScenarioScore.outcome_class field. One of "TP" / "FP" / "TN" / "FN" or None for unclassified.
- new classify_outcome() classifier. Healthy ground truth maps agent-says-healthy to TN, else FP. Real-fault ground truth maps category-match to TP, miss or wrong category to FN.
- new compute_classification_stats() aggregator returning the four counts plus accuracy / precision / recall / F1, with safe zero-denominator handling.

score_result() calls classify_outcome and attaches the result. run_suite() prints a Classification line in text mode; JSON mode gets the field for free via asdict().

Three of the existing 15 fixtures are healthy ground truth (000-healthy, 007-noisy-healthy, 013-storage-recovery-false-alert), so the classifier has real coverage on both sides of the True / False split.

Test coverage in tests/synthetic/rds_postgres/test_run_suite_classification.py:

- 10 parametrised truth-table cases on classify_outcome
- aggregator: empty input, count-each-class, full arithmetic on accuracy / precision / recall / F1, all-correct upper bound, all-failing lower bound, unknown outcome_class skipping, zero-division safety
- ScenarioScore: outcome_class defaults to None, can be set explicitly

Independently mergeable from #1410, #1420 (same file, no conflicting fields) and from PR B (docs-only, doesn't depend on this).

cc @VaibhavUpreti @muddlebee @cerencamkiran

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes
- [ ] No

**If yes, did you understand and verify all the code that was generated?**
- [x] Yes, I understand and verified all the code
- [ ] No

**Are you able to explain the implementation choices and trade-offs?**
- [x] Yes
- [ ] No