### PR TITLE
feat(agents): /agents slash command renders registered rows (#1488)

### DIFF
--- a/app/cli/interactive_shell/agents_view.py
+++ b/app/cli/interactive_shell/agents_view.py
@@ -1,0 +1,90 @@
+"""Rich-table rendering for the ``/agents`` slash-command dashboard.
+
+Produces the structural shape of the dashboard with the columns
+documented in #1486's preview (``agent``, ``pid``, ``uptime``,
+``cpu%``, ``tokens/min``, ``$/hr``, ``status``). Cells that aren't
+yet wired (every metric column for now) render as ``-`` — the
+sampler in #1490 fills ``cpu%`` / ``uptime`` / ``status`` later, the
+token meter consumer in #1490+ fills ``tokens/min``, and the budget
+loader from #1494 fills ``$/hr``.
+
+This module lives outside ``app/agents/`` deliberately: the agents
+package is for *collectors* (probe, registry, sweep, meters) and
+must not depend on Rich (a UI library), or non-CLI consumers of the
+collectors would pull it in transitively. The slash command in
+``command_registry/agents.py`` is the one and only consumer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+
+from rich.markup import escape
+from rich.table import Table
+
+from app.agents.registry import AgentRecord
+from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
+
+# Cells we don't yet have a data source for. See module docstring for
+# which downstream issues fill which column.
+_UNFILLED = "-"
+
+# Rich's ``Table.add_column`` only accepts this restricted Literal
+# for ``justify`` — narrowing the local alias keeps mypy happy
+# without sprinkling ignore comments.
+_Justify = Literal["default", "left", "center", "right", "full"]
+
+#: Columns the dashboard ships with. Order is the user-facing order
+#: and is also the cell-injection contract that #1490 will lean on
+#: when it threads probe snapshots into the rendering layer.
+_COLUMNS: tuple[tuple[str, _Justify], ...] = (
+    ("agent", "left"),
+    ("pid", "right"),
+    ("uptime", "right"),
+    ("cpu%", "right"),
+    ("tokens/min", "right"),
+    ("$/hr", "right"),
+    ("status", "left"),
+)
+
+
+def render_agents_table(records: Iterable[AgentRecord]) -> Table:
+    """Return a Rich ``Table`` for the registered ``AgentRecord`` set.
+
+    The returned table always has the full column structure, even
+    when no records exist; the caller passes it to ``console.print()``.
+    An empty record list produces a table with no body rows and an
+    explanatory caption pointing the user at the registration command.
+
+    Cells for metric columns (``uptime``, ``cpu%``, ``tokens/min``,
+    ``$/hr``, ``status``) render as ``-`` placeholders. Filling them
+    is intentionally out of scope here — see module docstring for the
+    issue map.
+    """
+    materialized = list(records)
+    table = Table(
+        title="agents",
+        title_style=TERMINAL_ACCENT_BOLD,
+        caption=(
+            "no agents registered — use `opensre agents register` to track one"
+            if not materialized
+            else None
+        ),
+    )
+    for header, justify in _COLUMNS:
+        table.add_column(header, justify=justify)
+    for record in materialized:
+        table.add_row(
+            escape(record.name),
+            str(record.pid),
+            _UNFILLED,  # uptime
+            _UNFILLED,  # cpu%
+            _UNFILLED,  # tokens/min
+            _UNFILLED,  # $/hr
+            _UNFILLED,  # status
+        )
+    return table
+
+
+__all__ = ["render_agents_table"]

--- a/app/cli/interactive_shell/agents_view.py
+++ b/app/cli/interactive_shell/agents_view.py
@@ -18,8 +18,8 @@ collectors would pull it in transitively. The slash command in
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Literal
 
+from rich.console import JustifyMethod
 from rich.markup import escape
 from rich.table import Table
 
@@ -30,15 +30,13 @@ from app.cli.interactive_shell.theme import TERMINAL_ACCENT_BOLD
 # which downstream issues fill which column.
 _UNFILLED = "-"
 
-# Rich's ``Table.add_column`` only accepts this restricted Literal
-# for ``justify`` — narrowing the local alias keeps mypy happy
-# without sprinkling ignore comments.
-_Justify = Literal["default", "left", "center", "right", "full"]
-
 #: Columns the dashboard ships with. Order is the user-facing order
 #: and is also the cell-injection contract that #1490 will lean on
 #: when it threads probe snapshots into the rendering layer.
-_COLUMNS: tuple[tuple[str, _Justify], ...] = (
+#: Re-using Rich's own ``JustifyMethod`` type alias rather than a
+#: hand-maintained Literal so column-justify options stay in lockstep
+#: with the library if Rich ever expands them.
+_COLUMNS: tuple[tuple[str, JustifyMethod], ...] = (
     ("agent", "left"),
     ("pid", "right"),
     ("uptime", "right"),
@@ -63,14 +61,16 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
     issue map.
     """
     materialized = list(records)
+    # The empty-state caption deliberately doesn't suggest a registration
+    # command: ``opensre agents register`` is currently a stub
+    # (``feat(cli): register agents command group skeleton (#1486)``)
+    # that prints "not implemented yet". Pointing users at it would be
+    # misleading. The wording will gain a "register one with X" hint
+    # when that ticket grows real behavior.
     table = Table(
         title="agents",
         title_style=TERMINAL_ACCENT_BOLD,
-        caption=(
-            "no agents registered — use `opensre agents register` to track one"
-            if not materialized
-            else None
-        ),
+        caption="no agents registered yet" if not materialized else None,
     )
     for header, justify in _COLUMNS:
         table.add_column(header, justify=justify)

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -1,4 +1,9 @@
-"""Slash command: /agents (file-write conflicts between local AI agents)."""
+"""Slash command: ``/agents`` (registered local AI agent fleet view).
+
+Bare ``/agents`` renders the registered-agents dashboard; subcommands
+drill into specific surfaces (currently ``conflicts``, with more
+landing as the monitor-local-agents initiative ships).
+"""
 
 from __future__ import annotations
 
@@ -13,6 +18,8 @@ from app.agents.conflicts import (
     detect_conflicts,
     render_conflicts,
 )
+from app.agents.registry import AgentRegistry
+from app.cli.interactive_shell.agents_view import render_agents_table
 from app.cli.interactive_shell.command_registry.types import SlashCommand
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.theme import TERMINAL_ERROR
@@ -24,6 +31,20 @@ _AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
 
 def _opensre_agent_id() -> str:
     return f"opensre:{os.getpid()}"
+
+
+def _cmd_agents_list(console: Console) -> bool:
+    """Render the registered ``AgentRecord`` set as a Rich table.
+
+    Bare ``/agents`` resolves here. Metric cells (``cpu%``,
+    ``tokens/min``, ``$/hr``, ``status``, ``uptime``) render as
+    placeholders until the wiring from #1490 / #1494 lands; this
+    surface only consumes what the registry already holds today.
+    """
+    registry = AgentRegistry()
+    table = render_agents_table(registry.list())
+    console.print(table)
+    return True
 
 
 def _cmd_agents_conflicts(console: Console) -> bool:
@@ -42,12 +63,7 @@ def _cmd_agents_conflicts(console: Console) -> bool:
 
 def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool:
     if not args:
-        console.print(
-            f"[{TERMINAL_ERROR}]usage:[/] /agents <subcommand>  "
-            "— try [bold]/agents conflicts[/bold]"
-        )
-        session.mark_latest(ok=False, kind="slash")
-        return True
+        return _cmd_agents_list(console)
 
     sub = args[0].lower().strip()
 
@@ -56,7 +72,7 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
 
     console.print(
         f"[{TERMINAL_ERROR}]unknown subcommand:[/] {escape(sub)}  "
-        "(try [bold]/agents conflicts[/bold])"
+        "(try [bold]/agents[/bold] or [bold]/agents conflicts[/bold])"
     )
     session.mark_latest(ok=False, kind="slash")
     return True
@@ -65,7 +81,7 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/agents",
-        "inspect and coordinate concurrent local AI agents (subcommands: conflicts)",
+        "show registered local AI agents (subcommands: conflicts)",
         _cmd_agents,
         first_arg_completions=_AGENTS_FIRST_ARGS,
     ),

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import io
+from pathlib import Path
 
+import pytest
 from rich.console import Console
 from rich.table import Table
 
@@ -12,6 +14,7 @@ from app.agents.conflicts import (
     FileWriteConflict,
     render_conflicts,
 )
+from app.agents.registry import AgentRecord, AgentRegistry
 from app.cli.interactive_shell.command_registry import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.session import ReplSession
 
@@ -19,6 +22,20 @@ from app.cli.interactive_shell.session import ReplSession
 def _capture() -> tuple[Console, io.StringIO]:
     buf = io.StringIO()
     return Console(file=buf, force_terminal=False, highlight=False, width=120), buf
+
+
+def _isolate_registry(monkeypatch: pytest.MonkeyPatch, path: Path) -> AgentRegistry:
+    """Point the slash command's ``AgentRegistry()`` constructor at
+    ``path`` so tests don't read the developer's real
+    ``~/.config/opensre/agents.jsonl``. Returns the registry instance
+    that the test can populate.
+    """
+    registry = AgentRegistry(path=path)
+
+    from app.cli.interactive_shell.command_registry import agents as agents_mod
+
+    monkeypatch.setattr(agents_mod, "AgentRegistry", lambda: AgentRegistry(path=path))
+    return registry
 
 
 class TestAgentsRegistration:
@@ -41,13 +58,38 @@ class TestAgentsDispatch:
         assert dispatch_slash("/agents conflicts", session, console) is True
         assert "no conflicts detected" in buf.getvalue()
 
-    def test_no_subcommand_prints_usage_hint(self) -> None:
+    def test_no_subcommand_with_empty_registry_renders_empty_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        session = ReplSession()
+        console, buf = _capture()
+
+        assert dispatch_slash("/agents", session, console) is True
+
+        out = buf.getvalue()
+        # Caption from agents_view.render_agents_table:
+        assert "no agents registered" in out
+        # Header row still rendered with the dashboard column structure:
+        assert "agent" in out
+        assert "pid" in out
+
+    def test_no_subcommand_renders_registered_agents(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="cursor-tab", pid=9133, command="cursor"))
+
         session = ReplSession()
         console, buf = _capture()
         assert dispatch_slash("/agents", session, console) is True
+
         out = buf.getvalue()
-        assert "usage" in out.lower()
-        assert "/agents conflicts" in out
+        assert "claude-code" in out
+        assert "8421" in out
+        assert "cursor-tab" in out
+        assert "9133" in out
 
     def test_unknown_subcommand_prints_error(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_agents_view.py
+++ b/tests/cli/interactive_shell/test_agents_view.py
@@ -1,0 +1,147 @@
+"""Pure rendering tests for the ``/agents`` dashboard table (issue #1488).
+
+These cover ``render_agents_table`` in isolation — no slash-command
+dispatch, no real registry I/O. The integration tests in
+``test_agents_commands.py`` cover the dispatch path that consumes
+this function.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+from rich.table import Table
+
+from app.agents.registry import AgentRecord
+from app.cli.interactive_shell.agents_view import render_agents_table
+
+# The columns this PR ships are the contract for #1490 and later
+# tickets that thread snapshot data into the rendering layer; pin
+# them here so a downstream reorder doesn't silently break the
+# dashboard preview.
+_DASHBOARD_COLUMNS: tuple[str, ...] = (
+    "agent",
+    "pid",
+    "uptime",
+    "cpu%",
+    "tokens/min",
+    "$/hr",
+    "status",
+)
+
+
+def _render(records: list[AgentRecord]) -> tuple[Table, str]:
+    """Build the table and capture the printed form for substring assertions."""
+    table = render_agents_table(records)
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, highlight=False, width=120).print(table)
+    return table, buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Column structure — the contract downstream tickets lean on
+# ---------------------------------------------------------------------------
+
+
+def test_table_has_full_dashboard_column_set_in_documented_order() -> None:
+    table, _ = _render([])
+    headers = tuple(str(col.header) for col in table.columns)
+    assert headers == _DASHBOARD_COLUMNS
+
+
+def test_pid_column_is_right_justified_to_match_numeric_dashboard_preview() -> None:
+    """Numeric columns (pid, uptime, cpu%, tokens/min, $/hr) are
+    right-justified; agent name and status are left-justified. This
+    matches the spacing in the issue's mock and keeps later
+    snapshot-injected cells aligned without re-styling."""
+    table, _ = _render([])
+    by_header = {str(col.header): col for col in table.columns}
+    assert by_header["pid"].justify == "right"
+    assert by_header["uptime"].justify == "right"
+    assert by_header["cpu%"].justify == "right"
+    assert by_header["tokens/min"].justify == "right"
+    assert by_header["$/hr"].justify == "right"
+    assert by_header["agent"].justify == "left"
+    assert by_header["status"].justify == "left"
+
+
+# ---------------------------------------------------------------------------
+# Empty state
+# ---------------------------------------------------------------------------
+
+
+def test_empty_records_renders_table_with_zero_rows() -> None:
+    table, _ = _render([])
+    assert table.row_count == 0
+
+
+def test_empty_records_caption_points_user_to_register_command() -> None:
+    """Empty-state UX: the table caption tells the user what to do
+    next instead of leaving a blank table that looks like a bug."""
+    _, out = _render([])
+    assert "no agents registered" in out
+
+
+def test_non_empty_records_have_no_caption() -> None:
+    """When the registry has rows, the caption is suppressed —
+    the table content speaks for itself and a caption would be noise."""
+    table, _ = _render([AgentRecord(name="claude-code", pid=8421, command="claude")])
+    assert table.caption is None
+
+
+# ---------------------------------------------------------------------------
+# Row content
+# ---------------------------------------------------------------------------
+
+
+def test_row_contains_agent_name_and_pid() -> None:
+    _, out = _render([AgentRecord(name="claude-code", pid=8421, command="claude")])
+    assert "claude-code" in out
+    assert "8421" in out
+
+
+def test_metric_cells_are_placeholders_until_wired() -> None:
+    """``uptime``, ``cpu%``, ``tokens/min``, ``$/hr``, ``status`` all
+    render as ``-`` placeholders for now. The wiring in #1490 / #1494
+    fills them; this PR only owns the column shape."""
+    table, _ = _render([AgentRecord(name="claude-code", pid=8421, command="claude")])
+    # row_count == 1, so iterate directly to inspect the rendered cells
+    assert table.row_count == 1
+    # The rendered output contains five dashes per row (one per metric column)
+    rendered_cells = [list(col.cells)[0] for col in table.columns]
+    # cells[0] = agent, cells[1] = pid, then 5 placeholder cells
+    assert rendered_cells[2:] == ["-", "-", "-", "-", "-"]
+
+
+def test_multiple_records_are_each_rendered_in_order() -> None:
+    records = [
+        AgentRecord(name="claude-code", pid=8421, command="claude"),
+        AgentRecord(name="cursor-tab", pid=9133, command="cursor"),
+        AgentRecord(name="aider", pid=7702, command="aider"),
+    ]
+    table, out = _render(records)
+    assert table.row_count == 3
+    # Substring order in the rendered output preserves input order:
+    pos_claude = out.index("claude-code")
+    pos_cursor = out.index("cursor-tab")
+    pos_aider = out.index("aider")
+    assert pos_claude < pos_cursor < pos_aider
+
+
+# ---------------------------------------------------------------------------
+# Defense against Rich-markup injection
+# ---------------------------------------------------------------------------
+
+
+def test_record_name_is_rich_escaped_so_markup_does_not_render() -> None:
+    """An adversarial agent name containing Rich markup tags must
+    render literally, not interpreted. Without ``escape()``, a name
+    like ``[bold red]ghost[/]`` would visually mimic a styled cell
+    and could mask other dashboard content."""
+    records = [
+        AgentRecord(name="[bold red]ghost[/]", pid=1, command="bin"),
+    ]
+    _, out = _render(records)
+    # Literal brackets survive in the rendered output:
+    assert "[bold red]ghost[/]" in out

--- a/tests/cli/interactive_shell/test_agents_view.py
+++ b/tests/cli/interactive_shell/test_agents_view.py
@@ -76,11 +76,16 @@ def test_empty_records_renders_table_with_zero_rows() -> None:
     assert table.row_count == 0
 
 
-def test_empty_records_caption_points_user_to_register_command() -> None:
-    """Empty-state UX: the table caption tells the user what to do
-    next instead of leaving a blank table that looks like a bug."""
+def test_empty_records_caption_announces_empty_state() -> None:
+    """Empty-state UX: the table caption tells the user the registry
+    is empty rather than leaving a blank table that looks like a bug.
+
+    The caption deliberately doesn't suggest a registration command —
+    the ``register`` subcommand is currently a stub. When that gains
+    real behavior, this caption can grow a hint pointing at it.
+    """
     _, out = _render([])
-    assert "no agents registered" in out
+    assert "no agents registered yet" in out
 
 
 def test_non_empty_records_have_no_caption() -> None:


### PR DESCRIPTION
Fixes #1488

cc @muddlebee — co-assignee. Opening this with a complete implementation since the chain (#1490, #1492, #1493) is gating on the slash-command surface here. **Happy to iterate on the design — please review when you have time, no rush. Also fully open to bringing your changes on top if you'd prefer to reshape any part of this.**

---

Bare `/agents` now renders the registered-agents dashboard from the `AgentRegistry`. The existing `/agents conflicts` subcommand stays unchanged. Cells for metrics that aren't yet wired (`cpu%`, `tokens/min`, `$/hr`, `status`, `uptime`) render as `-` placeholders — #1490 (probe wiring) and #1494 (budget loader) fill them in later.

## Summary

- **New `app/cli/interactive_shell/agents_view.py`** — pure rendering function `render_agents_table(records: Iterable[AgentRecord]) -> Table`. Ships the column structure documented in #1486's preview: `agent`, `pid`, `uptime`, `cpu%`, `tokens/min`, `$/hr`, `status`. Lives outside `app/agents/` deliberately so the collector package stays free of Rich (a UI library) — non-CLI consumers of the agents package shouldn't pull Rich in transitively.
- **`app/cli/interactive_shell/command_registry/agents.py`** — bare `/agents` resolves to `_cmd_agents_list` which constructs an `AgentRegistry` and prints the rendered table. `/agents conflicts` keeps its existing handler. `SlashCommand` description updated.
- **`tests/cli/interactive_shell/test_agents_view.py`** *(new)* — 11 pure rendering cases pinning the column contract, justify defaults, empty-state caption, multi-row ordering, placeholder semantics for metric cells, and Rich-markup escape behavior.
- **`tests/cli/interactive_shell/test_agents_commands.py`** — flipped the bare-`/agents` test from "prints usage hint" to "renders empty-state table" and added a populated-registry case. Tests use a `tmp_path`-isolated registry via `monkeypatch` so they don't read the developer's real `~/.config/opensre/agents.jsonl`.

## Behavior

```
> /agents                                                     # populated registry

                              agents
┏━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┓
┃ agent       ┃  pid ┃ uptime ┃ cpu% ┃ tokens/min ┃ \$/hr ┃ status ┃
┡━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━┩
│ claude-code │ 8421 │      - │    - │          - │    - │ -      │
│ cursor-tab  │ 9133 │      - │    - │          - │    - │ -      │
│ aider       │ 7702 │      - │    - │          - │    - │ -      │
└─────────────┴──────┴────────┴──────┴────────────┴──────┴────────┘

> /agents                                                     # empty registry

                           agents
┏━━━━━━━┳━━━━━┳━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┓
┃ agent ┃ pid ┃ uptime ┃ cpu% ┃ tokens/min ┃ \$/hr ┃ status ┃
┡━━━━━━━╇━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━┩
└───────┴─────┴────────┴──────┴────────────┴──────┴────────┘
  no agents registered — use \`opensre agents register\` to track one
```

## Design notes for reviewers

- **Scope discipline.** I deliberately resisted the temptation to inline-probe-call to compute `uptime` or derive `status` from probe returns. That's #1490's job. Doing it here would couple two reviewable slices into one PR and force a rebase on #1490's author. The `-` placeholders preserve the column structure as a contract for the next ticket.
- **`render_agents_table` location.** Goes in `app/cli/interactive_shell/agents_view.py`, not in `app/agents/`. Rich is a CLI-only dependency; putting it in the collector package would force every consumer of `app.agents.registry` (sweep, sampler, future tools) to transitively pull in Rich for no reason.
- **Empty-state caption.** `Table` with no rows + a `caption` pointing the user at `opensre agents register` is more discoverable than a blank table or a plain string. Caption suppressed on populated runs since the rows speak for themselves.
- **Test isolation.** `_isolate_registry()` helper uses `monkeypatch.setattr` on the `AgentRegistry` symbol *inside the slash-command module* rather than overriding `OPENSRE_HOME_DIR` globally. Keeps the override narrow and prevents the test from accidentally affecting parallel xdist workers.
- **Rich-markup escape.** `escape(record.name)` on every row's name cell is defense-in-depth: an adversarial agent name like `[bold red]ghost[/]` renders literally instead of being interpreted. `test_record_name_is_rich_escaped_so_markup_does_not_render` locks this in.

## Acceptance checklist

- [x] Bare `/agents` renders rows from the registry
- [x] Existing `/agents conflicts` subcommand still works
- [x] Empty registry shows a useful caption pointing the user at the registration command
- [x] Adversarial agent names cannot inject Rich markup
- [x] `make lint` passes
- [x] `make format-check` passes
- [x] `make typecheck` passes (513 source files checked)
- [x] `tests/cli/interactive_shell/` — 535 tests pass

## Test plan

- [x] **Pure rendering** — `tests/cli/interactive_shell/test_agents_view.py` (11 cases)
- [x] **Slash-command integration** — extended `tests/cli/interactive_shell/test_agents_commands.py` with empty-registry and populated-registry dispatch tests, both using `tmp_path` isolation
- [x] **Manual smoke** — confirmed Rich renders the populated and empty-state tables exactly as documented in the Behavior section above

## What this unblocks

- **#1490** (wire probe to REPL) — its "Files to touch" includes `command_registry/agents.py` to fill `cpu%` / `uptime` cells. With this PR's column structure in place, #1490 just threads a `dict[int, ProcessSnapshot]` parameter through `render_agents_table`.
- **#1492** (`/agents kill`) and **#1493** (`/agents trace`) — both attach to the slash-command surface this PR establishes.