### PR TITLE
fix(ci): reformat run_suite.py to pass ruff format check

### DIFF
--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -571,9 +571,7 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
         results.append(score)
 
         executed_hypotheses = final_state.get("executed_hypotheses") or []
-        loops_used = int(
-            final_state.get("investigation_loop_count") or len(executed_hypotheses)
-        )
+        loops_used = int(final_state.get("investigation_loop_count") or len(executed_hypotheses))
         golden_trajectory, max_loops = _resolved_golden_trajectory(fixture)
         trajectory_metrics = compute_trajectory_metrics(
             executed_hypotheses=executed_hypotheses,


### PR DESCRIPTION
## Summary
- Collapses a multi-line `loops_used = int(...)` expression to a single line in `tests/synthetic/rds_postgres/run_suite.py`
- Unblocks the `quality` CI job (ruff format check was failing with exit code 1)
- All downstream test jobs (`test`, `test-kubernetes`, `test-thorough`) were blocked by this failure

## Test plan
- [ ] CI `quality` job passes (`ruff format --check` clean)
- [ ] Downstream test jobs unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)