### PR TITLE
fix(llm-client): catch RateLimitError and honour provider retry-delay hint

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -23,6 +23,7 @@ from anthropic import Anthropic, AnthropicBedrock, AuthenticationError, NotFound
 from openai import AuthenticationError as OpenAIAuthError
 from openai import NotFoundError as OpenAINotFoundError
 from openai import OpenAI
+from openai import RateLimitError as OpenAIRateLimitError
 from pydantic import BaseModel, ValidationError
 
 from app.config import (
@@ -438,6 +439,30 @@ def _format_anthropic_retry_error(err: Exception) -> str:
     return f"Anthropic API request failed after multiple retries: {error_name}."
 
 
+def _parse_retry_after(err: Exception) -> float:
+    """Extract the suggested retry delay in seconds from a RateLimitError.
+
+    Google/Gemini embeds the delay in the error body's ``details`` array as a
+    ``retryDelay`` field (e.g. ``"5s"``), and also in the human-readable
+    message (``"Please retry in 5.478238622s"``).  Returns 0 if nothing is
+    found so callers can fall back to their own backoff.
+    """
+    body = getattr(err, "body", None)
+    if isinstance(body, dict):
+        error_obj = body.get("error", {})
+        if isinstance(error_obj, dict):
+            for detail in error_obj.get("details", []):
+                delay_str = detail.get("retryDelay", "")
+                if delay_str:
+                    m = re.match(r"(\d+(?:\.\d+)?)s", str(delay_str))
+                    if m:
+                        return min(float(m.group(1)), 60.0)
+    m = re.search(r"[Rr]etry in (\d+(?:\.\d+)?)s", str(err))
+    if m:
+        return min(float(m.group(1)), 60.0)
+    return 0.0
+
+
 def _uses_max_completion_tokens(model: str) -> bool:
     """Reasoning models (o1, o3, o4, gpt-5 series) require max_completion_tokens."""
     return model.startswith(("o1", "o3", "o4", "gpt-5"))
@@ -550,6 +575,17 @@ class OpenAILLMClient:
                 ) from err
             except GuardrailBlockedError:
                 raise
+            except OpenAIRateLimitError as err:
+                last_err = err
+                if attempt == max_attempts - 1:
+                    raise RuntimeError(
+                        f"{self._provider_label} rate limit exceeded (HTTP 429) after multiple retries. "
+                        "Check your quota and billing details."
+                    ) from err
+                suggested = _parse_retry_after(err)
+                wait = max(suggested, backoff_seconds)
+                time.sleep(wait)
+                backoff_seconds = wait * 2
             except Exception as err:
                 last_err = err
                 if attempt == max_attempts - 1:
@@ -606,6 +642,18 @@ class OpenAILLMClient:
                 ) from err
             except GuardrailBlockedError:
                 raise
+            except OpenAIRateLimitError as err:
+                if emitted:
+                    raise
+                if attempt == max_attempts - 1:
+                    raise RuntimeError(
+                        f"{self._provider_label} rate limit exceeded (HTTP 429) after multiple retries. "
+                        "Check your quota and billing details."
+                    ) from err
+                suggested = _parse_retry_after(err)
+                wait = max(suggested, backoff_seconds)
+                time.sleep(wait)
+                backoff_seconds = wait * 2
             except Exception as err:
                 if emitted:
                     # Mid-stream failure: never retry — chunks are already on

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -454,7 +454,7 @@ def _parse_retry_after(err: Exception) -> float:
             for detail in error_obj.get("details", []):
                 delay_str = detail.get("retryDelay", "")
                 if delay_str:
-                    m = re.match(r"(\d+(?:\.\d+)?)s", str(delay_str))
+                    m = re.search(r"^(\d+(?:\.\d+)?)\s*s$", str(delay_str).strip())
                     if m:
                         return min(float(m.group(1)), 60.0)
     m = re.search(r"[Rr]etry in (\d+(?:\.\d+)?)s", str(err))

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -830,3 +830,180 @@ def test_anthropic_invoke_stream_not_found_raises_friendly_runtime_error(monkeyp
     msg = str(exc_info.value)
     assert "was not found" in msg
     assert "Check your configured model name" in msg
+
+
+# ---------------------------------------------------------------------------
+# _parse_retry_after — retry delay extraction
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_after_reads_body_details() -> None:
+    """Extracts retryDelay from a Google/Gemini-style error body."""
+
+    class _FakeErr(Exception):
+        body = {
+            "error": {
+                "details": [
+                    {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "5s"},
+                ]
+            }
+        }
+
+    assert llm_client._parse_retry_after(_FakeErr()) == 5.0
+
+
+def test_parse_retry_after_reads_message_fallback() -> None:
+    """Falls back to parsing 'retry in Xs' from the error message string."""
+    err = Exception("Please retry in 8.5s due to quota exceeded")
+    assert llm_client._parse_retry_after(err) == 8.5
+
+
+def test_parse_retry_after_caps_at_sixty_seconds() -> None:
+    """Never returns more than 60 seconds to prevent runaway waits."""
+
+    class _FakeErr(Exception):
+        body = {"error": {"details": [{"retryDelay": "120s"}]}}
+
+    assert llm_client._parse_retry_after(_FakeErr()) == 60.0
+
+
+def test_parse_retry_after_returns_zero_when_no_hint() -> None:
+    """Returns 0 when neither body nor message contains a delay."""
+    assert llm_client._parse_retry_after(Exception("quota exceeded")) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# OpenAILLMClient.invoke — RateLimitError handling
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_rate_limit_error(retry_delay: str = "5s") -> Exception:
+    """Construct a minimal fake that looks like openai.RateLimitError with Google body."""
+    err = llm_client.OpenAIRateLimitError.__new__(llm_client.OpenAIRateLimitError)
+    err.status_code = 429  # type: ignore[attr-defined]
+    err.body = {  # type: ignore[attr-defined]
+        "error": {
+            "details": [{"retryDelay": retry_delay}],
+        }
+    }
+    err.message = f"quota exceeded, retry in {retry_delay}"  # type: ignore[attr-defined]
+    return err
+
+
+def test_openai_invoke_rate_limit_retries_with_suggested_delay(monkeypatch) -> None:
+    """On RateLimitError, invoke() sleeps for the suggested delay and retries."""
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    class _Delta:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.message = type("_Msg", (), {"content": content})()
+
+    class _Response:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **_kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise _make_fake_rate_limit_error("6s")
+            return _Response("ok")
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gemini-test", api_key_env="GEMINI_API_KEY")
+    result = client.invoke("hi")
+
+    assert result.content == "ok"
+    assert len(attempts) == 2
+    # Must sleep for the suggested 6s (>= initial backoff of 1s)
+    assert sleeps == [6.0]
+
+
+def test_openai_invoke_rate_limit_raises_quota_message_after_exhaustion(monkeypatch) -> None:
+    """After all retries on RateLimitError, raise a quota-specific RuntimeError."""
+    sleeps: list[float] = []
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_rate_limit_error("5s")
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gemini-test", api_key_env="GEMINI_API_KEY")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        client.invoke("hi")
+
+    msg = str(exc_info.value)
+    assert "rate limit" in msg.lower()
+    assert "quota" in msg.lower()
+
+
+def test_openai_invoke_stream_rate_limit_retries_before_emit(monkeypatch) -> None:
+    """RateLimitError before any chunk is emitted should retry with the suggested delay."""
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    class _Delta:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.delta = _Delta(content)
+
+    class _Chunk:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **_kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise _make_fake_rate_limit_error("7s")
+            return iter([_Chunk("recovered")])
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gemini-test", api_key_env="GEMINI_API_KEY")
+    chunks = list(client.invoke_stream("hi"))
+
+    assert chunks == ["recovered"]
+    assert len(attempts) == 2
+    assert sleeps == [7.0]

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -877,17 +877,24 @@ def test_parse_retry_after_returns_zero_when_no_hint() -> None:
 # ---------------------------------------------------------------------------
 
 
+class _FakeRateLimitError(llm_client.OpenAIRateLimitError):
+    """Minimal stand-in for openai.RateLimitError with a Google-style body.
+
+    Inherits from the real class so it's caught by ``except OpenAIRateLimitError``.
+    Calls ``Exception.__init__`` directly to bypass ``APIStatusError.__init__``,
+    which requires a live ``request``/``response`` pair not available in unit tests.
+    This also ensures ``str(err)`` works correctly via ``args``.
+    """
+
+    def __init__(self, retry_delay: str) -> None:
+        Exception.__init__(self, f"quota exceeded, retry in {retry_delay}")
+        self.status_code = 429
+        self.body = {"error": {"details": [{"retryDelay": retry_delay}]}}
+
+
 def _make_fake_rate_limit_error(retry_delay: str = "5s") -> Exception:
-    """Construct a minimal fake that looks like openai.RateLimitError with Google body."""
-    err = llm_client.OpenAIRateLimitError.__new__(llm_client.OpenAIRateLimitError)
-    err.status_code = 429  # type: ignore[attr-defined]
-    err.body = {  # type: ignore[attr-defined]
-        "error": {
-            "details": [{"retryDelay": retry_delay}],
-        }
-    }
-    err.message = f"quota exceeded, retry in {retry_delay}"  # type: ignore[attr-defined]
-    return err
+    """Return a fake openai.RateLimitError carrying a Google-style retry body."""
+    return _FakeRateLimitError(retry_delay)
 
 
 def test_openai_invoke_rate_limit_retries_with_suggested_delay(monkeypatch) -> None:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -895,10 +895,6 @@ def test_openai_invoke_rate_limit_retries_with_suggested_delay(monkeypatch) -> N
     attempts: list[int] = []
     sleeps: list[float] = []
 
-    class _Delta:
-        def __init__(self, content: str) -> None:
-            self.content = content
-
     class _Choice:
         def __init__(self, content: str) -> None:
             self.message = type("_Msg", (), {"content": content})()


### PR DESCRIPTION
## Summary

- **Root cause**: `OpenAILLMClient.invoke()` and `invoke_stream()` caught all non-auth exceptions with a bare `except Exception`, ignoring the `retryDelay` hint Gemini (and other Google-backed providers) embed in their HTTP 429 response bodies. After exhaustion the code raised a generic, unhelpful `RuntimeError`.
- **Fix**: Import `OpenAIRateLimitError` and handle it explicitly before the generic handler. A new `_parse_retry_after()` helper extracts the suggested delay from the Google-style error body (`details[].retryDelay`) or falls back to the `"retry in Xs"` text in the message, capped at 60 s. The retry sleep honours `max(suggested, current_backoff)` and the final error message now says "rate limit exceeded … check your quota" instead of the misleading generic text.
- **Tests**: 7 new unit tests cover the retry delay parser, the retry-with-suggested-delay path for `invoke`, the quota error message after exhaustion, and the pre-emit retry path for `invoke_stream`.

## Test plan

- [x] `uv run pytest tests/services/test_llm_client.py` — all 39 tests pass
- [x] `make lint` — clean
- [x] `make format-check` — clean
- [x] `make typecheck` — clean

Closes #1626

https://claude.ai/code/session_01J9vWjMSEf4C1Rqq4fRUXuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9vWjMSEf4C1Rqq4fRUXuZ)_