### PR TITLE
fix(cli): force UTF-8 stdio so themed UI renders on legacy Windows consoles

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -35,6 +35,17 @@ _CLI_ANALYTICS_CAPTURED = "cli_analytics_captured"
 _CLI_ARGV = "cli_argv"
 
 
+def _ensure_utf8_stdio() -> None:
+    """Force UTF-8 on stdout/stderr so the themed UI renders on legacy
+    Windows consoles (cp1252) without UnicodeEncodeError."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        with suppress(Exception):
+            reconfigure(encoding="utf-8", errors="replace")
+
+
 def _option_value_count(command: click.Command, token: str) -> int:
     for param in command.params:
         if not isinstance(param, click.Option):
@@ -196,6 +207,7 @@ def _should_capture_cli_exception(exc: click.ClickException) -> bool:
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``opensre`` console script."""
+    _ensure_utf8_stdio()
     load_dotenv(override=False)
     cli_argv = list(sys.argv[1:] if argv is None else argv)
     try:


### PR DESCRIPTION
## Problem

Running the PyInstaller-built `opensre.exe` on Windows crashes when rendering the themed help/landing UI:

```
File "app\cli\support\layout.py", line 89, in render_help
    console.print(build_ready_panel(console))
  ...
File "rich\_win32_console.py", line 402, in write_text
File "encodings\cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-2: character maps to <undefined>
```

`build_ready_panel` emits Unicode box-drawing glyphs (`│`, `─`, …). On legacy Windows consoles the default stdout encoding is `cp1252`, which Rich's `legacy_windows_render` path then tries to encode with — and crashes.

## Fix

Reconfigure `sys.stdout` / `sys.stderr` to UTF-8 (`errors="replace"`) at the top of `main()` in `app/cli/__main__.py`. Every `Console(...)` instance picks up the new encoding without per-call overrides; macOS/Linux are unaffected (already UTF-8).

```python
def _ensure_utf8_stdio() -> None:
    """Force UTF-8 on stdout/stderr so the themed UI renders on legacy
    Windows consoles (cp1252) without UnicodeEncodeError."""
    for stream in (sys.stdout, sys.stderr):
        reconfigure = getattr(stream, "reconfigure", None)
        if reconfigure is None:
            continue
        with suppress(Exception):
            reconfigure(encoding="utf-8", errors="replace")
```

Called once, very first thing in `main()` — before `load_dotenv`, Sentry init, Click dispatch, or any Rich rendering.

## Verification

- `make lint` ✅
- `make format-check` ✅
- `make typecheck` ✅ (524 source files)
- `pytest tests/cli/ tests/cli_smoke_test.py` ✅ (1019 passed, 2 skipped)

## Scope

One file, 12 added lines. No behavioural change on macOS/Linux.
