### PR TITLE
refactor(shell): register grounding sources

### DIFF
--- a/app/cli/interactive_shell/agents_md_reference.py
+++ b/app/cli/interactive_shell/agents_md_reference.py
@@ -260,6 +260,18 @@ def build_agents_md_reference_text(*, max_chars: int = _DEFAULT_MAX_TOTAL_CHARS)
     return text
 
 
+def _register_grounding_source() -> None:
+    from app.cli.interactive_shell.grounding_diagnostics import (
+        GroundingSource,
+        register_grounding_source,
+    )
+
+    register_grounding_source(GroundingSource(name="agents_md", stats_fn=get_agents_md_cache_stats))
+
+
+_register_grounding_source()
+
+
 __all__ = [
     "AgentsMdFile",
     "build_agents_md_reference_text",

--- a/app/cli/interactive_shell/cli_reference.py
+++ b/app/cli/interactive_shell/cli_reference.py
@@ -156,6 +156,18 @@ def build_cli_reference_text() -> str:
     return text
 
 
+def _register_grounding_source() -> None:
+    from app.cli.interactive_shell.grounding_diagnostics import (
+        GroundingSource,
+        register_grounding_source,
+    )
+
+    register_grounding_source(GroundingSource(name="cli", stats_fn=get_cli_reference_cache_stats))
+
+
+_register_grounding_source()
+
+
 __all__ = [
     "build_cli_reference_text",
     "get_cli_reference_cache_stats",

--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -37,8 +37,7 @@ def _cmd_trust(session: ReplSession, console: Console, args: list[str]) -> bool:
 
 
 def _cmd_status(session: ReplSession, console: Console, _args: list[str]) -> bool:
-    from app.cli.interactive_shell.cli_reference import get_cli_reference_cache_stats
-    from app.cli.interactive_shell.docs_reference import get_docs_cache_stats
+    from app.cli.interactive_shell.grounding_diagnostics import iter_grounding_sources
 
     table = repl_table(title="Session status", title_style=TERMINAL_ACCENT_BOLD, show_header=False)
     table.add_column("key", style="bold")
@@ -47,18 +46,8 @@ def _cmd_status(session: ReplSession, console: Console, _args: list[str]) -> boo
     table.add_row("last investigation", "yes" if session.last_state else "none")
     table.add_row("trust mode", "on" if session.trust_mode else "off")
     table.add_row("provider", os.getenv("LLM_PROVIDER", "anthropic"))
-    cli_stats = get_cli_reference_cache_stats()
-    doc_stats = get_docs_cache_stats()
-    table.add_row(
-        "grounding cli cache",
-        f"hits={cli_stats['hits']} misses={cli_stats['misses']} "
-        f"cached={'yes' if cli_stats['cached'] else 'no'}",
-    )
-    table.add_row(
-        "grounding docs cache",
-        f"hits={doc_stats['hits']} misses={doc_stats['misses']} "
-        f"entries={doc_stats['currsize']}/{doc_stats['maxsize']}",
-    )
+    for source in iter_grounding_sources():
+        table.add_row(f"grounding {source.name} cache", source.format_fn(source.stats_fn()))
     acc = session.accumulated_context
     if acc:
         table.add_row("accumulated context", ", ".join(sorted(acc.keys())))

--- a/app/cli/interactive_shell/docs_reference.py
+++ b/app/cli/interactive_shell/docs_reference.py
@@ -451,6 +451,18 @@ def build_docs_reference_text(
     return text
 
 
+def _register_grounding_source() -> None:
+    from app.cli.interactive_shell.grounding_diagnostics import (
+        GroundingSource,
+        register_grounding_source,
+    )
+
+    register_grounding_source(GroundingSource(name="docs", stats_fn=get_docs_cache_stats))
+
+
+_register_grounding_source()
+
+
 __all__ = [
     "DocPage",
     "build_docs_index",

--- a/app/cli/interactive_shell/grounding_diagnostics.py
+++ b/app/cli/interactive_shell/grounding_diagnostics.py
@@ -4,25 +4,66 @@ from __future__ import annotations
 
 import logging
 import os
+from collections import OrderedDict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
 
 _logger = logging.getLogger(__name__)
+
+_GROUNDING_SOURCE_REGISTRY: OrderedDict[str, GroundingSource] = OrderedDict()
+
+
+def _format_grounding_stats(stats: dict[str, Any]) -> str:
+    hits = stats.get("hits", 0)
+    misses = stats.get("misses", 0)
+    if "cached" in stats:
+        return f"hits={hits} misses={misses} cached={'yes' if stats['cached'] else 'no'}"
+    if "currsize" in stats and "maxsize" in stats:
+        return f"hits={hits} misses={misses} entries={stats['currsize']}/{stats['maxsize']}"
+    return str(stats)
+
+
+@dataclass(frozen=True)
+class GroundingSource:
+    name: str
+    stats_fn: Callable[[], dict[str, Any]]
+    format_fn: Callable[[dict[str, Any]], str] = _format_grounding_stats
+
+
+def register_grounding_source(source: GroundingSource) -> None:
+    _GROUNDING_SOURCE_REGISTRY[source.name] = source
+
+
+def _ensure_builtin_grounding_sources_registered() -> None:
+    if "cli" not in _GROUNDING_SOURCE_REGISTRY:
+        from app.cli.interactive_shell import cli_reference  # noqa: F401
+    if "docs" not in _GROUNDING_SOURCE_REGISTRY:
+        from app.cli.interactive_shell import docs_reference  # noqa: F401
+    if "agents_md" not in _GROUNDING_SOURCE_REGISTRY:
+        from app.cli.interactive_shell import agents_md_reference  # noqa: F401
+
+
+def iter_grounding_sources() -> Iterable[GroundingSource]:
+    _ensure_builtin_grounding_sources_registered()
+    return tuple(_GROUNDING_SOURCE_REGISTRY.values())
 
 
 def log_grounding_cache_diagnostics(reason: str) -> None:
     """Log CLI/docs grounding cache stats when ``TRACER_VERBOSE=1``."""
     if os.environ.get("TRACER_VERBOSE") != "1":
         return
-    from app.cli.interactive_shell.agents_md_reference import get_agents_md_cache_stats
-    from app.cli.interactive_shell.cli_reference import get_cli_reference_cache_stats
-    from app.cli.interactive_shell.docs_reference import get_docs_cache_stats
-
+    rendered = " ".join(f"{source.name}={source.stats_fn()}" for source in iter_grounding_sources())
     _logger.debug(
-        "grounding cache [%s] cli=%s docs=%s agents_md=%s",
+        "grounding cache [%s] %s",
         reason,
-        get_cli_reference_cache_stats(),
-        get_docs_cache_stats(),
-        get_agents_md_cache_stats(),
+        rendered,
     )
 
 
-__all__ = ["log_grounding_cache_diagnostics"]
+__all__ = [
+    "GroundingSource",
+    "iter_grounding_sources",
+    "log_grounding_cache_diagnostics",
+    "register_grounding_source",
+]

--- a/app/cli/interactive_shell/grounding_diagnostics.py
+++ b/app/cli/interactive_shell/grounding_diagnostics.py
@@ -11,8 +11,6 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
-_GROUNDING_SOURCE_REGISTRY: OrderedDict[str, GroundingSource] = OrderedDict()
-
 
 def _format_grounding_stats(stats: dict[str, Any]) -> str:
     hits = stats.get("hits", 0)
@@ -31,21 +29,18 @@ class GroundingSource:
     format_fn: Callable[[dict[str, Any]], str] = _format_grounding_stats
 
 
+_GROUNDING_SOURCE_REGISTRY: OrderedDict[str, GroundingSource] = OrderedDict()
+
+
 def register_grounding_source(source: GroundingSource) -> None:
     _GROUNDING_SOURCE_REGISTRY[source.name] = source
 
 
-def _ensure_builtin_grounding_sources_registered() -> None:
-    if "cli" not in _GROUNDING_SOURCE_REGISTRY:
-        from app.cli.interactive_shell import cli_reference  # noqa: F401
-    if "docs" not in _GROUNDING_SOURCE_REGISTRY:
-        from app.cli.interactive_shell import docs_reference  # noqa: F401
-    if "agents_md" not in _GROUNDING_SOURCE_REGISTRY:
-        from app.cli.interactive_shell import agents_md_reference  # noqa: F401
+def unregister_grounding_source(name: str) -> None:
+    _GROUNDING_SOURCE_REGISTRY.pop(name, None)
 
 
 def iter_grounding_sources() -> Iterable[GroundingSource]:
-    _ensure_builtin_grounding_sources_registered()
     return tuple(_GROUNDING_SOURCE_REGISTRY.values())
 
 
@@ -66,4 +61,5 @@ __all__ = [
     "iter_grounding_sources",
     "log_grounding_cache_diagnostics",
     "register_grounding_source",
+    "unregister_grounding_source",
 ]

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -9,12 +9,18 @@ import pytest
 from prompt_toolkit.history import FileHistory
 from rich.console import Console
 
-import app.cli.interactive_shell.grounding_diagnostics as grounding_diagnostics
+from app.cli.interactive_shell import (
+    agents_md_reference,
+    cli_reference,
+    docs_reference,
+)
 from app.cli.interactive_shell.command_registry import repl_data as repl_data_module
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.grounding_diagnostics import (
     GroundingSource,
+    iter_grounding_sources,
     register_grounding_source,
+    unregister_grounding_source,
 )
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
@@ -27,12 +33,16 @@ def _capture() -> tuple[Console, io.StringIO]:
 
 @pytest.fixture(autouse=True)
 def restore_grounding_source_registry() -> None:
-    original_registry = grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.copy()
+    snapshot_names = {source.name for source in iter_grounding_sources()}
     try:
         yield
     finally:
-        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.clear()
-        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.update(original_registry)
+        for source in list(iter_grounding_sources()):
+            if source.name not in snapshot_names:
+                unregister_grounding_source(source.name)
+        cli_reference._register_grounding_source()
+        docs_reference._register_grounding_source()
+        agents_md_reference._register_grounding_source()
 
 
 class TestDispatchSlash:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -9,8 +9,13 @@ import pytest
 from prompt_toolkit.history import FileHistory
 from rich.console import Console
 
+import app.cli.interactive_shell.grounding_diagnostics as grounding_diagnostics
 from app.cli.interactive_shell.command_registry import repl_data as repl_data_module
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
+from app.cli.interactive_shell.grounding_diagnostics import (
+    GroundingSource,
+    register_grounding_source,
+)
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
 
@@ -18,6 +23,16 @@ from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
 def _capture() -> tuple[Console, io.StringIO]:
     buf = io.StringIO()
     return Console(file=buf, force_terminal=False, highlight=False), buf
+
+
+@pytest.fixture(autouse=True)
+def restore_grounding_source_registry() -> None:
+    original_registry = grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.copy()
+    try:
+        yield
+    finally:
+        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.clear()
+        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.update(original_registry)
 
 
 class TestDispatchSlash:
@@ -87,6 +102,23 @@ class TestDispatchSlash:
         assert "trust mode" in output
         assert "grounding cli cache" in output
         assert "grounding docs cache" in output
+
+    def test_status_renders_registered_grounding_sources(self) -> None:
+        register_grounding_source(
+            GroundingSource(
+                name="custom_status_source",
+                stats_fn=lambda: {"items": 4},
+                format_fn=lambda stats: f"items={stats['items']}",
+            )
+        )
+        session = ReplSession()
+        console, buf = _capture()
+
+        dispatch_slash("/status", session, console)
+
+        output = buf.getvalue()
+        assert "grounding custom_status_source cache" in output
+        assert "items=4" in output
 
     def test_unknown_command_does_not_exit(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_grounding_diagnostics.py
+++ b/tests/cli/interactive_shell/test_grounding_diagnostics.py
@@ -6,7 +6,23 @@ import logging
 
 import pytest
 
-from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
+import app.cli.interactive_shell.grounding_diagnostics as grounding_diagnostics
+from app.cli.interactive_shell.grounding_diagnostics import (
+    GroundingSource,
+    iter_grounding_sources,
+    log_grounding_cache_diagnostics,
+    register_grounding_source,
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_grounding_source_registry() -> None:
+    original_registry = grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.copy()
+    try:
+        yield
+    finally:
+        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.clear()
+        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.update(original_registry)
 
 
 def test_log_skips_when_tracer_verbose_unset(
@@ -27,11 +43,53 @@ def test_log_skips_when_tracer_verbose_not_one(
     assert not caplog.records
 
 
-def test_log_emits_debug_when_tracer_verbose_on(
+def test_iter_grounding_sources_includes_builtin_sources_in_order() -> None:
+    names = [source.name for source in iter_grounding_sources()]
+    assert "cli" in names
+    assert "docs" in names
+    assert "agents_md" in names
+    assert names.index("cli") < names.index("docs")
+
+
+def test_register_grounding_source_reregisters_same_name_without_duplication() -> None:
+    register_grounding_source(
+        GroundingSource(
+            name="custom_idempotent_source",
+            stats_fn=lambda: {"hits": 1},
+            format_fn=lambda _stats: "first",
+        )
+    )
+    register_grounding_source(
+        GroundingSource(
+            name="custom_idempotent_source",
+            stats_fn=lambda: {"hits": 2},
+            format_fn=lambda _stats: "second",
+        )
+    )
+
+    custom_sources = [
+        source for source in iter_grounding_sources() if source.name == "custom_idempotent_source"
+    ]
+    assert len(custom_sources) == 1
+    assert custom_sources[0].format_fn(custom_sources[0].stats_fn()) == "second"
+
+
+def test_log_emits_registered_source_stats_when_tracer_verbose_on(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     monkeypatch.setenv("TRACER_VERBOSE", "1")
+    register_grounding_source(
+        GroundingSource(
+            name="custom_log_source",
+            stats_fn=lambda: {"hits": 3, "misses": 1},
+            format_fn=lambda stats: f"hits={stats['hits']} misses={stats['misses']}",
+        )
+    )
     with caplog.at_level(logging.DEBUG):
         log_grounding_cache_diagnostics("unit_test_reason")
     assert any("unit_test_reason" in r.message for r in caplog.records)
     assert any("grounding cache" in r.message.lower() for r in caplog.records)
+    assert any("cli={" in r.message for r in caplog.records)
+    assert any("docs={" in r.message for r in caplog.records)
+    assert any("agents_md={" in r.message for r in caplog.records)
+    assert any("custom_log_source={'hits': 3, 'misses': 1}" in r.message for r in caplog.records)

--- a/tests/cli/interactive_shell/test_grounding_diagnostics.py
+++ b/tests/cli/interactive_shell/test_grounding_diagnostics.py
@@ -6,23 +6,32 @@ import logging
 
 import pytest
 
-import app.cli.interactive_shell.grounding_diagnostics as grounding_diagnostics
+from app.cli.interactive_shell import (
+    agents_md_reference,
+    cli_reference,
+    docs_reference,
+)
 from app.cli.interactive_shell.grounding_diagnostics import (
     GroundingSource,
     iter_grounding_sources,
     log_grounding_cache_diagnostics,
     register_grounding_source,
+    unregister_grounding_source,
 )
 
 
 @pytest.fixture(autouse=True)
 def restore_grounding_source_registry() -> None:
-    original_registry = grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.copy()
+    snapshot_names = {source.name for source in iter_grounding_sources()}
     try:
         yield
     finally:
-        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.clear()
-        grounding_diagnostics._GROUNDING_SOURCE_REGISTRY.update(original_registry)
+        for source in list(iter_grounding_sources()):
+            if source.name not in snapshot_names:
+                unregister_grounding_source(source.name)
+        cli_reference._register_grounding_source()
+        docs_reference._register_grounding_source()
+        agents_md_reference._register_grounding_source()
 
 
 def test_log_skips_when_tracer_verbose_unset(


### PR DESCRIPTION
Fixes #1447

#### Describe the changes you have made in this PR -

- added a shared `GroundingSource` registry in the interactive shell grounding diagnostics module
- self-registered the existing CLI help, docs, and `AGENTS.md` grounding cache stats providers
- updated `/status` to render grounding cache rows from the registry while preserving the existing CLI/docs rows
- kept verbose grounding diagnostics on the raw builtin stats payload shape so the debug output still includes the existing dict fields
- added coverage for builtin source registration/order, idempotent re-registration, registry-driven `/status`, and verbose logging through the registry

### Demo/Screenshot for feature changes and bug fixes - 

```text
$ make lint && make format-check && make typecheck && make test-cov
...
5803 passed, 5 skipped, 165 warnings in 80.84s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I kept the refactor narrow around the two current grounding call sites. `grounding_diagnostics.py` now owns a small registration surface so each grounding source can register itself with its stats callback once, and both verbose diagnostics and `/status` iterate that same registry. For the user-facing `/status` rows I used a shared formatter that preserves the current `cli` and `docs` text while allowing additional sources to render naturally; for verbose logging I kept the raw builtin payload shape so the existing debug fields are still present. The tests pin the public registry behavior (builtin sources, order, idempotent re-registration) and the two caller surfaces so adding future grounding sources only requires self-registration.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
