### PR TITLE
fix(deploy): surface NoCredentialsError as a clean user error on EC2 deploy

### DIFF
--- a/app/cli/commands/deploy.py
+++ b/app/cli/commands/deploy.py
@@ -365,7 +365,20 @@ def deploy_ec2(down: bool, branch: str) -> None:
             raise
         raise _ec2_deploy_not_bundled_error() from exc
 
-    outputs = run_deploy(branch=branch)
+    from botocore.exceptions import NoCredentialsError
+
+    try:
+        outputs = run_deploy(branch=branch)
+    except NoCredentialsError as exc:
+        raise OpenSREError(
+            "AWS credentials not found.",
+            suggestion=(
+                "Configure AWS credentials before deploying to EC2:\n"
+                "  1. Run 'aws configure' to set up ~/.aws/credentials\n"
+                "  2. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars\n"
+                "  3. Attach an IAM role if running on EC2"
+            ),
+        ) from exc
     _persist_remote_url(outputs)
 
     remote_url = _build_remote_url(outputs)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Sentry reported `NoCredentialsError: Unable to locate credentials` crashing `opensre deploy ec2` with a raw botocore traceback (issue #1659 / Sentry PYTHON-18).
- Root cause: `deploy_ec2` called `run_deploy()` with no AWS credential check, so botocore raised an unhandled exception the moment it tried to describe VPCs.
- Fix: catch `botocore.exceptions.NoCredentialsError` around the `run_deploy` call and re-raise as `OpenSREError` with three actionable steps.

## Test plan

- [ ] `uv run ruff check app/cli/commands/deploy.py` — passes (no lint errors)
- [ ] `uv run pytest tests/cli/ tests/tools/ -q` — 2667 passed, 1 skipped
- [ ] Manual: run `opensre deploy ec2` without AWS credentials configured and confirm a clean, readable error is shown instead of a traceback

Closes #1659

https://claude.ai/code/session_01BztMQfvpjfteuDrG1HJooS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BztMQfvpjfteuDrG1HJooS)_