### PR TITLE
fix(cli): Slack local store credentials are ignored by verification and CLI publishing 

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1600,8 +1600,20 @@ def _service_metadata(
 
 
 def _raw_credentials(config: dict[str, Any]) -> dict[str, Any]:
-    raw_credentials = config.get("credentials", config)
-    return raw_credentials if isinstance(raw_credentials, dict) else {}
+    credentials = config.get("credentials")
+    if isinstance(credentials, dict):
+        return credentials
+
+    instances = config.get("instances")
+    if isinstance(instances, list):
+        for instance in instances:
+            if not isinstance(instance, dict):
+                continue
+            instance_credentials = instance.get("credentials")
+            if isinstance(instance_credentials, dict):
+                return instance_credentials
+
+    return config
 
 
 def resolve_effective_integrations(

--- a/app/utils/slack_delivery.py
+++ b/app/utils/slack_delivery.py
@@ -171,6 +171,23 @@ def _merge_payload(
     return payload
 
 
+def _configured_webhook_url() -> str:
+    """Return the standalone Slack webhook from env or the local integration store."""
+    env_webhook_url = os.getenv("SLACK_WEBHOOK_URL", "").strip()
+    if env_webhook_url:
+        return env_webhook_url
+
+    try:
+        from app.integrations.catalog import resolve_effective_integrations
+
+        slack_integration = resolve_effective_integrations().get("slack") or {}
+        config = slack_integration.get("config") if isinstance(slack_integration, dict) else {}
+        return str(config.get("webhook_url", "") if isinstance(config, dict) else "").strip()
+    except Exception:
+        logger.debug("Failed to resolve Slack webhook from integration store", exc_info=True)
+        return ""
+
+
 def send_slack_report(
     slack_message: str,
     channel: str | None = None,
@@ -184,7 +201,8 @@ def send_slack_report(
 
     When thread context is available, prefers a thread reply to avoid creating
     loops for inbound Slack-triggered investigations. For standalone CLI or
-    local investigations, falls back to SLACK_WEBHOOK_URL if configured.
+    local investigations, falls back to SLACK_WEBHOOK_URL or the local Slack
+    integration store if configured.
 
     Args:
         slack_message: The formatted RCA report text.
@@ -198,7 +216,7 @@ def send_slack_report(
         (success, error_detail) — success is True if posted, error_detail is non-empty on failure.
     """
     if not thread_ts:
-        webhook_url = os.getenv("SLACK_WEBHOOK_URL", "").strip()
+        webhook_url = _configured_webhook_url()
         if webhook_url:
             webhook_ok = _post_via_incoming_webhook(
                 slack_message,
@@ -208,7 +226,7 @@ def send_slack_report(
             )
             return (True, "") if webhook_ok else (False, "webhook=failed")
         logger.debug("[slack] Delivery skipped: no thread_ts (channel=%s)", channel)
-        debug_print("Slack delivery skipped: no thread_ts and no SLACK_WEBHOOK_URL configured.")
+        debug_print("Slack delivery skipped: no thread_ts and no Slack webhook configured.")
         return False, "no_thread_ts"
 
     if access_token and channel:

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -118,6 +118,40 @@ def test_resolve_effective_integrations_keeps_incomplete_datadog_store_record(
     assert effective["datadog"]["config"]["api_key"] == ""
 
 
+def test_verify_slack_uses_v2_store_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.integrations.catalog.load_integrations",
+        lambda: [
+            {
+                "id": "slack-local",
+                "service": "slack",
+                "status": "active",
+                "instances": [
+                    {
+                        "name": "default",
+                        "tags": {},
+                        "credentials": {
+                            "webhook_url": "https://hooks.slack.com/services/T000/B000/test"
+                        },
+                    }
+                ],
+            }
+        ],
+    )
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+    results = verify_integrations("slack")
+
+    assert results == [
+        {
+            "service": "slack",
+            "source": "local store",
+            "status": "passed",
+            "detail": "Configured. Use --send-slack-test to validate delivery.",
+        }
+    ]
+
+
 def test_verify_grafana_passes_with_supported_datasource(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_requests_get(*_args: Any, **_kwargs: Any) -> _FakeResponse:
         return _FakeResponse(

--- a/tests/utils/test_slack_delivery.py
+++ b/tests/utils/test_slack_delivery.py
@@ -258,6 +258,7 @@ class TestPostViaWebapp:
 class TestSendSlackReport:
     def test_no_thread_ts_no_webhook_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.setattr(slack_delivery, "_configured_webhook_url", lambda: "")
         ok, err = slack_delivery.send_slack_report("hi", channel="C1", thread_ts=None)
         assert ok is False
         assert err == "no_thread_ts"
@@ -273,6 +274,31 @@ class TestSendSlackReport:
         assert ok is True
         assert err == ""
         assert captured["url"] == "https://hooks.slack.test/abc"
+
+    def test_no_thread_ts_uses_store_webhook_when_env_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+        monkeypatch.setattr(
+            "app.integrations.catalog.resolve_effective_integrations",
+            lambda: {
+                "slack": {
+                    "source": "local store",
+                    "config": {"webhook_url": "https://hooks.slack.test/store"},
+                }
+            },
+        )
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "app.utils.delivery_transport.httpx.post",
+            lambda url, **kw: captured.update({"url": url}, **kw) or _mock_response(200, None, ""),
+        )
+
+        ok, err = slack_delivery.send_slack_report("hi", channel="C1", thread_ts=None)
+
+        assert ok is True
+        assert err == ""
+        assert captured["url"] == "https://hooks.slack.test/store"
 
     def test_direct_post_used_when_token_and_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[str] = []


### PR DESCRIPTION
Fixes #1588

#### Describe the changes you have made in this PR

- **`_raw_credentials` in `app/integrations/_catalog_impl.py`** — Reads Slack (and other) credentials from v2 store records: prefers top-level `credentials`, otherwise walks `instances[].credentials`. Previously only `config.get("credentials", config)` was used, so v2-only shapes effectively had empty credentials and Slack from the local store was ignored for verification and resolution.
- **`send_slack_report` in `app/utils/slack_delivery.py`** — When there is no Slack thread context (`thread_ts`), webhook delivery now uses **`SLACK_WEBHOOK_URL` first**, then falls back to the **webhook URL from `resolve_effective_integrations()`** (local store / catalog), not env alone.
- **Tests** — `test_verify_slack_uses_v2_store_credentials` ensures `verify_integrations("slack")` passes with a v2 store record and no env webhook; Slack delivery tests cover store webhook when env is unset and keep the “no webhook” case deterministic via patching `_configured_webhook_url`.