### PR TITLE
fix(llm-cli): raise CLIAuthenticationRequired on post-invocation auth failure

### DIFF
--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -147,11 +147,18 @@ class CLIBackedLLMClient:
             # CLIAuthenticationRequired so callers (reraise_cli_runtime_error,
             # server endpoints) get structured, actionable handling instead of
             # a bare RuntimeError that lands in Sentry as a spurious bug.
+            # Patterns cover all current adapters:
+            #   kimi        → "not logged in", "api key invalid", "re-authenticate"
+            #   cursor      → "not logged in"
+            #   opencode    → "authentication failed", "not authenticated"
+            #   claude/gemini/codex pass raw stderr which may contain these phrases too
             _base_lower = base.lower()
             if (
                 "not logged in" in _base_lower
                 or "api key invalid" in _base_lower
                 or "re-authenticate" in _base_lower
+                or "authentication failed" in _base_lower
+                or "not authenticated" in _base_lower
             ):
                 raise CLIAuthenticationRequired(
                     provider=self._adapter.name,

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -143,6 +143,21 @@ class CLIBackedLLMClient:
             base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()
+            # When the failure message signals an auth problem raise
+            # CLIAuthenticationRequired so callers (reraise_cli_runtime_error,
+            # server endpoints) get structured, actionable handling instead of
+            # a bare RuntimeError that lands in Sentry as a spurious bug.
+            _base_lower = base.lower()
+            if (
+                "not logged in" in _base_lower
+                or "api key invalid" in _base_lower
+                or "re-authenticate" in _base_lower
+            ):
+                raise CLIAuthenticationRequired(
+                    provider=self._adapter.name,
+                    auth_hint=self._adapter.auth_hint,
+                    detail=base,
+                )
             if auth_probe_unclear:
                 message = (
                     f"{base}\n\n"

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -316,6 +316,8 @@ def _init_sentry_once(
     """
     import sentry_sdk
 
+    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(
             dsn=dsn,
@@ -330,6 +332,7 @@ def _init_sentry_once(
             integrations=_build_sentry_integrations(),
             before_send=_before_send,
             before_breadcrumb=_before_breadcrumb,
+            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError],
         )
 
 


### PR DESCRIPTION
## Summary

- **Root cause**: When a CLI adapter (e.g. kimi) exits with an auth-related error message (`"not logged in"`, `"API key invalid"`, `"re-authenticate"`) at invocation time, `runner.invoke()` was raising a bare `RuntimeError`. This bypassed `reraise_cli_runtime_error` (which only maps `CLIAuthenticationRequired` → `OpenSREError`) and caused Sentry to capture a spurious bug report.
- **Fix in `runner.py`**: After calling `explain_failure()`, detect auth-failure patterns in the message and raise `CLIAuthenticationRequired` instead of `RuntimeError`. This is consistent with the pre-probe check (which already raises `CLIAuthenticationRequired` when `probe.logged_in is False`) and allows all callers to handle auth errors uniformly.
- **Fix in `sentry_sdk.py`**: Add `CLIAuthenticationRequired` and `CLITimeoutError` to `ignore_errors`. Both are documented expected operational failures (user hasn't logged in / subprocess timed out), not code bugs.

## Test plan

- [x] `uv run ruff check app/integrations/llm_cli/runner.py app/utils/sentry_sdk.py` — passes
- [x] `uv run pytest tests/integrations/ tests/remote/ -x -q` — 288 passed
- [x] `uv run pytest tests/ -k "llm_cli or runner or kimi"` — 243 passed

Closes #1766
Closes #1767

https://claude.ai/code/session_01BoCqfZG6L9hAPgxvG2PhUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoCqfZG6L9hAPgxvG2PhUM)_