### PR TITLE
docs(helm): add Helm CLI integration guide and env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,16 @@ ARGOCD_VERIFY_SSL=true
 # ARGOCD_INSTANCES='[{"name":"prod","base_url":"https://argocd.example.com","bearer_token":"***","project":"default"}]'
 ARGOCD_INSTANCES=
 
+# Helm 3 (read-only CLI — list/status/history/get values/get manifest)
+# Requires OSRE_HELM_INTEGRATION=1 (or true/yes) to activate from env.
+OSRE_HELM_INTEGRATION=
+HELM_PATH=helm
+HELM_KUBE_CONTEXT=
+HELM_KUBECONFIG=
+HELM_NAMESPACE=
+# Optional: cap manifest size from helm get manifest (integer, min 1024; default 600000).
+# HELM_MANIFEST_MAX_CHARS=
+
 # Datadog
 DD_API_KEY=
 DD_APP_KEY=

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,8 +113,8 @@
               "bitbucket",
               "github",
               "gitlab",
-              "helm",
               "google-docs",
+              "helm",
               "jira",
               "vercel"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,6 +113,7 @@
               "bitbucket",
               "github",
               "gitlab",
+              "helm",
               "google-docs",
               "jira",
               "vercel"

--- a/docs/helm.mdx
+++ b/docs/helm.mdx
@@ -1,0 +1,171 @@
+---
+title: "Helm (CLI)"
+description: "Connect Helm 3 so OpenSRE can list releases, inspect status and history, and read rendered values and manifests during Kubernetes investigations"
+---
+
+OpenSRE runs the **Helm 3** command-line client on the machine where the agent executes. It uses **read-only** subcommands (`helm list`, `helm status`, `helm history`, `helm get values`, `helm get manifest`) with explicit `--kube-context` and `--kubeconfig` flags so investigations target the same cluster your engineers use.
+
+<Note>
+  **Helm 2 is not supported.** Verification checks `helm version --client` and requires a Helm **3.x** client.
+</Note>
+
+## Prerequisites
+
+- **Helm 3** installed and on `PATH` (or configured via `helm_path`)
+- **`kubectl` access** to the cluster (kubeconfig on disk or in the default search path)
+- Optional: alert annotations or Kubernetes labels that identify a Helm release and namespace (see [Usage in investigations](#usage-in-investigations))
+
+## Setup
+
+Configure Helm like other local integrations: environment variables and/or `~/.config/opensre/integrations.json`.
+
+### Option 1: Environment variables
+
+Enable the integration and point it at your cluster:
+
+```bash
+# Required gate — set to 1, true, or yes
+OSRE_HELM_INTEGRATION=1
+
+# Optional overrides (defaults shown where applicable)
+HELM_PATH=helm
+HELM_KUBE_CONTEXT=
+HELM_KUBECONFIG=
+# Default namespace hint when the alert does not specify one
+HELM_NAMESPACE=
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OSRE_HELM_INTEGRATION` | — | **Required** to activate Helm from env. Must be `1`, `true`, or `yes` (case-insensitive). |
+| `HELM_PATH` | `helm` | Helm binary name or absolute path. |
+| `HELM_KUBE_CONTEXT` | — | Passed to every Helm invocation as `--kube-context`. |
+| `HELM_KUBECONFIG` | — | Passed as `--kubeconfig` (path to the kubeconfig file). |
+| `HELM_NAMESPACE` | — | `default_namespace` in the resolved integration; used as a fallback namespace when the alert does not supply one. |
+
+To raise the maximum size of stored manifest text (see [Advanced](#advanced)):
+
+```bash
+# Integer, minimum 1024; default in code is 600_000 characters
+HELM_MANIFEST_MAX_CHARS=600000
+```
+
+### Option 2: Persistent store
+
+Add an active `helm` record to `~/.config/opensre/integrations.json`:
+
+```json
+{
+  "version": 1,
+  "integrations": [
+    {
+      "id": "helm-prod",
+      "service": "helm",
+      "status": "active",
+      "credentials": {
+        "helm_path": "helm",
+        "kube_context": "prod-admin",
+        "kubeconfig": "",
+        "default_namespace": "production"
+      }
+    }
+  ]
+}
+```
+
+**Credential field aliases** (store / API compatibility): `context` for `kube_context`, `kubeconfig_path` or `kube_config` for `kubeconfig`, and `namespace` for `default_namespace`.
+
+## Verify
+
+```bash
+opensre integrations verify helm
+```
+
+A passing check runs `helm version --client` (must report Helm 3) and a minimal `helm list -A --max 1 -o json` against your cluster to validate JSON output and reachability.
+
+## Usage in investigations
+
+When Helm is configured, OpenSRE adds a `helm` entry to `detect_sources` only if the alert shows **Helm-specific** context — avoiding generic “deployment” noise.
+
+**Annotations** (including top-level enriched fields merged into annotations):
+
+| Key | Purpose |
+| --- | --- |
+| `helm_release` / `helm_release_name` | Release name |
+| `helm_namespace` | Namespace hint |
+| `helm_chart`, `helm_revision` | Extra Helm signals |
+| Keys prefixed with `meta.helm.sh/` | Treated as Helm metadata |
+
+**Labels** (from Prometheus/Alertmanager-style `labels` / `commonLabels` on the alert payload):
+
+| Label | Purpose |
+| --- | --- |
+| `meta.helm.sh/release-name` | Release name |
+| `meta.helm.sh/release-namespace` | Namespace paired with the release |
+
+**Alert text:** Strong phrases such as `helm upgrade`, `helm install`, `helm rollback`, `helm chart`, or `helm release` in `summary` / `description` / `message` (or top-level `alert_name` / `error_message`) can also enable the Helm source when other hints are absent.
+
+**Top-level payload fields** (dict alerts only): `helm_release`, `helm_release_name`, `helm_namespace`, etc., are consulted as fallbacks.
+
+Example minimal alert:
+
+```json
+{
+  "labels": {
+    "meta.helm.sh/release-name": "my-api",
+    "meta.helm.sh/release-namespace": "prod"
+  },
+  "annotations": {
+    "summary": "Errors after helm upgrade"
+  }
+}
+```
+
+Then run:
+
+```bash
+opensre investigate -i alert.json
+```
+
+## Investigation tools
+
+| Tool | What it does |
+| --- | --- |
+| `helm_list_releases` | Lists releases (JSON from `helm list`); uses all namespaces when no namespace filter is set. |
+| `helm_release_status` | `helm status -o json` for one release. |
+| `helm_release_history` | `helm history -o json` for one release. |
+| `helm_get_release_values` | `helm get values -o json` (user-supplied values; JSON `null` from Helm is treated as an empty object). |
+| `helm_get_release_manifest` | Rendered manifest YAML (may be truncated; see below). |
+
+## Evidence keys
+
+Post-processing writes **distinct** evidence keys so parallel tools do not overwrite each other:
+
+| Evidence key | Content |
+| --- | --- |
+| `helm_releases` | Parsed release list |
+| `helm_release_status` | Status object from `helm status` |
+| `helm_release_history` | Revision history array |
+| `helm_release_values` | Values object |
+| `helm_release_manifest` | Manifest string (`helm_manifest_truncated` when capped) |
+
+## Advanced
+
+- **Manifest size:** Very large charts can produce multi-megabyte manifests. The client truncates manifest text by default; override with `HELM_MANIFEST_MAX_CHARS` (see Option 1).
+- **Local kind demo:** From a repo checkout with Docker, kind, kubectl, and Helm installed, run `./scripts/demo-helm-kind.sh` to create a sample cluster and release (see script comments for teardown).
+
+## Security and operations
+
+- The integration is **read-only**: it does not `install`, `upgrade`, or `uninstall` releases.
+- `helm get values` output can include **secrets**; treat evidence like any other sensitive kubectl/Helm output.
+- Prefer a dedicated kubeconfig or context with **least privilege** if your policy requires it.
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| **Verify: missing** | Helm not in store / env gate `OSRE_HELM_INTEGRATION` not set / invalid JSON store entry. |
+| **Verify: Helm 3 required** | Upgrade to Helm 3 or point `helm_path` at a v3 binary. |
+| **Verify: list JSON / cluster** | kubeconfig and context; cluster reachable with `helm list -A` manually. |
+| **No Helm tools in plan** | Alert must include Helm annotations, `meta.helm.sh/*` labels, or strong Helm phrases (see above). |
+| **Wrong namespace / release not found** | Ensure `meta.helm.sh/release-namespace` or `helm_namespace` / `k8s_namespace` annotations match the release; set `default_namespace` in config when alerts lack namespace. |

--- a/docs/helm.mdx
+++ b/docs/helm.mdx
@@ -147,7 +147,8 @@ Post-processing writes **distinct** evidence keys so parallel tools do not overw
 | `helm_release_status` | Status object from `helm status` |
 | `helm_release_history` | Revision history array |
 | `helm_release_values` | Values object |
-| `helm_release_manifest` | Manifest string (`helm_manifest_truncated` when capped) |
+| `helm_release_manifest` | Rendered manifest YAML **string**; unchanged key name. When the manifest exceeds the size cap, this value is **truncated** text, not a separate key. |
+| `helm_manifest_truncated` | Boolean: `true` when `helm_release_manifest` was truncated because of `HELM_MANIFEST_MAX_CHARS` / the client default cap. |
 
 ## Advanced
 

--- a/docs/integrations-overview.mdx
+++ b/docs/integrations-overview.mdx
@@ -53,6 +53,7 @@ Or set environment variables and OpenSRE picks them up automatically.
 | **Observability** | [Better Stack](/betterstack), [Honeycomb](/honeycomb), [Coralogix](/coralogix), [Sentry](/sentry) |
 | **Databases** | [MongoDB](/mongodb), [MariaDB](/mariadb), [ClickHouse](/clickhouse), [Kafka](/kafka) |
 | **Source control** | [GitHub](/github), [GitLab](/gitlab), [Bitbucket](/bitbucket) |
+| **Kubernetes releases** | [Helm](/helm) |
 | **Deployments** | [Vercel](/vercel) |
 | **Orchestration** | [Prefect](/prefect) |
 | **Incident management** | [OpsGenie](/opsgenie), [Jira](/jira) |


### PR DESCRIPTION
Fixes #1684
#### Describe the changes you have made in this PR
- Added **`docs/helm.mdx`**: user-facing guide for the Helm 3 CLI integration — prerequisites (Helm 3 only), env-based activation (`OSRE_HELM_INTEGRATION`, `HELM_PATH`, `HELM_KUBE_CONTEXT`, `HELM_KUBECONFIG`, `HELM_NAMESPACE`, optional `HELM_MANIFEST_MAX_CHARS`), persistent store JSON and credential field aliases, `opensre integrations verify helm`, how `detect_sources` enables Helm (annotations, `meta.helm.sh/*` labels, phrases), investigation tools and evidence keys, local `./scripts/demo-helm-kind.sh` pointer, security notes, and troubleshooting.
- Registered the page in **`docs/docs.json`** under Integrations → Cloud, code, and collaboration.
- Linked Helm from **`docs/integrations-overview.mdx`** (Kubernetes releases row).
- Extended **`.env.example`** with a commented Helm block so operators see the same variables in the template.
No runtime / app code changes — documentation and env example only.

---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)
**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions
**Explain your implementation approach:**
The issue asked for Helm CLI documentation and configuration pointers after the integration landed in code (see PR #1657). I mirrored the structure of existing integration guides (e.g. Argo CD): front matter, prerequisites, env vs store setup, verify command, investigation behavior, evidence keys, and operational notes. Wording was checked against the actual catalog/classifier and `HelmIntegrationConfig` / env gate behavior on `main` so field names and aliases match what OpenSRE resolves. The integrations overview table and `docs.json` navigation were updated so the page is discoverable. `.env.example` was updated in parallel so the template matches the documented variables.
---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added** *(N/A — prose/docs only; no new application code)*
- [x] I understand why my changes work and have tested them thoroughly *(content reviewed against `main`; links and filenames validated)*
- [x] I have considered potential edge cases and how my code handles them *(documented Helm 3-only behavior, env gate, aliases, troubleshooting)*
- [ ] If it is a core feature, I have added thorough tests *(not applicable — documentation only)*
- [x] My code follows the project's style guidelines and conventions
---