### PR TITLE
feat(cli): surface discovered local agents

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -12,6 +12,7 @@ silently omitted from the built wheel.
 """
 
 from app.agents.coordination import BranchClaim, BranchClaims
+from app.agents.discovery import ProcessRow, discover_agents, registered_and_discovered_agents
 from app.agents.lifecycle import TerminateResult, terminate
 from app.agents.quality import LoopDetector
 from app.agents.registry import AgentRecord, AgentRegistry
@@ -22,6 +23,9 @@ __all__ = [
     "BranchClaim",
     "BranchClaims",
     "LoopDetector",
+    "ProcessRow",
     "TerminateResult",
+    "discover_agents",
+    "registered_and_discovered_agents",
     "terminate",
 ]

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -64,7 +64,7 @@ def registered_and_discovered_agents(
     records_by_pid = {record.pid: record for record in registry.list()}
     for record in discover_agents():
         records_by_pid.setdefault(record.pid, record)
-    return list(records_by_pid.values())
+    return sorted(records_by_pid.values(), key=lambda record: (record.name, record.pid))
 
 
 def _current_process_rows() -> list[ProcessRow]:
@@ -154,7 +154,7 @@ def _agent_name_for_command(command: str) -> str | None:
         return "cursor-agent-exec"
     if "cursor-agent" in lower or "cursor agent" in lower:
         return "cursor-agent"
-    if _has_command_token(lower, "claude") and " code" in f" {lower} ":
+    if _has_command_token(lower, "claude") and _has_command_token(lower, "code"):
         return "claude-code"
     if _has_command_token(lower, "codex"):
         return "codex"

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -1,0 +1,178 @@
+"""Read-only discovery of local AI agent processes."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.agents.registry import AgentRecord, AgentRegistry
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CURSOR_PROJECTS_DIR = Path.home() / ".cursor" / "projects"
+_PS_COMMAND = ("ps", "-axo", "pid=,args=")
+
+
+@dataclass(frozen=True)
+class ProcessRow:
+    """Minimal process-list row used by the discovery rules."""
+
+    pid: int
+    command: str
+
+
+def discover_agents(
+    *,
+    process_rows: Iterable[ProcessRow] | None = None,
+    cursor_projects_dir: Path = _DEFAULT_CURSOR_PROJECTS_DIR,
+) -> list[AgentRecord]:
+    """Return agent-like processes discovered from the local machine.
+
+    Discovery is intentionally read-only. The registry remains the source of
+    explicit user-tracked agents; this function surfaces obvious Cursor,
+    Claude Code, Codex, Aider, and Gemini CLI processes that are already
+    running but have not been registered.
+    """
+    records_by_pid: dict[int, AgentRecord] = {}
+
+    rows = list(process_rows) if process_rows is not None else _current_process_rows()
+    for row in rows:
+        name = _agent_name_for_command(row.command)
+        if name is None:
+            continue
+        records_by_pid[row.pid] = AgentRecord(
+            name=name,
+            pid=row.pid,
+            command=row.command,
+            source="discovered",
+        )
+
+    for record in _discover_cursor_terminal_agents(cursor_projects_dir):
+        records_by_pid.setdefault(record.pid, record)
+
+    return sorted(records_by_pid.values(), key=lambda record: (record.name, record.pid))
+
+
+def registered_and_discovered_agents(
+    registry: AgentRegistry | None = None,
+) -> list[AgentRecord]:
+    """Merge explicit registry rows with read-only discovered agent rows."""
+    registry = registry or AgentRegistry()
+    records_by_pid = {record.pid: record for record in registry.list()}
+    for record in discover_agents():
+        records_by_pid.setdefault(record.pid, record)
+    return list(records_by_pid.values())
+
+
+def _current_process_rows() -> list[ProcessRow]:
+    try:
+        proc = subprocess.run(
+            _PS_COMMAND,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        logger.debug("agent discovery: failed to run ps", exc_info=True)
+        return []
+    if proc.returncode != 0:
+        logger.debug("agent discovery: ps exited with code %s", proc.returncode)
+        return []
+    rows: list[ProcessRow] = []
+    for line in proc.stdout.splitlines():
+        row = _parse_ps_line(line)
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
+def _parse_ps_line(line: str) -> ProcessRow | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    parts = stripped.split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    try:
+        pid = int(parts[0])
+    except ValueError:
+        return None
+    return ProcessRow(pid=pid, command=parts[1])
+
+
+def _discover_cursor_terminal_agents(cursor_projects_dir: Path) -> list[AgentRecord]:
+    if not cursor_projects_dir.is_dir():
+        return []
+
+    records: list[AgentRecord] = []
+    for path in sorted(cursor_projects_dir.glob("*/terminals/*.txt")):
+        record = _record_from_cursor_terminal(path)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def _record_from_cursor_terminal(path: Path) -> AgentRecord | None:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[:8]
+    except OSError:
+        return None
+
+    metadata: dict[str, str] = {}
+    for line in lines:
+        if line == "---":
+            continue
+        key, sep, value = line.partition(":")
+        if sep:
+            metadata[key.strip()] = value.strip()
+
+    raw_pid = metadata.get("pid")
+    command = metadata.get("active_command") or metadata.get("last_command")
+    if raw_pid is None or command is None:
+        return None
+    try:
+        pid = int(raw_pid)
+    except ValueError:
+        return None
+
+    name = _agent_name_for_command(command)
+    if name is None:
+        return None
+    return AgentRecord(name=name, pid=pid, command=command, source="discovered")
+
+
+def _agent_name_for_command(command: str) -> str | None:
+    lower = command.lower()
+
+    if ".cursor/extensions/anthropic.claude-code" in lower:
+        return "cursor-claude-code"
+    if "extension-host (agent-exec)" in lower:
+        return "cursor-agent-exec"
+    if "cursor-agent" in lower or "cursor agent" in lower:
+        return "cursor-agent"
+    if _has_command_token(lower, "claude") and " code" in f" {lower} ":
+        return "claude-code"
+    if _has_command_token(lower, "codex"):
+        return "codex"
+    if _has_command_token(lower, "aider"):
+        return "aider"
+    if _has_command_token(lower, "gemini"):
+        return "gemini-cli"
+    return None
+
+
+def _has_command_token(command: str, token: str) -> bool:
+    normalized = command.replace("/", " ").replace("\\", " ")
+    normalized = normalized.replace("-", " ").replace("_", " ")
+    return token in normalized.split()
+
+
+__all__ = [
+    "ProcessRow",
+    "discover_agents",
+    "registered_and_discovered_agents",
+]

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -24,6 +24,7 @@ class AgentRecord:
     pid: int
     command: str
     registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    source: str = "registered"
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -37,6 +38,7 @@ class AgentRecord:
             pid=pid,
             command=str(data["command"]),
             registered_at=str(data.get("registered_at", datetime.now(UTC).isoformat())),
+            source=str(data.get("source", "registered")),
         )
 
 

--- a/app/cli/commands/agent.py
+++ b/app/cli/commands/agent.py
@@ -1,14 +1,12 @@
-"""Local agent fleet management CLI commands.
-
-Phase-0 skeleton for the ``monitor-local-agents`` initiative. The subcommands
-intentionally print a placeholder message; real functionality lands in later
-phases (registry persistence, psutil probing, slash-command surfacing in the
-interactive shell).
-"""
+"""Local agent fleet management CLI commands."""
 
 from __future__ import annotations
 
 import click
+from rich.console import Console
+
+from app.agents.discovery import registered_and_discovered_agents
+from app.cli.interactive_shell.agents_view import render_agents_table
 
 _NOT_IMPLEMENTED_MESSAGE = "not implemented yet"
 
@@ -20,8 +18,8 @@ def agents() -> None:
 
 @agents.command(name="list")
 def list_agents() -> None:
-    """List tracked local agents."""
-    click.echo(_NOT_IMPLEMENTED_MESSAGE)
+    """List registered and auto-discovered local agents."""
+    Console().print(render_agents_table(registered_and_discovered_agents()))
 
 
 @agents.command(name="register")

--- a/app/cli/interactive_shell/agents_view.py
+++ b/app/cli/interactive_shell/agents_view.py
@@ -4,9 +4,10 @@ Produces the structural shape of the dashboard with the columns
 documented in #1486's preview (``agent``, ``pid``, ``uptime``,
 ``cpu%``, ``tokens/min``, ``$/hr``, ``status``). The ``$/hr`` cell
 reads from ``agents.yaml`` via :func:`app.agents.config.load_agents_config`;
-the remaining metric columns still render as ``-`` until #1490 wires
-the per-PID sampler (``cpu%`` / ``uptime`` / ``status``) and the
-token-meter consumer (``tokens/min``).
+the ``status`` cell shows whether the row came from the explicit
+registry or read-only process discovery; remaining metric columns still
+render as ``-`` until #1490 wires the per-PID sampler and token-meter
+consumer.
 
 This module lives outside ``app/agents/`` deliberately: the agents
 package is for *collectors* (probe, registry, sweep, meters) and
@@ -55,24 +56,18 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
     The returned table always has the full column structure, even
     when no records exist; the caller passes it to ``console.print()``.
     An empty record list produces a table with no body rows and an
-    explanatory caption pointing the user at the registration command.
+    explanatory caption.
 
     The ``$/hr`` cell reads ``hourly_budget_usd`` from ``agents.yaml``
     when configured. The other metric cells (``uptime``, ``cpu%``,
-    ``tokens/min``, ``status``) still render as ``-`` placeholders;
-    filling them is out of scope here.
+    ``tokens/min``) still render as ``-`` placeholders; filling them is
+    out of scope here.
     """
     materialized = list(records)
-    # The empty-state caption deliberately doesn't suggest a registration
-    # command: ``opensre agents register`` is currently a stub
-    # (``feat(cli): register agents command group skeleton (#1486)``)
-    # that prints "not implemented yet". Pointing users at it would be
-    # misleading. The wording will gain a "register one with X" hint
-    # when that ticket grows real behavior.
     table = Table(
         title="agents",
         title_style=BOLD_BRAND,
-        caption="no agents registered yet" if not materialized else None,
+        caption="no agents discovered or registered yet" if not materialized else None,
     )
     for header, justify in _COLUMNS:
         table.add_column(header, justify=justify)
@@ -101,7 +96,7 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
             _UNFILLED,  # cpu%
             _UNFILLED,  # tokens/min
             hourly_cell,
-            _UNFILLED,  # status
+            escape(record.source),
         )
     return table
 

--- a/app/cli/interactive_shell/cli_agent.py
+++ b/app/cli/interactive_shell/cli_agent.py
@@ -11,6 +11,7 @@ from rich.markup import escape
 
 from app.cli.interactive_shell.agents_md_reference import build_agents_md_reference_text
 from app.cli.interactive_shell.cli_reference import build_cli_reference_text
+from app.cli.interactive_shell.graph_pipeline_reference import build_graph_pipeline_reference_text
 from app.cli.interactive_shell.grounding_diagnostics import log_grounding_cache_diagnostics
 from app.cli.interactive_shell.prompt_rules import (
     CLI_ASSISTANT_MARKDOWN_RULE,
@@ -66,32 +67,47 @@ def _format_history_for_prompt(session: ReplSession) -> str:
     return "\n".join(lines) if lines else "(no prior messages in this CLI thread)"
 
 
-def _build_system_prompt(reference: str, history: str, agents_md: str = "") -> str:
+def _build_system_prompt(
+    reference: str,
+    history: str,
+    agents_md: str = "",
+    graph_pipeline: str = "",
+) -> str:
     """Build the system prompt for one assistant turn.
 
     Split out so tests can assert on terminology / formatting rules without
     invoking an LLM. ``agents_md`` is the optional repo-map block from
     :mod:`app.cli.interactive_shell.agents_md_reference`; when empty the
     section is omitted so callers in environments that ship no AGENTS.md
-    files don't waste tokens on an empty header.
+    files don't waste tokens on an empty header. ``graph_pipeline`` is a
+    concise reference to the LangGraph pipeline used by investigations.
     """
     repo_map_block = f"--- Repo map (AGENTS.md) ---\n{agents_md}\n\n" if agents_md else ""
+    graph_pipeline_block = (
+        f"--- Graph pipeline reference ---\n{graph_pipeline}\n\n" if graph_pipeline else ""
+    )
     return (
         "You are the OpenSRE terminal assistant. You help with OpenSRE CLI "
         "usage, the interactive shell, and onboarding. A deterministic pre-pass "
         "runs first: it executes eligible local commands as argv (no shell) "
         "under a read-only allowlist; users must prefix with ! for full-shell "
         "semantics (pipes, redirects, mutating commands). Do not tell users the "
-        "interactive shell cannot execute commands. You do NOT run incident investigations yourself "
-        "(those use a separate LangGraph pipeline).\n"
+        "interactive shell cannot execute commands. You do NOT run incident "
+        "investigations yourself "
+        "(those use a separate LangGraph pipeline), but you are grounded on that "
+        "pipeline's architecture below and can answer questions about its nodes, "
+        "edges, routing, and source files.\n"
         "When the user wants to investigate an alert, tell them to paste "
         "alert text, JSON, or a concrete incident description (errors, "
         "services, symptoms). Mention `opensre investigate` and pasting "
         "into this interactive shell.\n"
         "Be brief and friendly. Ground CLI facts in the reference below; do "
-        "not invent subcommands.\n\n"
+        "not invent subcommands. For graph pipeline questions, use the graph "
+        "pipeline reference below and do not claim the graph definition is "
+        "unavailable.\n\n"
         f"{_TERMINOLOGY_RULE}\n{_MARKDOWN_RULE}\n{_ACTION_RULE}\n\n"
         f"--- CLI reference ---\n{reference}\n\n"
+        f"{graph_pipeline_block}"
         f"{repo_map_block}"
         f"--- Recent CLI conversation ---\n{history}\n"
     )
@@ -342,9 +358,15 @@ def answer_cli_agent(
 
     reference = build_cli_reference_text()
     agents_md = build_agents_md_reference_text()
+    graph_pipeline = build_graph_pipeline_reference_text()
     log_grounding_cache_diagnostics("cli_agent_grounding")
     history = _format_history_for_prompt(session)
-    system = _build_system_prompt(reference, history, agents_md=agents_md)
+    system = _build_system_prompt(
+        reference,
+        history,
+        agents_md=agents_md,
+        graph_pipeline=graph_pipeline,
+    )
     user_block = f"--- User message ---\n{message}"
     prompt = f"{system}\n{user_block}"
 

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -28,6 +28,7 @@ from app.agents.conflicts import (
     render_conflicts,
 )
 from app.agents.coordination import BranchClaims
+from app.agents.discovery import registered_and_discovered_agents
 from app.agents.lifecycle import TerminateResult, terminate
 from app.agents.registry import AgentRegistry
 from app.analytics.events import Event
@@ -64,16 +65,14 @@ def _print_config_error(console: Console, exc: ValidationError) -> None:
 
 
 def _cmd_agents_list(console: Console) -> bool:
-    """Render the registered ``AgentRecord`` set as a Rich table.
+    """Render registered plus read-only discovered agents as a Rich table.
 
-    Bare ``/agents`` resolves here. The ``$/hr`` cell reads
-    ``hourly_budget_usd`` from ``agents.yaml``; the remaining metric
-    cells (``cpu%``, ``tokens/min``, ``status``, ``uptime``) still
-    render as placeholders until the per-PID sampler and token-meter
-    consumer from #1490 land.
+    Bare ``/agents`` resolves here. Explicit registry rows keep winning
+    on PID collisions; process discovery fills in Cursor, Claude Code,
+    Codex, Aider, and Gemini CLI sessions that the user never registered.
     """
     registry = AgentRegistry()
-    table = render_agents_table(registry.list())
+    table = render_agents_table(registered_and_discovered_agents(registry))
     console.print(table)
     return True
 

--- a/app/cli/interactive_shell/graph_pipeline_reference.py
+++ b/app/cli/interactive_shell/graph_pipeline_reference.py
@@ -1,0 +1,57 @@
+"""Static grounding for the OpenSRE LangGraph pipeline.
+
+The interactive-shell assistant is intentionally LangGraph-free, but users ask
+it architectural questions about the investigation graph that powers pasted
+alerts and ``opensre investigate``. Keep this concise reference aligned with
+``app/pipeline/graph.py`` and ``app/pipeline/routing.py`` so those answers are
+grounded in the actual pipeline shape.
+"""
+
+from __future__ import annotations
+
+_GRAPH_PIPELINE_REFERENCE = """\
+Source files:
+- app/pipeline/graph.py builds and compiles the LangGraph StateGraph.
+- app/pipeline/routing.py owns conditional edge functions.
+- app/state/agent_state.py defines AgentState / InvestigationState.
+- app/nodes/ contains node implementations.
+
+Entry point:
+- inject_auth is always first.
+- route_by_mode sends mode="investigation" to extract_alert; all other modes use chat.
+
+Chat flow:
+- inject_auth -> router.
+- route_chat sends route="tracer_data" to chat_agent, otherwise to general.
+- chat_agent loops through tool_executor while the last AI message has tool calls.
+- general and completed chat_agent turns end the graph.
+
+Investigation flow:
+- inject_auth -> extract_alert.
+- route_after_extract ends early for noise alerts.
+- non-noise alerts continue to resolve_integrations.
+- resolve_integrations -> plan_actions.
+- distribute_hypotheses fans planned actions out to investigate_hypothesis in parallel.
+- if no planned actions exist, the graph goes directly to merge_hypothesis_results.
+- investigate_hypothesis -> merge_hypothesis_results -> diagnose.
+- diagnose uses route_investigation_loop.
+- if more investigation is recommended, diagnose -> adapt_window -> plan_actions.
+- otherwise diagnose -> publish.
+- diagnose -> opensre_eval -> publish when OpenSRE eval is enabled.
+- publish ends the graph.
+
+Important distinction:
+- The interactive terminal assistant does not execute the graph itself.
+- Pasting an alert into the interactive shell launches this pipeline.
+- running opensre investigate launches this pipeline.
+- Do not say the graph definition is unavailable.
+- Summarize this reference and point to the files above.
+"""
+
+
+def build_graph_pipeline_reference_text() -> str:
+    """Return a concise architectural reference for the interactive assistant."""
+    return _GRAPH_PIPELINE_REFERENCE
+
+
+__all__ = ["build_graph_pipeline_reference_text"]

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -36,8 +36,7 @@ def test_discovers_cursor_agent_exec_helper() -> None:
             ProcessRow(
                 pid=23995,
                 command=(
-                    "Cursor Helper (Plugin): extension-host (agent-exec) "
-                    "tracer-agent-2026 [1-4]"
+                    "Cursor Helper (Plugin): extension-host (agent-exec) tracer-agent-2026 [1-4]"
                 ),
             )
         ],

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -84,6 +84,18 @@ def test_discovers_agent_cli_from_cursor_terminal_metadata(tmp_path: Path) -> No
     ]
 
 
+def test_ignores_plain_claude_commands_with_code_prefix_arguments() -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=601, command="claude codebase.py"),
+            ProcessRow(pid=602, command="claude codegen --project src"),
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert records == []
+
+
 def test_registered_records_win_over_discovered_pid(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -114,3 +126,21 @@ def test_registered_records_win_over_discovered_pid(
     assert len(records) == 1
     assert records[0].name == "manual-claude"
     assert records[0].source == "registered"
+
+
+def test_registered_and_discovered_agents_returns_sorted_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry = AgentRegistry(path=tmp_path / "agents.jsonl")
+    registry.register(AgentRecord(name="z-manual", pid=20, command="manual"))
+
+    monkeypatch.setattr(
+        "app.agents.discovery.discover_agents",
+        lambda: [
+            AgentRecord(name="aider", pid=10, command="aider", source="discovered"),
+        ],
+    )
+
+    records = registered_and_discovered_agents(registry)
+
+    assert [(record.name, record.pid) for record in records] == [("aider", 10), ("z-manual", 20)]

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -1,0 +1,117 @@
+"""Tests for read-only local agent discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.agents.discovery import ProcessRow, discover_agents, registered_and_discovered_agents
+from app.agents.registry import AgentRecord, AgentRegistry
+
+
+def test_discovers_cursor_claude_code_process() -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(
+                pid=80435,
+                command=(
+                    "/Users/me/.cursor/extensions/anthropic.claude-code-2.1.128-darwin-arm64/"
+                    "resources/native-binary/claude --output-format stream-json"
+                ),
+            )
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert len(records) == 1
+    assert records[0].name == "cursor-claude-code"
+    assert records[0].pid == 80435
+    assert records[0].source == "discovered"
+
+
+def test_discovers_cursor_agent_exec_helper() -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(
+                pid=23995,
+                command=(
+                    "Cursor Helper (Plugin): extension-host (agent-exec) "
+                    "tracer-agent-2026 [1-4]"
+                ),
+            )
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert [(record.name, record.pid) for record in records] == [("cursor-agent-exec", 23995)]
+
+
+def test_ignores_generic_desktop_cursor_processes() -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=23521, command="/Applications/Cursor.app/Contents/MacOS/Cursor"),
+            ProcessRow(
+                pid=23540,
+                command=(
+                    "/Applications/Cursor.app/Contents/Frameworks/"
+                    "Cursor Helper (Renderer).app/Contents/MacOS/Cursor Helper (Renderer)"
+                ),
+            ),
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert records == []
+
+
+def test_discovers_agent_cli_from_cursor_terminal_metadata(tmp_path: Path) -> None:
+    terminal = tmp_path / "project" / "terminals" / "70.txt"
+    terminal.parent.mkdir(parents=True)
+    terminal.write_text(
+        "---\n"
+        "pid: 12345\n"
+        "cwd: /repo\n"
+        "active_command: claude code\n"
+        "last_command: source .venv/bin/activate\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    records = discover_agents(process_rows=[], cursor_projects_dir=tmp_path)
+
+    assert [(record.name, record.pid, record.source) for record in records] == [
+        ("claude-code", 12345, "discovered")
+    ]
+
+
+def test_registered_records_win_over_discovered_pid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    registry = AgentRegistry(path=tmp_path / "agents.jsonl")
+    registry.register(
+        AgentRecord(
+            name="manual-claude",
+            pid=42,
+            command="custom claude wrapper",
+            registered_at="2026-05-07T12:00:00+00:00",
+        )
+    )
+
+    monkeypatch.setattr(
+        "app.agents.discovery.discover_agents",
+        lambda: [
+            AgentRecord(
+                name="claude-code",
+                pid=42,
+                command="claude code",
+                source="discovered",
+            )
+        ],
+    )
+
+    records = registered_and_discovered_agents(registry)
+
+    assert len(records) == 1
+    assert records[0].name == "manual-claude"
+    assert records[0].source == "registered"

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -36,6 +36,11 @@ def _isolate_registry(monkeypatch: pytest.MonkeyPatch, path: Path) -> AgentRegis
     from app.cli.interactive_shell.command_registry import agents as agents_mod
 
     monkeypatch.setattr(agents_mod, "AgentRegistry", lambda: AgentRegistry(path=path))
+    monkeypatch.setattr(
+        agents_mod,
+        "registered_and_discovered_agents",
+        lambda _registry=None: AgentRegistry(path=path).list(),
+    )
     return registry
 
 
@@ -82,7 +87,7 @@ class TestAgentsDispatch:
 
         out = buf.getvalue()
         # Caption from agents_view.render_agents_table:
-        assert "no agents registered" in out
+        assert "no agents discovered or registered" in out
         # Header row still rendered with the dashboard column structure:
         assert "agent" in out
         assert "pid" in out
@@ -103,6 +108,33 @@ class TestAgentsDispatch:
         assert "8421" in out
         assert "cursor-tab" in out
         assert "9133" in out
+
+    def test_no_subcommand_renders_discovered_agents(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import agents as agents_mod
+
+        monkeypatch.setattr(
+            agents_mod,
+            "registered_and_discovered_agents",
+            lambda _registry=None: [
+                AgentRecord(
+                    name="cursor-claude-code",
+                    pid=80435,
+                    command="claude --output-format stream-json",
+                    source="discovered",
+                )
+            ],
+        )
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents", session, console) is True
+
+        out = buf.getvalue()
+        assert "cursor-claude-code" in out
+        assert "80435" in out
+        assert "discovered" in out
 
     def test_unknown_subcommand_prints_error(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -109,9 +109,7 @@ class TestAgentsDispatch:
         assert "cursor-tab" in out
         assert "9133" in out
 
-    def test_no_subcommand_renders_discovered_agents(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_subcommand_renders_discovered_agents(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from app.cli.interactive_shell.command_registry import agents as agents_mod
 
         monkeypatch.setattr(

--- a/tests/cli/interactive_shell/test_agents_view.py
+++ b/tests/cli/interactive_shell/test_agents_view.py
@@ -96,15 +96,11 @@ def test_empty_records_renders_table_with_zero_rows() -> None:
 
 
 def test_empty_records_caption_announces_empty_state() -> None:
-    """Empty-state UX: the table caption tells the user the registry
+    """Empty-state UX: the table caption tells the user the fleet
     is empty rather than leaving a blank table that looks like a bug.
-
-    The caption deliberately doesn't suggest a registration command —
-    the ``register`` subcommand is currently a stub. When that gains
-    real behavior, this caption can grow a hint pointing at it.
     """
     _, out = _render([])
-    assert "no agents registered yet" in out
+    assert "no agents discovered or registered yet" in out
 
 
 def test_non_empty_records_have_no_caption() -> None:
@@ -126,16 +122,14 @@ def test_row_contains_agent_name_and_pid() -> None:
 
 
 def test_metric_cells_are_placeholders_until_wired() -> None:
-    """``uptime``, ``cpu%``, ``tokens/min``, ``$/hr``, ``status`` all
-    render as ``-`` placeholders for now. The wiring in #1490 / #1494
-    fills them; this PR only owns the column shape."""
+    """``uptime``, ``cpu%``, ``tokens/min``, and ``$/hr`` render as
+    placeholders for now; ``status`` shows the row source."""
     table, _ = _render([AgentRecord(name="claude-code", pid=8421, command="claude")])
     # row_count == 1, so iterate directly to inspect the rendered cells
     assert table.row_count == 1
-    # The rendered output contains five dashes per row (one per metric column)
     rendered_cells = [list(col.cells)[0] for col in table.columns]
-    # cells[0] = agent, cells[1] = pid, then 5 placeholder cells
-    assert rendered_cells[2:] == ["-", "-", "-", "-", "-"]
+    # cells[0] = agent, cells[1] = pid, then metric cells and row source.
+    assert rendered_cells[2:] == ["-", "-", "-", "-", "registered"]
 
 
 def test_multiple_records_are_each_rendered_in_order() -> None:

--- a/tests/cli/interactive_shell/test_cli_agent.py
+++ b/tests/cli/interactive_shell/test_cli_agent.py
@@ -143,6 +143,43 @@ class TestSystemPromptAgentsMdGrounding:
         assert "--- Repo map (AGENTS.md) ---" not in prompt
 
 
+class TestSystemPromptGraphPipelineGrounding:
+    """The conversational shell knows the actual LangGraph pipeline shape."""
+
+    def test_graph_pipeline_section_present_when_reference_provided(self) -> None:
+        prompt = _build_system_prompt(
+            reference="(ref)",
+            history="(hist)",
+            graph_pipeline="inject_auth -> extract_alert -> publish",
+        )
+
+        assert "--- Graph pipeline reference ---" in prompt
+        assert "inject_auth -> extract_alert -> publish" in prompt
+        assert "do not claim the graph definition is unavailable" in prompt
+
+    def test_graph_pipeline_section_omitted_when_reference_empty(self) -> None:
+        prompt = _build_system_prompt(reference="(ref)", history="(hist)", graph_pipeline="")
+
+        assert "--- Graph pipeline reference ---" not in prompt
+
+    def test_answer_cli_agent_injects_graph_pipeline_reference(self, monkeypatch: Any) -> None:
+        client = _patch_llm(monkeypatch, "Yes, I can describe the pipeline.")
+        monkeypatch.setattr(cli_agent, "build_cli_reference_text", lambda: "(ref)")
+        monkeypatch.setattr(cli_agent, "build_agents_md_reference_text", lambda: "")
+        monkeypatch.setattr(
+            cli_agent,
+            "build_graph_pipeline_reference_text",
+            lambda: "diagnose -> adapt_window -> plan_actions",
+        )
+
+        console, _ = _capture()
+        answer_cli_agent("Can you see your own graph pipeline?", ReplSession(), console)
+
+        assert client.last_prompt is not None
+        assert "--- Graph pipeline reference ---" in client.last_prompt
+        assert "diagnose -> adapt_window -> plan_actions" in client.last_prompt
+
+
 class TestActionPlanParsing:
     def test_parses_prose_wrapped_json(self) -> None:
         actions = _parse_action_plan(

--- a/tests/cli/test_agents_command.py
+++ b/tests/cli/test_agents_command.py
@@ -1,16 +1,13 @@
-"""Smoke tests for the ``opensre agents`` command group (issue #1486).
-
-Phase-0 of the ``monitor-local-agents`` initiative: ensure the new top-level
-group is reachable and each placeholder subcommand exits cleanly. Real
-behavior is added by later tickets in the same series.
-"""
+"""Smoke tests for the ``opensre agents`` command group."""
 
 from __future__ import annotations
 
 import pytest
 from click.testing import CliRunner
 
+from app.agents.registry import AgentRecord
 from app.cli.__main__ import cli
+from app.cli.commands import agent as agent_cmd_mod
 
 
 def test_agents_help_lists_all_subcommands() -> None:
@@ -24,7 +21,30 @@ def test_agents_help_lists_all_subcommands() -> None:
         assert subcommand in result.output, f"missing {subcommand!r} in help: {result.output}"
 
 
-@pytest.mark.parametrize("subcommand", ["list", "register", "forget"])
+def test_agents_list_renders_discovered_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        agent_cmd_mod,
+        "registered_and_discovered_agents",
+        lambda: [
+            AgentRecord(
+                name="cursor-claude-code",
+                pid=80435,
+                command="claude --output-format stream-json",
+                source="discovered",
+            )
+        ],
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["agents", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "cursor-claude-code" in result.output
+    assert "80435" in result.output
+    assert "discovered" in result.output
+
+
+@pytest.mark.parametrize("subcommand", ["register", "forget"])
 def test_agents_subcommand_prints_placeholder(subcommand: str) -> None:
     """Each stub subcommand must run successfully and print the placeholder."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- Add read-only local agent discovery for Cursor, Claude Code, Codex, Aider, and Gemini CLI processes.
- Surface discovered agents in `opensre agents list` and the interactive `/agents` table while preserving registered rows on PID collisions.
- Add graph pipeline grounding for the interactive shell assistant so it can answer architecture questions about the investigation graph.

## Test plan
- Added unit coverage for process discovery, registry/discovery merging, `/agents`, `opensre agents list`, and graph-pipeline prompt grounding.
- TODO: run lint/tests after PR creation and address review/CI feedback.

Made with [Cursor](https://cursor.com)