### PR TITLE
feat(agents): add AgentRecord dataclass and AgentRegistry with JSONL persistence

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,1 +1,5 @@
 """Cross-agent coordination primitives for the `/agents` slash command."""
+
+from app.agents.registry import AgentRecord, AgentRegistry
+
+__all__ = ["AgentRecord", "AgentRegistry"]

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -1,0 +1,111 @@
+"""Agent record storage and JSONL-backed registry for tracked local processes."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.constants import OPENSRE_HOME_DIR
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REGISTRY_PATH = OPENSRE_HOME_DIR / "agents.jsonl"
+
+
+@dataclass(frozen=True)
+class AgentRecord:
+    """Immutable snapshot of a registered local AI agent process."""
+
+    name: str
+    pid: int
+    command: str
+    registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AgentRecord:
+        raw_pid = data["pid"]
+        pid = int(str(raw_pid))
+        return cls(
+            name=str(data["name"]),
+            pid=pid,
+            command=str(data["command"]),
+            registered_at=str(data.get("registered_at", datetime.now(UTC).isoformat())),
+        )
+
+
+class AgentRegistry:
+    """JSONL-backed registry of locally running AI agent processes.
+
+    Persists to ``~/.config/opensre/agents.jsonl`` by default.  The file is
+    append-only for ``register`` and fully rewritten on ``forget`` / ``clear``.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _DEFAULT_REGISTRY_PATH
+        self._records: dict[int, AgentRecord] = {}
+        self._load_from_disk()
+
+    def register(self, record: AgentRecord) -> None:
+        overwrite = record.pid in self._records
+        self._records[record.pid] = record
+        if overwrite:
+            self._rewrite()
+        else:
+            self._append(record)
+
+    def forget(self, pid: int) -> AgentRecord | None:
+        removed = self._records.pop(pid, None)
+        if removed is not None:
+            self._rewrite()
+        return removed
+
+    def list(self) -> list[AgentRecord]:
+        return list(self._records.values())
+
+    def get(self, pid: int) -> AgentRecord | None:
+        return self._records.get(pid)
+
+    def clear(self) -> None:
+        self._records.clear()
+        self._rewrite()
+
+    def _load_from_disk(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            lines = self._path.read_text(encoding="utf-8").strip().splitlines()
+        except OSError:
+            logger.warning("Failed to read agent registry from %s", self._path)
+            return
+        for line in lines:
+            try:
+                data = json.loads(line)
+                record = AgentRecord.from_dict(data)
+                self._records[record.pid] = record
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                logger.warning("Skipping corrupt agent registry line: %s", line[:80])
+
+    def _append(self, record: AgentRecord) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record.to_dict()) + "\n")
+        except OSError:
+            logger.warning("Failed to append to agent registry at %s", self._path)
+
+    def _rewrite(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_name(self._path.name + ".tmp")
+            with tmp.open("w", encoding="utf-8") as fh:
+                for record in self._records.values():
+                    fh.write(json.dumps(record.to_dict()) + "\n")
+            tmp.replace(self._path)
+        except OSError:
+            logger.warning("Failed to rewrite agent registry at %s", self._path)

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -1,0 +1,164 @@
+"""Tests for agent record storage and JSONL-backed registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.agents.registry import AgentRecord, AgentRegistry
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(path=tmp_path / "agents.jsonl")
+
+
+@pytest.fixture
+def sample_record() -> AgentRecord:
+    return AgentRecord(
+        name="claude-code",
+        pid=8421,
+        command="claude --dangerously-skip-permissions",
+        registered_at="2026-05-07T12:00:00+00:00",
+    )
+
+
+class TestAgentRecord:
+    def test_frozen(self, sample_record: AgentRecord) -> None:
+        with pytest.raises(AttributeError):
+            sample_record.name = "aider"  # type: ignore[misc]
+
+    def test_round_trip_dict(self, sample_record: AgentRecord) -> None:
+        restored = AgentRecord.from_dict(sample_record.to_dict())
+        assert restored == sample_record
+
+    def test_from_dict_missing_registered_at(self) -> None:
+        record = AgentRecord.from_dict({"name": "aider", "pid": 1234, "command": "aider"})
+        assert record.name == "aider"
+        assert record.registered_at  # auto-populated
+
+    def test_from_dict_coerces_types(self) -> None:
+        record = AgentRecord.from_dict({"name": "codex", "pid": "9999", "command": "codex"})
+        assert record.pid == 9999
+        assert isinstance(record.pid, int)
+
+
+class TestAgentRegistry:
+    def test_register_and_list(self, registry: AgentRegistry, sample_record: AgentRecord) -> None:
+        registry.register(sample_record)
+        records = registry.list()
+        assert len(records) == 1
+        assert records[0] == sample_record
+
+    def test_register_overwrites_same_pid(
+        self, registry: AgentRegistry, sample_record: AgentRecord
+    ) -> None:
+        registry.register(sample_record)
+        updated = AgentRecord(
+            name="claude-code-v2",
+            pid=8421,
+            command="claude",
+            registered_at="2026-05-07T13:00:00+00:00",
+        )
+        registry.register(updated)
+        assert len(registry.list()) == 1
+        record = registry.get(8421)
+        assert record is not None
+        assert record.name == "claude-code-v2"
+
+    def test_register_overwrite_deduplicates_disk(
+        self, tmp_path: Path, sample_record: AgentRecord
+    ) -> None:
+        path = tmp_path / "agents.jsonl"
+        reg = AgentRegistry(path=path)
+        reg.register(sample_record)
+        updated = AgentRecord(
+            name="claude-code-v2",
+            pid=8421,
+            command="claude",
+            registered_at="2026-05-07T13:00:00+00:00",
+        )
+        reg.register(updated)
+
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["name"] == "claude-code-v2"
+
+    def test_get_returns_none_for_missing(self, registry: AgentRegistry) -> None:
+        assert registry.get(99999) is None
+
+    def test_forget_removes_record(
+        self, registry: AgentRegistry, sample_record: AgentRecord
+    ) -> None:
+        registry.register(sample_record)
+        removed = registry.forget(8421)
+        assert removed == sample_record
+        assert registry.list() == []
+
+    def test_forget_missing_returns_none(self, registry: AgentRegistry) -> None:
+        assert registry.forget(99999) is None
+
+    def test_clear_empties_registry(
+        self, registry: AgentRegistry, sample_record: AgentRecord
+    ) -> None:
+        registry.register(sample_record)
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider"))
+        registry.clear()
+        assert registry.list() == []
+
+    def test_persistence_round_trip(self, tmp_path: Path, sample_record: AgentRecord) -> None:
+        path = tmp_path / "agents.jsonl"
+        reg1 = AgentRegistry(path=path)
+        reg1.register(sample_record)
+        reg1.register(AgentRecord(name="aider", pid=7702, command="aider"))
+
+        reg2 = AgentRegistry(path=path)
+        assert len(reg2.list()) == 2
+        assert reg2.get(8421) == sample_record
+
+    def test_forget_updates_disk(self, tmp_path: Path, sample_record: AgentRecord) -> None:
+        path = tmp_path / "agents.jsonl"
+        reg1 = AgentRegistry(path=path)
+        reg1.register(sample_record)
+        reg1.register(AgentRecord(name="aider", pid=7702, command="aider"))
+        reg1.forget(8421)
+
+        reg2 = AgentRegistry(path=path)
+        assert len(reg2.list()) == 1
+        assert reg2.get(8421) is None
+        assert reg2.get(7702) is not None
+
+    def test_corrupt_line_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "agents.jsonl"
+        path.write_text(
+            '{"name":"claude-code","pid":8421,"command":"claude","registered_at":"2026-05-07T12:00:00+00:00"}\n'
+            "this is not json\n"
+            '{"name":"aider","pid":7702,"command":"aider","registered_at":"2026-05-07T12:00:00+00:00"}\n',
+            encoding="utf-8",
+        )
+        reg = AgentRegistry(path=path)
+        assert len(reg.list()) == 2
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "agents.jsonl"
+        path.write_text("", encoding="utf-8")
+        reg = AgentRegistry(path=path)
+        assert reg.list() == []
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "does_not_exist.jsonl"
+        reg = AgentRegistry(path=path)
+        assert reg.list() == []
+
+    def test_jsonl_file_format(self, tmp_path: Path, sample_record: AgentRecord) -> None:
+        path = tmp_path / "agents.jsonl"
+        reg = AgentRegistry(path=path)
+        reg.register(sample_record)
+
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["name"] == "claude-code"
+        assert parsed["pid"] == 8421


### PR DESCRIPTION
Fixes #1487

#### Describe the changes you have made in this PR -

Adds the `app/agents/` package as phase-0 foundation for local agent fleet monitoring

- `AgentRecord`: frozen dataclass capturing name, pid, command, and registered_at for an AI agent process, with `to_dict()`/`from_dict()` round-tripping and type coercion for PID
- `AgentRegistry`: JSONL-backed store keyed by PID. New registrations append to file, overwrites and removals trigger a full rewrite. Same pattern as `app/guardrails/audit.py`
- 17 pytest cases covering immutability, serialization, PID-overwrite dedup (in-memory and on-disk), persistence across instances, corrupt-line tolerance, empty/nonexistent file handling

### Demo/Screenshot for feature changes and bug fixes -

**Test output (17/17 passing):**
```
tests/agents/test_registry.py::TestAgentRecord::test_frozen PASSED
tests/agents/test_registry.py::TestAgentRecord::test_round_trip_dict PASSED
tests/agents/test_registry.py::TestAgentRecord::test_from_dict_missing_registered_at PASSED
tests/agents/test_registry.py::TestAgentRecord::test_from_dict_coerces_types PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_register_and_list PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_register_overwrites_same_pid PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_register_overwrite_deduplicates_disk PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_get_returns_none_for_missing PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_forget_removes_record PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_forget_missing_returns_none PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_clear_empties_registry PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_persistence_round_trip PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_forget_updates_disk PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_corrupt_line_skipped PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_empty_file PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_nonexistent_file PASSED
tests/agents/test_registry.py::TestAgentRegistry::test_jsonl_file_format PASSED
```

**Quality gate:**
```
make lint          -> All checks passed!
make format-check  -> 1153 files already formatted
make typecheck     -> Success: no issues found in 495 source files
make test-cov      -> 5419 passed, 5 skipped
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Used Claude as a coding assistant for scaffolding but I drove all the design decisions and implementation choices

First thing I did was study `app/guardrails/audit.py` to understand how the repo already handles JSONL persistence. Followed that same append/rewrite pattern rather than introducing file locks or atomic writes, keeping it consistent with what's already there

Design choices:
- `frozen=True` on AgentRecord since these are snapshots of process state, not mutable objects. PID is the natural identity key
- `from_dict()` coerces PID through `int(str(raw_pid))` to handle JSON deserialization where numbers can arrive as strings
- `register()` checks if the PID already exists to distinguish between append (new) vs rewrite (overwrite), avoiding unnecessary full-file rewrites
- Corrupt JSONL lines get logged and skipped rather than failing the whole load, since one bad line shouldn't block reading valid records

Wrote 17 tests covering the full behavior matrix including edge cases like corrupt lines, empty files, nonexistent paths, and verifying that disk state stays in sync after overwrites and forgets

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.