### PR TITLE
fix(llm): raise immediately on non-retryable API errors across all clients

### DIFF
--- a/app/services/chat_sdk_adapter.py
+++ b/app/services/chat_sdk_adapter.py
@@ -30,6 +30,9 @@ _NON_LEADING_SYSTEM_MARK = "[system]"
 def _openai_chat_completions_with_retry(client: Any, kwargs: dict[str, Any]) -> Any:
     """Call OpenAI chat completions with retry; raises ``RuntimeError`` on final failure."""
     from openai import AuthenticationError as OpenAIAuthError
+    from openai import BadRequestError as OpenAIBadRequestError
+    from openai import NotFoundError as OpenAINotFoundError
+    from openai import RateLimitError as OpenAIRateLimitError
 
     backoff = _RETRY_INITIAL_BACKOFF_SEC
     for attempt in range(_RETRY_MAX_ATTEMPTS):
@@ -39,6 +42,24 @@ def _openai_chat_completions_with_retry(client: Any, kwargs: dict[str, Any]) -> 
             raise RuntimeError(
                 "OpenAI authentication failed. Check OPENAI_API_KEY in your environment or .env."
             ) from err
+        except OpenAINotFoundError as err:
+            raise RuntimeError(
+                "OpenAI model not found. Check your configured model name or endpoint."
+            ) from err
+        except OpenAIBadRequestError as err:
+            raise RuntimeError(f"OpenAI request rejected (HTTP 400): {err}") from err
+        except OpenAIRateLimitError as err:
+            body = getattr(err, "body", None)
+            if isinstance(body, dict) and body.get("error", {}).get("code") == "insufficient_quota":
+                raise RuntimeError(
+                    "OpenAI billing quota exceeded. Check your plan and billing details."
+                ) from err
+            if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                raise RuntimeError(
+                    "OpenAI API request failed after multiple retries. Try again in a few seconds."
+                ) from err
+            time.sleep(backoff)
+            backoff *= 2
         except Exception as err:
             if attempt == _RETRY_MAX_ATTEMPTS - 1:
                 raise RuntimeError(
@@ -52,6 +73,9 @@ def _openai_chat_completions_with_retry(client: Any, kwargs: dict[str, Any]) -> 
 def _anthropic_messages_create_with_retry(client: Any, kwargs: dict[str, Any]) -> Any:
     """Call Anthropic ``messages.create`` with retry."""
     from anthropic import AuthenticationError as AnthropicAuthError
+    from anthropic import BadRequestError as AnthropicBadRequestError
+    from anthropic import NotFoundError as AnthropicNotFoundError
+    from anthropic import PermissionDeniedError as AnthropicPermissionDeniedError
 
     backoff = _RETRY_INITIAL_BACKOFF_SEC
     for attempt in range(_RETRY_MAX_ATTEMPTS):
@@ -61,6 +85,16 @@ def _anthropic_messages_create_with_retry(client: Any, kwargs: dict[str, Any]) -
             raise RuntimeError(
                 "Anthropic authentication failed. Check ANTHROPIC_API_KEY in your environment or .env."
             ) from err
+        except AnthropicNotFoundError as err:
+            raise RuntimeError(
+                "Anthropic model not found. Check your configured model name."
+            ) from err
+        except AnthropicPermissionDeniedError as err:
+            raise RuntimeError(
+                "Anthropic API access denied. Check your API key permissions."
+            ) from err
+        except AnthropicBadRequestError as err:
+            raise RuntimeError(f"Anthropic request rejected (HTTP 400): {err}") from err
         except Exception as err:
             if attempt == _RETRY_MAX_ATTEMPTS - 1:
                 raise RuntimeError(

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -779,8 +779,6 @@ class OpenAILLMClient:
                     _format_openai_connection_error(err, self._provider_label)
                 ) from err
             except OpenAIRateLimitError as err:
-                if emitted:
-                    raise
                 body = getattr(err, "body", None)
                 if (
                     isinstance(body, dict)
@@ -790,6 +788,8 @@ class OpenAILLMClient:
                         f"{self._provider_label} billing quota exceeded. "
                         "Check your plan and billing details."
                     ) from err
+                if emitted:
+                    raise
                 if attempt == max_attempts - 1:
                     raise RuntimeError(
                         f"{self._provider_label} rate limit exceeded (HTTP 429) after multiple retries. "

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -693,6 +693,15 @@ class OpenAILLMClient:
                     _format_openai_connection_error(err, self._provider_label)
                 ) from err
             except OpenAIRateLimitError as err:
+                body = getattr(err, "body", None)
+                if (
+                    isinstance(body, dict)
+                    and body.get("error", {}).get("code") == "insufficient_quota"
+                ):
+                    raise RuntimeError(
+                        f"{self._provider_label} billing quota exceeded. "
+                        "Check your plan and billing details."
+                    ) from err
                 last_err = err
                 if attempt == max_attempts - 1:
                     raise RuntimeError(
@@ -772,6 +781,15 @@ class OpenAILLMClient:
             except OpenAIRateLimitError as err:
                 if emitted:
                     raise
+                body = getattr(err, "body", None)
+                if (
+                    isinstance(body, dict)
+                    and body.get("error", {}).get("code") == "insufficient_quota"
+                ):
+                    raise RuntimeError(
+                        f"{self._provider_label} billing quota exceeded. "
+                        "Check your plan and billing details."
+                    ) from err
                 if attempt == max_attempts - 1:
                     raise RuntimeError(
                         f"{self._provider_label} rate limit exceeded (HTTP 429) after multiple retries. "

--- a/tests/services/test_chat_sdk_adapter_comprehensive.py
+++ b/tests/services/test_chat_sdk_adapter_comprehensive.py
@@ -929,3 +929,147 @@ def test_messages_to_invocation_dicts_tool_shaped_object() -> None:
         "tool_call_id": "z",
         "name": "n",
     }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Non-retryable error handling in retry helpers
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_openai_not_found_raises_immediately_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NotFoundError (wrong model name) must surface immediately without retry."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    adapter = _OpenAIChatAdapter(model="gpt-nonexistent", with_tools=False)
+
+    from openai import NotFoundError as OAINotFoundErr
+
+    not_found_err = OAINotFoundErr("model not found", response=MagicMock(), body={})
+
+    with patch("openai.OpenAI") as cls, patch("time.sleep") as sleep_mock:
+        client = MagicMock()
+        client.chat.completions.create.side_effect = not_found_err
+        cls.return_value = client
+
+        with pytest.raises(RuntimeError, match="not found"):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+
+    sleep_mock.assert_not_called()
+    assert client.chat.completions.create.call_count == 1
+
+
+def test_openai_bad_request_raises_immediately_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BadRequestError (billing/invalid request) must surface immediately without retry."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    adapter = _OpenAIChatAdapter(model="gpt-4o", with_tools=False)
+
+    from openai import BadRequestError as OAIBadReqErr
+
+    bad_req_err = OAIBadReqErr("overdue payment", response=MagicMock(), body={})
+
+    with patch("openai.OpenAI") as cls, patch("time.sleep") as sleep_mock:
+        client = MagicMock()
+        client.chat.completions.create.side_effect = bad_req_err
+        cls.return_value = client
+
+        with pytest.raises(RuntimeError, match="400"):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+
+    sleep_mock.assert_not_called()
+    assert client.chat.completions.create.call_count == 1
+
+
+def test_openai_insufficient_quota_raises_immediately_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RateLimitError with insufficient_quota code must raise immediately (billing limit)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    adapter = _OpenAIChatAdapter(model="gpt-4o", with_tools=False)
+
+    from openai import RateLimitError as OAIRateLimitErr
+
+    quota_err = OAIRateLimitErr("quota exceeded", response=MagicMock(), body={})
+    quota_err.body = {"error": {"code": "insufficient_quota"}}
+
+    with patch("openai.OpenAI") as cls, patch("time.sleep") as sleep_mock:
+        client = MagicMock()
+        client.chat.completions.create.side_effect = quota_err
+        cls.return_value = client
+
+        with pytest.raises(RuntimeError, match="quota"):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+
+    sleep_mock.assert_not_called()
+    assert client.chat.completions.create.call_count == 1
+
+
+def test_anthropic_not_found_raises_immediately_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic NotFoundError must surface immediately without retry."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    adapter = _AnthropicChatAdapter(model="claude-nonexistent", with_tools=False)
+
+    from anthropic import NotFoundError as AntNotFoundErr
+
+    not_found_err = AntNotFoundErr("model not found", response=MagicMock(), body={})
+
+    with patch("anthropic.Anthropic") as cls, patch("time.sleep") as sleep_mock:
+        client = MagicMock()
+        client.messages.create.side_effect = not_found_err
+        cls.return_value = client
+
+        with pytest.raises(RuntimeError, match="not found"):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+
+    sleep_mock.assert_not_called()
+    assert client.messages.create.call_count == 1
+
+
+def test_anthropic_bad_request_raises_immediately_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic BadRequestError (e.g. credit balance too low) must not retry."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    adapter = _AnthropicChatAdapter(model="claude-3-5-sonnet-20241022", with_tools=False)
+
+    from anthropic import BadRequestError as AntBadReqErr
+
+    bad_req_err = AntBadReqErr("credit balance too low", response=MagicMock(), body={})
+
+    with patch("anthropic.Anthropic") as cls, patch("time.sleep") as sleep_mock:
+        client = MagicMock()
+        client.messages.create.side_effect = bad_req_err
+        cls.return_value = client
+
+        with pytest.raises(RuntimeError, match="400"):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+
+    sleep_mock.assert_not_called()
+    assert client.messages.create.call_count == 1
+
+
+def test_anthropic_permission_denied_raises_immediately_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic PermissionDeniedError must surface immediately without retry."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    adapter = _AnthropicChatAdapter(model="claude-3-5-sonnet-20241022", with_tools=False)
+
+    from anthropic import PermissionDeniedError as AntPermDeniedErr
+
+    perm_err = AntPermDeniedErr("access denied", response=MagicMock(), body={})
+
+    with patch("anthropic.Anthropic") as cls, patch("time.sleep") as sleep_mock:
+        client = MagicMock()
+        client.messages.create.side_effect = perm_err
+        cls.return_value = client
+
+        with pytest.raises(RuntimeError, match="access denied"):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+
+    sleep_mock.assert_not_called()
+    assert client.messages.create.call_count == 1

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1304,6 +1304,89 @@ def test_openai_invoke_stream_rate_limit_retries_before_emit(monkeypatch) -> Non
     assert sleeps == [7.0]
 
 
+class _FakeInsufficientQuotaError(llm_client.OpenAIRateLimitError):
+    """Fake RateLimitError with ``insufficient_quota`` error code (billing limit)."""
+
+    def __init__(self) -> None:
+        Exception.__init__(self, "You exceeded your current quota")
+        self.status_code = 429
+        self.body = {
+            "error": {
+                "message": "You exceeded your current quota",
+                "type": "insufficient_quota",
+                "code": "insufficient_quota",
+            }
+        }
+
+
+def test_openai_invoke_rate_limit_insufficient_quota_raises_immediately(monkeypatch) -> None:
+    """insufficient_quota (billing limit) must raise RuntimeError without retrying."""
+    call_count = 0
+
+    class _Completions:
+        def create(self, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise _FakeInsufficientQuotaError()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    with pytest.raises(RuntimeError) as exc_info:
+        client.invoke("hi")
+
+    assert call_count == 1, "insufficient_quota must not be retried"
+    assert sleeps == [], "insufficient_quota must not sleep before raising"
+    msg = str(exc_info.value).lower()
+    assert "quota" in msg or "billing" in msg
+
+
+def test_openai_invoke_stream_rate_limit_insufficient_quota_raises_immediately(
+    monkeypatch,
+) -> None:
+    """insufficient_quota in invoke_stream() must raise immediately without retry."""
+    call_count = 0
+
+    class _Completions:
+        def create(self, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise _FakeInsufficientQuotaError()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    with pytest.raises(RuntimeError) as exc_info:
+        list(client.invoke_stream("hi"))
+
+    assert call_count == 1, "insufficient_quota must not be retried in invoke_stream"
+    assert sleeps == []
+    msg = str(exc_info.value).lower()
+    assert "quota" in msg or "billing" in msg
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # BedrockLLMClient – non-transient error handling
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1387,6 +1387,61 @@ def test_openai_invoke_stream_rate_limit_insufficient_quota_raises_immediately(
     assert "quota" in msg or "billing" in msg
 
 
+def test_openai_invoke_stream_rate_limit_insufficient_quota_after_emit_is_wrapped(
+    monkeypatch,
+) -> None:
+    """insufficient_quota after a streamed token still uses the friendly quota error."""
+    call_count = 0
+
+    class _Delta:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.delta = _Delta(content)
+
+    class _Chunk:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            def _stream():
+                yield _Chunk("partial")
+                raise _FakeInsufficientQuotaError()
+
+            return _stream()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    stream = client.invoke_stream("hi")
+
+    assert next(stream) == "partial"
+    with pytest.raises(RuntimeError) as exc_info:
+        next(stream)
+
+    assert call_count == 1, "mid-stream insufficient_quota must not be retried"
+    assert sleeps == []
+    msg = str(exc_info.value).lower()
+    assert "quota" in msg or "billing" in msg
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # BedrockLLMClient – non-transient error handling
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `OpenAILLMClient.invoke` / `invoke_stream`: detect `insufficient_quota` in the `RateLimitError` body and raise immediately instead of sleeping and retrying 3× (fixes #1770, #1669, #1670)
- `chat_sdk_adapter._openai_chat_completions_with_retry`: add non-retryable handlers for `NotFoundError`, `BadRequestError`, and `RateLimitError` with `insufficient_quota`
- `chat_sdk_adapter._anthropic_messages_create_with_retry`: add non-retryable handlers for `NotFoundError`, `PermissionDeniedError`, and `BadRequestError` (fixes #1769)

## Root cause

`OpenAIRateLimitError` with error code `insufficient_quota` is a **billing limit** (account has no credits), not a transient rate limit. Retrying it wastes time and generates duplicate Sentry events. Similarly, `BadRequestError` (400) and `NotFoundError` (404) in `chat_sdk_adapter`'s retry helpers were falling through to the generic `except Exception` clause and being retried. The `LLMClient` and `OpenAILLMClient` paths in `llm_client.py` were already fixed on main; this PR closes the same gap in `chat_sdk_adapter`.

## Test plan

- [x] `test_openai_invoke_rate_limit_insufficient_quota_raises_immediately` — `invoke()` raises on first attempt, no sleep
- [x] `test_openai_invoke_stream_rate_limit_insufficient_quota_raises_immediately` — `invoke_stream()` same
- [x] `test_openai_not_found_raises_immediately_without_retry` — adapter `NotFoundError` handler
- [x] `test_openai_bad_request_raises_immediately_without_retry` — adapter `BadRequestError` handler
- [x] `test_openai_insufficient_quota_raises_immediately_without_retry` — adapter quota handler
- [x] `test_anthropic_not_found_raises_immediately_without_retry` — Anthropic `NotFoundError`
- [x] `test_anthropic_bad_request_raises_immediately_without_retry` — Anthropic `BadRequestError`
- [x] `test_anthropic_permission_denied_raises_immediately_without_retry` — Anthropic `PermissionDeniedError`

Closes #1770
Closes #1669
Closes #1670
Closes #1732
Closes #1769

https://claude.ai/code/session_01KkVMYowPVJZtcKvbJHH1LX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkVMYowPVJZtcKvbJHH1LX)_