### PR TITLE
fix(cloudwatch): default job_queue to "" to prevent TypeError in execute_actions

### DIFF
--- a/app/tools/CloudWatchBatchMetricsTool/__init__.py
+++ b/app/tools/CloudWatchBatchMetricsTool/__init__.py
@@ -38,7 +38,7 @@ from app.tools.utils.compaction import truncate_list
     },
 )
 def get_cloudwatch_batch_metrics(
-    job_queue: str, metric_type: str = "cpu", limit: int = 50
+    job_queue: str = "", metric_type: str = "cpu", limit: int = 50
 ) -> dict[str, Any]:
     """Get CloudWatch metrics for AWS Batch jobs."""
     if not job_queue:

--- a/tests/tools/test_cloudwatch_batch_metrics_tool.py
+++ b/tests/tools/test_cloudwatch_batch_metrics_tool.py
@@ -25,6 +25,13 @@ def test_run_returns_error_when_no_job_queue() -> None:
     assert "error" in result
 
 
+def test_run_returns_error_when_called_with_no_args() -> None:
+    # execute_actions calls action.run(**{}) when extract_params returns {};
+    # the default prevents TypeError and the guard returns a proper error dict.
+    result = get_cloudwatch_batch_metrics()
+    assert "error" in result
+
+
 def test_run_returns_error_for_invalid_metric_type() -> None:
     result = get_cloudwatch_batch_metrics(job_queue="my-queue", metric_type="invalid")
     assert "error" in result


### PR DESCRIPTION
## Summary

- `get_cloudwatch_batch_metrics` declared `job_queue: str` with no default.
- When `execute_actions` calls `action.run(**{})` (because `extract_params` returns `{}`), Python raised `TypeError: missing 1 required positional argument: 'job_queue'` before the function body's `if not job_queue` guard could return a structured error dict.
- Fixed by giving `job_queue` a default of `""` so the existing guard handles the missing-arg case gracefully.

## Test plan

- [x] `test_run_returns_error_when_called_with_no_args` — confirms `get_cloudwatch_batch_metrics()` returns `{\"error\": \"job_queue is required\"}` instead of raising `TypeError`
- [x] All 13 existing CloudWatch batch metrics tests pass

Closes #1747

https://claude.ai/code/session_01YMiZVpiyZxPY753y9HGcVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMiZVpiyZxPY753y9HGcVG)_