### PR TITLE
feat(error-handling): capture action-execution thread/future failures

### DIFF
--- a/app/nodes/investigate/execution/execute_actions.py
+++ b/app/nodes/investigate/execution/execute_actions.py
@@ -1,12 +1,17 @@
 """Investigation action execution."""
 
+import logging
 import time
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 
 from app.tools.registered_tool import RegisteredTool as InvestigationAction
+from app.utils.errors import report_exception
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -43,8 +48,11 @@ def _execute_with_retry(
 ) -> ActionExecutionResult:
     """Execute action with exponential backoff retry for transient failures."""
     last_error = None
+    last_transient = False
+    attempts_made = 0
 
     for attempt in range(max_attempts):
+        attempts_made = attempt + 1
         try:
             kwargs = action.extract_params(available_sources)
             data = action.run(**kwargs)
@@ -81,14 +89,44 @@ def _execute_with_retry(
                 )
         except Exception as e:
             last_error = e
-            if attempt < max_attempts - 1 and _is_transient_error(e):
+            last_transient = _is_transient_error(e)
+            if attempt < max_attempts - 1 and last_transient:
+                with suppress(Exception):
+                    import sentry_sdk
+
+                    sentry_sdk.add_breadcrumb(
+                        category="action_execution",
+                        message=f"{action_name} attempt {attempts_made} failed, retrying",
+                        level="warning",
+                        data={
+                            "action_name": action_name,
+                            "attempt": attempts_made,
+                            "transient": True,
+                            "error": f"{type(e).__name__}: {e}",
+                        },
+                    )
                 backoff_seconds = 2**attempt
                 time.sleep(backoff_seconds)
                 continue
             break
 
+    if last_error is not None:
+        severity = "warning" if last_transient else "error"
+        report_exception(
+            last_error,
+            logger=logger,
+            message=f"Action {action_name} failed after {attempts_made} attempt(s)",
+            severity=severity,
+            tags={"surface": "node", "component": "execute_actions"},
+            extras={"action_name": action_name, "attempts": attempts_made},
+        )
+
     available_source_keys = list(available_sources.keys()) if available_sources else []
-    error_detail = f"{type(last_error).__name__}: {str(last_error)} | Available sources: {available_source_keys}"
+    error_detail = (
+        f"{type(last_error).__name__}: {last_error} | Available sources: {available_source_keys}"
+        if last_error is not None
+        else f"No attempts made | Available sources: {available_source_keys}"
+    )
     return ActionExecutionResult(
         action_name=action_name,
         success=False,
@@ -172,6 +210,17 @@ def execute_actions(
             try:
                 results[action_name] = future.result()
             except Exception as e:
+                report_exception(
+                    e,
+                    logger=logger,
+                    message=f"Action {action_name} future failed",
+                    severity="error",
+                    tags={
+                        "surface": "node",
+                        "component": "execute_actions",
+                    },
+                    extras={"action_name": action_name},
+                )
                 results[action_name] = ActionExecutionResult(
                     action_name=action_name,
                     success=False,

--- a/tests/nodes/investigate/test_execute_actions.py
+++ b/tests/nodes/investigate/test_execute_actions.py
@@ -1,0 +1,114 @@
+"""Tests for execute_actions error reporting."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.nodes.investigate.execution.execute_actions import (
+    _execute_with_retry,
+    execute_actions,
+)
+
+
+def _make_action(*, run_fn, extract_params_fn=None, is_available_fn=None, name="test_action"):
+    """Build a minimal action stub matching the RegisteredTool interface."""
+    action = SimpleNamespace(
+        name=name,
+        run=run_fn,
+        extract_params=extract_params_fn or (lambda _sources: {}),
+        is_available=is_available_fn or (lambda _sources: True),
+    )
+    return action
+
+
+class TestRetryBreadcrumbOnTransientRecovery:
+    """Transient failure that recovers on retry."""
+
+    @patch("app.nodes.investigate.execution.execute_actions.time.sleep")
+    @patch("app.nodes.investigate.execution.execute_actions.report_exception")
+    @patch("sentry_sdk.add_breadcrumb")
+    def test_breadcrumb_emitted_no_sentry_event(self, mock_breadcrumb, mock_report, _mock_sleep):
+        call_count = 0
+
+        def flaky_run(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("connection reset")
+            return {"result": "ok"}
+
+        action = _make_action(run_fn=flaky_run)
+        result = _execute_with_retry("my_action", action, {}, max_attempts=3)
+
+        assert result.success is True
+        mock_breadcrumb.assert_called_once()
+        breadcrumb_kwargs = mock_breadcrumb.call_args
+        assert breadcrumb_kwargs[1]["data"]["action_name"] == "my_action"
+        assert breadcrumb_kwargs[1]["data"]["attempt"] == 1
+        assert breadcrumb_kwargs[1]["data"]["transient"] is True
+        mock_report.assert_not_called()
+
+
+class TestRetryExhaustionReportsToSentry:
+    """All retries exhausted."""
+
+    @patch("app.nodes.investigate.execution.execute_actions.time.sleep")
+    @patch("app.nodes.investigate.execution.execute_actions.report_exception")
+    @patch("sentry_sdk.add_breadcrumb")
+    def test_transient_failure_reports_warning(self, mock_breadcrumb, mock_report, _mock_sleep):
+        def always_timeout(**kwargs):
+            raise TimeoutError("timeout")
+
+        action = _make_action(run_fn=always_timeout)
+        result = _execute_with_retry("my_action", action, {}, max_attempts=3)
+
+        assert result.success is False
+        assert mock_breadcrumb.call_count == 2
+        mock_report.assert_called_once()
+        call_kwargs = mock_report.call_args
+        assert call_kwargs[1]["severity"] == "warning"
+        assert call_kwargs[1]["extras"]["attempts"] == 3
+        assert call_kwargs[1]["tags"]["surface"] == "node"
+
+    @patch("app.nodes.investigate.execution.execute_actions.time.sleep")
+    @patch("app.nodes.investigate.execution.execute_actions.report_exception")
+    @patch("sentry_sdk.add_breadcrumb")
+    def test_nontransient_failure_reports_error(self, mock_breadcrumb, mock_report, _mock_sleep):
+        def always_value_error(**kwargs):
+            raise ValueError("bad input")
+
+        action = _make_action(run_fn=always_value_error)
+        result = _execute_with_retry("my_action", action, {}, max_attempts=3)
+
+        assert result.success is False
+        mock_breadcrumb.assert_not_called()
+        mock_report.assert_called_once()
+        assert mock_report.call_args[1]["severity"] == "error"
+        assert mock_report.call_args[1]["extras"]["attempts"] == 1
+
+
+class TestFutureFailureReportsToSentry:
+    """Future raises outside the retry loop."""
+
+    @patch("app.nodes.investigate.execution.execute_actions.report_exception")
+    @patch("sentry_sdk.add_breadcrumb")
+    def test_future_exception_captured(self, _mock_breadcrumb, mock_report):
+        action = _make_action(run_fn=lambda **_: {}, name="boom_action")
+
+        with patch(
+            "app.nodes.investigate.execution.execute_actions._execute_single_action",
+            side_effect=RuntimeError("executor blew up"),
+        ):
+            results = execute_actions(
+                action_names=["boom_action"],
+                available_actions={"boom_action": action},
+                available_sources={},
+            )
+
+        assert results["boom_action"].success is False
+        assert "executor blew up" in results["boom_action"].error
+        mock_report.assert_called_once()
+        call_kwargs = mock_report.call_args
+        assert call_kwargs[1]["tags"]["surface"] == "node"
+        assert call_kwargs[1]["extras"]["action_name"] == "boom_action"


### PR DESCRIPTION
Fixes #1466

#### Describe the changes you have made in this PR -

adds sentry instrumentation to the retry loop and future handler in `execute_actions.py`

three things:
1. **breadcrumbs on transient retries** - when an action hits a transient error and retries, a sentry breadcrumb gets logged with action name, attempt number, and error so the retry history shows up if it eventually dies
2. **report_exception on final failures** - once retries run out, calls `report_exception` with severity="warning" for transient exhaustion vs severity="error" for non-transient
3. **report_exception on future exceptions** - the ThreadPoolExecutor future handler now captures exceptions that escape the executor

uses `report_exception` from `app/utils/errors.py` (from #1620) to stay consistent with how the rest of the error-handling layer works

### Demo/Screenshot for feature changes and bug fixes -

```
tests/nodes/investigate/test_execute_actions.py::TestRetryBreadcrumbOnTransientRecovery::test_breadcrumb_emitted_no_sentry_event PASSED
tests/nodes/investigate/test_execute_actions.py::TestRetryExhaustionReportsToSentry::test_transient_failure_reports_warning PASSED
tests/nodes/investigate/test_execute_actions.py::TestRetryExhaustionReportsToSentry::test_nontransient_failure_reports_error PASSED
tests/nodes/investigate/test_execute_actions.py::TestFutureFailureReportsToSentry::test_future_exception_captured PASSED

4 passed in 1.12s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

the retry loop already catches exceptions and decides transient vs not so breadcrumbs go right before the `continue` and the final report goes after the loop exits when it failed - severity is warning for transient exhaustion (network hiccup that lasted too long) vs error for non-transient (actually broken). future handler just wraps the existing except block

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.