### PR TITLE
fix(cli): validate slash-command args before policy gate (#1712)

### DIFF
--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -111,6 +111,12 @@ def dispatch_slash(
         console.print()
         console.print(f"[{ERROR}]unknown command:[/] {escape(name)}  (type [bold]/help[/bold])")
         return True
+    if cmd.validate_args is not None:
+        validation_error = cmd.validate_args(args)
+        if validation_error is not None:
+            console.print(validation_error)
+            session.record("slash", stripped, ok=False)
+            return True
     if policy_precleared:
         session.record("slash", stripped, ok=True)
         return cmd.handler(session, console, args)

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -72,13 +72,20 @@ def _cmd_template(session: ReplSession, console: Console, args: list[str]) -> bo
     return True
 
 
+def _validate_investigate_args(args: list[str]) -> str | None:
+    if not args:
+        return f"[{DIM}]usage:[/] /investigate <file>"
+    return None
+
+
+def _validate_save_args(args: list[str]) -> str | None:
+    if not args:
+        return f"[{DIM}]usage:[/] /save <path>  (e.g. /save report.md or /save out.json)"
+    return None
+
+
 def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str]) -> bool:
     from app.cli.investigation import run_investigation_for_session
-
-    if not args:
-        console.print(f"[{DIM}]usage:[/] /investigate <file>")
-        session.mark_latest(ok=False, kind="slash")
-        return True
 
     path = Path(args[0])
     if not path.exists():
@@ -165,10 +172,6 @@ def _cmd_save(session: ReplSession, console: Console, args: list[str]) -> bool:
         console.print(f"[{DIM}]nothing to save — run an investigation first.[/]")
         return True
 
-    if not args:
-        console.print(f"[{DIM}]usage:[/] /save <path>  (e.g. /save report.md or /save out.json)")
-        return True
-
     dest = Path(args[0])
     try:
         if dest.suffix.lower() == ".json":
@@ -214,6 +217,7 @@ COMMANDS: list[SlashCommand] = [
         "run an RCA investigation from a file ('/investigate <file>')",
         _cmd_investigate_file,
         execution_tier=ExecutionTier.ELEVATED,
+        validate_args=_validate_investigate_args,
     ),
     SlashCommand(
         "/last",
@@ -226,6 +230,7 @@ COMMANDS: list[SlashCommand] = [
         "save last investigation to a file ('/save <path>')",
         _cmd_save,
         execution_tier=ExecutionTier.ELEVATED,
+        validate_args=_validate_save_args,
     ),
 ]
 

--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -100,13 +100,13 @@ def _cmd_stop(session: ReplSession, console: Console, args: list[str]) -> bool: 
     return True
 
 
-def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool:
+def _validate_cancel_args(args: list[str]) -> str | None:
     if not args:
-        console.print(
-            f"[{ERROR}]usage:[/] /cancel <task_id>  — use [{HIGHLIGHT}]/tasks[/] to list ids"
-        )
-        return True
+        return f"[{ERROR}]usage:[/] /cancel <task_id>  — use [{HIGHLIGHT}]/tasks[/] to list ids"
+    return None
 
+
+def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool:
     needle = args[0]
     candidates = session.task_registry.candidates(needle)
     if not candidates:
@@ -149,6 +149,7 @@ COMMANDS: list[SlashCommand] = [
         "cancel a running task by id ('/cancel <task_id>' — see /tasks)",
         _cmd_cancel,
         execution_tier=ExecutionTier.ELEVATED,
+        validate_args=_validate_cancel_args,
     ),
     SlashCommand(
         "/stop",

--- a/app/cli/interactive_shell/command_registry/types.py
+++ b/app/cli/interactive_shell/command_registry/types.py
@@ -19,6 +19,10 @@ class SlashCommand:
     #: Tab-completion hints for the first argument after the command name (keyword, meta text).
     first_arg_completions: tuple[tuple[str, str], ...] = ()
     execution_tier: ExecutionTier = ExecutionTier.SAFE
+    #: Optional pre-policy arg validator. Returns ``None`` if args are valid, or
+    #: a user-facing error string (rendered via ``console.print``) to short-circuit
+    #: dispatch with no policy prompt and no handler invocation.
+    validate_args: Callable[[list[str]], str | None] | None = None
 
 
 __all__ = ["ExecutionTier", "SlashCommand"]

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -10,6 +10,11 @@ from prompt_toolkit.history import FileHistory
 from rich.console import Console
 
 from app.cli.interactive_shell.command_registry import repl_data as repl_data_module
+from app.cli.interactive_shell.command_registry.investigation import (
+    _validate_investigate_args,
+    _validate_save_args,
+)
+from app.cli.interactive_shell.command_registry.tasks_cmds import _validate_cancel_args
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
@@ -1138,6 +1143,110 @@ class TestCancelCommand:
         dispatch_slash("/cancel", ReplSession(), console)
         assert "usage" in buf.getvalue().lower()
         assert "/tasks" in buf.getvalue()
+
+
+class TestPrePolicyValidation:
+    """Regression for #1712: ``validate_args`` runs before the policy gate, so
+    invalid args never trigger the ``Proceed?`` confirmation prompt."""
+
+    @pytest.mark.parametrize(
+        "command,expected_usage_fragment",
+        [
+            ("/investigate", "/investigate <file>"),
+            ("/save", "/save <path>"),
+            ("/cancel", "/cancel <task_id>"),
+        ],
+    )
+    def test_missing_arg_skips_policy_prompt(
+        self, command: str, expected_usage_fragment: str
+    ) -> None:
+        confirm_calls: list[str] = []
+
+        def _confirm(prompt: str) -> str:
+            confirm_calls.append(prompt)
+            return "n"
+
+        session = ReplSession()
+        # /save also short-circuits when there is no last_state; preset one so we
+        # actually exercise the args validator rather than the state guard.
+        session.last_state = {"root_cause": "x"}
+
+        console, buf = _capture()
+        dispatch_slash(command, session, console, confirm_fn=_confirm, is_tty=True)
+
+        assert expected_usage_fragment in buf.getvalue()
+        assert confirm_calls == [], f"confirm_fn must not be called for {command} with no args"
+        assert session.history[-1] == {"type": "slash", "text": command, "ok": False}
+
+    def test_validate_args_fires_in_trust_mode(self) -> None:
+        """Trust mode bypasses the policy prompt but must not bypass arg validation."""
+        confirm_calls: list[str] = []
+
+        def _confirm(prompt: str) -> str:
+            confirm_calls.append(prompt)
+            return "y"
+
+        session = ReplSession()
+        session.trust_mode = True
+
+        console, buf = _capture()
+        dispatch_slash("/investigate", session, console, confirm_fn=_confirm, is_tty=True)
+
+        assert "/investigate <file>" in buf.getvalue()
+        assert confirm_calls == [], "trust mode must not skip arg validation"
+
+    def test_valid_arg_still_fires_policy_prompt(self, tmp_path: Path) -> None:
+        """The fix must not accidentally remove the policy gate entirely."""
+        alert_file = tmp_path / "alert.json"
+        alert_file.write_text('{"alert_name": "test"}', encoding="utf-8")
+
+        confirm_calls: list[str] = []
+
+        def _confirm(prompt: str) -> str:
+            confirm_calls.append(prompt)
+            return "n"  # decline so we don't run a real investigation
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash(
+            f"/investigate {alert_file}",
+            session,
+            console,
+            confirm_fn=_confirm,
+            is_tty=True,
+        )
+
+        assert len(confirm_calls) == 1, "policy prompt must still fire for valid args"
+
+
+class TestSlashValidatorFunctions:
+    """Direct unit tests for the per-command pre-policy validators."""
+
+    @pytest.mark.parametrize(
+        "validator,expected_usage_fragment",
+        [
+            (_validate_investigate_args, "/investigate <file>"),
+            (_validate_save_args, "/save <path>"),
+            (_validate_cancel_args, "/cancel <task_id>"),
+        ],
+    )
+    def test_returns_usage_when_args_empty(
+        self, validator: object, expected_usage_fragment: str
+    ) -> None:
+        result = validator([])  # type: ignore[operator]
+        assert isinstance(result, str)
+        assert expected_usage_fragment in result
+
+    @pytest.mark.parametrize(
+        "validator,args",
+        [
+            (_validate_investigate_args, ["alert.json"]),
+            (_validate_save_args, ["report.md"]),
+            (_validate_cancel_args, ["task-abc"]),
+        ],
+    )
+    def test_returns_none_when_args_present(self, validator: object, args: list[str]) -> None:
+        assert validator(args) is None  # type: ignore[operator]
 
 
 class TestCliDelegatedCommands:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1167,9 +1167,6 @@ class TestPrePolicyValidation:
             return "n"
 
         session = ReplSession()
-        # /save also short-circuits when there is no last_state; preset one so we
-        # actually exercise the args validator rather than the state guard.
-        session.last_state = {"root_cause": "x"}
 
         console, buf = _capture()
         dispatch_slash(command, session, console, confirm_fn=_confirm, is_tty=True)


### PR DESCRIPTION
Fixes #1712

#### Describe the changes you have made in this PR -

Adds an optional `validate_args` field to `SlashCommand` and wires it into `dispatch_slash` so per-command arg validation runs before the policy gate, not inside the handler. With this in place, typing `/investigate` (or `/save`, or `/cancel`) with no args prints the usage line immediately and never triggers the `Proceed? [y/N]` confirmation prompt.

The same bug shape exists across three ELEVATED-tier commands, not just the one named in the issue: `/investigate` (`investigation.py`), `/save` (`investigation.py`), and `/cancel` (`tasks_cmds.py`) all carry an `if not args: print usage` block inside the handler that runs after the policy prompt. Fixing only `/investigate` would leave `/save` and `/cancel` broken in the same way, so the PR migrates all three together. SAFE-tier commands (`/template`, `/last`, `/list`, etc.) are untouched because they never prompt and their usage messages already print immediately.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1359" height="617" alt="Screenshot 2026-05-09 at 3 00 52 PM" src="https://github.com/user-attachments/assets/8e513dc6-ca4b-4eac-a302-2f2f26a76fde" />

---


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The validator is a `Callable[[list[str]], str | None]` declared on `SlashCommand`. It returns `None` for valid args, or a fully-rendered usage string (Rich markup included) for invalid ones. The dispatcher prints the string, records the slash entry as `ok=False`, and short-circuits before the policy tier resolution runs. This keeps the existing handler bodies focused on the happy path and addresses the reporter's point that validation should live with the command definition rather than in scattered handler branches.

The validator runs even when `policy_precleared` is set, because pre-clearance only attests that policy was already approved by the caller, not that args are correct. Invalid input should still fail fast on that path. Trust mode also does not bypass the validator, because trust mode is about confirmations, not correctness. A regression test pins this.

Considered and rejected: a surgical patch in `dispatch_slash` that hardcodes command names like `if name in {"/investigate", "/save", "/cancel"} and not args: ...`. That couples the dispatcher to specific handlers and ignores the reporter's design framing. A full refactor of every command into declarative validators was also rejected as out of scope for a bug fix; the new field is opt-in so existing commands are unchanged.

The /cancel validator preserves its [ERROR] red usage styling rather than standardising to the [DIM] grey used by /investigate and /save. This is not the PR to standardise styling.

Tests live in `tests/cli/interactive_shell/test_commands.py` under two new classes. `TestPrePolicyValidation` parametrizes the ordering invariant across all three commands (with `is_tty=True` and a recording `confirm_fn`, missing args print usage and never call `confirm_fn`), plus the trust-mode-still-validates case and a regression test that valid args still fire the policy prompt. `TestSlashValidatorFunctions` adds direct unit tests on each validator. The existing `test_missing_arg_prints_usage` cases continue to pass because they exercise the same string output, just via the new code path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions