### PR TITLE
fix(cli): use in_thread=True for questionary prompts inside async REPL

### DIFF
--- a/app/cli/support/prompt_support.py
+++ b/app/cli/support/prompt_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import time
 from collections.abc import Callable
@@ -114,9 +115,20 @@ def _with_ctrl_c_double_exit(
     def _patched_ask(*args: Any, **kwargs: Any) -> Any:
         while True:
             try:
-                # unsafe_ask() propagates KeyboardInterrupt instead of
-                # swallowing it the way ask() does.
-                result = question.unsafe_ask(*args, **kwargs)
+                # unsafe_ask() → application.run() → asyncio.run(), which
+                # raises RuntimeError when called from inside a running event
+                # loop (e.g. the async REPL). Use in_thread=True so
+                # prompt_toolkit creates its own event loop in a background
+                # thread instead.
+                try:
+                    asyncio.get_running_loop()
+                    _in_event_loop = True
+                except RuntimeError:
+                    _in_event_loop = False
+                if _in_event_loop:
+                    result = question.application.run(in_thread=True)
+                else:
+                    result = question.unsafe_ask(*args, **kwargs)
                 _last_ctrl_c[0] = None  # reset on clean exit so next prompt starts fresh
                 return result
             except KeyboardInterrupt as exc:

--- a/tests/cli/test_prompt_support.py
+++ b/tests/cli/test_prompt_support.py
@@ -139,3 +139,30 @@ def test_ctrl_c_hint_resets_after_window(capsys) -> None:
     handle_ctrl_c_press()
     out = capsys.readouterr().out
     assert "(Press Ctrl+C again to exit)" in out
+
+
+def test_questionary_ask_inside_running_event_loop_does_not_raise() -> None:
+    """q.ask() called from within a running asyncio event loop must not raise.
+
+    Regression test for Sentry issue #1650: asyncio.run() cannot be called
+    from a running event loop — triggered when questionary prompts are shown
+    inside the async REPL dispatch path.
+    """
+    import asyncio
+
+    _last_ctrl_c[0] = None
+    install_questionary_ctrl_c_double_exit()
+
+    async def _run() -> object:
+        with create_pipe_input() as pipe_input:
+            q = questionary.select(
+                "Pick",
+                choices=["a", "b"],
+                input=pipe_input,
+                output=DummyOutput(),
+            )
+            pipe_input.send_bytes(b"\r")
+            return q.ask()
+
+    result = asyncio.run(_run())
+    assert result == "a"


### PR DESCRIPTION
## Summary

- `questionary.Question.unsafe_ask()` calls `application.run()` which calls `asyncio.run()` internally (via prompt_toolkit)
- The REPL runs inside `asyncio.run(_repl_main())`, so any questionary prompt dispatched from a slash-command handler crashes with `RuntimeError: asyncio.run() cannot be called from a running event loop`
- Fix: detect a running event loop via `asyncio.get_running_loop()` and call `application.run(in_thread=True)` — prompt_toolkit creates its own loop in a background thread, avoiding the nesting error
- Regression test added that calls `q.ask()` from inside `asyncio.run()` and asserts no error

## Test plan

- [x] `uv run pytest tests/cli/test_prompt_support.py -v` — all 10 tests pass including the new regression test
- [x] `ruff check` — clean
- [x] `mypy` — clean

Closes #1650

https://claude.ai/code/session_01CUrEtqvBEQtxVc1aytSLUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUrEtqvBEQtxVc1aytSLUz)_