### PR TITLE
feat(interactive_shell): AST-aware Python and Markdown chunkers

### DIFF
--- a/app/cli/interactive_shell/source_chunker.py
+++ b/app/cli/interactive_shell/source_chunker.py
@@ -40,14 +40,17 @@ def chunk_python_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
     if "__pycache__" in path.parts or path.name.startswith("_"):
         return []
 
-    text = path.read_text(encoding="utf-8")
+    rel = _relpath(path, repo_root)
+    if rel is None:
+        return []
+
+    text = path.read_text(encoding="utf-8-sig")
     try:
         tree = ast.parse(text)
     except SyntaxError:
         return []
 
     source_lines = text.splitlines()
-    rel = _relpath(path, repo_root)
     chunks: list[SourceChunk] = []
 
     module_chunk = _build_module_chunk(tree, source_lines, rel, path.stem)
@@ -64,9 +67,12 @@ def chunk_python_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
 
 def chunk_markdown_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
     """Chunk a Markdown/MDX file by H2 headings, stripping YAML frontmatter."""
-    text = path.read_text(encoding="utf-8")
-    body, _ = _strip_frontmatter(text)
     rel = _relpath(path, repo_root)
+    if rel is None:
+        return []
+
+    text = path.read_text(encoding="utf-8-sig")
+    body, _ = _strip_frontmatter(text)
 
     if not body.strip():
         return []
@@ -115,8 +121,12 @@ def chunk_path(path: Path, *, repo_root: Path) -> list[SourceChunk]:
     return []
 
 
-def _relpath(path: Path, repo_root: Path) -> str:
-    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+def _relpath(path: Path, repo_root: Path) -> str | None:
+    """Return the path's POSIX-style relpath inside repo_root, or None if outside."""
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return None
 
 
 def _truncate_content(content: str) -> str:
@@ -185,14 +195,26 @@ def _build_def_chunk(
 
 
 def _find_h2_starts(body_lines: list[str]) -> list[tuple[int, str]]:
-    """Return ``(index, heading)`` for every H2 outside fenced code blocks."""
-    in_fence = False
+    """Return ``(index, heading)`` for every H2 outside fenced code blocks.
+
+    Tracks the opening fence character so a backtick fence is only closed by
+    backticks (and tilde by tilde) — mismatched fences don't toggle state.
+    """
+    open_fence: str | None = None
     starts: list[tuple[int, str]] = []
     for i, line in enumerate(body_lines):
         stripped = line.lstrip()
-        if stripped.startswith("```") or stripped.startswith("~~~"):
-            in_fence = not in_fence
+        if open_fence is None:
+            if stripped.startswith("```"):
+                open_fence = "```"
+                continue
+            if stripped.startswith("~~~"):
+                open_fence = "~~~"
+                continue
+        else:
+            if stripped.startswith(open_fence):
+                open_fence = None
             continue
-        if not in_fence and line.startswith("## "):
+        if line.startswith("## "):
             starts.append((i, line[3:].strip()))
     return starts

--- a/app/cli/interactive_shell/source_chunker.py
+++ b/app/cli/interactive_shell/source_chunker.py
@@ -44,10 +44,14 @@ def chunk_python_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
     if rel is None:
         return []
 
-    text = path.read_text(encoding="utf-8-sig")
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeDecodeError):
+        return []
     try:
         tree = ast.parse(text)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
+        # ValueError covers source containing null bytes; SyntaxError covers everything else.
         return []
 
     source_lines = text.splitlines()
@@ -66,13 +70,24 @@ def chunk_python_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
 
 
 def chunk_markdown_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
-    """Chunk a Markdown/MDX file by H2 headings, stripping YAML frontmatter."""
+    """Chunk a Markdown/MDX file by H2 headings, stripping YAML frontmatter.
+
+    Line numbers are file-relative — i.e. they include any frontmatter lines
+    that were stripped before scanning, so a consumer can use them to navigate
+    back to the original source location.
+    """
     rel = _relpath(path, repo_root)
     if rel is None:
         return []
 
-    text = path.read_text(encoding="utf-8-sig")
-    body, _ = _strip_frontmatter(text)
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeDecodeError):
+        return []
+    body, frontmatter = _strip_frontmatter(text)
+    # Number of source lines consumed by frontmatter; markdown line numbers
+    # below are reported as file-relative by adding this offset.
+    fm_line_offset = text[: len(text) - len(body)].count("\n") if frontmatter is not None else 0
 
     if not body.strip():
         return []
@@ -86,8 +101,8 @@ def chunk_markdown_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
                 relpath=rel,
                 kind="md_section",
                 symbol=path.stem,
-                start_line=1,
-                end_line=len(body_lines),
+                start_line=1 + fm_line_offset,
+                end_line=len(body_lines) + fm_line_offset,
                 content=_truncate_content(body),
             )
         ]
@@ -103,8 +118,8 @@ def chunk_markdown_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
                 relpath=rel,
                 kind="md_section",
                 symbol=heading,
-                start_line=start_idx + 1,
-                end_line=end_idx + 1,
+                start_line=start_idx + 1 + fm_line_offset,
+                end_line=end_idx + 1 + fm_line_offset,
                 content=_truncate_content(section_text),
             )
         )

--- a/app/cli/interactive_shell/source_chunker.py
+++ b/app/cli/interactive_shell/source_chunker.py
@@ -1,0 +1,198 @@
+"""Source-file chunking primitives for future RAG over the OpenSRE codebase.
+
+This module delivers chunking only — no persistence, embeddings, repo walking,
+or cache invalidation. Each chunker is a pure function: it reads the passed-in
+Path and returns SourceChunks with no side effects.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from app.cli.interactive_shell.docs_reference import _excerpt, _strip_frontmatter
+
+ChunkKind = Literal["py_func", "py_class", "py_module", "md_section"]
+
+_MAX_CONTENT_CHARS = 6000
+_MAX_BODY_LINES = 80
+
+
+@dataclass(frozen=True)
+class SourceChunk:
+    relpath: str
+    kind: ChunkKind
+    symbol: str
+    start_line: int
+    end_line: int
+    content: str
+
+
+def chunk_python_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
+    """Chunk a Python file by top-level def/class, plus an optional module chunk.
+
+    Returns an empty list for files in ``__pycache__``, private modules
+    (basename starts with ``_``), files that fail to parse, or files with
+    no top-level definitions and no module preamble.
+    """
+    if "__pycache__" in path.parts or path.name.startswith("_"):
+        return []
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+
+    source_lines = text.splitlines()
+    rel = _relpath(path, repo_root)
+    chunks: list[SourceChunk] = []
+
+    module_chunk = _build_module_chunk(tree, source_lines, rel, path.stem)
+    if module_chunk is not None:
+        chunks.append(module_chunk)
+
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        chunks.append(_build_def_chunk(node, source_lines, rel))
+
+    return chunks
+
+
+def chunk_markdown_file(path: Path, *, repo_root: Path) -> list[SourceChunk]:
+    """Chunk a Markdown/MDX file by H2 headings, stripping YAML frontmatter."""
+    text = path.read_text(encoding="utf-8")
+    body, _ = _strip_frontmatter(text)
+    rel = _relpath(path, repo_root)
+
+    if not body.strip():
+        return []
+
+    body_lines = body.splitlines()
+    section_starts = _find_h2_starts(body_lines)
+
+    if not section_starts:
+        return [
+            SourceChunk(
+                relpath=rel,
+                kind="md_section",
+                symbol=path.stem,
+                start_line=1,
+                end_line=len(body_lines),
+                content=_truncate_content(body),
+            )
+        ]
+
+    chunks: list[SourceChunk] = []
+    for idx, (start_idx, heading) in enumerate(section_starts):
+        end_idx = (
+            section_starts[idx + 1][0] - 1 if idx + 1 < len(section_starts) else len(body_lines) - 1
+        )
+        section_text = "\n".join(body_lines[start_idx : end_idx + 1])
+        chunks.append(
+            SourceChunk(
+                relpath=rel,
+                kind="md_section",
+                symbol=heading,
+                start_line=start_idx + 1,
+                end_line=end_idx + 1,
+                content=_truncate_content(section_text),
+            )
+        )
+    return chunks
+
+
+def chunk_path(path: Path, *, repo_root: Path) -> list[SourceChunk]:
+    """Dispatch to the right chunker by file suffix; unknown suffixes return ``[]``."""
+    suffix = path.suffix.lower()
+    if suffix == ".py":
+        return chunk_python_file(path, repo_root=repo_root)
+    if suffix in (".md", ".mdx"):
+        return chunk_markdown_file(path, repo_root=repo_root)
+    return []
+
+
+def _relpath(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def _truncate_content(content: str) -> str:
+    return _excerpt(content, max_chars=_MAX_CONTENT_CHARS)
+
+
+def _build_module_chunk(
+    tree: ast.Module, source_lines: list[str], rel: str, stem: str
+) -> SourceChunk | None:
+    last_preamble_node: ast.stmt | None = None
+    for node in tree.body:
+        if _is_module_docstring(node) or isinstance(node, (ast.Import, ast.ImportFrom)):
+            last_preamble_node = node
+            continue
+        break
+
+    if last_preamble_node is None:
+        return None
+
+    end_line = last_preamble_node.end_lineno or last_preamble_node.lineno
+    content = "\n".join(source_lines[:end_line])
+    return SourceChunk(
+        relpath=rel,
+        kind="py_module",
+        symbol=stem,
+        start_line=1,
+        end_line=end_line,
+        content=_truncate_content(content),
+    )
+
+
+def _is_module_docstring(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _build_def_chunk(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+    source_lines: list[str],
+    rel: str,
+) -> SourceChunk:
+    start_line = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+    real_end_line = node.end_lineno or node.lineno
+    body_lines = real_end_line - start_line + 1
+
+    if body_lines > _MAX_BODY_LINES:
+        cut_end = start_line + _MAX_BODY_LINES - 1
+        kept = source_lines[start_line - 1 : cut_end]
+        kept.append(f"# … truncated, real end line: {real_end_line} …")
+        content = "\n".join(kept)
+    else:
+        content = "\n".join(source_lines[start_line - 1 : real_end_line])
+
+    kind: ChunkKind = "py_class" if isinstance(node, ast.ClassDef) else "py_func"
+    return SourceChunk(
+        relpath=rel,
+        kind=kind,
+        symbol=node.name,
+        start_line=start_line,
+        end_line=real_end_line,
+        content=_truncate_content(content),
+    )
+
+
+def _find_h2_starts(body_lines: list[str]) -> list[tuple[int, str]]:
+    """Return ``(index, heading)`` for every H2 outside fenced code blocks."""
+    in_fence = False
+    starts: list[tuple[int, str]] = []
+    for i, line in enumerate(body_lines):
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and line.startswith("## "):
+            starts.append((i, line[3:].strip()))
+    return starts

--- a/tests/cli/interactive_shell/test_source_chunker.py
+++ b/tests/cli/interactive_shell/test_source_chunker.py
@@ -301,6 +301,73 @@ body
     assert [c.symbol for c in chunks] == ["Real Section A", "Real Section B"]
 
 
+def test_markdown_line_numbers_are_file_relative_not_body_relative(tmp_path: Path) -> None:
+    """Locks in the fix for Greptile finding: line numbers must include
+    frontmatter lines so consumers can navigate to the original source."""
+    source = """---
+title: Example
+description: test
+---
+
+Intro paragraph on file line 6.
+
+## First Section
+
+First body.
+"""
+    path = _write(tmp_path, "doc.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    section = chunks[0]
+    assert section.symbol == "First Section"
+    # File layout: line 1 `---`, 2 `title: Example`, 3 `description: test`,
+    # 4 `---`, 5 blank, 6 intro, 7 blank, 8 `## First Section`, 9 blank,
+    # 10 `First body.`. The frontmatter regex's trailing `\s*\n` consumes the
+    # blank line after the closing `---` too, so fm_line_offset = 5.
+    assert section.start_line == 8
+    assert section.end_line == 10
+
+
+def test_markdown_no_h2_with_frontmatter_offsets_line_numbers(tmp_path: Path) -> None:
+    source = """---
+title: Plain
+---
+
+Just body text, no headings.
+"""
+    path = _write(tmp_path, "plain.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    # File layout: 1 `---`, 2 `title: Plain`, 3 `---`, 4 blank, 5 body. The
+    # frontmatter regex's trailing `\s*\n` also consumes the blank line, so
+    # the body's first line ("Just body text...") is file line 5.
+    assert chunks[0].start_line == 5
+    assert chunks[0].end_line == 5
+
+
+def test_python_file_with_null_bytes_returns_empty(tmp_path: Path) -> None:
+    """ast.parse raises ValueError (not SyntaxError) on null bytes;
+    the chunker must catch that too."""
+    path = tmp_path / "null.py"
+    path.write_bytes(b"def f():\n    return 1\n\x00\n")
+    assert chunk_python_file(path, repo_root=tmp_path) == []
+
+
+def test_python_file_with_undecodable_bytes_returns_empty(tmp_path: Path) -> None:
+    path = tmp_path / "binary.py"
+    # Bytes that are not valid UTF-8
+    path.write_bytes(b"\xff\xfe\x00\x01garbage")
+    assert chunk_python_file(path, repo_root=tmp_path) == []
+
+
+def test_markdown_file_with_undecodable_bytes_returns_empty(tmp_path: Path) -> None:
+    path = tmp_path / "binary.md"
+    path.write_bytes(b"\xff\xfe\x00\x01garbage")
+    assert chunk_markdown_file(path, repo_root=tmp_path) == []
+
+
 def test_source_chunk_is_frozen() -> None:
     chunk = SourceChunk(
         relpath="x.py",

--- a/tests/cli/interactive_shell/test_source_chunker.py
+++ b/tests/cli/interactive_shell/test_source_chunker.py
@@ -223,6 +223,84 @@ def test_relpath_uses_forward_slashes(tmp_path: Path) -> None:
     assert chunks[0].relpath == "a/b/thing.py"
 
 
+def test_python_class_with_decorator(tmp_path: Path) -> None:
+    source = (
+        "from dataclasses import dataclass\n\n\n@dataclass\nclass Point:\n    x: int\n    y: int\n"
+    )
+    path = _write(tmp_path, "deco_class.py", source)
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+    cls = next(c for c in chunks if c.kind == "py_class")
+    assert cls.symbol == "Point"
+    assert cls.start_line == 4  # decorator line, not the class line
+    assert cls.end_line == 7
+
+
+def test_python_nested_def_inside_class_is_not_top_level(tmp_path: Path) -> None:
+    source = (
+        "class Foo:\n    def bar(self):\n        return 1\n\n    def baz(self):\n        return 2\n"
+    )
+    path = _write(tmp_path, "nested.py", source)
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+    # Only Foo should appear; bar/baz are nested and not top-level
+    symbols = [c.symbol for c in chunks]
+    assert symbols == ["Foo"]
+    assert chunks[0].kind == "py_class"
+
+
+def test_python_file_outside_repo_root_returns_empty(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.py"
+    outside.write_text("def f():\n    return 1\n", encoding="utf-8")
+    other_root = tmp_path / "other_root"
+    other_root.mkdir()
+    assert chunk_python_file(outside, repo_root=other_root) == []
+    assert chunk_path(outside, repo_root=other_root) == []
+
+
+def test_markdown_file_outside_repo_root_returns_empty(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.md"
+    outside.write_text("## H\n\nbody\n", encoding="utf-8")
+    other_root = tmp_path / "other_root"
+    other_root.mkdir()
+    assert chunk_markdown_file(outside, repo_root=other_root) == []
+
+
+def test_markdown_with_utf8_bom_is_handled(tmp_path: Path) -> None:
+    path = tmp_path / "bom.md"
+    # Write a UTF-8 BOM followed by an H2 heading and body
+    path.write_bytes(b"\xef\xbb\xbf## Section\n\nbody\n")
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+    assert len(chunks) == 1
+    assert chunks[0].symbol == "Section"
+    assert chunks[0].content.startswith("## Section")
+
+
+def test_python_with_utf8_bom_is_handled(tmp_path: Path) -> None:
+    path = tmp_path / "bom.py"
+    path.write_bytes(b"\xef\xbb\xbfdef hello():\n    return 1\n")
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+    func = next(c for c in chunks if c.kind == "py_func")
+    assert func.symbol == "hello"
+
+
+def test_markdown_mismatched_fence_types_do_not_swap_state(tmp_path: Path) -> None:
+    # Open with ``` then a ~~~ line appears; the ~~~ should NOT close the
+    # backtick fence. Then ``` actually closes it.
+    source = """## Real Section A
+
+```python
+~~~ this is content, not a fence close ~~~
+## also content, not a heading
+```
+
+## Real Section B
+
+body
+"""
+    path = _write(tmp_path, "mixed.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+    assert [c.symbol for c in chunks] == ["Real Section A", "Real Section B"]
+
+
 def test_source_chunk_is_frozen() -> None:
     chunk = SourceChunk(
         relpath="x.py",

--- a/tests/cli/interactive_shell/test_source_chunker.py
+++ b/tests/cli/interactive_shell/test_source_chunker.py
@@ -1,0 +1,236 @@
+"""Tests for ``app.cli.interactive_shell.source_chunker``."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from app.cli.interactive_shell.source_chunker import (
+    SourceChunk,
+    chunk_markdown_file,
+    chunk_path,
+    chunk_python_file,
+)
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    target = tmp_path / name
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+def test_python_file_with_multiple_funcs_and_class(tmp_path: Path) -> None:
+    source = '''"""Module docstring."""
+
+import os
+from pathlib import Path
+
+
+def alpha():
+    return 1
+
+
+async def beta(x: int) -> int:
+    return x + 1
+
+
+class Gamma:
+    def method(self) -> None:
+        pass
+'''
+    path = _write(tmp_path, "sample.py", source)
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+
+    kinds = [c.kind for c in chunks]
+    assert kinds == ["py_module", "py_func", "py_func", "py_class"]
+    assert [c.symbol for c in chunks] == ["sample", "alpha", "beta", "Gamma"]
+    assert chunks[0].start_line == 1
+    assert chunks[0].end_line == 4
+
+    by_symbol = {c.symbol: c for c in chunks}
+    assert by_symbol["alpha"].start_line == 7 and by_symbol["alpha"].end_line == 8
+    assert by_symbol["beta"].start_line == 11 and by_symbol["beta"].end_line == 12
+    assert by_symbol["Gamma"].start_line == 15 and by_symbol["Gamma"].end_line == 17
+
+    assert "def alpha" in by_symbol["alpha"].content
+    assert "class Gamma" in by_symbol["Gamma"].content
+    assert by_symbol["Gamma"].relpath == "sample.py"
+
+
+def test_python_file_module_docstring_only(tmp_path: Path) -> None:
+    path = _write(tmp_path, "doc_only.py", '"""Just a docstring."""\n')
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    assert chunks[0].kind == "py_module"
+    assert chunks[0].symbol == "doc_only"
+    assert chunks[0].start_line == 1
+    assert chunks[0].end_line == 1
+
+
+def test_empty_python_file_returns_empty(tmp_path: Path) -> None:
+    path = _write(tmp_path, "empty.py", "")
+    assert chunk_python_file(path, repo_root=tmp_path) == []
+
+
+def test_python_file_skips_private_module(tmp_path: Path) -> None:
+    private = _write(tmp_path, "_private.py", "def helper():\n    return 1\n")
+    init = _write(tmp_path, "__init__.py", "from .public import thing\n")
+    assert chunk_python_file(private, repo_root=tmp_path) == []
+    assert chunk_python_file(init, repo_root=tmp_path) == []
+
+
+def test_python_file_skips_pycache(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "__pycache__"
+    cache_dir.mkdir()
+    cached = cache_dir / "x.py"
+    cached.write_text("def f():\n    return 1\n", encoding="utf-8")
+    assert chunk_python_file(cached, repo_root=tmp_path) == []
+
+
+def test_python_file_with_syntax_error_returns_empty(tmp_path: Path) -> None:
+    path = _write(tmp_path, "broken.py", "def oops(:\n    pass\n")
+    assert chunk_python_file(path, repo_root=tmp_path) == []
+
+
+def test_python_function_truncation_marker(tmp_path: Path) -> None:
+    body_lines = [f"    x_{i} = {i}" for i in range(120)]
+    source = "def big():\n" + "\n".join(body_lines) + "\n"
+    path = _write(tmp_path, "big.py", source)
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.symbol == "big"
+    assert chunk.start_line == 1
+    # end_line preserves the real end of the function (signature + 120 body lines)
+    assert chunk.end_line == 121
+    assert chunk.content.rstrip().endswith("# … truncated, real end line: 121 …")
+
+
+def test_python_decorator_extends_start_line(tmp_path: Path) -> None:
+    source = "import functools\n\n\n@functools.cache\ndef cached(x):\n    return x\n"
+    path = _write(tmp_path, "deco.py", source)
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+
+    func = next(c for c in chunks if c.kind == "py_func")
+    assert func.start_line == 4  # decorator line, not the def line
+    assert func.end_line == 6
+
+
+def test_markdown_with_frontmatter_and_h2_sections(tmp_path: Path) -> None:
+    source = """---
+title: Example
+description: test fixture
+---
+
+Intro paragraph.
+
+## First Section
+
+First body.
+
+## Second Section
+
+Second body.
+"""
+    path = _write(tmp_path, "doc.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+
+    assert [c.symbol for c in chunks] == ["First Section", "Second Section"]
+    assert all(c.kind == "md_section" for c in chunks)
+    assert "title: Example" not in chunks[0].content
+    assert chunks[0].content.startswith("## First Section")
+    assert chunks[1].content.startswith("## Second Section")
+
+
+def test_markdown_no_h2_emits_single_chunk(tmp_path: Path) -> None:
+    source = "# Title\n\nJust some intro text.\n"
+    path = _write(tmp_path, "no_h2.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    assert chunks[0].kind == "md_section"
+    assert chunks[0].symbol == "no_h2"
+    assert chunks[0].start_line == 1
+
+
+def test_markdown_h2_inside_fenced_code_block_does_not_split(tmp_path: Path) -> None:
+    source = """## Real Section
+
+```markdown
+## Not a real heading — it's inside a fence
+```
+
+Trailing text.
+"""
+    path = _write(tmp_path, "fenced.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    assert chunks[0].symbol == "Real Section"
+
+
+def test_markdown_truncation_uses_paragraph_boundary(tmp_path: Path) -> None:
+    paragraphs = ["paragraph " + ("x" * 200) for _ in range(40)]
+    source = "## Big\n\n" + "\n\n".join(paragraphs) + "\n"
+    path = _write(tmp_path, "big.md", source)
+    chunks = chunk_markdown_file(path, repo_root=tmp_path)
+
+    assert len(chunks) == 1
+    assert len(chunks[0].content) <= 6500
+    assert "[... excerpt truncated ...]" in chunks[0].content
+
+
+def test_markdown_empty_body_returns_empty(tmp_path: Path) -> None:
+    path = _write(tmp_path, "blank.md", "---\ntitle: x\n---\n\n")
+    assert chunk_markdown_file(path, repo_root=tmp_path) == []
+
+
+def test_chunk_path_dispatches_by_suffix(tmp_path: Path) -> None:
+    py = _write(tmp_path, "x.py", "def f():\n    return 1\n")
+    md = _write(tmp_path, "y.md", "## H\n\nbody\n")
+    mdx = _write(tmp_path, "z.mdx", "## H\n\nbody\n")
+    other = _write(tmp_path, "ignored.txt", "plain text\n")
+
+    py_chunks = chunk_path(py, repo_root=tmp_path)
+    md_chunks = chunk_path(md, repo_root=tmp_path)
+    mdx_chunks = chunk_path(mdx, repo_root=tmp_path)
+    other_chunks = chunk_path(other, repo_root=tmp_path)
+
+    assert py_chunks and py_chunks[0].kind == "py_func"
+    assert md_chunks and md_chunks[0].kind == "md_section"
+    assert mdx_chunks and mdx_chunks[0].kind == "md_section"
+    assert other_chunks == []
+
+
+def test_chunk_path_uppercase_suffix(tmp_path: Path) -> None:
+    md = _write(tmp_path, "Y.MD", "## H\n\nbody\n")
+    chunks = chunk_path(md, repo_root=tmp_path)
+    assert chunks and chunks[0].kind == "md_section"
+
+
+def test_relpath_uses_forward_slashes(tmp_path: Path) -> None:
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    path = nested / "thing.py"
+    path.write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    chunks = chunk_python_file(path, repo_root=tmp_path)
+    assert chunks
+    assert chunks[0].relpath == "a/b/thing.py"
+
+
+def test_source_chunk_is_frozen() -> None:
+    chunk = SourceChunk(
+        relpath="x.py",
+        kind="py_func",
+        symbol="f",
+        start_line=1,
+        end_line=2,
+        content="def f(): ...",
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        chunk.symbol = "g"  # type: ignore[misc]


### PR DESCRIPTION
Fixes #1445

#### Describe the changes you have made in this PR -

Adds `app/cli/interactive_shell/source_chunker.py` — the standalone chunking primitive the issue describes. Pure functions, no consumers yet; future RAG work will compose this with persistence, embeddings, and a retriever in separate issues.

**API (matches the issue scope exactly):**

```python
@dataclass(frozen=True)
class SourceChunk:
    relpath: str
    kind: Literal["py_func", "py_class", "py_module", "md_section"]
    symbol: str
    start_line: int
    end_line: int
    content: str

def chunk_python_file(path: Path, *, repo_root: Path) -> list[SourceChunk]: ...
def chunk_markdown_file(path: Path, *, repo_root: Path) -> list[SourceChunk]: ...
def chunk_path(path: Path, *, repo_root: Path) -> list[SourceChunk]: ...
```

**Implementation notes:**

- **Python chunking** uses the stdlib `ast` module. One chunk per top-level `def` / `async def` / `class` with decorators included via `node.decorator_list[0].lineno`, plus an optional `py_module` chunk when the file has a leading docstring and/or imports. Bodies over 80 lines are truncated with `# … truncated, real end line: N …`; `end_line` is preserved as the function's actual close so a reader can still jump there. Skips `__pycache__`, private modules (basename starts with `_`), and files that fail `ast.parse`.
- **Markdown chunking** splits on `## ` while tracking fenced-code-block state, so an H2 inside a ``` fence does not trigger a false split. YAML frontmatter is stripped via `_strip_frontmatter` from [`docs_reference.py`](app/cli/interactive_shell/docs_reference.py). Files with no H2 emit a single whole-file chunk; empty bodies return `[]`.
- **Hard 6000-char cap** on every chunk's content using `docs_reference._excerpt` for paragraph-boundary truncation — explicit reuse rather than copy-paste, per the issue's "reuse the boundary logic" note.
- **`chunk_path`** dispatches by lower-cased suffix (`.py`, `.md`, `.mdx`); unknown suffixes return `[]`.

**Out of scope (per the issue):** persistence, embeddings, repo walking, cache invalidation. No consumers wired up.

### Demo/Screenshot for feature changes and bug fixes -

Library-only change with no UI; nothing to screenshot. The 17 tests cover every acceptance bullet:

```
$ make lint            # All checks passed!
$ make format-check    # 1186 files already formatted
$ make typecheck       # Success: no issues found in 511 source files
$ uv run pytest tests/cli/interactive_shell/test_source_chunker.py -q
                       # 24 passed in 0.30s
$ make test-cov        # passes — no regressions in the full suite
```

Test cases:
- Python file with multiple top-level functions and a class — verifies count, kinds, line ranges, symbol names
- Python file with module docstring only
- Empty Python file → `[]`
- Skips `__pycache__` and `_*.py` private modules / `__init__.py`
- Syntax error → `[]`
- Function body > 80 lines → truncation marker present, `end_line` preserves real close
- Decorator extends `start_line` (not the `def` line)
- Markdown with frontmatter + H2 sections → frontmatter stripped, section count + headings correct
- Markdown with no H2 → single whole-file chunk
- H2 inside ```` ``` ```` fence → no false split (only the real H2 becomes a section)
- Long markdown → paragraph-boundary truncation with `[... excerpt truncated ...]` marker
- Empty markdown body (frontmatter only) → `[]`
- `chunk_path` dispatches by suffix (`.py` → py_func, `.md` / `.mdx` → md_section, `.txt` → `[]`)
- `.MD` (uppercase) is dispatched correctly
- `relpath` always uses forward slashes via `Path.as_posix`
- `SourceChunk` is frozen — mutation raises `FrozenInstanceError`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I read the issue scope first to extract the exact API contract (dataclass + 3 functions, six chunk kinds enum, line numbering convention, truncation rules, out-of-scope), then read [`docs_reference.py:175-180`](app/cli/interactive_shell/docs_reference.py#L175) and [`docs_reference.py:388-396`](app/cli/interactive_shell/docs_reference.py#L388) to confirm `_strip_frontmatter` and `_excerpt` exist exactly as the issue references them. Reusing them directly (not duplicating) is what "reuse the boundary logic" is asking for.

A few decisions that aren't obvious from the issue text:

1. **Decorator handling.** Used `node.decorator_list[0].lineno` for `start_line` so the chunk includes the decorator. The issue says "Include the signature, decorators, and docstring," so the chunk has to start at the decorator, not the `def`. Tested explicitly with a `@functools.cache` fixture.

2. **Truncation marker preserves `real_end_line`.** The issue says "preserving the closing line number." I read this as: when the body is cut, `end_line` on the chunk should still be the function's real end (so callers can jump to the actual close), and the marker text mentions the real line. I went with `# … truncated, real end line: N …` and kept `end_line = real_end_line` even when the rendered content stops earlier.

3. **Fenced-code-block state for H2 detection.** Not in the spec, but a real failure mode for any markdown chunker — `## ` inside a ``` fence is content, not a heading. I track fence open/close while scanning lines, and only count `## ` as a section start when `not in_fence`. Added a regression test for this.

4. **Skip `_*.py`.** The spec says "skip files matching `_*` private modules." I read this glob-style: any basename starting with underscore (`_helper.py`, `__init__.py`, `__main__.py`). The reasoning: `__init__.py` files are usually re-export shims that don't add chunkable content. Tested with `__init__.py` explicitly.

5. **Module chunk only when there's a preamble.** A file with no docstring and no imports skips the module chunk entirely — otherwise we'd emit empty `py_module` chunks for every plain script. The walker breaks on the first non-doc/non-import statement and uses that node's `end_lineno` as the module-chunk close.

6. **Reusing `_excerpt` directly.** The issue says "reuse the boundary logic from `docs_reference.py:388–396`." I imported `_excerpt` rather than copy-pasting `rfind("\n\n")` boundary code. The "[... excerpt truncated ...]" marker that ships with `_excerpt` is generic enough to apply to source chunks.

I considered (and rejected) two alternatives:

- **Tree-sitter for Python parsing** — works for Python *and* JS/TS/Go in the future, but adds a third-party dependency for what `ast` already does. Out of scope per the issue, and the issue's "References" section explicitly points at the stdlib `ast` module.
- **A separate `_truncate_long_body` step that returns `(content, was_truncated)`.** Cleaner abstractly, but adds one extra return tuple for one caller. Inlined the body-line check in `_build_def_chunk` instead.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

