### PR TITLE
feat(agents): startup orphan / stale-lockfile sweep

### DIFF
--- a/app/agents/probe.py
+++ b/app/agents/probe.py
@@ -44,6 +44,28 @@ class ProcessSnapshot:
     started_at: datetime
 
 
+def pid_exists(pid: int) -> bool:
+    """Return whether ``pid`` corresponds to a process the OS knows about.
+
+    Thin wrapper over ``psutil.pid_exists`` exposed here so ``psutil``
+    stays confined to this module per the issue #1489 acceptance
+    criterion. Unlike ``probe()``, this returns ``True`` for processes
+    we can't introspect (cross-user on macOS, restricted ``/proc``,
+    etc.) — the OS-level existence check doesn't traverse the access
+    boundary, which is exactly what the boot sweep (#1501) needs to
+    avoid pruning live foreign-user agents.
+
+    Returns ``False`` for PIDs outside the platform's valid range
+    (e.g. an int that overflows the kernel's PID type) — psutil
+    raises ``OverflowError`` or ``ValueError`` on those, which we
+    treat as "not a real PID" rather than propagating.
+    """
+    try:
+        return psutil.pid_exists(pid)
+    except (OverflowError, ValueError):
+        return False
+
+
 def probe(pid: int, *, cpu_interval: float = 0.1) -> ProcessSnapshot | None:
     """Return a one-shot resource snapshot for ``pid``.
 

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -62,6 +63,25 @@ class AgentRegistry:
     def forget(self, pid: int) -> AgentRecord | None:
         removed = self._records.pop(pid, None)
         if removed is not None:
+            self._rewrite()
+        return removed
+
+    def forget_many(self, pids: Iterable[int]) -> list[AgentRecord]:
+        """Remove every PID in ``pids`` and rewrite the JSONL file once.
+
+        Functionally equivalent to calling :meth:`forget` in a loop,
+        but does only **one** disk rewrite at the end. Use this when
+        pruning many records at once (e.g. the boot-time sweep) so a
+        registry holding N dead PIDs doesn't trigger N full rewrites.
+        Returns the records that were actually removed (silently
+        skips PIDs not present in the registry).
+        """
+        removed: list[AgentRecord] = []
+        for pid in pids:
+            record = self._records.pop(pid, None)
+            if record is not None:
+                removed.append(record)
+        if removed:
             self._rewrite()
         return removed
 

--- a/app/agents/sweep.py
+++ b/app/agents/sweep.py
@@ -1,0 +1,143 @@
+"""Startup orphan / stale-lockfile sweep for the local agent registry.
+
+Run once at REPL boot. Idempotent — running twice in a row is a no-op
+the second time. Removes ``AgentRegistry`` entries whose PIDs no longer
+exist plus lockfiles in ``~/.config/opensre/agents/`` that correspond
+to dead PIDs.
+
+The function is split from the boot wiring so it stays unit-testable
+without spinning up the REPL: the loop.py side just calls
+``run_startup_sweep()`` and lets this module handle path defaults and
+error suppression.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from app.agents.probe import probe
+from app.agents.registry import AgentRecord, AgentRegistry
+from app.constants import OPENSRE_HOME_DIR
+
+logger = logging.getLogger(__name__)
+
+#: Default location of the per-PID lockfile directory.
+DEFAULT_LOCK_DIR: Path = OPENSRE_HOME_DIR / "agents"
+
+
+@dataclass(frozen=True)
+class SweepResult:
+    """What a single ``sweep()`` invocation removed.
+
+    Empty tuples on an already-clean run; an already-pruned registry
+    paired with no stale lockfiles produces ``SweepResult()`` — that's
+    the contract idempotency rests on.
+    """
+
+    removed_records: tuple[AgentRecord, ...] = field(default_factory=tuple)
+    removed_locks: tuple[Path, ...] = field(default_factory=tuple)
+
+    @property
+    def total(self) -> int:
+        """Sum of removed records and lockfiles. Useful for log messages."""
+        return len(self.removed_records) + len(self.removed_locks)
+
+
+def sweep(
+    registry: AgentRegistry,
+    lock_dir: Path = DEFAULT_LOCK_DIR,
+) -> SweepResult:
+    """Remove dead-PID registry entries and stale lockfiles.
+
+    Parameters
+    ----------
+    registry
+        The ``AgentRegistry`` to prune. Mutated in place.
+    lock_dir
+        Directory containing per-PID lockfiles named ``<pid>.lock``.
+        Missing directories are tolerated (returned with empty
+        ``removed_locks``); files whose stems aren't integer PIDs are
+        left untouched so the sweep can't accidentally delete unrelated
+        artifacts.
+
+    Returns
+    -------
+    SweepResult
+        Lists of what was removed. Empty after an already-clean run.
+    """
+    removed_records = _sweep_registry(registry)
+    removed_locks = _sweep_locks(lock_dir)
+    return SweepResult(
+        removed_records=tuple(removed_records),
+        removed_locks=tuple(removed_locks),
+    )
+
+
+def run_startup_sweep() -> SweepResult:
+    """Convenience wrapper for the REPL boot path.
+
+    Constructs an ``AgentRegistry`` at the default location, runs
+    ``sweep()`` against the default lockfile dir, and swallows any
+    exception so a sweep failure never prevents the REPL from
+    starting. Returns an empty ``SweepResult`` on error.
+    """
+    try:
+        registry = AgentRegistry()
+        result = sweep(registry)
+    except Exception:  # pragma: no cover — defensive boundary
+        logger.warning("agent sweep failed at REPL boot", exc_info=True)
+        return SweepResult()
+    if result.total > 0:
+        logger.debug(
+            "agent sweep removed %d records and %d lockfiles",
+            len(result.removed_records),
+            len(result.removed_locks),
+        )
+    return result
+
+
+def _sweep_registry(registry: AgentRegistry) -> list[AgentRecord]:
+    removed: list[AgentRecord] = []
+    for record in registry.list():
+        # ``cpu_interval=0.0`` because we only need the existence
+        # signal, not an accurate CPU sample. Blocking 100 ms per
+        # registered agent at boot would be a noticeable startup tax.
+        if probe(record.pid, cpu_interval=0.0) is None:
+            forgotten = registry.forget(record.pid)
+            if forgotten is not None:
+                removed.append(forgotten)
+                logger.debug(
+                    "sweep: forgot dead agent record pid=%s name=%s",
+                    forgotten.pid,
+                    forgotten.name,
+                )
+    return removed
+
+
+def _sweep_locks(lock_dir: Path) -> list[Path]:
+    removed: list[Path] = []
+    if not lock_dir.is_dir():
+        return removed
+    for path in sorted(lock_dir.glob("*.lock")):
+        # Filename convention: ``<pid>.lock``. Anything whose stem
+        # isn't a valid PID is ignored — we don't know what produced
+        # it, and a future naming convention shouldn't trigger
+        # spurious removals.
+        try:
+            pid = int(path.stem)
+        except ValueError:
+            continue
+        if probe(pid, cpu_interval=0.0) is None:
+            try:
+                path.unlink()
+            except OSError:
+                logger.warning("sweep: failed to remove stale lockfile %s", path)
+                continue
+            removed.append(path)
+            logger.debug("sweep: removed stale lockfile %s (pid=%s)", path, pid)
+    return removed
+
+
+__all__ = ["DEFAULT_LOCK_DIR", "SweepResult", "run_startup_sweep", "sweep"]

--- a/app/agents/sweep.py
+++ b/app/agents/sweep.py
@@ -5,6 +5,15 @@ the second time. Removes ``AgentRegistry`` entries whose PIDs no longer
 exist plus lockfiles in ``~/.config/opensre/agents/`` that correspond
 to dead PIDs.
 
+Liveness is checked via ``pid_exists`` rather than ``probe()``
+because ``probe()`` returns ``None`` for two distinct reasons —
+"PID doesn't exist" and "PID exists but I can't access its fields"
+(``psutil.AccessDenied``, common for cross-user processes on macOS
+or with a hardened ``/proc``). Treating both cases as "dead" would
+silently delete records and lockfiles for live processes owned by
+other users. ``pid_exists`` is the right primitive: it does an
+OS-level existence check that doesn't traverse the access boundary.
+
 The function is split from the boot wiring so it stays unit-testable
 without spinning up the REPL: the loop.py side just calls
 ``run_startup_sweep()`` and lets this module handle path defaults and
@@ -17,7 +26,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from app.agents.probe import probe
+from app.agents.probe import pid_exists
 from app.agents.registry import AgentRecord, AgentRegistry
 from app.constants import OPENSRE_HOME_DIR
 
@@ -86,7 +95,10 @@ def run_startup_sweep() -> SweepResult:
     try:
         registry = AgentRegistry()
         result = sweep(registry)
-    except Exception:  # pragma: no cover — defensive boundary
+    except Exception:
+        # Pinned by ``test_run_startup_sweep_swallows_exceptions`` which
+        # mocks ``AgentRegistry()`` to raise. The REPL must boot even if
+        # the sweep is broken; logging is the only side effect.
         logger.warning("agent sweep failed at REPL boot", exc_info=True)
         return SweepResult()
     if result.total > 0:
@@ -99,20 +111,22 @@ def run_startup_sweep() -> SweepResult:
 
 
 def _sweep_registry(registry: AgentRegistry) -> list[AgentRecord]:
-    removed: list[AgentRecord] = []
-    for record in registry.list():
-        # ``cpu_interval=0.0`` because we only need the existence
-        # signal, not an accurate CPU sample. Blocking 100 ms per
-        # registered agent at boot would be a noticeable startup tax.
-        if probe(record.pid, cpu_interval=0.0) is None:
-            forgotten = registry.forget(record.pid)
-            if forgotten is not None:
-                removed.append(forgotten)
-                logger.debug(
-                    "sweep: forgot dead agent record pid=%s name=%s",
-                    forgotten.pid,
-                    forgotten.name,
-                )
+    """Prune dead-PID records in a single batched rewrite.
+
+    Building the dead-PID set first and calling ``forget_many`` once
+    means a registry with N dead entries triggers exactly one
+    ``_rewrite()`` instead of N — relevant if a developer crashes and
+    relaunches the REPL many times without registry maintenance. See
+    AgentRegistry.forget_many for the contract.
+    """
+    dead_pids = [record.pid for record in registry.list() if not pid_exists(record.pid)]
+    removed = registry.forget_many(dead_pids)
+    for record in removed:
+        logger.debug(
+            "sweep: forgot dead agent record pid=%s name=%s",
+            record.pid,
+            record.name,
+        )
     return removed
 
 
@@ -129,14 +143,28 @@ def _sweep_locks(lock_dir: Path) -> list[Path]:
             pid = int(path.stem)
         except ValueError:
             continue
-        if probe(pid, cpu_interval=0.0) is None:
-            try:
-                path.unlink()
-            except OSError:
-                logger.warning("sweep: failed to remove stale lockfile %s", path)
-                continue
-            removed.append(path)
-            logger.debug("sweep: removed stale lockfile %s (pid=%s)", path, pid)
+        if pid_exists(pid):
+            continue
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            # Race against another sweep / external cleanup that
+            # already removed this exact lockfile. Idempotent
+            # success — don't log a warning, don't claim we did it.
+            continue
+        except OSError:
+            # Read-only filesystem, permission denied, etc. Log with
+            # ``exc_info`` so a downstream operator can tell exactly
+            # why; carry on with the rest of the sweep.
+            logger.warning(
+                "sweep: failed to remove stale lockfile %s (pid=%s)",
+                path,
+                pid,
+                exc_info=True,
+            )
+            continue
+        removed.append(path)
+        logger.debug("sweep: removed stale lockfile %s (pid=%s)", path, pid)
     return removed
 
 

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -10,6 +10,7 @@ from prompt_toolkit import PromptSession
 from rich.console import Console
 from rich.markup import escape
 
+from app.agents.sweep import run_startup_sweep
 from app.analytics.cli import capture_terminal_turn_summarized
 from app.cli.interactive_shell.agent_actions import execute_cli_actions_with_metrics
 from app.cli.interactive_shell.banner import render_banner
@@ -181,6 +182,10 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
     # literal escape codes in some terminal emulators.
     console = Console(highlight=False, force_terminal=True, color_system="truecolor")
     render_banner(console)
+    # Prune dead-PID agent records and stale lockfiles before the user's
+    # first ``/agents`` call. Errors are caught inside; a sweep failure
+    # must never prevent the REPL from starting.
+    run_startup_sweep()
     session = ReplSession()
     prompt = _build_prompt_session()
     session.prompt_history_backend = prompt.history

--- a/tests/agents/test_sweep.py
+++ b/tests/agents/test_sweep.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+import app.agents.sweep as sweep_module
 from app.agents.registry import AgentRecord, AgentRegistry
 from app.agents.sweep import SweepResult, run_startup_sweep, sweep
 
@@ -49,6 +50,82 @@ def test_live_pid_record_is_kept(isolated_registry: AgentRegistry, tmp_path: Pat
 
     assert isolated_registry.get(self_pid) is not None
     assert result.removed_records == ()
+
+
+def test_access_denied_pid_is_kept_not_pruned(
+    isolated_registry: AgentRegistry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live PID owned by another user (where ``psutil.Process(pid)``
+    construction would raise ``AccessDenied`` and the old probe-based
+    check would falsely return ``None``) must NOT be pruned.
+
+    Locks in the fix for the Copilot review concern: the sweep now
+    uses ``psutil.pid_exists`` which doesn't traverse the access
+    boundary, so cross-user processes survive both the registry and
+    lockfile sweeps.
+    """
+    foreign_pid = 4242  # arbitrary; we mock pid_exists to say "alive"
+    isolated_registry.register(
+        AgentRecord(name="other-users-claude", pid=foreign_pid, command="claude")
+    )
+
+    monkeypatch.setattr(sweep_module, "pid_exists", lambda pid: pid == foreign_pid)
+
+    result = sweep(isolated_registry, lock_dir=tmp_path / "no-such-dir")
+
+    assert isolated_registry.get(foreign_pid) is not None
+    assert result.removed_records == ()
+
+
+def test_access_denied_pid_lockfile_is_kept(
+    isolated_registry: AgentRegistry, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Symmetric to the registry case: a lockfile for a live foreign
+    PID must survive the sweep even though the calling process can't
+    introspect it. Without the ``pid_exists`` fix, the sweep would
+    delete this file and break the foreign agent's coordination.
+    """
+    foreign_pid = 4242
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    foreign_lock = lock_dir / f"{foreign_pid}.lock"
+    foreign_lock.write_text("locked")
+
+    monkeypatch.setattr(sweep_module, "pid_exists", lambda pid: pid == foreign_pid)
+
+    result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    assert foreign_lock.exists()
+    assert result.removed_locks == ()
+
+
+def test_many_dead_pids_trigger_one_rewrite_not_n(
+    isolated_registry: AgentRegistry, tmp_path: Path
+) -> None:
+    """Pruning N dead records must rewrite the JSONL once, not N times.
+
+    Spies on ``AgentRegistry._rewrite`` to count calls — locks in the
+    Copilot review concern about boot-time N-rewrite scaling.
+    """
+    for pid in range(_DEAD_PID - 5, _DEAD_PID):
+        isolated_registry.register(AgentRecord(name=f"ghost-{pid}", pid=pid, command="bin"))
+
+    rewrite_call_count = 0
+    real_rewrite = isolated_registry._rewrite
+
+    def _spy() -> None:
+        nonlocal rewrite_call_count
+        rewrite_call_count += 1
+        real_rewrite()
+
+    isolated_registry._rewrite = _spy  # type: ignore[method-assign]
+
+    result = sweep(isolated_registry, lock_dir=tmp_path / "no-such-dir")
+
+    assert len(result.removed_records) == 5
+    assert rewrite_call_count == 1, (
+        f"expected 1 batched rewrite for 5 dead PIDs, got {rewrite_call_count}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -130,12 +207,14 @@ def test_missing_lock_dir_is_tolerated(isolated_registry: AgentRegistry, tmp_pat
     assert result.removed_locks == ()
 
 
-def test_lockfile_unlink_failure_is_logged_not_raised(
+def test_lockfile_unlink_failure_is_logged_with_exc_info(
     isolated_registry: AgentRegistry, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """If the OS refuses to remove a lockfile (e.g. permission denied
-    on a read-only filesystem), the sweep logs and continues rather
-    than crashing the REPL boot."""
+    on a read-only filesystem), the sweep logs at WARNING **with**
+    ``exc_info`` so the operator can diagnose the cause, then
+    continues rather than crashing the REPL boot.
+    """
     lock_dir = tmp_path / "agents"
     lock_dir.mkdir()
     stuck_lock = lock_dir / f"{_DEAD_PID}.lock"
@@ -151,8 +230,39 @@ def test_lockfile_unlink_failure_is_logged_not_raised(
     assert stuck_lock.exists()
     # ...but the sweep didn't claim a successful removal
     assert stuck_lock not in result.removed_locks
-    # ...and it logged the failure for ops visibility
-    assert any("failed to remove stale lockfile" in r.getMessage() for r in caplog.records)
+    # ...and it logged the failure with exception info attached so
+    # an ops operator sees *why* the unlink failed, not just *that*
+    # it did.
+    matching = [r for r in caplog.records if "failed to remove stale lockfile" in r.getMessage()]
+    assert matching, "expected a WARNING log for the unlink failure"
+    assert matching[0].exc_info is not None, (
+        "warning log must include exc_info so the underlying exception is visible"
+    )
+
+
+def test_lockfile_already_gone_is_silently_idempotent(
+    isolated_registry: AgentRegistry, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A concurrent sweep / external cleanup may have already removed
+    the lockfile between our existence check and our unlink call.
+    ``FileNotFoundError`` is expected behaviour, not a warning —
+    treat it as idempotent success and emit no log line.
+    """
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    racy_lock = lock_dir / f"{_DEAD_PID}.lock"
+    racy_lock.write_text("locked")
+
+    with (
+        patch.object(Path, "unlink", side_effect=FileNotFoundError("already gone")),
+        caplog.at_level("WARNING", logger="app.agents.sweep"),
+    ):
+        result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    # The race-already-removed file is treated as nothing-to-do:
+    # not in removed_locks, but also no warning logged.
+    assert racy_lock not in result.removed_locks
+    assert not [r for r in caplog.records if "failed to remove stale lockfile" in r.getMessage()]
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +277,9 @@ def test_sweep_result_total_property(isolated_registry: AgentRegistry, tmp_path:
     lock_dir.mkdir()
     isolated_registry.register(AgentRecord(name="ghost", pid=_DEAD_PID, command="bin"))
     (lock_dir / f"{_DEAD_PID}.lock").write_text("locked")
-    (lock_dir / f"{_DEAD_PID + 1}.lock").write_text("locked")
+    # ``_DEAD_PID - 1`` to stay within int32 — ``_DEAD_PID`` is the
+    # signed-int32 max, so ``+ 1`` would overflow ``psutil.pid_exists``.
+    (lock_dir / f"{_DEAD_PID - 1}.lock").write_text("locked")
 
     result = sweep(isolated_registry, lock_dir=lock_dir)
 

--- a/tests/agents/test_sweep.py
+++ b/tests/agents/test_sweep.py
@@ -304,7 +304,6 @@ def test_run_startup_sweep_swallows_exceptions(monkeypatch: pytest.MonkeyPatch) 
     """``run_startup_sweep`` is the REPL's boot hook; an unexpected
     exception inside must NOT propagate, otherwise a sweep bug could
     block the REPL from starting at all."""
-    import app.agents.sweep as sweep_module
 
     def _explode(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("simulated registry-load failure")

--- a/tests/agents/test_sweep.py
+++ b/tests/agents/test_sweep.py
@@ -1,0 +1,205 @@
+"""Tests for the startup orphan / stale-lockfile sweep (issue #1501)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.agents.registry import AgentRecord, AgentRegistry
+from app.agents.sweep import SweepResult, run_startup_sweep, sweep
+
+# A PID large enough to never be allocated on Linux/macOS
+# (``kernel.pid_max`` defaults to 32768 or 4194304). Cross-platform
+# Windows would also fail to find this process.
+_DEAD_PID = 2**31 - 1
+
+
+@pytest.fixture
+def isolated_registry(tmp_path: Path) -> AgentRegistry:
+    """An ``AgentRegistry`` writing to a tmp dir so tests don't touch
+    the developer's real ``~/.config/opensre/agents.jsonl``."""
+    return AgentRegistry(path=tmp_path / "agents.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Registry-side sweep
+# ---------------------------------------------------------------------------
+
+
+def test_dead_pid_record_is_forgotten(isolated_registry: AgentRegistry, tmp_path: Path) -> None:
+    isolated_registry.register(AgentRecord(name="ghost", pid=_DEAD_PID, command="bin"))
+    assert isolated_registry.get(_DEAD_PID) is not None  # sanity: registered ok
+
+    result = sweep(isolated_registry, lock_dir=tmp_path / "no-such-dir")
+
+    assert isolated_registry.get(_DEAD_PID) is None
+    assert len(result.removed_records) == 1
+    assert result.removed_records[0].pid == _DEAD_PID
+
+
+def test_live_pid_record_is_kept(isolated_registry: AgentRegistry, tmp_path: Path) -> None:
+    """The current Python process is alive; its record must not be pruned."""
+    self_pid = os.getpid()
+    isolated_registry.register(AgentRecord(name="opensre", pid=self_pid, command="opensre"))
+
+    result = sweep(isolated_registry, lock_dir=tmp_path / "no-such-dir")
+
+    assert isolated_registry.get(self_pid) is not None
+    assert result.removed_records == ()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — the headline acceptance criterion
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_second_run_is_a_noop(isolated_registry: AgentRegistry, tmp_path: Path) -> None:
+    """Running ``sweep`` twice in a row: the second invocation removes
+    nothing because the first already cleaned up. This is the contract
+    the issue spec leans on for safe boot-time invocation."""
+    isolated_registry.register(AgentRecord(name="ghost", pid=_DEAD_PID, command="bin"))
+    isolated_registry.register(AgentRecord(name="opensre", pid=os.getpid(), command="opensre"))
+
+    first = sweep(isolated_registry, lock_dir=tmp_path / "no-such-dir")
+    second = sweep(isolated_registry, lock_dir=tmp_path / "no-such-dir")
+
+    assert len(first.removed_records) == 1
+    assert second.removed_records == ()
+    # The live record survives both rounds.
+    assert isolated_registry.get(os.getpid()) is not None
+
+
+# ---------------------------------------------------------------------------
+# Lockfile-side sweep
+# ---------------------------------------------------------------------------
+
+
+def test_stale_lockfile_for_dead_pid_is_removed(
+    isolated_registry: AgentRegistry, tmp_path: Path
+) -> None:
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    stale_lock = lock_dir / f"{_DEAD_PID}.lock"
+    stale_lock.write_text("locked")
+
+    result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    assert not stale_lock.exists()
+    assert stale_lock in result.removed_locks
+
+
+def test_live_lockfile_is_kept(isolated_registry: AgentRegistry, tmp_path: Path) -> None:
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    live_lock = lock_dir / f"{os.getpid()}.lock"
+    live_lock.write_text("locked")
+
+    result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    assert live_lock.exists()
+    assert result.removed_locks == ()
+
+
+def test_non_pid_lockfile_names_are_ignored(
+    isolated_registry: AgentRegistry, tmp_path: Path
+) -> None:
+    """Files in lock_dir whose stem isn't an integer (foreign tools'
+    artifacts, future conventions, etc.) are left untouched. The
+    sweep only acts on its own ``<pid>.lock`` shape."""
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    foreign = lock_dir / "registry.lock"
+    foreign.write_text("not ours")
+    other = lock_dir / "settings.json"
+    other.write_text("{}")
+
+    result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    assert foreign.exists()
+    assert other.exists()
+    assert result.removed_locks == ()
+
+
+def test_missing_lock_dir_is_tolerated(isolated_registry: AgentRegistry, tmp_path: Path) -> None:
+    """A non-existent lock_dir doesn't raise — common on a fresh
+    install where no agent has registered yet."""
+    result = sweep(isolated_registry, lock_dir=tmp_path / "definitely-not-here")
+    assert result.removed_locks == ()
+
+
+def test_lockfile_unlink_failure_is_logged_not_raised(
+    isolated_registry: AgentRegistry, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """If the OS refuses to remove a lockfile (e.g. permission denied
+    on a read-only filesystem), the sweep logs and continues rather
+    than crashing the REPL boot."""
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    stuck_lock = lock_dir / f"{_DEAD_PID}.lock"
+    stuck_lock.write_text("locked")
+
+    with (
+        patch.object(Path, "unlink", side_effect=PermissionError("read-only fs")),
+        caplog.at_level("WARNING", logger="app.agents.sweep"),
+    ):
+        result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    # The file is still there because unlink was mocked to fail
+    assert stuck_lock.exists()
+    # ...but the sweep didn't claim a successful removal
+    assert stuck_lock not in result.removed_locks
+    # ...and it logged the failure for ops visibility
+    assert any("failed to remove stale lockfile" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# SweepResult ergonomics
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_result_total_property(isolated_registry: AgentRegistry, tmp_path: Path) -> None:
+    """``SweepResult.total`` is the sum of removed records and locks —
+    the single number that's most useful in a debug log line."""
+    lock_dir = tmp_path / "agents"
+    lock_dir.mkdir()
+    isolated_registry.register(AgentRecord(name="ghost", pid=_DEAD_PID, command="bin"))
+    (lock_dir / f"{_DEAD_PID}.lock").write_text("locked")
+    (lock_dir / f"{_DEAD_PID + 1}.lock").write_text("locked")
+
+    result = sweep(isolated_registry, lock_dir=lock_dir)
+
+    assert result.total == 1 + 2  # 1 record + 2 locks
+
+
+def test_empty_sweep_result_is_falsy_in_total() -> None:
+    """A no-op sweep produces ``SweepResult()`` with total == 0 — the
+    boot-time logger uses this to decide whether to emit a message."""
+    empty = SweepResult()
+    assert empty.total == 0
+    assert empty.removed_records == ()
+    assert empty.removed_locks == ()
+
+
+# ---------------------------------------------------------------------------
+# REPL-boot wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_run_startup_sweep_swallows_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run_startup_sweep`` is the REPL's boot hook; an unexpected
+    exception inside must NOT propagate, otherwise a sweep bug could
+    block the REPL from starting at all."""
+    import app.agents.sweep as sweep_module
+
+    def _explode(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("simulated registry-load failure")
+
+    monkeypatch.setattr(sweep_module, "AgentRegistry", _explode)
+
+    result = sweep_module.run_startup_sweep()
+
+    assert isinstance(result, SweepResult)
+    assert result.total == 0


### PR DESCRIPTION
Fixes #1501

Phase-3 safety hygiene for the [`monitor-local-agents`](https://github.com/Tracer-Cloud/opensre/labels/monitor-local-agents) initiative. Idempotent run-once-on-REPL-boot pass that prunes `AgentRegistry` entries whose PIDs no longer exist plus stale lockfiles in `~/.config/opensre/agents/`.

The result: when the REPL crashes or an agent process dies between sessions, `/agents` no longer shows phantom rows for PIDs that don't exist, and stale lockfiles can't block legitimate new agents from registering.

## Summary

- **`app/agents/sweep.py`** *(new)* — `sweep(registry, lock_dir=DEFAULT_LOCK_DIR) -> SweepResult` plus a `run_startup_sweep()` boot wrapper. Frozen `SweepResult` dataclass exposes `removed_records`, `removed_locks`, and a `total` property for log lines.
- **`app/cli/interactive_shell/loop.py`** — call `run_startup_sweep()` once, immediately after `render_banner(console)`, so dead-PID rows are pruned before the user's first `/agents` invocation.
- **`tests/agents/test_sweep.py`** *(new)* — 11 cases covering both registry-side and lockfile-side sweeps, idempotency, edge cases, and the boot-wrapper contract.

## Design notes for reviewers

- **`cpu_interval=0.0` for the probe call.** The sweep only needs the existence signal — `probe(pid)` returns `None` when the PID doesn't exist regardless of CPU sample accuracy. The default 100 ms blocking sample × N registered agents would be a noticeable startup tax for users who track many agents.
- **Lockfile dir tolerance.** A missing `lock_dir` is the common case on a fresh install before any agent has registered. The sweep tolerates it silently. Files in `lock_dir` whose stems aren't valid integers are left untouched — the sweep only acts on its own `<pid>.lock` convention so it can't accidentally delete `settings.json` or another tool's `registry.lock`.
- **OS-level unlink failure is logged, not raised.** If the filesystem refuses to remove a stale lockfile (read-only mount, permission denied), the sweep logs at WARNING and continues with the rest. This keeps the REPL boot resilient.
- **`run_startup_sweep()` swallows any exception.** A sweep bug must never prevent the REPL from starting at all. Locked in by `test_run_startup_sweep_swallows_exceptions` which mocks `AgentRegistry()` to raise.
- **Idempotency comes for free** from the design: the sweep reads current registry/lockfile state on each call and acts only on dead PIDs. After a clean run, every remaining entry is alive, so a second invocation removes nothing. `test_idempotent_second_run_is_a_noop` locks this in.

## Acceptance checklist

- [x] Idempotent (running twice in a row is a no-op the second time)
- [x] Logs each removal at debug level (`logger.debug` calls in both `_sweep_registry` and `_sweep_locks`; warning level reserved for OS-level unlink failures)
- [x] `make lint` passes
- [x] `make format-check` passes
- [x] `make typecheck` passes (513 source files checked)
- [x] `tests/agents/test_sweep.py` — 11/11 pass

## Test plan

- [x] **`test_dead_pid_record_is_forgotten`** — registered PID 2³¹−1 is pruned.
- [x] **`test_live_pid_record_is_kept`** — current Python process (`os.getpid()`) survives.
- [x] **`test_idempotent_second_run_is_a_noop`** — first run prunes, second run returns empty `SweepResult` (the contract underlying safe boot-time invocation).
- [x] **`test_stale_lockfile_for_dead_pid_is_removed`** + **`test_live_lockfile_is_kept`** — symmetric coverage of the lockfile path.
- [x] **`test_non_pid_lockfile_names_are_ignored`** — `registry.lock`, `settings.json` etc. left untouched.
- [x] **`test_missing_lock_dir_is_tolerated`** — fresh-install case doesn't raise.
- [x] **`test_lockfile_unlink_failure_is_logged_not_raised`** — `Path.unlink` mocked to `PermissionError`, sweep logs and continues.
- [x] **`test_sweep_result_total_property`** + **`test_empty_sweep_result_is_falsy_in_total`** — the dataclass ergonomics used by the boot logger.
- [x] **`test_run_startup_sweep_swallows_exceptions`** — `AgentRegistry()` mocked to raise; `run_startup_sweep()` returns empty `SweepResult` instead of propagating.
- [x] Broader sweep `tests/agents/ tests/cli/interactive_shell/` — 536 passed.

Note on the full coverage suite: `make test-cov` shows one pre-existing flake in `tests/pipeline/test_runners_sentry.py::test_run_chat_initializes_sentry_and_captures_unhandled_errors` that fails identically on plain `main` without my changes — confirmed by checking out `main` and running the same test in isolation.