### PR TITLE
fix: update contributor display format to use markdown avatars

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -118,6 +118,7 @@ jobs:
 
           # Build markdown avatar links (10 per line)
           def avatar_with_size(url, size=48):
+              url = re.sub(r"[?&]s=\d+", "", url)
               sep = "&" if "?" in url else "?"
               return f"{url}{sep}s={size}"
 

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -116,24 +116,23 @@ jobs:
           # Sort by first commit date ascending (earliest contributor first)
           contributors.sort(key=lambda c: c["first_commit"])
 
-          # Build the table HTML (12 columns per row)
-          cols = 12
+          # Build markdown avatar links (10 per line)
+          def avatar_with_size(url, size=48):
+              sep = "&" if "?" in url else "?"
+              return f"{url}{sep}s={size}"
+
+          cols = 10
           rows = [contributors[i:i+cols] for i in range(0, len(contributors), cols)]
-          lines = ["<table width=\"100%\" style=\"table-layout: fixed;\">", "\t<tbody>"]
+          lines = []
           for row in rows:
-              lines.append("\t\t<tr>")
+              links = []
               for c in row:
-                  lines.append(f"""            <td align="center" width="8%">
-                  <a href="{c['html_url']}">
-                      <img src="{c['avatar_url']}" width="45" alt="{c['login']}"/>
-                      <br />
-                      <sub><b>{c['login']}</b></sub>
-                  </a>
-              </td>""")
-              lines.append("\t\t</tr>")
-          lines.append("\t</tbody>")
-          lines.append("</table>")
-          table = "\n".join(lines)
+                  login = c["login"]
+                  avatar_url = avatar_with_size(c["avatar_url"], 48)
+                  profile_url = c["html_url"]
+                  links.append(f"[![{login}]({avatar_url})]({profile_url})")
+              lines.append(" ".join(links))
+          contributors_block = "\n".join(lines)
 
           # Replace the section in README.md
           with open("README.md", "r") as f:
@@ -141,7 +140,7 @@ jobs:
 
           new_content = re.sub(
               r"<!-- readme: contributors -start -->.*?<!-- readme: contributors -end -->",
-              f"<!-- readme: contributors -start -->\n{table}\n<!-- readme: contributors -end -->",
+              f"<!-- readme: contributors -start -->\n{contributors_block}\n<!-- readme: contributors -end -->",
               content,
               flags=re.DOTALL
           )


### PR DESCRIPTION
This pull request updates the way contributors are displayed in the `README.md` by switching from an HTML table layout to a simpler markdown-based avatar grid. The main goal is to improve readability and maintainability of the contributors section.

**Contributors section formatting:**

* Changed the contributors display from an HTML table with 12 columns per row to a markdown grid with 10 avatars per line, making the layout simpler and more consistent with markdown best practices.
* Added a helper function to ensure contributor avatar images are rendered at a consistent size, improving visual alignment.
* Each contributor is now represented by a clickable avatar image linking to their profile, using markdown image links instead of HTML.
* Updated the script to generate and insert the new markdown block into `README.md` between the appropriate start and end comments.