### PR TITLE
feat: add Amazon Bedrock to /model wizard with curated inference profiles

### DIFF
--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -35,6 +35,10 @@ def _is_model_supported(
     if provider_value == "ollama":
         # Ollama supports any local model name the daemon exposes.
         return bool(model)
+    if provider_value == "bedrock":
+        # Bedrock supports any model ID, inference profile ID (us.*, eu.*, global.*),
+        # or application inference profile ARN the account has access to.
+        return bool(model)
     supported_values = {str(getattr(option, "value", "")) for option in provider_models}
     return model in supported_values
 
@@ -233,6 +237,8 @@ def _reasoning_model_menu_choices(provider: object) -> list[tuple[str, str]]:
         value = str(getattr(option, "value", ""))
         display = value if value else "cli-default"
         choices.append((value, display))
+    if getattr(provider, "value", "") == "bedrock":
+        choices.append(("__custom__", "custom model / inference profile ID"))
     return choices
 
 
@@ -246,7 +252,23 @@ def _toolcall_model_menu_choices(provider: object) -> list[tuple[str, str]]:
         value = str(getattr(option, "value", ""))
         display = value if value else "cli-default"
         choices.append((value, display))
+    if getattr(provider, "value", "") == "bedrock":
+        choices.append(("__custom__", "custom model / inference profile ID"))
     return choices
+
+
+def _prompt_custom_model_id(console: Console) -> str | None:
+    """Prompt the user to type a custom Bedrock model/inference profile ID."""
+    console.print()
+    console.print(
+        f"[{DIM}]Enter a Bedrock model ID, inference profile ID (us.*/eu.*/global.*), "
+        f"or application inference profile ARN:[/]"
+    )
+    try:
+        value = console.input(f"[{HIGHLIGHT}]model ID> [/]").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    return value if value else None
 
 
 def _interactive_set_provider(console: Console) -> bool | None:
@@ -275,6 +297,12 @@ def _interactive_set_provider(console: Console) -> bool | None:
             if reasoning_choice is None:
                 break
 
+            if reasoning_choice == "__custom__":
+                custom = _prompt_custom_model_id(console)
+                if custom is None:
+                    continue
+                reasoning_choice = custom
+
             model_choice = (
                 None if reasoning_choice == "__provider_default__" else str(reasoning_choice)
             )
@@ -295,6 +323,12 @@ def _interactive_set_provider(console: Console) -> bool | None:
                         break
                     if toolcall_value == "__match_reasoning__":
                         toolcall_model = model_choice or provider.default_model
+                        break
+                    if toolcall_value == "__custom__":
+                        custom_tc = _prompt_custom_model_id(console)
+                        if custom_tc is None:
+                            continue
+                        toolcall_model = custom_tc
                         break
                     toolcall_model = str(toolcall_value)
                     break

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -385,6 +385,11 @@ def _interactive_set_toolcall(console: Console) -> bool | None:
     if model_value == "__match_reasoning__":
         reasoning = (os.getenv(provider.model_env, "") or "").strip() or provider.default_model
         return switch_toolcall_model(reasoning, console, provider_name=provider.value)
+    if model_value == "__custom__":
+        custom_tc = _prompt_custom_model_id(console)
+        if custom_tc is None:
+            return None
+        model_value = custom_tc
     return switch_toolcall_model(str(model_value), console, provider_name=provider.value)
 
 

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 from app.config import (
     ANTHROPIC_REASONING_MODEL,
+    BEDROCK_REASONING_MODEL,
     DEFAULT_OLLAMA_HOST,
     DEFAULT_OLLAMA_MODEL,
     GEMINI_REASONING_MODEL,
@@ -144,6 +145,53 @@ NVIDIA_MODELS = (
         label="Nemotron 3 Super 120B (5x higher throughput for agentic AI)",
     ),
     ModelOption(value="nvidia/nemotron-3-nano-30b-a3b", label="Nemotron 3 Nano 30B"),
+)
+
+BEDROCK_MODELS = (
+    ModelOption(
+        value=BEDROCK_REASONING_MODEL,
+        label="Claude Sonnet 4.6 (US cross-region) — default",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-opus-4-7",
+        label="Claude Opus 4.7 (US cross-region) — most capable",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-opus-4-6-v1",
+        label="Claude Opus 4.6 (US cross-region)",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-opus-4-5-20251101-v1:0",
+        label="Claude Opus 4.5 (US cross-region)",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-opus-4-1-20250805-v1:0",
+        label="Claude Opus 4.1 (US cross-region)",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        label="Claude Sonnet 4.5 (US cross-region)",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        label="Claude Sonnet 4 (US cross-region)",
+    ),
+    ModelOption(
+        value="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        label="Claude Haiku 4.5 (US cross-region) — fast, cost-efficient",
+    ),
+    ModelOption(
+        value="us.meta.llama4-maverick-17b-instruct-v1:0",
+        label="Llama 4 Maverick 17B (US cross-region)",
+    ),
+    ModelOption(
+        value="us.amazon.nova-pro-v1:0",
+        label="Amazon Nova Pro (US cross-region)",
+    ),
+    ModelOption(
+        value="mistral.mistral-large-3-675b-instruct",
+        label="Mistral Large 3 675B Instruct (on-demand)",
+    ),
 )
 
 OLLAMA_MODELS = (
@@ -340,6 +388,20 @@ SUPPORTED_PROVIDERS = (
         models=NVIDIA_MODELS,
         legacy_model_env="NVIDIA_MODEL",
         toolcall_model_env="NVIDIA_TOOLCALL_MODEL",
+    ),
+    ProviderOption(
+        value="bedrock",
+        label="Amazon Bedrock (IAM auth)",
+        group="Hosted providers",
+        api_key_env="",
+        model_env="BEDROCK_REASONING_MODEL",
+        default_model=BEDROCK_REASONING_MODEL,
+        models=BEDROCK_MODELS,
+        toolcall_model_env="BEDROCK_TOOLCALL_MODEL",
+        credential_label="AWS region (uses IAM credentials)",
+        credential_secret=False,
+        credential_kind="host",
+        credential_default="us-east-1",
     ),
     ProviderOption(
         value="codex",

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -393,6 +393,10 @@ SUPPORTED_PROVIDERS = (
         value="bedrock",
         label="Amazon Bedrock (IAM auth)",
         group="Hosted providers",
+        # Intentionally empty: Bedrock authenticates via the IAM credential
+        # chain (env, ~/.aws/credentials, instance profile) — no API key to
+        # prompt for.  Empty string is safe: every downstream check uses
+        # ``bool(provider.api_key_env)`` or ``.get()`` (never subscript).
         api_key_env="",
         model_env="BEDROCK_REASONING_MODEL",
         default_model=BEDROCK_REASONING_MODEL,
@@ -400,8 +404,9 @@ SUPPORTED_PROVIDERS = (
         toolcall_model_env="BEDROCK_TOOLCALL_MODEL",
         credential_label="AWS region (uses IAM credentials)",
         credential_secret=False,
+        # credential_kind="none" causes flow.py to skip the credential prompt
+        # entirely.  Region is picked up from AWS_DEFAULT_REGION / ~/.aws/config.
         credential_kind="none",
-        credential_default="us-east-1",
     ),
     ProviderOption(
         value="codex",

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -24,7 +24,7 @@ from app.integrations.llm_cli.base import LLMCLIAdapter
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 PROJECT_ENV_PATH = Path(os.getenv("OPENSRE_PROJECT_ENV_PATH", PROJECT_ROOT / ".env"))
 
-CredentialKind = Literal["api_key", "host", "cli"]
+CredentialKind = Literal["api_key", "host", "cli", "none"]
 
 
 @dataclass(frozen=True)
@@ -400,7 +400,7 @@ SUPPORTED_PROVIDERS = (
         toolcall_model_env="BEDROCK_TOOLCALL_MODEL",
         credential_label="AWS region (uses IAM credentials)",
         credential_secret=False,
-        credential_kind="host",
+        credential_kind="none",
         credential_default="us-east-1",
     ),
     ProviderOption(

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -2110,7 +2110,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                 )
             ]
             model = provider.default_model
-            if provider.credential_kind != "cli":
+            if provider.credential_kind not in ("cli", "none"):
                 _step(provider.credential_label.title())
                 try:
                     api_key = _prompt_value(
@@ -2127,7 +2127,7 @@ def run_wizard(_argv: list[str] | None = None) -> int:
             assert saved_provider is not None
             provider = saved_provider
             model = saved_model_value or provider.default_model
-            if provider.credential_kind != "cli":
+            if provider.credential_kind not in ("cli", "none"):
                 has_api_key = bool(defaults["has_api_key"])
                 legacy_api_key = str(defaults["legacy_api_key"] or "").strip()
                 if not has_api_key and legacy_api_key:

--- a/tests/cli/interactive_shell/test_bedrock_model.py
+++ b/tests/cli/interactive_shell/test_bedrock_model.py
@@ -1,0 +1,194 @@
+"""Tests for Bedrock-specific model validation and custom ID handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.cli.interactive_shell.command_registry.model import (
+    _is_model_supported,
+    _prompt_custom_model_id,
+    _reasoning_model_menu_choices,
+    _toolcall_model_menu_choices,
+)
+
+
+@dataclass(frozen=True)
+class _FakeModelOption:
+    value: str
+    label: str = ""
+
+
+@dataclass(frozen=True)
+class _FakeProvider:
+    value: str
+    models: tuple[_FakeModelOption, ...] = ()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _is_model_supported — Bedrock bypass
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsModelSupportedBedrock:
+    """Bedrock must accept any non-empty model string (ARNs, regional prefixes, etc.)."""
+
+    def test_bedrock_accepts_inference_profile_id(self) -> None:
+        assert _is_model_supported("bedrock", "us.anthropic.claude-sonnet-4-6", ()) is True
+
+    def test_bedrock_accepts_eu_prefix(self) -> None:
+        assert _is_model_supported("bedrock", "eu.anthropic.claude-sonnet-4-6", ()) is True
+
+    def test_bedrock_accepts_global_prefix(self) -> None:
+        assert _is_model_supported("bedrock", "global.anthropic.claude-opus-4-7", ()) is True
+
+    def test_bedrock_accepts_on_demand_model(self) -> None:
+        assert _is_model_supported("bedrock", "mistral.mistral-large-3-675b-instruct", ()) is True
+
+    def test_bedrock_accepts_full_arn(self) -> None:
+        arn = "arn:aws:bedrock:us-east-1:123456789012:inference-profile/my-profile"
+        assert _is_model_supported("bedrock", arn, ()) is True
+
+    def test_bedrock_rejects_empty_string(self) -> None:
+        assert _is_model_supported("bedrock", "", ()) is False
+
+    def test_ollama_also_accepts_any_model(self) -> None:
+        """Ollama shares the same bypass pattern — verify it still works."""
+        assert _is_model_supported("ollama", "llama3.2", ()) is True
+
+    def test_other_provider_requires_match(self) -> None:
+        """Non-bypass providers must match the curated model list."""
+        models = (_FakeModelOption(value="gpt-5.4"),)
+        assert _is_model_supported("openai", "gpt-5.4", models) is True
+        assert _is_model_supported("openai", "gpt-unknown", models) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Menu choices — __custom__ sentinel
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMenuChoicesCustomOption:
+    """Bedrock menus must include the __custom__ escape hatch."""
+
+    def test_reasoning_menu_includes_custom_for_bedrock(self) -> None:
+        provider = _FakeProvider(
+            value="bedrock", models=(_FakeModelOption(value="us.anthropic.claude-sonnet-4-6"),)
+        )
+        choices = _reasoning_model_menu_choices(provider)
+        values = [v for v, _ in choices]
+        assert "__custom__" in values
+
+    def test_toolcall_menu_includes_custom_for_bedrock(self) -> None:
+        provider = _FakeProvider(
+            value="bedrock", models=(_FakeModelOption(value="us.anthropic.claude-sonnet-4-6"),)
+        )
+        choices = _toolcall_model_menu_choices(provider)
+        values = [v for v, _ in choices]
+        assert "__custom__" in values
+
+    def test_reasoning_menu_no_custom_for_openai(self) -> None:
+        provider = _FakeProvider(value="openai", models=(_FakeModelOption(value="gpt-5.4"),))
+        choices = _reasoning_model_menu_choices(provider)
+        values = [v for v, _ in choices]
+        assert "__custom__" not in values
+
+    def test_toolcall_menu_no_custom_for_openai(self) -> None:
+        provider = _FakeProvider(value="openai", models=(_FakeModelOption(value="gpt-5.4"),))
+        choices = _toolcall_model_menu_choices(provider)
+        values = [v for v, _ in choices]
+        assert "__custom__" not in values
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _prompt_custom_model_id
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPromptCustomModelId:
+    """Custom model ID prompt edge cases."""
+
+    def test_returns_stripped_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rich.console import Console
+
+        console = Console(force_terminal=False)
+        monkeypatch.setattr(console, "input", lambda _prompt: "  us.anthropic.claude-opus-4-7  ")
+        result = _prompt_custom_model_id(console)
+        assert result == "us.anthropic.claude-opus-4-7"
+
+    def test_returns_none_on_empty_input(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rich.console import Console
+
+        console = Console(force_terminal=False)
+        monkeypatch.setattr(console, "input", lambda _prompt: "   ")
+        result = _prompt_custom_model_id(console)
+        assert result is None
+
+    def test_returns_none_on_keyboard_interrupt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rich.console import Console
+
+        console = Console(force_terminal=False)
+
+        def _raise_interrupt(_prompt: str) -> str:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(console, "input", _raise_interrupt)
+        result = _prompt_custom_model_id(console)
+        assert result is None
+
+    def test_returns_none_on_eof(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rich.console import Console
+
+        console = Console(force_terminal=False)
+
+        def _raise_eof(_prompt: str) -> str:
+            raise EOFError
+
+        monkeypatch.setattr(console, "input", _raise_eof)
+        result = _prompt_custom_model_id(console)
+        assert result is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bedrock ProviderOption in wizard config
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBedrockProviderConfig:
+    """Verify Bedrock is registered correctly in the wizard config."""
+
+    def test_bedrock_in_supported_providers(self) -> None:
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        assert "bedrock" in PROVIDER_BY_VALUE
+
+    def test_bedrock_credential_kind_is_none(self) -> None:
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        provider = PROVIDER_BY_VALUE["bedrock"]
+        assert provider.credential_kind == "none"
+
+    def test_bedrock_has_curated_models(self) -> None:
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        provider = PROVIDER_BY_VALUE["bedrock"]
+        assert len(provider.models) >= 10
+
+    def test_bedrock_curated_models_use_inference_profiles(self) -> None:
+        """All Claude models in the curated list must use us.* inference profile IDs."""
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        provider = PROVIDER_BY_VALUE["bedrock"]
+        claude_models = [m for m in provider.models if "anthropic" in str(getattr(m, "value", ""))]
+        for model in claude_models:
+            value = str(getattr(model, "value", ""))
+            assert value.startswith("us."), (
+                f"Claude model '{value}' must use a us.* inference profile ID"
+            )
+
+    def test_bedrock_has_toolcall_model_env(self) -> None:
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        provider = PROVIDER_BY_VALUE["bedrock"]
+        assert provider.toolcall_model_env == "BEDROCK_TOOLCALL_MODEL"

--- a/tests/cli/interactive_shell/test_bedrock_model.py
+++ b/tests/cli/interactive_shell/test_bedrock_model.py
@@ -192,3 +192,72 @@ class TestBedrockProviderConfig:
 
         provider = PROVIDER_BY_VALUE["bedrock"]
         assert provider.toolcall_model_env == "BEDROCK_TOOLCALL_MODEL"
+
+    def test_bedrock_api_key_env_is_empty(self) -> None:
+        """api_key_env="" is intentional — Bedrock uses IAM auth, not an API key."""
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        provider = PROVIDER_BY_VALUE["bedrock"]
+        assert provider.api_key_env == ""
+        # Empty string must be falsy so downstream ``bool(provider.api_key_env)``
+        # checks correctly skip API-key validation for Bedrock.
+        assert not provider.api_key_env
+
+    def test_bedrock_no_credential_default(self) -> None:
+        """credential_default must use the dataclass default (empty string).
+
+        Region is picked up from AWS_DEFAULT_REGION / ~/.aws/config, not from
+        the wizard credential prompt (which is skipped for credential_kind="none").
+        """
+        from app.cli.wizard.config import PROVIDER_BY_VALUE
+
+        provider = PROVIDER_BY_VALUE["bedrock"]
+        assert provider.credential_default == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _interactive_set_toolcall + __custom__ integration
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInteractiveSetToolcallCustom:
+    """Verify the __custom__ branch inside _interactive_set_toolcall wires through correctly."""
+
+    def test_custom_toolcall_calls_switch_with_typed_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Selecting __custom__ in toolcall menu should prompt and call switch_toolcall_model."""
+        from unittest.mock import patch
+
+        from rich.console import Console
+
+        from app.cli.interactive_shell.command_registry import model as model_mod
+
+        console = Console(force_terminal=False)
+        custom_id = "eu.anthropic.claude-sonnet-4-6"
+
+        # First call: pick provider "bedrock"; second call: pick "__custom__"
+        choose_returns = iter(["bedrock", "__custom__"])
+        monkeypatch.setattr(model_mod, "repl_choose_one", lambda **_kw: next(choose_returns))
+        monkeypatch.setattr(model_mod, "_prompt_custom_model_id", lambda _c: custom_id)
+
+        with patch.object(model_mod, "switch_toolcall_model", return_value=True) as mock_switch:
+            result = model_mod._interactive_set_toolcall(console)
+
+        assert result is True
+        mock_switch.assert_called_once_with(custom_id, console, provider_name="bedrock")
+
+    def test_custom_toolcall_returns_none_on_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If user cancels the custom prompt, _interactive_set_toolcall returns None."""
+        from rich.console import Console
+
+        from app.cli.interactive_shell.command_registry import model as model_mod
+
+        console = Console(force_terminal=False)
+
+        choose_returns = iter(["bedrock", "__custom__"])
+        monkeypatch.setattr(model_mod, "repl_choose_one", lambda **_kw: next(choose_returns))
+        monkeypatch.setattr(model_mod, "_prompt_custom_model_id", lambda _c: None)
+
+        result = model_mod._interactive_set_toolcall(console)
+        assert result is None


### PR DESCRIPTION
Fixes #1729

#### Describe the changes you have made in this PR -

**`app/cli/wizard/config.py`:**
- Added `BEDROCK_MODELS` with 11 curated models using correct `us.*` inference profile IDs + Mistral on-demand
- Added `ProviderOption` for Bedrock in `SUPPORTED_PROVIDERS` (IAM auth, no API key needed)

**`app/cli/interactive_shell/command_registry/model.py`:**
- Bypass strict model validation for Bedrock (like Ollama) to support custom ARNs and regional prefixes
- Added "custom model / inference profile ID" option in interactive menus with free-text prompt

<!-- Add a screenshot of /model menu showing Bedrock -->
<img width="1502" height="703" alt="image" src="https://github.com/user-attachments/assets/c19ff48b-2811-436b-a9d3-330261f0fc06" />
<img width="1508" height="750" alt="image" src="https://github.com/user-attachments/assets/8246a833-ace2-4fc2-9cfa-bd2c19c4685c" />
<img width="1483" height="735" alt="image" src="https://github.com/user-attachments/assets/7bc812c3-da30-4005-b9c2-3cb94ee7db6d" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Bedrock was the only provider missing from `SUPPORTED_PROVIDERS` in the wizard config, so users had no curated model list and typed raw foundation model IDs that AWS rejects for newer models.

I added Bedrock as a selectable provider with pre-validated `us.*` inference profile IDs. For power users with custom inference profiles (ARNs, `eu.*`, `global.*`), I added a "custom" option with free-text input and bypassed strict model validation — matching how Ollama already handles arbitrary model names.

I chose this over auto-prefixing `us.*` to raw IDs because users may legitimately use `eu.*`, `global.*`, or full ARNs, and silently rewriting input would be surprising.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
