### PR TITLE
fix(cli): accept optional session param in _build_prompt_session for compat

### DIFF
--- a/app/cli/interactive_shell/prompt_surface.py
+++ b/app/cli/interactive_shell/prompt_surface.py
@@ -300,7 +300,7 @@ def _build_prompt_style() -> Style:
     )
 
 
-def _build_prompt_session() -> PromptSession[str]:
+def _build_prompt_session(_session: ReplSession | None = None) -> PromptSession[str]:
     return _install_prompt_frame(
         PromptSession(
             completer=ShellCompleter(),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Some deployed builds call `_build_prompt_session(session)` with a positional argument; without that parameter in the signature the call raises `TypeError: _build_prompt_session() missing 1 required positional argument: 'session'`
- Fix: add `_session: ReplSession | None = None` as an optional parameter — the `_` prefix follows Python / ruff convention for intentionally-unused arguments (silences `ARG001`) and removes the need for an explicit discard statement

## Test plan

- [x] `make lint` — clean
- [x] `make format-check` — clean
- [x] `make typecheck` — 520 files, no issues
- [x] `uv run pytest tests/cli/interactive_shell/test_loop.py -q` — 44 passed

Closes #1656

https://claude.ai/code/session_018rsyVPDNXVCrEwPCaCAdo7
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018rsyVPDNXVCrEwPCaCAdo7)_