### PR TITLE
feat(agents): agents.yaml config loader and /agents budget (#1494)

### DIFF
--- a/app/agents/config.py
+++ b/app/agents/config.py
@@ -89,7 +89,9 @@ def set_agent_budget(name: str, hourly_budget_usd: float) -> AgentsConfig:
     """
     name = name.strip()
     config = load_agents_config()
-    existing = config.agents.get(name) or AgentBudget()
+    existing = config.agents.get(name)
+    if existing is None:
+        existing = AgentBudget()
     config.agents[name] = existing.model_copy(update={"hourly_budget_usd": hourly_budget_usd})
     save_agents_config(config)
     return config

--- a/app/agents/config.py
+++ b/app/agents/config.py
@@ -28,9 +28,13 @@ class AgentBudget(StrictConfigModel):
     them.
     """
 
-    hourly_budget_usd: float | None = Field(default=None, gt=0)
+    # ``allow_inf_nan=False`` keeps non-finite floats out of the
+    # config. ``inf > 0`` is ``True`` so ``gt=0`` alone wouldn't block
+    # ``inf``; ``nan > 0`` is ``False`` but the explicit flag yields
+    # a clearer error message either way.
+    hourly_budget_usd: float | None = Field(default=None, gt=0, allow_inf_nan=False)
     progress_minutes: int | None = Field(default=None, ge=0)
-    error_rate_pct: float | None = Field(default=None, ge=0, le=100)
+    error_rate_pct: float | None = Field(default=None, ge=0, le=100, allow_inf_nan=False)
 
 
 class AgentsConfig(StrictConfigModel):
@@ -86,13 +90,22 @@ def set_agent_budget(name: str, hourly_budget_usd: float) -> AgentsConfig:
     surrounding whitespace so callers don't accidentally split one
     logical agent into two dict keys (``"claude-code"`` vs
     ``" claude-code "``).
+
+    Goes through ``model_validate`` rather than ``model_copy`` because
+    the latter skips field validators — a programmatic caller passing
+    ``float("nan")`` or ``float("inf")`` could otherwise persist a
+    value that fails ``gt=0`` on the next load and corrupts
+    ``agents.yaml``. Re-validation here keeps the public mutation
+    surface consistent with the constructor's invariants.
     """
     name = name.strip()
     config = load_agents_config()
     existing = config.agents.get(name)
     if existing is None:
         existing = AgentBudget()
-    config.agents[name] = existing.model_copy(update={"hourly_budget_usd": hourly_budget_usd})
+    merged = existing.model_dump(exclude_none=True)
+    merged["hourly_budget_usd"] = hourly_budget_usd
+    config.agents[name] = AgentBudget.model_validate(merged)
     save_agents_config(config)
     return config
 

--- a/app/agents/config.py
+++ b/app/agents/config.py
@@ -1,0 +1,105 @@
+"""Per-agent budget config loaded from ``~/.config/opensre/agents.yaml``.
+
+The ``/agents`` dashboard reads ``hourly_budget_usd`` and surfaces it
+in the ``$/hr`` column. ``progress_minutes`` and ``error_rate_pct``
+are stored for the SLO watchdog landing in a later phase of the
+monitor-local-agents roadmap; nothing consumes them today.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+from pydantic import Field
+
+from app.constants import OPENSRE_HOME_DIR
+from app.strict_config import StrictConfigModel
+
+logger = logging.getLogger(__name__)
+
+
+class AgentBudget(StrictConfigModel):
+    """Per-agent SLO thresholds.
+
+    Every field is optional so users can set just one threshold
+    (typically ``hourly_budget_usd``) without having to specify all of
+    them.
+    """
+
+    hourly_budget_usd: float | None = Field(default=None, gt=0)
+    progress_minutes: int | None = Field(default=None, ge=0)
+    error_rate_pct: float | None = Field(default=None, ge=0, le=100)
+
+
+class AgentsConfig(StrictConfigModel):
+    """Top-level shape of ``~/.config/opensre/agents.yaml``."""
+
+    agents: dict[str, AgentBudget] = Field(default_factory=dict)
+
+
+def agents_config_path() -> Path:
+    """On-disk path. Indirected so tests can monkeypatch the location."""
+    return OPENSRE_HOME_DIR / "agents.yaml"
+
+
+def load_agents_config() -> AgentsConfig:
+    """Return the parsed config, or an empty one if the file is absent.
+
+    A corrupted (unparseable) YAML file is treated as absent and logs
+    at debug level — the REPL keeps working with defaults rather than
+    crashing on a hand-edit gone wrong. ``pydantic.ValidationError``
+    is *not* swallowed: a schema mismatch (e.g. a misspelled field
+    key) needs to surface so the user can fix the typo, otherwise
+    every ``/agents budget`` write would silently overwrite their
+    other data.
+    """
+    path = agents_config_path()
+    if not path.exists():
+        return AgentsConfig()
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        logger.debug("agents.yaml at %s is unparseable; using empty config", path)
+        return AgentsConfig()
+    if raw is None:
+        return AgentsConfig()
+    return AgentsConfig.model_validate(raw)
+
+
+def save_agents_config(config: AgentsConfig) -> Path:
+    """Persist ``config`` to disk, creating the parent directory if needed."""
+    path = agents_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = config.model_dump(exclude_none=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def set_agent_budget(name: str, hourly_budget_usd: float) -> AgentsConfig:
+    """Set ``hourly_budget_usd`` for ``name`` and persist the result.
+
+    Loads the current config, updates (or inserts) the entry for
+    ``name`` while preserving any other fields it already had, writes
+    back, and returns the new config. ``name`` is stripped of
+    surrounding whitespace so callers don't accidentally split one
+    logical agent into two dict keys (``"claude-code"`` vs
+    ``" claude-code "``).
+    """
+    name = name.strip()
+    config = load_agents_config()
+    existing = config.agents.get(name) or AgentBudget()
+    config.agents[name] = existing.model_copy(update={"hourly_budget_usd": hourly_budget_usd})
+    save_agents_config(config)
+    return config
+
+
+__all__ = [
+    "AgentBudget",
+    "AgentsConfig",
+    "agents_config_path",
+    "load_agents_config",
+    "save_agents_config",
+    "set_agent_budget",
+]

--- a/app/cli/interactive_shell/agents_view.py
+++ b/app/cli/interactive_shell/agents_view.py
@@ -2,11 +2,11 @@
 
 Produces the structural shape of the dashboard with the columns
 documented in #1486's preview (``agent``, ``pid``, ``uptime``,
-``cpu%``, ``tokens/min``, ``$/hr``, ``status``). Cells that aren't
-yet wired (every metric column for now) render as ``-`` — the
-sampler in #1490 fills ``cpu%`` / ``uptime`` / ``status`` later, the
-token meter consumer in #1490+ fills ``tokens/min``, and the budget
-loader from #1494 fills ``$/hr``.
+``cpu%``, ``tokens/min``, ``$/hr``, ``status``). The ``$/hr`` cell
+reads from ``agents.yaml`` via :func:`app.agents.config.load_agents_config`;
+the remaining metric columns still render as ``-`` until #1490 wires
+the per-PID sampler (``cpu%`` / ``uptime`` / ``status``) and the
+token-meter consumer (``tokens/min``).
 
 This module lives outside ``app/agents/`` deliberately: the agents
 package is for *collectors* (probe, registry, sweep, meters) and
@@ -23,6 +23,7 @@ from rich.console import JustifyMethod
 from rich.markup import escape
 from rich.table import Table
 
+from app.agents.config import load_agents_config
 from app.agents.registry import AgentRecord
 from app.cli.interactive_shell.theme import BOLD_BRAND
 
@@ -55,10 +56,10 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
     An empty record list produces a table with no body rows and an
     explanatory caption pointing the user at the registration command.
 
-    Cells for metric columns (``uptime``, ``cpu%``, ``tokens/min``,
-    ``$/hr``, ``status``) render as ``-`` placeholders. Filling them
-    is intentionally out of scope here — see module docstring for the
-    issue map.
+    The ``$/hr`` cell reads ``hourly_budget_usd`` from ``agents.yaml``
+    when configured. The other metric cells (``uptime``, ``cpu%``,
+    ``tokens/min``, ``status``) still render as ``-`` placeholders;
+    filling them is out of scope here.
     """
     materialized = list(records)
     # The empty-state caption deliberately doesn't suggest a registration
@@ -74,14 +75,24 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
     )
     for header, justify in _COLUMNS:
         table.add_column(header, justify=justify)
+    # Load once per render: agents.yaml is small and the dashboard is
+    # invoked interactively, so a single read per ``/agents`` invocation
+    # is cheaper than caching with invalidation.
+    budgets = load_agents_config().agents
     for record in materialized:
+        budget = budgets.get(record.name)
+        hourly_cell = (
+            f"${budget.hourly_budget_usd:.2f}"
+            if budget is not None and budget.hourly_budget_usd is not None
+            else _UNFILLED
+        )
         table.add_row(
             escape(record.name),
             str(record.pid),
             _UNFILLED,  # uptime
             _UNFILLED,  # cpu%
             _UNFILLED,  # tokens/min
-            _UNFILLED,  # $/hr
+            hourly_cell,
             _UNFILLED,  # status
         )
     return table

--- a/app/cli/interactive_shell/agents_view.py
+++ b/app/cli/interactive_shell/agents_view.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from pydantic import ValidationError
 from rich.console import JustifyMethod
 from rich.markup import escape
 from rich.table import Table
@@ -77,8 +78,15 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
         table.add_column(header, justify=justify)
     # Load once per render: agents.yaml is small and the dashboard is
     # invoked interactively, so a single read per ``/agents`` invocation
-    # is cheaper than caching with invalidation.
-    budgets = load_agents_config().agents
+    # is cheaper than caching with invalidation. A schema-invalid file
+    # falls back to empty budgets here (``$/hr`` cells render as ``-``)
+    # rather than crashing the dashboard with a raw traceback — the
+    # same hand-edit surfaces a friendly error in ``/agents budget``,
+    # which is the surface that exists to fix it.
+    try:
+        budgets = load_agents_config().agents
+    except ValidationError:
+        budgets = {}
     for record in materialized:
         budget = budgets.get(record.name)
         hourly_cell = (

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -1,17 +1,24 @@
 """Slash command: ``/agents`` (registered local AI agent fleet view).
 
 Bare ``/agents`` renders the registered-agents dashboard; subcommands
-drill into specific surfaces (currently ``conflicts``, with more
+drill into specific surfaces (``budget``, ``conflicts``, with more
 landing as the monitor-local-agents initiative ships).
 """
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
+from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape
 
+from app.agents.config import (
+    agents_config_path,
+    load_agents_config,
+    set_agent_budget,
+)
 from app.agents.conflicts import (
     DEFAULT_WINDOW_SECONDS,
     WriteEvent,
@@ -21,10 +28,12 @@ from app.agents.conflicts import (
 from app.agents.registry import AgentRegistry
 from app.cli.interactive_shell.agents_view import render_agents_table
 from app.cli.interactive_shell.command_registry.types import SlashCommand
+from app.cli.interactive_shell.rendering import repl_table
 from app.cli.interactive_shell.session import ReplSession
-from app.cli.interactive_shell.theme import ERROR
+from app.cli.interactive_shell.theme import BOLD_BRAND, DIM, ERROR
 
 _AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("budget", "view or edit per-agent hourly budgets"),
     ("conflicts", "show file-write conflicts between local AI agents"),
 )
 
@@ -36,10 +45,11 @@ def _opensre_agent_id() -> str:
 def _cmd_agents_list(console: Console) -> bool:
     """Render the registered ``AgentRecord`` set as a Rich table.
 
-    Bare ``/agents`` resolves here. Metric cells (``cpu%``,
-    ``tokens/min``, ``$/hr``, ``status``, ``uptime``) render as
-    placeholders until the wiring from #1490 / #1494 lands; this
-    surface only consumes what the registry already holds today.
+    Bare ``/agents`` resolves here. The ``$/hr`` cell reads
+    ``hourly_budget_usd`` from ``agents.yaml``; the remaining metric
+    cells (``cpu%``, ``tokens/min``, ``status``, ``uptime``) still
+    render as placeholders until the per-PID sampler and token-meter
+    consumer from #1490 land.
     """
     registry = AgentRegistry()
     table = render_agents_table(registry.list())
@@ -61,18 +71,100 @@ def _cmd_agents_conflicts(console: Console) -> bool:
     return True
 
 
+def _display_path(path: Path) -> str:
+    """Replace the user's home prefix with ``~`` for cleaner CLI output."""
+    try:
+        return f"~/{path.relative_to(Path.home())}"
+    except ValueError:
+        return str(path)
+
+
+def _print_config_error(console: Console, exc: ValidationError) -> None:
+    console.print(f"[{ERROR}]agents.yaml has invalid contents:[/] {escape(str(exc))}")
+
+
+def _cmd_agents_budget(session: ReplSession, console: Console, args: list[str]) -> bool:
+    """View or edit per-agent budgets stored in ``~/.config/opensre/agents.yaml``.
+
+    No args → render the current budgets as a table. Two args
+    (``<agent> <usd>``) → set ``hourly_budget_usd`` for that agent and
+    persist. Anything else → usage hint.
+    """
+    if not args:
+        try:
+            config = load_agents_config()
+        except ValidationError as exc:
+            _print_config_error(console, exc)
+            session.mark_latest(ok=False, kind="slash")
+            return True
+        if not config.agents:
+            console.print(
+                f"[{DIM}]no per-agent budgets configured.[/]  "
+                "use [bold]/agents budget <agent> <usd>[/bold] to set one."
+            )
+            return True
+        table = repl_table(title="agent budgets", title_style=BOLD_BRAND)
+        table.add_column("agent", style="bold")
+        table.add_column("hourly $", justify="right")
+        table.add_column("progress min", justify="right")
+        table.add_column("error %", justify="right")
+        for name in sorted(config.agents):
+            budget = config.agents[name]
+            table.add_row(
+                escape(name),
+                f"${budget.hourly_budget_usd:.2f}" if budget.hourly_budget_usd is not None else "-",
+                str(budget.progress_minutes) if budget.progress_minutes is not None else "-",
+                f"{budget.error_rate_pct:.1f}" if budget.error_rate_pct is not None else "-",
+            )
+        console.print(table)
+        return True
+
+    if len(args) != 2:
+        console.print(f"[{ERROR}]usage:[/] /agents budget [<agent> <usd>]")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    name = args[0].strip()
+    raw_usd = args[1]
+    try:
+        usd = float(raw_usd)
+    except ValueError:
+        console.print(f"[{ERROR}]invalid budget:[/] {escape(raw_usd)} is not a number")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+    if usd <= 0:
+        console.print(f"[{ERROR}]invalid budget:[/] must be a positive number")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    try:
+        set_agent_budget(name, usd)
+    except ValidationError as exc:
+        _print_config_error(console, exc)
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    console.print(
+        f"updated [bold]{escape(name)}[/]: ${usd:.2f}/hr → {_display_path(agents_config_path())}"
+    )
+    return True
+
+
 def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool:
     if not args:
         return _cmd_agents_list(console)
 
     sub = args[0].lower().strip()
 
+    if sub == "budget":
+        return _cmd_agents_budget(session, console, args[1:])
     if sub == "conflicts":
         return _cmd_agents_conflicts(console)
 
     console.print(
         f"[{ERROR}]unknown subcommand:[/] {escape(sub)}  "
-        "(try [bold]/agents[/bold] or [bold]/agents conflicts[/bold])"
+        "(try [bold]/agents[/bold], [bold]/agents budget[/bold], "
+        "or [bold]/agents conflicts[/bold])"
     )
     session.mark_latest(ok=False, kind="slash")
     return True
@@ -81,7 +173,7 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/agents",
-        "show registered local AI agents (subcommands: conflicts)",
+        "show registered local AI agents (subcommands: budget, conflicts)",
         _cmd_agents,
         first_arg_completions=_AGENTS_FIRST_ARGS,
     ),

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -7,6 +7,7 @@ landing as the monitor-local-agents initiative ships).
 
 from __future__ import annotations
 
+import math
 import os
 from pathlib import Path
 
@@ -132,8 +133,13 @@ def _cmd_agents_budget(session: ReplSession, console: Console, args: list[str]) 
         console.print(f"[{ERROR}]invalid budget:[/] {escape(raw_usd)} is not a number")
         session.mark_latest(ok=False, kind="slash")
         return True
-    if usd <= 0:
-        console.print(f"[{ERROR}]invalid budget:[/] must be a positive number")
+    # ``nan`` and ``inf`` slip past ``usd <= 0`` because both
+    # ``float("nan") <= 0`` and ``float("inf") <= 0`` are ``False``.
+    # Without this guard a stored ``nan`` would corrupt agents.yaml
+    # (next load fails Pydantic's ``gt=0`` since ``nan > 0`` is
+    # ``False``) and ``inf`` would render as ``$inf`` in the dashboard.
+    if not math.isfinite(usd) or usd <= 0:
+        console.print(f"[{ERROR}]invalid budget:[/] must be a positive finite number")
         session.mark_latest(ok=False, kind="slash")
         return True
 

--- a/tests/agents/test_config.py
+++ b/tests/agents/test_config.py
@@ -1,0 +1,178 @@
+"""Tests for the per-agent budget config loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.agents import config as config_mod
+from app.agents.config import (
+    AgentBudget,
+    AgentsConfig,
+    load_agents_config,
+    save_agents_config,
+    set_agent_budget,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Autouse: redirect ``agents_config_path`` at a per-test tmp file so
+    tests never touch the developer's real ``~/.config/opensre/agents.yaml``.
+    Tests that need the path itself can still request it by name.
+    """
+    target = tmp_path / "agents.yaml"
+    monkeypatch.setattr(config_mod, "agents_config_path", lambda: target)
+    return target
+
+
+class TestAgentBudget:
+    def test_all_fields_optional(self) -> None:
+        assert AgentBudget().hourly_budget_usd is None
+        assert AgentBudget().progress_minutes is None
+        assert AgentBudget().error_rate_pct is None
+
+    def test_negative_budget_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentBudget(hourly_budget_usd=-1.0)
+
+    def test_zero_budget_rejected(self) -> None:
+        # gt=0 keeps the model in lockstep with the CLI's `usd <= 0`
+        # check so a hand-edit can't sneak in a $0/hr ceiling.
+        with pytest.raises(ValidationError):
+            AgentBudget(hourly_budget_usd=0.0)
+
+    def test_negative_progress_minutes_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentBudget(progress_minutes=-5)
+
+    def test_error_rate_above_100_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentBudget(error_rate_pct=150.0)
+
+    def test_unknown_field_rejected_with_suggestion(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            AgentBudget.model_validate({"hourly_budegt_usd": 5.0})
+        # StrictConfigModel surfaces a "did you mean" hint
+        message = str(exc.value)
+        assert "hourly_budegt_usd" in message
+        assert "hourly_budget_usd" in message
+
+
+class TestAgentsConfigModel:
+    def test_default_is_empty_dict(self) -> None:
+        assert AgentsConfig().agents == {}
+
+    def test_top_level_unknown_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentsConfig.model_validate({"agents": {}, "version": 1})
+
+
+class TestLoadAgentsConfig:
+    def test_returns_empty_when_file_missing(self, isolated_path: Path) -> None:
+        assert not isolated_path.exists()
+        config = load_agents_config()
+        assert config == AgentsConfig()
+
+    def test_returns_empty_when_file_is_blank(self, isolated_path: Path) -> None:
+        isolated_path.parent.mkdir(parents=True, exist_ok=True)
+        isolated_path.write_text("", encoding="utf-8")
+        assert load_agents_config() == AgentsConfig()
+
+    def test_parses_existing_yaml(self, isolated_path: Path) -> None:
+        isolated_path.parent.mkdir(parents=True, exist_ok=True)
+        isolated_path.write_text(
+            yaml.safe_dump(
+                {
+                    "agents": {
+                        "claude-code": {"hourly_budget_usd": 5.0, "progress_minutes": 8},
+                        "aider": {"hourly_budget_usd": 1.4},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        config = load_agents_config()
+        assert config.agents["claude-code"].hourly_budget_usd == 5.0
+        assert config.agents["claude-code"].progress_minutes == 8
+        assert config.agents["aider"].hourly_budget_usd == 1.4
+        assert config.agents["aider"].progress_minutes is None
+
+    def test_returns_empty_on_unparseable_yaml(self, isolated_path: Path) -> None:
+        isolated_path.parent.mkdir(parents=True, exist_ok=True)
+        # Unclosed brace: yaml.YAMLError on parse → loader falls back to empty.
+        isolated_path.write_text("agents: {unclosed", encoding="utf-8")
+        assert load_agents_config() == AgentsConfig()
+
+    def test_raises_on_strict_typing_violation(self, isolated_path: Path) -> None:
+        # Valid YAML, invalid schema (typo). The loader does NOT swallow
+        # this because surfacing the error lets the user fix the typo
+        # rather than silently overwriting it on the next write.
+        isolated_path.parent.mkdir(parents=True, exist_ok=True)
+        isolated_path.write_text(
+            yaml.safe_dump({"agents": {"claude-code": {"hourly_budegt_usd": 5.0}}}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValidationError):
+            load_agents_config()
+
+
+class TestSaveAgentsConfig:
+    def test_creates_parent_directory(self, isolated_path: Path) -> None:
+        # tmp_path is the parent of `isolated_path`; the loader writes
+        # one level deeper to exercise mkdir(parents=True).
+        save_agents_config(AgentsConfig(agents={"aider": AgentBudget(hourly_budget_usd=2.0)}))
+        assert isolated_path.exists()
+        on_disk = yaml.safe_load(isolated_path.read_text(encoding="utf-8"))
+        assert on_disk == {"agents": {"aider": {"hourly_budget_usd": 2.0}}}
+
+    def test_round_trips_through_load(self) -> None:
+        original = AgentsConfig(
+            agents={
+                "claude-code": AgentBudget(hourly_budget_usd=5.0, progress_minutes=8),
+                "aider": AgentBudget(error_rate_pct=10.0),
+            }
+        )
+        save_agents_config(original)
+        assert load_agents_config() == original
+
+
+class TestSetAgentBudget:
+    def test_writes_and_reloads(self) -> None:
+        set_agent_budget("claude-code", 5.0)
+        reloaded = load_agents_config()
+        assert reloaded.agents["claude-code"].hourly_budget_usd == 5.0
+
+    def test_preserves_other_agents(self) -> None:
+        save_agents_config(AgentsConfig(agents={"aider": AgentBudget(hourly_budget_usd=1.4)}))
+        set_agent_budget("claude-code", 5.0)
+        reloaded = load_agents_config()
+        assert reloaded.agents["aider"].hourly_budget_usd == 1.4
+        assert reloaded.agents["claude-code"].hourly_budget_usd == 5.0
+
+    def test_preserves_other_fields_on_same_agent(self) -> None:
+        save_agents_config(
+            AgentsConfig(
+                agents={"claude-code": AgentBudget(progress_minutes=8, error_rate_pct=2.5)}
+            )
+        )
+        set_agent_budget("claude-code", 5.0)
+        reloaded = load_agents_config().agents["claude-code"]
+        assert reloaded.hourly_budget_usd == 5.0
+        assert reloaded.progress_minutes == 8
+        assert reloaded.error_rate_pct == 2.5
+
+    def test_overwrites_existing_hourly_value(self) -> None:
+        set_agent_budget("claude-code", 3.0)
+        set_agent_budget("claude-code", 7.5)
+        assert load_agents_config().agents["claude-code"].hourly_budget_usd == 7.5
+
+    def test_strips_surrounding_whitespace_from_name(self) -> None:
+        set_agent_budget("  claude-code ", 5.0)
+        reloaded = load_agents_config()
+        assert "claude-code" in reloaded.agents
+        # The padded variant did not become a separate key.
+        assert "  claude-code " not in reloaded.agents

--- a/tests/agents/test_config.py
+++ b/tests/agents/test_config.py
@@ -176,3 +176,15 @@ class TestSetAgentBudget:
         assert "claude-code" in reloaded.agents
         # The padded variant did not become a separate key.
         assert "  claude-code " not in reloaded.agents
+
+    def test_rejects_nan_at_api_layer(self) -> None:
+        # ``model_copy`` would skip validators and silently persist a
+        # ``nan`` that the next load can't parse. Re-validating in
+        # ``set_agent_budget`` blocks corruption from any caller that
+        # bypasses the CLI's pre-check.
+        with pytest.raises(ValidationError):
+            set_agent_budget("claude-code", float("nan"))
+
+    def test_rejects_inf_at_api_layer(self) -> None:
+        with pytest.raises(ValidationError):
+            set_agent_budget("claude-code", float("inf"))

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -128,6 +128,30 @@ class TestAgentsDispatch:
         assert dispatch_slash("/agents", session, list_console) is True
         assert "$5.00" in list_buf.getvalue()
 
+    def test_bare_agents_does_not_crash_on_schema_invalid_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_agents_yaml: Path
+    ) -> None:
+        # Hand-edited agents.yaml with a typo'd field used to crash bare
+        # /agents with a raw ValidationError traceback. The dashboard
+        # must degrade gracefully (render with $/hr = '-') so the user
+        # can still see their fleet while /agents budget surfaces the
+        # actual error message.
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        isolated_agents_yaml.parent.mkdir(parents=True, exist_ok=True)
+        isolated_agents_yaml.write_text(
+            "agents:\n  claude-code:\n    hourly_budegt_usd: 5.0\n",
+            encoding="utf-8",
+        )
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents", session, console) is True
+        out = buf.getvalue()
+        # Dashboard still renders the agent row.
+        assert "claude-code" in out
+        assert "8421" in out
+
 
 class TestAgentsBudget:
     def test_no_args_empty_state_when_no_config(self) -> None:

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -9,6 +9,7 @@ import pytest
 from rich.console import Console
 from rich.table import Table
 
+from app.agents import config as config_mod
 from app.agents.conflicts import (
     DEFAULT_WINDOW_SECONDS,
     FileWriteConflict,
@@ -36,6 +37,18 @@ def _isolate_registry(monkeypatch: pytest.MonkeyPatch, path: Path) -> AgentRegis
 
     monkeypatch.setattr(agents_mod, "AgentRegistry", lambda: AgentRegistry(path=path))
     return registry
+
+
+@pytest.fixture(autouse=True)
+def isolated_agents_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Autouse: redirect ``agents_config_path()`` to a per-test tmp path so
+    ``/agents`` (which now reads ``agents.yaml`` for the ``$/hr`` cell)
+    and ``/agents budget`` never touch the developer's real
+    ``~/.config/opensre/agents.yaml``.
+    """
+    target = tmp_path / "agents.yaml"
+    monkeypatch.setattr(config_mod, "agents_config_path", lambda: target)
+    return target
 
 
 class TestAgentsRegistration:
@@ -98,6 +111,102 @@ class TestAgentsDispatch:
         out = buf.getvalue()
         assert "unknown subcommand" in out.lower()
         assert "bogus" in out
+
+    def test_dollar_hr_cell_reads_from_agents_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+
+        # Pre-seed the budget via the slash command itself so we exercise
+        # the full write→read round-trip (set → list).
+        session = ReplSession()
+        write_console, _ = _capture()
+        assert dispatch_slash("/agents budget claude-code 5", session, write_console) is True
+
+        list_console, list_buf = _capture()
+        assert dispatch_slash("/agents", session, list_console) is True
+        assert "$5.00" in list_buf.getvalue()
+
+
+class TestAgentsBudget:
+    def test_no_args_empty_state_when_no_config(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget", session, console) is True
+        assert "no per-agent budgets" in buf.getvalue().lower()
+
+    def test_writes_and_round_trips_through_load(self, isolated_agents_yaml: Path) -> None:
+        session = ReplSession()
+        write_console, write_buf = _capture()
+        assert dispatch_slash("/agents budget claude-code 5", session, write_console) is True
+
+        # Confirmation message references the agent and amount.
+        write_out = write_buf.getvalue()
+        assert "claude-code" in write_out
+        assert "$5.00" in write_out
+
+        # Subsequent /agents budget lists the just-written entry.
+        read_console, read_buf = _capture()
+        assert dispatch_slash("/agents budget", session, read_console) is True
+        read_out = read_buf.getvalue()
+        assert "claude-code" in read_out
+        assert "$5.00" in read_out
+
+        # File on disk has the expected shape.
+        assert isolated_agents_yaml.exists()
+
+    def test_rejects_negative_budget(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget claude-code -3", session, console) is True
+        out = buf.getvalue()
+        assert "invalid budget" in out.lower()
+        # Latest slash invocation should be marked failed.
+        assert session.history[-1]["ok"] is False
+
+    def test_rejects_zero_budget(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget claude-code 0", session, console) is True
+        assert "invalid budget" in buf.getvalue().lower()
+        assert session.history[-1]["ok"] is False
+
+    def test_rejects_non_numeric_budget(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget claude-code five", session, console) is True
+        assert "invalid budget" in buf.getvalue().lower()
+        assert session.history[-1]["ok"] is False
+
+    def test_single_arg_prints_usage(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget claude-code", session, console) is True
+        assert "usage" in buf.getvalue().lower()
+        assert session.history[-1]["ok"] is False
+
+    def test_first_arg_completions_include_budget(self) -> None:
+        cmd = SLASH_COMMANDS["/agents"]
+        keywords = [pair[0] for pair in cmd.first_arg_completions]
+        assert "budget" in keywords
+
+    def test_corrupt_config_surfaces_friendly_error(self, isolated_agents_yaml: Path) -> None:
+        # Hand-edit an agents.yaml with a typo'd field. The loader
+        # raises ValidationError; the slash handler catches it and
+        # renders a "agents.yaml has invalid contents" message rather
+        # than crashing the REPL.
+        isolated_agents_yaml.parent.mkdir(parents=True, exist_ok=True)
+        isolated_agents_yaml.write_text(
+            "agents:\n  claude-code:\n    hourly_budegt_usd: 5.0\n",
+            encoding="utf-8",
+        )
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget", session, console) is True
+        out = buf.getvalue()
+        assert "invalid contents" in out.lower()
+        assert session.history[-1]["ok"] is False
 
 
 class TestRenderConflicts:

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -203,6 +203,29 @@ class TestAgentsBudget:
         assert "invalid budget" in buf.getvalue().lower()
         assert session.history[-1]["ok"] is False
 
+    def test_rejects_nan_budget(self, isolated_agents_yaml: Path) -> None:
+        # ``float("nan") <= 0`` is ``False``, so without ``math.isfinite``
+        # ``nan`` would slip past the guard, hit set_agent_budget, and
+        # poison agents.yaml so the next load raises ValidationError.
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget claude-code nan", session, console) is True
+        assert "invalid budget" in buf.getvalue().lower()
+        assert session.history[-1]["ok"] is False
+        # The file must not exist — a single non-finite write can't be
+        # allowed to leave agents.yaml in an unreadable state.
+        assert not isolated_agents_yaml.exists()
+
+    def test_rejects_inf_budget(self, isolated_agents_yaml: Path) -> None:
+        # ``float("inf") <= 0`` is ``False`` and ``gt=0`` alone accepts
+        # ``inf`` (``inf > 0`` is ``True``); only ``isfinite`` blocks it.
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents budget claude-code inf", session, console) is True
+        assert "invalid budget" in buf.getvalue().lower()
+        assert session.history[-1]["ok"] is False
+        assert not isolated_agents_yaml.exists()
+
     def test_single_arg_prints_usage(self) -> None:
         session = ReplSession()
         console, buf = _capture()

--- a/tests/cli/interactive_shell/test_agents_view.py
+++ b/tests/cli/interactive_shell/test_agents_view.py
@@ -9,12 +9,31 @@ this function.
 from __future__ import annotations
 
 import io
+from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from app.agents import config as config_mod
 from app.agents.registry import AgentRecord
+from app.cli.interactive_shell import agents_view as agents_view_mod
 from app.cli.interactive_shell.agents_view import render_agents_table
+
+
+@pytest.fixture(autouse=True)
+def isolated_agents_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Autouse: redirect ``agents_config_path`` to a per-test tmp file
+    so the rendering tests don't read the developer's real
+    ``~/.config/opensre/agents.yaml`` (which would let real budgets
+    leak into the placeholder assertions and create cross-machine
+    flakes).
+    """
+    target = tmp_path / "agents.yaml"
+    monkeypatch.setattr(config_mod, "agents_config_path", lambda: target)
+    return target
+
 
 # The columns this PR ships are the contract for #1490 and later
 # tickets that thread snapshot data into the rendering layer; pin
@@ -150,3 +169,35 @@ def test_record_name_is_rich_escaped_so_markup_does_not_render() -> None:
     _, out = _render(records)
     # Literal brackets survive in the rendered output:
     assert "[bold red]ghost[/]" in out
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation when agents.yaml has a schema violation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_invalid_budget_config_does_not_crash_render(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo'd field key in ``agents.yaml`` raises
+    ``pydantic.ValidationError`` from ``load_agents_config()``. The
+    rendering function must catch it and fall back to empty budgets so
+    bare ``/agents`` still renders (with ``$/hr`` as ``-``) instead of
+    crashing the REPL with a raw traceback. The same hand-edit is
+    surfaced as a friendly error in ``/agents budget``, which is the
+    surface that exists to fix it.
+    """
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise ValidationError.from_exception_data("AgentsConfig", [])
+
+    monkeypatch.setattr(agents_view_mod, "load_agents_config", _raise)
+
+    table, out = _render([AgentRecord(name="claude-code", pid=8421, command="claude")])
+    assert table.row_count == 1
+    assert "claude-code" in out
+    # $/hr cell falls back to the placeholder rather than the
+    # configured value, but the table still renders.
+    rendered_cells = [list(col.cells)[0] for col in table.columns]
+    # cells[5] is the $/hr column.
+    assert rendered_cells[5] == "-"


### PR DESCRIPTION
Fixes #1494

#### Describe the changes you have made in this PR -

Adds the first SLO knob of the **monitor-local-agents** roadmap (Phase 2 — Quality & cost):

1. **`app/agents/config.py`** (new) — Pydantic `StrictConfigModel` loader for `~/.config/opensre/agents.yaml`. Holds per-agent thresholds (`hourly_budget_usd`, `progress_minutes`, `error_rate_pct`) keyed by agent name. Public API: `agents_config_path()`, `load_agents_config()`, `save_agents_config()`, `set_agent_budget()`.
2. **`/agents budget [<agent> <usd>]`** subcommand in `app/cli/interactive_shell/command_registry/agents.py` — bare form prints the current budgets as a Rich table; two-arg form validates and persists `hourly_budget_usd` for that agent.
3. **`$/hr` cell wired** in `app/cli/interactive_shell/agents_view.py` — reads `hourly_budget_usd` from the loader, fulfilling the contract that the `agents_view` module docstring from #1488 reserved for this issue.

Loader semantics: missing or unparseable YAML falls back to an empty config (the REPL keeps working on a hand-edit gone wrong); valid YAML with a schema mismatch (e.g. a misspelled field) **raises** `pydantic.ValidationError` so the user can see and fix the typo instead of silently overwriting their data on the next write.

### Demo/Screenshot for feature changes and bug fixes -

Captured by exercising the slash commands in-process against a fake home directory, so the rendered output and on-disk file are exactly what a user would see in production:

```
> /agents budget
no per-agent budgets configured.  use /agents budget <agent> <usd> to set one.

> /agents budget claude-code 5
updated claude-code: $5.00/hr → ~/.config/opensre/agents.yaml

> /agents budget aider 1.4
updated aider: $1.40/hr → ~/.config/opensre/agents.yaml

> /agents budget claude-code -3
invalid budget: must be a positive number

> /agents budget
                 agent budgets
agent       │ hourly $ │ progress min │ error %
━━━━━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━━┿━━━━━━━━
aider       │    $1.40 │            - │       -
claude-code │    $5.00 │            - │       -

> /agents
                               agents
┏━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┓
┃ agent       ┃  pid ┃ uptime ┃ cpu% ┃ tokens/min ┃  $/hr ┃ status ┃
┡━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━┩
│ claude-code │ 8421 │      - │    - │          - │ $5.00 │ -      │
│ aider       │ 7702 │      - │    - │          - │ $1.40 │ -      │
└─────────────┴──────┴────────┴──────┴────────────┴───────┴────────┘

--- ~/.config/opensre/agents.yaml ---
agents:
  aider:
    hourly_budget_usd: 1.4
  claude-code:
    hourly_budget_usd: 5.0
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** Today the `/agents` dashboard renders every metric cell as `-`, and there is no way for a user to express per-agent thresholds ("warn me if `claude-code` burns more than `$5/hr`"). Without a config file, every threshold would be hardcoded and the SLO watchdog landing in Phase 5 has nothing to read.

**Alternatives considered:**
- *JSON instead of YAML* — rejected because the closest existing config files (`guardrails.yml`, `config.yml`) use YAML, and YAML is friendlier for hand-edits.
- *A flat dict (`{agent_name: hourly_budget_usd}`)* — rejected because the issue acceptance criteria asks for `progress_minutes` and `error_rate_pct` too, even if no detector consumes them yet; nesting them under each agent now avoids a breaking-shape migration when Phase 5 lands.
- *Swallowing `pydantic.ValidationError` like YAML errors* — rejected. A YAML parse error is "the file is corrupted, fall back gracefully", but a validation error is "the user wrote a typo, surface it so they can fix it". Silently swallowing schema errors would mean every `/agents budget` write overwrites their other entries.
- *Lazy import of `app.agents.config` from `agents_view.py`* — rejected. The dependency arrow is `view → config`; the agents collectors package never depends on Rich, so there is no cycle risk and an eager import is more predictable.

**Why this implementation:**
- `StrictConfigModel` (`app/strict_config.py`) is the project's canonical pattern for fail-fast config; it gives "did you mean…" hints when a YAML key is misspelled, which makes typo recovery painless.
- `agents_config_path()` is a function (not a constant) so tests can `monkeypatch.setattr(...)` it without touching the developer's real home directory. Both new test files use an autouse fixture that activates this isolation by default.
- `set_agent_budget` strips surrounding whitespace from the agent name to avoid one logical agent landing under two dict keys (`"claude-code"` vs `" claude-code "`), and uses `model_copy(update=...)` so it only touches `hourly_budget_usd` and preserves any `progress_minutes` / `error_rate_pct` already present.

**Key functions:**
- `AgentBudget` / `AgentsConfig` — Pydantic models defining the on-disk shape, with `Field(gt=0)` on `hourly_budget_usd` so the model and the CLI agree that `$0/hr` is invalid.
- `load_agents_config()` — Returns an empty config if the file is missing or unparseable; raises on schema violations.
- `save_agents_config()` — Creates `~/.config/opensre/` if needed and writes via `yaml.safe_dump(..., sort_keys=True)`.
- `set_agent_budget(name, hourly_budget_usd)` — Load → mutate → save → return. The single mutation surface the slash subcommand consumes.
- `_cmd_agents_budget()` — Slash handler. Validates that `<usd>` parses as a positive `float`, catches `ValidationError` from a corrupted file and renders a friendly message, and confirms successful writes with the resolved on-disk path.
- `render_agents_table()` — Loads the budgets once per render and threads `hourly_budget_usd` into the `$/hr` cell of the existing dashboard.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

Tests cover: missing/blank/unparseable/typo'd YAML, model strictness (`extra="forbid"`, `gt=0`, `ge=0`, `le=100`), `set_agent_budget` round-trip, preservation of other agents and other fields on the same agent, whitespace stripping, the 5 CLI input-validation paths (no args, single arg, negative, zero, non-numeric), and an end-to-end test that `/agents budget claude-code 5` followed by `/agents` renders `\$5.00` in the `\$/hr` cell. Quality gate: \`make lint\`, \`make format-check\`, \`make typecheck\` (525 source files), and 48 focused tests all green; the full \`make test-cov\` flags pass everything except one pre-existing smoke-test failure on \`upstream/main\` that is unrelated to these changes.

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.