### PR TITLE
feat(agents): add /agents bus shared context channel (#1505)

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -11,6 +11,7 @@ discovery — without it the ``app.agents.*`` subpackages would be
 silently omitted from the built wheel.
 """
 
+from app.agents.bus import BusMessage, publish, subscribe
 from app.agents.coordination import BranchClaim, BranchClaims
 from app.agents.discovery import ProcessRow, discover_agents, registered_and_discovered_agents
 from app.agents.lifecycle import TerminateResult, terminate
@@ -22,10 +23,13 @@ __all__ = [
     "AgentRegistry",
     "BranchClaim",
     "BranchClaims",
+    "BusMessage",
     "LoopDetector",
     "ProcessRow",
     "TerminateResult",
     "discover_agents",
     "registered_and_discovered_agents",
+    "publish",
+    "subscribe",
     "terminate",
 ]

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -13,10 +13,12 @@ attach as plain clients. If the broker dies, the next operation re-elects.
 
 from __future__ import annotations
 
+import atexit
 import errno
 import json
 import logging
 import os
+import select
 import socket
 import threading
 import types
@@ -39,6 +41,12 @@ BUS_SCHEMA_VERSION: int = 1
 #: Max bytes per JSONL frame on the wire. Frames over this are dropped with a
 #: warning; a finding payload that big is almost certainly a bug.
 _MAX_FRAME_BYTES: int = 64 * 1024
+
+#: Per-subscriber write deadline used by ``BusServer._broadcast``. A subscriber
+#: whose kernel recv buffer is full for longer than this is considered
+#: unresponsive and evicted, so one wedged client cannot stall fan-out for
+#: every other publisher's reader thread.
+_BROADCAST_WRITE_TIMEOUT_SECONDS: float = 0.2
 
 
 @dataclass(frozen=True)
@@ -342,8 +350,22 @@ class BusServer:
                 # Don't echo a publisher's own frame back to itself.
                 continue
             try:
+                # Write-readiness gate via select: a blocking ``sendall`` on a
+                # subscriber whose kernel recv buffer is full would wedge the
+                # reader thread of *every* publisher, freezing fan-out across
+                # the bus. Using ``select`` instead of ``sub.settimeout`` so
+                # the per-connection ``_reader_loop``'s ``recv`` is unaffected
+                # (a quiet healthy subscriber must not be evicted).
+                _r, ready, _x = select.select([], [sub], [], _BROADCAST_WRITE_TIMEOUT_SECONDS)
+                if not ready:
+                    logger.warning("bus subscriber unresponsive; evicting from fan-out")
+                    dead.append(sub)
+                    continue
                 sub.sendall(frame)
-            except OSError:
+            except (OSError, ValueError):
+                # ValueError: ``select`` rejects a closed fd (-1) by raising
+                # ValueError rather than OSError. Treat it the same as a
+                # broken socket — the subscriber is gone, drop it.
                 dead.append(sub)
         for sub in dead:
             self._drop_subscriber(sub)
@@ -408,6 +430,106 @@ def _connect_client(path: Path, timeout: float) -> socket.socket:
     return client
 
 
+@dataclass
+class _CachedPublisher:
+    """A persistent publisher connection plus the bookkeeping to share it safely.
+
+    ``send_lock`` serializes ``sendall`` from concurrent publish() calls in the
+    same process so frames don't interleave on the wire. ``drain_thread`` is a
+    daemon that reads-and-discards anything the broker fans back to us — under
+    multi-publisher load the broker would otherwise fill our kernel recv buffer
+    with peers' frames, hit the write-timeout in ``_broadcast``, and evict our
+    connection. Draining keeps the cached socket usable indefinitely.
+    """
+
+    sock: socket.socket
+    send_lock: threading.Lock
+    drain_thread: threading.Thread
+
+
+_publisher_lock = threading.Lock()
+_publishers: dict[Path, _CachedPublisher] = {}
+
+
+def _drain_publisher_socket(sock: socket.socket) -> None:
+    """Read-and-discard everything the broker sends to a cached publisher.
+
+    Exits silently on EOF or socket error — at that point the cache entry
+    will already have been (or is about to be) invalidated by the publish
+    retry path.
+    """
+    try:
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                return
+    except OSError:
+        return
+
+
+def _open_cached_publisher(path: Path, *, connect_timeout: float) -> _CachedPublisher:
+    """Connect a fresh publisher and start its drain thread. Caller holds no lock."""
+    sock = _connect_client(path, timeout=connect_timeout)
+    cached = _CachedPublisher(
+        sock=sock,
+        send_lock=threading.Lock(),
+        drain_thread=threading.Thread(
+            target=_drain_publisher_socket,
+            args=(sock,),
+            name="agents-bus-publisher-drain",
+            daemon=True,
+        ),
+    )
+    cached.drain_thread.start()
+    return cached
+
+
+def _get_or_open_publisher(path: Path, *, connect_timeout: float) -> _CachedPublisher:
+    """Return a cached publisher for ``path``, opening one if none exists."""
+    with _publisher_lock:
+        existing = _publishers.get(path)
+        if existing is not None:
+            return existing
+    # Open outside the lock so concurrent first-publishers don't all serialize
+    # behind a slow connect.
+    fresh = _open_cached_publisher(path, connect_timeout=connect_timeout)
+    with _publisher_lock:
+        existing = _publishers.get(path)
+        if existing is not None:
+            # Lost the race; close ours and reuse theirs.
+            with suppress(OSError):
+                fresh.sock.close()
+            return existing
+        _publishers[path] = fresh
+        return fresh
+
+
+def _drop_publisher(path: Path, sock: socket.socket) -> None:
+    """Remove the cached publisher for ``path`` if it still references ``sock``."""
+    with _publisher_lock:
+        cached = _publishers.get(path)
+        if cached is not None and cached.sock is sock:
+            del _publishers[path]
+        else:
+            cached = None
+    if cached is not None:
+        with suppress(OSError):
+            cached.sock.close()
+
+
+def _close_all_publishers() -> None:
+    """Drop every cached publisher (e.g. at process exit). Safe to call repeatedly."""
+    with _publisher_lock:
+        sockets = [c.sock for c in _publishers.values()]
+        _publishers.clear()
+    for sock in sockets:
+        with suppress(OSError):
+            sock.close()
+
+
+atexit.register(_close_all_publishers)
+
+
 def publish(
     message: BusMessage,
     *,
@@ -419,15 +541,29 @@ def publish(
     Self-elects a broker if none is running. Send is fire-and-forget: if no
     subscribers are attached, the frame is dropped by the broker (live-only,
     no replay buffer in v1).
+
+    Publisher sockets are cached per ``path`` and reused across calls so a
+    burst of publishes does not spawn one broker reader-thread per call. On a
+    broken connection (broker died, peer reset) the cache is invalidated and
+    one reconnect is attempted before propagating the error.
     """
     target = path or DEFAULT_BUS_SOCKET_PATH
     _ensure_broker(target)
-    client = _connect_client(target, timeout=connect_timeout)
-    try:
-        client.sendall(message.to_jsonl())
-    finally:
-        with suppress(OSError):
-            client.close()
+    frame = message.to_jsonl()
+    last_err: OSError | None = None
+    for attempt in range(2):
+        cached = _get_or_open_publisher(target, connect_timeout=connect_timeout)
+        try:
+            with cached.send_lock:
+                cached.sock.sendall(frame)
+            return
+        except OSError as exc:
+            last_err = exc
+            _drop_publisher(target, cached.sock)
+            if attempt == 0:
+                _ensure_broker(target)
+    assert last_err is not None
+    raise last_err
 
 
 def subscribe(

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -561,23 +561,26 @@ def publish(
     no replay buffer in v1).
 
     Publisher sockets are cached per ``path`` and reused across calls so a
-    burst of publishes does not spawn one broker reader-thread per call. On a
-    broken connection (broker died, peer reset) the cache is invalidated and
-    one reconnect is attempted before propagating the error.
+    burst of publishes does not spawn one broker reader-thread per call. On
+    any transient ``OSError`` — failed initial connect, broken cached
+    connection, or send error — one retry is attempted (re-electing the
+    broker if needed) before propagating the error.
     """
     target = path or DEFAULT_BUS_SOCKET_PATH
     _ensure_broker(target)
     frame = message.to_jsonl()
     last_err: OSError | None = None
     for attempt in range(2):
-        cached = _get_or_open_publisher(target, connect_timeout=connect_timeout)
+        cached: _CachedPublisher | None = None
         try:
+            cached = _get_or_open_publisher(target, connect_timeout=connect_timeout)
             with cached.send_lock:
                 cached.sock.sendall(frame)
             return
         except OSError as exc:
             last_err = exc
-            _drop_publisher(target, cached.sock)
+            if cached is not None:
+                _drop_publisher(target, cached.sock)
             if attempt == 0:
                 _ensure_broker(target)
     assert last_err is not None
@@ -601,10 +604,24 @@ def subscribe(
     can ``bind()`` the socket first (filesystem perms are the only auth) could
     otherwise stream unlimited bytes without newlines and exhaust subscriber
     memory. On overflow the subscriber logs a warning and disconnects.
+
+    Initial connect failures are retried once (mirroring ``publish()``) — the
+    most common cause is a broker that just exited, in which case
+    ``_ensure_broker`` will re-elect on the second pass.
     """
     target = path or DEFAULT_BUS_SOCKET_PATH
-    _ensure_broker(target)
-    client = _connect_client(target, timeout=connect_timeout)
+    last_connect_err: OSError | None = None
+    client: socket.socket | None = None
+    for _attempt in range(2):
+        _ensure_broker(target)
+        try:
+            client = _connect_client(target, timeout=connect_timeout)
+            break
+        except OSError as exc:
+            last_connect_err = exc
+    if client is None:
+        assert last_connect_err is not None
+        raise last_connect_err
     buf = b""
     try:
         while True:

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -321,6 +321,11 @@ def subscribe(
     misbehaving publisher should not kill an inspector REPL. The iterator ends
     cleanly on broker disconnect; ``KeyboardInterrupt`` propagates so callers
     (e.g. ``/agents bus``) can return to their prompt.
+
+    A buffer cap mirrors the broker's ``_reader_loop`` guard: any process that
+    can ``bind()`` the socket first (filesystem perms are the only auth) could
+    otherwise stream unlimited bytes without newlines and exhaust subscriber
+    memory. On overflow the subscriber logs a warning and disconnects.
     """
     target = path or DEFAULT_BUS_SOCKET_PATH
     _ensure_broker(target)
@@ -335,9 +340,18 @@ def subscribe(
             if not chunk:
                 return
             buf += chunk
+            if len(buf) > _MAX_FRAME_BYTES * 4:
+                logger.warning(
+                    "bus broker exceeded subscriber buffer cap (%d bytes); disconnecting",
+                    len(buf),
+                )
+                return
             while b"\n" in buf:
                 line, buf = buf.split(b"\n", 1)
                 if not line:
+                    continue
+                if len(line) > _MAX_FRAME_BYTES:
+                    logger.warning("dropping oversized bus frame (%d bytes)", len(line))
                     continue
                 try:
                     yield BusMessage.from_jsonl(line)

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -1,0 +1,358 @@
+"""Local-host pub/sub bus for cross-agent findings over a Unix-domain socket.
+
+Carries the same shape as ``app/state/agent_state.py``'s ``evidence`` records so
+findings published by one agent (claude-code, cursor, aider, ...) can later be
+lifted into ``AgentState.evidence`` without re-mapping fields. See
+``docs/agents.mdx`` for the on-the-wire schema.
+
+Topology is a self-electing broker: the first ``publish`` or ``subscribe`` call
+that finds no live socket binds it and runs an in-process daemon thread that
+fans incoming JSONL messages out to every connected subscriber. Other processes
+attach as plain clients. If the broker dies, the next operation re-elects.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import suppress
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.constants import OPENSRE_HOME_DIR
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUS_SOCKET_PATH: Path = OPENSRE_HOME_DIR / "agents-bus.sock"
+
+#: Bus message wire-format version. Bump when ``BusMessage`` fields change shape.
+BUS_SCHEMA_VERSION: int = 1
+
+#: Max bytes per JSONL frame on the wire. Frames over this are dropped with a
+#: warning; a finding payload that big is almost certainly a bug.
+_MAX_FRAME_BYTES: int = 64 * 1024
+
+
+@dataclass(frozen=True)
+class BusMessage:
+    """A single finding published on the agent bus.
+
+    Field shape mirrors ``AgentState.evidence`` entries so a message can be
+    folded into investigation state without renaming. ``agent`` follows the
+    ``"<name>:<pid>"`` convention used by ``app.agents.conflicts.WriteEvent``.
+    """
+
+    agent: str
+    topic: str
+    summary: str
+    source: str = ""
+    path: str = ""
+    data: dict[str, object] = field(default_factory=dict)
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    schema_version: int = BUS_SCHEMA_VERSION
+
+    def to_jsonl(self) -> bytes:
+        """Encode as a single newline-terminated JSON frame ready for the socket."""
+        return (json.dumps(asdict(self), separators=(",", ":")) + "\n").encode("utf-8")
+
+    @classmethod
+    def from_jsonl(cls, line: bytes | str) -> BusMessage:
+        """Decode one JSONL frame into a ``BusMessage``. Raises on malformed input."""
+        text = line.decode("utf-8") if isinstance(line, bytes) else line
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("bus frame must be a JSON object")
+        return cls(
+            agent=str(data["agent"]),
+            topic=str(data["topic"]),
+            summary=str(data["summary"]),
+            source=str(data.get("source", "")),
+            path=str(data.get("path", "")),
+            data=dict(data.get("data", {})),
+            id=str(data.get("id", uuid.uuid4())),
+            timestamp=str(data.get("timestamp", datetime.now(UTC).isoformat())),
+            schema_version=int(data.get("schema_version", BUS_SCHEMA_VERSION)),
+        )
+
+
+def _socket_is_live(path: Path) -> bool:
+    """Return True if a broker is currently listening on ``path``."""
+    if not path.exists():
+        return False
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(0.2)
+    try:
+        probe.connect(str(path))
+    except OSError:
+        return False
+    finally:
+        with suppress(OSError):
+            probe.close()
+    return True
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+
+def _unlink_stale(path: Path) -> None:
+    """Remove a socket file that exists on disk but has no listener."""
+    with suppress(FileNotFoundError, OSError):
+        os.unlink(path)
+
+
+class BusServer:
+    """In-process broker that fans JSONL frames out to every connected subscriber.
+
+    The first publisher or subscriber on a given socket path elects itself as
+    broker by calling ``BusServer(path).start()``. The server runs an accept
+    loop and per-connection reader threads as daemons, so the host process
+    exits without needing to join them. Subscribers that disconnect or fail to
+    receive are removed from the fan-out set on the next broadcast.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._listener: socket.socket | None = None
+        self._subscribers: set[socket.socket] = set()
+        self._lock = threading.Lock()
+        self._running = threading.Event()
+        self._accept_thread: threading.Thread | None = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def is_running(self) -> bool:
+        return self._running.is_set()
+
+    def start(self) -> None:
+        """Bind the socket and spawn the accept loop. Raises ``OSError`` on bind failure."""
+        if self._running.is_set():
+            return
+        _ensure_parent_dir(self._path)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            listener.bind(str(self._path))
+        except OSError:
+            listener.close()
+            raise
+        with suppress(OSError):
+            os.chmod(self._path, 0o600)
+        listener.listen(16)
+        self._listener = listener
+        self._running.set()
+        self._accept_thread = threading.Thread(
+            target=self._accept_loop,
+            name="agents-bus-accept",
+            daemon=True,
+        )
+        self._accept_thread.start()
+
+    def stop(self) -> None:
+        """Shut the broker down: close the listener, drop all subscribers, unlink the socket."""
+        if not self._running.is_set():
+            return
+        self._running.clear()
+        listener, self._listener = self._listener, None
+        if listener is not None:
+            with suppress(OSError):
+                listener.shutdown(socket.SHUT_RDWR)
+            with suppress(OSError):
+                listener.close()
+        with self._lock:
+            for sub in self._subscribers:
+                with suppress(OSError):
+                    sub.close()
+            self._subscribers.clear()
+        _unlink_stale(self._path)
+
+    def _accept_loop(self) -> None:
+        listener = self._listener
+        if listener is None:
+            return
+        while self._running.is_set():
+            try:
+                conn, _ = listener.accept()
+            except OSError:
+                # Listener closed during ``stop()`` — exit cleanly.
+                return
+            conn.setblocking(True)
+            with self._lock:
+                self._subscribers.add(conn)
+            reader = threading.Thread(
+                target=self._reader_loop,
+                args=(conn,),
+                name="agents-bus-reader",
+                daemon=True,
+            )
+            reader.start()
+
+    def _reader_loop(self, conn: socket.socket) -> None:
+        """Read newline-delimited frames from one client and broadcast them."""
+        buf = b""
+        try:
+            while self._running.is_set():
+                chunk = conn.recv(4096)
+                if not chunk:
+                    return
+                buf += chunk
+                if len(buf) > _MAX_FRAME_BYTES * 4:
+                    logger.warning("bus client exceeded buffer cap; disconnecting")
+                    return
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    if not line:
+                        continue
+                    if len(line) > _MAX_FRAME_BYTES:
+                        logger.warning("dropping oversized bus frame (%d bytes)", len(line))
+                        continue
+                    self._broadcast(line + b"\n", origin=conn)
+        except OSError:
+            return
+        finally:
+            self._drop_subscriber(conn)
+
+    def _broadcast(self, frame: bytes, origin: socket.socket | None) -> None:
+        with self._lock:
+            targets = list(self._subscribers)
+        dead: list[socket.socket] = []
+        for sub in targets:
+            if sub is origin:
+                # Don't echo a publisher's own frame back to itself.
+                continue
+            try:
+                sub.sendall(frame)
+            except OSError:
+                dead.append(sub)
+        for sub in dead:
+            self._drop_subscriber(sub)
+
+    def _drop_subscriber(self, conn: socket.socket) -> None:
+        with self._lock:
+            self._subscribers.discard(conn)
+        with suppress(OSError):
+            conn.close()
+
+
+_broker_lock = threading.Lock()
+_brokers: dict[Path, BusServer] = {}
+
+
+def _ensure_broker(path: Path) -> BusServer | None:
+    """Elect a broker for ``path`` if none is live, else return ``None``.
+
+    Idempotent per-path: if this process already owns the broker, returns the
+    existing instance. If another process owns it, returns ``None`` (the caller
+    should connect as a client). If a stale socket file exists, unlinks it and
+    retries the bind.
+    """
+    with _broker_lock:
+        existing = _brokers.get(path)
+        if existing is not None and existing.is_running:
+            return existing
+        if _socket_is_live(path):
+            return None
+        # Path either doesn't exist or is stale. Unlink any leftover and try to bind.
+        _unlink_stale(path)
+        server = BusServer(path)
+        try:
+            server.start()
+        except OSError:
+            # Lost the race to another process between liveness check and bind.
+            return None
+        _brokers[path] = server
+        return server
+
+
+def _connect_client(path: Path, timeout: float) -> socket.socket:
+    """Open a blocking UDS connection to the broker at ``path``."""
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(timeout)
+    try:
+        client.connect(str(path))
+    except OSError:
+        with suppress(OSError):
+            client.close()
+        raise
+    client.settimeout(None)
+    return client
+
+
+def publish(
+    message: BusMessage,
+    *,
+    path: Path | None = None,
+    connect_timeout: float = 1.0,
+) -> None:
+    """Publish ``message`` to every current subscriber on the bus.
+
+    Self-elects a broker if none is running. Send is fire-and-forget: if no
+    subscribers are attached, the frame is dropped by the broker (live-only,
+    no replay buffer in v1).
+    """
+    target = path or DEFAULT_BUS_SOCKET_PATH
+    _ensure_broker(target)
+    client = _connect_client(target, timeout=connect_timeout)
+    try:
+        client.sendall(message.to_jsonl())
+    finally:
+        with suppress(OSError):
+            client.close()
+
+
+def subscribe(
+    *,
+    path: Path | None = None,
+    connect_timeout: float = 1.0,
+) -> Iterator[BusMessage]:
+    """Yield ``BusMessage``s as they arrive on the bus until the broker disconnects.
+
+    Self-elects a broker if none is running, then attaches as a subscriber and
+    streams frames. Malformed lines are logged at WARNING and skipped — one
+    misbehaving publisher should not kill an inspector REPL. The iterator ends
+    cleanly on broker disconnect; ``KeyboardInterrupt`` propagates so callers
+    (e.g. ``/agents bus``) can return to their prompt.
+    """
+    target = path or DEFAULT_BUS_SOCKET_PATH
+    _ensure_broker(target)
+    client = _connect_client(target, timeout=connect_timeout)
+    buf = b""
+    try:
+        while True:
+            try:
+                chunk = client.recv(4096)
+            except OSError:
+                return
+            if not chunk:
+                return
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line:
+                    continue
+                try:
+                    yield BusMessage.from_jsonl(line)
+                except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+                    logger.warning("dropping malformed bus frame: %s", line[:80])
+    finally:
+        with suppress(OSError):
+            client.close()
+
+
+__all__ = [
+    "BUS_SCHEMA_VERSION",
+    "BusMessage",
+    "BusServer",
+    "DEFAULT_BUS_SOCKET_PATH",
+    "publish",
+    "subscribe",
+]

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -13,6 +13,7 @@ attach as plain clients. If the broker dies, the next operation re-elects.
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
@@ -176,7 +177,14 @@ def _unlink_stale(path: Path) -> None:
 
 
 def _write_pid_file_atomic(path: Path, pid: int) -> None:
-    """Write ``pid`` to the sidecar atomically (tmpfile + rename)."""
+    """Write ``pid`` to the sidecar atomically (tmpfile + rename).
+
+    Raises ``OSError`` on failure. Callers (i.e. ``BusServer.start``) must
+    treat a missing PID file as a hard error: in multi-process operation,
+    ``_socket_is_live`` reads the sidecar, and silently swallowing a write
+    failure would let peers see the broker as dead, ``_unlink_stale`` its
+    socket file out from under it, and silently split the bus.
+    """
     pid_path = _pid_file_for(path)
     tmp = pid_path.with_name(pid_path.name + ".tmp")
     try:
@@ -187,9 +195,7 @@ def _write_pid_file_atomic(path: Path, pid: int) -> None:
     except OSError:
         with suppress(FileNotFoundError, OSError):
             os.unlink(tmp)
-        # PID file is best-effort: bus still works without it, ``_socket_is_live``
-        # just falls back to "not live" and a peer might re-elect.
-        logger.warning("failed to write bus pid file at %s", pid_path)
+        raise
 
 
 class BusServer:
@@ -219,7 +225,13 @@ class BusServer:
         return self._running.is_set()
 
     def start(self) -> None:
-        """Bind the socket and spawn the accept loop. Raises ``OSError`` on bind failure."""
+        """Bind the socket, write the PID sidecar, and spawn the accept loop.
+
+        Raises ``OSError`` on bind failure or on PID-file write failure (the
+        sidecar is required for correct multi-process liveness; see
+        ``_write_pid_file_atomic``). Any partial state is rolled back so a
+        half-started broker never persists.
+        """
         if self._running.is_set():
             return
         _ensure_parent_dir(self._path)
@@ -232,12 +244,24 @@ class BusServer:
         with suppress(OSError):
             os.chmod(self._path, 0o600)
         listener.listen(16)
-        self._listener = listener
-        self._running.set()
         # Publish our PID via the sidecar so peers can answer "is the broker
         # live?" without making a real connection (which would otherwise spawn
-        # a short-lived phantom subscriber on every probe).
-        _write_pid_file_atomic(self._path, os.getpid())
+        # a short-lived phantom subscriber on every probe). If this fails we
+        # tear the bind down so a peer doesn't ``_unlink_stale`` our orphaned
+        # socket file out from under us — ``_socket_is_live`` reads the
+        # sidecar, and a missing one would silently split the bus.
+        try:
+            _write_pid_file_atomic(self._path, os.getpid())
+        except OSError:
+            with suppress(OSError):
+                listener.shutdown(socket.SHUT_RDWR)
+            with suppress(OSError):
+                listener.close()
+            with suppress(FileNotFoundError, OSError):
+                os.unlink(self._path)
+            raise
+        self._listener = listener
+        self._running.set()
         self._accept_thread = threading.Thread(
             target=self._accept_loop,
             name="agents-bus-accept",
@@ -335,6 +359,9 @@ _broker_lock = threading.Lock()
 _brokers: dict[Path, BusServer] = {}
 
 
+_BIND_RACE_ERRNOS: frozenset[int] = frozenset({errno.EADDRINUSE, errno.EEXIST})
+
+
 def _ensure_broker(path: Path) -> BusServer | None:
     """Elect a broker for ``path`` if none is live, else return ``None``.
 
@@ -342,6 +369,12 @@ def _ensure_broker(path: Path) -> BusServer | None:
     existing instance. If another process owns it, returns ``None`` (the caller
     should connect as a client). If a stale socket file exists, unlinks it and
     retries the bind.
+
+    A lost bind race (``EADDRINUSE`` / ``EEXIST``) is converted to ``None``
+    because that just means a peer beat us to the elect. Any other ``OSError``
+    from ``start()`` (e.g. PID-file write failure, parent-dir creation failure)
+    is propagated — those are real errors users need to see, not bus splits to
+    paper over silently.
     """
     with _broker_lock:
         existing = _brokers.get(path)
@@ -349,14 +382,14 @@ def _ensure_broker(path: Path) -> BusServer | None:
             return existing
         if _socket_is_live(path):
             return None
-        # Path either doesn't exist or is stale. Unlink any leftover and try to bind.
         _unlink_stale(path)
         server = BusServer(path)
         try:
             server.start()
-        except OSError:
-            # Lost the race to another process between liveness check and bind.
-            return None
+        except OSError as exc:
+            if exc.errno in _BIND_RACE_ERRNOS:
+                return None
+            raise
         _brokers[path] = server
         return server
 

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import atexit
 import errno
+import fcntl
 import json
 import logging
 import os
@@ -402,6 +403,43 @@ _brokers: dict[Path, BusServer] = {}
 _BIND_RACE_ERRNOS: frozenset[int] = frozenset({errno.EADDRINUSE, errno.EEXIST})
 
 
+def _election_lock_path(socket_path: Path) -> Path:
+    """Sidecar lock file used to serialize broker election across processes."""
+    return socket_path.with_name(socket_path.name + ".lock")
+
+
+def _acquire_election_flock(path: Path) -> int | None:
+    """Open the election lock file and acquire an exclusive ``flock``.
+
+    Returns the open fd on success, or ``None`` if the lock could not be
+    obtained (file system without ``flock`` support, permission denied,
+    ...). The caller is responsible for releasing + closing the fd via
+    ``_release_election_flock``.
+    """
+    lock_path = _election_lock_path(path)
+    try:
+        _ensure_parent_dir(lock_path)
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    except OSError:
+        return None
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError:
+        with suppress(OSError):
+            os.close(fd)
+        return None
+    return fd
+
+
+def _release_election_flock(fd: int | None) -> None:
+    if fd is None:
+        return
+    with suppress(OSError):
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    with suppress(OSError):
+        os.close(fd)
+
+
 def _ensure_broker(path: Path) -> BusServer | None:
     """Elect a broker for ``path`` if none is live, else return ``None``.
 
@@ -410,28 +448,51 @@ def _ensure_broker(path: Path) -> BusServer | None:
     should connect as a client). If a stale socket file exists, unlinks it and
     retries the bind.
 
-    A lost bind race (``EADDRINUSE`` / ``EEXIST``) is converted to ``None``
-    because that just means a peer beat us to the elect. Any other ``OSError``
-    from ``start()`` (e.g. PID-file write failure, parent-dir creation failure)
-    is propagated — those are real errors users need to see, not bus splits to
+    Cross-process election is serialized by a POSIX ``flock`` on a sidecar
+    lock file (``<socket>.lock``). Without it, two processes that both
+    observe ``_socket_is_live`` → False can race through ``_unlink_stale`` +
+    ``bind``: the kernel guarantees one bind succeeds, but the loser is left
+    holding a listener fd whose filesystem path the winner just took, plus
+    the accept/reader daemon threads it spawned — a real resource leak that
+    persists for the loser's process lifetime. Holding the flock around the
+    check-then-bind sequence makes election atomic across processes.
+
+    A lost bind race (``EADDRINUSE`` / ``EEXIST``) is still converted to
+    ``None`` defensively — flock is best-effort on exotic filesystems. Any
+    other ``OSError`` from ``start()`` (e.g. PID-file write failure) is
+    propagated — those are real errors users need to see, not bus splits to
     paper over silently.
     """
+    # Fast in-process path: if we already own a running broker, no
+    # cross-process work is needed.
     with _broker_lock:
         existing = _brokers.get(path)
         if existing is not None and existing.is_running:
             return existing
-        if _socket_is_live(path):
-            return None
-        _unlink_stale(path)
-        server = BusServer(path)
-        try:
-            server.start()
-        except OSError as exc:
-            if exc.errno in _BIND_RACE_ERRNOS:
+
+    flock_fd = _acquire_election_flock(path)
+    try:
+        with _broker_lock:
+            # Re-check inside the cross-process lock: a peer (or another
+            # thread that also raced past the fast path) may have just
+            # elected.
+            existing = _brokers.get(path)
+            if existing is not None and existing.is_running:
+                return existing
+            if _socket_is_live(path):
                 return None
-            raise
-        _brokers[path] = server
-        return server
+            _unlink_stale(path)
+            server = BusServer(path)
+            try:
+                server.start()
+            except OSError as exc:
+                if exc.errno in _BIND_RACE_ERRNOS:
+                    return None
+                raise
+            _brokers[path] = server
+            return server
+    finally:
+        _release_election_flock(flock_fd)
 
 
 def _connect_client(path: Path, timeout: float) -> socket.socket:

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -219,7 +219,14 @@ class BusServer:
     def __init__(self, path: Path) -> None:
         self._path = path
         self._listener: socket.socket | None = None
-        self._subscribers: set[socket.socket] = set()
+        # Map of subscriber socket -> per-connection write lock. Concurrent
+        # broadcasts from multiple publisher reader-threads to the same
+        # subscriber socket would otherwise interleave bytes mid-frame
+        # (``sendall`` is multi-syscall for frames near the 64 KiB cap),
+        # producing a garbled JSONL line the subscriber cannot parse. The
+        # lock is per-subscriber so broadcasts to *different* subscribers
+        # still proceed in parallel.
+        self._subscribers: dict[socket.socket, threading.Lock] = {}
         self._lock = threading.Lock()
         self._running = threading.Event()
         self._accept_thread: threading.Thread | None = None
@@ -307,7 +314,7 @@ class BusServer:
                 return
             conn.setblocking(True)
             with self._lock:
-                self._subscribers.add(conn)
+                self._subscribers[conn] = threading.Lock()
             reader = threading.Thread(
                 target=self._reader_loop,
                 args=(conn,),
@@ -343,25 +350,36 @@ class BusServer:
 
     def _broadcast(self, frame: bytes, origin: socket.socket | None) -> None:
         with self._lock:
-            targets = list(self._subscribers)
+            # Snapshot (sub, write_lock) pairs so concurrent broadcasts to
+            # different subscribers can proceed in parallel — only writes to
+            # the *same* subscriber are serialized.
+            targets = list(self._subscribers.items())
         dead: list[socket.socket] = []
-        for sub in targets:
+        for sub, write_lock in targets:
             if sub is origin:
                 # Don't echo a publisher's own frame back to itself.
                 continue
             try:
-                # Write-readiness gate via select: a blocking ``sendall`` on a
-                # subscriber whose kernel recv buffer is full would wedge the
-                # reader thread of *every* publisher, freezing fan-out across
-                # the bus. Using ``select`` instead of ``sub.settimeout`` so
-                # the per-connection ``_reader_loop``'s ``recv`` is unaffected
-                # (a quiet healthy subscriber must not be evicted).
-                _r, ready, _x = select.select([], [sub], [], _BROADCAST_WRITE_TIMEOUT_SECONDS)
-                if not ready:
-                    logger.warning("bus subscriber unresponsive; evicting from fan-out")
-                    dead.append(sub)
-                    continue
-                sub.sendall(frame)
+                # Per-subscriber write lock prevents two publisher reader-
+                # threads from interleaving bytes mid-frame on the same
+                # socket (``sendall`` may issue multiple ``send`` syscalls
+                # for large frames). Different subscribers have independent
+                # locks, so cross-subscriber fan-out is unaffected.
+                with write_lock:
+                    # Write-readiness gate via ``select``: a blocking
+                    # ``sendall`` on a subscriber whose kernel recv buffer is
+                    # full would wedge the reader thread of *every*
+                    # publisher, freezing fan-out across the bus. Using
+                    # ``select`` instead of ``sub.settimeout`` so the
+                    # per-connection ``_reader_loop``'s ``recv`` is
+                    # unaffected (a quiet healthy subscriber must not be
+                    # evicted).
+                    _r, ready, _x = select.select([], [sub], [], _BROADCAST_WRITE_TIMEOUT_SECONDS)
+                    if not ready:
+                        logger.warning("bus subscriber unresponsive; evicting from fan-out")
+                        dead.append(sub)
+                        continue
+                    sub.sendall(frame)
             except (OSError, ValueError):
                 # ValueError: ``select`` rejects a closed fd (-1) by raising
                 # ValueError rather than OSError. Treat it the same as a
@@ -372,7 +390,7 @@ class BusServer:
 
     def _drop_subscriber(self, conn: socket.socket) -> None:
         with self._lock:
-            self._subscribers.discard(conn)
+            self._subscribers.pop(conn, None)
         with suppress(OSError):
             conn.close()
 

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -18,10 +18,11 @@ import logging
 import os
 import socket
 import threading
+import types
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import suppress
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -46,6 +47,12 @@ class BusMessage:
     Field shape mirrors ``AgentState.evidence`` entries so a message can be
     folded into investigation state without renaming. ``agent`` follows the
     ``"<name>:<pid>"`` convention used by ``app.agents.conflicts.WriteEvent``.
+
+    ``data`` is wrapped in ``types.MappingProxyType`` at construction so the
+    payload is read-only post-init; mutating ``msg.data["x"] = 1`` raises
+    ``TypeError``. ``__hash__`` is explicitly disabled because ``data`` is a
+    mapping and would otherwise produce a misleading auto-generated hash that
+    fails at call time.
     """
 
     agent: str
@@ -53,14 +60,34 @@ class BusMessage:
     summary: str
     source: str = ""
     path: str = ""
-    data: dict[str, object] = field(default_factory=dict)
+    data: Mapping[str, object] = field(default_factory=dict)
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     schema_version: int = BUS_SCHEMA_VERSION
 
+    # Disable hashing: a BusMessage carries a mapping and is not a value-key.
+    __hash__ = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        # Defensive copy + read-only view: protects against both external
+        # mutation of the original dict and ``msg.data["x"] = 1`` after
+        # construction. ``object.__setattr__`` bypasses the frozen check.
+        object.__setattr__(self, "data", types.MappingProxyType(dict(self.data)))
+
     def to_jsonl(self) -> bytes:
         """Encode as a single newline-terminated JSON frame ready for the socket."""
-        return (json.dumps(asdict(self), separators=(",", ":")) + "\n").encode("utf-8")
+        payload = {
+            "agent": self.agent,
+            "topic": self.topic,
+            "summary": self.summary,
+            "source": self.source,
+            "path": self.path,
+            "data": dict(self.data),
+            "id": self.id,
+            "timestamp": self.timestamp,
+            "schema_version": self.schema_version,
+        }
+        return (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
 
     @classmethod
     def from_jsonl(cls, line: bytes | str) -> BusMessage:
@@ -82,20 +109,58 @@ class BusMessage:
         )
 
 
-def _socket_is_live(path: Path) -> bool:
-    """Return True if a broker is currently listening on ``path``."""
-    if not path.exists():
-        return False
-    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    probe.settimeout(0.2)
+def _pid_file_for(socket_path: Path) -> Path:
+    """Return the sidecar PID-file path for a given bus socket path."""
+    return socket_path.with_name(socket_path.name + ".pid")
+
+
+def _read_broker_pid(socket_path: Path) -> int | None:
+    """Read the broker PID from the sidecar file, or ``None`` if missing/garbled."""
+    pid_path = _pid_file_for(socket_path)
     try:
-        probe.connect(str(path))
+        text = pid_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _process_is_alive(pid: int) -> bool:
+    """``os.kill(pid, 0)`` probe: True iff the PID maps to a live process we can signal."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it. Treat as alive — we still can't
+        # safely unlink the socket out from under whoever owns it.
+        return True
     except OSError:
         return False
-    finally:
-        with suppress(OSError):
-            probe.close()
     return True
+
+
+def _socket_is_live(path: Path) -> bool:
+    """Return True if a broker is currently listening on ``path``.
+
+    Uses a PID-file side channel rather than connecting to the socket: the
+    broker writes its PID on ``start()`` and removes it on ``stop()``. We treat
+    the broker as live iff the socket file exists, the PID file exists, and
+    the recorded PID maps to a process we can signal. This avoids creating a
+    short-lived phantom subscriber + reader thread on every ``publish()`` /
+    ``subscribe()`` call by a non-owner process.
+
+    A stale PID file (broker crashed without cleanup) is reported as not-live;
+    the caller's ``_unlink_stale`` path will remove the socket file and rebind.
+    """
+    if not path.exists():
+        return False
+    pid = _read_broker_pid(path)
+    if pid is None:
+        return False
+    return _process_is_alive(pid)
 
 
 def _ensure_parent_dir(path: Path) -> None:
@@ -103,9 +168,28 @@ def _ensure_parent_dir(path: Path) -> None:
 
 
 def _unlink_stale(path: Path) -> None:
-    """Remove a socket file that exists on disk but has no listener."""
+    """Remove a socket file (and its sidecar PID file) that has no live listener."""
     with suppress(FileNotFoundError, OSError):
         os.unlink(path)
+    with suppress(FileNotFoundError, OSError):
+        os.unlink(_pid_file_for(path))
+
+
+def _write_pid_file_atomic(path: Path, pid: int) -> None:
+    """Write ``pid`` to the sidecar atomically (tmpfile + rename)."""
+    pid_path = _pid_file_for(path)
+    tmp = pid_path.with_name(pid_path.name + ".tmp")
+    try:
+        tmp.write_text(str(pid), encoding="utf-8")
+        with suppress(OSError):
+            os.chmod(tmp, 0o600)
+        os.replace(tmp, pid_path)
+    except OSError:
+        with suppress(FileNotFoundError, OSError):
+            os.unlink(tmp)
+        # PID file is best-effort: bus still works without it, ``_socket_is_live``
+        # just falls back to "not live" and a peer might re-elect.
+        logger.warning("failed to write bus pid file at %s", pid_path)
 
 
 class BusServer:
@@ -150,6 +234,10 @@ class BusServer:
         listener.listen(16)
         self._listener = listener
         self._running.set()
+        # Publish our PID via the sidecar so peers can answer "is the broker
+        # live?" without making a real connection (which would otherwise spawn
+        # a short-lived phantom subscriber on every probe).
+        _write_pid_file_atomic(self._path, os.getpid())
         self._accept_thread = threading.Thread(
             target=self._accept_loop,
             name="agents-bus-accept",

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape
 
+from app.agents.bus import BusMessage, subscribe
 from app.agents.config import (
     agents_config_path,
     load_agents_config,
@@ -41,6 +42,7 @@ from app.cli.interactive_shell.theme import BOLD_BRAND, DIM, ERROR, HIGHLIGHT, W
 
 _AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("budget", "view or edit per-agent hourly budgets"),
+    ("bus", "live-tail the cross-agent context bus"),
     ("claim", "claim a branch for an agent"),
     ("conflicts", "show file-write conflicts between local AI agents"),
     ("kill", "SIGTERM → SIGKILL a local agent by PID"),
@@ -74,6 +76,37 @@ def _cmd_agents_list(console: Console) -> bool:
     registry = AgentRegistry()
     table = render_agents_table(registered_and_discovered_agents(registry))
     console.print(table)
+    return True
+
+
+def _format_bus_message(msg: BusMessage) -> str:
+    """Render one ``BusMessage`` as ``[agent] path — summary`` (path optional)."""
+    parts = [f"[{HIGHLIGHT}]\\[{escape(msg.agent)}][/]"]
+    if msg.path:
+        parts.append(escape(msg.path))
+        parts.append("—")
+    parts.append(escape(msg.summary))
+    return " ".join(parts)
+
+
+def _cmd_agents_bus(console: Console) -> bool:
+    """Live-tail the cross-agent context bus until ``Ctrl-C``.
+
+    Self-elects a broker if none is running, then streams each ``BusMessage``
+    as it arrives. ``KeyboardInterrupt`` is the only documented way to exit
+    and returns to the REPL prompt without raising.
+    """
+    console.print(
+        f"[{DIM}]tailing /agents bus — Ctrl-C to exit[/]",
+    )
+    try:
+        for msg in subscribe():
+            console.print(_format_bus_message(msg))
+    except KeyboardInterrupt:
+        console.print(f"[{DIM}](detached)[/]")
+    except OSError as exc:
+        console.print(f"[{ERROR}]bus error:[/] {escape(str(exc))}")
+        return False
     return True
 
 
@@ -338,6 +371,8 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
 
     if sub == "budget":
         return _cmd_agents_budget(session, console, args[1:])
+    if sub == "bus":
+        return _cmd_agents_bus(console)
     if sub == "conflicts":
         return _cmd_agents_conflicts(console)
 
@@ -353,8 +388,9 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
     console.print(
         f"[{ERROR}]unknown subcommand:[/] {escape(sub)}  "
         "(try [bold]/agents[/bold], [bold]/agents budget[/bold], "
-        "[bold]/agents conflicts[/bold], [bold]/agents kill[/bold], "
-        "[bold]/agents claim[/bold], or [bold]/agents release[/bold])"
+        "[bold]/agents bus[/bold], [bold]/agents conflicts[/bold], "
+        "[bold]/agents kill[/bold], [bold]/agents claim[/bold], "
+        "or [bold]/agents release[/bold])"
     )
     session.mark_latest(ok=False, kind="slash")
     return True
@@ -363,7 +399,7 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/agents",
-        "show registered local AI agents (subcommands: budget, claim, conflicts, kill, release)",
+        "show registered local AI agents (subcommands: budget, bus, claim, conflicts, kill, release)",
         _cmd_agents,
         first_arg_completions=_AGENTS_FIRST_ARGS,
     ),

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -90,11 +90,12 @@ def _format_bus_message(msg: BusMessage) -> str:
 
 
 def _cmd_agents_bus(console: Console) -> bool:
-    """Live-tail the cross-agent context bus until ``Ctrl-C``.
+    """Live-tail the cross-agent context bus until ``Ctrl-C`` or broker exit.
 
     Self-elects a broker if none is running, then streams each ``BusMessage``
-    as it arrives. ``KeyboardInterrupt`` is the only documented way to exit
-    and returns to the REPL prompt without raising.
+    as it arrives. The loop ends in three ways, each with explicit feedback:
+    ``KeyboardInterrupt`` (user detached), broker disconnect (e.g. the
+    publishing process exited), or socket error.
     """
     console.print(
         f"[{DIM}]tailing /agents bus — Ctrl-C to exit[/]",
@@ -104,9 +105,14 @@ def _cmd_agents_bus(console: Console) -> bool:
             console.print(_format_bus_message(msg))
     except KeyboardInterrupt:
         console.print(f"[{DIM}](detached)[/]")
+        return True
     except OSError as exc:
         console.print(f"[{ERROR}]bus error:[/] {escape(str(exc))}")
         return False
+    # ``subscribe()`` returned cleanly — the broker closed our connection
+    # (e.g. it stopped, or its host process exited). Surface that explicitly
+    # so the user isn't left wondering why the prompt came back.
+    console.print(f"[{DIM}]bus broker disconnected[/]")
     return True
 
 

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -40,6 +40,16 @@ late subscribers — the bus is **live-only** in v1.
 ### Transport
 
 - **Socket**: Unix-domain stream socket at `~/.config/opensre/agents-bus.sock`.
+- **PID sidecar**: `~/.config/opensre/agents-bus.sock.pid` (mode `0600`). The
+  broker writes its PID here on `start()` and removes it on `stop()`. The
+  liveness probe used by every `publish()` / `subscribe()` reads this file
+  rather than connecting to the socket — connection probing would otherwise
+  register a short-lived phantom subscriber on every call.
+  **The directory must be writable.** If the PID file write fails (disk full,
+  permission denied, ...), the broker refuses to start and the `OSError`
+  propagates to the caller. This is intentional: silently running without a
+  sidecar would let peers see the broker as dead, unlink its socket, and
+  silently split the bus.
 - **Permissions**: `0600` — only the user who started the broker can read or
   write it.
 - **Wire format**: JSON Lines (one JSON object per `\n`-terminated frame).

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -35,7 +35,11 @@ tailing /agents bus — Ctrl-C to exit
 ```
 
 Ctrl-C returns to the prompt. Messages already published are not replayed to
-late subscribers — the bus is **live-only** in v1.
+late subscribers. The bus provides **at-most-once delivery with no ordering
+guarantees** — a frame may be dropped if a subscriber's socket is slow or
+disconnected, and two publishers writing concurrently may be interleaved in
+different orders at different subscribers. Do not assume per-publisher or
+global FIFO ordering.
 
 ### Transport
 
@@ -135,10 +139,19 @@ EOF
 
 - **Local-only.** The bus never leaves the machine. The socket has no network
   binding.
-- **No auth beyond filesystem perms.** Any process running as your user can
-  publish or subscribe. Treat the bus as roughly equivalent to a shared file
-  in `~/.config/opensre/`.
+- **Trusted-peer channel — treat findings as unverified input.** The bus has
+  no authentication beyond filesystem permissions: any process running as your
+  user can publish arbitrary findings. This is intentional — the bus is
+  designed for cooperative agents, not adversarial ones. Downstream consumers
+  (agents, the REPL, investigation state) **must not act on a bus finding
+  without independent confirmation**; treat it as a hint or lead, not a
+  verified fact. A compromised or misbehaving agent on the same user account
+  can inject any payload it likes.
 - **Frame cap.** Frames over 64 KiB are dropped with a warning — a finding
   payload that big is almost certainly a bug.
+- **At-most-once, unordered delivery.** A frame is dropped silently if a
+  subscriber is slow or disconnected at broadcast time. Two publishers writing
+  concurrently may arrive in different orders at different subscribers. Do not
+  build logic that depends on delivery guarantees or ordering.
 - **No replay buffer.** Subscribers see only what is published *after* they
   attach. A persistent ring buffer is a candidate for a follow-up phase.

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -1,0 +1,134 @@
+---
+title: 'Local Agent Fleet'
+description: 'Slash-command surface for monitoring, coordinating, and exchanging context between local AI agents (Claude Code, Cursor, Aider, ...)'
+---
+
+## Overview
+
+OpenSRE treats every other AI agent running on your machine — Claude Code,
+Cursor, Aider, Codex CLI, Gemini, and friends — as a microservice and applies
+normal SRE practice: golden signals, SLOs, and incident response. The whole
+fleet view lives behind one slash command in the interactive shell:
+
+```text
+> /agents
+```
+
+Subcommands drill into specific surfaces. This page documents the cross-agent
+**context bus** behind `/agents bus`.
+
+## `/agents bus` — shared context channel
+
+The bus is an opt-in, local-only pub/sub channel that carries findings between
+agents. One agent publishes a finding (e.g. *"the auth bug is in
+`services/auth.py:42`"*) and every attached subscriber sees it live. The
+inspector is the REPL itself:
+
+```text
+> /agents bus
+tailing /agents bus — Ctrl-C to exit
+[claude-code:8421] services/auth.py:42 — null deref on missing token
+[cursor:9133] services/auth.py:42 — confirmed, repro on commit abc123
+^C
+(detached)
+>
+```
+
+Ctrl-C returns to the prompt. Messages already published are not replayed to
+late subscribers — the bus is **live-only** in v1.
+
+### Transport
+
+- **Socket**: Unix-domain stream socket at `~/.config/opensre/agents-bus.sock`.
+- **Permissions**: `0600` — only the user who started the broker can read or
+  write it.
+- **Wire format**: JSON Lines (one JSON object per `\n`-terminated frame).
+- **Topology**: self-electing broker. The first `publish()` or `subscribe()`
+  call that finds no live socket binds it and runs an in-process daemon thread
+  that fans frames out. Other processes attach as plain clients. If the broker
+  dies, the next operation re-elects — agents can publish and subscribe even
+  when OpenSRE itself is not running.
+
+### Message schema
+
+The wire payload mirrors the shape of `evidence` records in
+`app/state/agent_state.py` so a finding can later be lifted into an
+investigation without renaming fields.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `agent` | string | yes | `"<name>:<pid>"`, e.g. `"claude-code:8421"`. Same convention as `WriteEvent.agent`. |
+| `topic` | string | yes | `"finding"` is the canonical value; other topics are reserved for future phases. |
+| `summary` | string | yes | One-line human-readable description. |
+| `source` | string | no | One of the `EvidenceSource` literals (`github`, `datadog`, ...) or free-form. |
+| `path` | string | no | `"file.py:42"` style location. Optional. |
+| `data` | object | no | Free-form payload. Default `{}`. |
+| `id` | string | no | UUID. Generated if omitted. |
+| `timestamp` | string | no | ISO-8601 UTC. Generated if omitted. |
+| `schema_version` | int | no | Currently `1`. |
+
+Example frame on the wire (single line, broken here for readability):
+
+```json
+{
+  "agent": "claude-code:8421",
+  "topic": "finding",
+  "summary": "null deref on missing token",
+  "source": "github",
+  "path": "services/auth.py:42",
+  "data": {"commit": "abc123"},
+  "id": "f4c4...",
+  "timestamp": "2026-05-09T15:04:42+00:00",
+  "schema_version": 1
+}
+```
+
+### Publishing from another agent
+
+Any process that can speak Unix-domain sockets can publish. The simplest path
+is to import the helper:
+
+```python
+from app.agents import BusMessage, publish
+
+publish(BusMessage(
+    agent="claude-code:8421",
+    topic="finding",
+    summary="null deref on missing token",
+    source="github",
+    path="services/auth.py:42",
+    data={"commit": "abc123"},
+))
+```
+
+Publishers without a Python dependency on OpenSRE can connect directly:
+
+```bash
+python - <<'EOF'
+import json, os, socket, uuid, datetime
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.path.expanduser("~/.config/opensre/agents-bus.sock"))
+sock.sendall((json.dumps({
+    "agent": "claude-code:8421",
+    "topic": "finding",
+    "summary": "null deref on missing token",
+    "path": "services/auth.py:42",
+    "id": str(uuid.uuid4()),
+    "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+    "schema_version": 1,
+}) + "\n").encode())
+sock.close()
+EOF
+```
+
+### Limits and trust boundary
+
+- **Local-only.** The bus never leaves the machine. The socket has no network
+  binding.
+- **No auth beyond filesystem perms.** Any process running as your user can
+  publish or subscribe. Treat the bus as roughly equivalent to a shared file
+  in `~/.config/opensre/`.
+- **Frame cap.** Frames over 64 KiB are dropped with a warning — a finding
+  payload that big is almost certainly a bug.
+- **No replay buffer.** Subscribers see only what is published *after* they
+  attach. A persistent ring buffer is a candidate for a follow-up phase.

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -89,17 +89,11 @@ class TestBusMessage:
     def test_is_not_hashable(self) -> None:
         # ``data`` is a mapping, so a value hash would be misleading and would
         # fail at call time on the auto-generated ``__hash__``. We disable it
-        # explicitly. Assert the contract directly (``__hash__ is None``)
-        # rather than triggering ``hash()`` — the latter trips static
-        # analysers that statically see the unhashability.
+        # explicitly. Assert the contract directly (``__hash__ is None``);
+        # Python's hash protocol guarantees ``TypeError`` from there, no need
+        # to re-test the language (and triggering ``hash()`` here trips
+        # CodeQL's "Unhashable object hashed" rule).
         assert BusMessage.__hash__ is None
-        msg = BusMessage(agent="a:1", topic="finding", summary="x", data={"k": 1})
-        assert getattr(msg, "__hash__", "missing") is None
-        # Sanity-check the runtime behavior matches by routing the call
-        # through ``object`` so static analysis can't pre-resolve the type.
-        opaque: object = msg
-        with pytest.raises(TypeError):
-            hash(opaque)
 
     def test_data_is_read_only_post_construction(self) -> None:
         msg = BusMessage(agent="a:1", topic="finding", summary="x", data={"k": 1})

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -150,6 +150,40 @@ class TestBusServerLifecycle:
             server.stop()
         assert not _pid_file_for(sock_path).exists()
 
+    def test_start_rolls_back_when_pid_file_write_fails(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate ENOSPC / EACCES during the PID-file write. ``start`` must
+        # raise *and* leave no orphaned socket file behind — otherwise peers
+        # would see a path with no live listener via ``_socket_is_live``,
+        # ``_unlink_stale`` it, and silently split the bus.
+        def _boom_enospc(*args: object) -> None:
+            del args
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(bus_module, "_write_pid_file_atomic", _boom_enospc)
+
+        server = BusServer(sock_path)
+        with pytest.raises(OSError):
+            server.start()
+        assert not sock_path.exists()
+        assert not _pid_file_for(sock_path).exists()
+        assert not server.is_running
+
+    def test_ensure_broker_propagates_pid_write_failure(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``_ensure_broker`` swallows EADDRINUSE/EEXIST as a lost bind race,
+        # but real failures (disk full, permission denied) must propagate so
+        # callers see the error instead of silently splitting the bus.
+        def _boom_eacces(*args: object) -> None:
+            del args
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(bus_module, "_write_pid_file_atomic", _boom_eacces)
+        with pytest.raises(OSError):
+            bus_module._ensure_broker(sock_path)
+
 
 class TestLivenessProbe:
     def test_socket_is_live_does_not_create_phantom_subscriber(self, sock_path: Path) -> None:

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -1,0 +1,245 @@
+"""Tests for the local-host pub/sub agent bus over a Unix-domain socket."""
+
+from __future__ import annotations
+
+import queue
+import socket
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from app.agents import bus as bus_module
+from app.agents.bus import (
+    BUS_SCHEMA_VERSION,
+    BusMessage,
+    BusServer,
+    _socket_is_live,
+    publish,
+    subscribe,
+)
+
+
+@pytest.fixture
+def sock_path(tmp_path: Path) -> Path:
+    return tmp_path / "bus.sock"
+
+
+@pytest.fixture(autouse=True)
+def isolated_brokers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts with an empty broker registry, no cross-test bleed."""
+    monkeypatch.setattr(bus_module, "_brokers", {})
+
+
+def _drain_subscriber(
+    sock_path: Path, into: queue.Queue[BusMessage], stop_after: int = 1
+) -> threading.Thread:
+    """Spawn a daemon thread that puts up to ``stop_after`` messages into ``into``."""
+
+    def _loop() -> None:
+        for count, msg in enumerate(subscribe(path=sock_path), start=1):
+            into.put(msg)
+            if count >= stop_after:
+                return
+
+    thread = threading.Thread(target=_loop, daemon=True)
+    thread.start()
+    # Give the subscriber a moment to bind/connect before tests publish.
+    time.sleep(0.15)
+    return thread
+
+
+class TestBusMessage:
+    def test_round_trip_preserves_all_fields(self) -> None:
+        original = BusMessage(
+            agent="claude-code:8421",
+            topic="finding",
+            summary="null deref on missing token",
+            source="github",
+            path="services/auth.py:42",
+            data={"commit": "abc", "line": 42},
+        )
+        decoded = BusMessage.from_jsonl(original.to_jsonl())
+        assert decoded == original
+
+    def test_to_jsonl_ends_with_newline(self) -> None:
+        msg = BusMessage(agent="a:1", topic="finding", summary="x")
+        assert msg.to_jsonl().endswith(b"\n")
+
+    def test_from_jsonl_supplies_defaults_for_optional_fields(self) -> None:
+        # Minimum required fields only — source/path/data should default.
+        wire = b'{"agent":"a:1","topic":"finding","summary":"x"}\n'
+        msg = BusMessage.from_jsonl(wire)
+        assert msg.source == ""
+        assert msg.path == ""
+        assert msg.data == {}
+        assert msg.schema_version == BUS_SCHEMA_VERSION
+
+    def test_from_jsonl_rejects_non_object_payload(self) -> None:
+        with pytest.raises(ValueError):
+            BusMessage.from_jsonl(b'["not","an","object"]')
+
+    def test_from_jsonl_rejects_missing_required_field(self) -> None:
+        with pytest.raises(KeyError):
+            BusMessage.from_jsonl(b'{"agent":"a:1","topic":"finding"}')
+
+
+class TestBusServerLifecycle:
+    def test_start_binds_socket_and_stop_unlinks(self, sock_path: Path) -> None:
+        server = BusServer(sock_path)
+        try:
+            server.start()
+            assert sock_path.exists()
+            assert _socket_is_live(sock_path)
+            assert server.is_running
+        finally:
+            server.stop()
+        assert not sock_path.exists()
+        assert not server.is_running
+
+    def test_start_is_idempotent(self, sock_path: Path) -> None:
+        server = BusServer(sock_path)
+        try:
+            server.start()
+            server.start()  # second call should be a no-op, not raise
+            assert server.is_running
+        finally:
+            server.stop()
+
+    def test_stop_is_idempotent(self, sock_path: Path) -> None:
+        server = BusServer(sock_path)
+        server.start()
+        server.stop()
+        server.stop()  # second call should be a no-op, not raise
+
+
+class TestPublishSubscribe:
+    def test_round_trip_one_publisher_one_subscriber(self, sock_path: Path) -> None:
+        received: queue.Queue[BusMessage] = queue.Queue()
+        _drain_subscriber(sock_path, received)
+
+        publish(
+            BusMessage(
+                agent="claude-code:8421",
+                topic="finding",
+                summary="null deref",
+                path="services/auth.py:42",
+            ),
+            path=sock_path,
+        )
+
+        msg = received.get(timeout=2.0)
+        assert msg.agent == "claude-code:8421"
+        assert msg.summary == "null deref"
+        assert msg.path == "services/auth.py:42"
+
+    def test_one_publisher_multiple_subscribers_all_receive(self, sock_path: Path) -> None:
+        n_subs = 3
+        sub_queues: list[queue.Queue[BusMessage]] = [queue.Queue() for _ in range(n_subs)]
+        for q in sub_queues:
+            _drain_subscriber(sock_path, q)
+
+        publish(BusMessage(agent="a:1", topic="finding", summary="hello"), path=sock_path)
+
+        for q in sub_queues:
+            msg = q.get(timeout=2.0)
+            assert msg.summary == "hello"
+
+    def test_publisher_does_not_receive_own_frame(self, sock_path: Path) -> None:
+        # Self-elect a broker so we can attach as a single client that
+        # both publishes and subscribes — and verify the broadcaster
+        # does not echo the frame back to its origin.
+        bus_module._ensure_broker(sock_path)
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.connect(str(sock_path))
+        client.settimeout(0.5)
+        try:
+            client.sendall(BusMessage(agent="a:1", topic="finding", summary="x").to_jsonl())
+            with pytest.raises(socket.timeout):
+                client.recv(4096)
+        finally:
+            client.close()
+
+    def test_subscribe_skips_malformed_frames(self, sock_path: Path) -> None:
+        received: queue.Queue[BusMessage] = queue.Queue()
+        _drain_subscriber(sock_path, received)
+
+        # Connect a raw publisher and inject a malformed frame followed by a valid one.
+        bus_module._ensure_broker(sock_path)
+        raw = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        raw.connect(str(sock_path))
+        try:
+            raw.sendall(b"this-is-not-json\n")
+            raw.sendall(BusMessage(agent="a:1", topic="finding", summary="ok").to_jsonl())
+        finally:
+            # Keep the publisher alive briefly so the broker can forward both frames.
+            time.sleep(0.1)
+            raw.close()
+
+        msg = received.get(timeout=2.0)
+        assert msg.summary == "ok"
+
+
+class TestBrokerSelfElection:
+    def test_stale_socket_file_is_unlinked_and_rebound(self, sock_path: Path) -> None:
+        sock_path.parent.mkdir(parents=True, exist_ok=True)
+        sock_path.touch()  # stale: no listener
+        assert sock_path.exists() and not _socket_is_live(sock_path)
+
+        server = bus_module._ensure_broker(sock_path)
+        try:
+            assert server is not None
+            assert server.is_running
+            assert _socket_is_live(sock_path)
+        finally:
+            if server is not None:
+                server.stop()
+
+    def test_ensure_broker_returns_none_when_other_process_owns_it(self, sock_path: Path) -> None:
+        # Stand up an "other" broker via direct BusServer (simulating another process),
+        # then call _ensure_broker — it should detect the live socket and back off.
+        other = BusServer(sock_path)
+        other.start()
+        try:
+            # Pretend our process has not yet elected: empty the registry.
+            bus_module._brokers.clear()
+            result = bus_module._ensure_broker(sock_path)
+            assert result is None
+        finally:
+            other.stop()
+
+    def test_ensure_broker_idempotent_for_same_process(self, sock_path: Path) -> None:
+        first = bus_module._ensure_broker(sock_path)
+        second = bus_module._ensure_broker(sock_path)
+        try:
+            assert first is not None
+            assert first is second
+        finally:
+            if first is not None:
+                first.stop()
+
+
+class TestSlashCommandFormatter:
+    def test_format_includes_agent_and_summary(self) -> None:
+        from app.cli.interactive_shell.command_registry.agents import _format_bus_message
+
+        msg = BusMessage(agent="claude-code:8421", topic="finding", summary="hi")
+        out = _format_bus_message(msg)
+        assert "claude-code:8421" in out
+        assert "hi" in out
+
+    def test_format_includes_path_when_present(self) -> None:
+        from app.cli.interactive_shell.command_registry.agents import _format_bus_message
+
+        msg = BusMessage(agent="a:1", topic="finding", summary="x", path="services/auth.py:42")
+        out = _format_bus_message(msg)
+        assert "services/auth.py:42" in out
+        assert "—" in out
+
+    def test_format_omits_separator_when_no_path(self) -> None:
+        from app.cli.interactive_shell.command_registry.agents import _format_bus_message
+
+        msg = BusMessage(agent="a:1", topic="finding", summary="x")
+        out = _format_bus_message(msg)
+        assert "—" not in out

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -632,14 +632,14 @@ class TestPublishSubscribe:
         server.start()
         try:
             done = threading.Event()
-            error: list[BaseException] = []
+            error: list[Exception] = []
 
             def _consume() -> None:
                 try:
                     # Drain until subscribe() returns (which it should, on cap breach).
                     for _ in subscribe(path=sock_path):
                         pass
-                except BaseException as exc:  # noqa: BLE001
+                except Exception as exc:
                     error.append(exc)
                 finally:
                     done.set()

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -15,6 +15,8 @@ from app.agents.bus import (
     BUS_SCHEMA_VERSION,
     BusMessage,
     BusServer,
+    _pid_file_for,
+    _read_broker_pid,
     _socket_is_live,
     publish,
     subscribe,
@@ -84,6 +86,27 @@ class TestBusMessage:
         with pytest.raises(KeyError):
             BusMessage.from_jsonl(b'{"agent":"a:1","topic":"finding"}')
 
+    def test_is_not_hashable(self) -> None:
+        # ``data`` is a mapping, so a value hash would be misleading and would
+        # fail at call time on the auto-generated ``__hash__``. Disable it
+        # explicitly so callers see the unhashability up front.
+        msg = BusMessage(agent="a:1", topic="finding", summary="x", data={"k": 1})
+        with pytest.raises(TypeError):
+            hash(msg)
+
+    def test_data_is_read_only_post_construction(self) -> None:
+        msg = BusMessage(agent="a:1", topic="finding", summary="x", data={"k": 1})
+        with pytest.raises(TypeError):
+            msg.data["k"] = 2  # type: ignore[index]
+
+    def test_data_is_isolated_from_caller_mutation(self) -> None:
+        # External mutation of the originally-passed dict must not bleed into
+        # the message — defensive copy in ``__post_init__`` enforces this.
+        src: dict[str, object] = {"k": 1}
+        msg = BusMessage(agent="a:1", topic="finding", summary="x", data=src)
+        src["k"] = 999
+        assert msg.data["k"] == 1
+
 
 class TestBusServerLifecycle:
     def test_start_binds_socket_and_stop_unlinks(self, sock_path: Path) -> None:
@@ -112,6 +135,48 @@ class TestBusServerLifecycle:
         server.start()
         server.stop()
         server.stop()  # second call should be a no-op, not raise
+
+    def test_start_writes_pid_file_and_stop_removes_it(self, sock_path: Path) -> None:
+        import os
+
+        server = BusServer(sock_path)
+        server.start()
+        try:
+            pid_path = _pid_file_for(sock_path)
+            assert pid_path.exists()
+            assert _read_broker_pid(sock_path) == os.getpid()
+        finally:
+            server.stop()
+        assert not _pid_file_for(sock_path).exists()
+
+
+class TestLivenessProbe:
+    def test_socket_is_live_does_not_create_phantom_subscriber(self, sock_path: Path) -> None:
+        # _socket_is_live used to make a real connection on every probe; under
+        # publish/subscribe bursts that registered a short-lived subscriber +
+        # reader thread per call. Verify the side-channel probe makes none.
+        server = BusServer(sock_path)
+        server.start()
+        try:
+            for _ in range(20):
+                assert _socket_is_live(sock_path)
+            with server._lock:
+                assert len(server._subscribers) == 0
+        finally:
+            server.stop()
+
+    def test_socket_is_live_false_when_pid_missing(self, sock_path: Path) -> None:
+        sock_path.parent.mkdir(parents=True, exist_ok=True)
+        sock_path.touch()  # socket file present but no pid sidecar
+        assert not _socket_is_live(sock_path)
+
+    def test_socket_is_live_false_when_pid_dead(self, sock_path: Path) -> None:
+        sock_path.parent.mkdir(parents=True, exist_ok=True)
+        sock_path.touch()
+        # PID 999999 is almost certainly not a real process. The probe must
+        # report not-live so the caller will unlink + rebind.
+        _pid_file_for(sock_path).write_text("999999")
+        assert not _socket_is_live(sock_path)
 
 
 class TestPublishSubscribe:

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -88,11 +88,18 @@ class TestBusMessage:
 
     def test_is_not_hashable(self) -> None:
         # ``data`` is a mapping, so a value hash would be misleading and would
-        # fail at call time on the auto-generated ``__hash__``. Disable it
-        # explicitly so callers see the unhashability up front.
+        # fail at call time on the auto-generated ``__hash__``. We disable it
+        # explicitly. Assert the contract directly (``__hash__ is None``)
+        # rather than triggering ``hash()`` — the latter trips static
+        # analysers that statically see the unhashability.
+        assert BusMessage.__hash__ is None
         msg = BusMessage(agent="a:1", topic="finding", summary="x", data={"k": 1})
+        assert getattr(msg, "__hash__", "missing") is None
+        # Sanity-check the runtime behavior matches by routing the call
+        # through ``object`` so static analysis can't pre-resolve the type.
+        opaque: object = msg
         with pytest.raises(TypeError):
-            hash(msg)
+            hash(opaque)
 
     def test_data_is_read_only_post_construction(self) -> None:
         msg = BusMessage(agent="a:1", topic="finding", summary="x", data={"k": 1})

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -41,9 +41,19 @@ def isolated_brokers(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _drain_subscriber(
-    sock_path: Path, into: queue.Queue[BusMessage], stop_after: int = 1
+    sock_path: Path,
+    into: queue.Queue[BusMessage],
+    stop_after: int = 1,
+    *,
+    attach_timeout: float = 3.0,
 ) -> threading.Thread:
-    """Spawn a daemon thread that puts up to ``stop_after`` messages into ``into``."""
+    """Spawn a daemon subscriber and block until it has attached to the broker.
+
+    Avoids the flaky ``time.sleep(0.15)`` pattern: we busy-poll the broker's
+    in-memory subscriber set until it ticks up by exactly one. Works because
+    our process is the broker for the test path (the autouse fixture clears
+    the broker registry, so ``subscribe()`` self-elects on first attach).
+    """
 
     def _loop() -> None:
         for count, msg in enumerate(subscribe(path=sock_path), start=1):
@@ -51,11 +61,23 @@ def _drain_subscriber(
             if count >= stop_after:
                 return
 
+    # Snapshot the pre-attach subscriber count so we don't race against
+    # subscribers spawned by other helpers in the same test.
+    broker_before = bus_module._brokers.get(sock_path)
+    before = len(broker_before._subscribers) if broker_before is not None else 0
+
     thread = threading.Thread(target=_loop, daemon=True)
     thread.start()
-    # Give the subscriber a moment to bind/connect before tests publish.
-    time.sleep(0.15)
-    return thread
+
+    deadline = time.monotonic() + attach_timeout
+    while time.monotonic() < deadline:
+        broker = bus_module._brokers.get(sock_path)
+        if broker is not None:
+            with broker._lock:
+                if len(broker._subscribers) > before:
+                    return thread
+        time.sleep(0.005)
+    raise AssertionError(f"_drain_subscriber: subscriber did not attach within {attach_timeout}s")
 
 
 class TestBusMessage:

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -180,6 +180,52 @@ class TestPublishSubscribe:
         msg = received.get(timeout=2.0)
         assert msg.summary == "ok"
 
+    def test_subscriber_disconnects_on_oversized_unterminated_stream(self, sock_path: Path) -> None:
+        # Simulate a hostile broker that wins the bind race and streams unlimited
+        # bytes without newlines. The subscriber must cap its buffer and bail
+        # rather than grow memory unboundedly.
+        from app.agents.bus import _MAX_FRAME_BYTES, BusServer, subscribe
+
+        # Stand up a fake "hostile" broker that pushes garbage to every client.
+        server = BusServer(sock_path)
+        server.start()
+        try:
+            done = threading.Event()
+            error: list[BaseException] = []
+
+            def _consume() -> None:
+                try:
+                    # Drain until subscribe() returns (which it should, on cap breach).
+                    for _ in subscribe(path=sock_path):
+                        pass
+                except BaseException as exc:  # noqa: BLE001
+                    error.append(exc)
+                finally:
+                    done.set()
+
+            t = threading.Thread(target=_consume, daemon=True)
+            t.start()
+            # Wait for the subscriber to attach to the broker.
+            deadline = time.time() + 2.0
+            while time.time() < deadline:
+                with server._lock:
+                    if server._subscribers:
+                        break
+                time.sleep(0.02)
+            assert server._subscribers, "subscriber never attached"
+
+            # Push a single oversized chunk through to all subscribers.
+            payload = b"X" * (_MAX_FRAME_BYTES * 4 + 1024)
+            with server._lock:
+                victim = next(iter(server._subscribers))
+            victim.sendall(payload)
+
+            # Subscriber should disconnect on its own without raising.
+            assert done.wait(timeout=2.0), "subscriber did not disconnect on cap breach"
+            assert not error, f"subscribe() raised unexpectedly: {error}"
+        finally:
+            server.stop()
+
 
 class TestBrokerSelfElection:
     def test_stale_socket_file_is_unlinked_and_rebound(self, sock_path: Path) -> None:

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -302,6 +302,72 @@ class TestPublisherCache:
         new_cached = next(iter(bus_module._publishers.values()))
         assert new_cached.sock is not broken_sock
 
+    def test_publish_retries_on_initial_connect_failure(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The first ``_get_or_open_publisher`` raises (e.g. broker exited
+        # between liveness check and connect). ``publish`` must run
+        # ``_ensure_broker`` and retry once instead of failing immediately.
+        real_get = bus_module._get_or_open_publisher
+        calls = {"n": 0}
+
+        def _flaky(target: Path, *, connect_timeout: float) -> bus_module._CachedPublisher:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionRefusedError(111, "Connection refused")
+            return real_get(target, connect_timeout=connect_timeout)
+
+        monkeypatch.setattr(bus_module, "_get_or_open_publisher", _flaky)
+
+        received: queue.Queue[BusMessage] = queue.Queue()
+        _drain_subscriber(sock_path, received, stop_after=1)
+
+        publish(BusMessage(agent="a:1", topic="finding", summary="retried"), path=sock_path)
+        msg = received.get(timeout=2.0)
+        assert msg.summary == "retried"
+        assert calls["n"] == 2, "publish() did not retry on initial connect failure"
+
+    def test_subscribe_retries_on_initial_connect_failure(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``subscribe`` previously raised on the first connect failure;
+        # symmetric with ``publish``, it now retries once.
+        real_connect = bus_module._connect_client
+        calls = {"n": 0}
+
+        def _flaky(target: Path, timeout: float) -> socket.socket:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionRefusedError(111, "Connection refused")
+            return real_connect(target, timeout=timeout)
+
+        monkeypatch.setattr(bus_module, "_connect_client", _flaky)
+
+        # Just calling subscribe() and pulling the first batch is enough —
+        # if the retry didn't happen, the call would raise.
+        received: queue.Queue[BusMessage] = queue.Queue()
+
+        def _loop() -> None:
+            for msg in subscribe(path=sock_path):
+                received.put(msg)
+                return
+
+        thread = threading.Thread(target=_loop, daemon=True)
+        thread.start()
+
+        # Wait for subscribe() to attach, give up to 2s.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            broker = bus_module._brokers.get(sock_path)
+            if broker is not None:
+                with broker._lock:
+                    if broker._subscribers:
+                        break
+            time.sleep(0.005)
+        broker = bus_module._brokers.get(sock_path)
+        assert broker is not None and broker._subscribers, "subscriber never attached after retry"
+        assert calls["n"] >= 2, "subscribe() did not retry on initial connect failure"
+
     def test_concurrent_publishes_do_not_interleave_frames(self, sock_path: Path) -> None:
         # If the per-socket send_lock weren't held around sendall(), concurrent
         # publishes from different threads could interleave bytes mid-frame,

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -30,8 +30,14 @@ def sock_path(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def isolated_brokers(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure each test starts with an empty broker registry, no cross-test bleed."""
+    """Ensure each test starts with empty broker + publisher caches.
+
+    Without this, the publisher socket cached from a prior test would point at
+    a now-stopped broker's socket path, and the first ``publish()`` of the
+    next test would silently sendall onto a dead fd.
+    """
     monkeypatch.setattr(bus_module, "_brokers", {})
+    monkeypatch.setattr(bus_module, "_publishers", {})
 
 
 def _drain_subscriber(
@@ -214,6 +220,101 @@ class TestLivenessProbe:
         assert not _socket_is_live(sock_path)
 
 
+class TestPublisherCache:
+    def test_burst_of_publishes_reuses_one_connection(self, sock_path: Path) -> None:
+        # Each publish() previously opened a fresh UDS connection, which the
+        # broker accepted, registered as a subscriber, and ran a per-connection
+        # reader thread for. A burst of N publishes spawned N short-lived
+        # threads. With the cache, all publishes from one process share one
+        # persistent connection and one persistent broker reader thread.
+        received: queue.Queue[BusMessage] = queue.Queue()
+        _drain_subscriber(sock_path, received, stop_after=20)
+
+        for i in range(20):
+            publish(BusMessage(agent="a:1", topic="finding", summary=f"n{i}"), path=sock_path)
+
+        # All frames arrive in order.
+        for i in range(20):
+            msg = received.get(timeout=2.0)
+            assert msg.summary == f"n{i}"
+
+        # Exactly one cached publisher socket for our process.
+        assert len(bus_module._publishers) == 1
+        cached = next(iter(bus_module._publishers.values()))
+        assert cached.sock.fileno() >= 0
+
+        # Broker side: at most one publisher-origin connection (plus the one
+        # subscriber drain). Check by counting connections opened by us. The
+        # broker only sees what we sent it; if reuse is working, every publish
+        # came from the same socket and the broker registered exactly one
+        # publisher connection for the burst.
+        broker = bus_module._brokers[sock_path]
+        with broker._lock:
+            # 1 subscriber (the drain thread above) + 1 cached publisher = 2.
+            # If the cache were broken we'd see many transient connections,
+            # but most would have closed by now — so this is a weak check;
+            # the strong check is len(bus_module._publishers) == 1 above.
+            assert len(broker._subscribers) <= 2
+
+    def test_reconnects_after_cached_socket_breaks(self, sock_path: Path) -> None:
+        received: queue.Queue[BusMessage] = queue.Queue()
+        _drain_subscriber(sock_path, received, stop_after=2)
+
+        publish(BusMessage(agent="a:1", topic="finding", summary="first"), path=sock_path)
+        msg1 = received.get(timeout=2.0)
+        assert msg1.summary == "first"
+
+        # Forcibly break the cached publisher connection.
+        broken_cached = next(iter(bus_module._publishers.values()))
+        broken_sock = broken_cached.sock
+        broken_sock.close()
+
+        # Next publish must transparently reconnect (one retry on OSError).
+        publish(BusMessage(agent="a:1", topic="finding", summary="second"), path=sock_path)
+        msg2 = received.get(timeout=2.0)
+        assert msg2.summary == "second"
+
+        # The cache now holds a fresh socket object (the OS may recycle the
+        # underlying fd number, so compare object identity, not fileno()).
+        new_cached = next(iter(bus_module._publishers.values()))
+        assert new_cached.sock is not broken_sock
+
+    def test_concurrent_publishes_do_not_interleave_frames(self, sock_path: Path) -> None:
+        # If the per-socket send_lock weren't held around sendall(), concurrent
+        # publishes from different threads could interleave bytes mid-frame,
+        # corrupting the JSONL stream.
+        n_threads = 10
+        per_thread = 5
+        total = n_threads * per_thread
+
+        received: queue.Queue[BusMessage] = queue.Queue()
+        _drain_subscriber(sock_path, received, stop_after=total)
+
+        def _spam(tid: int) -> None:
+            for i in range(per_thread):
+                publish(
+                    BusMessage(
+                        agent=f"t{tid}:1",
+                        topic="finding",
+                        summary=f"t{tid}-n{i}",
+                    ),
+                    path=sock_path,
+                )
+
+        threads = [threading.Thread(target=_spam, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        # Every frame must be parseable (no byte interleaving) and unique.
+        seen: set[str] = set()
+        for _ in range(total):
+            msg = received.get(timeout=5.0)
+            seen.add(msg.summary)
+        assert len(seen) == total, f"frame loss or corruption: got {len(seen)} unique of {total}"
+
+
 class TestPublishSubscribe:
     def test_round_trip_one_publisher_one_subscriber(self, sock_path: Path) -> None:
         received: queue.Queue[BusMessage] = queue.Queue()
@@ -279,6 +380,98 @@ class TestPublishSubscribe:
 
         msg = received.get(timeout=2.0)
         assert msg.summary == "ok"
+
+    def test_unresponsive_subscriber_does_not_stall_broadcast(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If one subscriber's recv buffer fills, ``sendall`` on a blocking UDS
+        # would wedge indefinitely with no exception, freezing fan-out for
+        # every publisher. Verify the write-readiness gate evicts the slow
+        # subscriber and lets healthy ones keep receiving.
+        monkeypatch.setattr(bus_module, "_BROADCAST_WRITE_TIMEOUT_SECONDS", 0.05)
+
+        server = BusServer(sock_path)
+        server.start()
+        slow: socket.socket | None = None
+        try:
+            # Healthy subscriber: drains until it sees the "alive" sentinel.
+            seen_alive = threading.Event()
+
+            def _healthy_drain() -> None:
+                client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                client.connect(str(sock_path))
+                client.settimeout(3.0)
+                buf = b""
+                try:
+                    while not seen_alive.is_set():
+                        chunk = client.recv(8192)
+                        if not chunk:
+                            return
+                        buf += chunk
+                        while b"\n" in buf:
+                            line, buf = buf.split(b"\n", 1)
+                            if not line:
+                                continue
+                            try:
+                                msg = BusMessage.from_jsonl(line)
+                            except (ValueError, KeyError, TypeError):
+                                continue
+                            if msg.summary == "alive":
+                                seen_alive.set()
+                                return
+                except OSError:
+                    return
+                finally:
+                    client.close()
+
+            t = threading.Thread(target=_healthy_drain, daemon=True)
+            t.start()
+            # Slow subscriber: shrink recv buffer so it fills fast, never reads.
+            slow = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            slow.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1024)
+            slow.connect(str(sock_path))
+
+            # Wait for both to attach.
+            deadline = time.time() + 2.0
+            while time.time() < deadline:
+                with server._lock:
+                    if len(server._subscribers) >= 2:
+                        break
+                time.sleep(0.02)
+
+            # Pump enough large frames to fill ``slow``'s tiny recv buffer.
+            for _ in range(8):
+                publish(
+                    BusMessage(agent="a:1", topic="finding", summary="x" * 4000),
+                    path=sock_path,
+                )
+
+            # Final small frame. Healthy subscriber must receive it — that
+            # proves the broker did not stall behind the wedged ``slow``.
+            publish(BusMessage(agent="a:1", topic="finding", summary="alive"), path=sock_path)
+
+            assert seen_alive.wait(timeout=3.0), (
+                "broker stalled: healthy subscriber never received the post-fill frame"
+            )
+
+            # Slow subscriber should have been evicted from the fan-out set.
+            deadline = time.time() + 1.0
+            slow_fd = slow.fileno()
+            while time.time() < deadline:
+                with server._lock:
+                    still_attached = any(s.fileno() == slow_fd for s in server._subscribers)
+                if not still_attached:
+                    break
+                time.sleep(0.05)
+            with server._lock:
+                attached_fds = {s.fileno() for s in server._subscribers}
+            assert slow_fd not in attached_fds, (
+                "unresponsive subscriber was not evicted from fan-out set"
+            )
+        finally:
+            if slow is not None:
+                slow.close()
+            server.stop()
 
     def test_subscriber_disconnects_on_oversized_unterminated_stream(self, sock_path: Path) -> None:
         # Simulate a hostile broker that wins the bind race and streams unlimited

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -668,6 +668,152 @@ class TestPublishSubscribe:
             server.stop()
 
 
+class TestBrokerElectionRace:
+    def test_concurrent_cold_start_election_does_not_orphan_a_broker(self, sock_path: Path) -> None:
+        # Cold-start race: two processes both observe ``_socket_is_live``
+        # → False, both call ``_unlink_stale``, both try to bind. The
+        # kernel only lets one bind succeed, but without cross-process
+        # serialization the loser is left holding a listener fd whose
+        # filesystem path the winner just unlinked, plus the accept/
+        # reader daemon threads. The election ``flock`` prevents that.
+        #
+        # We simulate the race by holding the flock from this test
+        # process and concurrently spawning a child that calls
+        # ``_ensure_broker``. The child must block on the flock until we
+        # release it, then return ``None`` (we elected first).
+        import os
+        import subprocess
+        import sys
+        import textwrap
+
+        # Bind a broker first; once it's live, any peer (including the
+        # subprocess we'll spawn) sees it via the PID-file side channel and
+        # backs off. The flock only matters during the check-unlink-bind
+        # window, which closes after ``server.start()`` returns.
+        server = bus_module.BusServer(sock_path)
+        server.start()
+        try:
+            assert sock_path.exists()
+            assert _pid_file_for(sock_path).exists()
+
+            # Spawn a real subprocess that calls ``_ensure_broker`` for
+            # the same path. With the election lock and the live PID
+            # sidecar, the child must observe our broker and return
+            # ``None``. Without the flock contract, a concurrent cold
+            # start could unlink our socket file and rebind, orphaning
+            # this server.
+            repo_root = Path(__file__).resolve().parents[2]
+            child = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    textwrap.dedent(
+                        f"""
+                        from pathlib import Path
+                        from app.agents import bus
+
+                        result = bus._ensure_broker(Path({str(sock_path)!r}))
+                        print("OWNER" if result is not None else "PEER")
+                        """
+                    ),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10.0,
+                env={**os.environ, "PYTHONPATH": str(repo_root)},
+            )
+            assert child.returncode == 0, child.stderr
+            assert child.stdout.strip() == "PEER", (
+                f"child wrongly elected itself: stdout={child.stdout!r} stderr={child.stderr!r}"
+            )
+
+            # Our broker is unscathed: socket file + pid file still there,
+            # listener still accepting connections.
+            assert sock_path.exists(), "winner's socket file vanished"
+            assert _pid_file_for(sock_path).exists(), "winner's pid file vanished"
+            assert server.is_running
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.settimeout(2.0)
+            client.connect(str(sock_path))
+            client.close()
+        finally:
+            server.stop()
+
+    def test_election_lock_path_lives_next_to_socket(self, sock_path: Path) -> None:
+        # Sanity-check the sidecar location so future refactors don't
+        # silently move it (which would re-open the cross-process race).
+        lock_path = bus_module._election_lock_path(sock_path)
+        assert lock_path.parent == sock_path.parent
+        assert lock_path.name == sock_path.name + ".lock"
+
+    def test_ensure_broker_blocks_on_election_flock_held_by_peer(self, sock_path: Path) -> None:
+        # Direct test of the cross-process serialization: a child process
+        # holds the election flock; this process's ``_ensure_broker``
+        # must block on ``flock(LOCK_EX)`` until the child releases it.
+        # Without this, two concurrent cold-start callers can race
+        # through unlink+bind and leave one orphaned.
+        import os
+        import subprocess
+        import sys
+        import textwrap
+
+        repo_root = Path(__file__).resolve().parents[2]
+        # Ensure parent dir exists so the child can open the lock file.
+        sock_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Child: open + flock the election file, signal "READY", sleep,
+        # then exit (flock auto-released on close).
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                "-u",
+                "-c",
+                textwrap.dedent(
+                    f"""
+                    import os, fcntl, sys, time
+                    from pathlib import Path
+                    from app.agents import bus
+
+                    fd = bus._acquire_election_flock(Path({str(sock_path)!r}))
+                    print("READY", flush=True)
+                    time.sleep(0.5)
+                    bus._release_election_flock(fd)
+                    """
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(repo_root)},
+        )
+        try:
+            # Wait for the child to confirm it holds the lock.
+            assert child.stdout is not None
+            line = child.stdout.readline()
+            assert line.strip() == "READY", f"child did not signal ready: {line!r}"
+
+            # Now ``_ensure_broker`` here must wait on the flock. Time
+            # the call: it should take roughly the remaining sleep time.
+            t0 = time.monotonic()
+            server = bus_module._ensure_broker(sock_path)
+            elapsed = time.monotonic() - t0
+            try:
+                assert server is not None, "we should have elected after child released"
+                # The child slept 0.5s total starting before READY; we
+                # should have waited for some appreciable fraction of
+                # that. 0.1s is well under the 0.5s sleep but well above
+                # zero, so it cleanly distinguishes "blocked on flock"
+                # from "didn't block at all".
+                assert elapsed >= 0.1, (
+                    f"_ensure_broker did not block on the election flock (elapsed={elapsed:.3f}s)"
+                )
+            finally:
+                if server is not None:
+                    server.stop()
+        finally:
+            child.wait(timeout=5.0)
+
+
 class TestBrokerSelfElection:
     def test_stale_socket_file_is_unlinked_and_rebound(self, sock_path: Path) -> None:
         sock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -6,6 +6,7 @@ import queue
 import socket
 import threading
 import time
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
@@ -368,6 +369,65 @@ class TestPublishSubscribe:
         for q in sub_queues:
             msg = q.get(timeout=2.0)
             assert msg.summary == "hello"
+
+    def test_broadcast_holds_per_subscriber_write_lock(self, sock_path: Path) -> None:
+        # The bug: two reader-threads broadcasting concurrently to the same
+        # subscriber socket can interleave bytes mid-frame because
+        # ``sendall`` is multi-syscall under back-pressure. The fix is a
+        # per-subscriber write lock acquired around ``select`` + ``sendall``
+        # in ``_broadcast``.
+        #
+        # Reliably reproducing kernel-level byte interleaving across
+        # systems is fragile (depends on SNDBUF/RCVBUF tuning). Test the
+        # lock contract directly: hold the per-subscriber write_lock
+        # externally and confirm ``_broadcast`` blocks until release.
+        server = BusServer(sock_path)
+        server.start()
+        sub: socket.socket | None = None
+        try:
+            sub = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sub.connect(str(sock_path))
+
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                with server._lock:
+                    if server._subscribers:
+                        break
+                time.sleep(0.005)
+            with server._lock:
+                assert server._subscribers, "subscriber never attached"
+                # Grab the broker-side (sub, write_lock) pair.
+                ((_broker_sub, write_lock),) = server._subscribers.items()
+
+            # Hold the lock as if another reader-thread were mid-sendall.
+            assert write_lock.acquire(timeout=1.0)
+            broadcast_returned = threading.Event()
+            try:
+
+                def _bcast() -> None:
+                    server._broadcast(b'{"x":"y"}\n', origin=None)
+                    broadcast_returned.set()
+
+                t = threading.Thread(target=_bcast, daemon=True)
+                t.start()
+
+                # While we hold the lock, ``_broadcast`` must wait — without
+                # the lock it would race straight into ``sendall``.
+                assert not broadcast_returned.wait(timeout=0.2), (
+                    "broadcast did not block on per-subscriber write lock"
+                )
+            finally:
+                write_lock.release()
+
+            # After release, broadcast should complete promptly.
+            assert broadcast_returned.wait(timeout=2.0), (
+                "broadcast did not return after lock release"
+            )
+        finally:
+            if sub is not None:
+                with suppress(OSError):
+                    sub.close()
+            server.stop()
 
     def test_publisher_does_not_receive_own_frame(self, sock_path: Path) -> None:
         # Self-elect a broker so we can attach as a single client that


### PR DESCRIPTION
Live-only pub/sub channel for cross-agent findings over a Unix-domain socket at ~/.config/opensre/agents-bus.sock. Self-electing broker so agents can publish/subscribe even when OpenSRE is not running. Message shape mirrors AgentState.evidence so a finding can be lifted into investigation state without renaming fields.

Fixes #1505 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Adds /agents bus, a live-only pub/sub channel for cross-agent findings over a Unix-domain socket at ~/.config/opensre/agents-bus.sock. The first publisher or subscriber self-elects as broker, so agents can exchange context even when OpenSRE itself isn't running; the REPL just attaches as another client. Message shape mirrors AgentState.evidence so a finding can be lifted into an investigation without renaming fields. Schema and usage are documented in docs/agents.mdx.

#### Demo video-


https://github.com/user-attachments/assets/d9b01fb7-e491-45ec-b9f7-ca1160ea5ba3


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Implemented as a self-electing broker over a Unix-domain stream socket: the first publish() or subscribe() call that finds no live listener binds the socket and runs an in-process daemon thread that fans JSONL frames out to every attached client; everyone else connects as a plain client, and stale socket files are unlinked and rebound on the next call. The wire format is one newline-terminated JSON object per frame, with fields (agent, topic, summary, source, path, data, id, timestamp, schema_version) chosen to mirror AgentState.evidence so findings round-trip into investigation state without renaming. The REPL's /agents bus is just a thin consumer of subscribe() that prints each BusMessage until Ctrl-C.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
