### PR TITLE
fix(catalog): log warning when integration validation fails

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -162,7 +162,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if not grafana_config.endpoint:
             return None, None
@@ -194,7 +195,8 @@ def _classify_service_instance(
                 AWSIntegrationConfig.model_validate(raw_config).model_dump(exclude_none=True),
                 "aws",
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
 
     if key == "datadog":
@@ -207,7 +209,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if datadog_config.api_key and datadog_config.app_key:
             return datadog_config.model_dump(), "datadog"
@@ -223,7 +226,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if honeycomb_config.api_key:
             return honeycomb_config.model_dump(), "honeycomb"
@@ -240,7 +244,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if coralogix_config.api_key:
             return coralogix_config.model_dump(), "coralogix"
@@ -259,7 +264,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         return github_config.model_dump(), "github"
 
@@ -274,7 +280,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if sentry_config.organization_slug and sentry_config.auth_token:
             return sentry_config.model_dump(), "sentry"
@@ -288,7 +295,8 @@ def _classify_service_instance(
                     "auth_token": credentials.get("auth_token", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         return gitlab_config.model_dump(), "gitlab"
 
@@ -302,7 +310,8 @@ def _classify_service_instance(
                     "tls": credentials.get("tls", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if mongodb_config.connection_string:
             return mongodb_config.model_dump(), "mongodb"
@@ -320,7 +329,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "prefer"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if postgresql_config.host and postgresql_config.database:
             return postgresql_config.model_dump(), "postgresql"
@@ -338,7 +348,8 @@ def _classify_service_instance(
                     ),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if atlas_config.api_public_key and atlas_config.api_private_key and atlas_config.project_id:
             return {
@@ -362,7 +373,8 @@ def _classify_service_instance(
                     "ssl": credentials.get("ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if mariadb_config.host and mariadb_config.database:
             return {
@@ -385,7 +397,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if vercel_config.api_token:
             return vercel_config.model_dump(), "vercel"
@@ -400,7 +413,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if opsgenie_config.api_key:
             return opsgenie_config.model_dump(), "opsgenie"
@@ -417,7 +431,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if jira_config.base_url and jira_config.email and jira_config.api_token:
             return jira_config.model_dump(), "jira"
@@ -433,7 +448,8 @@ def _classify_service_instance(
                     "default_channel_id": credentials.get("default_channel_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if discord_config.bot_token:
             return discord_config.model_dump(), "discord"
@@ -447,7 +463,8 @@ def _classify_service_instance(
                     "default_chat_id": credentials.get("default_chat_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if tg_config.bot_token:
             return tg_config.model_dump(), "telegram"
@@ -465,7 +482,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if openclaw_config.is_configured:
             return openclaw_config.model_dump(), "openclaw"
@@ -483,7 +501,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "preferred"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if mysql_config.host and mysql_config.database:
             return {
@@ -510,7 +529,8 @@ def _classify_service_instance(
                     "verify_ssl": credentials.get("verify_ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if rabbitmq_config.host and rabbitmq_config.username:
             return {
@@ -533,7 +553,8 @@ def _classify_service_instance(
                     "region": credentials.get("region", DEFAULT_RDS_REGION),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if rds_config.is_configured:
             return {**rds_config.model_dump(), "integration_id": record_id}, "rds"
@@ -552,7 +573,8 @@ def _classify_service_instance(
                     "max_results": credentials.get("max_results", 50),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if airflow_config.is_configured:
             return {
@@ -571,7 +593,8 @@ def _classify_service_instance(
                     "sources": credentials.get("sources", []),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if bs_config.query_endpoint and bs_config.username:
             return {
@@ -596,7 +619,8 @@ def _classify_service_instance(
                     "encrypt": credentials.get("encrypt", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if azure_sql_config.server and azure_sql_config.database:
             return azure_sql_config.model_dump(), "azure_sql"
@@ -613,7 +637,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if alertmanager_config.base_url:
             return alertmanager_config.model_dump(), "alertmanager"
@@ -635,7 +660,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if argocd_config.base_url and (
             argocd_config.bearer_token or (argocd_config.username and argocd_config.password)
@@ -658,7 +684,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         return helm_config.model_dump(), "helm"
 
@@ -671,7 +698,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if victoria_logs_config.base_url:
             return victoria_logs_config.model_dump(), "victoria_logs"
@@ -780,7 +808,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
             return None, None
         if splunk_config.base_url and splunk_config.token:
             return splunk_config.model_dump(), "splunk"


### PR DESCRIPTION
## Summary

Fixes silent exception swallowing in `_classify_service_instance()` in `app/integrations/_catalog_impl.py`.

**Problem:** All 29 service classifiers (`grafana`, `aws`, `datadog`, etc.) wrapped their `Pydantic` model validation in bare `except Exception:` blocks that returned `None, None` with no logging. When a user misconfigured an integration — e.g. malformed URL, wrong field type, missing required field — the `ValidationError` was silently dropped. The integration would simply be absent from the active list with no trace in any log.

**Fix:** Replace each bare `except Exception:` with:

```python
except Exception as exc:
    logger.warning("Failed to validate %s integration %s: %s", key, record_id, exc)
    return None, None
```

This gives operators visibility into misconfigured integrations without changing the runtime behaviour (integration is still skipped, just now with a warning).

## Changes

- `app/integrations/_catalog_impl.py`: +58/-29 lines
  - 29 `except Exception:` blocks in `_classify_service_instance()` now log a warning with the integration key, `record_id`, and exception message before returning `None, None`

## Testing

```bash
# Should log a warning when an integration has invalid config
python -c "
from app.integrations._catalog_impl import _classify_service_instance
import logging
logging.basicConfig(level='WARNING')
_classify_service_instance('grafana', {'endpoint': 'not-a-url', 'api_key': 12345}, record_id='test-1')
"  # expected: WARNING - Failed to validate grafana integration test-1: ...
```

Fixes: #1554
