### PR TITLE
feat: agent_incident synthesizer and graph entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1405,6 +1405,13 @@ Thanks goes to these amazing people:
             <sub><b>VibhorGautam</b></sub>
         </a>
     </td>
+            <td align="center" width="8%">
+        <a href="https://github.com/samdiano">
+            <img src="https://avatars.githubusercontent.com/u/27571135?v=4" width="45" alt="samdiano"/>
+            <br />
+            <sub><b>samdiano</b></sub>
+        </a>
+    </td>
 		</tr>
 	</tbody>
 </table>

--- a/app/nodes/__init__.py
+++ b/app/nodes/__init__.py
@@ -1,6 +1,7 @@
 """LangGraph nodes for investigation workflow."""
 
 from app.nodes.adapt_window import node_adapt_window
+from app.nodes.agent_incident import node_agent_incident
 from app.nodes.extract_alert import node_extract_alert
 from app.nodes.plan_actions.node import node_plan_actions
 from app.nodes.publish_findings import node_publish_findings
@@ -9,6 +10,7 @@ from app.nodes.root_cause_diagnosis import node_diagnose_root_cause
 
 __all__ = [
     "node_adapt_window",
+    "node_agent_incident",
     "node_diagnose_root_cause",
     "node_extract_alert",
     "node_plan_actions",

--- a/app/nodes/agent_incident/__init__.py
+++ b/app/nodes/agent_incident/__init__.py
@@ -1,0 +1,5 @@
+"""Agent fleet incident synthesizer entry node for the investigation graph."""
+
+from app.nodes.agent_incident.node import node_agent_incident
+
+__all__ = ["node_agent_incident"]

--- a/app/nodes/agent_incident/node.py
+++ b/app/nodes/agent_incident/node.py
@@ -1,0 +1,142 @@
+"""Synthesize a structured alert from local agent-fleet SLO breaches.
+
+``node_agent_incident`` is a sibling entry to ``node_extract_alert``: both feed the
+same ``route_after_extract → resolve_integrations → …`` path. This node skips the
+LLM-based extractor and builds :class:`~app.nodes.extract_alert.models.AlertDetails`
+deterministically from ``context["agent_incident"]`` (see
+:func:`app.state.factory.make_agent_incident_state`).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from langsmith import traceable
+
+from app.alerts import normalize_alert_payload
+from app.incident_window import resolve_incident_window
+from app.nodes.extract_alert.models import AlertDetails
+from app.output import debug_print, get_tracker, render_investigation_header
+from app.state import InvestigationState
+from app.types.config import NodeConfig
+
+_AGENT_INCIDENT_SOURCE = "agent_incident"
+
+
+def _extract_payload(state: InvestigationState) -> dict[str, Any] | None:
+    """Return the agent-incident payload dict or ``None`` if missing/invalid."""
+    ctx = state.get("context", {}) or {}
+    if not isinstance(ctx, dict):
+        return None
+    raw = ctx.get("agent_incident")
+    if not isinstance(raw, dict):
+        return None
+    name = str(raw.get("agent_name", "")).strip()
+    reason = str(raw.get("breach_reason", "")).strip()
+    if not name or not reason:
+        return None
+    return raw
+
+
+def _make_problem_md(details: AlertDetails, payload: dict[str, Any]) -> str:
+    pid = payload.get("pid", "")
+    parts = [
+        f"# {details.alert_name}",
+        f"Pipeline: {details.pipeline_name} | Severity: {details.severity}",
+        f"Source: {_AGENT_INCIDENT_SOURCE} | Agent: {payload.get('agent_name')} (pid {pid})",
+    ]
+    if details.error_message:
+        parts.append(f"\n**Breach:** {details.error_message}")
+    tail = str(payload.get("stdout_tail") or "").strip()
+    if tail:
+        snippet = tail[-4000:] if len(tail) > 4000 else tail
+        parts.append(f"\n## Recent output\n```\n{snippet}\n```")
+    snap = payload.get("resource_snapshot")
+    if isinstance(snap, dict) and snap:
+        try:
+            snap_txt = json.dumps(snap, indent=2, default=str)[:2000]
+        except (TypeError, ValueError):
+            snap_txt = str(snap)[:2000]
+        parts.append(f"\n## Resource snapshot\n```json\n{snap_txt}\n```")
+    return "\n".join(parts)
+
+
+@traceable(name="node_agent_incident")
+def node_agent_incident(
+    state: InvestigationState, config: NodeConfig | None = None
+) -> dict[str, Any]:
+    """Build investigation state fields usually produced by ``extract_alert`` without an LLM call."""
+    del config
+    tracker = get_tracker()
+    tracker.start("agent_incident", "Synthesizing alert from agent fleet incident")
+
+    payload = _extract_payload(state)
+    if payload is None:
+        debug_print("agent_incident: missing context.agent_incident — classifying as noise")
+        tracker.complete("agent_incident", fields_updated=["is_noise"])
+        return {"is_noise": True}
+
+    agent_name = str(payload.get("agent_name", "")).strip()
+    breach_reason = str(payload.get("breach_reason", "")).strip()
+    pid = payload.get("pid", "")
+    pid_display = str(pid) if pid != "" else "-"
+
+    alert_name = f"{agent_name} (pid {pid_display}) — agent incident"
+    details = AlertDetails(
+        is_noise=False,
+        alert_name=alert_name,
+        pipeline_name="local_agent_fleet",
+        severity="warning",
+        alert_source=_AGENT_INCIDENT_SOURCE,
+        summary=breach_reason[:500] if breach_reason else None,
+        error_message=breach_reason,
+    )
+
+    raw_alert: dict[str, Any] = {
+        "alert_source": _AGENT_INCIDENT_SOURCE,
+        "alert_name": alert_name,
+        "severity": details.severity,
+        "error_message": breach_reason,
+        "annotations": {
+            "summary": f"Local agent {agent_name} breached SLO: {breach_reason}",
+        },
+        "agent_incident": dict(payload),
+    }
+    raw_alert = normalize_alert_payload(raw_alert)
+
+    debug_print(
+        f"agent_incident: {alert_name} | breach={breach_reason[:120]!r}",
+    )
+    render_investigation_header(details.alert_name, details.pipeline_name, details.severity)
+
+    tracker.complete(
+        "agent_incident",
+        fields_updated=[
+            "is_noise",
+            "alert_name",
+            "pipeline_name",
+            "severity",
+            "alert_source",
+            "alert_json",
+            "problem_md",
+            "raw_alert",
+            "incident_window",
+        ],
+    )
+
+    result: dict[str, Any] = {
+        "is_noise": False,
+        "alert_name": details.alert_name,
+        "pipeline_name": details.pipeline_name,
+        "severity": details.severity,
+        "alert_source": _AGENT_INCIDENT_SOURCE,
+        "alert_json": details.model_dump(),
+        "raw_alert": raw_alert,
+        "problem_md": _make_problem_md(details, payload),
+        "incident_window": resolve_incident_window(raw_alert).to_dict(),
+    }
+    if not state.get("investigation_started_at"):
+        result["investigation_started_at"] = time.monotonic()
+    return result

--- a/app/nodes/agent_incident/node.py
+++ b/app/nodes/agent_incident/node.py
@@ -111,6 +111,19 @@ def node_agent_incident(
     )
     render_investigation_header(details.alert_name, details.pipeline_name, details.severity)
 
+    result: dict[str, Any] = {
+        "is_noise": False,
+        "alert_name": details.alert_name,
+        "pipeline_name": details.pipeline_name,
+        "severity": details.severity,
+        "alert_source": _AGENT_INCIDENT_SOURCE,
+        "alert_json": details.model_dump(),
+        "raw_alert": raw_alert,
+        "problem_md": _make_problem_md(details, payload),
+        "incident_window": resolve_incident_window(raw_alert).to_dict(),
+    }
+    if not state.get("investigation_started_at"):
+        result["investigation_started_at"] = time.monotonic()
     tracker.complete(
         "agent_incident",
         fields_updated=[
@@ -125,18 +138,4 @@ def node_agent_incident(
             "incident_window",
         ],
     )
-
-    result: dict[str, Any] = {
-        "is_noise": False,
-        "alert_name": details.alert_name,
-        "pipeline_name": details.pipeline_name,
-        "severity": details.severity,
-        "alert_source": _AGENT_INCIDENT_SOURCE,
-        "alert_json": details.model_dump(),
-        "raw_alert": raw_alert,
-        "problem_md": _make_problem_md(details, payload),
-        "incident_window": resolve_incident_window(raw_alert).to_dict(),
-    }
-    if not state.get("investigation_started_at"):
-        result["investigation_started_at"] = time.monotonic()
     return result

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -14,6 +14,7 @@ from app.nodes import (
     node_publish_findings,
     node_resolve_integrations,
 )
+from app.nodes.agent_incident import node_agent_incident
 from app.nodes.auth import inject_auth_node
 from app.nodes.chat import (
     chat_agent_node,
@@ -62,6 +63,7 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     graph.add_node("tool_executor", tool_executor_node)
 
     graph.add_node("extract_alert", _accept_langgraph_config(node_extract_alert))
+    graph.add_node("agent_incident", _accept_langgraph_config(node_agent_incident))
     graph.add_node("resolve_integrations", _accept_langgraph_config(node_resolve_integrations))
     graph.add_node("plan_actions", _accept_langgraph_config(node_plan_actions))
     graph.add_node("investigate_hypothesis", node_investigate_hypothesis)
@@ -74,7 +76,13 @@ def build_graph(config: None = None) -> CompiledStateGraph:
     graph.set_entry_point("inject_auth")
 
     graph.add_conditional_edges(
-        "inject_auth", route_by_mode, {"chat": "router", "investigation": "extract_alert"}
+        "inject_auth",
+        route_by_mode,
+        {
+            "chat": "router",
+            "investigation": "extract_alert",
+            "agent_incident": "agent_incident",
+        },
     )
 
     graph.add_conditional_edges(
@@ -88,6 +96,11 @@ def build_graph(config: None = None) -> CompiledStateGraph:
 
     graph.add_conditional_edges(
         "extract_alert", route_after_extract, {"end": END, "investigate": "resolve_integrations"}
+    )
+    graph.add_conditional_edges(
+        "agent_incident",
+        route_after_extract,
+        {"end": END, "investigate": "resolve_integrations"},
     )
     graph.add_edge("resolve_integrations", "plan_actions")
     graph.add_conditional_edges("plan_actions", distribute_hypotheses)

--- a/app/pipeline/graph.py
+++ b/app/pipeline/graph.py
@@ -8,13 +8,13 @@ from langgraph.graph.state import CompiledStateGraph
 
 from app.nodes import (
     node_adapt_window,
+    node_agent_incident,
     node_diagnose_root_cause,
     node_extract_alert,
     node_plan_actions,
     node_publish_findings,
     node_resolve_integrations,
 )
-from app.nodes.agent_incident import node_agent_incident
 from app.nodes.auth import inject_auth_node
 from app.nodes.chat import (
     chat_agent_node,

--- a/app/pipeline/routing.py
+++ b/app/pipeline/routing.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 
 def route_by_mode(state: AgentState) -> str:
     """Route based on agent mode. Defaults to chat when mode is not set."""
-    return "investigation" if state.get("mode") == "investigation" else "chat"
+    mode = state.get("mode")
+    if mode == "investigation":
+        return "investigation"
+    if mode == "agent_incident":
+        return "agent_incident"
+    return "chat"
 
 
 def route_chat(state: AgentState) -> str:

--- a/app/state/__init__.py
+++ b/app/state/__init__.py
@@ -1,7 +1,12 @@
 """Agent state definitions — types, state shape, and factory functions."""
 
 from app.state.agent_state import AgentState, AgentStateModel, InvestigationState
-from app.state.factory import STATE_DEFAULTS, make_chat_state, make_initial_state
+from app.state.factory import (
+    STATE_DEFAULTS,
+    make_agent_incident_state,
+    make_chat_state,
+    make_initial_state,
+)
 from app.state.types import AgentMode, ChatMessage, ChatMessageModel
 
 __all__ = [
@@ -12,6 +17,7 @@ __all__ = [
     "ChatMessageModel",
     "InvestigationState",
     "STATE_DEFAULTS",
+    "make_agent_incident_state",
     "make_chat_state",
     "make_initial_state",
 ]

--- a/app/state/factory.py
+++ b/app/state/factory.py
@@ -93,6 +93,40 @@ def make_initial_state(
     return cast(AgentState, state.model_dump(mode="python", by_alias=True, exclude_none=True))
 
 
+def make_agent_incident_state(
+    *,
+    agent_name: str,
+    breach_reason: str,
+    pid: str | int = "",
+    stdout_tail: str = "",
+    resource_snapshot: dict[str, Any] | None = None,
+    opensre_evaluate: bool = False,
+) -> AgentState:
+    """Create initial state for :func:`node_agent_incident` (local agent fleet SLO breach).
+
+    The synthesizer reads ``context["agent_incident"]``. Callers should populate it
+    with at least ``agent_name`` and ``breach_reason``.
+    """
+    payload: dict[str, Any] = {
+        "agent_name": str(agent_name).strip(),
+        "breach_reason": str(breach_reason).strip(),
+        "pid": pid,
+        "stdout_tail": str(stdout_tail or ""),
+        "resource_snapshot": dict(resource_snapshot or {}),
+    }
+    state = AgentStateModel.model_validate(
+        {
+            "mode": "agent_incident",
+            "raw_alert": {},
+            "context": {"agent_incident": payload},
+            "investigation_started_at": time.monotonic(),
+            "opensre_evaluate": opensre_evaluate,
+            **{k: v for k, v in STATE_DEFAULTS.items() if k not in ("mode", "messages", "context")},
+        }
+    )
+    return cast(AgentState, state.model_dump(mode="python", by_alias=True, exclude_none=True))
+
+
 def make_chat_state(
     org_id: str = "",
     user_id: str = "",

--- a/app/state/types.py
+++ b/app/state/types.py
@@ -9,7 +9,7 @@ from typing_extensions import TypedDict
 
 from app.strict_config import StrictConfigModel
 
-AgentMode = Literal["chat", "investigation"]
+AgentMode = Literal["chat", "investigation", "agent_incident"]
 
 
 class ChatMessage(TypedDict, total=False):

--- a/tests/nodes/agent_incident/__init__.py
+++ b/tests/nodes/agent_incident/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ``agent_incident`` investigation entry node."""

--- a/tests/nodes/agent_incident/test_agent_incident_node.py
+++ b/tests/nodes/agent_incident/test_agent_incident_node.py
@@ -1,0 +1,52 @@
+"""Tests for ``node_agent_incident``."""
+
+from __future__ import annotations
+
+from app.nodes.agent_incident.node import node_agent_incident
+from app.state.factory import make_agent_incident_state
+
+
+def test_agent_incident_returns_noise_without_payload() -> None:
+    state = make_agent_incident_state(agent_name="x", breach_reason="y")
+    state["context"] = {}
+    out = node_agent_incident(state)
+    assert out["is_noise"] is True
+    assert "raw_alert" not in out
+
+
+def test_agent_incident_returns_noise_when_required_fields_blank() -> None:
+    state = make_agent_incident_state(agent_name="", breach_reason="stuck")
+    out = node_agent_incident(state)
+    assert out["is_noise"] is True
+
+    state2 = make_agent_incident_state(agent_name="aider", breach_reason="   ")
+    out2 = node_agent_incident(state2)
+    assert out2["is_noise"] is True
+
+
+def test_agent_incident_synthesizes_investigation_fields() -> None:
+    state = make_agent_incident_state(
+        agent_name="claude-code",
+        breach_reason="no progress for 8m",
+        pid=8421,
+        stdout_tail="line1\nline2\n",
+        resource_snapshot={"cpu_pct": 4.2},
+    )
+    out = node_agent_incident(state)
+    assert out["is_noise"] is False
+    assert out["alert_source"] == "agent_incident"
+    assert "claude-code" in out["alert_name"]
+    assert "8421" in out["alert_name"]
+    assert out["pipeline_name"] == "local_agent_fleet"
+    assert out["severity"] == "warning"
+    assert isinstance(out["raw_alert"], dict)
+    assert out["raw_alert"]["alert_source"] == "agent_incident"
+    assert out["raw_alert"]["agent_incident"]["agent_name"] == "claude-code"
+    assert "problem_md" in out and "Breach:" in out["problem_md"]
+    assert isinstance(out["alert_json"], dict)
+    assert out["alert_json"]["is_noise"] is False
+    iw = out["incident_window"]
+    assert isinstance(iw, dict)
+    assert iw.get("_schema_version") == 1
+    assert iw.get("source") == "default"
+    assert "since" in iw and "until" in iw

--- a/tests/pipeline/__init__.py
+++ b/tests/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for LangGraph pipeline construction and routing."""

--- a/tests/pipeline/test_graph_agent_incident_wiring.py
+++ b/tests/pipeline/test_graph_agent_incident_wiring.py
@@ -1,0 +1,39 @@
+"""Graph wiring for the ``agent_incident`` entry node."""
+
+from __future__ import annotations
+
+from app.pipeline.graph import build_graph
+
+
+def _builder():
+    return build_graph().builder
+
+
+def _branch_ends(source: str, branch_name: str) -> dict[str, str] | None:
+    branches = _builder().branches.get(source, {})
+    branch = branches.get(branch_name)
+    return getattr(branch, "ends", None) if branch is not None else None
+
+
+def _nodes() -> set[str]:
+    return set(_builder().nodes.keys())
+
+
+def test_agent_incident_node_is_registered() -> None:
+    assert "agent_incident" in _nodes()
+
+
+def test_inject_auth_routes_agent_incident_mode() -> None:
+    ends = _branch_ends("inject_auth", "route_by_mode")
+    assert ends is not None
+    assert ends.get("chat") == "router"
+    assert ends.get("investigation") == "extract_alert"
+    assert ends.get("agent_incident") == "agent_incident"
+
+
+def test_agent_incident_shares_route_after_extract() -> None:
+    for source in ("extract_alert", "agent_incident"):
+        ends = _branch_ends(source, "route_after_extract")
+        assert ends is not None, f"{source} must use route_after_extract"
+        assert ends.get("end") == "__end__" or ends.get("end") == "__END__"  # LangGraph internal
+        assert ends.get("investigate") == "resolve_integrations"


### PR DESCRIPTION
Fixes #1507
#### Describe the changes you have made in this PR -
- Added **`agent_incident`** as a sibling entry to **`extract_alert`**: **`node_agent_incident`** synthesizes the same investigation-shaped fields (`AlertDetails`,
`raw_alert`, `problem_md`, `incident_window`, etc.) from **`context["agent_incident"]`** without the LLM extractor.
- Wired **`inject_auth` → `agent_incident`** and reused **`route_after_extract`** so non-noise runs follow **`resolve_integrations → plan_actions → … → diagnose →
publish`**, same as normal alerts.
- Extended **`route_by_mode`**, **`AgentMode`**, and added **`make_agent_incident_state`** for future callers (e.g. SLO watchdog in related issues).
- Tests for the node and graph wiring; node tests live in **`tests/nodes/agent_incident/test_agent_incident_node.py`** to avoid pytest import clashes with other
**`test_node.py`** files under **`tests/nodes/`**.
---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)
**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions
**Explain your implementation approach:**
Local agent SLO breaches should drive the **existing** investigation graph (plan → investigate → diagnose → publish) without duplicating RCA logic or forcing an LLM through **`extract_alert`**.
**Alternatives:** folding this into **`extract_alert`** with a special prompt (extra LLM, muddied responsibility), or a separate post-extract mini-graph (duplicates routing **`route_after_extract`** already solves).
**Choice:** A dedicated **`agent_incident`** node mirrors **`extract_alert`**’s outputs so **`route_after_extract`** and downstream nodes stay unchanged. Invalid or empty **`agent_name` / `breach_reason`** returns **`is_noise: True`**, consistent with a failed extraction.
**Main pieces:** **`node_agent_incident`** (synthesize alert + tracker/header), **`route_by_mode` + `graph.py`** (entry and edges), **`make_agent_incident_state`** (bootstrap), tests under **`tests/nodes/agent_incident/`** and **`tests/pipeline/test_graph_agent_incident_wiring.py`**.
---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
---