### PR TITLE
fix(pipeline): raise LangGraph recursion limit to 50 to prevent GraphRecursionError

### DIFF
--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -71,7 +71,7 @@ def run_investigation(
     if resolved_integrations is not None:
         cast(dict[str, Any], initial)["resolved_integrations"] = resolved_integrations
     try:
-        return cast(AgentState, compiled_graph.invoke(initial))
+        return cast(AgentState, compiled_graph.invoke(initial, {"recursion_limit": 50}))
     except Exception as exc:
         capture_exception(exc)
         raise
@@ -103,7 +103,9 @@ async def astream_investigation(
     )
 
     try:
-        async for event in compiled_graph.astream_events(initial, version="v2"):
+        async for event in compiled_graph.astream_events(
+            initial, version="v2", config={"recursion_limit": 50}
+        ):
             yield _map_langgraph_event(dict(event))
     except Exception as exc:
         capture_exception(exc)

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -12,6 +12,8 @@ from app.state import AgentState, make_initial_state
 from app.types.config import NodeConfig
 from app.utils.sentry_sdk import capture_exception, init_sentry
 
+_GRAPH_RECURSION_LIMIT = 50
+
 
 def _merge_state(state: AgentState, updates: dict[str, Any]) -> None:
     if not updates:
@@ -71,7 +73,7 @@ def run_investigation(
     if resolved_integrations is not None:
         cast(dict[str, Any], initial)["resolved_integrations"] = resolved_integrations
     try:
-        return cast(AgentState, compiled_graph.invoke(initial, {"recursion_limit": 50}))
+        return cast(AgentState, compiled_graph.invoke(initial, {"recursion_limit": _GRAPH_RECURSION_LIMIT}))
     except Exception as exc:
         capture_exception(exc)
         raise
@@ -104,7 +106,7 @@ async def astream_investigation(
 
     try:
         async for event in compiled_graph.astream_events(
-            initial, version="v2", config={"recursion_limit": 50}
+            initial, version="v2", config={"recursion_limit": _GRAPH_RECURSION_LIMIT}
         ):
             yield _map_langgraph_event(dict(event))
     except Exception as exc:
@@ -143,7 +145,7 @@ class SimpleAgent:
         init_sentry(entrypoint="graph_pipeline")
         from app.pipeline.graph import graph as compiled_graph  # lazy to avoid circular import
 
-        cfg = config or {"configurable": {}}
+        cfg: dict[str, Any] = {**(config or {"configurable": {}}), "recursion_limit": _GRAPH_RECURSION_LIMIT}
         try:
             return cast(AgentState, compiled_graph.invoke(state, cast(Any, cfg)))
         except Exception as exc:

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -73,7 +73,9 @@ def run_investigation(
     if resolved_integrations is not None:
         cast(dict[str, Any], initial)["resolved_integrations"] = resolved_integrations
     try:
-        return cast(AgentState, compiled_graph.invoke(initial, {"recursion_limit": _GRAPH_RECURSION_LIMIT}))
+        return cast(
+            AgentState, compiled_graph.invoke(initial, {"recursion_limit": _GRAPH_RECURSION_LIMIT})
+        )
     except Exception as exc:
         capture_exception(exc)
         raise
@@ -145,7 +147,10 @@ class SimpleAgent:
         init_sentry(entrypoint="graph_pipeline")
         from app.pipeline.graph import graph as compiled_graph  # lazy to avoid circular import
 
-        cfg: dict[str, Any] = {**(config or {"configurable": {}}), "recursion_limit": _GRAPH_RECURSION_LIMIT}
+        cfg: dict[str, Any] = {
+            **(config or {"configurable": {}}),
+            "recursion_limit": _GRAPH_RECURSION_LIMIT,
+        }
         try:
             return cast(AgentState, compiled_graph.invoke(state, cast(Any, cfg)))
         except Exception as exc:


### PR DESCRIPTION
## Summary

- LangGraph's default `recursion_limit` of 25 is too low for complex investigations: each node transition counts as one step, and an investigation with multiple tool-call loops (chat mode) or multi-iteration plan/investigate cycles can easily exceed 25
- Pass `{"recursion_limit": 50}` in the run config for both `compiled_graph.invoke()` (sync path) and `compiled_graph.astream_events()` (async streaming path)

## Test plan

- [ ] Verify `make test-cov` passes
- [ ] Verify `make lint` and `make typecheck` pass
- [ ] Run an investigation that exercises multiple hypothesis loops and confirm it completes without `GraphRecursionError`

Closes #1538
Closes #1539

https://claude.ai/code/session_01MrxV1cy3cU675pZBWVUD3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrxV1cy3cU675pZBWVUD3V)_