### PR TITLE
fix(pipeline): remove banned RunnableConfig import from graph.py

### DIFF
--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -1,9 +1,8 @@
 """Unified agent pipeline — wires nodes and edges into a LangGraph."""
 
 from collections.abc import Callable
-from typing import Any, Optional, cast
+from typing import Any, cast
 
-from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
@@ -40,9 +39,9 @@ NodeWithConfig = Callable[[AgentState, NodeConfig | None], dict[str, Any]]
 
 
 def _accept_langgraph_config(func: NodeWithConfig) -> Callable[..., dict[str, Any]]:
-    """Expose a RunnableConfig-typed config kwarg for LangGraph runtime injection."""
+    """Adapt a NodeConfig-typed node for LangGraph runtime injection."""
 
-    def _wrapped(state: AgentState, config: Optional[RunnableConfig] = None) -> dict[str, Any]:  # noqa: UP045
+    def _wrapped(state: AgentState, config: Any = None) -> dict[str, Any]:
         return func(state, cast(NodeConfig | None, config))
 
     _wrapped.__name__ = func.__name__


### PR DESCRIPTION
## What was broken

CI was failing on `main` with:

```
FAILED tests/types/test_config.py::test_core_nodes_do_not_import_runnable_config
AssertionError: assert ['app/pipeline/graph.py'] == []
```

The refactor in commit `697bb4a` (`refactor: update langgraph config handling to use RunnableConfig type`) added:

```python
from langchain_core.runnables import RunnableConfig
```

to `app/pipeline/graph.py`. This violates the project invariant enforced by `test_core_nodes_do_not_import_runnable_config`, which bans both `RunnableConfig` and `langchain_core.runnables` from `app/nodes/`, `app/pipeline/graph.py`, and `app/pipeline/runners.py`.

## What was changed

**`app/pipeline/graph.py`** — 3-line fix:
- Removed `from langchain_core.runnables import RunnableConfig`
- Changed `config: Optional[RunnableConfig] = None` → `config: Any = None` (the value is immediately cast to `NodeConfig | None` anyway, so the annotation only served type-checker aesthetics)
- Removed now-unused `Optional` import

## Verification

```
make test-cov   → 5523 passed, 7 skipped
make lint       → All checks passed!
make typecheck  → Success: no issues found in 500 source files
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBsVsP1Bh3gKN7qKmaca1D)_