### PR TITLE
feat(agents): add /agents conflicts subcommand for file-write conflict detection

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-agent coordination primitives for the `/agents` slash command."""

--- a/app/agents/conflicts.py
+++ b/app/agents/conflicts.py
@@ -1,0 +1,140 @@
+"""File-write conflict detection and rendering for `/agents conflicts`.
+
+Detection is pure logic over a list of write events. Whatever upstream component
+(a watcher; eventually #1500's blast-radius watcher, or a polling collector)
+produces these events is out of scope for this module — we accept events as
+input and treat collection as somebody else's problem.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from rich.markup import escape
+from rich.table import Table
+
+#: Default conflict window. Two distinct agents writing the same file within
+#: this many seconds is treated as a conflict (per AniketXD on Discord).
+DEFAULT_WINDOW_SECONDS: float = 10.0
+
+
+@dataclass(frozen=True)
+class WriteEvent:
+    """A single observed write to a path by an agent process.
+
+    ``agent`` is a display name plus pid (e.g. ``"claude-code:8421"``).
+    ``timestamp`` is unix seconds, when the write was observed.
+    """
+
+    agent: str
+    path: str
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class FileWriteConflict:
+    """Two or more distinct agents wrote to the same path within the window.
+
+    ``agents`` is sorted alphabetically for stable output. ``first_seen`` and
+    ``last_seen`` are the earliest and latest observed write timestamps in the
+    colliding cluster.
+    """
+
+    path: str
+    agents: tuple[str, ...]
+    first_seen: float
+    last_seen: float
+
+
+def detect_conflicts(
+    events: Sequence[WriteEvent],
+    window_seconds: float,
+    opensre_agent_id: str,
+) -> list[FileWriteConflict]:
+    """Return file-write conflicts within ``window_seconds`` of the most recent event.
+
+    A conflict is a path written by two or more distinct agents whose write
+    events all fall within ``window_seconds`` of the most recent non-OpenSRE
+    event. Repeated writes by the same agent collapse to a single entry in
+    ``agents``. Events whose ``agent`` matches ``opensre_agent_id`` are removed
+    before window selection so OpenSRE never reports itself as a colliding
+    agent and never anchors the window with its own activity.
+
+    The window is anchored on the most recent event timestamp rather than
+    wall-clock ``now`` so the function stays pure and testable. The boundary is
+    inclusive: an event exactly ``window_seconds`` older than the anchor is kept.
+    Results are sorted by ``last_seen`` descending (freshest collisions first),
+    with ``path`` ascending as a stable tiebreaker.
+    """
+    relevant = [e for e in events if e.agent != opensre_agent_id]
+    if not relevant:
+        return []
+
+    anchor = max(e.timestamp for e in relevant)
+    in_window = [e for e in relevant if anchor - e.timestamp <= window_seconds]
+
+    by_path: dict[str, list[WriteEvent]] = defaultdict(list)
+    for event in in_window:
+        by_path[event.path].append(event)
+
+    conflicts: list[FileWriteConflict] = []
+    for path, group in by_path.items():
+        distinct_agents = {e.agent for e in group}
+        if len(distinct_agents) < 2:
+            continue
+        timestamps = [e.timestamp for e in group]
+        conflicts.append(
+            FileWriteConflict(
+                path=path,
+                agents=tuple(sorted(distinct_agents)),
+                first_seen=min(timestamps),
+                last_seen=max(timestamps),
+            )
+        )
+
+    conflicts.sort(key=lambda c: c.path)
+    conflicts.sort(key=lambda c: c.last_seen, reverse=True)
+    return conflicts
+
+
+def _format_timestamp(t: float) -> str:
+    return datetime.fromtimestamp(t, tz=UTC).strftime("%H:%M:%S UTC")
+
+
+def render_conflicts(conflicts: list[FileWriteConflict]) -> Table | str:
+    """Render conflicts as a Rich table, or return ``"no conflicts detected"`` if empty."""
+    if not conflicts:
+        return "no conflicts detected"
+
+    # Deferred to avoid a circular import: the interactive-shell package eagerly
+    # initialises its REPL graph, which imports the /agents slash command, which
+    # imports this module.
+    from app.cli.interactive_shell.rendering import repl_table
+    from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
+
+    table = repl_table(title="Agent file-write conflicts", title_style=TERMINAL_ACCENT_BOLD)
+    table.add_column("path", style="bold", overflow="fold")
+    table.add_column("agents", overflow="fold")
+    table.add_column("first seen", style="dim")
+    table.add_column("last seen", style="dim")
+
+    for conflict in conflicts:
+        table.add_row(
+            escape(conflict.path),
+            escape(", ".join(conflict.agents)),
+            _format_timestamp(conflict.first_seen),
+            _format_timestamp(conflict.last_seen),
+        )
+    return table
+
+
+__all__ = [
+    "DEFAULT_WINDOW_SECONDS",
+    "FileWriteConflict",
+    "WriteEvent",
+    "detect_conflicts",
+    "render_conflicts",
+]

--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -8,6 +8,7 @@ from itertools import chain
 from rich.console import Console
 from rich.markup import escape
 
+from app.cli.interactive_shell.command_registry.agents import COMMANDS as AGENTS_COMMANDS
 from app.cli.interactive_shell.command_registry.help import COMMANDS as HELP_COMMANDS
 from app.cli.interactive_shell.command_registry.integrations import (
     COMMANDS as INTEGRATIONS_COMMANDS,
@@ -44,6 +45,7 @@ _MERGED_SEQUENCE = tuple(
         MODEL_COMMANDS,
         INVESTIGATION_COMMANDS,
         TASK_COMMANDS,
+        AGENTS_COMMANDS,
         SYSTEM_COMMANDS,
     )
 )

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -1,0 +1,74 @@
+"""Slash command: /agents (file-write conflicts between local AI agents)."""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+from rich.markup import escape
+
+from app.agents.conflicts import (
+    DEFAULT_WINDOW_SECONDS,
+    WriteEvent,
+    detect_conflicts,
+    render_conflicts,
+)
+from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.theme import TERMINAL_ERROR
+
+_AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("conflicts", "show file-write conflicts between local AI agents"),
+)
+
+
+def _opensre_agent_id() -> str:
+    return f"opensre:{os.getpid()}"
+
+
+def _cmd_agents_conflicts(console: Console) -> bool:
+    # Real write-event collection comes from #1500 (filesystem blast-radius
+    # watcher), out of scope for this PR. Until that lands, the event source
+    # is empty and `/agents conflicts` reports "no conflicts detected".
+    events: list[WriteEvent] = []
+    conflicts = detect_conflicts(
+        events,
+        window_seconds=DEFAULT_WINDOW_SECONDS,
+        opensre_agent_id=_opensre_agent_id(),
+    )
+    console.print(render_conflicts(conflicts))
+    return True
+
+
+def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool:
+    if not args:
+        console.print(
+            f"[{TERMINAL_ERROR}]usage:[/] /agents <subcommand>  "
+            "— try [bold]/agents conflicts[/bold]"
+        )
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    sub = args[0].lower().strip()
+
+    if sub == "conflicts":
+        return _cmd_agents_conflicts(console)
+
+    console.print(
+        f"[{TERMINAL_ERROR}]unknown subcommand:[/] {escape(sub)}  "
+        "(try [bold]/agents conflicts[/bold])"
+    )
+    session.mark_latest(ok=False, kind="slash")
+    return True
+
+
+COMMANDS: list[SlashCommand] = [
+    SlashCommand(
+        "/agents",
+        "inspect and coordinate concurrent local AI agents (subcommands: conflicts)",
+        _cmd_agents,
+        first_arg_completions=_AGENTS_FIRST_ARGS,
+    ),
+]
+
+__all__ = ["COMMANDS"]

--- a/tests/agents/test_conflicts.py
+++ b/tests/agents/test_conflicts.py
@@ -1,0 +1,130 @@
+"""Direct unit tests for app/agents/conflicts.py."""
+
+from __future__ import annotations
+
+from app.agents.conflicts import FileWriteConflict, WriteEvent, detect_conflicts
+
+OPENSRE_ID = "opensre:1"
+
+
+class TestEmptyAndTrivialInputs:
+    def test_empty_events_returns_empty_list(self) -> None:
+        assert detect_conflicts([], window_seconds=60.0, opensre_agent_id=OPENSRE_ID) == []
+
+    def test_only_opensre_events_returns_empty_list(self) -> None:
+        events = [
+            WriteEvent(agent=OPENSRE_ID, path="/a", timestamp=10.0),
+            WriteEvent(agent=OPENSRE_ID, path="/a", timestamp=20.0),
+        ]
+        assert detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID) == []
+
+    def test_single_agent_repeated_writes_no_conflict(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=10.0),
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=20.0),
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=30.0),
+        ]
+        assert detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID) == []
+
+
+class TestWindowBoundaries:
+    def test_two_agents_same_path_inside_window(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=100.0),
+            WriteEvent(agent="cursor:2", path="/a", timestamp=110.0),
+        ]
+        result = detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID)
+        assert result == [
+            FileWriteConflict(
+                path="/a",
+                agents=("claude-code:1", "cursor:2"),
+                first_seen=100.0,
+                last_seen=110.0,
+            )
+        ]
+
+    def test_two_agents_same_path_outside_window(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=10.0),
+            WriteEvent(agent="cursor:2", path="/a", timestamp=200.0),
+        ]
+        # claude's write is 190s before cursor's; window 60s drops it.
+        assert detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID) == []
+
+    def test_window_boundary_is_inclusive(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=40.0),
+            WriteEvent(agent="cursor:2", path="/a", timestamp=100.0),
+        ]
+        # 100 - 40 == 60, exactly at the boundary; must be included.
+        result = detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID)
+        assert len(result) == 1
+        assert result[0].agents == ("claude-code:1", "cursor:2")
+
+
+class TestMultiAgentAndFiltering:
+    def test_three_agents_same_path_inside_window(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=100.0),
+            WriteEvent(agent="cursor:2", path="/a", timestamp=105.0),
+            WriteEvent(agent="aider:3", path="/a", timestamp=110.0),
+        ]
+        result = detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID)
+        assert result == [
+            FileWriteConflict(
+                path="/a",
+                agents=("aider:3", "claude-code:1", "cursor:2"),
+                first_seen=100.0,
+                last_seen=110.0,
+            )
+        ]
+
+    def test_opensre_event_does_not_create_conflict_with_lone_agent(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=100.0),
+            WriteEvent(agent=OPENSRE_ID, path="/a", timestamp=105.0),
+        ]
+        # Only one real agent → no conflict, even though OpenSRE also wrote.
+        assert detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID) == []
+
+    def test_opensre_filtered_when_other_agents_collide(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=100.0),
+            WriteEvent(agent="cursor:2", path="/a", timestamp=105.0),
+            WriteEvent(agent=OPENSRE_ID, path="/a", timestamp=110.0),
+        ]
+        # OpenSRE must not appear in agents nor influence first_seen/last_seen.
+        result = detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID)
+        assert result == [
+            FileWriteConflict(
+                path="/a",
+                agents=("claude-code:1", "cursor:2"),
+                first_seen=100.0,
+                last_seen=105.0,
+            )
+        ]
+
+    def test_agents_tuple_is_deduplicated_and_sorted(self) -> None:
+        events = [
+            WriteEvent(agent="cursor:2", path="/a", timestamp=100.0),
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=101.0),
+            WriteEvent(agent="cursor:2", path="/a", timestamp=102.0),
+            WriteEvent(agent="claude-code:1", path="/a", timestamp=103.0),
+        ]
+        result = detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID)
+        assert len(result) == 1
+        assert result[0].agents == ("claude-code:1", "cursor:2")
+
+
+class TestMultipleConflicts:
+    def test_unrelated_paths_independent_conflicts_sorted_by_last_seen_desc(self) -> None:
+        events = [
+            WriteEvent(agent="claude-code:1", path="/old", timestamp=100.0),
+            WriteEvent(agent="cursor:2", path="/old", timestamp=105.0),
+            WriteEvent(agent="claude-code:1", path="/new", timestamp=140.0),
+            WriteEvent(agent="cursor:2", path="/new", timestamp=150.0),
+        ]
+        result = detect_conflicts(events, window_seconds=60.0, opensre_agent_id=OPENSRE_ID)
+        assert [c.path for c in result] == ["/new", "/old"]
+        assert result[0].last_seen == 150.0
+        assert result[1].last_seen == 105.0

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -1,0 +1,107 @@
+"""Unit tests for /agents slash command and conflict renderer."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+from rich.table import Table
+
+from app.agents.conflicts import (
+    DEFAULT_WINDOW_SECONDS,
+    FileWriteConflict,
+    render_conflicts,
+)
+from app.cli.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
+from app.cli.interactive_shell.session import ReplSession
+
+
+def _capture() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    return Console(file=buf, force_terminal=False, highlight=False, width=120), buf
+
+
+class TestAgentsRegistration:
+    def test_agents_command_is_registered(self) -> None:
+        assert "/agents" in SLASH_COMMANDS
+
+    def test_agents_first_arg_completions_include_conflicts(self) -> None:
+        cmd = SLASH_COMMANDS["/agents"]
+        keywords = [pair[0] for pair in cmd.first_arg_completions]
+        assert "conflicts" in keywords
+
+    def test_default_window_constant_is_ten_seconds(self) -> None:
+        assert DEFAULT_WINDOW_SECONDS == 10.0
+
+
+class TestAgentsDispatch:
+    def test_conflicts_with_empty_event_source_renders_empty_state(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents conflicts", session, console) is True
+        assert "no conflicts detected" in buf.getvalue()
+
+    def test_no_subcommand_prints_usage_hint(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents", session, console) is True
+        out = buf.getvalue()
+        assert "usage" in out.lower()
+        assert "/agents conflicts" in out
+
+    def test_unknown_subcommand_prints_error(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents bogus", session, console) is True
+        out = buf.getvalue()
+        assert "unknown subcommand" in out.lower()
+        assert "bogus" in out
+
+
+class TestRenderConflicts:
+    def test_empty_list_returns_empty_state_string(self) -> None:
+        assert render_conflicts([]) == "no conflicts detected"
+
+    def test_non_empty_list_returns_table_with_paths_and_agents(self) -> None:
+        conflicts = [
+            FileWriteConflict(
+                path="/repo/auth.py",
+                agents=("claude-code:1", "cursor:2"),
+                first_seen=100.0,
+                last_seen=110.0,
+            ),
+        ]
+        result = render_conflicts(conflicts)
+        assert isinstance(result, Table)
+
+        buf = io.StringIO()
+        Console(file=buf, force_terminal=False, highlight=False, width=120).print(result)
+        out = buf.getvalue()
+        assert "/repo/auth.py" in out
+        assert "claude-code:1" in out
+        assert "cursor:2" in out
+
+    def test_multiple_conflicts_each_rendered(self) -> None:
+        conflicts = [
+            FileWriteConflict(
+                path="/new.py",
+                agents=("claude-code:1", "cursor:2"),
+                first_seen=140.0,
+                last_seen=150.0,
+            ),
+            FileWriteConflict(
+                path="/old.py",
+                agents=("aider:3", "cursor:2"),
+                first_seen=100.0,
+                last_seen=105.0,
+            ),
+        ]
+        result = render_conflicts(conflicts)
+        assert isinstance(result, Table)
+
+        buf = io.StringIO()
+        Console(file=buf, force_terminal=False, highlight=False, width=120).print(result)
+        out = buf.getvalue()
+        assert "/new.py" in out
+        assert "/old.py" in out
+        assert "aider:3" in out


### PR DESCRIPTION
Fixes #1502

#### Describe the changes you have made in this PR -

Adds the `/agents conflicts` slash command to the OpenSRE interactive shell. It surfaces conflicts between writes to the same file by concurrent local AI agents as a Rich table, or "no conflicts detected" when there are none.

Three new files: `app/agents/conflicts.py` (detector and renderer), `app/cli/interactive_shell/command_registry/agents.py` (slash command registration), and tests under `tests/agents/` and `tests/cli/interactive_shell/`.

Scope: only conflicts between writes to the same file (not branches). The default conflict window is `DEFAULT_WINDOW_SECONDS = 10.0`. Real collection of write events is the responsibility of #1500. This PR ships the detector and command surface with an empty event source until #1500 lands.

### Demo/Screenshot for feature changes and bug fixes -


<img width="1374" height="284" alt="Screenshot 2026-05-07 at 11 52 20 PM" src="https://github.com/user-attachments/assets/2789d818-3dc3-4b5d-bf83-3bab7df47eea" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I split the work into a pure detector and a separate shell layer so the logic stays testable without time mocking or shell coupling. The detector anchors its window on the most recent event timestamp from agents other than OpenSRE itself, rather than the current system time, which keeps it deterministic. `/agents` registers as a single `SlashCommand` whose handler dispatches on `args[0]`. This shape is forced by `dispatch_slash`, which splits on whitespace and only looks up the first token. I considered snapshotting open writable handles via `psutil` instead of taking events as input, but the agreed framing was "wrote in the last N seconds". That is an event, not a handle, and #1500 is the right home for collection.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions