### PR TITLE
fix(remote): default INVESTIGATIONS_DIR to ~/.opensre/investigations

### DIFF
--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -58,7 +58,9 @@ from app.version import get_version
 load_dotenv(override=False)
 init_sentry(entrypoint="remote")
 
-INVESTIGATIONS_DIR = Path(os.getenv("INVESTIGATIONS_DIR", "/opt/opensre/investigations"))
+INVESTIGATIONS_DIR = Path(
+    os.getenv("INVESTIGATIONS_DIR", str(Path.home() / ".opensre" / "investigations"))
+)
 _AUTH_KEY = os.getenv("OPENSRE_API_KEY")
 _AUTH_EXEMPT_PATHS = {
     "/discord/interactions",


### PR DESCRIPTION
## Summary

- The previous default `INVESTIGATIONS_DIR` of `/opt/opensre/investigations` requires root to create, causing the remote server to crash at startup with `PermissionError` on non-root systems.
- Changed the default to `~/.opensre/investigations` (i.e. `Path.home() / ".opensre" / "investigations"`), which is always writable by the running user.
- Production deployments that need `/opt/opensre/investigations` can still override via the `INVESTIGATIONS_DIR` environment variable — no behavioural change for them.

## Test plan

- [ ] Start `app/remote/server.py` as a non-root user without setting `INVESTIGATIONS_DIR` — confirm server starts without `PermissionError`
- [ ] Confirm `~/.opensre/investigations` is created on startup
- [ ] Confirm setting `INVESTIGATIONS_DIR=/opt/opensre/investigations` still honours the override

Closes #1745
Closes #1746

https://claude.ai/code/session_01UrxTaJpUavGrr6GXFmtk7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrxTaJpUavGrr6GXFmtk7W)_