### PR TITLE
fix(llm): fail immediately on model-not-found (404) without retrying

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 import boto3
 from anthropic import Anthropic, AnthropicBedrock, AuthenticationError, NotFoundError
 from openai import AuthenticationError as OpenAIAuthError
+from openai import NotFoundError as OpenAINotFoundError
 from openai import OpenAI
 from pydantic import BaseModel, ValidationError
 
@@ -541,6 +542,11 @@ class OpenAILLMClient:
                 raise RuntimeError(
                     f"{self._provider_label} authentication failed. Check {self._api_key_env} in your environment, .env, or secure local keychain."
                 ) from err
+            except OpenAINotFoundError as err:
+                raise RuntimeError(
+                    f"{self._provider_label} model '{self._model}' was not found. "
+                    "Check your configured model name or endpoint."
+                ) from err
             except GuardrailBlockedError:
                 raise
             except Exception as err:
@@ -591,6 +597,11 @@ class OpenAILLMClient:
             except OpenAIAuthError as err:
                 raise RuntimeError(
                     f"{self._provider_label} authentication failed. Check {self._api_key_env} in your environment, .env, or secure local keychain."
+                ) from err
+            except OpenAINotFoundError as err:
+                raise RuntimeError(
+                    f"{self._provider_label} model '{self._model}' was not found. "
+                    "Check your configured model name or endpoint."
                 ) from err
             except GuardrailBlockedError:
                 raise


### PR DESCRIPTION
## Summary

- When an OpenAI-compatible provider returns `NotFoundError` (HTTP 404), the model endpoint does not exist and retrying is pointless — the code was burning through the full backoff window before surfacing a confusing generic error message.
- Added an explicit `except OpenAINotFoundError` handler (imported from `openai`) in both `invoke` and `invoke_stream` on `OpenAILLMClient`, mirroring the existing `NotFoundError` handling already present for the Anthropic client.
- The new handler raises immediately with a descriptive message identifying the provider and model name, consistent with the auth-failure message style.

Affected models from Sentry reports: `tencent/hy3-preview` (#1543, #1544) and `meta.llama-4-scout-17b-16e-instruct` (#1575).

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify `make typecheck` passes
- [ ] Verify `make test-cov` passes
- [ ] Confirm that configuring a non-existent model name raises `RuntimeError` immediately (no retry delay)

Closes #1543
Closes #1544
Closes #1575

https://claude.ai/code/session_01GhskJEVvLvk3sCEZ7K2sF7

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhskJEVvLvk3sCEZ7K2sF7)_