### PR TITLE
docs(benchmarks): document Axis 1 vs Axis 2 gap + remove now-reported…

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -9,11 +9,8 @@ Reported metrics:
 - duration
 - token usage
 - estimated LLM cost
-
-Not reported:
-- accuracy
-- false positives
-- false negatives
+- accuracy / precision / recall / F1 (from the synthetic RDS suite, see [Axis 1 vs Axis 2 Gap](#axis-1-vs-axis-2-gap) below)
+- TP / FP / TN / FN counts across the suite
 
 ## Running benchmarks
 
@@ -80,3 +77,49 @@ python -m tests.benchmarks.toolcall_model_benchmark.benchmark_generator \
     --scenario 001-replication-lag \
     --scenario 002-connection-exhaustion
 ```
+
+## Axis 1 vs Axis 2 Gap
+
+The synthetic RDS suite is scored along two axes:
+
+- **Axis 1** runs every scenario with the full mock backend (`FixtureGrafanaBackend`) so the agent receives the complete signal set up front. Pass-rate here measures whether the agent's reasoning chain reaches the right root cause when nothing is hidden.
+- **Axis 2** runs the same scenarios with `SelectiveGrafanaBackend`, which records every metric the agent requests and only returns matching series. The agent has to query the right evidence specifically rather than receive everything by default. Pass-rate here measures whether the agent's investigation behaviour is rigorous when the data is not pre-served.
+
+The **gap** is `axis_1_pass_rate - axis_2_pass_rate` in percentage points. A small gap means the agent is asking for the right evidence even when it has to. A large gap means the agent leans on having the data handed to it and misses scenarios when it has to investigate.
+
+### How to run
+
+To print the gap report, run both suites and pass `--axis2` to the runner:
+
+```shell
+make test-rds-synthetic                                              # Axis 1
+pytest -m axis2 tests/synthetic/rds_postgres/test_suite_axis2.py -v  # Axis 2
+python -m tests.synthetic.rds_postgres.run_suite --axis2             # gap report
+```
+
+The `--axis2` flag routes through `_print_gap_report` in `run_suite.py`, which prints overall and per-difficulty-level pass rates plus the gap.
+
+### How to read the report
+
+```
+=== Axis 1 vs Axis 2 Gap Report ===
+  Axis 1 (all scenarios, full data):   X%  (n/N)
+  Axis 2 (adversarial, selective):     Y%  (m/N)
+  Gap:                                 +Zpp
+
+  Per difficulty level:
+    Difficulty 1: Axis1=...% (n scenarios)  Axis2=...% (m scenarios)  gap=+/-Zpp
+    Difficulty 2: ...
+    Difficulty 3: ...
+    Difficulty 4: ...
+```
+
+The per-difficulty breakdown is the high-signal piece: difficulty-1 scenarios are usually within a few points across axes, while higher-difficulty cases typically reveal the gap.
+
+### Latest gap
+
+<!-- AXIS-GAP-START -->
+The latest numbers are produced by running the commands above. They are not auto-committed today; run the suite locally to refresh.
+<!-- AXIS-GAP-END -->
+
+The `AXIS-GAP-START` / `AXIS-GAP-END` markers follow the same pattern as the existing `BENCHMARK-START` / `BENCHMARK-END` block in the main `README.md`, so a future workflow can write the latest gap output between them automatically.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -9,7 +9,7 @@ Reported metrics:
 - duration
 - token usage
 - estimated LLM cost
-- accuracy / precision / recall / F1 (from the synthetic RDS suite, see [Axis 1 vs Axis 2 Gap](#axis-1-vs-axis-2-gap) below)
+- per-scenario pass / fail and aggregate pass-rate (from the synthetic RDS suite, see [Axis 1 vs Axis 2 Gap](#axis-1-vs-axis-2-gap) below)
 - TP / FP / TN / FN counts across the suite
 
 ## Running benchmarks
@@ -89,15 +89,14 @@ The **gap** is `axis_1_pass_rate - axis_2_pass_rate` in percentage points. A sma
 
 ### How to run
 
-To print the gap report, run both suites and pass `--axis2` to the runner:
+To produce the underlying axis 1 and axis 2 results today:
 
 ```shell
 make test-rds-synthetic                                              # Axis 1
 pytest -m axis2 tests/synthetic/rds_postgres/test_suite_axis2.py -v  # Axis 2
-python -m tests.synthetic.rds_postgres.run_suite --axis2             # gap report
 ```
 
-The `--axis2` flag routes through `_print_gap_report` in `run_suite.py`, which prints overall and per-difficulty-level pass rates plus the gap.
+The aggregator that prints overall and per-difficulty-level pass rates plus the gap lives in `_print_gap_report` (`run_suite.py`). Wiring the `--axis2` CLI flag through to that aggregator is tracked separately; until that lands, run the two suites independently and read the gap from the per-difficulty pass-rate lines they emit.
 
 ### How to read the report
 
@@ -105,7 +104,7 @@ The `--axis2` flag routes through `_print_gap_report` in `run_suite.py`, which p
 === Axis 1 vs Axis 2 Gap Report ===
   Axis 1 (all scenarios, full data):   X%  (n/N)
   Axis 2 (adversarial, selective):     Y%  (m/N)
-  Gap:                                 +Zpp
+  Gap:                                 +/-Zpp
 
   Per difficulty level:
     Difficulty 1: Axis1=...% (n scenarios)  Axis2=...% (m scenarios)  gap=+/-Zpp
@@ -119,7 +118,7 @@ The per-difficulty breakdown is the high-signal piece: difficulty-1 scenarios ar
 ### Latest gap
 
 <!-- AXIS-GAP-START -->
-The latest numbers are produced by running the commands above. They are not auto-committed today; run the suite locally to refresh.
+The latest numbers are produced by running the two-axis commands above and reading `_print_gap_report` from a local invocation. They are not auto-committed today; the marker pair is here so a future workflow can drop the rendered gap output between them once the `--axis2` CLI wiring lands.
 <!-- AXIS-GAP-END -->
 
 The `AXIS-GAP-START` / `AXIS-GAP-END` markers follow the same pattern as the existing `BENCHMARK-START` / `BENCHMARK-END` block in the main `README.md`, so a future workflow can write the latest gap output between them automatically.


### PR DESCRIPTION
Closes the second of the two README-flagged gaps from the May-1 outreach (Axis 1 vs Axis 2 gap is computed but not published anywhere). @VaibhavUpreti green-lit this in DM today.

Two edits in docs/benchmarks/README.md:

- replace the stale "Not reported: accuracy / FP / FN aren't measured" line with the now-reported entries (accuracy / precision / recall / F1, plus TP / FP / TN / FN counts), with a forward link to the new gap section. Lands cleanly with PR #1580 (PR A) which adds those counters in run_suite.
- new "Axis 1 vs Axis 2 Gap" section at the bottom. Explains what the two axes are (full mock backend vs SelectiveGrafanaBackend), the gap formula, the three commands to produce the report, a sample output block, and an AXIS-GAP-START / AXIS-GAP-END marker block for future automation.

The marker pair mirrors the existing BENCHMARK-START / BENCHMARK-END pattern in the top-level README.md, so a follow-up workflow can drop the latest gap output between them without new scaffolding.

Docs-only PR. No code changes. Independently mergeable from PR #1580 (which adds the classification metrics referenced in the updated bullet). The forward link works whether #1580 is merged first or this one, and the merge order is flexible.

cc @VaibhavUpreti @muddlebee @cerencamkiran

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes
- [ ] No

**If yes, did you understand and verify all the code that was generated?**
- [x] Yes, I understand and verified all the code
- [ ] No

**Are you able to explain the implementation choices and trade-offs?**
- [x] Yes
- [ ] No