### PR TITLE
feat(agents): count ctrl-c and correction interventions (#1498)

### DIFF
--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import sys
 from collections.abc import Callable
 
@@ -29,6 +30,32 @@ from app.cli.interactive_shell.theme import TERMINAL_ERROR
 from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
 from app.cli.support.prompt_support import repl_prompt_note_ctrl_c, repl_reset_ctrl_c_gate
+
+_INTERVENTION_CORRECTION_RE = re.compile(
+    r"("
+    r"no(?=[,.!?]|$)"
+    r"|nope\b"
+    r"|nvm\b"
+    r"|nevermind\b|never\s*mind\b"
+    r"|wrong\b"
+    r"|wait(?=[,.!?]|$)"
+    r"|stop(?=[,.!?]|$)"
+    r"|actually\b"
+    r"|scratch\s+that\b"
+    r"|instead(?=[,.!?]|$)"
+    r"|(?:let'?s\s+)?do\s+[^.\n]{1,60}\s+instead\b"
+    r"|try\s+[^.\n]{1,60}\s+instead\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_correction(text: str) -> bool:
+    """True when text begins with a short correction cue (intervention signal)."""
+    stripped = text.lstrip()
+    if not stripped or stripped.startswith("```"):
+        return False
+    return _INTERVENTION_CORRECTION_RE.match(stripped[:80]) is not None
 
 
 def _run_new_alert(
@@ -69,6 +96,7 @@ def _run_new_alert(
         )
     except KeyboardInterrupt:
         task.mark_cancelled()
+        session.record_intervention("ctrl_c")
         console.print("[yellow]investigation cancelled.[/yellow]")
         session.record("alert", text, ok=False)
         return
@@ -118,6 +146,9 @@ async def _run_one_turn(
     text = text.strip()
     if not text:
         return True
+
+    if _looks_like_correction(text):
+        session.record_intervention("correction")
 
     render_submitted_prompt(console, session, text)
     kind = classify_input(text, session)

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -147,11 +147,10 @@ async def _run_one_turn(
     if not text:
         return True
 
-    if _looks_like_correction(text):
-        session.record_intervention("correction")
-
     render_submitted_prompt(console, session, text)
     kind = classify_input(text, session)
+    if kind in ("follow_up", "new_alert") and _looks_like_correction(text):
+        session.record_intervention("correction")
     if kind == "slash":
         # Rewrite bare-word commands to their slash form before dispatch.
         cmd_text = text if text.startswith("/") else f"/{text}"

--- a/app/cli/interactive_shell/session.py
+++ b/app/cli/interactive_shell/session.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from prompt_toolkit.history import History
 
 from app.cli.interactive_shell.tasks import TaskRegistry
+
+InterventionKind = Literal["ctrl_c", "correction"]
 
 
 @dataclass
@@ -68,6 +70,9 @@ class ReplSession:
     terminal_actions_executed_count: int = 0
     terminal_actions_success_count: int = 0
 
+    ctrl_c_intervention_count: int = 0
+    correction_intervention_count: int = 0
+
     # Keys from a completed AgentState that carry reusable infra context into
     # the next investigation.  Kept as a class-level tuple so any caller that
     # wants to know "what counts as accumulated context" has a single source.
@@ -120,7 +125,17 @@ class ReplSession:
         self.terminal_fallback_count = 0
         self.terminal_actions_executed_count = 0
         self.terminal_actions_success_count = 0
+
+        self.ctrl_c_intervention_count = 0
+        self.correction_intervention_count = 0
         # trust_mode is intentionally preserved across /reset
+
+    def record_intervention(self, kind: InterventionKind) -> None:
+        """Increment the per-kind intervention counter (Ctrl-C or correction)."""
+        if kind == "ctrl_c":
+            self.ctrl_c_intervention_count += 1
+        else:
+            self.correction_intervention_count += 1
 
     def record_terminal_turn(
         self,

--- a/app/cli/interactive_shell/session.py
+++ b/app/cli/interactive_shell/session.py
@@ -71,7 +71,14 @@ class ReplSession:
     terminal_actions_success_count: int = 0
 
     ctrl_c_intervention_count: int = 0
+    """Incremented when the user Ctrl-Cs an active investigation. Bare-prompt
+    Ctrl-C with no agent running is intentionally not counted."""
+
     correction_intervention_count: int = 0
+    """Incremented when a follow-up or new-alert message starts with a
+    correction cue (see ``_looks_like_correction`` in ``loop.py``).
+    Slash and CLI-agent turns are not counted because content like
+    ``actually run ps aux`` is a command, not a correction."""
 
     # Keys from a completed AgentState that carry reusable infra context into
     # the next investigation.  Kept as a class-level tuple so any caller that
@@ -134,8 +141,10 @@ class ReplSession:
         """Increment the per-kind intervention counter (Ctrl-C or correction)."""
         if kind == "ctrl_c":
             self.ctrl_c_intervention_count += 1
-        else:
+        elif kind == "correction":
             self.correction_intervention_count += 1
+        else:
+            raise ValueError(f"Unknown intervention kind: {kind!r}")
 
     def record_terminal_turn(
         self,

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -394,3 +394,52 @@ def test_run_one_turn_renders_submitted_prompt_before_handler(
     assert should_continue is True
     assert "❯" in output
     assert "explain deploy" in output
+
+
+class TestLooksLikeCorrection:
+    """Unit tests for the ``_looks_like_correction`` heuristic.
+
+    Pins the v1 catches, false-positive guards, and limitations so future
+    iteration on ``_INTERVENTION_CORRECTION_RE`` has a regression baseline.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no, do that instead",
+            "nope",
+            "nvm",
+            "never mind",
+            "actually, let's check Datadog first",
+            "scratch that, run the synthetic test",
+            "wait, wrong dashboard",
+            "let's do an EKS health check instead",
+            "try a token refresh instead",
+            "wrong dashboard, fix it",
+            "instead, log a warning",
+            "Wait!",  # case-insensitive
+            "NO.",
+        ],
+    )
+    def test_correction_cues_match(self, text: str) -> None:
+        assert loop._looks_like_correction(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Punctuation-lookahead guards reject content uses of cue words.
+            "stop the server before redeploying",
+            "instead of returning null, log a warning",
+            "no problem, I'll handle it",
+            "wait for the result",
+            # v1 limitation: cue must be at start of message.
+            "hmm, scratch that",
+            "doesn't work, try X instead",
+            # Edge cases.
+            "",
+            "   ",
+            "```\nstop the server\n```",
+        ],
+    )
+    def test_non_correction_text_does_not_match(self, text: str) -> None:
+        assert loop._looks_like_correction(text) is False

--- a/tests/cli/interactive_shell/test_session.py
+++ b/tests/cli/interactive_shell/test_session.py
@@ -15,6 +15,8 @@ class TestReplSession:
         assert session.task_registry.list_recent() == []
         assert session.terminal_turn_count == 0
         assert session.terminal_fallback_count == 0
+        assert session.ctrl_c_intervention_count == 0
+        assert session.correction_intervention_count == 0
 
     def test_record_appends_entry(self) -> None:
         session = ReplSession()
@@ -42,6 +44,8 @@ class TestReplSession:
         session.record("alert", "something")
         session.last_state = {"foo": "bar"}
         session.cli_agent_messages.append(("user", "hey"))
+        session.record_intervention("ctrl_c")
+        session.record_intervention("correction")
 
         assert session.history_generation == 0
         session.clear()
@@ -52,6 +56,8 @@ class TestReplSession:
         assert session.accumulated_context == {}
         assert session.cli_agent_messages == []
         assert session.task_registry.list_recent() == []
+        assert session.ctrl_c_intervention_count == 0
+        assert session.correction_intervention_count == 0
         assert session.trust_mode is True  # preserved intentionally
 
     def test_accumulate_from_state_extracts_known_keys(self) -> None:
@@ -125,3 +131,33 @@ class TestReplSession:
         assert second.fallback_count == 1
         assert round(second.action_success_percent, 2) == 66.67
         assert second.fallback_rate_percent == 50.0
+
+    def test_record_intervention_increments_per_kind(self) -> None:
+        session = ReplSession()
+
+        session.record_intervention("ctrl_c")
+        session.record_intervention("ctrl_c")
+        session.record_intervention("correction")
+
+        assert session.ctrl_c_intervention_count == 2
+        assert session.correction_intervention_count == 1
+
+    def test_record_intervention_kinds_are_independent(self) -> None:
+        """Incrementing one kind does not touch the other."""
+        session = ReplSession()
+
+        session.record_intervention("correction")
+
+        assert session.ctrl_c_intervention_count == 0
+        assert session.correction_intervention_count == 1
+
+    def test_fresh_session_starts_with_zero_intervention_counts(self) -> None:
+        """A new ReplSession does not inherit any prior session's counters."""
+        first = ReplSession()
+        first.record_intervention("ctrl_c")
+        first.record_intervention("correction")
+
+        second = ReplSession()
+
+        assert second.ctrl_c_intervention_count == 0
+        assert second.correction_intervention_count == 0


### PR DESCRIPTION
Fixes #1498

#### Describe the changes you have made in this PR -

Adds a per-kind intervention counter on `ReplSession` that tracks two signals: Ctrl-C interrupts on an active investigation (`ctrl_c`) and follow-up user messages that begin with a correction cue (`correction`). Both counters reset on `/reset` and are surfaced via a new typed method `record_intervention(kind: Literal["ctrl_c", "correction"]) -> None`. Storage is two flat ints alongside the existing `terminal_*_count` analytics fields.

This PR ships only the data plumbing. The `/agents inspect <pid>` cell that displays the counts is deferred to a follow-up once the renderer in #1488 lands (a parallel PR #1627 is already open for that renderer work, as agreed in the issue thread).

### Demo/Screenshot for feature changes and bug fixes -

<img width="1372" height="379" alt="Screenshot 2026-05-08 at 1 40 27 PM" src="https://github.com/user-attachments/assets/013947fe-550b-4576-9dda-658b62bcc1b9" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The Ctrl-C hook is anchored only at the active investigation cancellation site in `_run_new_alert`'s `KeyboardInterrupt` handler. The bare prompt Ctrl-C site (`_run_one_turn`'s `prompt_async` interrupt) is intentionally not counted because no agent is running there, the user is just dismissing typing. The correction hook fires before `classify_input`, so every user message is checked regardless of whether it later routes to a slash command, CLI helper, or new alert.

The regex `_INTERVENTION_CORRECTION_RE` is anchored at the start of the lstripped message and uses punctuation lookaheads on `no` / `wait` / `stop` / `instead` to suppress the obvious false positives ("stop the server", "instead of returning null", "no problem") while still catching `no,` / `actually` / `scratch that` / `let's do X instead` / `try X instead` / `nope` / `nvm`. Code-fenced messages are skipped wholesale, matching the existing `cli_agent.py` precedent.

v1 limitations called out so future iteration is informed: the cue must be at the start of the message (corrections like "hmm, scratch that" will not fire), `actually X` always counts even when the user means "actually that worked, thanks", and the cue must land within the first 80 chars after `lstrip()`. Acceptable for a v1 quality signal.

Storage is two flat ints rather than a `dict[str, int]`. Matches the `terminal_*_count` neighbours, gives mypy a clean `Literal["ctrl_c", "correction"]` dispatch, and avoids `dict.get(kind, 0) + 1` ceremony. The dict shape is one PR away if a third kind is ever added.

Considered and rejected: a stateful "correction detector" that only fires on messages immediately after a non-cancelled turn. Out of scope for an XS issue and would add another invariant on `ReplSession` for marginal accuracy gain.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note on CI: a pre-existing failure in `tests/pipeline/test_runners_sentry.py::test_run_chat_initializes_sentry_and_captures_unhandled_errors` reproduces on `upstream/main@882abdfa` (#1620) without involvement from this PR. The local quality gate is otherwise green: 5692 passed, 1 unrelated failure.