### PR TITLE
fix(ci): format interactive shell session tests for main quality gate

### DIFF
--- a/tests/cli/interactive_shell/test_session.py
+++ b/tests/cli/interactive_shell/test_session.py
@@ -74,7 +74,9 @@ class TestReplSession:
         session = ReplSession()
         monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
         session.task_registry = TaskRegistry.persistent()
-        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST, command="opensre tests synthetic")
+        task = session.task_registry.create(
+            TaskKind.SYNTHETIC_TEST, command="opensre tests synthetic"
+        )
         task.mark_running()
 
         session.clear()


### PR DESCRIPTION
## Summary
- Apply Ruff formatting to `tests/cli/interactive_shell/test_session.py`.
- Resolve the `ruff format --check app/ tests/` failure currently red on `main`.

## Test plan
- [x] `make lint`
- [x] `make format-check`
- [x] `make typecheck`

Made with [Cursor](https://cursor.com)