### PR TITLE
docs(contributing): document pytest.mark.synthetic requirement for te…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,25 @@ Notes:
 - New features should have corresponding tests
 - Aim for >80% code coverage (run `make test-cov` to check)
 
+#### Tests under `tests/synthetic/` need an explicit `pytest.mark.synthetic` marker
+
+The synthetic test tree has its own Make target (`make test-synthetic`) and is excluded from `make test-cov`. The two targets use marker filters:
+
+- `make test-cov` runs `pytest --ignore=tests/synthetic -m "not synthetic"`, so the whole `tests/synthetic/` tree is excluded.
+- `make test-synthetic` runs `pytest -m synthetic`, so a file without `pytest.mark.synthetic` is collected but skipped.
+
+If you add a new test file under `tests/synthetic/`, declare the marker at module level so the file runs under `make test-synthetic`:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.synthetic
+```
+
+Without this marker the new file silently runs in **zero** standard CI configurations. The pattern is already in `tests/synthetic/rds_postgres/test_suite.py`; new files in the same tree should follow it.
+
+See [#1671](https://github.com/Tracer-Cloud/opensre/issues/1671) for the meta-issue tracking this discoverability gap.
+
 ### 4. Run Local Checks (Required Before PR)
 
 ```bash


### PR DESCRIPTION
Closes #1671.

Three eval-side PRs in 24 hours (#1410, #1420, #1580) hit the same gap: a new test file under `tests/synthetic/` without a module-level `pytestmark = pytest.mark.synthetic` is silently skipped under both default Make targets. @yashksaini-coder caught this on each one separately, which was the diagnostic that this is a process-doc gap, not three independent author errors.

## What this changes

A new "Tests under `tests/synthetic/` need an explicit `pytest.mark.synthetic` marker" subsection inside the existing "Add or Update Tests" section of `CONTRIBUTING.md`. The subsection:

- explains the marker filter on both Make targets (`make test-cov` excludes `tests/synthetic/`, `make test-synthetic` requires the marker)
- shows the canonical module-level pattern
- points new contributors at `tests/synthetic/rds_postgres/test_suite.py` as the existing reference
- links to the meta-issue (#1671) for the full context

Net diff: ~20 lines added, 0 modified.

## Why docs and not a conftest

The meta-issue (#1671) raised both the docs and the `tests/synthetic/conftest.py` auto-applied marker as candidate fixes. This PR is the docs-only path because:

- it is non-opinionated (preserves the option of an unmarked test under `tests/synthetic/`, e.g. for a non-synthetic helper)
- it ships immediately without changing test discovery for existing files
- the conftest path is a follow-up that can land if the team wants the closed-loop guarantee

Happy to ship the conftest path as a separate small PR if there's a preference.

## Local validation

```
$ markdownlint CONTRIBUTING.md
# (no installed config; visual scan only)
```

cc @VaibhavUpreti @muddlebee @yashksaini-coder

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes
- [ ] No

**If yes, did you understand and verify all the code that was generated?**
- [x] Yes, I understand and verified all the code
- [ ] No

**Are you able to explain the implementation choices and trade-offs?**
- [x] Yes
- [ ] No