### PR TITLE
fix(cli): annotate banner body to satisfy mypy on main

### DIFF
--- a/app/cli/interactive_shell/banner.py
+++ b/app/cli/interactive_shell/banner.py
@@ -387,6 +387,7 @@ def build_ready_panel(
         ]
     )
 
+    body: Group | Table
     if console.width - _PANEL_FRAME_WIDTH >= _MIN_TWO_COLUMN_CONTENT_WIDTH:
         left_width, right_width = _two_column_widths(console.width)
         height = max(
@@ -395,11 +396,12 @@ def build_ready_panel(
         )
         divider = _vertical_divider(height)
 
-        body = Table.grid(padding=0, expand=False)
-        body.add_column(justify="left", vertical="top", width=left_width)
-        body.add_column(justify="center", vertical="top", width=_DIVIDER_WIDTH)
-        body.add_column(justify="left", vertical="top", width=right_width)
-        body.add_row(left, divider, right)
+        grid = Table.grid(padding=0, expand=False)
+        grid.add_column(justify="left", vertical="top", width=left_width)
+        grid.add_column(justify="center", vertical="top", width=_DIVIDER_WIDTH)
+        grid.add_column(justify="left", vertical="top", width=right_width)
+        grid.add_row(left, divider, right)
+        body = grid
     else:
         body = Group(
             left,


### PR DESCRIPTION
## What was broken

`make typecheck` (and the equivalent CI quality gate) is failing on `main` after commit [`892d057` "fix: improve cli banner"](https://github.com/Tracer-Cloud/opensre/commit/892d057ca27f89bb555ed41848b32c8de9c4460f), which was pushed directly to `main` without going through a PR.

```
$ make typecheck
.venv/bin/python -m mypy app/
app/cli/interactive_shell/banner.py:404: error: Incompatible types in assignment
    (expression has type "Group", variable has type "Table")  [assignment]
Found 1 error in 1 file (checked 519 source files)
```

The banner refactor in `_build_welcome_panel` assigns `body = Table.grid(...)` in the wide-terminal branch (line 398) and `body = Group(...)` in the narrow-terminal `else` branch (line 404). Mypy infers `body` as `Table` from the first assignment and rejects the `Group` reassignment.

## What changed

`app/cli/interactive_shell/banner.py`:
- Add an explicit `body: Group | Table` annotation so both branches satisfy the declared type.
- Rename the intermediate two-column variable to `grid` (and assign `body = grid` after configuring it) so the annotated `body` is written exactly once per branch — same shape as the existing `else` branch.

No runtime behavior change; types only, plus a local rename.

## Verification

Local quality gate is fully green on this branch:

- `make lint` — ✅ All checks passed
- `make format-check` — ✅ 1202 files already formatted
- `make typecheck` — ✅ Success: no issues found in 519 source files
- `tests/cli/interactive_shell/test_banner.py` — ✅ 2 passed (`test_banner_shows_ollama_model`, `test_ready_box_expands_to_console_width`)
- `tests/pipeline/test_runners_sentry.py` — ✅ passed (verified the previously-flagged "pre-existing failure" referenced in #1632 no longer reproduces on current main)

## Why this slipped through CI

Commit `892d057` was pushed directly to `main` rather than via a PR, so the typical PR-gate `quality (ubuntu-latest)` job (which runs `make typecheck`) didn't run before the change landed. A PR-gated workflow would have caught this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpPBB3WJC3HPmHnJu5Wusj)_