### PR TITLE
now it shows the progress of a thread in the table terminal gui

### DIFF
--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import queue
 import shlex
 import subprocess
 import sys
@@ -72,6 +73,7 @@ def watch_synthetic_subprocess(
     session: ReplSession,
     suite_name: str,
     stderr_buf: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+    stdout_queue: queue.Queue[str] | None = None,
 ) -> None:
     def _history_text() -> str:
         return f"{suite_name} task:{task.task_id}"
@@ -101,6 +103,12 @@ def watch_synthetic_subprocess(
                 terminate_child_process(proc)
                 terminated_by_watcher = True
                 break
+            if stdout_queue is not None:
+                lines: list[str] = []
+                while not stdout_queue.empty():
+                    lines.append(stdout_queue.get_nowait())
+                if lines:
+                    task.update_progress("\n".join(lines))
             time.sleep(_SYNTHETIC_POLL_SECONDS)
 
         try:
@@ -515,7 +523,7 @@ def run_synthetic_test(
     try:
         proc = subprocess.Popen(
             [sys.executable, "-m", "app.cli", "tests", "synthetic"],
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=stderr_buf,
         )
     except Exception as exc:
@@ -526,8 +534,21 @@ def run_synthetic_test(
         session.record("synthetic_test", suite_name, ok=False)
         return
 
+    stdout_queue_local: queue.Queue[str] = queue.Queue()
+
+    def _read_stdout() -> None:
+        try:
+            for raw_line in proc.stdout or []:
+                line = raw_line.decode("utf-8", errors="replace").rstrip()
+                if line:
+                    stdout_queue_local.put(line)
+        except ValueError:
+            pass
+
+    threading.Thread(target=_read_stdout, daemon=True, name=f"stdout-{task.task_id}").start()
+
     task.attach_process(proc)
-    watch_synthetic_subprocess(task, proc, session, suite_name, stderr_buf)
+    watch_synthetic_subprocess(task, proc, session, suite_name, stderr_buf, stdout_queue=stdout_queue_local)
     console.print(
         f"[{DIM}]synthetic test started — task[/] [bold]{escape(task.task_id)}[/bold]. "
         f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "

--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -37,6 +37,8 @@ def _task_detail_label(task: TaskRecord) -> str:
         return str(task.error)
     if task.result:
         return str(task.result)
+    if task.progress:
+        return str(task.progress)
     return "—"
 
 

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -14,6 +14,7 @@ from typing import Any
 
 _TASK_ID_BYTES = 4
 _MAX_REGISTRY = 100
+_MAX_PROGRESS_CHARS = 500
 
 
 class TaskStatus(StrEnum):
@@ -41,6 +42,7 @@ class TaskRecord:
     ended_at: float | None = None
     result: str | None = None
     error: str | None = None
+    progress: str | None = None
     _cancel_requested: threading.Event = field(
         default_factory=threading.Event, repr=False, init=False
     )
@@ -85,6 +87,12 @@ class TaskRecord:
             self.status = TaskStatus.FAILED
             self.error = message
             self.ended_at = time.time()
+
+    def update_progress(self, text: str) -> None:
+        with self._lock:
+            if self.status != TaskStatus.RUNNING:
+                return
+            self.progress = text[:_MAX_PROGRESS_CHARS]
 
     def request_cancel(self) -> bool:
         """Signal cancellation and kill a bound subprocess. Returns True if task was running."""
@@ -146,4 +154,5 @@ __all__ = [
     "TaskRecord",
     "TaskRegistry",
     "TaskStatus",
+    "_MAX_PROGRESS_CHARS",
 ]

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -516,21 +516,22 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
 
     results: list[ScenarioScore] = []
     for fixture in fixtures:
+        if not args.json:
+            print(f"RUNNING {fixture.scenario_id}...", flush=True)
         _, score = run_scenario(fixture, use_mock_grafana=args.mock_grafana)
         results.append(score)
+        if not args.json:
+            status = "PASS" if score.passed else "FAIL"
+            detail = (
+                f"reason={score.failure_reason!r}"
+                if score.failure_reason
+                else f"category={score.actual_category}"
+            )
+            print(f"{status} {fixture.scenario_id} {detail}", flush=True)
 
     if args.json:
         print(json.dumps([asdict(result) for result in results], indent=2))
     else:
-        for result in results:
-            status = "PASS" if result.passed else "FAIL"
-            detail = (
-                f"reason={result.failure_reason!r}"
-                if result.failure_reason
-                else f"category={result.actual_category}"
-            )
-            print(f"{status} {result.scenario_id} {detail}")
-
         passed_count = sum(1 for result in results if result.passed)
         print(f"\nResults: {passed_count}/{len(results)} passed")
 


### PR DESCRIPTION
Fixes #1526 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
I have made it so such that the progress is visible when a user runs synthetic queries

### Demo/Screenshot for feature changes and bug fixes - 

### Tasks

| id | kind | status | started | duration |
| :--- | :--- | :--- | :--- | :--- |
| `3bb881b2` | `synthetic_test` | `failed` | 2026-05-08 19:57:23 UTC | 5.0s |

**Detail:**
```python
exit code 1: run_investigation failed
Traceback (most recent call last):
  File "/home/x1vi/Documents/development/opensource/sre/opensre/app/services/llm_client.py", line 820, in _create_llm_client
    settings = LLMSettings.from_env()
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x1vi/Documents/development/opensource/sre/opensre/app/config.py", line 241, in from_env
    return cls.model_validate(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/python3.12/site-packages/pydantic/main.py", line 732, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for LLMSettings
  Value error, LLM provider 'anthropic' requires ANTHROPIC_API_KEY to be set. [type=value_error, input_value={'provider': 'anthropic',...', 'max_tokens': '4096'}, input_type=dict]
    For further information visit [https://errors.pydantic.dev/2.13/v/value_error](https://errors.pydantic.dev/2.13/v/value_error)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/x1vi/Documents/development/opensource/sre/opensre/app/utils/errors.py", line 78, in report_and_reraise
    yield
  File "/home/x1vi/Documents/development/opensource/sre/opensre/app/pipeline/runners.py", line 87, in run_investigation
    compiled_graph.invoke(initial, {"recursion_limit": _GRAPH_RECURSION_LIMIT}),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/python3.12/site-packages/sentry_sdk/integrations/langgraph.py", line 196, in new_invoke
    result = f(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/python3.12/site-packages/langgraph/pregel/main.py", line 3365, in invoke
    for chunk in self.stream(
  File "/home/x1vi/Documents/development/opensource/u...
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

This is according to my understanding, when we running a command in interactive shell. The code spawns threads.
So I PIPE that thread that runs synthetic queries, took the context logs and put them in a queue data structure.
The I looped over this structure and rendered it into the tables.
When /task command is run the progress that is details is visible in the table.

The tests I ran after implementing the changes
```
uv run pytest tests/cli/interactive_shell/test_tasks.py -v          # task system + watcher
uv run pytest tests/cli/interactive_shell/ -v                        # all shell tests (562 tests)

```
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


<img width="939" height="309" alt="image" src="https://github.com/user-attachments/assets/c30a0373-0fd1-40c9-b363-feb09d2057cd" />



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
