### PR TITLE
feat(synthetic): add run observation metrics and Rich reporting

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -139,6 +139,12 @@ def _capture_accepted_cli_invocation(ctx: click.Context) -> None:
     help="Interactive-shell layout: 'classic' (scrolling) or 'pinned' (fixed "
     "input bar). Overrides OPENSRE_LAYOUT env var and ~/.config/opensre/config.yml.",
 )
+@click.option(
+    "--reload/--no-reload",
+    "reload_enabled",
+    default=None,
+    help="Enable or disable interactive-shell hot reload. Defaults to enabled.",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -148,6 +154,7 @@ def cli(
     yes: bool,
     interactive: bool,
     layout: str | None,
+    reload_enabled: bool | None,
 ) -> None:
     """OpenSRE - open-source SRE agent for automated incident investigation and root cause analysis."""
     ctx.ensure_object(dict)
@@ -170,6 +177,7 @@ def cli(
             config = ReplConfig.load(
                 cli_enabled=interactive,
                 cli_layout=layout,
+                cli_reload=reload_enabled,
             )
             if config.enabled:
                 raise SystemExit(run_repl(config=config))

--- a/app/cli/commands/tests.py
+++ b/app/cli/commands/tests.py
@@ -57,7 +57,14 @@ def _echo_catalog_item(item: Any, *, indent: int = 0) -> None:
         _echo_catalog_item(child, indent=indent + 1)
 
 
-def _build_synthetic_argv(*, scenario: str, output_json: bool, mock_grafana: bool) -> list[str]:
+def _build_synthetic_argv(
+    *,
+    scenario: str,
+    output_json: bool,
+    mock_grafana: bool,
+    report: bool | None,
+    observations_dir: str,
+) -> list[str]:
     argv: list[str] = []
     if scenario:
         argv.extend(["--scenario", scenario])
@@ -65,6 +72,12 @@ def _build_synthetic_argv(*, scenario: str, output_json: bool, mock_grafana: boo
         argv.append("--json")
     if mock_grafana:
         argv.append("--mock-grafana")
+    if report is True:
+        argv.append("--report")
+    elif report is False:
+        argv.append("--no-report")
+    if observations_dir:
+        argv.extend(["--observations-dir", observations_dir])
     return argv
 
 
@@ -146,7 +159,26 @@ def _synthetic_suite_not_bundled_error() -> OpenSREError:
     show_default=True,
     help="Serve fixture data via FixtureGrafanaBackend instead of real Grafana calls.",
 )
-def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) -> None:
+@click.option(
+    "--report/--no-report",
+    default=None,
+    help=(
+        "Print Rich observation report per scenario. Defaults to auto "
+        "(enabled for single-scenario runs)."
+    ),
+)
+@click.option(
+    "--observations-dir",
+    default="",
+    help="Directory where synthetic run observations are written.",
+)
+def run_synthetic_suite(
+    scenario: str,
+    output_json: bool,
+    mock_grafana: bool,
+    report: bool | None,
+    observations_dir: str,
+) -> None:
     """Run the synthetic RDS PostgreSQL RCA benchmark."""
     # ``packaging/opensre.spec`` only collects ``app/`` data files, so neither
     # the synthetic Python package's submodules nor the per-scenario data
@@ -188,6 +220,8 @@ def run_synthetic_suite(scenario: str, output_json: bool, mock_grafana: bool) ->
                 scenario=scenario,
                 output_json=output_json,
                 mock_grafana=mock_grafana,
+                report=report,
+                observations_dir=observations_dir,
             )
         )
     except Exception as exc:

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -194,7 +194,7 @@ def start_background_cli_task(
 ) -> TaskRecord | None:
     """Start a subprocess as a REPL task while streaming output above the prompt."""
     console.print(f"[bold]$ {display_command}[/bold]")
-    task = session.task_registry.create(kind)
+    task = session.task_registry.create(kind, command=display_command)
     task.mark_running()
     stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
         max_size=_SYNTHETIC_DIAG_CHARS * 2
@@ -220,6 +220,7 @@ def start_background_cli_task(
                 text=True,
                 encoding="utf-8",
                 errors="replace",
+                start_new_session=True,
             )
         else:
             _master_fd, slave_fd = pty_fds
@@ -229,6 +230,7 @@ def start_background_cli_task(
                 stdout=slave_fd,
                 stderr=slave_fd,
                 close_fds=True,
+                start_new_session=True,
             )
     except Exception as exc:  # noqa: BLE001
         if pty_fds is not None:
@@ -506,7 +508,7 @@ def run_claude_code_implementation(
 
     display_command = "claude -p"
     console.print(f"[bold]$ {display_command}[/bold]")
-    task = session.task_registry.create(TaskKind.CODE_AGENT)
+    task = session.task_registry.create(TaskKind.CODE_AGENT, command=display_command)
     task.mark_running()
     history_gen_when_started = session.history_generation
 
@@ -521,6 +523,7 @@ def run_claude_code_implementation(
             errors="replace",
             cwd=invocation.cwd,
             env=build_cli_subprocess_env(invocation.env),
+            start_new_session=True,
         )
     except Exception as exc:
         task.mark_failed(str(exc))
@@ -937,7 +940,9 @@ def run_sample_alert(
         return
 
     console.print(f"[bold]sample alert:[/bold] {escape(template_name)}")
-    task = session.task_registry.create(TaskKind.INVESTIGATION)
+    task = session.task_registry.create(
+        TaskKind.INVESTIGATION, command=f"sample alert:{template_name}"
+    )
     task.mark_running()
     try:
         final_state = run_sample_alert_for_session(
@@ -1000,7 +1005,7 @@ def run_synthetic_test(
 
     display_command = "opensre tests synthetic"
     console.print(f"[bold]$ {display_command}[/bold]")
-    task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+    task = session.task_registry.create(TaskKind.SYNTHETIC_TEST, command=display_command)
     task.mark_running()
     # Lifetime managed by the watcher thread's finally block; SIM115 ignored
     # for this file in ruff.toml.
@@ -1015,6 +1020,7 @@ def run_synthetic_test(
             text=True,
             encoding="utf-8",
             errors="replace",
+            start_new_session=True,
         )
     except Exception as exc:
         stderr_buf.close()

--- a/app/cli/interactive_shell/action_planner.py
+++ b/app/cli/interactive_shell/action_planner.py
@@ -15,6 +15,7 @@ from app.cli.interactive_shell.intent_parser import (
     extract_implementation_request,
     extract_llm_provider_switch,
     extract_shell_command,
+    extract_task_cancel_request,
     sample_alert_action,
     slash_action,
     split_prompt_clauses,
@@ -105,6 +106,11 @@ def plan_clause_actions(
     implementation = extract_implementation_request(clause)
     if implementation is not None:
         planned.append(implementation)
+        return planned
+
+    task_cancel = extract_task_cancel_request(clause)
+    if task_cancel is not None:
+        planned.append(task_cancel)
         return planned
 
     planned_shell = extract_shell_command(clause)

--- a/app/cli/interactive_shell/agent_actions.py
+++ b/app/cli/interactive_shell/agent_actions.py
@@ -22,7 +22,7 @@ from app.cli.interactive_shell.action_planner import (
     plan_cli_actions,
     plan_terminal_tasks,
 )
-from app.cli.interactive_shell.command_registry import (
+from app.cli.interactive_shell.commands import (
     SLASH_COMMANDS,
     dispatch_slash,
     switch_llm_provider,
@@ -35,6 +35,7 @@ from app.cli.interactive_shell.execution_policy import (
 )
 from app.cli.interactive_shell.rendering import print_planned_actions
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskKind, TaskRecord, TaskStatus
 from app.cli.interactive_shell.theme import BOLD_BRAND
 
 
@@ -55,6 +56,96 @@ def _plan_with_spinner(
     spinner = Spinner("dots12", text="thinking...", style=BOLD_BRAND)
     with Live(spinner, console=console, refresh_per_second=20, transient=True):
         return plan_actions_with_unhandled(message)
+
+
+def _running_task_matches(session: ReplSession, target: str) -> list[TaskRecord]:
+    running = [
+        task
+        for task in session.task_registry.list_recent(n=50)
+        if task.status == TaskStatus.RUNNING
+    ]
+    if target == "synthetic_test":
+        return [task for task in running if task.kind == TaskKind.SYNTHETIC_TEST]
+    if target == "task":
+        return running
+    return []
+
+
+def _resolve_task_cancel_target(
+    target: str,
+    session: ReplSession,
+    console: Console,
+) -> str | None:
+    if target in {"synthetic_test", "task"}:
+        matches = _running_task_matches(session, target)
+        if not matches:
+            console.print(
+                f"[dim]no running {escape(target)} task found. use[/] [bold]/tasks[/bold]"
+            )
+            session.record("slash", f"/cancel {target}", ok=False)
+            return None
+        if len(matches) > 1:
+            ids = ", ".join(task.task_id for task in matches)
+            console.print(
+                f"[yellow]multiple running tasks match {escape(target)}:[/] "
+                f"{escape(ids)} [dim](run /cancel <id>)[/]"
+            )
+            session.record("slash", f"/cancel {target}", ok=False)
+            return None
+        return matches[0].task_id
+
+    candidates = session.task_registry.candidates(target)
+    if not candidates:
+        console.print(f"[red]no task matches id:[/] {escape(target)}")
+        session.record("slash", f"/cancel {target}", ok=False)
+        return None
+    if len(candidates) > 1:
+        console.print(
+            f"[red]ambiguous id prefix:[/] {escape(target)} "
+            f"[dim]({len(candidates)} matches — use a longer prefix)[/]"
+        )
+        session.record("slash", f"/cancel {target}", ok=False)
+        return None
+    return candidates[0].task_id
+
+
+def _execute_task_cancel_action(
+    target: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> None:
+    task_id = _resolve_task_cancel_target(target, session, console)
+    if task_id is None:
+        return
+
+    command = f"/cancel {task_id}"
+    cmd = SLASH_COMMANDS["/cancel"]
+    tier = resolve_slash_execution_tier("/cancel", [task_id], cmd.execution_tier)
+    policy = evaluate_slash_tier(tier)
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=command,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=True,
+    ):
+        session.record("slash", command, ok=False)
+        return
+
+    console.print(f"[bold]$ {escape(command)}[/bold]")
+    dispatch_slash(
+        command,
+        session,
+        console,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        policy_precleared=True,
+    )
 
 
 def execute_cli_actions(
@@ -157,6 +248,14 @@ def execute_cli_actions(
             )
         elif action.kind == "cli_command":
             run_opensre_cli_command(
+                action.content,
+                session,
+                console,
+                confirm_fn=confirm_fn,
+                is_tty=is_tty,
+            )
+        elif action.kind == "task_cancel":
+            _execute_task_cancel_action(
                 action.content,
                 session,
                 console,

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -100,7 +100,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    task = session.task_registry.create(TaskKind.INVESTIGATION)
+    task = session.task_registry.create(TaskKind.INVESTIGATION, command=f"/investigate {path}")
     task.mark_running()
     try:
         with apply_reasoning_effort(session.reasoning_effort):

--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -37,6 +37,8 @@ def _task_detail_label(task: TaskRecord) -> str:
         return str(task.error)
     if task.result:
         return str(task.result)
+    if task.command:
+        return str(task.command)
     return "—"
 
 

--- a/app/cli/interactive_shell/commands.py
+++ b/app/cli/interactive_shell/commands.py
@@ -2,13 +2,48 @@
 
 from __future__ import annotations
 
-from app.cli.interactive_shell.command_registry import (
-    SLASH_COMMANDS,
-    dispatch_slash,
-    switch_llm_provider,
-    switch_toolcall_model,
-)
+from collections.abc import Iterator, Mapping
+from importlib import import_module
+from types import ModuleType
+from typing import Any, cast
+
 from app.cli.interactive_shell.command_registry.types import SlashCommand
+
+
+def _registry_module() -> ModuleType:
+    return import_module("app.cli.interactive_shell.command_registry")
+
+
+class _SlashCommandProxy(Mapping[str, SlashCommand]):
+    """Mapping facade that always reads from the current command registry module."""
+
+    def _commands(self) -> Mapping[str, SlashCommand]:
+        return cast(Mapping[str, SlashCommand], _registry_module().SLASH_COMMANDS)
+
+    def __getitem__(self, key: str) -> SlashCommand:
+        return self._commands()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._commands())
+
+    def __len__(self) -> int:
+        return len(self._commands())
+
+
+SLASH_COMMANDS: Mapping[str, SlashCommand] = _SlashCommandProxy()
+
+
+def dispatch_slash(*args: Any, **kwargs: Any) -> bool:
+    return cast(bool, _registry_module().dispatch_slash(*args, **kwargs))
+
+
+def switch_llm_provider(*args: Any, **kwargs: Any) -> bool:
+    return cast(bool, _registry_module().switch_llm_provider(*args, **kwargs))
+
+
+def switch_toolcall_model(*args: Any, **kwargs: Any) -> bool:
+    return cast(bool, _registry_module().switch_toolcall_model(*args, **kwargs))
+
 
 __all__ = [
     "SLASH_COMMANDS",

--- a/app/cli/interactive_shell/config.py
+++ b/app/cli/interactive_shell/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 _VALID_LAYOUTS = ("classic", "pinned")
+_FALSE_VALUES = ("0", "false", "off", "no")
 
 # ── Release notes ─────────────────────────────────────────────────────────────
 # Shown in the "What's new" panel on startup. Update this each release with
@@ -64,10 +65,25 @@ class ReplConfig:
         is accepted and stored so the flag round-trips cleanly once P3 lands.
         Controlled by ``--layout`` CLI option, ``OPENSRE_LAYOUT`` env var, or
         ``interactive.layout`` in ``~/.config/opensre/config.yml``.
+
+    reload : bool
+        When True, the interactive shell watches repo-local Python files and
+        reloads changed modules between prompt turns. Controlled by the
+        ``--reload`` / ``--no-reload`` CLI option, ``OPENSRE_RELOAD`` env var,
+        or ``interactive.reload`` in ``~/.config/opensre/config.yml``.
     """
 
     enabled: bool = True
     layout: str = "classic"
+    reload: bool = True
+
+    @staticmethod
+    def _coerce_bool(value: Any, *, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        return str(value).strip().lower() not in _FALSE_VALUES
 
     @classmethod
     def load(
@@ -75,12 +91,13 @@ class ReplConfig:
         *,
         cli_enabled: bool | None = None,
         cli_layout: str | None = None,
+        cli_reload: bool | None = None,
     ) -> ReplConfig:
         """Resolve config from all three tiers.
 
         Priority (highest wins):
-            1. CLI flag   — ``cli_enabled`` / ``cli_layout`` params
-            2. Env var    — ``OPENSRE_INTERACTIVE`` / ``OPENSRE_LAYOUT``
+            1. CLI flag   — ``cli_enabled`` / ``cli_layout`` / ``cli_reload`` params
+            2. Env var    — ``OPENSRE_INTERACTIVE`` / ``OPENSRE_LAYOUT`` / ``OPENSRE_RELOAD``
             3. Config file — ``~/.config/opensre/config.yml`` ``interactive`` section
             4. Built-in defaults (enabled=True, layout="classic")
         """
@@ -90,10 +107,9 @@ class ReplConfig:
         if cli_enabled is not None:
             enabled = cli_enabled
         elif (env_val := os.getenv("OPENSRE_INTERACTIVE")) is not None:
-            enabled = env_val.lower() not in ("0", "false", "off")
+            enabled = cls._coerce_bool(env_val, default=True)
         else:
-            raw = file_conf.get("enabled", True)
-            enabled = bool(raw)
+            enabled = cls._coerce_bool(file_conf.get("enabled"), default=True)
 
         # --- layout ---
         if cli_layout is not None:
@@ -106,7 +122,15 @@ class ReplConfig:
         if layout not in _VALID_LAYOUTS:
             layout = "classic"
 
-        return cls(enabled=enabled, layout=layout)
+        # --- reload ---
+        if cli_reload is not None:
+            reload = cli_reload
+        elif (env_val := os.getenv("OPENSRE_RELOAD")) is not None:
+            reload = cls._coerce_bool(env_val, default=True)
+        else:
+            reload = cls._coerce_bool(file_conf.get("reload"), default=True)
+
+        return cls(enabled=enabled, layout=layout, reload=reload)
 
     @classmethod
     def from_env(cls) -> ReplConfig:

--- a/app/cli/interactive_shell/config.py
+++ b/app/cli/interactive_shell/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 _VALID_LAYOUTS = ("classic", "pinned")
-_FALSE_VALUES = ("0", "false", "off", "no")
+_FALSE_VALUES = ("", "0", "false", "off", "no")
 
 # ── Release notes ─────────────────────────────────────────────────────────────
 # Shown in the "What's new" panel on startup. Update this each release with

--- a/app/cli/interactive_shell/hot_reload.py
+++ b/app/cli/interactive_shell/hot_reload.py
@@ -1,0 +1,185 @@
+"""Hot reload support for the interactive CLI."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+from rich.console import Console
+from rich.markup import escape
+
+from app.cli.interactive_shell.theme import DIM, WARNING
+
+_IGNORED_DIR_NAMES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+}
+
+_INTERACTIVE_RELOAD_DEPENDENTS = (
+    "app.cli.interactive_shell.command_registry",
+    "app.cli.interactive_shell.commands",
+    "app.cli.interactive_shell.prompt_surface",
+    "app.cli.interactive_shell.cli_reference",
+    "app.cli.interactive_shell.agent_actions",
+    "app.cli.interactive_shell.cli_agent",
+    "app.cli.interactive_shell.loop",
+)
+
+
+@dataclass(frozen=True)
+class ReloadResult:
+    """Summary of one hot reload pass."""
+
+    changed_paths: tuple[Path, ...]
+    reloaded_modules: tuple[str, ...]
+    errors: tuple[str, ...]
+
+
+class HotReloadCoordinator:
+    """Detect repo-local Python changes and reload loaded modules between turns."""
+
+    def __init__(
+        self,
+        *,
+        watch_root: Path | None = None,
+        package_prefix: str = "app",
+        dependent_modules: tuple[str, ...] = _INTERACTIVE_RELOAD_DEPENDENTS,
+    ) -> None:
+        self.watch_root = (watch_root or Path(__file__).resolve().parents[3] / "app").resolve()
+        self.package_prefix = package_prefix
+        self.dependent_modules = dependent_modules
+        self._snapshot = self._scan()
+
+    def check_and_reload(self, console: Console) -> ReloadResult | None:
+        """Reload changed modules and return a summary, or ``None`` if unchanged."""
+        current = self._scan()
+        changed_paths = tuple(
+            sorted(
+                path
+                for path, fingerprint in current.items()
+                if self._snapshot.get(path) != fingerprint
+            )
+        )
+        deleted_paths = tuple(path for path in self._snapshot if path not in current)
+        self._snapshot = current
+        if not changed_paths and not deleted_paths:
+            return None
+
+        module_names = self._loaded_modules_for_paths(changed_paths)
+        if module_names:
+            module_names.extend(
+                name
+                for name in self.dependent_modules
+                if name in sys.modules and name not in module_names
+            )
+
+        reloaded: list[str] = []
+        errors: list[str] = []
+        for module_name in self._reload_order(module_names):
+            module = sys.modules.get(module_name)
+            if module is None:
+                continue
+            try:
+                importlib.reload(module)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{module_name}: {exc}")
+                continue
+            reloaded.append(module_name)
+
+        self._clear_known_caches(errors)
+        result = ReloadResult(
+            changed_paths=changed_paths + deleted_paths,
+            reloaded_modules=tuple(reloaded),
+            errors=tuple(errors),
+        )
+        self._render_result(console, result)
+        return result
+
+    def _scan(self) -> dict[Path, tuple[int, int]]:
+        files: dict[Path, tuple[int, int]] = {}
+        if not self.watch_root.exists():
+            return files
+        for path in self.watch_root.rglob("*.py"):
+            if self._is_ignored(path):
+                continue
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            files[path.resolve()] = (stat.st_mtime_ns, stat.st_size)
+        return files
+
+    def _is_ignored(self, path: Path) -> bool:
+        return any(part in _IGNORED_DIR_NAMES for part in path.parts)
+
+    def _loaded_modules_for_paths(self, changed_paths: tuple[Path, ...]) -> list[str]:
+        changed = set(changed_paths)
+        module_names: list[str] = []
+        for module_name, module in sys.modules.items():
+            if not module_name.startswith(f"{self.package_prefix}."):
+                continue
+            module_path = self._module_source_path(module)
+            if module_path is None or module_path not in changed:
+                continue
+            module_names.append(module_name)
+        return sorted(module_names, key=lambda name: (name.count("."), name), reverse=True)
+
+    def _module_source_path(self, module: ModuleType) -> Path | None:
+        raw_file = getattr(module, "__file__", None)
+        if not raw_file:
+            return None
+        path = Path(raw_file)
+        if path.suffix != ".py":
+            return None
+        try:
+            resolved = path.resolve()
+        except OSError:
+            return None
+        try:
+            resolved.relative_to(self.watch_root)
+        except ValueError:
+            return None
+        return resolved
+
+    def _reload_order(self, module_names: list[str]) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(module_names))
+
+    def _clear_known_caches(self, errors: list[str]) -> None:
+        try:
+            from app.tools.registry import clear_tool_registry_cache
+
+            clear_tool_registry_cache()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"app.tools.registry.clear_tool_registry_cache: {exc}")
+
+        try:
+            from app.cli.interactive_shell.cli_reference import invalidate_cli_reference_cache
+
+            invalidate_cli_reference_cache()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(
+                f"app.cli.interactive_shell.cli_reference.invalidate_cli_reference_cache: {exc}"
+            )
+
+    def _render_result(self, console: Console, result: ReloadResult) -> None:
+        if result.errors:
+            console.print()
+            console.print(
+                f"[{WARNING}]hot reload had {len(result.errors)} error(s); "
+                "continuing with the last usable code[/]"
+            )
+            for error in result.errors[:5]:
+                console.print(f"[{DIM}]- {escape(error)}[/]")
+            return
+        if result.reloaded_modules:
+            console.print()
+            console.print(
+                f"[{DIM}]hot reload: reloaded {len(result.reloaded_modules)} module(s)[/]"
+            )

--- a/app/cli/interactive_shell/intent_parser.py
+++ b/app/cli/interactive_shell/intent_parser.py
@@ -124,6 +124,13 @@ SYNTHETIC_RDS_TEST_RE = re.compile(
     r"(?:.{0,80}?\b(?:r\s*d\s*s|postgres(?:ql)?|database|db)\b)?",
     re.IGNORECASE | re.DOTALL,
 )
+TASK_CANCEL_TRIGGER_RE = re.compile(r"\b(?:abort|cancel|kill|stop|terminate)\b", re.IGNORECASE)
+TASK_CANCEL_ID_RE = re.compile(r"\b(?P<task_id>[0-9a-f]{4,16})\b", re.IGNORECASE)
+TASK_CANCEL_SYNTHETIC_RE = re.compile(
+    r"\b(?:synthetic|syntehtic)(?:[_\s-]?tests?)?\b|\bbenchmark\b",
+    re.IGNORECASE,
+)
+TASK_CANCEL_GENERIC_RE = re.compile(r"\b(?:job|process|run|task|work)\b", re.IGNORECASE)
 IMPLEMENTATION_RE = re.compile(
     r"^\s*(?:please\s+)?(?:can\s+you\s+)?"
     r"(?:(?:use|launch|run)\s+claude(?:\s+code)?\s+(?:to\s+)?)?"
@@ -222,6 +229,10 @@ def synthetic_test_action(suite_name: str, position: int) -> PlannedAction:
     return PlannedAction(kind="synthetic_test", content=suite_name, position=position)
 
 
+def task_cancel_action(target: str, position: int) -> PlannedAction:
+    return PlannedAction(kind="task_cancel", content=target, position=position)
+
+
 def implementation_action(request: str, position: int) -> PlannedAction:
     return PlannedAction(kind="implementation", content=request, position=position)
 
@@ -304,6 +315,28 @@ def extract_shell_command(clause: PromptClause) -> PlannedAction | None:
     return None
 
 
+def extract_task_cancel_request(clause: PromptClause) -> PlannedAction | None:
+    trigger = TASK_CANCEL_TRIGGER_RE.search(clause.text)
+    if trigger is None:
+        return None
+
+    task_id = TASK_CANCEL_ID_RE.search(clause.text)
+    if task_id is not None:
+        return task_cancel_action(
+            task_id.group("task_id").lower(), clause.position + task_id.start()
+        )
+
+    synthetic = TASK_CANCEL_SYNTHETIC_RE.search(clause.text)
+    if synthetic is not None:
+        return task_cancel_action("synthetic_test", clause.position + synthetic.start())
+
+    generic = TASK_CANCEL_GENERIC_RE.search(clause.text)
+    if generic is not None:
+        return task_cancel_action("task", clause.position + generic.start())
+
+    return None
+
+
 def extract_implementation_request(clause: PromptClause) -> PlannedAction | None:
     match = IMPLEMENTATION_RE.match(clause.text)
     if match is None:
@@ -359,6 +392,7 @@ __all__ = [
     "extract_implementation_request",
     "extract_llm_provider_switch",
     "extract_shell_command",
+    "extract_task_cancel_request",
     "implementation_action",
     "looks_like_direct_shell_command",
     "sample_alert_action",
@@ -366,4 +400,5 @@ __all__ = [
     "shell_action",
     "split_prompt_clauses",
     "synthetic_test_action",
+    "task_cancel_action",
 ]

--- a/app/cli/interactive_shell/intent_parser.py
+++ b/app/cli/interactive_shell/intent_parser.py
@@ -130,6 +130,7 @@ TASK_CANCEL_SYNTHETIC_RE = re.compile(
     r"\b(?:synthetic|syntehtic)(?:[_\s-]?tests?)?\b|\bbenchmark\b",
     re.IGNORECASE,
 )
+TASK_CANCEL_GENERIC_TRIGGER_RE = re.compile(r"\b(?:abort|cancel)\b", re.IGNORECASE)
 TASK_CANCEL_GENERIC_RE = re.compile(r"\b(?:job|process|run|task|work)\b", re.IGNORECASE)
 IMPLEMENTATION_RE = re.compile(
     r"^\s*(?:please\s+)?(?:can\s+you\s+)?"
@@ -330,8 +331,9 @@ def extract_task_cancel_request(clause: PromptClause) -> PlannedAction | None:
     if synthetic is not None:
         return task_cancel_action("synthetic_test", clause.position + synthetic.start())
 
+    generic_trigger = TASK_CANCEL_GENERIC_TRIGGER_RE.search(clause.text)
     generic = TASK_CANCEL_GENERIC_RE.search(clause.text)
-    if generic is not None:
+    if generic_trigger is not None and generic is not None:
         return task_cancel_action("task", clause.position + generic.start())
 
     return None

--- a/app/cli/interactive_shell/interaction_models.py
+++ b/app/cli/interactive_shell/interaction_models.py
@@ -16,6 +16,7 @@ class PlannedAction:
         "shell",
         "sample_alert",
         "synthetic_test",
+        "task_cancel",
         "cli_command",
         "implementation",
     ]

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -34,6 +34,12 @@ from app.cli.support.exception_reporting import report_exception
 from app.cli.support.prompt_support import repl_prompt_note_ctrl_c, repl_reset_ctrl_c_gate
 from app.llm_reasoning_effort import apply_reasoning_effort
 
+_build_prompt_session = _prompt_surface._build_prompt_session
+_prompt_message = _prompt_surface._prompt_message
+route_input = _router.route_input
+answer_cli_help = _cli_help.answer_cli_help
+dispatch_slash = _commands.dispatch_slash
+
 _INTERVENTION_CORRECTION_RE = re.compile(
     r"("
     r"no(?=[,.!?]|$)"
@@ -140,7 +146,7 @@ async def _run_one_turn(
     while True:
         try:
             with patch_stdout(raw=True):
-                text = await prompt.prompt_async(lambda: _prompt_surface._prompt_message(session))
+                text = await prompt.prompt_async(lambda: _prompt_message(session))
         except EOFError:
             console.print()
             return False
@@ -158,7 +164,7 @@ async def _run_one_turn(
 
     _prompt_surface.render_submitted_prompt(console, session, text)
 
-    decision = _router.route_input(text, session)
+    decision = route_input(text, session)
     kind = decision.route_kind.value
     session.last_route_decision = decision
     get_analytics().capture(
@@ -171,7 +177,7 @@ async def _run_one_turn(
         # Rewrite bare-word commands to their slash form before dispatch.
         cmd_text = text if text.startswith("/") else f"/{text}"
         try:
-            should_continue = _commands.dispatch_slash(cmd_text, session, console)
+            should_continue = dispatch_slash(cmd_text, session, console)
         except Exception as exc:
             report_exception(exc, context="interactive_shell.slash_dispatch")
             console.print(
@@ -183,7 +189,7 @@ async def _run_one_turn(
 
     if kind == "cli_help":
         with apply_reasoning_effort(session.reasoning_effort):
-            _cli_help.answer_cli_help(text, session, console)
+            answer_cli_help(text, session, console)
         session.record("cli_help", text)
         return True
 
@@ -239,7 +245,7 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
     cfg = _config or ReplConfig.load()
     session = ReplSession()
     session.task_registry = TaskRegistry.persistent()
-    prompt = _prompt_surface._build_prompt_session()
+    prompt = _build_prompt_session()
     session.prompt_history_backend = prompt.history
     hot_reloader = HotReloadCoordinator() if cfg.reload else None
 
@@ -253,7 +259,7 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
                 continue
             _prompt_surface.render_submitted_prompt(console, session, stripped)
 
-            decision = _router.route_input(stripped, session)
+            decision = route_input(stripped, session)
             kind = decision.route_kind.value
             session.last_route_decision = decision
             get_analytics().capture(
@@ -262,12 +268,12 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
             )
             if kind == "slash":
                 cmd_text = stripped if stripped.startswith("/") else f"/{stripped}"
-                if not _commands.dispatch_slash(cmd_text, session, console):
+                if not dispatch_slash(cmd_text, session, console):
                     return 0
                 console.print()
             elif kind == "cli_help":
                 with apply_reasoning_effort(session.reasoning_effort):
-                    _cli_help.answer_cli_help(stripped, session, console)
+                    answer_cli_help(stripped, session, console)
                 session.record("cli_help", stripped)
             elif kind == "cli_agent":
                 turn = _agent_actions.execute_cli_actions_with_metrics(stripped, session, console)

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -16,20 +16,18 @@ from app.agents.sweep import run_startup_sweep
 from app.analytics.cli import capture_terminal_turn_summarized
 from app.analytics.events import Event
 from app.analytics.provider import get_analytics
-from app.cli.interactive_shell.agent_actions import execute_cli_actions_with_metrics
+from app.cli.interactive_shell import agent_actions as _agent_actions
+from app.cli.interactive_shell import cli_agent as _cli_agent
+from app.cli.interactive_shell import cli_help as _cli_help
+from app.cli.interactive_shell import commands as _commands
+from app.cli.interactive_shell import follow_up as _follow_up
+from app.cli.interactive_shell import prompt_surface as _prompt_surface
+from app.cli.interactive_shell import router as _router
 from app.cli.interactive_shell.banner import render_banner
-from app.cli.interactive_shell.cli_agent import answer_cli_agent
-from app.cli.interactive_shell.cli_help import answer_cli_help
-from app.cli.interactive_shell.commands import dispatch_slash
 from app.cli.interactive_shell.config import ReplConfig
-from app.cli.interactive_shell.follow_up import answer_follow_up
-from app.cli.interactive_shell.prompt_surface import (
-    _build_prompt_session,
-    _prompt_message,
-    render_submitted_prompt,
-)
-from app.cli.interactive_shell.router import route_input
+from app.cli.interactive_shell.hot_reload import HotReloadCoordinator
 from app.cli.interactive_shell.session import ReplSession
+from app.cli.interactive_shell.tasks import TaskRegistry
 from app.cli.interactive_shell.theme import DIM, ERROR, WARNING
 from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
@@ -91,7 +89,7 @@ def _run_new_alert(
         session.record("alert", text, ok=False)
         return
 
-    task = session.task_registry.create(TaskKind.INVESTIGATION)
+    task = session.task_registry.create(TaskKind.INVESTIGATION, command="free-text investigation")
     task.mark_running()
     try:
         with apply_reasoning_effort(session.reasoning_effort):
@@ -133,12 +131,16 @@ async def _run_one_turn(
     prompt: PromptSession[str],
     session: ReplSession,
     console: Console,
+    hot_reloader: HotReloadCoordinator | None = None,
 ) -> bool:
     """Read one line of input and dispatch. Returns False to exit."""
+    if hot_reloader is not None:
+        hot_reloader.check_and_reload(console)
+
     while True:
         try:
             with patch_stdout(raw=True):
-                text = await prompt.prompt_async(lambda: _prompt_message(session))
+                text = await prompt.prompt_async(lambda: _prompt_surface._prompt_message(session))
         except EOFError:
             console.print()
             return False
@@ -154,9 +156,9 @@ async def _run_one_turn(
     if not text:
         return True
 
-    render_submitted_prompt(console, session, text)
+    _prompt_surface.render_submitted_prompt(console, session, text)
 
-    decision = route_input(text, session)
+    decision = _router.route_input(text, session)
     kind = decision.route_kind.value
     session.last_route_decision = decision
     get_analytics().capture(
@@ -169,7 +171,7 @@ async def _run_one_turn(
         # Rewrite bare-word commands to their slash form before dispatch.
         cmd_text = text if text.startswith("/") else f"/{text}"
         try:
-            should_continue = dispatch_slash(cmd_text, session, console)
+            should_continue = _commands.dispatch_slash(cmd_text, session, console)
         except Exception as exc:
             report_exception(exc, context="interactive_shell.slash_dispatch")
             console.print(
@@ -181,12 +183,12 @@ async def _run_one_turn(
 
     if kind == "cli_help":
         with apply_reasoning_effort(session.reasoning_effort):
-            answer_cli_help(text, session, console)
+            _cli_help.answer_cli_help(text, session, console)
         session.record("cli_help", text)
         return True
 
     if kind == "cli_agent":
-        turn = execute_cli_actions_with_metrics(text, session, console)
+        turn = _agent_actions.execute_cli_actions_with_metrics(text, session, console)
         fallback_to_llm = not turn.handled
         snapshot = session.record_terminal_turn(
             executed_count=turn.executed_count,
@@ -206,7 +208,7 @@ async def _run_one_turn(
         if turn.handled:
             return True
         with apply_reasoning_effort(session.reasoning_effort):
-            answer_cli_agent(text, session, console)
+            _cli_agent.answer_cli_agent(text, session, console)
         session.record("cli_agent", text)
         return True
 
@@ -216,7 +218,7 @@ async def _run_one_turn(
 
     # follow_up — grounded answer against session.last_state
     with apply_reasoning_effort(session.reasoning_effort):
-        answer_follow_up(text, session, console)
+        _follow_up.answer_follow_up(text, session, console)
     session.record("follow_up", text)
     return True
 
@@ -234,19 +236,24 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
     # first ``/agents`` call. Errors are caught inside; a sweep failure
     # must never prevent the REPL from starting.
     run_startup_sweep()
+    cfg = _config or ReplConfig.load()
     session = ReplSession()
-    prompt = _build_prompt_session()
+    session.task_registry = TaskRegistry.persistent()
+    prompt = _prompt_surface._build_prompt_session()
     session.prompt_history_backend = prompt.history
+    hot_reloader = HotReloadCoordinator() if cfg.reload else None
 
     # Allow a single pre-seeded input for test harnesses
     if initial_input:
         for line in initial_input.splitlines():
+            if hot_reloader is not None:
+                hot_reloader.check_and_reload(console)
             stripped = line.strip()
             if not stripped:
                 continue
-            render_submitted_prompt(console, session, stripped)
+            _prompt_surface.render_submitted_prompt(console, session, stripped)
 
-            decision = route_input(stripped, session)
+            decision = _router.route_input(stripped, session)
             kind = decision.route_kind.value
             session.last_route_decision = decision
             get_analytics().capture(
@@ -255,15 +262,15 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
             )
             if kind == "slash":
                 cmd_text = stripped if stripped.startswith("/") else f"/{stripped}"
-                if not dispatch_slash(cmd_text, session, console):
+                if not _commands.dispatch_slash(cmd_text, session, console):
                     return 0
                 console.print()
             elif kind == "cli_help":
                 with apply_reasoning_effort(session.reasoning_effort):
-                    answer_cli_help(stripped, session, console)
+                    _cli_help.answer_cli_help(stripped, session, console)
                 session.record("cli_help", stripped)
             elif kind == "cli_agent":
-                turn = execute_cli_actions_with_metrics(stripped, session, console)
+                turn = _agent_actions.execute_cli_actions_with_metrics(stripped, session, console)
                 fallback_to_llm = not turn.handled
                 snapshot = session.record_terminal_turn(
                     executed_count=turn.executed_count,
@@ -282,17 +289,17 @@ async def _repl_main(initial_input: str | None = None, _config: ReplConfig | Non
                 )
                 if not turn.handled:
                     with apply_reasoning_effort(session.reasoning_effort):
-                        answer_cli_agent(stripped, session, console)
+                        _cli_agent.answer_cli_agent(stripped, session, console)
                     session.record("cli_agent", stripped)
             elif kind == "new_alert":
                 _run_new_alert(stripped, session, console)
             else:
                 with apply_reasoning_effort(session.reasoning_effort):
-                    answer_follow_up(stripped, session, console)
+                    _follow_up.answer_follow_up(stripped, session, console)
                 session.record("follow_up", stripped)
 
     while True:
-        should_continue = await _run_one_turn(prompt, session, console)
+        should_continue = await _run_one_turn(prompt, session, console, hot_reloader)
         if not should_continue:
             return 0
 

--- a/app/cli/interactive_shell/rendering.py
+++ b/app/cli/interactive_shell/rendering.py
@@ -127,6 +127,7 @@ def print_planned_actions(console: Console, actions: list[PlannedAction]) -> Non
             "shell": "shell",
             "slash": "command",
             "synthetic_test": "synthetic test",
+            "task_cancel": "cancel task",
             "cli_command": "opensre",
             "implementation": "implementation",
         }[action.kind]

--- a/app/cli/interactive_shell/session.py
+++ b/app/cli/interactive_shell/session.py
@@ -134,7 +134,7 @@ class ReplSession:
         self.accumulated_context.clear()
         self.token_usage.clear()
         self.cli_agent_messages.clear()
-        self.task_registry = TaskRegistry()
+        self.task_registry.clear()
 
         self.terminal_turn_count = 0
         self.terminal_fallback_count = 0

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -123,11 +123,10 @@ class TaskRecord:
             self._cancel_requested.set()
             proc = self._process
             pid = self.pid
-            rehydrated = self._rehydrated
         if proc is not None and proc.poll() is None:
             with contextlib.suppress(OSError):
                 proc.terminate()
-        elif was_active and pid is not None and rehydrated:
+        elif was_active and pid is not None:
             mark_cancelled_without_watcher = True
         if mark_cancelled_without_watcher:
             self.mark_cancelled()

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -3,17 +3,25 @@
 from __future__ import annotations
 
 import contextlib
+import json
+import os
 import secrets
+import signal
 import threading
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 from subprocess import Popen
 from typing import Any
 
+import app.constants as const_module
+
 _TASK_ID_BYTES = 4
 _MAX_REGISTRY = 100
+_TASKS_STORE_FILENAME = "interactive_tasks.json"
 
 
 class TaskStatus(StrEnum):
@@ -42,11 +50,19 @@ class TaskRecord:
     ended_at: float | None = None
     result: str | None = None
     error: str | None = None
+    pid: int | None = None
+    command: str | None = None
     _cancel_requested: threading.Event = field(
         default_factory=threading.Event, repr=False, init=False
     )
     _process: Popen[Any] | None = field(default=None, repr=False, init=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, init=False)
+    _on_change: Callable[[], None] | None = field(default=None, repr=False, init=False)
+    _rehydrated: bool = field(default=False, repr=False, init=False)
+
+    def _notify_changed(self) -> None:
+        if self._on_change is not None:
+            self._on_change()
 
     @property
     def cancel_requested(self) -> threading.Event:
@@ -57,12 +73,22 @@ class TaskRecord:
         """Bind a child process so :meth:`request_cancel` can terminate it."""
         with self._lock:
             self._process = proc
+            pid = getattr(proc, "pid", None)
+            self.pid = pid if isinstance(pid, int) else None
+        self._notify_changed()
+
+    def attach_pid(self, pid: int | None) -> None:
+        """Bind a previously-started process id without a live ``Popen`` object."""
+        with self._lock:
+            self.pid = pid
+        self._notify_changed()
 
     def mark_running(self) -> None:
         with self._lock:
             if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
                 return
             self.status = TaskStatus.RUNNING
+        self._notify_changed()
 
     def mark_completed(self, *, result: str | None = None) -> None:
         with self._lock:
@@ -71,6 +97,7 @@ class TaskRecord:
             self.status = TaskStatus.COMPLETED
             self.result = result
             self.ended_at = time.time()
+        self._notify_changed()
 
     def mark_cancelled(self) -> None:
         with self._lock:
@@ -78,6 +105,7 @@ class TaskRecord:
                 return
             self.status = TaskStatus.CANCELLED
             self.ended_at = time.time()
+        self._notify_changed()
 
     def mark_failed(self, message: str) -> None:
         with self._lock:
@@ -86,16 +114,27 @@ class TaskRecord:
             self.status = TaskStatus.FAILED
             self.error = message
             self.ended_at = time.time()
+        self._notify_changed()
 
     def request_cancel(self) -> bool:
         """Signal cancellation and kill a bound subprocess. Returns True if task was running."""
+        mark_cancelled_without_watcher = False
         with self._lock:
             was_active = self.status == TaskStatus.RUNNING
             self._cancel_requested.set()
             proc = self._process
+            pid = self.pid
         if proc is not None and proc.poll() is None:
             with contextlib.suppress(OSError):
                 proc.terminate()
+        elif was_active and pid is not None and _process_alive(pid):
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGTERM)
+                mark_cancelled_without_watcher = True
+        if mark_cancelled_without_watcher:
+            self.mark_cancelled()
+        else:
+            self._notify_changed()
         return was_active
 
     def duration_seconds(self) -> float | None:
@@ -103,22 +142,155 @@ class TaskRecord:
             return None
         return self.ended_at - self.started_at
 
+    def refresh_rehydrated_status(self) -> None:
+        """Mark persisted running tasks as finished once their PID disappears."""
+        with self._lock:
+            if (
+                not self._rehydrated
+                or self.status != TaskStatus.RUNNING
+                or self._process is not None
+            ):
+                return
+            if self.pid is not None and _process_alive(self.pid):
+                return
+            self.status = TaskStatus.COMPLETED
+            self.result = self.result or "process exited while shell was closed"
+            self.ended_at = time.time()
+        self._notify_changed()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "task_id": self.task_id,
+            "kind": self.kind.value,
+            "status": self.status.value,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "result": self.result,
+            "error": self.error,
+            "pid": self.pid,
+            "command": self.command,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> TaskRecord | None:
+        try:
+            task_id = str(data["task_id"])
+            kind = TaskKind(str(data["kind"]))
+            status = TaskStatus(str(data["status"]))
+            started_at_value = data["started_at"]
+            if not isinstance(started_at_value, int | float | str):
+                return None
+            started_at = float(started_at_value)
+        except (KeyError, TypeError, ValueError):
+            return None
+
+        ended_at_value = data.get("ended_at")
+        pid_value = data.get("pid")
+        record = cls(
+            task_id=task_id,
+            kind=kind,
+            status=status,
+            started_at=started_at,
+            ended_at=float(ended_at_value) if isinstance(ended_at_value, int | float) else None,
+            result=str(data["result"]) if data.get("result") is not None else None,
+            error=str(data["error"]) if data.get("error") is not None else None,
+            pid=int(pid_value) if isinstance(pid_value, int) else None,
+            command=str(data["command"]) if data.get("command") is not None else None,
+        )
+        record._rehydrated = True
+        return record
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _tasks_store_path() -> Path:
+    return const_module.OPENSRE_HOME_DIR / _TASKS_STORE_FILENAME
+
 
 class TaskRegistry:
-    """Recent tasks for /tasks and /cancel (ring buffer, in-process only)."""
+    """Recent tasks for /tasks and /cancel, optionally persisted across REPL sessions."""
 
-    def __init__(self, *, max_tasks: int = _MAX_REGISTRY) -> None:
+    def __init__(
+        self,
+        *,
+        max_tasks: int = _MAX_REGISTRY,
+        persist_path: Path | None = None,
+        load: bool = False,
+    ) -> None:
         self._tasks: deque[TaskRecord] = deque(maxlen=max_tasks)
         self._lock = threading.Lock()
+        self._persist_path = persist_path
+        self._max_tasks = max_tasks
+        if load:
+            self._load_persisted()
 
-    def create(self, kind: TaskKind) -> TaskRecord:
+    @classmethod
+    def persistent(cls, *, max_tasks: int = _MAX_REGISTRY) -> TaskRegistry:
+        return cls(max_tasks=max_tasks, persist_path=_tasks_store_path(), load=True)
+
+    def _attach(self, record: TaskRecord) -> TaskRecord:
+        record._on_change = self._persist
+        return record
+
+    def _load_persisted(self) -> None:
+        if self._persist_path is None or not self._persist_path.exists():
+            return
+        try:
+            payload = json.loads(self._persist_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, list):
+            return
+        records = [
+            self._attach(record)
+            for item in payload
+            if isinstance(item, dict)
+            if (record := TaskRecord.from_dict(item)) is not None
+        ]
+        for record in records[-self._max_tasks :]:
+            record.refresh_rehydrated_status()
+            self._tasks.append(record)
+        self._persist()
+
+    def _persist(self) -> None:
+        if self._persist_path is None:
+            return
+        with self._lock:
+            payload = [task.to_dict() for task in self._tasks]
+        try:
+            self._persist_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            tmp_path = self._persist_path.with_suffix(f"{self._persist_path.suffix}.tmp")
+            tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+            tmp_path.replace(self._persist_path)
+        except OSError:
+            return
+
+    def _refresh_rehydrated(self) -> None:
+        with self._lock:
+            items = list(self._tasks)
+        for task in items:
+            task.refresh_rehydrated_status()
+
+    def create(self, kind: TaskKind, *, command: str | None = None) -> TaskRecord:
         task_id = secrets.token_hex(_TASK_ID_BYTES)
-        record = TaskRecord(task_id=task_id, kind=kind)
+        record = self._attach(TaskRecord(task_id=task_id, kind=kind, command=command))
         with self._lock:
             self._tasks.append(record)
+        self._persist()
         return record
 
     def candidates(self, task_id_prefix: str) -> list[TaskRecord]:
+        self._refresh_rehydrated()
         needle = task_id_prefix.strip().lower()
         if not needle:
             return []
@@ -134,9 +306,15 @@ class TaskRegistry:
 
     def list_recent(self, n: int = 20) -> list[TaskRecord]:
         """Return up to ``n`` tasks, newer tasks first (FIFO buffer end is newest)."""
+        self._refresh_rehydrated()
         with self._lock:
             items = list(self._tasks)
         return list(reversed(items[-n:]))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._tasks.clear()
+        self._persist()
 
     def __contains__(self, task_id: str) -> bool:
         return self.get(task_id) is not None

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -6,7 +6,6 @@ import contextlib
 import json
 import os
 import secrets
-import signal
 import threading
 import time
 from collections import deque
@@ -130,10 +129,6 @@ class TaskRecord:
                 proc.terminate()
         elif was_active and pid is not None and rehydrated:
             mark_cancelled_without_watcher = True
-        elif was_active and pid is not None and _process_alive(pid):
-            with contextlib.suppress(OSError):
-                os.kill(pid, signal.SIGTERM)
-                mark_cancelled_without_watcher = True
         if mark_cancelled_without_watcher:
             self.mark_cancelled()
         else:
@@ -272,12 +267,18 @@ class TaskRegistry:
         with self._persist_lock:
             with self._lock:
                 payload = [task.to_dict() for task in self._tasks]
+            tmp_path: Path | None = None
             try:
                 self._persist_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-                tmp_path = self._persist_path.with_suffix(f"{self._persist_path.suffix}.tmp")
+                tmp_path = self._persist_path.with_name(
+                    f"{self._persist_path.name}.{threading.get_ident()}.{secrets.token_hex(4)}.tmp"
+                )
                 tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
                 tmp_path.replace(self._persist_path)
             except OSError:
+                if tmp_path is not None:
+                    with contextlib.suppress(OSError):
+                        tmp_path.unlink()
                 return
 
     def _refresh_rehydrated(self) -> None:

--- a/app/cli/interactive_shell/tasks.py
+++ b/app/cli/interactive_shell/tasks.py
@@ -124,9 +124,12 @@ class TaskRecord:
             self._cancel_requested.set()
             proc = self._process
             pid = self.pid
+            rehydrated = self._rehydrated
         if proc is not None and proc.poll() is None:
             with contextlib.suppress(OSError):
                 proc.terminate()
+        elif was_active and pid is not None and rehydrated:
+            mark_cancelled_without_watcher = True
         elif was_active and pid is not None and _process_alive(pid):
             with contextlib.suppress(OSError):
                 os.kill(pid, signal.SIGTERM)
@@ -229,6 +232,7 @@ class TaskRegistry:
     ) -> None:
         self._tasks: deque[TaskRecord] = deque(maxlen=max_tasks)
         self._lock = threading.Lock()
+        self._persist_lock = threading.Lock()
         self._persist_path = persist_path
         self._max_tasks = max_tasks
         if load:
@@ -265,15 +269,16 @@ class TaskRegistry:
     def _persist(self) -> None:
         if self._persist_path is None:
             return
-        with self._lock:
-            payload = [task.to_dict() for task in self._tasks]
-        try:
-            self._persist_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-            tmp_path = self._persist_path.with_suffix(f"{self._persist_path.suffix}.tmp")
-            tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-            tmp_path.replace(self._persist_path)
-        except OSError:
-            return
+        with self._persist_lock:
+            with self._lock:
+                payload = [task.to_dict() for task in self._tasks]
+            try:
+                self._persist_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                tmp_path = self._persist_path.with_suffix(f"{self._persist_path.suffix}.tmp")
+                tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+                tmp_path.replace(self._persist_path)
+            except OSError:
+                return
 
     def _refresh_rehydrated(self) -> None:
         with self._lock:

--- a/tests/cli/interactive_shell/test_action_planner.py
+++ b/tests/cli/interactive_shell/test_action_planner.py
@@ -46,6 +46,14 @@ def test_plan_task_cancel_before_shell_kill() -> None:
     assert plan_cli_actions(msg) == []
 
 
+def test_stop_process_prompt_is_not_task_cancel() -> None:
+    msg = "stop the process of auto-investigation and give me a manual runbook"
+    actions, unhandled = plan_actions_with_unhandled(msg)
+
+    assert actions == []
+    assert unhandled is True
+
+
 def test_plan_cli_actions_remote_deployment_inventory_questions() -> None:
     messages = (
         "Which remote deployments are connected?",

--- a/tests/cli/interactive_shell/test_action_planner.py
+++ b/tests/cli/interactive_shell/test_action_planner.py
@@ -36,6 +36,16 @@ def test_plan_terminal_tasks_returns_implementation_action() -> None:
     assert plan_cli_actions(msg) == []
 
 
+def test_plan_task_cancel_before_shell_kill() -> None:
+    msg = "kill the syntehtic_test because it is running way too long"
+    actions, unhandled = plan_actions_with_unhandled(msg)
+
+    assert not unhandled
+    assert [(a.kind, a.content) for a in actions] == [("task_cancel", "synthetic_test")]
+    assert plan_terminal_tasks(msg) == ["task_cancel"]
+    assert plan_cli_actions(msg) == []
+
+
 def test_plan_cli_actions_remote_deployment_inventory_questions() -> None:
     messages = (
         "Which remote deployments are connected?",

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -56,6 +56,13 @@ def test_generic_synthetic_test_request_plans_synthetic_action() -> None:
     assert plan_terminal_tasks("Can you run a synthetic test?") == ["synthetic_test"]
 
 
+def test_kill_synthetic_test_request_plans_cancel_action() -> None:
+    message = "kill the syntehtic_test because it is runnign way too long"
+
+    assert plan_terminal_tasks(message) == ["task_cancel"]
+    assert plan_cli_actions(message) == []
+
+
 def test_integration_prompt_plans_datadog_lookup_only() -> None:
     message = (
         "tell me about what the discord integration can do and then tell me what "
@@ -542,6 +549,39 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
     assert output.index("2.") < output.index("$ /list integrations")
     assert output.index("synthetic test") < output.index("$ opensre tests synthetic")
     assert output.index("$ /list integrations") < output.index("$ opensre tests synthetic")
+
+
+def test_execute_cli_actions_cancels_single_running_synthetic_task() -> None:
+    session = ReplSession()
+    session.trust_mode = True
+    task = session.task_registry.create(TaskKind.SYNTHETIC_TEST)
+    task.mark_running()
+    proc = MagicMock()
+    proc.poll.return_value = None
+    task.attach_process(proc)
+
+    console, buf = _capture()
+    handled = execute_cli_actions(
+        "kill the syntehtic_test because it is runnign way too long",
+        session,
+        console,
+    )
+
+    assert handled is True
+    assert task.cancel_requested.is_set()
+    proc.terminate.assert_called_once()
+    assert session.history == [
+        {
+            "type": "cli_agent",
+            "text": "kill the syntehtic_test because it is runnign way too long",
+            "ok": True,
+        },
+        {"type": "slash", "text": f"/cancel {task.task_id}", "ok": True},
+    ]
+    output = buf.getvalue()
+    assert "cancel task" in output
+    assert f"$ /cancel {task.task_id}" in output
+    assert "stop requested" in output
 
 
 def test_partial_match_reports_unhandled_clause(monkeypatch: object) -> None:

--- a/tests/cli/interactive_shell/test_command_registry.py
+++ b/tests/cli/interactive_shell/test_command_registry.py
@@ -23,7 +23,8 @@ from app.cli.interactive_shell.session import ReplSession
 
 
 def test_commands_shim_reexports_same_registry() -> None:
-    assert COMMANDS_EXPORT is SLASH_COMMANDS
+    assert COMMANDS_EXPORT["/help"] is SLASH_COMMANDS["/help"]
+    assert list(COMMANDS_EXPORT) == list(SLASH_COMMANDS)
 
 
 def _capture() -> tuple[Console, io.StringIO]:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -10,7 +10,9 @@ import pytest
 from prompt_toolkit.history import FileHistory
 from rich.console import Console
 
+from app.cli.interactive_shell import command_registry as registry_module
 from app.cli.interactive_shell.command_registry import repl_data as repl_data_module
+from app.cli.interactive_shell.command_registry import types as command_types
 from app.cli.interactive_shell.command_registry.investigation import (
     _validate_investigate_args,
     _validate_save_args,
@@ -156,6 +158,29 @@ class TestDispatchSlash:
     def test_local_llm_is_not_a_builtin_slash_action(self) -> None:
         assert "/local-llm" not in SLASH_COMMANDS
         assert "/local_llm" not in SLASH_COMMANDS
+
+    def test_slash_commands_proxy_reads_current_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        command = command_types.SlashCommand("/hot", "hot reload test", lambda *_args: True)
+        monkeypatch.setattr(registry_module, "SLASH_COMMANDS", {"/hot": command})
+
+        assert SLASH_COMMANDS.get("/hot") is command
+        assert list(SLASH_COMMANDS) == ["/hot"]
+
+    def test_dispatch_slash_proxy_calls_current_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+
+        def _fake_dispatch(command_line: str, *_args: object, **_kwargs: object) -> bool:
+            calls.append(command_line)
+            return False
+
+        monkeypatch.setattr(registry_module, "dispatch_slash", _fake_dispatch)
+
+        assert dispatch_slash("/hot", ReplSession(), _capture()[0]) is False
+        assert calls == ["/hot"]
 
     def test_empty_input_is_noop(self) -> None:
         session = ReplSession()

--- a/tests/cli/interactive_shell/test_config.py
+++ b/tests/cli/interactive_shell/test_config.py
@@ -60,6 +60,10 @@ class TestEnvVarResolution:
         monkeypatch.setenv("OPENSRE_RELOAD", "0")
         assert ReplConfig.load().reload is False
 
+    def test_opensre_reload_empty_disables_reload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSRE_RELOAD", "")
+        assert ReplConfig.load().reload is False
+
     def test_opensre_reload_1_enables_reload(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENSRE_RELOAD", "1")
         assert ReplConfig.load().reload is True

--- a/tests/cli/interactive_shell/test_config.py
+++ b/tests/cli/interactive_shell/test_config.py
@@ -18,6 +18,10 @@ class TestReplConfigDefaults:
         cfg = ReplConfig.load()
         assert cfg.layout == "classic"
 
+    def test_default_reload_is_true(self) -> None:
+        cfg = ReplConfig.load()
+        assert cfg.reload is True
+
 
 class TestEnvVarResolution:
     def test_opensre_interactive_0_disables_repl(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -48,6 +52,18 @@ class TestEnvVarResolution:
         monkeypatch.setenv("OPENSRE_LAYOUT", "fullscreen")
         assert ReplConfig.load().layout == "classic"
 
+    def test_opensre_reload_false_disables_reload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSRE_RELOAD", "false")
+        assert ReplConfig.load().reload is False
+
+    def test_opensre_reload_0_disables_reload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSRE_RELOAD", "0")
+        assert ReplConfig.load().reload is False
+
+    def test_opensre_reload_1_enables_reload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSRE_RELOAD", "1")
+        assert ReplConfig.load().reload is True
+
 
 class TestCliOverride:
     def test_cli_enabled_false_wins_over_env_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,6 +90,16 @@ class TestCliOverride:
         monkeypatch.setenv("OPENSRE_INTERACTIVE", "0")
         cfg = ReplConfig.load(cli_enabled=None)
         assert cfg.enabled is False
+
+    def test_cli_reload_false_wins_over_env_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSRE_RELOAD", "1")
+        cfg = ReplConfig.load(cli_reload=False)
+        assert cfg.reload is False
+
+    def test_cli_reload_none_does_not_override_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSRE_RELOAD", "false")
+        cfg = ReplConfig.load(cli_reload=None)
+        assert cfg.reload is False
 
 
 class TestFileResolution:
@@ -120,6 +146,26 @@ class TestFileResolution:
 
         cfg = ReplConfig.load()
         assert cfg.layout == "pinned"
+
+    def test_file_reload_false_is_read(
+        self, tmp_path: pytest.FixtureDef, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(
+            textwrap.dedent("""\
+                interactive:
+                  reload: false
+            """),
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("OPENSRE_RELOAD", raising=False)
+
+        import app.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+
+        cfg = ReplConfig.load()
+        assert cfg.reload is False
 
     def test_env_overrides_file(
         self, tmp_path: pytest.FixtureDef, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/interactive_shell/test_hot_reload.py
+++ b/tests/cli/interactive_shell/test_hot_reload.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib
+import io
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from app.cli.interactive_shell.hot_reload import HotReloadCoordinator
+
+
+def _console() -> tuple[Console, io.StringIO]:
+    buffer = io.StringIO()
+    return Console(file=buffer, force_terminal=False, highlight=False), buffer
+
+
+def _bump_mtime(path: Path) -> None:
+    stat = path.stat()
+    next_ns = stat.st_mtime_ns + 2_000_000_000
+    os.utime(path, ns=(next_ns, next_ns))
+
+
+def test_hot_reload_reloads_changed_loaded_module(tmp_path: Path) -> None:
+    package_dir = tmp_path / "demoapp"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    module_path = package_dir / "feature.py"
+    module_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        module = importlib.import_module("demoapp.feature")
+        assert module.VALUE == 1
+
+        coordinator = HotReloadCoordinator(
+            watch_root=package_dir,
+            package_prefix="demoapp",
+            dependent_modules=(),
+        )
+        module_path.write_text("VALUE = 2\n", encoding="utf-8")
+        _bump_mtime(module_path)
+        importlib.invalidate_caches()
+
+        console, _ = _console()
+        result = coordinator.check_and_reload(console)
+
+        assert result is not None
+        assert result.reloaded_modules == ("demoapp.feature",)
+        assert module.VALUE == 2
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("demoapp.feature", None)
+        sys.modules.pop("demoapp", None)
+
+
+def test_hot_reload_returns_none_when_unchanged(tmp_path: Path) -> None:
+    package_dir = tmp_path / "demoapp"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    coordinator = HotReloadCoordinator(
+        watch_root=package_dir,
+        package_prefix="demoapp",
+        dependent_modules=(),
+    )
+    console, _ = _console()
+
+    assert coordinator.check_and_reload(console) is None
+
+
+def test_hot_reload_reloads_changed_modules_before_dependents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_dir = tmp_path / "demoapp"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    changed_path = package_dir / "action_executor.py"
+    changed_path.write_text("VALUE = 1\n", encoding="utf-8")
+    (package_dir / "agent_actions.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        importlib.import_module("demoapp.action_executor")
+        importlib.import_module("demoapp.agent_actions")
+        coordinator = HotReloadCoordinator(
+            watch_root=package_dir,
+            package_prefix="demoapp",
+            dependent_modules=("demoapp.agent_actions",),
+        )
+        changed_path.write_text("VALUE = 2\n", encoding="utf-8")
+        _bump_mtime(changed_path)
+        reload_order: list[str] = []
+
+        def _fake_reload(module: object) -> object:
+            assert hasattr(module, "__name__")
+            reload_order.append(module.__name__)
+            return module
+
+        monkeypatch.setattr("app.cli.interactive_shell.hot_reload.importlib.reload", _fake_reload)
+
+        console, _ = _console()
+        result = coordinator.check_and_reload(console)
+
+        assert result is not None
+        assert reload_order == ["demoapp.action_executor", "demoapp.agent_actions"]
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("demoapp.action_executor", None)
+        sys.modules.pop("demoapp.agent_actions", None)
+        sys.modules.pop("demoapp", None)
+
+
+def test_hot_reload_reports_reload_errors(tmp_path: Path) -> None:
+    package_dir = tmp_path / "demoapp"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    module_path = package_dir / "broken.py"
+    module_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        importlib.import_module("demoapp.broken")
+        coordinator = HotReloadCoordinator(
+            watch_root=package_dir,
+            package_prefix="demoapp",
+            dependent_modules=(),
+        )
+        module_path.write_text("def nope(:\n", encoding="utf-8")
+        _bump_mtime(module_path)
+        importlib.invalidate_caches()
+
+        console, buffer = _console()
+        result = coordinator.check_and_reload(console)
+
+        assert result is not None
+        assert result.errors
+        assert "continuing with the last usable code" in buffer.getvalue()
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("demoapp.broken", None)
+        sys.modules.pop("demoapp", None)

--- a/tests/cli/interactive_shell/test_loop_hot_reload.py
+++ b/tests/cli/interactive_shell/test_loop_hot_reload.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.cli.interactive_shell import loop
+from app.cli.interactive_shell.config import ReplConfig
+
+
+def _patch_seeded_repl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(loop, "render_banner", lambda _console: None)
+    monkeypatch.setattr(loop, "run_startup_sweep", lambda: None)
+    monkeypatch.setattr(
+        loop._prompt_surface,
+        "_build_prompt_session",
+        lambda: SimpleNamespace(history=object()),
+    )
+    monkeypatch.setattr(loop._prompt_surface, "render_submitted_prompt", lambda *_args: None)
+    monkeypatch.setattr(
+        loop._router,
+        "route_input",
+        lambda *_args: SimpleNamespace(
+            route_kind=SimpleNamespace(value="slash"),
+            to_event_payload=lambda: {},
+        ),
+    )
+    monkeypatch.setattr(loop._commands, "dispatch_slash", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(loop, "get_analytics", lambda: SimpleNamespace(capture=lambda *_args: None))
+
+
+def test_repl_checks_hot_reload_for_seeded_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_seeded_repl(monkeypatch)
+    checks: list[int] = []
+
+    class _FakeHotReloadCoordinator:
+        def check_and_reload(self, _console: object) -> None:
+            checks.append(1)
+
+    monkeypatch.setattr(loop, "HotReloadCoordinator", _FakeHotReloadCoordinator)
+
+    exit_code = asyncio.run(loop._repl_main(initial_input="/exit", _config=ReplConfig(reload=True)))
+
+    assert exit_code == 0
+    assert checks == [1]
+
+
+def test_repl_skips_hot_reload_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_seeded_repl(monkeypatch)
+
+    class _FailingHotReloadCoordinator:
+        def __init__(self) -> None:
+            raise AssertionError("hot reload should be disabled")
+
+    monkeypatch.setattr(loop, "HotReloadCoordinator", _FailingHotReloadCoordinator)
+
+    exit_code = asyncio.run(
+        loop._repl_main(initial_input="/exit", _config=ReplConfig(reload=False))
+    )
+
+    assert exit_code == 0

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -167,7 +167,7 @@ class TestTaskRegistry:
         assert loaded.status == TaskStatus.COMPLETED
         assert loaded.result == "process exited while shell was closed"
 
-    def test_cancel_rehydrated_task_sends_sigterm(
+    def test_cancel_rehydrated_task_does_not_signal_pid(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -191,7 +191,7 @@ class TestTaskRegistry:
         assert loaded is not None
         assert loaded.request_cancel() is True
         assert loaded.status == TaskStatus.CANCELLED
-        assert calls[-1] == (12345, 15)
+        assert (12345, 15) not in calls
 
 
 class TestSlashTaskCommands:

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import io
+import json
+import os
 import tempfile
 from collections.abc import Callable, Iterator
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -105,6 +108,90 @@ class TestTaskRegistry:
         recent_ids = [t.task_id for t in reg.list_recent(10)]
         assert first.task_id not in recent_ids
         assert len(recent_ids) == 3
+
+    def test_persistent_registry_reloads_running_pid(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import app.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+        reg = TaskRegistry.persistent()
+        task = reg.create(TaskKind.SYNTHETIC_TEST, command="opensre tests synthetic")
+        task.mark_running()
+        task.attach_pid(os.getpid())
+
+        reloaded = TaskRegistry.persistent()
+        [loaded] = reloaded.list_recent()
+        assert loaded.task_id == task.task_id
+        assert loaded.status == TaskStatus.RUNNING
+        assert loaded.pid == os.getpid()
+        assert loaded.command == "opensre tests synthetic"
+
+    def test_persistent_registry_marks_missing_pid_finished(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import app.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+        store_path = tmp_path / "interactive_tasks.json"
+        store_path.parent.mkdir(parents=True, exist_ok=True)
+        store_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "task_id": "abc12345",
+                        "kind": "synthetic_test",
+                        "status": "running",
+                        "started_at": 1.0,
+                        "ended_at": None,
+                        "result": None,
+                        "error": None,
+                        "pid": 999_999,
+                        "command": "opensre tests synthetic",
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "app.cli.interactive_shell.tasks.os.kill",
+            lambda _pid, _sig: (_ for _ in ()).throw(ProcessLookupError()),
+        )
+
+        reloaded = TaskRegistry.persistent()
+        [loaded] = reloaded.list_recent()
+        assert loaded.status == TaskStatus.COMPLETED
+        assert loaded.result == "process exited while shell was closed"
+
+    def test_cancel_rehydrated_task_sends_sigterm(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import app.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+        calls: list[tuple[int, int]] = []
+
+        def _fake_kill(pid: int, sig: int) -> None:
+            calls.append((pid, sig))
+
+        monkeypatch.setattr("app.cli.interactive_shell.tasks.os.kill", _fake_kill)
+        reg = TaskRegistry.persistent()
+        task = reg.create(TaskKind.SYNTHETIC_TEST, command="opensre tests synthetic")
+        task.mark_running()
+        task.attach_pid(12345)
+
+        reloaded = TaskRegistry.persistent()
+        loaded = reloaded.get(task.task_id)
+        assert loaded is not None
+        assert loaded.request_cancel() is True
+        assert loaded.status == TaskStatus.CANCELLED
+        assert calls[-1] == (12345, 15)
 
 
 class TestSlashTaskCommands:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -501,4 +501,35 @@ def test_default_no_args_enters_repl(monkeypatch) -> None:
     assert load_calls[0].get("cli_enabled") is True, (
         f"default no-args run must pass cli_enabled=True, got {load_calls[0]}"
     )
+    assert load_calls[0].get("cli_reload") is None, (
+        f"default no-args run must leave reload env/config overridable, got {load_calls[0]}"
+    )
     assert landing_calls == [], "REPL should run, not landing page"
+
+
+def test_no_reload_flag_passes_reload_disabled(monkeypatch) -> None:
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("app.cli.__main__.sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("app.cli.__main__.sys.stdout.isatty", lambda: True)
+
+    load_calls: list[dict] = []
+
+    @classmethod  # type: ignore[misc]
+    def spy_load(_cls, **kw):  # type: ignore[no-untyped-def]
+        load_calls.append(kw)
+        return ReplConfig(enabled=True, layout="classic", reload=False)
+
+    monkeypatch.setattr("app.cli.interactive_shell.config.ReplConfig.load", spy_load)
+
+    with (
+        patch("app.cli.interactive_shell.run_repl", return_value=0),
+        patch("app.cli.interactive_shell.loop.run_repl", return_value=0),
+    ):
+        exit_code = main(["--no-reload"])
+
+    assert exit_code == 0
+    assert load_calls == [
+        {"cli_enabled": True, "cli_layout": None, "cli_reload": False},
+    ]

--- a/tests/synthetic/rds_postgres/_observations/.gitignore
+++ b/tests/synthetic/rds_postgres/_observations/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+@dataclass(frozen=True)
+class TrajectoryMetrics:
+    flat_actions: list[str]
+    actions_per_loop: list[int]
+    strict_match: bool | None
+    lcs_ratio: float | None
+    edit_distance: int | None
+    coverage: float | None
+    extra_actions: list[str]
+    missing_actions: list[str]
+    redundancy_count: int
+    loops_used: int
+    max_loops: int | None
+    loop_calibration_ok: bool | None
+    failed_action_count: int
+
+
+@dataclass(frozen=True)
+class RunObservation:
+    scenario_id: str
+    started_at: str
+    wall_time_s: float
+    suite: str
+    backend: str
+    score: dict[str, Any]
+    trajectory: TrajectoryMetrics
+    reasoning: dict[str, Any] | None
+    evidence_keys_present: list[str]
+    final_state_digest: str
+    observation_path: str = ""
+
+
+def lcs_length(a: list[str], b: list[str]) -> int:
+    if not a or not b:
+        return 0
+    rows = len(a) + 1
+    cols = len(b) + 1
+    dp = [[0] * cols for _ in range(rows)]
+    for i in range(1, rows):
+        for j in range(1, cols):
+            if a[i - 1] == b[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+    return dp[-1][-1]
+
+
+def edit_distance(a: list[str], b: list[str]) -> int:
+    rows = len(a) + 1
+    cols = len(b) + 1
+    dp = [[0] * cols for _ in range(rows)]
+    for i in range(rows):
+        dp[i][0] = i
+    for j in range(cols):
+        dp[0][j] = j
+
+    for i in range(1, rows):
+        for j in range(1, cols):
+            cost = 0 if a[i - 1] == b[j - 1] else 1
+            dp[i][j] = min(
+                dp[i - 1][j] + 1,
+                dp[i][j - 1] + 1,
+                dp[i - 1][j - 1] + cost,
+            )
+    return dp[-1][-1]
+
+
+def final_state_digest(final_state: dict[str, Any]) -> str:
+    canonical = json.dumps(final_state, sort_keys=True, separators=(",", ":"), default=str)
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _flatten_actions(executed_hypotheses: list[dict[str, Any]]) -> tuple[list[str], list[int], int]:
+    flat_actions: list[str] = []
+    actions_per_loop: list[int] = []
+    failed_action_count = 0
+
+    for hypothesis in executed_hypotheses:
+        actions = [str(action) for action in (hypothesis.get("actions") or [])]
+        flat_actions.extend(actions)
+        actions_per_loop.append(len(actions))
+        failed_action_count += len(hypothesis.get("failed_actions") or [])
+
+    return flat_actions, actions_per_loop, failed_action_count
+
+
+def _duplicate_count(items: list[str]) -> int:
+    counts = Counter(items)
+    return sum(count - 1 for count in counts.values() if count > 1)
+
+
+def _unique_in_order(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        ordered.append(item)
+    return ordered
+
+
+def compute_trajectory_metrics(
+    executed_hypotheses: list[dict[str, Any]],
+    golden: list[str],
+    loops_used: int,
+    max_loops: int | None,
+) -> TrajectoryMetrics:
+    flat_actions, actions_per_loop, failed_action_count = _flatten_actions(executed_hypotheses)
+
+    if not golden:
+        return TrajectoryMetrics(
+            flat_actions=flat_actions,
+            actions_per_loop=actions_per_loop,
+            strict_match=None,
+            lcs_ratio=None,
+            edit_distance=None,
+            coverage=None,
+            extra_actions=[],
+            missing_actions=[],
+            redundancy_count=_duplicate_count(flat_actions),
+            loops_used=loops_used,
+            max_loops=max_loops,
+            loop_calibration_ok=None if max_loops is None else loops_used <= max_loops,
+            failed_action_count=failed_action_count,
+        )
+
+    golden_set = set(golden)
+    actual_unique = _unique_in_order(flat_actions)
+    actual_set = set(actual_unique)
+    missing = [action for action in golden if action not in actual_set]
+    extra = [action for action in actual_unique if action not in golden_set]
+    lcs = lcs_length(flat_actions, golden)
+
+    return TrajectoryMetrics(
+        flat_actions=flat_actions,
+        actions_per_loop=actions_per_loop,
+        strict_match=flat_actions == golden,
+        lcs_ratio=lcs / len(golden),
+        edit_distance=edit_distance(flat_actions, golden),
+        coverage=len(golden_set & actual_set) / len(golden_set),
+        extra_actions=extra,
+        missing_actions=missing,
+        redundancy_count=_duplicate_count(flat_actions),
+        loops_used=loops_used,
+        max_loops=max_loops,
+        loop_calibration_ok=None if max_loops is None else loops_used <= max_loops,
+        failed_action_count=failed_action_count,
+    )
+
+
+def build_observation(
+    *,
+    scenario_id: str,
+    suite: str,
+    backend: str,
+    score: dict[str, Any],
+    reasoning: dict[str, Any] | None,
+    trajectory: TrajectoryMetrics,
+    final_state: dict[str, Any],
+    started_at: datetime,
+    wall_time_s: float,
+) -> RunObservation:
+    evidence = final_state.get("evidence") or {}
+    evidence_keys = sorted(str(key) for key in evidence if evidence.get(key))
+
+    return RunObservation(
+        scenario_id=scenario_id,
+        started_at=started_at.astimezone(UTC).isoformat(),
+        wall_time_s=round(wall_time_s, 3),
+        suite=suite,
+        backend=backend,
+        score=score,
+        trajectory=trajectory,
+        reasoning=reasoning,
+        evidence_keys_present=evidence_keys,
+        final_state_digest=final_state_digest(final_state),
+    )
+
+
+def write_observation(observation: RunObservation, observations_dir: Path) -> Path:
+    scenario_dir = observations_dir / observation.scenario_id
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    status = "pass" if bool(observation.score.get("passed")) else "fail"
+    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
+    target = scenario_dir / f"{stamp}__{status}.json"
+
+    payload = asdict(observation)
+    payload["observation_path"] = str(target.relative_to(observations_dir))
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    latest = scenario_dir / "latest.json"
+    latest.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target
+
+
+def _fmt_ratio(value: float | None) -> str:
+    return "-" if value is None else f"{value:.2f}"
+
+
+def _fmt_list(values: list[str]) -> str:
+    return "-" if not values else ", ".join(values)
+
+
+def render_report_to_console(observation: RunObservation, console: Console) -> None:
+    score = observation.score
+    passed = bool(score.get("passed"))
+    pass_label = Text("PASS" if passed else "FAIL", style="bold green" if passed else "bold red")
+    status_line = Text.assemble(
+        pass_label,
+        f"  category={score.get('actual_category', 'unknown')}",
+        f"  loops={observation.trajectory.loops_used}/{observation.trajectory.max_loops or '-'}",
+        f"  wall={observation.wall_time_s:.2f}s",
+    )
+
+    correctness = Table.grid(padding=(0, 2))
+    correctness.add_column(style="cyan", no_wrap=True)
+    correctness.add_column()
+
+    missing_keywords = score.get("missing_keywords") or []
+    matched_keywords = score.get("matched_keywords") or []
+    total_keywords = len(matched_keywords) + len(missing_keywords)
+
+    correctness.add_row("Required keywords", f"{len(matched_keywords)}/{total_keywords} matched")
+    correctness.add_row(
+        "Forbidden keywords",
+        "clear" if not score.get("failure_reason", "").startswith("forbidden keywords") else "hit",
+    )
+    correctness.add_row(
+        "Forbidden categories",
+        "clear" if not score.get("failure_reason", "").startswith("forbidden category") else "hit",
+    )
+    correctness.add_row("Evidence sources", _fmt_list(observation.evidence_keys_present))
+
+    trajectory = observation.trajectory
+    trajectory_table = Table.grid(padding=(0, 2))
+    trajectory_table.add_column(style="cyan", no_wrap=True)
+    trajectory_table.add_column()
+
+    score_trajectory = score.get("trajectory") or {}
+    golden = score_trajectory.get("expected_sequence") or []
+    trajectory_table.add_row("golden", " -> ".join(golden) if golden else "-")
+    trajectory_table.add_row("actual", _fmt_list(trajectory.flat_actions))
+    if trajectory.lcs_ratio is not None:
+        match_text = (
+            f"strict={trajectory.strict_match} "
+            f"(lcs={_fmt_ratio(trajectory.lcs_ratio)}, edit_distance={trajectory.edit_distance})"
+        )
+        trajectory_table.add_row("match", match_text)
+    trajectory_table.add_row("extras", _fmt_list(trajectory.extra_actions))
+    trajectory_table.add_row("missing", _fmt_list(trajectory.missing_actions))
+    trajectory_table.add_row("redundant", str(trajectory.redundancy_count))
+    trajectory_table.add_row("per-loop", str(trajectory.actions_per_loop))
+    trajectory_table.add_row("failed", str(trajectory.failed_action_count))
+
+    body = Group(
+        status_line,
+        Text(""),
+        Text("Correctness", style="bold cyan"),
+        correctness,
+        Text(""),
+        Text("Trajectory", style="bold cyan"),
+        trajectory_table,
+        Text(""),
+        Text(f"Observation: {observation.observation_path or '(not persisted)'}", style="dim"),
+    )
+    console.print(
+        Panel(
+            body,
+            title=f"Synthetic RDS Run - {observation.scenario_id}",
+            border_style="green" if passed else "red",
+        )
+    )
+
+
+def render_report_to_string(observation: RunObservation) -> str:
+    console = Console(record=True, width=120, color_system=None, highlight=False)
+    render_report_to_console(observation, console)
+    return console.export_text()

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from dataclasses import asdict, dataclass
+import time
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
+
+from rich.console import Console
 
 from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
+from tests.synthetic.rds_postgres.observations import (
+    build_observation,
+    compute_trajectory_metrics,
+    render_report_to_console,
+    write_observation,
+)
 from tests.synthetic.rds_postgres.scenario_loader import (
     SUITE_DIR,
     ScenarioFixture,
@@ -87,6 +98,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--axis2",
         action="store_true",
         help="Print Axis 1 vs Axis 2 gap report (requires results from both suites).",
+    )
+    report_group = parser.add_mutually_exclusive_group()
+    report_group.add_argument(
+        "--report",
+        action="store_true",
+        dest="report",
+        help="Print Rich observation report per scenario.",
+    )
+    report_group.add_argument(
+        "--no-report",
+        action="store_false",
+        dest="report",
+        help="Disable Rich observation report output.",
+    )
+    parser.set_defaults(report=None)
+    parser.add_argument(
+        "--observations-dir",
+        default=str(SUITE_DIR / "_observations"),
+        help="Directory where per-run observation JSON files are written.",
     )
     return parser.parse_args(argv)
 
@@ -467,6 +497,17 @@ def run_scenario(
     return state_dict, score_result(fixture, state_dict, queried_metrics=queried_metrics)
 
 
+def _resolved_golden_trajectory(fixture: ScenarioFixture) -> tuple[list[str], int | None]:
+    golden_cfg = fixture.answer_key.golden_trajectory or {}
+    ordered = golden_cfg.get("ordered_actions")
+    if isinstance(ordered, list) and ordered:
+        max_loops = golden_cfg.get("max_loops")
+        if isinstance(max_loops, int):
+            return [str(action) for action in ordered], max_loops
+        return [str(action) for action in ordered], fixture.answer_key.max_investigation_loops
+    return list(fixture.answer_key.optimal_trajectory), fixture.answer_key.max_investigation_loops
+
+
 def _print_gap_report(
     axis1_results: list[ScenarioScore],
     axis2_results: list[ScenarioScore],
@@ -514,10 +555,52 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
         if not fixtures:
             raise SystemExit(f"Unknown scenario: {args.scenario}")
 
+    observations_dir = Path(args.observations_dir)
+    should_report = bool(args.report) if args.report is not None else len(fixtures) == 1
+    if args.json:
+        should_report = False
+    report_console = Console(highlight=False, soft_wrap=True)
+
     results: list[ScenarioScore] = []
     for fixture in fixtures:
-        _, score = run_scenario(fixture, use_mock_grafana=args.mock_grafana)
+        started_at = datetime.now(UTC)
+        started_monotonic = time.monotonic()
+        final_state, score = run_scenario(fixture, use_mock_grafana=args.mock_grafana)
+        wall_time_s = time.monotonic() - started_monotonic
+
         results.append(score)
+
+        executed_hypotheses = final_state.get("executed_hypotheses") or []
+        loops_used = int(
+            final_state.get("investigation_loop_count") or len(executed_hypotheses)
+        )
+        golden_trajectory, max_loops = _resolved_golden_trajectory(fixture)
+        trajectory_metrics = compute_trajectory_metrics(
+            executed_hypotheses=executed_hypotheses,
+            golden=golden_trajectory,
+            loops_used=loops_used,
+            max_loops=max_loops,
+        )
+        observation = build_observation(
+            scenario_id=fixture.scenario_id,
+            suite="axis1",
+            backend="FixtureGrafanaBackend" if args.mock_grafana else "LiveGrafanaBackend",
+            score=asdict(score),
+            reasoning=asdict(score.reasoning) if score.reasoning is not None else None,
+            trajectory=trajectory_metrics,
+            final_state=final_state,
+            started_at=started_at,
+            wall_time_s=wall_time_s,
+        )
+        observation_path = write_observation(observation, observations_dir)
+        relative_observation_path = str(observation_path.relative_to(observations_dir))
+        observation_for_report = replace(
+            observation,
+            observation_path=relative_observation_path,
+        )
+
+        if should_report:
+            render_report_to_console(observation_for_report, report_console)
 
     if args.json:
         print(json.dumps([asdict(result) for result in results], indent=2))

--- a/tests/synthetic/rds_postgres/scenario_loader.py
+++ b/tests/synthetic/rds_postgres/scenario_loader.py
@@ -53,6 +53,7 @@ class ScenarioAnswerKey:
     max_investigation_loops: int = 1
     ruling_out_keywords: list[str] = ()  # type: ignore[assignment]
     required_queries: list[str] = ()  # type: ignore[assignment]
+    golden_trajectory: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -236,6 +237,11 @@ def _parse_answer_yaml(path: Path) -> ScenarioAnswerKey:
         max_investigation_loops=int(validated.get("max_investigation_loops") or 1),
         ruling_out_keywords=list(validated.get("ruling_out_keywords") or []),
         required_queries=list(validated.get("required_queries") or []),
+        golden_trajectory=(
+            dict(validated["golden_trajectory"])
+            if isinstance(validated.get("golden_trajectory"), dict)
+            else None
+        ),
     )
 
 

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from tests.synthetic.rds_postgres.observations import (
+    build_observation,
+    compute_trajectory_metrics,
+    edit_distance,
+    lcs_length,
+    render_report_to_string,
+    write_observation,
+)
+from tests.synthetic.rds_postgres.scenario_loader import load_all_scenarios
+
+
+def _sample_final_state() -> dict[str, Any]:
+    return {
+        "evidence": {
+            "grafana_metrics": [{"metric_name": "CPUUtilization"}],
+            "grafana_logs": [{"message": "replica lag detected"}],
+        },
+        "executed_hypotheses": [
+            {"actions": ["query_grafana_metrics", "query_grafana_logs"], "failed_actions": []}
+        ],
+        "investigation_loop_count": 1,
+        "root_cause": "Replication lag from write-heavy workload.",
+    }
+
+
+def _sample_score_payload() -> dict[str, Any]:
+    return {
+        "scenario_id": "001-replication-lag",
+        "passed": True,
+        "expected_category": "resource_exhaustion",
+        "actual_category": "resource_exhaustion",
+        "missing_keywords": [],
+        "matched_keywords": ["replication lag", "wal"],
+        "failure_reason": "",
+        "trajectory": {
+            "expected_sequence": [
+                "query_grafana_metrics",
+                "query_grafana_logs",
+                "query_grafana_alert_rules",
+            ]
+        },
+    }
+
+
+def test_lcs_length_and_edit_distance() -> None:
+    a = ["query_grafana_metrics", "query_grafana_logs", "query_grafana_alert_rules"]
+    b = ["query_grafana_metrics", "query_grafana_alert_rules"]
+    assert lcs_length(a, b) == 2
+    assert edit_distance(a, b) == 1
+
+
+def test_compute_trajectory_metrics_detects_missing_and_redundancy() -> None:
+    executed = [
+        {
+            "actions": [
+                "query_grafana_metrics",
+                "query_grafana_metrics",
+                "query_grafana_logs",
+            ],
+            "failed_actions": [],
+        }
+    ]
+    golden = [
+        "query_grafana_metrics",
+        "query_grafana_logs",
+        "query_grafana_alert_rules",
+    ]
+    metrics = compute_trajectory_metrics(
+        executed_hypotheses=executed,
+        golden=golden,
+        loops_used=1,
+        max_loops=4,
+    )
+    assert metrics.missing_actions == ["query_grafana_alert_rules"]
+    assert metrics.extra_actions == []
+    assert metrics.redundancy_count == 1
+    assert metrics.failed_action_count == 0
+    assert metrics.loop_calibration_ok is True
+
+
+def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
+    final_state = _sample_final_state()
+    score = _sample_score_payload()
+    trajectory = compute_trajectory_metrics(
+        executed_hypotheses=final_state["executed_hypotheses"],
+        golden=score["trajectory"]["expected_sequence"],
+        loops_used=1,
+        max_loops=4,
+    )
+    observation = build_observation(
+        scenario_id="001-replication-lag",
+        suite="axis1",
+        backend="FixtureGrafanaBackend",
+        score=score,
+        reasoning=None,
+        trajectory=trajectory,
+        final_state=final_state,
+        started_at=datetime.now(UTC),
+        wall_time_s=1.2,
+    )
+
+    output_path = write_observation(observation, tmp_path)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["scenario_id"] == "001-replication-lag"
+    assert payload["score"]["actual_category"] == "resource_exhaustion"
+    assert (tmp_path / "001-replication-lag" / "latest.json").exists()
+
+    report_text = render_report_to_string(observation)
+    assert "Synthetic RDS Run - 001-replication-lag" in report_text
+    assert "PASS" in report_text
+    assert "Trajectory" in report_text
+    assert "lcs=0.67" in report_text
+    assert "Observation:" in report_text
+
+
+def test_compute_trajectory_metrics_handles_all_rds_scenarios() -> None:
+    fixtures = load_all_scenarios()
+    for fixture in fixtures:
+        metrics = compute_trajectory_metrics(
+            executed_hypotheses=[],
+            golden=list(fixture.answer_key.optimal_trajectory),
+            loops_used=0,
+            max_loops=fixture.answer_key.max_investigation_loops,
+        )
+        assert metrics.loops_used == 0
+        assert metrics.actions_per_loop == []

--- a/tests/synthetic/schemas.py
+++ b/tests/synthetic/schemas.py
@@ -213,6 +213,16 @@ class AnswerKeySchema(TypedDict):
     required_queries: NotRequired[
         list[str]
     ]  # metric names agent must have specifically requested via query_timeseries
+    golden_trajectory: NotRequired[GoldenTrajectorySchema]
+
+
+class GoldenTrajectorySchema(TypedDict, total=False):
+    ordered_actions: list[str]
+    matching: str
+    max_edit_distance: int
+    max_extra_actions: int
+    max_redundancy: int
+    max_loops: int
 
 
 # ---------------------------------------------------------------------------
@@ -477,6 +487,40 @@ def validate_answer_key(data: dict[str, Any]) -> AnswerKeySchema:
         )
     for axis2_list_field in ("ruling_out_keywords", "required_queries"):
         _require_non_empty_str_list(data, axis2_list_field, "answer.yml")
+    golden = data.get("golden_trajectory")
+    if golden is not None:
+        if not isinstance(golden, dict):
+            raise ValueError("answer.yml: 'golden_trajectory' must be an object when present")
+        ordered_actions = golden.get("ordered_actions")
+        if ordered_actions is not None:
+            if (
+                not isinstance(ordered_actions, list)
+                or not ordered_actions
+                or not all(isinstance(action, str) and action.strip() for action in ordered_actions)
+            ):
+                raise ValueError(
+                    "answer.yml: 'golden_trajectory.ordered_actions' must be a non-empty list "
+                    "of strings when present"
+                )
+            unknown_actions = [a for a in ordered_actions if a not in VALID_TRAJECTORY_ACTIONS]
+            if unknown_actions:
+                raise ValueError(
+                    "answer.yml: unknown action(s) in golden_trajectory.ordered_actions "
+                    f"{unknown_actions}; expected subset of {sorted(VALID_TRAJECTORY_ACTIONS)}"
+                )
+        matching = golden.get("matching")
+        if matching is not None and matching not in {"strict", "lcs", "set"}:
+            raise ValueError(
+                "answer.yml: 'golden_trajectory.matching' must be one of "
+                "'strict', 'lcs', or 'set' when present"
+            )
+        for int_field in ("max_edit_distance", "max_extra_actions", "max_redundancy", "max_loops"):
+            value = golden.get(int_field)
+            if value is not None and (not isinstance(value, int) or value < 0):
+                raise ValueError(
+                    f"answer.yml: 'golden_trajectory.{int_field}' must be a non-negative integer "
+                    "when present"
+                )
     return data  # type: ignore[return-value]
 
 


### PR DESCRIPTION
## Summary
- add synthetic observation modeling and persistence (`RunObservation`, `TrajectoryMetrics`) with per-scenario JSON artifacts under `_observations/<scenario>/`
- extend synthetic scoring inputs with optional `golden_trajectory` schema/loading and fallback to existing `optimal_trajectory` for all current scenarios
- render a Rich report after synthetic runs (status, correctness, trajectory metrics, observation path) and plumb `--report/--no-report` plus `--observations-dir` through the CLI

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run pytest tests/synthetic/rds_postgres/test_observation_metrics.py -q`
- [x] `uv run opensre tests synthetic --scenario 001-replication-lag --mock-grafana`
- [x] `uv run opensre tests synthetic --scenario 005-failover --mock-grafana`
- [ ] `make test-cov` (currently failing due to unrelated existing failures in interactive-shell and smoke tests)

Made with [Cursor](https://cursor.com)