### PR TITLE
fix(llm): convert LLMSettings ValidationError to RuntimeError in _create_llm_client

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -816,7 +816,10 @@ def _get_cli_provider_registration(provider: str) -> CLIProviderRegistration | N
 
 
 def _create_llm_client(model_type: str) -> _LLMClientType:
-    settings = LLMSettings.from_env()
+    try:
+        settings = LLMSettings.from_env()
+    except ValidationError as exc:
+        raise RuntimeError(str(exc)) from exc
     provider = settings.provider
     if provider == "openai":
         config = OPENAI_LLM_CONFIG

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -740,6 +740,21 @@ def test_create_llm_client_gemini_cli_reads_optional_model_env(monkeypatch) -> N
         llm_client.reset_llm_singletons()
 
 
+# _create_llm_client — missing API key raises RuntimeError (not ValidationError)
+# ---------------------------------------------------------------------------
+
+
+def test_create_llm_client_missing_api_key_raises_runtime_error(monkeypatch) -> None:
+    """Sentry #1678: missing API key must surface as RuntimeError, not pydantic.ValidationError."""
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    llm_client.reset_llm_singletons()
+    try:
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            llm_client._create_llm_client("reasoning")
+    finally:
+        llm_client.reset_llm_singletons()
+
 # ---------------------------------------------------------------------------
 # LLMClient.invoke / invoke_stream — NotFoundError handling
 # ---------------------------------------------------------------------------

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -755,6 +755,7 @@ def test_create_llm_client_missing_api_key_raises_runtime_error(monkeypatch) -> 
     finally:
         llm_client.reset_llm_singletons()
 
+
 # ---------------------------------------------------------------------------
 # LLMClient.invoke / invoke_stream — NotFoundError handling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_create_llm_client` called `LLMSettings.from_env()` with no exception handling; when a required API key (e.g. `ANTHROPIC_API_KEY`) is absent, Pydantic raises a `ValidationError` that propagated uncaught through `get_llm_for_tools()` into the LangGraph node, causing `run_investigation failed` with an opaque traceback.
- Wrap `LLMSettings.from_env()` in `try/except ValidationError` and re-raise as `RuntimeError(str(exc))` — consistent with how `AuthenticationError`, `NotFoundError`, and rate-limit errors are surfaced elsewhere in the file.
- Added a regression test: `test_create_llm_client_missing_api_key_raises_runtime_error`.

## Test plan

- [x] `uv run pytest tests/services/test_llm_client.py` — 40 passed
- [x] `ruff check app/services/llm_client.py` — no issues
- [x] `mypy app/services/llm_client.py` — no issues

Closes #1678

https://claude.ai/code/session_01ArYmUKLXUKx3kzvTjFwi7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArYmUKLXUKx3kzvTjFwi7D)_