### PR TITLE
fix(verify): catch verifier exceptions and use .get() in result formatter

### DIFF
--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -109,7 +109,10 @@ def build_probe_verifier[ConfigT](
             normalized_config = build_config(config)
         except Exception as err:
             return result(service, source, "missing", str(err))
-        probe_result = client_factory(normalized_config).probe_access()
+        try:
+            probe_result = client_factory(normalized_config).probe_access()
+        except Exception as err:
+            return result(service, source, "failed", str(err))
         return result(service, source, probe_result.status, probe_result.detail)
 
     return _verifier

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -144,7 +144,7 @@ def verification_exit_code(
     if requested_service:
         return 1 if any(row.get("status") in {"missing", "failed"} for row in results) else 0
     core_results = [row for row in results if row.get("service") in CORE_VERIFY_SERVICES]
-    if not any(row["status"] == "passed" for row in core_results):
+    if not any(row.get("status") == "passed" for row in core_results):
         return 1
     return 0
 

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -110,7 +110,12 @@ def verify_integrations(
             )
             continue
 
-        results.append(verifier(str(integration["source"]), dict(integration["config"])))
+        try:
+            results.append(verifier(str(integration["source"]), dict(integration["config"])))
+        except Exception as exc:
+            results.append(
+                _result(current_service, str(integration.get("source", "-")), "failed", str(exc))
+            )
 
     return results
 
@@ -119,7 +124,11 @@ def format_verification_results(results: list[dict[str, str]]) -> str:
     """Render verification results as a compact terminal table."""
     lines = ["", "  SERVICE    SOURCE       STATUS      DETAIL"]
     for row in results:
-        lines.append(f"  {row['service']:<10}{row['source']:<13}{row['status']:<12}{row['detail']}")
+        service = row.get("service", "?")
+        source = row.get("source", "-")
+        status = row.get("status", "?")
+        detail = row.get("detail", "")
+        lines.append(f"  {service:<10}{source:<13}{status:<12}{detail}")
     lines.append("")
     return "\n".join(lines)
 
@@ -130,11 +139,11 @@ def verification_exit_code(
     requested_service: str | None = None,
 ) -> int:
     """Return a CLI exit code for a verification run."""
-    if any(row["status"] == "failed" for row in results):
+    if any(row.get("status") == "failed" for row in results):
         return 1
     if requested_service:
-        return 1 if any(row["status"] in {"missing", "failed"} for row in results) else 0
-    core_results = [row for row in results if row["service"] in CORE_VERIFY_SERVICES]
+        return 1 if any(row.get("status") in {"missing", "failed"} for row in results) else 0
+    core_results = [row for row in results if row.get("service") in CORE_VERIFY_SERVICES]
     if not any(row["status"] == "passed" for row in core_results):
         return 1
     return 0


### PR DESCRIPTION
## Summary

- Wraps each `verifier()` call in `verify_integrations` in a `try/except` so a probe failure for one service surfaces as a `failed` row instead of aborting the entire verification run
- Catches `probe_access()` exceptions in `build_probe_verifier` (previously only `build_config` exceptions were caught)
- Switches `format_verification_results` and `verification_exit_code` from bare `row[key]` access to `row.get(key, fallback)` to prevent `KeyError` if a row is ever missing an expected key (Sentry PYTHON-11)

## Test plan

- [ ] `uv run pytest tests/integrations/test_verify.py` — all 22 tests pass
- [ ] Run `opensre integrations verify` locally with and without integrations configured

Closes #1637

https://claude.ai/code/session_011pqvdLj6jXcXLAY76W3AXs

---
_Generated by [Claude Code](https://claude.ai/code/session_011pqvdLj6jXcXLAY76W3AXs)_