### PR TITLE
fix: detect Anthropic overloaded_error from SSE stream body in invoke_stream

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -431,7 +431,12 @@ def _format_anthropic_retry_error(err: Exception) -> str:
             "Anthropic API connection failed after multiple retries. "
             "Check network access and try again."
         )
-    if status_code == 529:
+    # Detect overloaded via HTTP status (error-response path) or via body error
+    # type (SSE streaming path: the SDK raises APIStatusError from body events
+    # where the initial HTTP response was 200, so status_code is absent/not 529).
+    body = getattr(err, "body", None)
+    body_error_type = body.get("error", {}).get("type", "") if isinstance(body, dict) else ""
+    if status_code == 529 or body_error_type == "overloaded_error":
         return (
             "Anthropic API is overloaded (HTTP 529) after multiple retries. "
             "Try again in a few seconds."

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -435,7 +435,8 @@ def _format_anthropic_retry_error(err: Exception) -> str:
     # type (SSE streaming path: the SDK raises APIStatusError from body events
     # where the initial HTTP response was 200, so status_code is absent/not 529).
     body = getattr(err, "body", None)
-    body_error_type = body.get("error", {}).get("type", "") if isinstance(body, dict) else ""
+    error_obj = body.get("error") if isinstance(body, dict) else None
+    body_error_type = error_obj.get("type", "") if isinstance(error_obj, dict) else ""
     if status_code == 529 or body_error_type == "overloaded_error":
         return (
             "Anthropic API is overloaded (HTTP 529) after multiple retries. "

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -519,6 +519,18 @@ def test_anthropic_invoke_stream_overloaded_via_body_raises_friendly_error(
         list(client.invoke_stream("hi"))
 
 
+def test_format_anthropic_retry_error_handles_non_dict_body_error() -> None:
+    """Unexpected Anthropic body shapes should not mask the original error class."""
+
+    class _ApiStatusError(Exception):
+        body = {"error": "overloaded_error"}
+
+    assert (
+        llm_client._format_anthropic_retry_error(_ApiStatusError())
+        == "Anthropic API request failed after multiple retries: _ApiStatusError."
+    )
+
+
 # ---------------------------------------------------------------------------
 # OpenAILLMClient.invoke / invoke_stream — kwargs builder + streaming behavior
 # ---------------------------------------------------------------------------

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -475,6 +475,50 @@ def test_anthropic_invoke_stream_does_not_retry_after_yielding(monkeypatch) -> N
     assert len(attempts) == 1, "Must not retry after emitting any chunk"
 
 
+def test_anthropic_invoke_stream_overloaded_via_body_raises_friendly_error(
+    monkeypatch,
+) -> None:
+    """APIStatusError with overloaded_error body (SSE path, no HTTP 529) raises the
+    friendly overloaded message, not the raw 'APIStatusError' class name."""
+
+    class _OverloadedBodyError(Exception):
+        """Simulates APIStatusError raised from the SSE stream body (status_code absent)."""
+
+        def __init__(self) -> None:
+            super().__init__("Overloaded")
+            self.body = {"error": {"type": "overloaded_error", "message": "Overloaded"}}
+
+    def _yield_overloaded():
+        raise _OverloadedBodyError()
+        yield  # make it a generator
+
+    class _Stream:
+        def __init__(self) -> None:
+            self.text_stream = _yield_overloaded()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    class _Messages:
+        def stream(self, **_kwargs):
+            return _Stream()
+
+    class _Anthropic:
+        def __init__(self, **_kwargs) -> None:
+            self.messages = _Messages()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "Anthropic", _Anthropic)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda _s: None)
+
+    client = llm_client.LLMClient(model="claude-test")
+    with pytest.raises(RuntimeError, match="overloaded"):
+        list(client.invoke_stream("hi"))
+
+
 # ---------------------------------------------------------------------------
 # OpenAILLMClient.invoke / invoke_stream — kwargs builder + streaming behavior
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause (Sentry #1694 / PYTHON-1E):** In the streaming path (`invoke_stream`), the Anthropic SDK raises `APIStatusError` from SSE body error events. Because the HTTP response was already `200 OK`, `status_code` is not `529`, so the existing `if status_code == 529` check in `_format_anthropic_retry_error` was bypassed. The user saw the raw class name — `"Anthropic API request failed after multiple retries: APIStatusError."` — instead of the friendly overloaded message.
- **Fix:** Also inspect `err.body["error"]["type"]` for `"overloaded_error"` so both the HTTP-error path (`status_code == 529`) and the SSE-stream-body path produce the human-readable `"Anthropic API is overloaded (HTTP 529) after multiple retries."` message.
- **Test:** Added `test_anthropic_invoke_stream_overloaded_via_body_raises_friendly_error` which simulates an `APIStatusError` carrying only a body (no `status_code`) and asserts the friendly "overloaded" message is raised.

Issues #1695, #1696 (SSL `WRONG_VERSION_NUMBER`) and #1669, #1670 (OpenAI insufficient quota) are external service/config failures with no actionable code fix.

## Test plan

- [x] `uv run pytest tests/services/test_llm_client.py` — all 41 tests pass
- [x] `ruff check` and `ruff format --check` — clean
- [x] `mypy app/services/llm_client.py` — no issues

Closes #1694

https://claude.ai/code/session_013auyd8qGCv5dchqaJGcXH3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013auyd8qGCv5dchqaJGcXH3)_