### PR TITLE
fix(doctor): check keyring as fallback when env var missing

### DIFF
--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -103,9 +103,11 @@ def _check_llm_provider() -> tuple[bool, str]:
             return False, f"provider={provider}, CLI auth status unclear ({probe.detail})"
         return True, f"provider={provider}, CLI ready ({probe.detail})"
 
+    from app.llm_credentials import has_llm_api_key
+
     expected_key = key_vars.get(provider)
-    if expected_key and not os.getenv(expected_key):
-        return False, f"provider={provider}, but {expected_key} is not set"
+    if expected_key and not has_llm_api_key(expected_key):
+        return False, f"provider={provider}, {expected_key} not found in environment or keyring"
     return True, f"provider={provider}"
 
 


### PR DESCRIPTION
## Summary

_check_llm_provider() used os.getenv() to check for the active LLM provider API key, so it warned "provider=gemini, but GEMINI_API_KEY is not set" even when the key was stored in the system keyring via opensre onboard.

## Fix

Replaced os.getenv(expected_key) with has_llm_api_key(expected_key), which resolves keys from env first then falls back to the system keyring -- the same path used by runtime and onboarding.

Also improved the error message to distinguish "not found in environment or keyring" from simply "not set in env".

## Diff

```diff
--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -96,8 +96,9 @@ def _check_llm_provider() -> tuple[bool, str]:
         return True, f"provider={provider}, CLI ready ({probe.detail})"

     from app.llm_credentials import has_llm_api_key

     expected_key = key_vars.get(provider)
-    if expected_key and not os.getenv(expected_key):
-        return False, f"provider={provider}, but {expected_key} is not set"
+    if expected_key and not has_llm_api_key(expected_key):
+        return False, f"provider={provider}, {expected_key} not found in environment or keyring"
     return True, f"provider={provider}"
```

## Issue

Fixes #1686