### PR TITLE
fix(cli): convert LLMSettings ValidationError to user-facing OpenSREError

### DIFF
--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -30,7 +30,12 @@ def _check_llm_settings() -> None:
         LLMSettings.from_env()
     except ValidationError as exc:
         errors = exc.errors()
-        msg = errors[0]["msg"] if errors else str(exc)
+        if errors:
+            ctx = errors[0].get("ctx", {})
+            original = ctx.get("error")
+            msg = str(original) if isinstance(original, Exception) else errors[0]["msg"]
+        else:
+            msg = str(exc)
         raise OpenSREError(
             msg,
             suggestion="Run `opensre onboard` to configure your LLM provider and API credentials.",

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -20,6 +20,23 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+def _check_llm_settings() -> None:
+    """Validate LLM settings early and surface misconfiguration as a structured error."""
+    from pydantic import ValidationError
+
+    from app.cli.support.errors import OpenSREError
+
+    try:
+        LLMSettings.from_env()
+    except ValidationError as exc:
+        errors = exc.errors()
+        msg = errors[0]["msg"] if errors else str(exc)
+        raise OpenSREError(
+            msg,
+            suggestion="Run `opensre onboard` to configure your LLM provider and API credentials.",
+        ) from exc
+
+
 def _reraise_investigation_failure(exc: BaseException) -> NoReturn:
     """Map investigation runtime failures to structured CLI errors."""
     reraise_cli_runtime_error(exc)
@@ -70,7 +87,7 @@ def run_investigation_cli(
     opensre_evaluate: bool = False,
 ) -> dict[str, Any]:
     """Run the investigation and return the CLI-facing JSON payload."""
-    LLMSettings.from_env()
+    _check_llm_settings()
     resolved_alert_name, resolved_pipeline_name, resolved_severity = resolve_investigation_context(
         raw_alert=raw_alert,
         alert_name=alert_name,
@@ -133,7 +150,7 @@ def stream_investigation_cli(
 
     from app.pipeline.runners import astream_investigation
 
-    LLMSettings.from_env()
+    _check_llm_settings()
     resolved_alert_name, resolved_pipeline_name, resolved_severity = resolve_investigation_context(
         raw_alert=raw_alert,
         alert_name=alert_name,
@@ -223,7 +240,7 @@ def _run_session_alert_payload(
     from app.pipeline.runners import astream_investigation
     from app.remote.renderer import StreamRenderer
 
-    LLMSettings.from_env()
+    _check_llm_settings()
     if context_overrides:
         raw_alert.setdefault("annotations", {}).update(context_overrides)
 

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import NoReturn
 
 import pytest
-from pydantic import ValidationError
 
 from app.cli.investigation import (
     resolve_investigation_context,
@@ -124,7 +123,7 @@ def test_run_investigation_cli_fails_fast_for_invalid_llm_config(monkeypatch) ->
         lambda *_args, **_kwargs: pytest.fail("investigation should not start"),
     )
 
-    with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
+    with pytest.raises(OpenSREError, match="OPENAI_API_KEY"):
         run_investigation_cli(raw_alert={"alert_name": "PayloadAlert"})
 
 


### PR DESCRIPTION
## Summary

- `LLMSettings.from_env()` raises `pydantic.ValidationError` when the configured provider's API key is not set
- This error propagated to the bare `except Exception` handler in the REPL loop, which sent it to Sentry as a crash — but a missing API key is a user-configuration issue, not a bug
- Added `_check_llm_settings()` helper that catches `ValidationError` and re-raises as `OpenSREError` with a clear message and `opensre onboard` suggestion
- Replaced all three `LLMSettings.from_env()` call sites in `investigate.py` with `_check_llm_settings()`

## Test plan

- [ ] Verify `make test-cov` passes
- [ ] Verify `make lint` and `make typecheck` pass
- [ ] Run `opensre investigate` without `ANTHROPIC_API_KEY` set — should show a clear error with "Run `opensre onboard`" suggestion instead of a raw pydantic traceback

Closes #1523
Closes #1524

https://claude.ai/code/session_01MrxV1cy3cU675pZBWVUD3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrxV1cy3cU675pZBWVUD3V)_