### PR TITLE
fix(cli): include /agents in grouped /help output (#1502)

### DIFF
--- a/app/cli/interactive_shell/command_registry/help.py
+++ b/app/cli/interactive_shell/command_registry/help.py
@@ -11,6 +11,7 @@ from app.cli.interactive_shell.theme import ACCENT_DIM, TERMINAL_ACCENT_BOLD, TE
 
 
 def _cmd_help(_session: ReplSession, console: Console, _args: list[str]) -> bool:
+    from app.cli.interactive_shell.command_registry.agents import COMMANDS as AGENTS_CMDS
     from app.cli.interactive_shell.command_registry.integrations import COMMANDS as INT_CMDS
     from app.cli.interactive_shell.command_registry.investigation import COMMANDS as INV_CMDS
     from app.cli.interactive_shell.command_registry.model import COMMANDS as MODEL_CMDS
@@ -24,6 +25,7 @@ def _cmd_help(_session: ReplSession, console: Console, _args: list[str]) -> bool
         ("Integrations & Models", list(INT_CMDS) + list(MODEL_CMDS)),
         ("Investigation", list(INV_CMDS)),
         ("Tasks", list(TASK_CMDS)),
+        ("Agents", list(AGENTS_CMDS)),
         ("System", list(SYS_CMDS)),
     ]
 


### PR DESCRIPTION
Follow-up to #1589.

#### Describe the changes you have made in this PR -

`#1589` added the `/agents` slash command to `SLASH_COMMANDS` but did not register it with the grouped `/help` renderer introduced in `#1563`. As a result, `tests/cli/interactive_shell/test_commands.py::TestDispatchSlash::test_help_lists_all_commands` (which iterates over `SLASH_COMMANDS` and asserts each name appears in the rendered help table) fails on `main`. This PR adds an "Agents" section to the hardcoded `sections` list in `app/cli/interactive_shell/command_registry/help.py` so `/agents` shows up under `/help` and the test passes.

Two-line diff: one new import for `AGENTS_CMDS`, one new entry in the `sections` tuple between `Tasks` and `System` (matching the `_MERGED_SEQUENCE` order in `command_registry/__init__.py`).

### Demo/Screenshot for feature changes and bug fixes -

Local quality gate after the change:

```
make lint           ->  All checks passed!
make format-check   ->  1161 files already formatted
make typecheck      ->  Success: no issues found in 499 source files
make test-cov       ->  5488 passed, 6 skipped, 115 warnings in 46.97s
```

The previously failing `test_help_lists_all_commands` passes.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The grouped `/help` renderer in `help.py` builds its table from a hardcoded `sections` list rather than iterating over `SLASH_COMMANDS` directly, so adding a new top-level slash command requires both registry wiring (already done in `#1589`) and a `sections` entry. I placed the new `Agents` section between `Tasks` and `System` to match the order in `_MERGED_SEQUENCE`. I considered iterating `SLASH_COMMANDS` directly to remove the hardcoded list, but that would change rendering behaviour beyond the scope of this fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions