### PR TITLE
fix(error-handling): shared error helpers + close silent Sentry gaps

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import signal
 import sys
+from contextlib import suppress
 
 import click
 from dotenv import load_dotenv
@@ -26,7 +27,7 @@ from app.cli.support.prompt_support import (
     install_questionary_ctrl_c_double_exit,
     install_questionary_escape_cancel,
 )
-from app.utils.sentry_sdk import init_sentry
+from app.utils.sentry_sdk import capture_exception, init_sentry
 from app.version import get_version
 
 _CAPTURE_CLI_ANALYTICS = "capture_cli_analytics"
@@ -238,6 +239,14 @@ def main(argv: list[str] | None = None) -> int:
             click.echo(exc.code, err=True)
             return 1
         return 0
+    except BaseException as exc:
+        if not isinstance(exc, KeyboardInterrupt):
+            capture_exception(exc, context="cli.main.unhandled")
+            with suppress(Exception):
+                import sentry_sdk as _sentry_sdk
+
+                _sentry_sdk.flush(timeout=2)
+        raise
     finally:
         shutdown_analytics(flush=True)
     return 0

--- a/app/cli/wizard/grafana_seed.py
+++ b/app/cli/wizard/grafana_seed.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import json
 import time
+from contextlib import suppress
 from typing import Any
 
 import requests
+
+from app.utils.sentry_sdk import init_sentry
 
 LOCAL_LOKI_URL = "http://localhost:3100"
 SERVICE_NAME = "prefect-etl-pipeline-local"
@@ -160,6 +163,8 @@ def seed_logs() -> None:
 
 
 def main() -> int:
+    with suppress(ModuleNotFoundError):
+        init_sentry(entrypoint="wizard")
     seed_logs()
     return 0
 

--- a/app/pipeline/routing.py
+++ b/app/pipeline/routing.py
@@ -9,6 +9,7 @@ from langgraph.constants import Send
 from app.investigation_constants import MAX_INVESTIGATION_LOOPS
 from app.output import debug_print
 from app.state import AgentState, InvestigationState
+from app.utils.sentry_sdk import capture_exception
 
 logger = logging.getLogger(__name__)
 
@@ -94,5 +95,6 @@ def should_continue_investigation(state: InvestigationState) -> str:
         return "publish"
     except Exception as e:
         logger.exception("should_continue_investigation failed, defaulting to publish: %s", e)
+        capture_exception(e, context="pipeline.routing.should_continue_investigation")
         debug_print(f"Routing function failed: {e} -> publish")
         return "publish"

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, cast
@@ -10,7 +11,10 @@ from app.nodes.chat import chat_agent_node, general_node, router_node
 from app.remote.stream import StreamEvent
 from app.state import AgentState, make_initial_state
 from app.types.config import NodeConfig
+from app.utils.errors import report_and_reraise
 from app.utils.sentry_sdk import capture_exception, init_sentry
+
+logger = logging.getLogger(__name__)
 
 _GRAPH_RECURSION_LIMIT = 50
 
@@ -32,15 +36,16 @@ def run_chat(state: AgentState, config: NodeConfig | None = None) -> AgentState:
     """Run chat routing + response without LangGraph (for testing)."""
     init_sentry(entrypoint="graph_pipeline")
     cfg = config or {"configurable": {}}
-    try:
+    with report_and_reraise(
+        logger=logger,
+        message="run_chat failed",
+        tags={"surface": "pipeline", "component": "app.pipeline.runners"},
+    ):
         _merge_state(state, router_node(state))
         if state.get("route") == "tracer_data":
             _merge_state(state, chat_agent_node(state, cfg))
         else:
             _merge_state(state, general_node(state, cfg))
-    except Exception as exc:
-        capture_exception(exc)
-        raise
     return state
 
 
@@ -72,13 +77,15 @@ def run_investigation(
     )
     if resolved_integrations is not None:
         cast(dict[str, Any], initial)["resolved_integrations"] = resolved_integrations
-    try:
+    with report_and_reraise(
+        logger=logger,
+        message="run_investigation failed",
+        tags={"surface": "pipeline", "component": "app.pipeline.runners"},
+    ):
         return cast(
-            AgentState, compiled_graph.invoke(initial, {"recursion_limit": _GRAPH_RECURSION_LIMIT})
+            AgentState,
+            compiled_graph.invoke(initial, {"recursion_limit": _GRAPH_RECURSION_LIMIT}),
         )
-    except Exception as exc:
-        capture_exception(exc)
-        raise
 
 
 async def astream_investigation(
@@ -151,8 +158,9 @@ class SimpleAgent:
             **(config or {"configurable": {}}),
             "recursion_limit": _GRAPH_RECURSION_LIMIT,
         }
-        try:
+        with report_and_reraise(
+            logger=logger,
+            message="SimpleAgent.invoke failed",
+            tags={"surface": "pipeline", "component": "app.pipeline.runners"},
+        ):
             return cast(AgentState, compiled_graph.invoke(state, cast(Any, cfg)))
-        except Exception as exc:
-            capture_exception(exc)
-            raise

--- a/app/utils/errors.py
+++ b/app/utils/errors.py
@@ -1,0 +1,85 @@
+"""Shared error-reporting helpers for boundary exception handling.
+
+Use these helpers at every ``except`` site that intentionally swallows or
+re-raises an exception, so the failure is always visible in Sentry and logs.
+
+Tagging conventions (pass via ``tags``):
+  surface   — cli | interactive_shell | service_client | tool | node |
+               pipeline | integration | remote_server | analytics | auth |
+               webapp | mcp | sandbox | deployment | masking
+  component — module-level identifier, e.g. ``app.services.grafana.tempo``
+  integration — vendor when applicable: grafana | splunk | vercel | …
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from app.utils.sentry_sdk import capture_exception
+
+
+def report_exception(
+    exc: BaseException,
+    *,
+    logger: logging.Logger,
+    message: str,
+    severity: str = "error",
+    tags: dict[str, str] | None = None,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    """Log + Sentry-capture an exception with structured context.
+
+    Use at boundaries where an exception is intentionally swallowed (the
+    function returns a degraded value to its caller).
+    """
+    log_fn = getattr(logger, severity, logger.error)
+    log_fn("%s", message, exc_info=exc)
+    combined: dict[str, Any] = {}
+    if tags:
+        combined.update({f"tag.{k}": v for k, v in tags.items()})
+    if extras:
+        combined.update(extras)
+    capture_exception(exc, extra=combined or None)
+
+
+@contextmanager
+def report_and_swallow(
+    *,
+    logger: logging.Logger,
+    message: str,
+    tags: dict[str, str] | None = None,
+    extras: dict[str, Any] | None = None,
+    swallow: type[BaseException] | tuple[type[BaseException], ...] = Exception,
+) -> Iterator[None]:
+    """Context manager that logs + reports a matching exception, then swallows it.
+
+    Replaces bare ``try/except Exception: pass`` patterns where the caller does
+    not need the value but does want the failure visible in Sentry.
+    """
+    try:
+        yield
+    except swallow as exc:
+        report_exception(exc, logger=logger, message=message, tags=tags, extras=extras)
+
+
+@contextmanager
+def report_and_reraise(
+    *,
+    logger: logging.Logger,
+    message: str,
+    tags: dict[str, str] | None = None,
+    extras: dict[str, Any] | None = None,
+) -> Iterator[None]:
+    """Context manager that captures to Sentry + re-raises (for top-level boundaries)."""
+    try:
+        yield
+    except Exception as exc:
+        report_exception(exc, logger=logger, message=message, tags=tags, extras=extras)
+        raise
+
+
+class OpenSRESilentFallback(Warning):
+    """Warning class for debug-only fallback paths that should still reach Sentry."""

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -1,0 +1,161 @@
+"""Tests for app.utils.errors helpers."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.errors import (
+    OpenSRESilentFallback,
+    report_and_reraise,
+    report_and_swallow,
+    report_exception,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+
+
+def _mock_logger() -> MagicMock:
+    return MagicMock(spec=logging.Logger)
+
+
+class TestReportException:
+    def test_logs_and_captures(self) -> None:
+        mock_log = _mock_logger()
+        exc = ValueError("test error")
+        with patch("app.utils.errors.capture_exception") as mock_cap:
+            report_exception(exc, logger=mock_log, message="Something failed")
+        mock_log.error.assert_called_once()
+        mock_cap.assert_called_once_with(exc, extra=None)
+
+    def test_warning_severity(self) -> None:
+        mock_log = _mock_logger()
+        exc = RuntimeError("warn")
+        with patch("app.utils.errors.capture_exception"):
+            report_exception(exc, logger=mock_log, message="m", severity="warning")
+        mock_log.warning.assert_called_once()
+        mock_log.error.assert_not_called()
+
+    def test_tags_are_prefixed(self) -> None:
+        mock_log = _mock_logger()
+        exc = RuntimeError("boom")
+        with patch("app.utils.errors.capture_exception") as mock_cap:
+            report_exception(
+                exc,
+                logger=mock_log,
+                message="msg",
+                tags={"surface": "cli", "component": "app.cli"},
+            )
+        extra = mock_cap.call_args[1]["extra"]
+        assert extra["tag.surface"] == "cli"
+        assert extra["tag.component"] == "app.cli"
+
+    def test_extras_are_merged(self) -> None:
+        mock_log = _mock_logger()
+        exc = RuntimeError("boom")
+        with patch("app.utils.errors.capture_exception") as mock_cap:
+            report_exception(
+                exc,
+                logger=mock_log,
+                message="msg",
+                tags={"surface": "tool"},
+                extras={"detail": "x"},
+            )
+        extra = mock_cap.call_args[1]["extra"]
+        assert extra["tag.surface"] == "tool"
+        assert extra["detail"] == "x"
+
+    def test_no_tags_or_extras_passes_none(self) -> None:
+        mock_log = _mock_logger()
+        exc = ValueError("plain")
+        with patch("app.utils.errors.capture_exception") as mock_cap:
+            report_exception(exc, logger=mock_log, message="msg")
+        mock_cap.assert_called_once_with(exc, extra=None)
+
+
+class TestReportAndSwallow:
+    def test_swallows_matching_exception(self) -> None:
+        mock_log = _mock_logger()
+        with (
+            patch("app.utils.errors.capture_exception"),
+            report_and_swallow(logger=mock_log, message="swallowed"),
+        ):
+            raise ValueError("silent")
+
+    def test_does_not_swallow_other_types(self) -> None:
+        mock_log = _mock_logger()
+        with pytest.raises(TypeError), report_and_swallow(
+            logger=mock_log, message="only value", swallow=ValueError
+        ):
+            raise TypeError("not swallowed")
+
+    def test_calls_report_exception_on_match(self) -> None:
+        mock_log = _mock_logger()
+        exc = RuntimeError("reported")
+        with patch("app.utils.errors.capture_exception") as mock_cap, report_and_swallow(
+            logger=mock_log, message="msg"
+        ):
+            raise exc
+        mock_cap.assert_called_once_with(exc, extra=None)
+
+    def test_no_exception_passes_through(self) -> None:
+        mock_log = _mock_logger()
+        result: list[int] = []
+        with patch("app.utils.errors.capture_exception") as mock_cap, report_and_swallow(
+            logger=mock_log, message="msg"
+        ):
+            result.append(1)
+        assert result == [1]
+        mock_cap.assert_not_called()
+
+    def test_tuple_of_swallow_types(self) -> None:
+        mock_log = _mock_logger()
+        for exc_type in (ValueError, KeyError):
+            with patch("app.utils.errors.capture_exception"), report_and_swallow(
+                logger=mock_log,
+                message="multi",
+                swallow=(ValueError, KeyError),
+            ):
+                raise exc_type("x")
+
+
+class TestReportAndReraise:
+    def test_propagates_exception(self) -> None:
+        mock_log = _mock_logger()
+        with (
+            patch("app.utils.errors.capture_exception") as mock_cap,
+            pytest.raises(RuntimeError, match="propagated"),
+            report_and_reraise(logger=mock_log, message="reraised"),
+        ):
+            raise RuntimeError("propagated")
+        mock_cap.assert_called_once()
+
+    def test_no_exception_passes_through(self) -> None:
+        mock_log = _mock_logger()
+        result: list[int] = []
+        with patch("app.utils.errors.capture_exception") as mock_cap, report_and_reraise(
+            logger=mock_log, message="no error"
+        ):
+            result.append(42)
+        assert result == [42]
+        mock_cap.assert_not_called()
+
+    def test_logs_before_reraising(self) -> None:
+        mock_log = _mock_logger()
+        with (
+            patch("app.utils.errors.capture_exception"),
+            pytest.raises(ValueError),
+            report_and_reraise(logger=mock_log, message="logged"),
+        ):
+            raise ValueError("x")
+        mock_log.error.assert_called_once()
+
+
+class TestOpenSRESilentFallback:
+    def test_is_a_warning(self) -> None:
+        assert issubclass(OpenSRESilentFallback, Warning)

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -89,16 +89,18 @@ class TestReportAndSwallow:
 
     def test_does_not_swallow_other_types(self) -> None:
         mock_log = _mock_logger()
-        with pytest.raises(TypeError), report_and_swallow(
-            logger=mock_log, message="only value", swallow=ValueError
+        with (
+            pytest.raises(TypeError),
+            report_and_swallow(logger=mock_log, message="only value", swallow=ValueError),
         ):
             raise TypeError("not swallowed")
 
     def test_calls_report_exception_on_match(self) -> None:
         mock_log = _mock_logger()
         exc = RuntimeError("reported")
-        with patch("app.utils.errors.capture_exception") as mock_cap, report_and_swallow(
-            logger=mock_log, message="msg"
+        with (
+            patch("app.utils.errors.capture_exception") as mock_cap,
+            report_and_swallow(logger=mock_log, message="msg"),
         ):
             raise exc
         mock_cap.assert_called_once_with(exc, extra=None)
@@ -106,8 +108,9 @@ class TestReportAndSwallow:
     def test_no_exception_passes_through(self) -> None:
         mock_log = _mock_logger()
         result: list[int] = []
-        with patch("app.utils.errors.capture_exception") as mock_cap, report_and_swallow(
-            logger=mock_log, message="msg"
+        with (
+            patch("app.utils.errors.capture_exception") as mock_cap,
+            report_and_swallow(logger=mock_log, message="msg"),
         ):
             result.append(1)
         assert result == [1]
@@ -116,10 +119,13 @@ class TestReportAndSwallow:
     def test_tuple_of_swallow_types(self) -> None:
         mock_log = _mock_logger()
         for exc_type in (ValueError, KeyError):
-            with patch("app.utils.errors.capture_exception"), report_and_swallow(
-                logger=mock_log,
-                message="multi",
-                swallow=(ValueError, KeyError),
+            with (
+                patch("app.utils.errors.capture_exception"),
+                report_and_swallow(
+                    logger=mock_log,
+                    message="multi",
+                    swallow=(ValueError, KeyError),
+                ),
             ):
                 raise exc_type("x")
 
@@ -138,8 +144,9 @@ class TestReportAndReraise:
     def test_no_exception_passes_through(self) -> None:
         mock_log = _mock_logger()
         result: list[int] = []
-        with patch("app.utils.errors.capture_exception") as mock_cap, report_and_reraise(
-            logger=mock_log, message="no error"
+        with (
+            patch("app.utils.errors.capture_exception") as mock_cap,
+            report_and_reraise(logger=mock_log, message="no error"),
         ):
             result.append(42)
         assert result == [42]


### PR DESCRIPTION
## Summary

- Introduces `app/utils/errors.py` with three reusable helpers (`report_exception`, `report_and_swallow`, `report_and_reraise`) so boundary catch sites log + report to Sentry without copy-pasting boilerplate (#1454)
- Migrates `app/pipeline/runners.py` (3 call sites) to `report_and_reraise` as the reference implementation (#1454)
- Wires `capture_exception` into the previously-silent `should_continue_investigation` fallback in `routing.py` (#1467)
- Adds `init_sentry(entrypoint="wizard")` to `grafana_seed.py` so the entrypoint is covered (#1456)
- Adds a `BaseException` catch-all in the CLI dispatcher so unhandled exceptions always reach Sentry before the process exits (#1457)
- Adds 14 unit tests under `tests/utils/test_errors.py` covering all helpers and edge cases

## Test plan

- [ ] `uv run python -m pytest tests/utils/test_errors.py -v` — all 14 tests pass
- [ ] `uv run ruff check app/utils/errors.py app/pipeline/runners.py app/pipeline/routing.py app/cli/__main__.py app/cli/wizard/grafana_seed.py tests/utils/test_errors.py` — clean
- [ ] `uv run mypy app/utils/errors.py app/pipeline/runners.py app/pipeline/routing.py app/cli/__main__.py app/cli/wizard/grafana_seed.py --ignore-missing-imports` — clean
- [ ] CI passes

Closes #1454
Closes #1456
Closes #1457
Closes #1467

https://claude.ai/code/session_01VwtHnj3F2Tmqz6tbaCds8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwtHnj3F2Tmqz6tbaCds8S)_