### PR TITLE
Fix LangGraph config adapter typing

### DIFF
--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from typing import Any, cast
 
+from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
@@ -38,10 +39,12 @@ from app.types.config import NodeConfig
 NodeWithConfig = Callable[[AgentState, NodeConfig | None], dict[str, Any]]
 
 
-def _accept_langgraph_config(func: NodeWithConfig) -> Callable[..., dict[str, Any]]:
+def _accept_langgraph_config(
+    func: NodeWithConfig,
+) -> Callable[[AgentState, RunnableConfig | None], dict[str, Any]]:
     """Adapt a NodeConfig-typed node for LangGraph runtime injection."""
 
-    def _wrapped(state: AgentState, config: Any = None) -> dict[str, Any]:
+    def _wrapped(state: AgentState, config: RunnableConfig | None = None) -> dict[str, Any]:
         return func(state, cast(NodeConfig | None, config))
 
     _wrapped.__name__ = func.__name__

--- a/tests/pipeline/test_graph_config_adapter.py
+++ b/tests/pipeline/test_graph_config_adapter.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import warnings
+
+from app.pipeline.graph import build_graph
+
+
+def test_build_graph_does_not_warn_about_config_annotation() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        build_graph()
+
+    assert not any(
+        "config' parameter should be typed as 'RunnableConfig'" in str(warning.message)
+        for warning in captured
+    )

--- a/tests/types/test_config.py
+++ b/tests/types/test_config.py
@@ -18,12 +18,11 @@ def test_get_configurable_tolerates_missing_or_invalid_configurable() -> None:
     assert get_configurable(cast(NodeConfig, {"configurable": None})) == {}
 
 
-def test_core_nodes_do_not_import_runnable_config() -> None:
+def test_core_nodes_and_runners_do_not_import_runnable_config() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     targets = [
         repo_root / "app" / "nodes",
         repo_root / "app" / "pipeline" / "runners.py",
-        repo_root / "app" / "pipeline" / "graph.py",
     ]
     banned = ("RunnableConfig", "langchain_core.runnables")
     offenders: list[str] = []


### PR DESCRIPTION
Fixes #1681 

#### Describe the changes you have made in this PR -

- Typed the LangGraph boundary adapter's `config` parameter as `RunnableConfig | None`, which matches LangGraph's expected node signature and removes the repeated config annotation warnings during graph construction.
- Preserved OpenSRE's internal `NodeConfig` abstraction by casting only inside `_accept_langgraph_config()`, so core node signatures do not need to import LangGraph/LangChain runtime types.
- Narrowed the existing `RunnableConfig` import guard so it still prevents framework types from leaking into core nodes and runners, while allowing the graph adapter to use the framework boundary type.
- Added regression coverage that builds the graph under warning capture and verifies the LangGraph config annotation warning is no longer emitted.

### Demo/Screenshot for feature changes and bug fixes -

Focused tests:

```powershell
.\.venv\Scripts\python.exe -m pytest tests\pipeline\test_graph_config_adapter.py tests\types\test_config.py
```

Result:

```text
4 passed
```

The repeated warnings like this are no longer emitted:

```text
UserWarning: The 'config' parameter should be typed as 'RunnableConfig' or 'RunnableConfig | None', not 'typing.Any'.
```

Note: the command still emits a separate pre-existing LangGraph deprecation warning from `app/pipeline/routing.py` about importing `Send` from `langgraph.constants`; that is unrelated to this fix.
