### PR TITLE
fix(analytics): suppress Sentry noise for PostHog 4xx HTTP errors

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -798,6 +798,12 @@ class Analytics:
         }
         try:
             client.post(f"{POSTHOG_HOST}/capture/", json=payload).raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            _log_failure("posthog_send", exc, event=item.event)
+            # 4xx errors (e.g. 403 Forbidden) are operational/config issues on
+            # the PostHog side; only report 5xx server errors to Sentry.
+            if exc.response.status_code >= 500:
+                _capture_sentry_failure(exc)
         except Exception as exc:
             _log_failure("posthog_send", exc, event=item.event)
             _capture_sentry_failure(exc)


### PR DESCRIPTION
## Summary

- PostHog 403 Forbidden responses (e.g. blocked API key, rejected capture endpoint) were being forwarded to Sentry via `_capture_sentry_failure`, generating actionless noise.
- `_send` in `app/analytics/provider.py` now handles `httpx.HTTPStatusError` explicitly: 4xx responses are logged locally only; 5xx responses (PostHog server errors) still reach Sentry as they indicate a genuine outage.
- All other exception types (network errors, timeouts) still capture to Sentry as before.

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify `make typecheck` passes
- [ ] Verify `make test-cov` passes
- [ ] Manually confirm that a simulated 403 response from PostHog does **not** produce a Sentry event

Closes #1603

https://claude.ai/code/session_01GhskJEVvLvk3sCEZ7K2sF7

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhskJEVvLvk3sCEZ7K2sF7)_