### PR TITLE
feat(cli): add local agent monitoring

### DIFF
--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -1,0 +1,177 @@
+"""Discover local AI-agent processes that can be tracked by ``opensre agents``."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+import psutil
+
+from app.agents.registry import AgentRecord
+
+_NOISE_PROCESS_TOKENS: tuple[str, ...] = (
+    "chrome_crashpad_handler",
+    "shipit",
+    "helper",
+    "extension-host",
+    "filewatcher",
+    "pty-host",
+    "shared-process",
+    "language-server",
+    "languageserver",
+    "serverworker",
+    "rust-analyzer",
+    "esbuild",
+)
+_NOISE_ARG_PREFIXES: tuple[str, ...] = ("--type=", "--utility-sub-type=")
+_LOOSE_AGENT_SIGNATURES: tuple[tuple[str, str], ...] = (
+    ("claude", "claude-code"),
+    ("claude-code", "claude-code"),
+    ("cursor", "cursor"),
+    ("aider", "aider"),
+    ("codex", "codex"),
+)
+_MAX_DISPLAY_COMMAND_LENGTH = 120
+
+
+@dataclass(frozen=True)
+class DiscoveredAgent:
+    """Candidate process discovered from the local process table."""
+
+    name: str
+    pid: int
+    command: str
+
+    def to_record(self) -> AgentRecord:
+        return AgentRecord(name=self.name, pid=self.pid, command=self.command)
+
+
+def discover_agent_processes(*, include_all: bool = False) -> list[DiscoveredAgent]:
+    """Return likely local AI-agent sessions visible to the current user."""
+
+    candidates: list[DiscoveredAgent] = []
+    current_pid = os.getpid()
+    for proc in psutil.process_iter(attrs=["pid", "name", "cmdline"]):
+        try:
+            info = proc.info
+            pid = int(info.get("pid") or 0)
+            if pid <= 0 or pid == current_pid:
+                continue
+            cmdline = _cmdline_from_info(info)
+            command = _command_from_cmdline(cmdline, info)
+            process_name = str(info.get("name") or "")
+        except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied, ValueError):
+            continue
+
+        agent_name = _classify_agent(process_name, cmdline, include_all=include_all)
+        if agent_name is None:
+            continue
+        candidates.append(DiscoveredAgent(name=f"{agent_name}-{pid}", pid=pid, command=command))
+
+    return sorted(candidates, key=lambda item: (item.name, item.pid))
+
+
+def process_command(pid: int) -> str | None:
+    """Best-effort command line for a PID, or ``None`` if unavailable."""
+
+    try:
+        proc = psutil.Process(pid)
+        cmdline = proc.cmdline()
+    except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied, ProcessLookupError):
+        return None
+    if cmdline:
+        return " ".join(shlex.quote(part) for part in cmdline)
+    try:
+        return proc.name()
+    except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
+        return None
+
+
+def display_command(command: str) -> str:
+    """Return a terminal-friendly one-line command for scan output."""
+
+    collapsed = " ".join(command.split())
+    if len(collapsed) <= _MAX_DISPLAY_COMMAND_LENGTH:
+        return collapsed
+    return f"{collapsed[: _MAX_DISPLAY_COMMAND_LENGTH - 3]}..."
+
+
+def _cmdline_from_info(info: dict[str, object]) -> list[str]:
+    raw_cmdline = info.get("cmdline")
+    if isinstance(raw_cmdline, list) and raw_cmdline:
+        return [str(part) for part in raw_cmdline if str(part)]
+    name = str(info.get("name") or "")
+    return [name] if name else []
+
+
+def _command_from_cmdline(cmdline: list[str], info: dict[str, object]) -> str:
+    if cmdline:
+        return " ".join(shlex.quote(part) for part in cmdline)
+    return str(info.get("name") or "")
+
+
+def _classify_agent(process_name: str, cmdline: list[str], *, include_all: bool) -> str | None:
+    if not cmdline:
+        return None
+    if _is_noise_process(process_name, cmdline):
+        return _classify_agent_loose(process_name, cmdline) if include_all else None
+
+    executable = _normalized_token(cmdline[0])
+    args = [_normalized_token(part) for part in cmdline[1:]]
+    lowered = [part.lower() for part in cmdline]
+
+    if executable == "claude" and (
+        "code" in args
+        or _has_option_pair(lowered, "--input-format", "stream-json")
+        or _has_option_pair(lowered, "--output-format", "stream-json")
+    ):
+        return "claude-code"
+    if executable == "aider":
+        return "aider"
+    if executable == "codex":
+        return "codex"
+    if executable in {"cursor-agent", "cursor-agent-cli"}:
+        return "cursor"
+    if include_all:
+        return _classify_agent_loose(process_name, cmdline)
+    return None
+
+
+def _classify_agent_loose(process_name: str, cmdline: list[str]) -> str | None:
+    haystack = f"{process_name} {' '.join(cmdline)}".lower()
+    tokens = {_normalized_token(part) for part in cmdline}
+    tokens.add(_normalized_token(process_name))
+
+    for signature, label in _LOOSE_AGENT_SIGNATURES:
+        if signature in tokens or signature in haystack:
+            return label
+    return None
+
+
+def _is_noise_process(process_name: str, cmdline: list[str]) -> bool:
+    haystack_parts = [
+        _normalized_token(process_name),
+        *(_normalized_token(part) for part in cmdline),
+    ]
+    haystack = " ".join(part for part in haystack_parts if part)
+    if any(token in haystack for token in _NOISE_PROCESS_TOKENS):
+        return True
+    return any(arg.startswith(_NOISE_ARG_PREFIXES) for arg in cmdline[1:])
+
+
+def _has_option_pair(cmdline: list[str], option: str, value: str) -> bool:
+    for index, part in enumerate(cmdline):
+        if part == option and index + 1 < len(cmdline) and cmdline[index + 1] == value:
+            return True
+        if part == f"{option}={value}":
+            return True
+    return False
+
+
+def _normalized_token(value: str) -> str:
+    return Path(value.strip("'\"")).name.lower()
+
+
+__all__ = ["DiscoveredAgent", "discover_agent_processes", "display_command", "process_command"]

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -10,8 +10,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-import psutil
-
 from app.agents.registry import AgentRecord, AgentRegistry
 
 logger = logging.getLogger(__name__)
@@ -69,22 +67,18 @@ def discover_agent_processes(*, include_all: bool = False) -> list[DiscoveredAge
 
     candidates: list[DiscoveredAgent] = []
     current_pid = os.getpid()
-    for proc in psutil.process_iter(attrs=["pid", "name", "cmdline"]):
-        try:
-            info = proc.info
-            pid = int(info.get("pid") or 0)
-            if pid <= 0 or pid == current_pid:
-                continue
-            cmdline = _cmdline_from_info(info)
-            command = _command_from_cmdline(cmdline, info)
-            process_name = str(info.get("name") or "")
-        except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied, ValueError):
+    for row in _current_process_rows():
+        if row.pid <= 0 or row.pid == current_pid:
             continue
+        cmdline = _split_command(row.command)
+        process_name = _normalized_token(cmdline[0]) if cmdline else ""
 
         agent_name = _classify_agent(process_name, cmdline, include_all=include_all)
         if agent_name is None:
             continue
-        candidates.append(DiscoveredAgent(name=f"{agent_name}-{pid}", pid=pid, command=command))
+        candidates.append(
+            DiscoveredAgent(name=f"{agent_name}-{row.pid}", pid=row.pid, command=row.command)
+        )
 
     return sorted(candidates, key=lambda item: (item.name, item.pid))
 
@@ -136,16 +130,18 @@ def process_command(pid: int) -> str | None:
     """Best-effort command line for a PID, or ``None`` if unavailable."""
 
     try:
-        proc = psutil.Process(pid)
-        cmdline = proc.cmdline()
-    except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied, ProcessLookupError):
+        proc = subprocess.run(
+            ("ps", "-p", str(pid), "-o", "args="),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError):
         return None
-    if cmdline:
-        return " ".join(shlex.quote(part) for part in cmdline)
-    try:
-        return proc.name()
-    except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
+    if proc.returncode != 0:
         return None
+    return proc.stdout.strip() or None
 
 
 def display_command(command: str) -> str:
@@ -194,18 +190,11 @@ def _parse_ps_line(line: str) -> ProcessRow | None:
     return ProcessRow(pid=pid, command=parts[1])
 
 
-def _cmdline_from_info(info: dict[str, object]) -> list[str]:
-    raw_cmdline = info.get("cmdline")
-    if isinstance(raw_cmdline, list) and raw_cmdline:
-        return [str(part) for part in raw_cmdline if str(part)]
-    name = str(info.get("name") or "")
-    return [name] if name else []
-
-
-def _command_from_cmdline(cmdline: list[str], info: dict[str, object]) -> str:
-    if cmdline:
-        return " ".join(shlex.quote(part) for part in cmdline)
-    return str(info.get("name") or "")
+def _split_command(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
 
 
 def _discover_cursor_terminal_agents(cursor_projects_dir: Path) -> list[AgentRecord]:

--- a/app/cli/commands/agent.py
+++ b/app/cli/commands/agent.py
@@ -1,16 +1,18 @@
-"""Local agent fleet management CLI commands.
-
-Phase-0 skeleton for the ``monitor-local-agents`` initiative. The subcommands
-intentionally print a placeholder message; real functionality lands in later
-phases (registry persistence, psutil probing, slash-command surfacing in the
-interactive shell).
-"""
+"""Local agent fleet management CLI commands."""
 
 from __future__ import annotations
 
-import click
+import time
 
-_NOT_IMPLEMENTED_MESSAGE = "not implemented yet"
+import click
+from rich.console import Console
+from rich.markup import escape
+
+from app.agents.discovery import discover_agent_processes, display_command, process_command
+from app.agents.probe import pid_exists
+from app.agents.registry import AgentRecord, AgentRegistry
+from app.cli.interactive_shell.rendering import repl_table
+from app.cli.interactive_shell.theme import BOLD_BRAND, DIM, HIGHLIGHT
 
 
 @click.group(name="agents")
@@ -21,16 +23,104 @@ def agents() -> None:
 @agents.command(name="list")
 def list_agents() -> None:
     """List tracked local agents."""
-    click.echo(_NOT_IMPLEMENTED_MESSAGE)
+    records = AgentRegistry().list()
+    if not records:
+        click.echo("no agents registered")
+        return
+
+    for record in records:
+        click.echo(f"{record.pid}\t{record.name}\t{record.command}")
 
 
 @agents.command(name="register")
-def register_agent() -> None:
+@click.argument("pid", type=int)
+@click.argument("name", required=False)
+@click.option("--command", "command_override", help="Command string to store for this agent.")
+def register_agent(pid: int, name: str | None, command_override: str | None) -> None:
     """Start tracking a local agent process."""
-    click.echo(_NOT_IMPLEMENTED_MESSAGE)
+    if pid <= 0:
+        raise click.BadParameter("must be a positive integer", param_hint="pid")
+
+    agent_name = name or f"agent-{pid}"
+    command = command_override or process_command(pid) or agent_name
+    AgentRegistry().register(AgentRecord(name=agent_name, pid=pid, command=command))
+    click.echo(f"registered {agent_name} (pid {pid})")
 
 
 @agents.command(name="forget")
-def forget_agent() -> None:
+@click.argument("pid", type=int)
+def forget_agent(pid: int) -> None:
     """Stop tracking a local agent process."""
-    click.echo(_NOT_IMPLEMENTED_MESSAGE)
+    removed = AgentRegistry().forget(pid)
+    if removed is None:
+        click.echo(f"no registered agent for pid {pid}")
+        return
+    click.echo(f"forgot {removed.name} (pid {pid})")
+
+
+@agents.command(name="scan")
+@click.option("--register", "should_register", is_flag=True, help="Register all discovered agents.")
+@click.option("--all", "include_all", is_flag=True, help="Include noisy helper processes.")
+def scan_agents(should_register: bool, include_all: bool) -> None:
+    """Discover running Cursor, Claude Code, Aider, and Codex sessions."""
+    console = Console(highlight=False)
+    candidates = discover_agent_processes(include_all=include_all)
+    if not candidates:
+        console.print(f"[{DIM}]no running AI-agent sessions detected[/]")
+        console.print(f"[{DIM}]use [bold]opensre agents scan --all[/bold] to inspect helpers[/]")
+        return
+
+    table = repl_table(title="agent scan", title_style=BOLD_BRAND)
+    table.add_column("pid", justify="right", style=DIM, no_wrap=True)
+    table.add_column("agent", style="bold")
+    table.add_column("command", overflow="ellipsis", no_wrap=True, max_width=48)
+
+    registry = AgentRegistry()
+    for candidate in candidates:
+        table.add_row(
+            str(candidate.pid),
+            escape(candidate.name),
+            escape(display_command(candidate.command)),
+        )
+        if should_register:
+            registry.register(candidate.to_record())
+
+    console.print(table)
+    if should_register:
+        console.print(f"[{HIGHLIGHT}]registered {len(candidates)} agent(s)[/]")
+    elif include_all:
+        console.print(
+            f"[{DIM}]showing helper processes; use "
+            "[bold]opensre agents scan[/bold] for likely agent sessions only[/]"
+        )
+    else:
+        console.print(
+            f"[{DIM}]Next: run [bold]opensre agents scan --register[/bold] "
+            f"to track {len(candidates)} process(es)[/]"
+        )
+
+
+@agents.command(name="watch")
+@click.argument("pid", type=int)
+@click.option("--interval", default=1.0, show_default=True, help="Polling interval in seconds.")
+@click.option("--timeout", type=float, default=None, help="Stop watching after this many seconds.")
+def watch_agent(pid: int, interval: float, timeout: float | None) -> None:
+    """Watch a PID until it exits and print a notification."""
+    if pid <= 0:
+        raise click.BadParameter("must be a positive integer", param_hint="pid")
+    if interval <= 0:
+        raise click.BadParameter("must be positive", param_hint="--interval")
+    if timeout is not None and timeout <= 0:
+        raise click.BadParameter("must be positive", param_hint="--timeout")
+
+    started = time.monotonic()
+    if not pid_exists(pid):
+        click.echo(f"pid {pid} is not running")
+        return
+
+    click.echo(f"watching pid {pid}; press Ctrl+C to stop")
+    while pid_exists(pid):
+        if timeout is not None and time.monotonic() - started >= timeout:
+            raise click.ClickException(f"pid {pid} is still running after {timeout:g}s")
+        time.sleep(interval)
+    click.echo(f"pid {pid} exited")

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -199,15 +199,17 @@ def start_background_cli_task(
     stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
         max_size=_SYNTHETIC_DIAG_CHARS * 2
     )
-    stdout_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
-        max_size=_MAX_COMMAND_OUTPUT_CHARS
-    )
     pty_fds: tuple[int, int] | None = None
     if _should_use_pty(console, use_pty):
         try:
             pty_fds = os.openpty()
         except OSError:
             pty_fds = None
+    stdout_buf: tempfile.SpooledTemporaryFile[bytes] | None = None  # type: ignore[type-arg]
+    if pty_fds is None:
+        stdout_buf = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+            max_size=_MAX_COMMAND_OUTPUT_CHARS
+        )
     proc: subprocess.Popen[Any]
     try:
         if pty_fds is None:
@@ -233,7 +235,8 @@ def start_background_cli_task(
             for fd in pty_fds:
                 with contextlib.suppress(OSError):
                     os.close(fd)
-        stdout_buf.close()
+        if stdout_buf is not None:
+            stdout_buf.close()
         stderr_buf.close()
         task.mark_failed(str(exc))
         console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
@@ -300,7 +303,8 @@ def start_background_cli_task(
             console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
         finally:
             _join_task_output_streams(output_threads)
-            stdout_buf.close()
+            if stdout_buf is not None:
+                stdout_buf.close()
             stderr_buf.close()
 
     thread = threading.Thread(target=_watch, daemon=True)
@@ -757,7 +761,7 @@ def _should_run_opensre_in_foreground(tokens: list[str]) -> bool:
         return True
     if first_token == "agents":
         subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
-        return subcommand in {"list", "register", "forget", "scan"}
+        return subcommand in {"list", "register", "forget", "scan", "watch"}
     return False
 
 

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -804,6 +804,38 @@ def _run_opensre_foreground(
     session.record("cli_command", display_command, ok=ok)
 
 
+def _run_opensre_foreground_streaming(
+    argv_list: list[str],
+    display_command: str,
+    session: ReplSession,
+    console: Console,
+) -> None:
+    console.print(f"[bold]$ {escape(display_command)}[/bold]")
+    try:
+        proc = subprocess.Popen(
+            argv_list,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="interactive_shell.opensre_cli.start")
+        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+        session.record("cli_command", display_command, ok=False)
+        return
+
+    if proc.stdout is not None:
+        for line in proc.stdout:
+            print_command_output(console, line)
+    code = proc.wait()
+    ok = code == 0
+    if not ok:
+        console.print(f"[{ERROR}]command failed (exit {code}):[/]")
+    session.record("cli_command", display_command, ok=ok)
+
+
 def run_opensre_cli_command(
     args: str,
     session: ReplSession,
@@ -864,6 +896,9 @@ def run_opensre_cli_command(
     argv_list = [sys.executable, "-m", "app.cli"] + tokens
     display_command = f"opensre {' '.join(tokens)}"
     if _should_run_opensre_in_foreground(tokens):
+        if [token.lower() for token in tokens[:2]] == ["agents", "watch"]:
+            _run_opensre_foreground_streaming(argv_list, display_command, session, console)
+            return True
         _run_opensre_foreground(argv_list, display_command, session, console)
         return True
 

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
 import shlex
 import subprocess
@@ -12,7 +13,7 @@ import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from rich.console import Console
 from rich.markup import escape
@@ -20,6 +21,7 @@ from rich.text import Text
 
 import app.cli.interactive_shell.intent_parser as _intent_parser
 from app.cli.interactive_shell.execution_policy import (
+    evaluate_code_agent_launch,
     evaluate_investigation_launch,
     evaluate_shell_from_parsed,
     evaluate_synthetic_test_launch,
@@ -36,13 +38,19 @@ from app.cli.interactive_shell.tasks import TaskKind, TaskRecord
 from app.cli.interactive_shell.theme import DIM, ERROR, HIGHLIGHT, WARNING
 from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
+from app.integrations.llm_cli.claude_code import ClaudeCodeAdapter
+from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 
 SHELL_COMMAND_TIMEOUT_SECONDS = 120
 SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
+CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS = 1800
 _SYNTHETIC_POLL_SECONDS = 0.25
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
 _SYNTHETIC_DIAG_CHARS = 2_000  # max stderr bytes captured from a failing synthetic run
 _SIGTERM_GRACE_SECONDS = 10  # wait for clean exit after SIGTERM before escalating to SIGKILL
+_TASK_OUTPUT_JOIN_TIMEOUT_SECONDS = 2
+_IMPLEMENT_PERMISSION_MODE_ENV = "CLAUDE_CODE_IMPLEMENT_PERMISSION_MODE"
+_DEFAULT_IMPLEMENT_PERMISSION_MODE = "acceptEdits"
 
 
 def terminate_child_process(proc: subprocess.Popen[Any]) -> None:
@@ -66,12 +74,252 @@ def read_diag(buf: tempfile.SpooledTemporaryFile[bytes]) -> str:  # type: ignore
     return buf.read(_SYNTHETIC_DIAG_CHARS).decode("utf-8", errors="replace").strip()
 
 
+def _print_task_output_line(
+    console: Console,
+    task: TaskRecord,
+    stream_name: str,
+    line: str,
+    *,
+    style: str | None = None,
+) -> None:
+    text = Text()
+    text.append(f"{task.task_id} {stream_name} │ ", style=DIM)
+    text.append(line.rstrip("\r\n"), style=style)
+    console.print(text)
+
+
+def _pump_task_stream(
+    *,
+    task: TaskRecord,
+    stream_name: str,
+    stream: IO[str],
+    console: Console,
+    style: str | None = None,
+    capture: tempfile.SpooledTemporaryFile[bytes] | None = None,  # type: ignore[type-arg]
+) -> None:
+    try:
+        for line in stream:
+            if capture is not None:
+                capture.write(line.encode("utf-8", errors="replace"))
+            if line.strip():
+                _print_task_output_line(console, task, stream_name, line, style=style)
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[{DIM}]task output stream ended unexpectedly:[/] {escape(str(exc))}")
+
+
+def _start_task_output_streams(
+    *,
+    task: TaskRecord,
+    proc: subprocess.Popen[Any],
+    console: Console,
+    stdout_capture: tempfile.SpooledTemporaryFile[bytes] | None = None,  # type: ignore[type-arg]
+    stderr_capture: tempfile.SpooledTemporaryFile[bytes] | None = None,  # type: ignore[type-arg]
+) -> list[threading.Thread]:
+    threads: list[threading.Thread] = []
+    streams: tuple[tuple[str, IO[str] | None, str | None, Any], ...] = (
+        ("stdout", proc.stdout, None, stdout_capture),
+        ("stderr", proc.stderr, ERROR, stderr_capture),
+    )
+    for stream_name, stream, style, capture in streams:
+        if stream is None:
+            continue
+        thread = threading.Thread(
+            target=_pump_task_stream,
+            kwargs={
+                "task": task,
+                "stream_name": stream_name,
+                "stream": stream,
+                "console": console,
+                "style": style,
+                "capture": capture,
+            },
+            daemon=True,
+            name=f"task-output-{task.task_id}-{stream_name}",
+        )
+        thread.start()
+        threads.append(thread)
+    return threads
+
+
+def _join_task_output_streams(threads: list[threading.Thread]) -> None:
+    for thread in threads:
+        thread.join(timeout=_TASK_OUTPUT_JOIN_TIMEOUT_SECONDS)
+
+
+def _console_file_is_tty(console: Console) -> bool:
+    isatty = getattr(console.file, "isatty", None)
+    return bool(isatty and isatty())
+
+
+def _should_use_pty(console: Console, requested: bool) -> bool:
+    return requested and hasattr(os, "openpty") and _console_file_is_tty(console)
+
+
+def _pump_task_pty(
+    *,
+    master_fd: int,
+    console: Console,
+    capture: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+) -> None:
+    try:
+        while True:
+            try:
+                chunk = os.read(master_fd, 4096)
+            except OSError as exc:
+                # BSD/macOS PTYs raise EIO at EOF; Linux commonly returns b"".
+                if exc.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            capture.write(chunk)
+            console.file.write(chunk.decode("utf-8", errors="replace"))
+            console.file.flush()
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[{DIM}]task terminal stream ended unexpectedly:[/] {escape(str(exc))}")
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(master_fd)
+
+
+def start_background_cli_task(
+    *,
+    display_command: str,
+    argv_list: list[str],
+    session: ReplSession,
+    console: Console,
+    timeout_seconds: int = SHELL_COMMAND_TIMEOUT_SECONDS,
+    kind: TaskKind = TaskKind.CLI_COMMAND,
+    use_pty: bool = False,
+) -> TaskRecord | None:
+    """Start a subprocess as a REPL task while streaming output above the prompt."""
+    console.print(f"[bold]$ {display_command}[/bold]")
+    task = session.task_registry.create(kind)
+    task.mark_running()
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+        max_size=_SYNTHETIC_DIAG_CHARS * 2
+    )
+    stdout_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+        max_size=_MAX_COMMAND_OUTPUT_CHARS
+    )
+    pty_fds: tuple[int, int] | None = None
+    if _should_use_pty(console, use_pty):
+        try:
+            pty_fds = os.openpty()
+        except OSError:
+            pty_fds = None
+    proc: subprocess.Popen[Any]
+    try:
+        if pty_fds is None:
+            proc = subprocess.Popen(
+                argv_list,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        else:
+            _master_fd, slave_fd = pty_fds
+            proc = subprocess.Popen(
+                argv_list,
+                stdin=subprocess.DEVNULL,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                close_fds=True,
+            )
+    except Exception as exc:  # noqa: BLE001
+        if pty_fds is not None:
+            for fd in pty_fds:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+        stdout_buf.close()
+        stderr_buf.close()
+        task.mark_failed(str(exc))
+        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+        return None
+
+    task.attach_process(proc)
+    started_at = time.monotonic()
+    if pty_fds is None:
+        output_threads = _start_task_output_streams(
+            task=task,
+            proc=proc,
+            console=console,
+            stdout_capture=stdout_buf,
+            stderr_capture=stderr_buf,
+        )
+    else:
+        master_fd, slave_fd = pty_fds
+        with contextlib.suppress(OSError):
+            os.close(slave_fd)
+        output_thread = threading.Thread(
+            target=_pump_task_pty,
+            kwargs={"master_fd": master_fd, "console": console, "capture": stderr_buf},
+            daemon=True,
+            name=f"task-terminal-{task.task_id}",
+        )
+        output_thread.start()
+        output_threads = [output_thread]
+
+    def _watch() -> None:
+        terminated_by_watcher = False
+        timed_out = False
+        while proc.poll() is None:
+            if time.monotonic() - started_at > timeout_seconds:
+                timed_out = True
+                task.request_cancel()
+                terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            if task.cancel_requested.is_set():
+                terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            time.sleep(_SYNTHETIC_POLL_SECONDS)
+
+        try:
+            if timed_out:
+                task.mark_failed(f"timed out after {timeout_seconds}s")
+                return
+            if terminated_by_watcher and task.cancel_requested.is_set():
+                task.mark_cancelled()
+                return
+
+            _join_task_output_streams(output_threads)
+            code = proc.returncode
+            if code == 0:
+                task.mark_completed()
+            else:
+                diag = read_diag(stderr_buf)
+                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+                task.mark_failed(error_msg)
+                console.print(f"[{ERROR}]command failed (exit {code}):[/]")
+        except Exception as exc:  # noqa: BLE001
+            task.mark_failed(str(exc))
+            console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
+        finally:
+            _join_task_output_streams(output_threads)
+            stdout_buf.close()
+            stderr_buf.close()
+
+    thread = threading.Thread(target=_watch, daemon=True)
+    thread.start()
+    console.print(
+        f"[{DIM}]started — task[/] [bold]{escape(task.task_id)}[/bold]. "
+        f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "
+        f"[{HIGHLIGHT}]/cancel {escape(task.task_id)}[/] [{DIM}]to stop.[/]"
+    )
+    return task
+
+
 def watch_synthetic_subprocess(
     task: TaskRecord,
     proc: subprocess.Popen[Any],
     session: ReplSession,
     suite_name: str,
     stderr_buf: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+    console: Console | None = None,
 ) -> None:
     def _history_text() -> str:
         return f"{suite_name} task:{task.task_id}"
@@ -84,6 +332,16 @@ def watch_synthetic_subprocess(
         session.record("synthetic_test", _history_text(), ok=ok)
 
     def _run() -> None:
+        output_threads = (
+            _start_task_output_streams(
+                task=task,
+                proc=proc,
+                console=console,
+                stderr_capture=stderr_buf,
+            )
+            if console is not None
+            else []
+        )
         started = time.monotonic()
         timed_out = False
         # Track whether *we* explicitly terminated the process so we can
@@ -109,6 +367,7 @@ def watch_synthetic_subprocess(
                 _record_synthetic_if_current_session(ok=False)
                 return
 
+            _join_task_output_streams(output_threads)
             code = proc.returncode
             if code is None:
                 task.mark_failed("subprocess did not report exit code")
@@ -132,9 +391,204 @@ def watch_synthetic_subprocess(
                 task.mark_failed(error_msg)
                 _record_synthetic_if_current_session(ok=False)
         finally:
+            _join_task_output_streams(output_threads)
             stderr_buf.close()
 
     threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
+
+
+def _recent_cli_agent_context(session: ReplSession, *, limit: int = 6) -> str:
+    recent = session.cli_agent_messages[-limit:]
+    if not recent:
+        return ""
+    return "\n".join(f"{role}: {text}" for role, text in recent)
+
+
+def _is_context_dependent_implementation_request(request: str) -> bool:
+    normalized = " ".join(request.strip().lower().split())
+    return normalized in {
+        "implement",
+        "please implement",
+        "code",
+        "make the change",
+        "make those changes",
+    }
+
+
+def _build_claude_code_implementation_prompt(request: str, session: ReplSession) -> str:
+    context = _recent_cli_agent_context(session)
+    context_block = (
+        f"--- Recent OpenSRE terminal assistant context ---\n{context}\n\n" if context else ""
+    )
+    return (
+        "You are Claude Code working in the current OpenSRE repository.\n\n"
+        f"{context_block}"
+        f"--- User implementation request ---\n{request.strip()}\n\n"
+        "--- Rules ---\n"
+        "- Implement the requested change in this repository.\n"
+        "- Follow AGENTS.md, existing project conventions, and local code style.\n"
+        "- Do not create a git commit or push changes.\n"
+        "- Do not run destructive git commands such as reset --hard or checkout --.\n"
+        "- Preserve unrelated user changes in the working tree.\n"
+        "- Run focused tests or lint checks when practical.\n"
+        "- Finish with a concise summary of changed files and verification performed.\n"
+    )
+
+
+def _implementation_argv(argv: tuple[str, ...]) -> list[str]:
+    exec_argv = list(argv)
+    permission_mode = os.environ.get(
+        _IMPLEMENT_PERMISSION_MODE_ENV,
+        _DEFAULT_IMPLEMENT_PERMISSION_MODE,
+    ).strip()
+    if permission_mode and permission_mode.lower() not in {"default", "none", "off"}:
+        exec_argv.extend(["--permission-mode", permission_mode])
+    return exec_argv
+
+
+def run_claude_code_implementation(
+    request: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    action_already_listed: bool = False,
+) -> None:
+    policy = evaluate_code_agent_launch()
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"Claude Code implementation: {request}",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=action_already_listed,
+    ):
+        session.record("implementation", request, ok=False)
+        return
+
+    if _is_context_dependent_implementation_request(request) and not session.cli_agent_messages:
+        console.print(
+            f"[{ERROR}]implementation request is too vague:[/] "
+            "describe what Claude Code should change."
+        )
+        session.record("implementation", request, ok=False)
+        return
+
+    adapter = ClaudeCodeAdapter()
+    probe = adapter.detect()
+    if not probe.installed or not probe.bin_path:
+        console.print(f"[{ERROR}]Claude Code CLI not available:[/] {escape(probe.detail)}")
+        session.record("implementation", request, ok=False)
+        return
+    if probe.logged_in is False:
+        console.print(f"[{ERROR}]Claude Code is not authenticated:[/] {escape(probe.detail)}")
+        session.record("implementation", request, ok=False)
+        return
+
+    prompt = _build_claude_code_implementation_prompt(request, session)
+    try:
+        invocation = adapter.build(
+            prompt=prompt,
+            model=os.environ.get("CLAUDE_CODE_MODEL"),
+            workspace=str(Path.cwd()),
+        )
+    except Exception as exc:
+        report_exception(exc, context="interactive_shell.claude_code.build")
+        console.print(f"[{ERROR}]Claude Code failed to prepare:[/] {escape(str(exc))}")
+        session.record("implementation", request, ok=False)
+        return
+
+    display_command = "claude -p"
+    console.print(f"[bold]$ {display_command}[/bold]")
+    task = session.task_registry.create(TaskKind.CODE_AGENT)
+    task.mark_running()
+    history_gen_when_started = session.history_generation
+
+    try:
+        proc = subprocess.Popen(
+            _implementation_argv(invocation.argv),
+            stdin=subprocess.PIPE if invocation.stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=invocation.cwd,
+            env=build_cli_subprocess_env(invocation.env),
+        )
+    except Exception as exc:
+        task.mark_failed(str(exc))
+        report_exception(exc, context="interactive_shell.claude_code.start")
+        console.print(f"[{ERROR}]Claude Code failed to start:[/] {escape(str(exc))}")
+        session.record("implementation", request, ok=False)
+        return
+
+    task.attach_process(proc)
+    session.record("implementation", request, ok=True)
+
+    def _watch() -> None:
+        try:
+            timed_out = False
+            try:
+                stdout, stderr = proc.communicate(
+                    input=invocation.stdin,
+                    timeout=CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                task.request_cancel()
+                terminate_child_process(proc)
+                stdout, stderr = proc.communicate()
+
+            out = (stdout or "")[:_MAX_COMMAND_OUTPUT_CHARS]
+            err = (stderr or "")[:_MAX_COMMAND_OUTPUT_CHARS]
+            if timed_out:
+                task.mark_failed(f"timed out after {CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS}s")
+                console.print(
+                    f"[{ERROR}]Claude Code timed out after "
+                    f"{CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS} seconds[/]"
+                )
+                return
+
+            code = proc.returncode
+            if task.cancel_requested.is_set() and code != 0:
+                task.mark_cancelled()
+                if session.history_generation == history_gen_when_started:
+                    session.mark_latest(ok=False, kind="implementation")
+                console.print(f"[{WARNING}]Claude Code task cancelled.[/]")
+                return
+
+            if code == 0:
+                task.mark_completed(result="ok")
+                console.print(f"[{HIGHLIGHT}]Claude Code completed[/] task {task.task_id}")
+                print_command_output(console, out)
+                if err:
+                    print_command_output(console, err, style=DIM)
+                return
+
+            diag = (err or out).strip()[:_SYNTHETIC_DIAG_CHARS]
+            error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+            task.mark_failed(error_msg)
+            if session.history_generation == history_gen_when_started:
+                session.mark_latest(ok=False, kind="implementation")
+            console.print(f"[{ERROR}]Claude Code failed (exit {code}):[/]")
+            print_command_output(console, out)
+            print_command_output(console, err, style=ERROR)
+        except Exception as exc:  # noqa: BLE001
+            task.mark_failed(str(exc))
+            report_exception(exc, context="interactive_shell.claude_code.watch")
+            if session.history_generation == history_gen_when_started:
+                session.mark_latest(ok=False, kind="implementation")
+            console.print(f"[{ERROR}]Claude Code watcher failed:[/] {escape(str(exc))}")
+
+    threading.Thread(target=_watch, daemon=True, name=f"claude-code-{task.task_id}").start()
+    console.print(
+        f"[{DIM}]Claude Code started — task[/] [bold]{escape(task.task_id)}[/bold]. "
+        f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "
+        f"[{HIGHLIGHT}]/cancel {escape(task.task_id)}[/] [{DIM}]to stop.[/]"
+    )
 
 
 def run_shell_command(
@@ -276,7 +730,84 @@ _READ_ONLY_OPENSRE_SUBCOMMANDS: frozenset[str] = frozenset(
 )
 
 
-def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -> bool:
+def _classify_opensre_command(tokens: list[str]) -> str:
+    first_token = tokens[0].lower()
+    if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS:
+        return "read_only"
+    if first_token == "agents":
+        subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
+        if subcommand in {"list"}:
+            return "read_only"
+        if subcommand == "scan" and "--register" not in tokens[2:]:
+            return "read_only"
+    return "mutating"
+
+
+def _opensre_confirmation_reason(tokens: list[str]) -> str:
+    if tokens[:2] == ["agents", "scan"] and "--register" in tokens[2:]:
+        return "register discovered local AI-agent processes"
+    if tokens and tokens[0] == "agents":
+        return "this updates the local AI-agent registry"
+    return "this opensre subcommand may change local config or infrastructure"
+
+
+def _should_run_opensre_in_foreground(tokens: list[str]) -> bool:
+    first_token = tokens[0].lower()
+    if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS:
+        return True
+    if first_token == "agents":
+        subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
+        return subcommand in {"list", "register", "forget", "scan"}
+    return False
+
+
+def _run_opensre_foreground(
+    argv_list: list[str],
+    display_command: str,
+    session: ReplSession,
+    console: Console,
+) -> None:
+    console.print(f"[bold]$ {escape(display_command)}[/bold]")
+    try:
+        result = subprocess.run(
+            argv_list,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=SHELL_COMMAND_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        print_command_output(console, str(exc.output or ""))
+        print_command_output(console, str(exc.stderr or ""), style=ERROR)
+        console.print(
+            f"[{ERROR}]command timed out after {SHELL_COMMAND_TIMEOUT_SECONDS} seconds[/]"
+        )
+        session.record("cli_command", display_command, ok=False)
+        return
+    except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="interactive_shell.opensre_cli.start")
+        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+        session.record("cli_command", display_command, ok=False)
+        return
+
+    print_command_output(console, result.stdout)
+    print_command_output(console, result.stderr, style=ERROR)
+    ok = result.returncode == 0
+    if not ok:
+        console.print(f"[{ERROR}]command failed (exit {result.returncode}):[/]")
+    session.record("cli_command", display_command, ok=ok)
+
+
+def run_opensre_cli_command(
+    args: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> bool:
     """Run an opensre subcommand (not agent).
 
     Returns True if the command was attempted (regardless of success),
@@ -294,9 +825,7 @@ def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -
         console.print(f"[{ERROR}]Cannot run `opensre {first_token}`: subcommand is blocked.[/]")
         return False
 
-    command_classification = (
-        "read_only" if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS else "mutating"
-    )
+    command_classification = _classify_opensre_command(tokens)
     from app.cli.interactive_shell.execution_policy import ExecutionPolicyResult, execution_allowed
 
     if command_classification == "read_only":
@@ -311,7 +840,7 @@ def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -
         policy_result = ExecutionPolicyResult(
             verdict="ask",
             action_type="cli_command",
-            reason="opensre subcommand requires confirmation",
+            reason=_opensre_confirmation_reason([token.lower() for token in tokens]),
             hint="Use a read-only subcommand (health, version, list, status, show)",
             shell_classification=command_classification,
         )
@@ -321,8 +850,8 @@ def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -
         session=session,
         console=console,
         action_summary=f"$ opensre {' '.join(tokens)}",
-        confirm_fn=None,
-        is_tty=None,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
         action_already_listed=True,
     ):
         session.record("cli_command", f"opensre {' '.join(tokens)}", ok=False)
@@ -330,90 +859,17 @@ def run_opensre_cli_command(args: str, session: ReplSession, console: Console) -
 
     argv_list = [sys.executable, "-m", "app.cli"] + tokens
     display_command = f"opensre {' '.join(tokens)}"
-    console.print(f"[bold]$ {display_command}[/bold]")
-
-    session.record("cli_command", display_command)
-
-    task = session.task_registry.create(TaskKind.CLI_COMMAND)
-    task.mark_running()
-    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
-        max_size=_SYNTHETIC_DIAG_CHARS * 2
-    )
-    stdout_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
-        max_size=_MAX_COMMAND_OUTPUT_CHARS
-    )
-    try:
-        proc = subprocess.Popen(
-            argv_list,
-            stdout=stdout_buf,
-            stderr=stderr_buf,
-        )
-    except Exception as exc:  # noqa: BLE001
-        stdout_buf.close()
-        stderr_buf.close()
-        task.mark_failed(str(exc))
-        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+    if _should_run_opensre_in_foreground(tokens):
+        _run_opensre_foreground(argv_list, display_command, session, console)
         return True
 
-    task.attach_process(proc)
-    started_at = time.monotonic()
-
-    def _watch() -> None:
-        terminated_by_watcher = False
-        timed_out = False
-        while proc.poll() is None:
-            if time.monotonic() - started_at > SHELL_COMMAND_TIMEOUT_SECONDS:
-                timed_out = True
-                task.request_cancel()
-                terminate_child_process(proc)
-                terminated_by_watcher = True
-                break
-            if task.cancel_requested.is_set():
-                terminate_child_process(proc)
-                terminated_by_watcher = True
-                break
-            time.sleep(_SYNTHETIC_POLL_SECONDS)
-
-        try:
-            if timed_out:
-                task.mark_failed(f"timed out after {SHELL_COMMAND_TIMEOUT_SECONDS}s")
-                stdout_buf.close()
-                stderr_buf.close()
-                return
-            if terminated_by_watcher and task.cancel_requested.is_set():
-                task.mark_cancelled()
-                stdout_buf.close()
-                stderr_buf.close()
-                return
-
-            code = proc.returncode
-            stdout_buf.seek(0)
-            stdout_lines = stdout_buf.read(_MAX_COMMAND_OUTPUT_CHARS).decode(
-                "utf-8", errors="replace"
-            )
-            if code == 0:
-                task.mark_completed()
-                if stdout_lines:
-                    print_command_output(console, stdout_lines)
-            else:
-                diag = read_diag(stderr_buf)
-                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
-                task.mark_failed(error_msg)
-                console.print(f"[{ERROR}]command failed (exit {code}):[/]")
-                if stdout_lines:
-                    print_command_output(console, stdout_lines)
-                if diag:
-                    console.print(f"[{DIM}]{escape(diag)}[/]")
-        except Exception as exc:  # noqa: BLE001
-            task.mark_failed(str(exc))
-            console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
-        finally:
-            stdout_buf.close()
-            stderr_buf.close()
-
-    thread = threading.Thread(target=_watch, daemon=True)
-    thread.start()
-    console.print(f"[{DIM}]started.[/]")
+    session.record("cli_command", display_command)
+    start_background_cli_task(
+        display_command=display_command,
+        argv_list=argv_list,
+        session=session,
+        console=console,
+    )
     return True
 
 
@@ -515,8 +971,11 @@ def run_synthetic_test(
     try:
         proc = subprocess.Popen(
             [sys.executable, "-m", "app.cli", "tests", "synthetic"],
-            stdout=subprocess.DEVNULL,
-            stderr=stderr_buf,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except Exception as exc:
         stderr_buf.close()
@@ -527,7 +986,7 @@ def run_synthetic_test(
         return
 
     task.attach_process(proc)
-    watch_synthetic_subprocess(task, proc, session, suite_name, stderr_buf)
+    watch_synthetic_subprocess(task, proc, session, suite_name, stderr_buf, console)
     console.print(
         f"[{DIM}]synthetic test started — task[/] [bold]{escape(task.task_id)}[/bold]. "
         f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "
@@ -539,12 +998,14 @@ __all__ = [
     "SHELL_COMMAND_TIMEOUT_SECONDS",
     "SYNTHETIC_TEST_TIMEOUT_SECONDS",
     "read_diag",
+    "run_claude_code_implementation",
     "run_cd_command",
     "run_opensre_cli_command",
     "run_pwd_command",
     "run_sample_alert",
     "run_shell_command",
     "run_synthetic_test",
+    "start_background_cli_task",
     "terminate_child_process",
     "watch_synthetic_subprocess",
 ]

--- a/app/cli/interactive_shell/action_planner.py
+++ b/app/cli/interactive_shell/action_planner.py
@@ -12,6 +12,7 @@ from app.cli.interactive_shell.intent_parser import (
     SAMPLE_ALERT_RE,
     SYNTHETIC_RDS_TEST_RE,
     cli_command_action,
+    extract_implementation_request,
     extract_llm_provider_switch,
     extract_shell_command,
     sample_alert_action,
@@ -99,6 +100,11 @@ def plan_clause_actions(
     sample_match = SAMPLE_ALERT_RE.search(clause.text)
     if sample_match is not None:
         planned.append(sample_alert_action("generic", clause.position + sample_match.start()))
+        return planned
+
+    implementation = extract_implementation_request(clause)
+    if implementation is not None:
+        planned.append(implementation)
         return planned
 
     planned_shell = extract_shell_command(clause)

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -11,6 +11,7 @@ from rich.markup import escape
 from rich.spinner import Spinner
 
 from app.cli.interactive_shell.action_executor import (
+    run_claude_code_implementation,
     run_opensre_cli_command,
     run_sample_alert,
     run_shell_command,
@@ -155,7 +156,22 @@ def execute_cli_actions(
                 action_already_listed=True,
             )
         elif action.kind == "cli_command":
-            run_opensre_cli_command(action.content, session, console)
+            run_opensre_cli_command(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            )
+        elif action.kind == "implementation":
+            run_claude_code_implementation(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+                action_already_listed=True,
+            )
         elif action.kind == "sample_alert":
             run_sample_alert(
                 action.content,
@@ -207,7 +223,7 @@ def execute_cli_actions_with_metrics(
     executed_entries = [
         item
         for item in session.history[history_start:]
-        if item.get("type") in {"slash", "shell", "alert", "synthetic_test"}
+        if item.get("type") in {"slash", "shell", "alert", "synthetic_test", "implementation"}
     ]
     executed_count = len(executed_entries)
     executed_success_count = sum(1 for item in executed_entries if item.get("ok", True))

--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -30,6 +30,7 @@ from app.cli.interactive_shell.command_registry.repl_data import (
     load_verified_integrations,
 )
 from app.cli.interactive_shell.command_registry.session_cmds import COMMANDS as SESSION_COMMANDS
+from app.cli.interactive_shell.command_registry.suggestions import closest_choice
 from app.cli.interactive_shell.command_registry.system import COMMANDS as SYSTEM_COMMANDS
 from app.cli.interactive_shell.command_registry.tasks_cmds import COMMANDS as TASK_COMMANDS
 from app.cli.interactive_shell.command_registry.types import SlashCommand
@@ -107,9 +108,17 @@ def dispatch_slash(
     args = parts[1:]
     cmd = SLASH_COMMANDS.get(name)
     if cmd is None:
+        suggestion = closest_choice(name, tuple(SLASH_COMMANDS))
         session.record("slash", stripped, ok=False)
         console.print()
-        console.print(f"[{ERROR}]unknown command:[/] {escape(name)}  (type [bold]/help[/bold])")
+        if suggestion is None:
+            console.print(f"[{ERROR}]unknown command:[/] {escape(name)}  (type [bold]/help[/bold])")
+        else:
+            console.print(
+                f"[{ERROR}]unknown command:[/] {escape(name)}  "
+                f"Did you mean [bold]{escape(suggestion)}[/bold]? "
+                "(type [bold]/help[/bold])"
+            )
         return True
     if cmd.validate_args is not None:
         validation_error = cmd.validate_args(args)

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shlex
@@ -106,8 +107,14 @@ def _start_test_command(
 
 def _run_test_picker_for_background(session: ReplSession, console: Console) -> bool:
     console.print()
-    with tempfile.NamedTemporaryFile(prefix="opensre-test-selection-", suffix=".json") as handle:
-        selection_path = Path(handle.name)
+    handle = tempfile.NamedTemporaryFile(  # noqa: SIM115
+        prefix="opensre-test-selection-",
+        suffix=".json",
+        delete=False,
+    )
+    selection_path = Path(handle.name)
+    handle.close()
+    try:
         env = dict(os.environ)
         env[_TEST_PICKER_SELECTION_FILE_ENV] = str(selection_path)
         result = subprocess.run(
@@ -123,6 +130,9 @@ def _run_test_picker_for_background(session: ReplSession, console: Console) -> b
             console.print()
             return True
         payload = json.loads(selection_path.read_text(encoding="utf-8"))
+    finally:
+        with contextlib.suppress(OSError):
+            selection_path.unlink()
 
     if not isinstance(payload, list):
         console.print(f"[{ERROR}]test picker returned an invalid selection[/]")

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -2,16 +2,31 @@
 
 from __future__ import annotations
 
+import json
+import os
+import shlex
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 from rich.console import Console
+from rich.markup import escape
 
+from app.cli.interactive_shell.action_executor import (
+    SYNTHETIC_TEST_TIMEOUT_SECONDS,
+    start_background_cli_task,
+)
+from app.cli.interactive_shell.command_registry.suggestions import closest_choice
 from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind
 from app.cli.interactive_shell.theme import DIM, ERROR
 
 _UPDATE_SUBPROCESS_TIMEOUT_SECONDS = 300
+_BACKGROUND_TEST_SUBCOMMANDS = frozenset({"run", "synthetic", "cloudopsbench"})
+_TEST_SUBCOMMANDS = ("list", "run", "synthetic", "cloudopsbench")
+_TEST_PICKER_SELECTION_FILE_ENV = "OPENSRE_TEST_PICKER_SELECTION_FILE"
 
 
 def run_cli_command(
@@ -59,7 +74,110 @@ def _cmd_remote(session: ReplSession, console: Console, args: list[str]) -> bool
     return run_cli_command(console, ["remote", *args])
 
 
-def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+def _catalog_task_kind(command: list[str]) -> TaskKind:
+    return TaskKind.SYNTHETIC_TEST if "synthetic" in command else TaskKind.CLI_COMMAND
+
+
+def _argv_for_catalog_command(command: list[str]) -> list[str]:
+    if command[:1] == ["opensre"]:
+        return [sys.executable, "-m", "app.cli", *command[1:]]
+    return command
+
+
+def _start_test_command(
+    *,
+    session: ReplSession,
+    console: Console,
+    command: list[str],
+    display_command: str | None = None,
+) -> None:
+    shown = display_command or shlex.join(command)
+    session.record("cli_command", shown)
+    start_background_cli_task(
+        display_command=shown,
+        argv_list=_argv_for_catalog_command(command),
+        session=session,
+        console=console,
+        timeout_seconds=SYNTHETIC_TEST_TIMEOUT_SECONDS,
+        kind=_catalog_task_kind(command),
+        use_pty=True,
+    )
+
+
+def _run_test_picker_for_background(session: ReplSession, console: Console) -> bool:
+    console.print()
+    with tempfile.NamedTemporaryFile(prefix="opensre-test-selection-", suffix=".json") as handle:
+        selection_path = Path(handle.name)
+        env = dict(os.environ)
+        env[_TEST_PICKER_SELECTION_FILE_ENV] = str(selection_path)
+        result = subprocess.run(
+            [sys.executable, "-m", "app.cli", "tests"],
+            check=False,
+            env=env,
+        )
+        if result.returncode != 0:
+            console.print(f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]")
+            console.print()
+            return True
+        if not selection_path.stat().st_size:
+            console.print()
+            return True
+        payload = json.loads(selection_path.read_text(encoding="utf-8"))
+
+    if not isinstance(payload, list):
+        console.print(f"[{ERROR}]test picker returned an invalid selection[/]")
+        console.print()
+        return True
+
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        command = item.get("command")
+        if not isinstance(command, list) or not all(isinstance(part, str) for part in command):
+            continue
+        display = item.get("command_display")
+        _start_test_command(
+            session=session,
+            console=console,
+            command=command,
+            display_command=display if isinstance(display, str) else None,
+        )
+    console.print()
+    return True
+
+
+def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
+    if not args:
+        return _run_test_picker_for_background(session, console)
+
+    subcommand = args[0].lower()
+    if subcommand in _BACKGROUND_TEST_SUBCOMMANDS:
+        _start_test_command(
+            session=session,
+            console=console,
+            command=["opensre", "tests", *args],
+        )
+        return True
+
+    if subcommand.startswith("-"):
+        return run_cli_command(console, ["tests", *args])
+
+    if subcommand not in _TEST_SUBCOMMANDS:
+        suggestion = closest_choice(subcommand, _TEST_SUBCOMMANDS)
+        if suggestion is None:
+            console.print(
+                f"[{ERROR}]unknown tests subcommand:[/] {escape(args[0])}  "
+                "(try [bold]/tests list[/bold], [bold]/tests run <test_id>[/bold], "
+                "[bold]/tests synthetic[/bold], or [bold]/tests cloudopsbench[/bold])"
+            )
+        else:
+            console.print(
+                f"[{ERROR}]unknown tests subcommand:[/] {escape(args[0])}  "
+                f"Did you mean [bold]/tests {suggestion}[/bold]?"
+            )
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
     return run_cli_command(console, ["tests", *args])
 
 
@@ -106,6 +224,7 @@ COMMANDS: list[SlashCommand] = [
         "/tests",
         "browse and run inventoried tests ('/tests list|run|synthetic')",
         _cmd_tests,
+        first_arg_completions=tuple((name, f"/tests {name}") for name in _TEST_SUBCOMMANDS),
         execution_tier=ExecutionTier.SAFE,
     ),
     SlashCommand(

--- a/app/cli/interactive_shell/command_registry/suggestions.py
+++ b/app/cli/interactive_shell/command_registry/suggestions.py
@@ -1,0 +1,17 @@
+"""Small helpers for human-friendly slash-command suggestions."""
+
+from __future__ import annotations
+
+from difflib import get_close_matches
+
+
+def closest_choice(value: str, choices: list[str] | tuple[str, ...]) -> str | None:
+    """Return the nearest command-like choice for a typo, if confidence is high enough."""
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    matches = get_close_matches(normalized, choices, n=1, cutoff=0.72)
+    return matches[0] if matches else None
+
+
+__all__ = ["closest_choice"]

--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -135,7 +135,8 @@ def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool
         )
     else:
         console.print(
-            f"[{HIGHLIGHT}]stop requested[/] [{DIM}]for synthetic test {escape(task.task_id)}.[/] "
+            f"[{HIGHLIGHT}]stop requested[/] "
+            f"[{DIM}]for {escape(task.kind.value)} {escape(task.task_id)}.[/] "
             f"[{DIM}]use[/] [{HIGHLIGHT}]/tasks[/] [{DIM}]to confirm status.[/]"
         )
     return True

--- a/app/cli/interactive_shell/execution_policy.py
+++ b/app/cli/interactive_shell/execution_policy.py
@@ -286,6 +286,14 @@ def evaluate_synthetic_test_launch() -> ExecutionPolicyResult:
     )
 
 
+def evaluate_code_agent_launch() -> ExecutionPolicyResult:
+    return ExecutionPolicyResult(
+        verdict="ask",
+        action_type="code_agent",
+        reason="Claude Code may edit files, run tools, and consume LLM quota",
+    )
+
+
 def evaluate_llm_runtime_switch(*, action_type: str) -> ExecutionPolicyResult:
     return ExecutionPolicyResult(
         verdict="ask",
@@ -298,6 +306,7 @@ __all__ = [
     "DEFAULT_CONFIRM_FN",
     "ExecutionPolicyResult",
     "ExecutionVerdict",
+    "evaluate_code_agent_launch",
     "evaluate_investigation_launch",
     "evaluate_llm_runtime_switch",
     "evaluate_shell_command",

--- a/app/cli/interactive_shell/intent_parser.py
+++ b/app/cli/interactive_shell/intent_parser.py
@@ -127,7 +127,7 @@ SYNTHETIC_RDS_TEST_RE = re.compile(
 IMPLEMENTATION_RE = re.compile(
     r"^\s*(?:please\s+)?(?:can\s+you\s+)?"
     r"(?:(?:use|launch|run)\s+claude(?:\s+code)?\s+(?:to\s+)?)?"
-    r"(?P<trigger>implement|code|make\s+the\s+change|make\s+those\s+changes)"
+    r"(?P<trigger>implement|make\s+the\s+change|make\s+those\s+changes)"
     r"(?P<request>\b.*)?$",
     re.IGNORECASE | re.DOTALL,
 )

--- a/app/cli/interactive_shell/intent_parser.py
+++ b/app/cli/interactive_shell/intent_parser.py
@@ -124,6 +124,13 @@ SYNTHETIC_RDS_TEST_RE = re.compile(
     r"(?:.{0,80}?\b(?:r\s*d\s*s|postgres(?:ql)?|database|db)\b)?",
     re.IGNORECASE | re.DOTALL,
 )
+IMPLEMENTATION_RE = re.compile(
+    r"^\s*(?:please\s+)?(?:can\s+you\s+)?"
+    r"(?:(?:use|launch|run)\s+claude(?:\s+code)?\s+(?:to\s+)?)?"
+    r"(?P<trigger>implement|code|make\s+the\s+change|make\s+those\s+changes)"
+    r"(?P<request>\b.*)?$",
+    re.IGNORECASE | re.DOTALL,
+)
 _LLM_PROVIDER_NAMES = frozenset(
     {
         "anthropic",
@@ -215,6 +222,10 @@ def synthetic_test_action(suite_name: str, position: int) -> PlannedAction:
     return PlannedAction(kind="synthetic_test", content=suite_name, position=position)
 
 
+def implementation_action(request: str, position: int) -> PlannedAction:
+    return PlannedAction(kind="implementation", content=request, position=position)
+
+
 def llm_provider_action(provider: str, position: int) -> PlannedAction:
     return PlannedAction(kind="llm_provider", content=provider, position=position)
 
@@ -293,6 +304,16 @@ def extract_shell_command(clause: PromptClause) -> PlannedAction | None:
     return None
 
 
+def extract_implementation_request(clause: PromptClause) -> PlannedAction | None:
+    match = IMPLEMENTATION_RE.match(clause.text)
+    if match is None:
+        return None
+    request = (match.group("request") or "").strip()
+    content = request or clause.text.strip()
+    position = clause.position + match.start("trigger")
+    return implementation_action(content, position)
+
+
 def split_prompt_clauses(message: str) -> list[PromptClause]:
     """Split compound prompts while preserving each clause's source position."""
     clauses: list[PromptClause] = []
@@ -327,6 +348,7 @@ def extract_llm_provider_switch(clause: PromptClause) -> PlannedAction | None:
 
 __all__ = [
     "ACTION_PATTERNS",
+    "IMPLEMENTATION_RE",
     "INTEGRATION_CAPABILITY_RE",
     "INTEGRATION_CONFIG_DETAIL_RE",
     "INTEGRATION_DETAIL_RE",
@@ -334,8 +356,10 @@ __all__ = [
     "SAMPLE_ALERT_RE",
     "SYNTHETIC_RDS_TEST_RE",
     "cli_command_action",
+    "extract_implementation_request",
     "extract_llm_provider_switch",
     "extract_shell_command",
+    "implementation_action",
     "looks_like_direct_shell_command",
     "sample_alert_action",
     "slash_action",

--- a/app/cli/interactive_shell/interaction_models.py
+++ b/app/cli/interactive_shell/interaction_models.py
@@ -10,7 +10,15 @@ from typing import Literal
 class PlannedAction:
     """A deterministic action inferred from a natural-language terminal request."""
 
-    kind: Literal["llm_provider", "slash", "shell", "sample_alert", "synthetic_test", "cli_command"]
+    kind: Literal[
+        "llm_provider",
+        "slash",
+        "shell",
+        "sample_alert",
+        "synthetic_test",
+        "cli_command",
+        "implementation",
+    ]
     content: str
     position: int
 

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Callable
 
 from prompt_toolkit import PromptSession
+from prompt_toolkit.patch_stdout import patch_stdout
 from rich.console import Console
 from rich.markup import escape
 
@@ -136,7 +137,8 @@ async def _run_one_turn(
     """Read one line of input and dispatch. Returns False to exit."""
     while True:
         try:
-            text = await prompt.prompt_async(lambda: _prompt_message(session))
+            with patch_stdout(raw=True):
+                text = await prompt.prompt_async(lambda: _prompt_message(session))
         except EOFError:
             console.print()
             return False

--- a/app/cli/interactive_shell/rendering.py
+++ b/app/cli/interactive_shell/rendering.py
@@ -128,6 +128,7 @@ def print_planned_actions(console: Console, actions: list[PlannedAction]) -> Non
             "slash": "command",
             "synthetic_test": "synthetic test",
             "cli_command": "opensre",
+            "implementation": "implementation",
         }[action.kind]
         console.print(f"[{DIM}]{index}.[/] [{BOLD_BRAND}]{label}[/] {escape(action.content)}")
 

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -28,6 +28,7 @@ class TaskKind(StrEnum):
     INVESTIGATION = "investigation"
     SYNTHETIC_TEST = "synthetic_test"
     CLI_COMMAND = "cli_command"
+    CODE_AGENT = "code_agent"
 
 
 @dataclass

--- a/app/cli/tests/interactive.py
+++ b/app/cli/tests/interactive.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib
+import json
+import os
 import sys
 from typing import Any
 
@@ -35,6 +37,7 @@ _console = Console()
 _BACK = object()
 _EXIT = object()
 _RUN_ALL = object()
+_BACKGROUND_SELECTION_FILE_ENV = "OPENSRE_TEST_PICKER_SELECTION_FILE"
 
 
 class _GoBack(Exception):
@@ -300,6 +303,25 @@ def _confirm_run_all(items: list[TestCatalogItem]) -> bool:
     return bool(result)
 
 
+def _write_background_selection(items: list[TestCatalogItem]) -> bool:
+    path = os.environ.get(_BACKGROUND_SELECTION_FILE_ENV)
+    if not path:
+        return False
+    payload = [
+        {
+            "id": item.id,
+            "display_name": item.display_name,
+            "command": list(item.command),
+            "command_display": format_command(item),
+        }
+        for item in items
+        if item.command
+    ]
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+    return True
+
+
 def run_interactive_picker(catalog: TestCatalog) -> int:
     _require_interactive_dependencies()
     if not sys.stdin.isatty() or not sys.stdout.isatty():
@@ -320,15 +342,21 @@ def run_interactive_picker(catalog: TestCatalog) -> int:
                         return 0
                 except _GoBack:
                     continue
+                if _write_background_selection(selection):
+                    return 0
                 return run_catalog_items(selection)
 
             if auto_selected:
+                if _write_background_selection([selection]):
+                    return 0
                 return run_catalog_item(selection)
             try:
                 if not _confirm_run(selection):
                     return 0
             except _GoBack:
                 continue
+            if _write_background_selection([selection]):
+                return 0
             return run_catalog_item(selection)
     except KeyboardInterrupt:
         return 0

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -1,0 +1,155 @@
+"""Tests for AI-agent process discovery."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.agents import discovery
+
+
+class FakeProcess:
+    def __init__(self, info: dict[str, Any]) -> None:
+        self.info = info
+
+
+def test_discover_agent_processes_matches_known_agent_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery.psutil,
+        "process_iter",
+        lambda **_kwargs: [
+            FakeProcess({"pid": 10, "name": "opensre", "cmdline": ["opensre"]}),
+            FakeProcess({"pid": 101, "name": "Claude", "cmdline": ["claude", "chat"]}),
+            FakeProcess(
+                {
+                    "pid": 102,
+                    "name": "claude",
+                    "cmdline": ["claude", "code"],
+                }
+            ),
+            FakeProcess(
+                {
+                    "pid": 103,
+                    "name": "claude",
+                    "cmdline": [
+                        "/Users/example/.cursor/extensions/anthropic.claude-code/resources/claude",
+                        "--output-format",
+                        "stream-json",
+                        "--input-format",
+                        "stream-json",
+                    ],
+                }
+            ),
+            FakeProcess({"pid": 104, "name": "aider", "cmdline": ["aider"]}),
+            FakeProcess({"pid": 105, "name": "codex", "cmdline": ["codex"]}),
+            FakeProcess({"pid": 202, "name": "python", "cmdline": ["python", "-m", "pytest"]}),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [
+        ("aider-104", 104),
+        ("claude-code-102", 102),
+        ("claude-code-103", 103),
+        ("codex-105", 105),
+    ]
+
+
+def test_discover_agent_processes_filters_desktop_helper_noise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery.psutil,
+        "process_iter",
+        lambda **_kwargs: [
+            FakeProcess(
+                {
+                    "pid": 201,
+                    "name": "Claude",
+                    "cmdline": ["/Applications/Claude.app/Contents/MacOS/Claude"],
+                }
+            ),
+            FakeProcess(
+                {
+                    "pid": 202,
+                    "name": "chrome_crashpad_handler",
+                    "cmdline": [
+                        "/Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler",
+                        "--database=/Users/example/Library/Application Support/Claude/Crashpad",
+                    ],
+                }
+            ),
+            FakeProcess(
+                {
+                    "pid": 203,
+                    "name": "Claude Helper (Renderer)",
+                    "cmdline": [
+                        "/Applications/Claude.app/Contents/Frameworks/Claude Helper (Renderer).app/Contents/MacOS/Claude Helper (Renderer)",
+                        "--type=renderer",
+                    ],
+                }
+            ),
+            FakeProcess(
+                {
+                    "pid": 204,
+                    "name": "Cursor Helper (Plugin)",
+                    "cmdline": [
+                        "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Plugin).app/Contents/MacOS/Cursor Helper (Plugin)",
+                        "/Applications/Cursor.app/Contents/Resources/app/extensions/json-language-features/server/dist/node/jsonServerMain",
+                    ],
+                }
+            ),
+            FakeProcess(
+                {
+                    "pid": 205,
+                    "name": "ShipIt",
+                    "cmdline": [
+                        "/Applications/Cursor.app/Contents/Frameworks/Squirrel.framework/Resources/ShipIt",
+                        "com.todesktop.230313mzl4w4u92.ShipIt",
+                    ],
+                }
+            ),
+        ],
+    )
+
+    assert discovery.discover_agent_processes() == []
+
+
+def test_discover_agent_processes_all_mode_includes_filtered_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery.psutil,
+        "process_iter",
+        lambda **_kwargs: [
+            FakeProcess(
+                {
+                    "pid": 202,
+                    "name": "chrome_crashpad_handler",
+                    "cmdline": [
+                        "/Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler",
+                    ],
+                }
+            ),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes(include_all=True)
+
+    assert [(item.name, item.pid) for item in candidates] == [("claude-code-202", 202)]
+
+
+def test_display_command_truncates_long_commands() -> None:
+    command = "claude " + ("--very-long-option " * 20)
+
+    display = discovery.display_command(command)
+
+    assert len(display) == 120
+    assert display.endswith("...")

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -12,44 +11,27 @@ from app.agents.discovery import ProcessRow, discover_agents, registered_and_dis
 from app.agents.registry import AgentRecord, AgentRegistry
 
 
-class FakeProcess:
-    def __init__(self, info: dict[str, Any]) -> None:
-        self.info = info
-
-
 def test_discover_agent_processes_matches_known_agent_commands(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
     monkeypatch.setattr(
-        discovery.psutil,
-        "process_iter",
-        lambda **_kwargs: [
-            FakeProcess({"pid": 10, "name": "opensre", "cmdline": ["opensre"]}),
-            FakeProcess({"pid": 101, "name": "Claude", "cmdline": ["claude", "chat"]}),
-            FakeProcess(
-                {
-                    "pid": 102,
-                    "name": "claude",
-                    "cmdline": ["claude", "code"],
-                }
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=10, command="opensre"),
+            ProcessRow(pid=101, command="claude chat"),
+            ProcessRow(pid=102, command="claude code"),
+            ProcessRow(
+                pid=103,
+                command=(
+                    "/Users/example/.cursor/extensions/anthropic.claude-code/resources/claude "
+                    "--output-format stream-json --input-format stream-json"
+                ),
             ),
-            FakeProcess(
-                {
-                    "pid": 103,
-                    "name": "claude",
-                    "cmdline": [
-                        "/Users/example/.cursor/extensions/anthropic.claude-code/resources/claude",
-                        "--output-format",
-                        "stream-json",
-                        "--input-format",
-                        "stream-json",
-                    ],
-                }
-            ),
-            FakeProcess({"pid": 104, "name": "aider", "cmdline": ["aider"]}),
-            FakeProcess({"pid": 105, "name": "codex", "cmdline": ["codex"]}),
-            FakeProcess({"pid": 202, "name": "python", "cmdline": ["python", "-m", "pytest"]}),
+            ProcessRow(pid=104, command="aider"),
+            ProcessRow(pid=105, command="codex"),
+            ProcessRow(pid=202, command="python -m pytest"),
         ],
     )
 
@@ -68,55 +50,40 @@ def test_discover_agent_processes_filters_desktop_helper_noise(
 ) -> None:
     monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
     monkeypatch.setattr(
-        discovery.psutil,
-        "process_iter",
-        lambda **_kwargs: [
-            FakeProcess(
-                {
-                    "pid": 201,
-                    "name": "Claude",
-                    "cmdline": ["/Applications/Claude.app/Contents/MacOS/Claude"],
-                }
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=201, command="/Applications/Claude.app/Contents/MacOS/Claude"),
+            ProcessRow(
+                pid=202,
+                command=(
+                    "/Applications/Claude.app/Contents/Frameworks/Electron "
+                    "Framework.framework/Helpers/chrome_crashpad_handler "
+                    "--database=/Users/example/Library/Application Support/Claude/Crashpad"
+                ),
             ),
-            FakeProcess(
-                {
-                    "pid": 202,
-                    "name": "chrome_crashpad_handler",
-                    "cmdline": [
-                        "/Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler",
-                        "--database=/Users/example/Library/Application Support/Claude/Crashpad",
-                    ],
-                }
+            ProcessRow(
+                pid=203,
+                command=(
+                    "/Applications/Claude.app/Contents/Frameworks/Claude Helper "
+                    "(Renderer).app/Contents/MacOS/Claude Helper (Renderer) --type=renderer"
+                ),
             ),
-            FakeProcess(
-                {
-                    "pid": 203,
-                    "name": "Claude Helper (Renderer)",
-                    "cmdline": [
-                        "/Applications/Claude.app/Contents/Frameworks/Claude Helper (Renderer).app/Contents/MacOS/Claude Helper (Renderer)",
-                        "--type=renderer",
-                    ],
-                }
+            ProcessRow(
+                pid=204,
+                command=(
+                    "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper "
+                    "(Plugin).app/Contents/MacOS/Cursor Helper (Plugin) "
+                    "/Applications/Cursor.app/Contents/Resources/app/extensions/"
+                    "json-language-features/server/dist/node/jsonServerMain"
+                ),
             ),
-            FakeProcess(
-                {
-                    "pid": 204,
-                    "name": "Cursor Helper (Plugin)",
-                    "cmdline": [
-                        "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Plugin).app/Contents/MacOS/Cursor Helper (Plugin)",
-                        "/Applications/Cursor.app/Contents/Resources/app/extensions/json-language-features/server/dist/node/jsonServerMain",
-                    ],
-                }
-            ),
-            FakeProcess(
-                {
-                    "pid": 205,
-                    "name": "ShipIt",
-                    "cmdline": [
-                        "/Applications/Cursor.app/Contents/Frameworks/Squirrel.framework/Resources/ShipIt",
-                        "com.todesktop.230313mzl4w4u92.ShipIt",
-                    ],
-                }
+            ProcessRow(
+                pid=205,
+                command=(
+                    "/Applications/Cursor.app/Contents/Frameworks/Squirrel.framework/Resources/"
+                    "ShipIt com.todesktop.230313mzl4w4u92.ShipIt"
+                ),
             ),
         ],
     )
@@ -129,17 +96,15 @@ def test_discover_agent_processes_all_mode_includes_filtered_helpers(
 ) -> None:
     monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
     monkeypatch.setattr(
-        discovery.psutil,
-        "process_iter",
-        lambda **_kwargs: [
-            FakeProcess(
-                {
-                    "pid": 202,
-                    "name": "chrome_crashpad_handler",
-                    "cmdline": [
-                        "/Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler",
-                    ],
-                }
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(
+                pid=202,
+                command=(
+                    "/Applications/Claude.app/Contents/Frameworks/Electron "
+                    "Framework.framework/Helpers/chrome_crashpad_handler"
+                ),
             ),
         ],
     )

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -416,17 +416,20 @@ def test_run_opensre_agents_scan_register_explains_confirmation(
 def test_run_opensre_agents_watch_runs_in_foreground(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command[-3:] == ["agents", "watch", "1234"]
-        assert kwargs["capture_output"] is True
-        return subprocess.CompletedProcess(
-            args=command,
-            returncode=0,
-            stdout="pid 1234 exited\n",
-            stderr="",
-        )
+    popen_kwargs: list[dict[str, object]] = []
 
-    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.run", _fake_run)
+    class _FakeProcess:
+        stdout = iter(["watching pid 1234; press Ctrl+C to stop\n", "pid 1234 exited\n"])
+
+        def wait(self) -> int:
+            return 0
+
+    def _fake_popen(command: list[str], **kwargs: object) -> _FakeProcess:
+        assert command[-3:] == ["agents", "watch", "1234"]
+        popen_kwargs.append(kwargs)
+        return _FakeProcess()
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.Popen", _fake_popen)
 
     session = ReplSession()
     buf = io.StringIO()
@@ -445,8 +448,11 @@ def test_run_opensre_agents_watch_runs_in_foreground(
 
     out = buf.getvalue()
     assert "$ opensre agents watch 1234" in out
+    assert "watching pid 1234" in out
     assert "pid 1234 exited" in out
     assert "started" not in out
+    assert "timeout" not in popen_kwargs[0]
+    assert popen_kwargs[0]["stderr"] is subprocess.STDOUT
     assert session.task_registry.list_recent() == []
     assert session.history[-1] == {
         "type": "cli_command",

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -52,7 +52,7 @@ class _ImmediateThread:
         self._target(*self._args, **self._kwargs)
 
     def join(self, timeout: float | None = None) -> None:
-        del timeout
+        self.join_timeout = timeout
 
 
 def test_terminate_child_process_noop_when_exited() -> None:

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import errno
 import io
+import subprocess
 import tempfile
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock
@@ -13,14 +15,44 @@ from rich.console import Console
 from app.cli.interactive_shell.action_executor import (
     read_diag,
     run_cd_command,
+    run_claude_code_implementation,
+    run_opensre_cli_command,
     run_pwd_command,
     run_shell_command,
     run_synthetic_test,
+    start_background_cli_task,
     terminate_child_process,
 )
 from app.cli.interactive_shell.session import ReplSession
 from app.cli.interactive_shell.shell_execution import ShellExecutionResult
 from app.cli.interactive_shell.shell_policy import PolicyDecision
+from app.cli.interactive_shell.tasks import TaskKind, TaskStatus
+from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
+
+
+class _ImmediateThread:
+    def __init__(
+        self,
+        group: object = None,
+        target: object = None,
+        name: object = None,
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+        *,
+        daemon: object = None,
+    ) -> None:
+        del group, name, daemon
+        if not callable(target):
+            raise TypeError("target required")
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self) -> None:
+        self._target(*self._args, **self._kwargs)
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
 
 
 def test_terminate_child_process_noop_when_exited() -> None:
@@ -107,6 +139,128 @@ def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.Monkey
     assert session.history[-1] == {"type": "shell", "text": "rm -rf /nope", "ok": False}
 
 
+def test_run_claude_code_implementation_starts_tracked_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    popen_calls: list[tuple[list[str], dict[str, object]]] = []
+    stdin_seen: list[str | None] = []
+
+    class _FakeAdapter:
+        def detect(self) -> CLIProbe:
+            return CLIProbe(
+                installed=True,
+                version="1.2.3",
+                logged_in=True,
+                bin_path="/usr/local/bin/claude",
+                detail="ok",
+            )
+
+        def build(
+            self,
+            *,
+            prompt: str,
+            model: str | None,
+            workspace: str,
+            reasoning_effort: str | None = None,
+        ) -> CLIInvocation:
+            assert model is None
+            assert workspace
+            assert reasoning_effort is None
+            assert "Recent OpenSRE terminal assistant context" in prompt
+            assert "Process auto-discovery" in prompt
+            assert "Do not create a git commit" in prompt
+            return CLIInvocation(
+                argv=("/usr/local/bin/claude", "-p", "--output-format", "text"),
+                stdin=prompt,
+                cwd=workspace,
+                env={"CLAUDE_TEST": "1"},
+                timeout_sec=120.0,
+            )
+
+    class _FakeProcess:
+        returncode = 0
+
+        def communicate(
+            self,
+            input: str | None = None,
+            timeout: int | None = None,
+        ) -> tuple[str, str]:
+            assert timeout is not None
+            stdin_seen.append(input)
+            return "changed app/cli/interactive_shell\n", ""
+
+        def poll(self) -> int:
+            return 0
+
+    def _fake_popen(command: list[str], **kwargs: object) -> _FakeProcess:
+        popen_calls.append((command, kwargs))
+        return _FakeProcess()
+
+    monkeypatch.delenv("CLAUDE_CODE_IMPLEMENT_PERMISSION_MODE", raising=False)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.ClaudeCodeAdapter",
+        _FakeAdapter,
+    )
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    session.cli_agent_messages.append(
+        ("assistant", "Process auto-discovery should scan local agent processes.")
+    )
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_claude_code_implementation(
+        "implement",
+        session,
+        console,
+        confirm_fn=lambda _prompt: "y",
+        is_tty=True,
+    )
+
+    assert len(popen_calls) == 1
+    command, kwargs = popen_calls[0]
+    assert command == [
+        "/usr/local/bin/claude",
+        "-p",
+        "--output-format",
+        "text",
+        "--permission-mode",
+        "acceptEdits",
+    ]
+    assert kwargs["cwd"]
+    assert stdin_seen and "Process auto-discovery" in stdin_seen[0]
+    assert session.history[-1] == {"type": "implementation", "text": "implement", "ok": True}
+    task = session.task_registry.list_recent(1)[0]
+    assert task.kind == TaskKind.CODE_AGENT
+    assert task.status == TaskStatus.COMPLETED
+    out = buf.getvalue()
+    assert "Claude Code started" in out
+    assert "Claude Code completed" in out
+
+
+def test_run_claude_code_implementation_rejects_vague_request_without_context() -> None:
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_claude_code_implementation(
+        "implement",
+        session,
+        console,
+        confirm_fn=lambda _prompt: "y",
+        is_tty=True,
+    )
+
+    assert "too vague" in buf.getvalue()
+    assert session.history[-1] == {"type": "implementation", "text": "implement", "ok": False}
+    assert session.task_registry.list_recent(1) == []
+
+
 def test_run_shell_command_silent_success_prints_checkmark(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_execute(**_kwargs: object) -> ShellExecutionResult:
         return ShellExecutionResult(
@@ -190,6 +344,139 @@ def test_run_shell_command_reports_start_failure(monkeypatch: pytest.MonkeyPatch
     assert session.history[-1] == {"type": "shell", "text": "true", "ok": False}
 
 
+def test_run_opensre_agents_scan_prints_clean_foreground_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command[-2:] == ["agents", "scan"]
+        assert kwargs["capture_output"] is True
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="agent scan\n777 claude-code-777 claude code\nNext: register\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.run", _fake_run)
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    assert run_opensre_cli_command("agents scan", session, console) is True
+
+    out = buf.getvalue()
+    assert "$ opensre agents scan" in out
+    assert "agent scan" in out
+    assert "777 claude-code-777 claude code" in out
+    assert "started." not in out
+    assert "stdout │" not in out
+    assert session.history[-1] == {"type": "cli_command", "text": "opensre agents scan", "ok": True}
+
+
+def test_run_opensre_agents_scan_register_explains_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="registered 1 agent(s)\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.run", _fake_run)
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    assert (
+        run_opensre_cli_command(
+            "agents scan --register",
+            session,
+            console,
+            confirm_fn=lambda _prompt: "y",
+            is_tty=True,
+        )
+        is True
+    )
+
+    out = buf.getvalue()
+    assert "register discovered local AI-agent processes" in out
+    assert "registered 1 agent(s)" in out
+    assert "stdout │" not in out
+    assert session.history[-1] == {
+        "type": "cli_command",
+        "text": "opensre agents scan --register",
+        "ok": True,
+    }
+
+
+def test_start_background_cli_task_uses_pty_for_live_terminal_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    popen_kwargs: list[dict[str, object]] = []
+    closed_fds: list[int] = []
+    chunks = [b"live progress\r\n"]
+
+    class _TtyBuffer(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    class _FakeProcess:
+        returncode = 0
+        stdout = None
+        stderr = None
+
+        def poll(self) -> int:
+            return 0
+
+    def _fake_popen(_command: list[str], **kwargs: object) -> _FakeProcess:
+        popen_kwargs.append(kwargs)
+        return _FakeProcess()
+
+    def _fake_read(fd: int, _size: int) -> bytes:
+        assert fd == 10
+        if chunks:
+            return chunks.pop(0)
+        raise OSError(errno.EIO, "pty closed")
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.os.openpty", lambda: (10, 11))
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.os.read", _fake_read)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.os.close",
+        lambda fd: closed_fds.append(fd),
+    )
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    buf = _TtyBuffer()
+    console = Console(file=buf, force_terminal=True)
+
+    task = start_background_cli_task(
+        display_command="opensre tests synthetic --scenario 001-replication-lag",
+        argv_list=["python", "-m", "app.cli", "tests", "synthetic"],
+        session=session,
+        console=console,
+        kind=TaskKind.SYNTHETIC_TEST,
+        use_pty=True,
+    )
+
+    assert task is not None
+    assert task.status == TaskStatus.COMPLETED
+    assert popen_kwargs[0]["stdout"] == 11
+    assert popen_kwargs[0]["stderr"] == 11
+    assert "text" not in popen_kwargs[0]
+    assert "live progress" in buf.getvalue()
+    assert 10 in closed_fds
+    assert 11 in closed_fds
+
+
 def test_run_synthetic_test_unknown_suite_records_failure() -> None:
     session = ReplSession()
     buf = io.StringIO()
@@ -200,3 +487,49 @@ def test_run_synthetic_test_unknown_suite_records_failure() -> None:
     entry = session.history[-1]
     assert entry["type"] == "synthetic_test"
     assert entry["ok"] is False
+
+
+def test_run_synthetic_test_streams_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    popen_kwargs: list[dict[str, object]] = []
+
+    class _FakeProcess:
+        returncode = 0
+        stdout = io.StringIO("collecting fixtures\nrunning investigation\n")
+        stderr = io.StringIO("warning: slow cloudwatch response\n")
+
+        def poll(self) -> int:
+            return 0
+
+    def _fake_popen(_command: list[str], **kwargs: object) -> _FakeProcess:
+        popen_kwargs.append(kwargs)
+        return _FakeProcess()
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_synthetic_test(
+        "rds_postgres",
+        session,
+        console,
+        confirm_fn=lambda _prompt: "y",
+        is_tty=True,
+    )
+
+    assert popen_kwargs[0]["stdout"] is not None
+    assert popen_kwargs[0]["stderr"] is not None
+    assert popen_kwargs[0]["text"] is True
+    out = buf.getvalue()
+    assert "collecting fixtures" in out
+    assert "running investigation" in out
+    assert "warning: slow cloudwatch response" in out
+    task = session.task_registry.list_recent(1)[0]
+    assert task.status == TaskStatus.COMPLETED

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -413,6 +413,48 @@ def test_run_opensre_agents_scan_register_explains_confirmation(
     }
 
 
+def test_run_opensre_agents_watch_runs_in_foreground(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command[-3:] == ["agents", "watch", "1234"]
+        assert kwargs["capture_output"] is True
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="pid 1234 exited\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.run", _fake_run)
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    assert (
+        run_opensre_cli_command(
+            "agents watch 1234",
+            session,
+            console,
+            confirm_fn=lambda _prompt: "y",
+            is_tty=True,
+        )
+        is True
+    )
+
+    out = buf.getvalue()
+    assert "$ opensre agents watch 1234" in out
+    assert "pid 1234 exited" in out
+    assert "started" not in out
+    assert session.task_registry.list_recent() == []
+    assert session.history[-1] == {
+        "type": "cli_command",
+        "text": "opensre agents watch 1234",
+        "ok": True,
+    }
+
+
 def test_start_background_cli_task_uses_pty_for_live_terminal_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/interactive_shell/test_action_planner.py
+++ b/tests/cli/interactive_shell/test_action_planner.py
@@ -26,6 +26,16 @@ def test_plan_terminal_tasks_returns_kinds() -> None:
     assert plan_terminal_tasks(msg) == ["slash", "slash"]
 
 
+def test_plan_terminal_tasks_returns_implementation_action() -> None:
+    msg = "please implement process auto-discovery"
+    actions, unhandled = plan_actions_with_unhandled(msg)
+
+    assert not unhandled
+    assert [(a.kind, a.content) for a in actions] == [("implementation", "process auto-discovery")]
+    assert plan_terminal_tasks(msg) == ["implementation"]
+    assert plan_cli_actions(msg) == []
+
+
 def test_plan_cli_actions_remote_deployment_inventory_questions() -> None:
     messages = (
         "Which remote deployments are connected?",

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -47,6 +47,11 @@ def test_provider_switch_plans_provider_action() -> None:
     assert plan_cli_actions(message) == []
 
 
+def test_implementation_request_plans_implementation_action() -> None:
+    assert plan_terminal_tasks("please implement /history search") == ["implementation"]
+    assert plan_cli_actions("please implement /history search") == []
+
+
 def test_generic_synthetic_test_request_plans_synthetic_action() -> None:
     assert plan_terminal_tasks("Can you run a synthetic test?") == ["synthetic_test"]
 
@@ -181,6 +186,40 @@ def test_execute_cli_actions_records_llm_provider_failure(monkeypatch: object) -
 
     assert handled is True
     assert session.history[-1] == {"type": "slash", "text": "/model set anthropic", "ok": False}
+
+
+def test_execute_cli_actions_runs_implementation_action(monkeypatch: object) -> None:
+    calls: list[str] = []
+
+    def _fake_run_implementation(
+        request: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> None:
+        calls.append(request)
+        session.record("implementation", request, ok=True)
+        console.print(f"implemented {request}")
+
+    monkeypatch.setattr(
+        agent_actions,
+        "run_claude_code_implementation",
+        _fake_run_implementation,
+    )
+
+    session = ReplSession()
+    console, buf = _capture()
+    handled = execute_cli_actions("please implement /history search", session, console)
+
+    assert handled is True
+    assert calls == ["/history search"]
+    assert session.history == [
+        {"type": "cli_agent", "text": "please implement /history search", "ok": True},
+        {"type": "implementation", "text": "/history search", "ok": True},
+    ]
+    output = buf.getvalue()
+    assert "implementation" in output
+    assert "implemented /history search" in output
 
 
 def test_execute_cli_actions_answers_discord_then_dispatches_datadog(

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1325,6 +1325,56 @@ class TestCliDelegatedCommands:
             )
         ]
 
+    def test_tests_picker_closes_selection_file_before_subprocess(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        selection_path = tmp_path / "selection.json"
+
+        class _SelectionFile:
+            name = str(selection_path)
+            closed = False
+
+            def __init__(self) -> None:
+                selection_path.touch()
+
+            def close(self) -> None:
+                self.closed = True
+
+        handle = _SelectionFile()
+        started: list[str] = []
+
+        def _fake_run(_command: list[str], **kwargs: object) -> object:
+            assert handle.closed is True
+            env = kwargs["env"]
+            assert isinstance(env, dict)
+            selection_path.write_text(
+                '[{"command": ["opensre", "tests", "synthetic"], '
+                '"command_display": "opensre tests synthetic"}]',
+                encoding="utf-8",
+            )
+
+            class _Result:
+                returncode = 0
+
+            return _Result()
+
+        monkeypatch.setattr(m.tempfile, "NamedTemporaryFile", lambda **_kwargs: handle)
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        monkeypatch.setattr(
+            m,
+            "start_background_cli_task",
+            lambda **kwargs: started.append(kwargs["display_command"]),
+        )
+
+        dispatch_slash("/tests", ReplSession(), Console())
+
+        assert started == ["opensre tests synthetic"]
+        assert not selection_path.exists()
+
     def test_tests_flag_first_invocation_delegates_to_cli(self, monkeypatch: object) -> None:
         from app.cli.interactive_shell.command_registry import cli_parity as m
 

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import sys
 from pathlib import Path
 
 import pytest
@@ -142,6 +143,15 @@ class TestDispatchSlash:
         console, buf = _capture()
         assert dispatch_slash("/made-up", session, console) is True
         assert "unknown command" in buf.getvalue()
+
+    def test_unknown_command_suggests_close_match(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/modle", session, console) is True
+        output = buf.getvalue()
+        assert "unknown command" in output
+        assert "Did you mean" in output
+        assert "/model" in output
 
     def test_local_llm_is_not_a_builtin_slash_action(self) -> None:
         assert "/local-llm" not in SLASH_COMMANDS
@@ -1275,3 +1285,85 @@ class TestCliDelegatedCommands:
         monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
         dispatch_slash(command, ReplSession(), Console())
         assert captured == [expected_args]
+
+    def test_tests_run_subcommand_starts_background_task(self, monkeypatch: object) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        started: list[tuple[str, list[str], TaskKind, bool]] = []
+
+        def _fake_start_background_cli_task(
+            *,
+            display_command: str,
+            argv_list: list[str],
+            session: ReplSession,
+            console: Console,
+            timeout_seconds: int,
+            kind: TaskKind,
+            use_pty: bool,
+        ) -> object:
+            del session, console, timeout_seconds
+            started.append((display_command, argv_list, kind, use_pty))
+            return object()
+
+        monkeypatch.setattr(m, "start_background_cli_task", _fake_start_background_cli_task)
+        dispatch_slash("/tests synthetic --scenario 001-replication-lag", ReplSession(), Console())
+
+        assert started == [
+            (
+                "opensre tests synthetic --scenario 001-replication-lag",
+                [
+                    sys.executable,
+                    "-m",
+                    "app.cli",
+                    "tests",
+                    "synthetic",
+                    "--scenario",
+                    "001-replication-lag",
+                ],
+                TaskKind.SYNTHETIC_TEST,
+                True,
+            )
+        ]
+
+    def test_tests_flag_first_invocation_delegates_to_cli(self, monkeypatch: object) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        delegated: list[list[str]] = []
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _console, args, **_kwargs: (delegated.append(args), True)[1],
+        )
+
+        dispatch_slash("/tests --help", ReplSession(), Console())
+
+        assert delegated == [["tests", "--help"]]
+
+    def test_tests_subcommand_typo_suggests_synthetic(self, monkeypatch: object) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        delegated: list[list[str]] = []
+        started: list[list[str]] = []
+
+        monkeypatch.setattr(
+            m,
+            "run_cli_command",
+            lambda _console, args, **_kwargs: (delegated.append(args), True)[1],
+        )
+        monkeypatch.setattr(
+            m,
+            "start_background_cli_task",
+            lambda **kwargs: started.append(kwargs["argv_list"]),
+        )
+
+        session = ReplSession()
+        console, buf = _capture()
+        dispatch_slash("/tests synthetics", session, console)
+
+        output = buf.getvalue()
+        assert "unknown tests subcommand" in output
+        assert "Did you mean" in output
+        assert "/tests synthetic" in output
+        assert session.history[-1]["ok"] is False
+        assert delegated == []
+        assert started == []

--- a/tests/cli/interactive_shell/test_intent_parser.py
+++ b/tests/cli/interactive_shell/test_intent_parser.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from app.cli.interactive_shell.intent_parser import (
     SAMPLE_ALERT_RE,
+    extract_implementation_request,
     normalize_shell_command,
     split_prompt_clauses,
 )
+from app.cli.interactive_shell.interaction_models import PromptClause
 
 
 def test_split_prompt_clauses_preserves_positions() -> None:
@@ -24,6 +26,25 @@ def test_normalize_shell_command_rejects_multiline() -> None:
 
 def test_normalize_shell_command_strips_ticks() -> None:
     assert normalize_shell_command("`whoami`") == "whoami"
+
+
+def test_extract_implementation_request_matches_explicit_implement_phrase() -> None:
+    action = extract_implementation_request(
+        PromptClause(text="please implement /history search", position=3)
+    )
+
+    assert action is not None
+    assert action.kind == "implementation"
+    assert action.content == "/history search"
+    assert action.position == 10
+
+
+def test_extract_implementation_request_allows_context_dependent_bare_implement() -> None:
+    action = extract_implementation_request(PromptClause(text="implement", position=0))
+
+    assert action is not None
+    assert action.kind == "implementation"
+    assert action.content == "implement"
 
 
 class TestSampleAlertRE:

--- a/tests/cli/interactive_shell/test_intent_parser.py
+++ b/tests/cli/interactive_shell/test_intent_parser.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
+import app.cli.interactive_shell.intent_parser as intent_parser
 from app.cli.interactive_shell.intent_parser import (
     SAMPLE_ALERT_RE,
     extract_implementation_request,
+    extract_shell_command,
     normalize_shell_command,
     split_prompt_clauses,
 )
@@ -45,6 +49,19 @@ def test_extract_implementation_request_allows_context_dependent_bare_implement(
     assert action is not None
     assert action.kind == "implementation"
     assert action.content == "implement"
+
+
+def test_code_editor_command_is_not_implementation_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(intent_parser.shutil, "which", lambda _command: "/usr/bin/code")
+    clause = PromptClause(text="code .", position=0)
+
+    assert extract_implementation_request(clause) is None
+    action = extract_shell_command(clause)
+    assert action is not None
+    assert action.kind == "shell"
+    assert action.content == "code ."
 
 
 class TestSampleAlertRE:

--- a/tests/cli/interactive_shell/test_intent_parser.py
+++ b/tests/cli/interactive_shell/test_intent_parser.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-import app.cli.interactive_shell.intent_parser as intent_parser
 from app.cli.interactive_shell.intent_parser import (
     SAMPLE_ALERT_RE,
     extract_implementation_request,
     extract_shell_command,
     normalize_shell_command,
+    shutil,
     split_prompt_clauses,
 )
 from app.cli.interactive_shell.interaction_models import PromptClause
@@ -54,7 +54,7 @@ def test_extract_implementation_request_allows_context_dependent_bare_implement(
 def test_code_editor_command_is_not_implementation_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(intent_parser.shutil, "which", lambda _command: "/usr/bin/code")
+    monkeypatch.setattr(shutil, "which", lambda _command: "/usr/bin/code")
     clause = PromptClause(text="code .", position=0)
 
     assert extract_implementation_request(clause) is None

--- a/tests/cli/test_agents_command.py
+++ b/tests/cli/test_agents_command.py
@@ -1,38 +1,141 @@
-"""Smoke tests for the ``opensre agents`` command group (issue #1486).
-
-Phase-0 of the ``monitor-local-agents`` initiative: ensure the new top-level
-group is reachable and each placeholder subcommand exits cleanly. Real
-behavior is added by later tickets in the same series.
-"""
+"""Smoke tests for the ``opensre agents`` command group."""
 
 from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
+from app.agents.discovery import DiscoveredAgent
+from app.agents.registry import AgentRegistry
 from app.cli.__main__ import cli
+from app.cli.commands import agent as agent_mod
+
+
+@pytest.fixture
+def isolated_registry_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    path = tmp_path / "agents.jsonl"
+    monkeypatch.setattr(agent_mod, "AgentRegistry", lambda: AgentRegistry(path=path))
+    return path
 
 
 def test_agents_help_lists_all_subcommands() -> None:
-    """``opensre agents --help`` must surface every placeholder subcommand."""
+    """``opensre agents --help`` must surface every subcommand."""
     runner = CliRunner()
 
     result = runner.invoke(cli, ["agents", "--help"])
 
     assert result.exit_code == 0, result.output
-    for subcommand in ("list", "register", "forget"):
+    for subcommand in ("list", "register", "forget", "scan", "watch"):
         assert subcommand in result.output, f"missing {subcommand!r} in help: {result.output}"
+    assert "--all" in runner.invoke(cli, ["agents", "scan", "--help"]).output
 
 
-@pytest.mark.parametrize("subcommand", ["list", "register", "forget"])
-def test_agents_subcommand_prints_placeholder(subcommand: str) -> None:
-    """Each stub subcommand must run successfully and print the placeholder."""
+def test_agents_register_list_and_forget(isolated_registry_path: Path) -> None:
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["agents", subcommand])
+    register = runner.invoke(
+        cli,
+        ["agents", "register", "1234", "claude-code", "--command", "claude"],
+    )
+    listed = runner.invoke(cli, ["agents", "list"])
+    forgotten = runner.invoke(cli, ["agents", "forget", "1234"])
+    listed_again = runner.invoke(cli, ["agents", "list"])
+
+    assert register.exit_code == 0, register.output
+    assert "registered claude-code" in register.output
+    assert listed.exit_code == 0, listed.output
+    assert "1234\tclaude-code\tclaude" in listed.output
+    assert forgotten.exit_code == 0, forgotten.output
+    assert "forgot claude-code" in forgotten.output
+    assert listed_again.exit_code == 0, listed_again.output
+    assert "no agents registered" in listed_again.output
+    assert AgentRegistry(path=isolated_registry_path).list() == []
+
+
+def test_agents_scan_can_register_discovered_processes(
+    isolated_registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        agent_mod,
+        "discover_agent_processes",
+        lambda **_kwargs: [DiscoveredAgent(name="claude-code-777", pid=777, command="claude code")],
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["agents", "scan", "--register"])
 
     assert result.exit_code == 0, result.output
-    assert "not implemented yet" in result.output
+    assert "agent scan" in result.output
+    assert "pid" in result.output
+    assert "agent" in result.output
+    assert "command" in result.output
+    assert "777" in result.output
+    assert "claude-code-777" in result.output
+    assert "claude code" in result.output
+    assert "registered 1 agent(s)" in result.output
+    assert AgentRegistry(path=isolated_registry_path).get(777) is not None
+
+
+def test_agents_scan_truncates_long_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        agent_mod,
+        "discover_agent_processes",
+        lambda **_kwargs: [
+            DiscoveredAgent(
+                name="claude-code-777",
+                pid=777,
+                command="claude " + "--flag " * 40,
+            )
+        ],
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["agents", "scan"])
+
+    assert result.exit_code == 0, result.output
+    assert "--flag --flag" in result.output
+    assert "..." in result.output or "…" in result.output
+    assert "Next: run opensre agents scan --register to track 1 process(es)" in result.output
+
+
+def test_agents_scan_all_passes_include_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    received: list[bool] = []
+
+    def _discover(*, include_all: bool = False) -> list[DiscoveredAgent]:
+        received.append(include_all)
+        return [DiscoveredAgent(name="cursor-888", pid=888, command="Cursor Helper")]
+
+    monkeypatch.setattr(agent_mod, "discover_agent_processes", _discover)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["agents", "scan", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert received == [True]
+    assert "showing helper processes" in result.output
+
+
+def test_agents_scan_empty_state_mentions_all_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(agent_mod, "discover_agent_processes", lambda **_kwargs: [])
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["agents", "scan"])
+
+    assert result.exit_code == 0, result.output
+    assert "no running AI-agent sessions detected" in result.output
+    assert "opensre agents scan --all" in result.output
+
+
+def test_agents_watch_reports_already_exited(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(agent_mod, "pid_exists", lambda _pid: False)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["agents", "watch", "9876"])
+
+    assert result.exit_code == 0, result.output
+    assert "pid 9876 is not running" in result.output
 
 
 def test_agents_group_registered_in_root_cli() -> None:

--- a/tests/cli/test_interactive.py
+++ b/tests/cli/test_interactive.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 from app.cli.tests import interactive
@@ -333,6 +334,40 @@ def test_run_interactive_picker_returns_to_selection_after_escape_from_confirm(m
     )
 
     assert interactive.run_interactive_picker(Catalog(items=(first, second))) == 7
+
+
+def test_run_interactive_picker_writes_selection_for_background_mode(monkeypatch, tmp_path) -> None:
+    item = CatalogItem(
+        id="synthetic:001-replication-lag",
+        kind="cli_command",
+        display_name="001-replication-lag",
+        description="Run synthetic scenario.",
+        command=("opensre", "tests", "synthetic", "--scenario", "001-replication-lag"),
+        tags=("synthetic",),
+    )
+    selection_file = tmp_path / "selection.json"
+
+    monkeypatch.setenv("OPENSRE_TEST_PICKER_SELECTION_FILE", str(selection_file))
+    monkeypatch.setattr(interactive, "_require_interactive_dependencies", lambda: None)
+    monkeypatch.setattr(interactive.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(interactive.sys, "stdout", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr(interactive, "choose_interactive_item", lambda _catalog: (item, False))
+    monkeypatch.setattr(interactive, "_confirm_run", lambda _item: True)
+    monkeypatch.setattr(
+        interactive,
+        "run_catalog_item",
+        lambda _item: (_ for _ in ()).throw(AssertionError("should not run inline")),
+    )
+
+    assert interactive.run_interactive_picker(Catalog(items=(item,))) == 0
+    assert json.loads(selection_file.read_text(encoding="utf-8")) == [
+        {
+            "id": "synthetic:001-replication-lag",
+            "display_name": "001-replication-lag",
+            "command": ["opensre", "tests", "synthetic", "--scenario", "001-replication-lag"],
+            "command_display": "opensre tests synthetic --scenario 001-replication-lag",
+        }
+    ]
 
 
 def test_run_catalog_items_skips_non_runnable_items() -> None:


### PR DESCRIPTION
## Summary
- Add `opensre agents` process discovery, registration, listing, scanning, and watch behavior for local AI-agent sessions.
- Extend the interactive shell to plan and run implementation/background tasks with tracked task output.
- Add command suggestions and focused coverage for discovery, agent CLI commands, and interactive task execution.

## Test plan
- `uv run ruff check app/agents/discovery.py app/cli/commands/agent.py app/cli/interactive_shell/action_executor.py app/cli/interactive_shell/action_planner.py app/cli/interactive_shell/agent_actions.py app/cli/interactive_shell/command_registry app/cli/interactive_shell/execution_policy.py app/cli/interactive_shell/intent_parser.py app/cli/interactive_shell/interaction_models.py app/cli/interactive_shell/loop.py app/cli/interactive_shell/rendering.py app/cli/interactive_shell/tasks.py app/cli/tests/interactive.py tests/agents/test_discovery.py tests/cli/interactive_shell/test_action_executor.py tests/cli/interactive_shell/test_action_planner.py tests/cli/interactive_shell/test_agent_actions.py tests/cli/interactive_shell/test_commands.py tests/cli/interactive_shell/test_intent_parser.py tests/cli/test_agents_command.py tests/cli/test_interactive.py`
- `uv run pytest tests/agents/test_discovery.py tests/cli/interactive_shell/test_action_executor.py tests/cli/interactive_shell/test_action_planner.py tests/cli/interactive_shell/test_agent_actions.py tests/cli/interactive_shell/test_commands.py tests/cli/interactive_shell/test_intent_parser.py tests/cli/test_agents_command.py tests/cli/test_interactive.py`
- `make format-check`
- `make typecheck`


Made with [Cursor](https://cursor.com)