### PR TITLE
fix(analytics): prevent SOCKS proxy ImportError by disabling env proxy discovery

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -757,7 +757,7 @@ class Analytics:
         self._worker = worker
 
     def _worker_loop(self) -> None:
-        with httpx.Client(timeout=_SEND_TIMEOUT) as client:
+        with httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False) as client:
             while True:
                 item = self._queue.get()
                 if item is None:


### PR DESCRIPTION
## Summary

- `httpx.Client` in `Analytics._worker_loop` was inheriting system proxy settings from environment variables (e.g. `https_proxy`, `HTTPS_PROXY`) by default
- When a SOCKS proxy is configured, httpx requires the `socksio` package, which is not in our dependencies — triggering `ImportError` at analytics startup
- Analytics traffic does not need proxy support, so passing `trust_env=False` disables env-based proxy discovery entirely

## Test plan

- [ ] Verify `make test-cov` passes
- [ ] Verify `make lint` and `make typecheck` pass
- [ ] Manually confirm analytics worker starts without error when `https_proxy=socks5://...` is set in the environment

Closes #1527

https://claude.ai/code/session_01MrxV1cy3cU675pZBWVUD3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrxV1cy3cU675pZBWVUD3V)_