### PR TITLE
fix(cleanup): remove remaining exception noqas and SIM115 noqa by add…

### DIFF
--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -348,8 +348,9 @@ def run_synthetic_test(
     console.print(f"[bold]$ {display_command}[/bold]")
     task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
     task.mark_running()
-    # Lifetime managed by the watcher thread's finally block. noqa: SIM115
-    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+    # Lifetime managed by the watcher thread's finally block; SIM115 ignored
+    # for this file in ruff.toml.
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg]
         max_size=_SYNTHETIC_DIAG_CHARS * 2
     )
     try:

--- a/app/cli/interactive_shell/banner.py
+++ b/app/cli/interactive_shell/banner.py
@@ -275,7 +275,7 @@ _LOGO_MARK_ROWS: tuple[tuple[str, str], ...] = (
 def _get_username() -> str:
     try:
         return getpass.getuser()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return "there"
 
 

--- a/app/cli/interactive_shell/prompt_surface.py
+++ b/app/cli/interactive_shell/prompt_surface.py
@@ -45,7 +45,7 @@ def _prompt_rule_line(width: int) -> str:
 def _prompt_rule_ansi() -> str:
     try:
         width = get_app().output.get_size().columns
-    except Exception:  # noqa: BLE001
+    except Exception:
         width = 80
     return f"{PROMPT_FRAME_ANSI}{_prompt_rule_line(width)}{ANSI_RESET}"
 

--- a/app/cli/interactive_shell/tool_catalog.py
+++ b/app/cli/interactive_shell/tool_catalog.py
@@ -87,7 +87,7 @@ def _resolve_source_file(tool: RegisteredTool) -> str:
         return ""
     try:
         module = importlib.import_module(module_name)
-    except Exception:  # noqa: BLE001
+    except Exception:
         return ""
     file_attr = getattr(module, "__file__", None)
     if not file_attr:

--- a/infra/opensre-dataset/query_opensre_telemetry.py
+++ b/infra/opensre-dataset/query_opensre_telemetry.py
@@ -33,6 +33,7 @@ import csv
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
@@ -111,27 +112,25 @@ def _cmd_raw(root: Path, rel_path: str, limit: int) -> None:
     print(json.dumps({"file": rel_path, "rows": rows}, indent=2))
 
 
-def _cmd_metrics(root: Path, contains: str) -> None:
+def _csv_backend(root: Path) -> Any:
+    """Lazy-construct the CSV Grafana backend after ``sys.path`` is set up."""
     from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
 
-    be = OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
-    out = be.query_timeseries(query=contains or "")
+    return OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
+
+
+def _cmd_metrics(root: Path, contains: str) -> None:
+    out = _csv_backend(root).query_timeseries(query=contains or "")
     print(json.dumps(out, indent=2, default=str))
 
 
 def _cmd_logs(root: Path, service: str) -> None:
-    from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
-
-    be = OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
-    out = be.query_logs(service_name=service or "")
+    out = _csv_backend(root).query_logs(service_name=service or "")
     print(json.dumps(out, indent=2, default=str))
 
 
 def _cmd_traces(root: Path, service: str) -> None:
-    from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
-
-    be = OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
-    out = be.query_traces(service_name=service or "")
+    out = _csv_backend(root).query_traces(service_name=service or "")
     print(json.dumps(out, indent=2, default=str))
 
 

--- a/infra/opensre-dataset/query_opensre_telemetry.py
+++ b/infra/opensre-dataset/query_opensre_telemetry.py
@@ -38,8 +38,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from app.integrations.opensre.constants import OPENSRE_HF_DATASET_ID  # noqa: E402
-from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend  # noqa: E402
+# App imports are deferred into the functions that use them. Doing them here
+# would be E402 (module-level imports after the sys.path mutation above) and
+# the alternative — module-level imports before sys.path setup — would fail
+# with ImportError when the script is run directly.
 
 
 def _resolve_telemetry_dir(args: argparse.Namespace) -> Path:
@@ -53,6 +55,7 @@ def _resolve_telemetry_dir(args: argparse.Namespace) -> Path:
         raise SystemExit("Pass --telemetry-dir or --relative PATH")
 
     if args.from_hub:
+        from app.integrations.opensre.constants import OPENSRE_HF_DATASET_ID
         from app.integrations.opensre.hf_remote import materialize_opensre_telemetry_from_hub
 
         dataset_id = (args.dataset_id or "").strip() or OPENSRE_HF_DATASET_ID
@@ -109,24 +112,32 @@ def _cmd_raw(root: Path, rel_path: str, limit: int) -> None:
 
 
 def _cmd_metrics(root: Path, contains: str) -> None:
+    from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
+
     be = OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
     out = be.query_timeseries(query=contains or "")
     print(json.dumps(out, indent=2, default=str))
 
 
 def _cmd_logs(root: Path, service: str) -> None:
+    from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
+
     be = OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
     out = be.query_logs(service_name=service or "")
     print(json.dumps(out, indent=2, default=str))
 
 
 def _cmd_traces(root: Path, service: str) -> None:
+    from app.integrations.opensre.csv_grafana_backend import OpenSRECsvGrafanaBackend
+
     be = OpenSRECsvGrafanaBackend(telemetry_dir=root, alert_fixture={})
     out = be.query_traces(service_name=service or "")
     print(json.dumps(out, indent=2, default=str))
 
 
 def main() -> None:
+    from app.integrations.opensre.constants import OPENSRE_HF_DATASET_ID
+
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--telemetry-dir",

--- a/ruff.toml
+++ b/ruff.toml
@@ -50,3 +50,7 @@ ignore = [
 # CLI entry points
 "app/main.py" = ["ARG001"]
 
+# stderr buffer outlives the function — closed in a watcher thread's `finally`,
+# so a `with` block at the call site would close it before the subprocess runs.
+"app/cli/interactive_shell/action_executor.py" = ["SIM115"]
+

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -31,10 +31,9 @@ def test_terminate_child_process_noop_when_exited() -> None:
 
 
 def test_read_diag_respects_byte_cap() -> None:
-    buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
-    buf.write(b"z" * 5_000)
-    text = read_diag(buf)
-    buf.close()
+    with tempfile.SpooledTemporaryFile() as buf:  # type: ignore[type-arg]
+        buf.write(b"z" * 5_000)
+        text = read_diag(buf)
     assert len(text) == 2_000
 
 

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,6 +18,19 @@ from app.cli.interactive_shell.tasks import TaskKind, TaskRegistry, TaskStatus
 def _capture() -> tuple[Console, io.StringIO]:
     buf = io.StringIO()
     return Console(file=buf, force_terminal=False, highlight=False), buf
+
+
+@pytest.fixture
+def stderr_buf() -> Iterator[tempfile.SpooledTemporaryFile]:  # type: ignore[type-arg]
+    """Stderr buffer for synthetic-watcher tests.
+
+    The watcher's ``finally`` block closes the buffer; the ``with`` here
+    is the belt-and-braces close that runs when a test exits before the
+    watcher does (e.g. deferred-thread tests where ``pending[0]()`` is
+    never invoked).
+    """
+    with tempfile.SpooledTemporaryFile() as buf:
+        yield buf
 
 
 class TestTaskRecord:
@@ -208,7 +221,9 @@ class _DeferredSyntheticThread:
 
 class TestSyntheticSubprocessWatcher:
     def test_watch_marks_completed_when_process_already_done(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
     ) -> None:
         import app.cli.interactive_shell.action_executor as ae
 
@@ -222,7 +237,6 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert task.status == TaskStatus.COMPLETED
         hist = session.history[-1]
@@ -231,7 +245,9 @@ class TestSyntheticSubprocessWatcher:
         assert "task:" in hist["text"]
 
     def test_watch_honours_exit_code_when_cancel_races_loop_exit(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
     ) -> None:
         """Process exits naturally (code 0) in the same poll tick that /cancel fires.
 
@@ -266,14 +282,15 @@ class TestSyntheticSubprocessWatcher:
             pending[0] = 0  # process finishes naturally in the same window
 
         monkeypatch.setattr(ae.time, "sleep", _fake_sleep)
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         # terminated_by_watcher is False → honour exit code 0 → COMPLETED
         assert task.status == TaskStatus.COMPLETED
         assert sleeps
 
     def test_watch_marks_cancelled_when_watcher_kills_process(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
     ) -> None:
         """cancel_requested is set while proc is still running; watcher terminates it."""
         import app.cli.interactive_shell.action_executor as ae
@@ -295,7 +312,6 @@ class TestSyntheticSubprocessWatcher:
         # Skip the sleep so the loop iterates immediately to the cancel branch.
         monkeypatch.setattr(ae.time, "sleep", lambda _: None)
 
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert task.status == TaskStatus.CANCELLED
         hist = session.history[-1]
@@ -303,7 +319,9 @@ class TestSyntheticSubprocessWatcher:
         assert hist["ok"] is False
 
     def test_watch_honours_exit_code_when_cancel_races_natural_exit(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
     ) -> None:
         """Process exits naturally (code 0) while /cancel fires concurrently.
 
@@ -326,11 +344,14 @@ class TestSyntheticSubprocessWatcher:
         # Simulate /cancel arriving just as the watcher reads poll()
         task.cancel_requested.set()
 
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert task.status == TaskStatus.COMPLETED
 
-    def test_watch_captures_stderr_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_watch_captures_stderr_on_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
+    ) -> None:
         """Diagnostic stderr output is included in mark_failed message."""
         import app.cli.interactive_shell.action_executor as ae
 
@@ -343,7 +364,6 @@ class TestSyntheticSubprocessWatcher:
         proc.poll.return_value = 1
         proc.returncode = 1
 
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         stderr_buf.write(b"ConnectionError: database unreachable\n")
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert task.status == TaskStatus.FAILED
@@ -351,7 +371,9 @@ class TestSyntheticSubprocessWatcher:
         assert "ConnectionError" in (task.error or "")
 
     def test_watch_skips_synthetic_history_after_reset(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
     ) -> None:
         import app.cli.interactive_shell.action_executor as ae
 
@@ -366,7 +388,6 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         assert len(_DeferredSyntheticThread.pending) == 1
         session.clear()
@@ -375,7 +396,9 @@ class TestSyntheticSubprocessWatcher:
         _DeferredSyntheticThread.pending.clear()
 
     def test_deferred_watcher_writes_history_when_no_reset(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stderr_buf: tempfile.SpooledTemporaryFile,  # type: ignore[type-arg]
     ) -> None:
         import app.cli.interactive_shell.action_executor as ae
 
@@ -390,7 +413,6 @@ class TestSyntheticSubprocessWatcher:
         task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
         task.mark_running()
         task.attach_process(proc)
-        stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]  # noqa: SIM115
         ae.watch_synthetic_subprocess(task, proc, session, "rds_postgres", stderr_buf)
         _DeferredSyntheticThread.pending[0]()
         assert session.history[-1]["type"] == "synthetic_test"


### PR DESCRIPTION
…ing ruff.toml exception and belt-and-braces test fixture

Fixes #1401 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR

 - This PR removes the remaining noqa suppressions from the codebase. The 9 SpooledTemporaryFile cases were handled by converting the test code to use with blocks via a shared pytest fixture, while the one production site keeps its long-lived buffer (closed in a watcher thread) covered by a per-file ignore in ruff.toml with a written reason. A few stragglers that other PRs introduced were dead suppressions and got auto-removed. One missed script under infra/ had its app imports moved into the functions that use them so they no longer trip the import-order rule. After this, no noqa comments remain in project source, and lint, format, typecheck, and the full test suite all pass.
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The codebase had a small set of remaining noqa suppressions that needed real fixes rather than just deletion. For the SpooledTemporaryFile cases in tests, I added a shared pytest fixture that creates the buffer inside a with block and yields it to each test, which let me drop the inline suppressions cleanly across seven test methods plus one standalone test. For the one production site where the buffer genuinely outlives the function (a watcher thread closes it later), a with block doesn't fit, so I moved the suppression into ruff.toml as a per-file ignore with a written reason — that satisfies the "no inline noqa" goal while keeping the documented exception. The straggler suppressions other PRs added were pointing at lint rules the project doesn't enforce, so removing them was a no-op confirmed by ruff. Finally, I caught one script under infra/ that was missed earlier and applied the same approach as app/main.py, moving the app imports into the functions that use them so the sys.path setup stays at the top.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---