### PR TITLE
feat(wizard): add Telegram onboarding to the setup wizard

### DIFF
--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -175,6 +175,12 @@ def validate_discord_bot(**kwargs):
     return _validate(**kwargs)
 
 
+def validate_telegram_integration(**kwargs):
+    from app.cli.wizard.integration_health import validate_telegram_integration as _validate
+
+    return _validate(**kwargs)
+
+
 def validate_openclaw_integration(**kwargs):
     from app.cli.wizard.integration_health import validate_openclaw_integration as _validate
 
@@ -1507,6 +1513,46 @@ def _configure_discord() -> tuple[str, str]:
         _console.print(f"[{TEXT_DIM}]Try again or press Ctrl+C to cancel.[/]")
 
 
+def _configure_telegram() -> tuple[str, str]:
+    _, credentials = _integration_defaults("telegram")
+    _console.print(
+        "\n[bold]Telegram Integration[/bold]\n"
+        f"[{TEXT_DIM}]Create a bot with BotFather and paste the bot token here.[/]\n"
+    )
+    while True:
+        bot_token = _prompt_value(
+            "Telegram bot token",
+            default=_string_value(credentials.get("bot_token")),
+            secret=True,
+        )
+        default_chat_id = _prompt_value(
+            "Default chat ID (optional)",
+            default=_string_value(credentials.get("default_chat_id")),
+            allow_empty=True,
+        )
+        with _console.status("Validating Telegram bot token...", spinner="dots"):
+            result = validate_telegram_integration(bot_token=bot_token)
+        _render_integration_result("Telegram", result)
+        if result.ok:
+            upsert_integration(
+                "telegram",
+                {
+                    "credentials": {
+                        "bot_token": bot_token,
+                        "default_chat_id": default_chat_id,
+                    }
+                },
+            )
+            env_path = sync_env_values(
+                {
+                    "TELEGRAM_BOT_TOKEN": bot_token,
+                    "TELEGRAM_DEFAULT_CHAT_ID": default_chat_id,
+                }
+            )
+            return "Telegram", str(env_path)
+        _console.print(f"[{TEXT_DIM}]Try again or press Ctrl+C to cancel.[/]")
+
+
 def _configure_splunk() -> tuple[str, str]:
     _, credentials = _integration_defaults("splunk")
     while True:
@@ -1596,6 +1642,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
             label="Discord",
             hint="Trigger investigations via slash commands and post findings to threads",
         ),
+        Choice(value="telegram", label="Telegram", hint="Post findings to a Telegram chat"),
         Choice(value="aws", label="AWS", hint="Inspect CloudWatch, EKS, and account resources"),
         Choice(
             value="github", label="GitHub MCP", hint="Let the agent inspect repos, PRs, and issues"
@@ -1669,6 +1716,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "coralogix": _configure_coralogix,
         "slack": _configure_slack,
         "discord": _configure_discord,
+        "telegram": _configure_telegram,
         "aws": _configure_aws,
         "github": _configure_github_mcp,
         "sentry": _configure_sentry,
@@ -1691,6 +1739,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "coralogix": "coralogix",
         "slack": "slack",
         "discord": "discord",
+        "telegram": "telegram",
         "aws": "aws",
         "github": "github mcp",
         "sentry": "sentry",

--- a/app/cli/wizard/integration_health.py
+++ b/app/cli/wizard/integration_health.py
@@ -22,6 +22,7 @@ from app.cli.wizard.integration_validators.http_probe_validators import (
     validate_jira_integration,
     validate_notion_integration,
     validate_slack_webhook,
+    validate_telegram_integration,
 )
 from app.cli.wizard.integration_validators.mcp_validators import (
     validate_github_mcp_integration,
@@ -49,5 +50,6 @@ __all__ = [
     "validate_sentry_integration",
     "validate_slack_webhook",
     "validate_splunk_integration",
+    "validate_telegram_integration",
     "validate_vercel_integration",
 ]

--- a/app/cli/wizard/integration_validators/http_probe_validators.py
+++ b/app/cli/wizard/integration_validators/http_probe_validators.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import httpx
 
 from app.integrations.models import SlackWebhookConfig
+from app.integrations.verify import _verify_telegram
 
 from .shared import IntegrationHealthResult
 
@@ -136,4 +137,16 @@ def validate_discord_bot(*, bot_token: str) -> IntegrationHealthResult:
         return IntegrationHealthResult(ok=False, detail="Discord bot token is invalid or revoked.")
     return IntegrationHealthResult(
         ok=False, detail=f"Discord API returned unexpected HTTP {resp.status_code}."
+    )
+
+
+def validate_telegram_integration(*, bot_token: str) -> IntegrationHealthResult:
+    """Validate a Telegram bot token via the shared integration verifier."""
+    result = _verify_telegram("onboarding", {"bot_token": bot_token})
+    detail = str(result["detail"])
+    if bot_token:
+        detail = detail.replace(bot_token, "<redacted>")
+    return IntegrationHealthResult(
+        ok=result["status"] == "passed",
+        detail=detail,
     )

--- a/app/cli/wizard/integration_validators/http_probe_validators.py
+++ b/app/cli/wizard/integration_validators/http_probe_validators.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import httpx
 
-from app.integrations.models import SlackWebhookConfig
-from app.integrations.verify import _verify_telegram
+from app.integrations.models import SlackWebhookConfig, TelegramBotConfig
 
 from .shared import IntegrationHealthResult
 
@@ -141,12 +140,49 @@ def validate_discord_bot(*, bot_token: str) -> IntegrationHealthResult:
 
 
 def validate_telegram_integration(*, bot_token: str) -> IntegrationHealthResult:
-    """Validate a Telegram bot token via the shared integration verifier."""
-    result = _verify_telegram("onboarding", {"bot_token": bot_token})
-    detail = str(result["detail"])
-    if bot_token:
-        detail = detail.replace(bot_token, "<redacted>")
+    """Validate a Telegram bot token with Telegram's getMe endpoint."""
+    try:
+        telegram_config = TelegramBotConfig.model_validate({"bot_token": bot_token})
+    except Exception as err:
+        return IntegrationHealthResult(ok=False, detail=str(err))
+
+    try:
+        resp = httpx.get(
+            f"https://api.telegram.org/bot{telegram_config.bot_token}/getMe",
+            timeout=10,
+        )
+    except httpx.RequestError as err:
+        detail = str(err).replace(telegram_config.bot_token, "<redacted>")
+        return IntegrationHealthResult(ok=False, detail=f"Telegram API unreachable: {detail}")
+
+    if resp.status_code != 200:
+        detail = f"Telegram API returned unexpected HTTP {resp.status_code}."
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict):
+            description = str(payload.get("description") or "").strip()
+            if description:
+                detail = f"Telegram API check failed: {description}"
+        return IntegrationHealthResult(ok=False, detail=detail)
+
+    try:
+        payload = resp.json()
+    except ValueError as err:
+        return IntegrationHealthResult(
+            ok=False, detail=f"Telegram API returned invalid JSON: {err}"
+        )
+
+    if not payload.get("ok"):
+        return IntegrationHealthResult(
+            ok=False,
+            detail=f"Telegram API check failed: {payload.get('description', 'unknown error')}",
+        )
+
+    user = payload.get("result", {})
+    username = str(user.get("username", "")).strip()
     return IntegrationHealthResult(
-        ok=result["status"] == "passed",
-        detail=detail,
+        ok=True,
+        detail=f"Connected to Telegram bot @{username or 'unknown'}.",
     )

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,15 +110,16 @@
             "pages": [
               "aws",
               "bitbucket",
-              "discord",
-              "github",
-              "gitlab",
-              "google-docs",
-              "jira",
-              "slack",
-              "vercel"
-            ]
-          },
+                "discord",
+                "github",
+                "gitlab",
+                "google-docs",
+                "jira",
+                "slack",
+                "telegram",
+                "vercel"
+              ]
+            },
           {
             "group": "Data and workflow systems",
             "pages": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,16 +110,16 @@
             "pages": [
               "aws",
               "bitbucket",
-                "discord",
-                "github",
-                "gitlab",
-                "google-docs",
-                "jira",
-                "slack",
-                "telegram",
-                "vercel"
-              ]
-            },
+              "discord",
+              "github",
+              "gitlab",
+              "google-docs",
+              "jira",
+              "slack",
+              "telegram",
+              "vercel"
+            ]
+          },
           {
             "group": "Data and workflow systems",
             "pages": [

--- a/docs/telegram.mdx
+++ b/docs/telegram.mdx
@@ -1,0 +1,110 @@
+---
+title: "Telegram"
+---
+
+OpenSRE's Telegram integration lets you post investigation findings into a personal chat, group, or channel using a BotFather-managed bot token.
+
+---
+
+## Step 1: Create a Telegram Bot
+
+1. Open Telegram and start a chat with [@BotFather](https://t.me/BotFather).
+2. Run `/newbot`.
+3. Follow the prompts to choose:
+   - A display name for the bot
+   - A unique bot username ending in `bot`
+4. Copy the bot token BotFather returns. Treat it like a password.
+
+---
+
+## Step 2: Add the Bot to the Destination Chat
+
+Choose where you want OpenSRE to post findings:
+
+- **Personal chat** — start a direct chat with the bot and send any message.
+- **Group** — add the bot to the group and send any message after it joins.
+- **Channel** — add the bot as an admin if the channel requires posting permissions.
+
+If you plan to use a group or channel, make sure the bot is allowed to post messages there.
+
+---
+
+## Step 3: Find the Chat ID
+
+Telegram uses a numeric `chat_id` to know where to post findings.
+
+### Personal chat
+
+1. Send a message to your bot.
+2. Open this URL in your browser, replacing `<BOT_TOKEN>` with the token from BotFather:
+
+   ```text
+   https://api.telegram.org/bot<BOT_TOKEN>/getUpdates
+   ```
+
+3. Look for `message.chat.id` in the JSON response.
+
+### Group or supergroup
+
+1. Add the bot to the group and send a message in that group.
+2. Refresh `getUpdates`.
+3. Look for `message.chat.id`.
+   - Supergroup IDs usually start with `-100`.
+
+If `getUpdates` is empty, make sure the bot has received at least one message since it was created or added to the chat.
+
+---
+
+## Step 4: Configure the Integration in OpenSRE
+
+Run the setup wizard and select **Telegram**:
+
+```bash
+opensre onboard
+```
+
+When prompted, enter:
+
+- **Telegram bot token** — from BotFather
+- **Default chat ID** *(optional)* — the chat where CLI-triggered findings should be posted
+
+OpenSRE validates the bot token with Telegram's `getMe` API before saving it.
+
+The wizard writes the following environment variables to your `.env` file:
+
+| Variable | Description |
+|---|---|
+| `TELEGRAM_BOT_TOKEN` | Bot token used for Telegram API calls |
+| `TELEGRAM_DEFAULT_CHAT_ID` | Default chat destination for findings posted outside a chat callback |
+
+---
+
+## Step 5: Verify It Works
+
+After onboarding, you can re-run the wizard or verify your integrations from the CLI:
+
+```bash
+opensre integrations verify telegram
+```
+
+A healthy result should mention the Telegram bot username returned by `getMe`.
+
+---
+
+## Troubleshooting
+
+**`Telegram API check failed` during onboarding**
+
+Double-check the bot token. BotFather tokens are long and easy to truncate when copying.
+
+**`chat not found` when posting findings**
+
+The bot is not in the destination chat, or the `chat_id` is wrong. Send a fresh message in the target chat and inspect `getUpdates` again.
+
+**No `getUpdates` results**
+
+Telegram only returns updates after the bot has received at least one message. Start a chat with the bot or mention it in the target group, then try again.
+
+**Group ID does not look like a normal number**
+
+That is expected. Supergroup chat IDs commonly start with `-100`, and OpenSRE accepts that format as-is.

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -221,6 +221,78 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     assert "Grafana" in output
 
 
+def test_run_wizard_configures_telegram(monkeypatch, tmp_path, capsys) -> None:
+    select_responses = iter(["quickstart", "anthropic", "telegram"])
+    password_responses = iter(["llm-secret", "123456:ABCDEF"])
+    text_responses = iter(["-1001234567890"])
+    saved_integrations: list[tuple[str, dict]] = []
+    synced_env_values: list[dict[str, str]] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(password_responses)
+        return m
+
+    def _mock_text(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(text_responses)
+        return m
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow.questionary, "text", _mock_text)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(
+        flow,
+        "validate_telegram_integration",
+        lambda **_kwargs: flow.IntegrationHealthResult(ok=True, detail="Telegram ok"),
+        raising=False,
+    )
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr(flow, "save_llm_api_key", lambda *_args, **_kwargs: None)
+
+    def _sync_env_values(values: dict[str, str], **_kwargs):
+        synced_env_values.append(values)
+        return tmp_path / ".env"
+
+    monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(
+        flow,
+        "upsert_integration",
+        lambda service, payload: saved_integrations.append((service, payload)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert saved_integrations == [
+        (
+            "telegram",
+            {
+                "credentials": {
+                    "bot_token": "123456:ABCDEF",
+                    "default_chat_id": "-1001234567890",
+                }
+            },
+        )
+    ]
+    assert synced_env_values == [
+        {
+            "TELEGRAM_BOT_TOKEN": "123456:ABCDEF",
+            "TELEGRAM_DEFAULT_CHAT_ID": "-1001234567890",
+        },
+    ]
+    output = capsys.readouterr().out
+    assert "Telegram" in output
+
+
 def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     select_responses = iter(["quickstart", "anthropic", "honeycomb"])
     password_responses = iter(["llm-secret", "hny_test"])

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -216,9 +216,9 @@ def test_validate_telegram_integration_uses_existing_verifier(monkeypatch) -> No
     module = import_module("app.cli.wizard.integration_health")
 
     monkeypatch.setattr(
-        "app.integrations._verification_adapters.requests.get",
+        "app.cli.wizard.integration_validators.http_probe_validators.httpx.get",
         lambda *_args, **_kwargs: types.SimpleNamespace(
-            raise_for_status=lambda: None,
+            status_code=200,
             json=lambda: {"ok": True, "result": {"username": "opensre_bot"}},
         ),
     )
@@ -236,10 +236,16 @@ def test_validate_telegram_integration_redacts_bot_token_on_error(monkeypatch) -
     module = import_module("app.cli.wizard.integration_health")
 
     def _raise_request_error(*_args, **_kwargs):
-        raise RuntimeError("request failed for https://api.telegram.org/bot123456:ABCDEF/getMe")
+        raise httpx.RequestError(
+            "request failed for https://api.telegram.org/bot123456:ABCDEF/getMe",
+            request=httpx.Request(
+                "GET",
+                "https://api.telegram.org/bot123456:ABCDEF/getMe",
+            ),
+        )
 
     monkeypatch.setattr(
-        "app.integrations._verification_adapters.requests.get",
+        "app.cli.wizard.integration_validators.http_probe_validators.httpx.get",
         _raise_request_error,
     )
 

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -47,6 +47,7 @@ def test_legacy_integration_health_import_surface_still_exports_validators() -> 
         "validate_sentry_integration",
         "validate_slack_webhook",
         "validate_splunk_integration",
+        "validate_telegram_integration",
         "validate_vercel_integration",
     }
 
@@ -209,6 +210,47 @@ def test_validate_slack_webhook_fails_for_invalid_host() -> None:
 
     assert result.ok is False
     assert "slack domain" in result.detail.lower()
+
+
+def test_validate_telegram_integration_uses_existing_verifier(monkeypatch) -> None:
+    module = import_module("app.cli.wizard.integration_health")
+
+    monkeypatch.setattr(
+        "app.integrations._verification_adapters.requests.get",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {"ok": True, "result": {"username": "opensre_bot"}},
+        ),
+    )
+
+    validate = getattr(module, "validate_telegram_integration", None)
+
+    assert validate is not None
+    result = validate(bot_token="123456:ABCDEF")
+
+    assert result.ok is True
+    assert "@opensre_bot" in result.detail
+
+
+def test_validate_telegram_integration_redacts_bot_token_on_error(monkeypatch) -> None:
+    module = import_module("app.cli.wizard.integration_health")
+
+    def _raise_request_error(*_args, **_kwargs):
+        raise RuntimeError("request failed for https://api.telegram.org/bot123456:ABCDEF/getMe")
+
+    monkeypatch.setattr(
+        "app.integrations._verification_adapters.requests.get",
+        _raise_request_error,
+    )
+
+    validate = getattr(module, "validate_telegram_integration", None)
+
+    assert validate is not None
+    result = validate(bot_token="123456:ABCDEF")
+
+    assert result.ok is False
+    assert "123456:ABCDEF" not in result.detail
+    assert "<redacted>" in result.detail
 
 
 def test_validate_aws_integration_succeeds_with_static_credentials(monkeypatch) -> None:

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -54,6 +54,8 @@ _CLEARED_ENV_KEYS = (
     "OPENSRE_PROJECT_ENV_PATH",
     "OPENSRE_RELEASES_API_URL",
     "SLACK_WEBHOOK_URL",
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_DEFAULT_CHAT_ID",
     "TRACER_API_URL",
     "TRACER_WEB_APP_URL",
 )
@@ -504,7 +506,7 @@ def test_tests_inventory_commands_smoke(cli_sandbox: CliSandbox) -> None:
 def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
     # One `j` per keypress (burst writes are not separate keys). The select list wraps;
     # from the first option, len(choices)-1 steps reach "Skip for now" without wrapping past it.
-    # 19 integrations + "Skip for now" = 20 choices → 19 j's from the top.
+    # 21 integrations + "Skip for now" = 22 choices → 21 j's from the top.
     result = _run_cli_pty(
         cli_sandbox,
         "onboard",
@@ -515,7 +517,7 @@ def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
             PtyAction(
                 expect="Choose an integration to configure",
                 send=b"\r",
-                stagger_j=20,
+                stagger_j=21,
             ),
         ],
         timeout=30.0,
@@ -594,7 +596,7 @@ def test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated(
             PtyAction(
                 expect="Choose an integration to configure",
                 send=b"\r",
-                stagger_j=20,
+                stagger_j=21,
             ),
         ],
         timeout=pty_timeout,

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -13,6 +13,7 @@ from app.integrations.verify import (
     _verify_honeycomb,
     _verify_sentry,
     _verify_snowflake,
+    _verify_telegram,
     _verify_tracer,
     _verify_vercel,
     resolve_effective_integrations,
@@ -140,6 +141,24 @@ def test_verify_grafana_passes_with_supported_datasource(monkeypatch: pytest.Mon
     assert result["status"] == "passed"
     assert "loki" in result["detail"]
     assert "prometheus" in result["detail"]
+
+
+def test_verify_telegram_passes_with_valid_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_requests_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse({"ok": True, "result": {"username": "opensre_bot"}})
+
+    monkeypatch.setattr(
+        "app.integrations._verification_adapters.requests.get",
+        _fake_requests_get,
+    )
+
+    result = _verify_telegram(
+        "local env",
+        {"bot_token": "123456:ABCDEF"},
+    )
+
+    assert result["status"] == "passed"
+    assert "@opensre_bot" in result["detail"]
 
 
 def test_verify_datadog_reports_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #1481

#### Describe the changes you have made in this PR -

- added a Telegram onboarding path to `opensre onboard`, including token validation, integration persistence, and `.env` sync
- exposed `validate_telegram_integration` through the wizard validator surface by reusing the existing Telegram verifier
- redacted Telegram bot tokens from onboarding validation failures so bad probes do not leak credentials to the terminal
- added wizard, verifier, docs-nav, and interactive smoke coverage for the new Telegram option
- added `docs/telegram.mdx` and wired it into `docs/docs.json`

### Demo/Screenshot for feature changes and bug fixes - 

```text
$ make lint && make format-check && make typecheck && make test-cov
...
5416 passed, 5 skipped, 133 warnings in 70.78s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I kept the change narrow to the onboarding gap already described in #1481. OpenSRE already had Telegram delivery, catalog/env resolution, and the shared `_verify_telegram` implementation, so I reused that verifier through a small wizard-facing validator instead of introducing a second Telegram-specific probe path. The wizard now prompts for the bot token and optional default chat ID, validates the token before saving, persists the Telegram credentials, and syncs the matching environment variables. I also updated the interactive smoke tests for the extra menu option, added direct regression coverage for the new validator path, and wired the new Telegram doc into the docs navigation so the setup guide is discoverable.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
