### PR TITLE
feat(watch_dog): Telegram outbound alarm helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@
 - `app/tools/` — Tool registry, decorator, base classes, per-tool packages, shared utilities, and registry helpers.
 - `app/types/` — Shared typed contracts for evidence, retrieval, and tool-related payloads.
 - `app/utils/` — Cross-cutting utility helpers used across the app and test harnesses.
+- `app/watch_dog/` — Watchdog feature: per-threshold Telegram alarm dispatch with cooldown, sitting on top of `app/utils/telegram_delivery.py`.
 - `app/main.py` and `app/webapp.py` — Application entrypoints for the CLI/runtime and web-facing surface.
 
 `tests/` is organized by capability boundary rather than by framework:

--- a/app/watch_dog/__init__.py
+++ b/app/watch_dog/__init__.py
@@ -1,0 +1,15 @@
+"""Watchdog package."""
+
+from __future__ import annotations
+
+from app.watch_dog.alarms import (
+    AlarmCredentials,
+    AlarmDispatcher,
+    load_credentials_from_env,
+)
+
+__all__ = [
+    "AlarmCredentials",
+    "AlarmDispatcher",
+    "load_credentials_from_env",
+]

--- a/app/watch_dog/alarms.py
+++ b/app/watch_dog/alarms.py
@@ -1,0 +1,123 @@
+"""Telegram alarm dispatcher for the watchdog."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+
+from app.cli.support.errors import OpenSREError
+from app.utils.telegram_delivery import post_telegram_message
+from app.utils.truncation import truncate
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COOLDOWN_SECONDS = 300.0
+_TELEGRAM_MESSAGE_LIMIT = 4096
+
+
+@dataclass(frozen=True)
+class AlarmCredentials:
+    # repr=False so the auto-generated __repr__ does not leak the token into
+    # pytest assertion output, tracebacks, or structured log capture.
+    bot_token: str = field(repr=False)
+    chat_id: str = field()
+
+
+def load_credentials_from_env(
+    *,
+    chat_id_override: str | None = None,
+) -> AlarmCredentials:
+    """Read TELEGRAM_BOT_TOKEN and TELEGRAM_DEFAULT_CHAT_ID; raise on missing."""
+    bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    if not bot_token:
+        raise OpenSREError(
+            "TELEGRAM_BOT_TOKEN is not set.",
+            suggestion=(
+                "Export TELEGRAM_BOT_TOKEN=<your-bot-token> in your environment "
+                "and retry. Get a token from @BotFather on Telegram."
+            ),
+        )
+
+    # Strip first so a whitespace-only override falls back to env consistently
+    # with an empty-string override, instead of raising a misleading
+    # "pass --chat-id" error after the caller already passed one.
+    stripped_override = chat_id_override.strip() if chat_id_override else ""
+    if stripped_override:
+        chat_id = stripped_override
+    else:
+        chat_id = os.getenv("TELEGRAM_DEFAULT_CHAT_ID", "").strip()
+    if not chat_id:
+        raise OpenSREError(
+            "Telegram chat id is not set.",
+            suggestion=(
+                "Export TELEGRAM_DEFAULT_CHAT_ID=<chat-id> in your environment "
+                "or pass --chat-id to the watchdog command and retry."
+            ),
+        )
+
+    return AlarmCredentials(bot_token=bot_token, chat_id=chat_id)
+
+
+class AlarmDispatcher:
+    """Dispatch watchdog alarms to Telegram with per-threshold cooldown."""
+
+    def __init__(
+        self,
+        creds: AlarmCredentials,
+        *,
+        cooldown_seconds: float = _DEFAULT_COOLDOWN_SECONDS,
+    ) -> None:
+        self._creds = creds
+        self._cooldown_seconds = cooldown_seconds
+        self._last_dispatched: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def dispatch(self, threshold_name: str, message: str) -> bool:
+        """Send to Telegram unless this threshold is in cooldown."""
+        now = self._now()
+
+        # Reserve the cooldown slot under the lock BEFORE the network call so
+        # a concurrent dispatch on the same threshold sees the reservation and
+        # is suppressed. Without this, two threads could both pass the check
+        # (state of last_dispatched at "check" time != "use" time, classic
+        # TOCTOU) and both send.
+        with self._lock:
+            last = self._last_dispatched.get(threshold_name)
+            if last is not None and (now - last) < self._cooldown_seconds:
+                logger.debug(
+                    "[watchdog] alarm suppressed by cooldown: name=%s remaining=%.1fs",
+                    threshold_name,
+                    self._cooldown_seconds - (now - last),
+                )
+                return False
+            self._last_dispatched[threshold_name] = now
+
+        ok, error, _ = post_telegram_message(
+            chat_id=self._creds.chat_id,
+            text=truncate(message, _TELEGRAM_MESSAGE_LIMIT, suffix="…"),
+            bot_token=self._creds.bot_token,
+        )
+        if ok:
+            return True
+
+        # Roll back the reservation only if it's still ours, so a transient
+        # failure does not silently swallow the next real alarm. Compare-and-
+        # delete prevents stomping on a parallel successful dispatch that
+        # may have updated the slot in the meantime.
+        with self._lock:
+            if self._last_dispatched.get(threshold_name) == now:
+                del self._last_dispatched[threshold_name]
+
+        logger.warning(
+            "[watchdog] alarm delivery failed: name=%s error=%s",
+            threshold_name,
+            error,
+        )
+        return False
+
+    @staticmethod
+    def _now() -> float:
+        return time.monotonic()

--- a/tests/watch_dog/test_alarms.py
+++ b/tests/watch_dog/test_alarms.py
@@ -1,0 +1,261 @@
+"""Tests for app/watch_dog/alarms.py."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.cli.support.errors import OpenSREError
+from app.watch_dog.alarms import (
+    AlarmCredentials,
+    AlarmDispatcher,
+    load_credentials_from_env,
+)
+
+
+def _stub_telegram(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ok: bool = True,
+    error: str = "",
+    captured: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = captured if captured is not None else []
+
+    def _fake_post(
+        chat_id: str,
+        text: str,
+        bot_token: str,
+    ) -> tuple[bool, str, str]:
+        calls.append({"chat_id": chat_id, "text": text, "bot_token": bot_token})
+        return ok, error, "1" if ok else ""
+
+    monkeypatch.setattr(
+        "app.watch_dog.alarms.post_telegram_message",
+        _fake_post,
+    )
+    return calls
+
+
+def _patch_clock(monkeypatch: pytest.MonkeyPatch, ticks: list[float]) -> None:
+    iterator = iter(ticks)
+
+    def _now() -> float:
+        return next(iterator)
+
+    monkeypatch.setattr(AlarmDispatcher, "_now", staticmethod(_now))
+
+
+def test_alarm_credentials_repr_does_not_leak_bot_token() -> None:
+    # Auto-generated dataclass __repr__ surfaces in pytest assertion output,
+    # tracebacks, and structured log capture. The token must stay out of it.
+    creds = AlarmCredentials(bot_token="super-secret-token", chat_id="chat-1")
+
+    rendered = repr(creds)
+
+    assert "super-secret-token" not in rendered
+    assert "chat-1" in rendered
+
+
+def test_load_credentials_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok-123")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-1")
+
+    creds = load_credentials_from_env()
+
+    assert creds == AlarmCredentials(bot_token="tok-123", chat_id="chat-1")
+
+
+def test_load_credentials_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "  tok-123  ")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "\tchat-1\n")
+
+    creds = load_credentials_from_env()
+
+    assert creds.bot_token == "tok-123"
+    assert creds.chat_id == "chat-1"
+
+
+def test_load_credentials_chat_id_override_beats_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "from-env")
+
+    creds = load_credentials_from_env(chat_id_override="from-arg")
+
+    assert creds.chat_id == "from-arg"
+
+
+def test_load_credentials_missing_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-1")
+
+    with pytest.raises(OpenSREError) as exc_info:
+        load_credentials_from_env()
+
+    assert "TELEGRAM_BOT_TOKEN" in str(exc_info.value)
+    assert exc_info.value.suggestion is not None
+    assert "TELEGRAM_BOT_TOKEN" in exc_info.value.suggestion
+
+
+def test_load_credentials_blank_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "   ")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-1")
+
+    with pytest.raises(OpenSREError):
+        load_credentials_from_env()
+
+
+def test_load_credentials_missing_chat_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+    monkeypatch.delenv("TELEGRAM_DEFAULT_CHAT_ID", raising=False)
+
+    with pytest.raises(OpenSREError) as exc_info:
+        load_credentials_from_env()
+
+    assert "chat id" in str(exc_info.value).lower()
+
+
+def test_load_credentials_missing_chat_id_with_blank_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-from-env")
+
+    # Empty string override falls through to env.
+    creds = load_credentials_from_env(chat_id_override="")
+
+    assert creds.chat_id == "chat-from-env"
+
+
+def test_load_credentials_whitespace_override_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A whitespace-only override must fall through to the env var the same
+    # way an empty-string override does, not raise a misleading error.
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+    monkeypatch.setenv("TELEGRAM_DEFAULT_CHAT_ID", "chat-from-env")
+
+    creds = load_credentials_from_env(chat_id_override="   ")
+
+    assert creds.chat_id == "chat-from-env"
+
+
+def test_first_dispatch_calls_telegram(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_telegram(monkeypatch)
+    _patch_clock(monkeypatch, [100.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+
+    assert dispatcher.dispatch("max_cpu", "CPU pegged at 95%") is True
+    assert len(calls) == 1
+    assert calls[0] == {
+        "chat_id": "chat-1",
+        "text": "CPU pegged at 95%",
+        "bot_token": "tok",
+    }
+
+
+def test_second_dispatch_within_cooldown_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_telegram(monkeypatch)
+    # 100s gap < 300s cooldown, second call must be suppressed.
+    _patch_clock(monkeypatch, [100.0, 200.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+        cooldown_seconds=300.0,
+    )
+
+    assert dispatcher.dispatch("max_cpu", "first") is True
+    assert dispatcher.dispatch("max_cpu", "second") is False
+    assert len(calls) == 1
+    assert calls[0]["text"] == "first"
+
+
+def test_second_dispatch_after_cooldown_calls_telegram_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_telegram(monkeypatch)
+    # 350s gap > 300s cooldown, second call must go through.
+    _patch_clock(monkeypatch, [100.0, 450.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+        cooldown_seconds=300.0,
+    )
+
+    assert dispatcher.dispatch("max_cpu", "first") is True
+    assert dispatcher.dispatch("max_cpu", "second") is True
+    assert len(calls) == 2
+    assert calls[1]["text"] == "second"
+
+
+def test_cooldown_is_per_threshold_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_telegram(monkeypatch)
+    _patch_clock(monkeypatch, [100.0, 110.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+        cooldown_seconds=300.0,
+    )
+
+    assert dispatcher.dispatch("max_cpu", "cpu") is True
+    assert dispatcher.dispatch("max_runtime", "runtime") is True
+    assert len(calls) == 2
+
+
+def test_dispatch_returns_false_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A failed Telegram call must NOT arm the cooldown, otherwise a transient
+    # outage would silently swallow the next real alarm.
+    calls: list[dict[str, Any]] = []
+    _stub_telegram(monkeypatch, ok=False, error="network down", captured=calls)
+    _patch_clock(monkeypatch, [100.0, 105.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+        cooldown_seconds=300.0,
+    )
+
+    assert dispatcher.dispatch("max_cpu", "first") is False
+    assert dispatcher.dispatch("max_cpu", "second") is False
+    assert len(calls) == 2
+
+
+def test_dispatch_uses_credentials_from_constructor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_telegram(monkeypatch)
+    _patch_clock(monkeypatch, [100.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="bot-XYZ", chat_id="my-chat"),
+    )
+    dispatcher.dispatch("max_runtime", "process exceeded 5m")
+
+    assert calls[0]["bot_token"] == "bot-XYZ"
+    assert calls[0]["chat_id"] == "my-chat"
+
+
+def test_dispatch_truncates_messages_over_telegram_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Telegram rejects messages over 4096 chars. Without truncation an
+    # oversized alarm would always fail, never arm cooldown, and retry forever.
+    calls = _stub_telegram(monkeypatch)
+    _patch_clock(monkeypatch, [100.0])
+
+    dispatcher = AlarmDispatcher(
+        AlarmCredentials(bot_token="tok", chat_id="chat-1"),
+    )
+    oversized = "X" * 5000
+    assert dispatcher.dispatch("max_cpu", oversized) is True
+    assert len(calls[0]["text"]) <= 4096
+    assert calls[0]["text"].endswith("…")


### PR DESCRIPTION
Closes #1450

Adds a small, focused helper for the watchdog to dispatch Telegram alarms when an SLO threshold is breached, with per-threshold cooldown so a single tripped threshold does not produce an alarm storm.

Sampling, threshold evaluation, and the CLI command are out of scope per the issue. Those land in the watchdog follow-up issues.

What landed:

- `AlarmCredentials` dataclass + `load_credentials_from_env` reading `TELEGRAM_BOT_TOKEN` and `TELEGRAM_DEFAULT_CHAT_ID`. Mirrors the env-loading shape of `SLACK_BOT_TOKEN` in `app/cli/commands/general.py`.
- `AlarmDispatcher` with per-threshold cooldown (default 300s), in-memory only, isolated per threshold name.
- 13 unit tests covering credential loading, success/error paths, cooldown windowing, per-threshold isolation.

`ruff` and `mypy` clean. No new dependencies added.

Fixes #1450

#### Describe the changes you have made in this PR -

A two-piece helper module under `app/watch_dog/`. The credentials loader reads the two env vars and raises `OpenSREError` with an actionable `suggestion=` if either is missing, matching the `SLACK_BOT_TOKEN` pattern already in the repo. The dispatcher wraps `post_telegram_message` and tracks a per-threshold last-dispatch timestamp in a dict, suppressing repeats within `cooldown_seconds`. A failed Telegram call does not arm the cooldown, so a transient network blip cannot silently swallow the next real alarm.

### Demo/Screenshot for feature changes and bug fixes -

Three dispatch calls in sequence against a real bot:

1. CPU threshold, first time. Message arrives.
2. Same CPU threshold within 60 seconds. Suppressed by cooldown. No message.
3. Different MEMORY threshold. Different cooldown timer. Message arrives.

Two messages reach the chat, three dispatch calls in the script. The cooldown is the difference.

https://github.com/user-attachments/assets/fcdb7547-a938-4717-81e2-82d26f5e89dc

Reproduce locally:

```bash
export TELEGRAM_BOT_TOKEN=<from @BotFather>
export TELEGRAM_DEFAULT_CHAT_ID=<chat id where the bot is a member>
uv run python -c "
from app.watch_dog.alarms import AlarmDispatcher, load_credentials_from_env
d = AlarmDispatcher(load_credentials_from_env(), cooldown_seconds=60)
print('first  cpu:', d.dispatch('cpu_pct_above_90', '[opensre] cpu 96%'))
print('repeat cpu:', d.dispatch('cpu_pct_above_90', 'should not arrive'))
print('first  mem:', d.dispatch('memory_mb_above_4096', '[opensre] mem 5GB'))
"
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The problem is dispatching Telegram alarms from the watchdog without storming the operator when a single threshold stays tripped sample after sample. The straightforward design is a wrapper around the existing `post_telegram_message` plus a small per-threshold cooldown table.

I considered two alternatives. A global cooldown is simpler but conflates unrelated incidents (CPU pegged silences memory alarms), so I went per-threshold. A persisted cooldown survives restarts but defeats the operator's escape hatch (restart the watchdog when you want a fresh page), so I kept it in memory.

One subtle choice in the code: a failed Telegram call returns `False` but does NOT update the last-dispatched timestamp. If transport fails on a real alarm, the next call should try again immediately, not be suppressed by a cooldown that was never earned. There is a regression test for this.

Constructor and env-loading shape follow `app/cli/commands/general.py` (`SLACK_BOT_TOKEN`) per the issue note. No new packages added.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
