### PR TITLE
feat(cli): two-tone ASCII art — highlight fill, brand shadow

### DIFF
--- a/app/cli/interactive_shell/banner.py
+++ b/app/cli/interactive_shell/banner.py
@@ -199,7 +199,8 @@ def render_splash(console: Console | None = None, *, first_run: bool | None = No
     for line in art.splitlines():
         t = Text()
         t.append("  ")
-        t.append(line, style=f"bold {HIGHLIGHT}")
+        for ch in line:
+            t.append(ch, style=f"bold {HIGHLIGHT}" if ch == "█" else f"bold {BRAND}")
         console.print(t)
 
     console.print()


### PR DESCRIPTION
Render splash art character-by-character so full-block characters (█) use HIGHLIGHT (#B9EDAF) and border/shadow glyphs use BRAND (#66A17D), giving the logo depth without changing its shape or font.