### PR TITLE
Aggregate synthetic observation metrics agent branches

### DIFF
--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -21,6 +21,7 @@ from rich.markup import escape
 from rich.text import Text
 
 import app.cli.interactive_shell.intent_parser as _intent_parser
+from app.cli.interactive_shell.action_planner import DEFAULT_SYNTHETIC_SCENARIO
 from app.cli.interactive_shell.execution_policy import (
     evaluate_code_agent_launch,
     evaluate_investigation_launch,
@@ -50,7 +51,6 @@ _MAX_COMMAND_OUTPUT_CHARS = 24_000
 _SYNTHETIC_DIAG_CHARS = 2_000  # max stderr bytes captured from a failing synthetic run
 _SIGTERM_GRACE_SECONDS = 10  # wait for clean exit after SIGTERM before escalating to SIGKILL
 _TASK_OUTPUT_JOIN_TIMEOUT_SECONDS = 2
-_DEFAULT_SYNTHETIC_SCENARIO = "001-replication-lag"
 _SYNTHETIC_SCENARIO_ID_RE = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*$")
 _IMPLEMENT_PERMISSION_MODE_ENV = "CLAUDE_CODE_IMPLEMENT_PERMISSION_MODE"
 _DEFAULT_IMPLEMENT_PERMISSION_MODE = "acceptEdits"
@@ -990,7 +990,7 @@ def run_synthetic_test(
 ) -> None:
     suite_spec = suite_name.strip().lower()
     resolved_suite_name = ""
-    resolved_scenario = _DEFAULT_SYNTHETIC_SCENARIO
+    resolved_scenario = DEFAULT_SYNTHETIC_SCENARIO
     if suite_spec == "rds_postgres":
         resolved_suite_name = "rds_postgres"
     elif suite_spec.startswith("rds_postgres:"):

--- a/app/cli/interactive_shell/action_executor.py
+++ b/app/cli/interactive_shell/action_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -49,6 +50,8 @@ _MAX_COMMAND_OUTPUT_CHARS = 24_000
 _SYNTHETIC_DIAG_CHARS = 2_000  # max stderr bytes captured from a failing synthetic run
 _SIGTERM_GRACE_SECONDS = 10  # wait for clean exit after SIGTERM before escalating to SIGKILL
 _TASK_OUTPUT_JOIN_TIMEOUT_SECONDS = 2
+_DEFAULT_SYNTHETIC_SCENARIO = "001-replication-lag"
+_SYNTHETIC_SCENARIO_ID_RE = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*$")
 _IMPLEMENT_PERMISSION_MODE_ENV = "CLAUDE_CODE_IMPLEMENT_PERMISSION_MODE"
 _DEFAULT_IMPLEMENT_PERMISSION_MODE = "acceptEdits"
 
@@ -985,7 +988,17 @@ def run_synthetic_test(
     is_tty: bool | None = None,
     action_already_listed: bool = False,
 ) -> None:
-    if suite_name != "rds_postgres":
+    suite_spec = suite_name.strip().lower()
+    resolved_suite_name = ""
+    resolved_scenario = _DEFAULT_SYNTHETIC_SCENARIO
+    if suite_spec == "rds_postgres":
+        resolved_suite_name = "rds_postgres"
+    elif suite_spec.startswith("rds_postgres:"):
+        requested_scenario = suite_spec.split(":", 1)[1].strip()
+        if requested_scenario and _SYNTHETIC_SCENARIO_ID_RE.fullmatch(requested_scenario):
+            resolved_suite_name = "rds_postgres"
+            resolved_scenario = requested_scenario
+    if resolved_suite_name != "rds_postgres":
         console.print(f"[{ERROR}]unknown synthetic suite:[/] {escape(suite_name)}")
         session.record("synthetic_test", suite_name, ok=False)
         return
@@ -995,7 +1008,7 @@ def run_synthetic_test(
         policy,
         session=session,
         console=console,
-        action_summary="opensre tests synthetic",
+        action_summary=f"opensre tests synthetic --scenario {resolved_scenario}",
         confirm_fn=confirm_fn,
         is_tty=is_tty,
         action_already_listed=action_already_listed,
@@ -1003,7 +1016,7 @@ def run_synthetic_test(
         session.record("synthetic_test", suite_name, ok=False)
         return
 
-    display_command = "opensre tests synthetic"
+    display_command = f"opensre tests synthetic --scenario {resolved_scenario}"
     console.print(f"[bold]$ {display_command}[/bold]")
     task = session.task_registry.create(TaskKind.SYNTHETIC_TEST, command=display_command)
     task.mark_running()
@@ -1014,7 +1027,16 @@ def run_synthetic_test(
     )
     try:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "app.cli", "tests", "synthetic"],
+            [
+                sys.executable,
+                "-u",
+                "-m",
+                "app.cli",
+                "tests",
+                "synthetic",
+                "--scenario",
+                resolved_scenario,
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -1031,7 +1053,14 @@ def run_synthetic_test(
         return
 
     task.attach_process(proc)
-    watch_synthetic_subprocess(task, proc, session, suite_name, stderr_buf, console)
+    watch_synthetic_subprocess(
+        task,
+        proc,
+        session,
+        f"{resolved_suite_name}:{resolved_scenario}",
+        stderr_buf,
+        console,
+    )
     console.print(
         f"[{DIM}]synthetic test started — task[/] [bold]{escape(task.task_id)}[/bold]. "
         f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "

--- a/app/cli/interactive_shell/action_planner.py
+++ b/app/cli/interactive_shell/action_planner.py
@@ -24,6 +24,26 @@ from app.cli.interactive_shell.intent_parser import (
 from app.cli.interactive_shell.interaction_models import PlannedAction, PromptClause
 from app.cli.interactive_shell.terminal_intent import mentioned_integration_services
 
+_SYNTHETIC_SCENARIO_ID_RE = re.compile(
+    r"\b(?P<scenario>\d{3}-[a-z0-9][a-z0-9-]*)\b",
+    re.IGNORECASE,
+)
+_DEFAULT_SYNTHETIC_SCENARIO = "001-replication-lag"
+
+
+def _synthetic_action_content(clause: PromptClause, *, synthetic_start: int) -> tuple[str, int]:
+    scenario_match = _SYNTHETIC_SCENARIO_ID_RE.search(clause.text)
+    if scenario_match is None:
+        return (
+            f"rds_postgres:{_DEFAULT_SYNTHETIC_SCENARIO}",
+            clause.position + synthetic_start,
+        )
+    scenario_id = scenario_match.group("scenario").lower()
+    return (
+        f"rds_postgres:{scenario_id}",
+        clause.position + scenario_match.start("scenario"),
+    )
+
 
 def plan_clause_actions(
     clause: PromptClause,
@@ -93,9 +113,11 @@ def plan_clause_actions(
 
     synthetic_match = SYNTHETIC_RDS_TEST_RE.search(clause.text)
     if synthetic_match is not None:
-        planned.append(
-            synthetic_test_action("rds_postgres", clause.position + synthetic_match.start())
+        synthetic_content, synthetic_position = _synthetic_action_content(
+            clause,
+            synthetic_start=synthetic_match.start(),
         )
+        planned.append(synthetic_test_action(synthetic_content, synthetic_position))
         return planned
 
     sample_match = SAMPLE_ALERT_RE.search(clause.text)

--- a/app/cli/interactive_shell/action_planner.py
+++ b/app/cli/interactive_shell/action_planner.py
@@ -28,14 +28,14 @@ _SYNTHETIC_SCENARIO_ID_RE = re.compile(
     r"\b(?P<scenario>\d{3}-[a-z0-9][a-z0-9-]*)\b",
     re.IGNORECASE,
 )
-_DEFAULT_SYNTHETIC_SCENARIO = "001-replication-lag"
+DEFAULT_SYNTHETIC_SCENARIO = "001-replication-lag"
 
 
 def _synthetic_action_content(clause: PromptClause, *, synthetic_start: int) -> tuple[str, int]:
     scenario_match = _SYNTHETIC_SCENARIO_ID_RE.search(clause.text)
     if scenario_match is None:
         return (
-            f"rds_postgres:{_DEFAULT_SYNTHETIC_SCENARIO}",
+            f"rds_postgres:{DEFAULT_SYNTHETIC_SCENARIO}",
             clause.position + synthetic_start,
         )
     scenario_id = scenario_match.group("scenario").lower()

--- a/app/cli/interactive_shell/execution_policy.py
+++ b/app/cli/interactive_shell/execution_policy.py
@@ -169,8 +169,8 @@ def execution_allowed(
         )
     else:
         console.print(f"[{WARNING}]Confirm:[/] [{DIM}]{escape(reason)}[/]")
-    answer = confirm("Proceed? [y/N] ").strip().lower()
-    if answer not in {"y", "yes"}:
+    answer = confirm("Proceed? [Y/n] ").strip().lower()
+    if answer not in {"", "y", "yes"}:
         _emit_decision(
             action_type=result.action_type,
             policy_verdict="ask",

--- a/app/cli/interactive_shell/execution_policy.py
+++ b/app/cli/interactive_shell/execution_policy.py
@@ -169,8 +169,8 @@ def execution_allowed(
         )
     else:
         console.print(f"[{WARNING}]Confirm:[/] [{DIM}]{escape(reason)}[/]")
-    answer = confirm("Proceed? [Y/n] ").strip().lower()
-    if answer not in {"", "y", "yes"}:
+    answer = confirm("Proceed? [y/N] ").strip().lower()
+    if answer not in {"y", "yes"}:
         _emit_decision(
             action_type=result.action_type,
             policy_verdict="ask",

--- a/tests/cli/interactive_shell/test_action_executor.py
+++ b/tests/cli/interactive_shell/test_action_executor.py
@@ -541,6 +541,7 @@ def test_run_synthetic_test_streams_subprocess_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     popen_kwargs: list[dict[str, object]] = []
+    popen_commands: list[list[str]] = []
 
     class _FakeProcess:
         returncode = 0
@@ -550,7 +551,8 @@ def test_run_synthetic_test_streams_subprocess_output(
         def poll(self) -> int:
             return 0
 
-    def _fake_popen(_command: list[str], **kwargs: object) -> _FakeProcess:
+    def _fake_popen(command: list[str], **kwargs: object) -> _FakeProcess:
+        popen_commands.append(command)
         popen_kwargs.append(kwargs)
         return _FakeProcess()
 
@@ -572,6 +574,8 @@ def test_run_synthetic_test_streams_subprocess_output(
         is_tty=True,
     )
 
+    assert popen_commands[0][1] == "-u"
+    assert popen_commands[0][-2:] == ["--scenario", "001-replication-lag"]
     assert popen_kwargs[0]["stdout"] is not None
     assert popen_kwargs[0]["stderr"] is not None
     assert popen_kwargs[0]["text"] is True
@@ -581,3 +585,42 @@ def test_run_synthetic_test_streams_subprocess_output(
     assert "warning: slow cloudwatch response" in out
     task = session.task_registry.list_recent(1)[0]
     assert task.status == TaskStatus.COMPLETED
+
+
+def test_run_synthetic_test_honours_explicit_scenario(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    popen_commands: list[list[str]] = []
+
+    class _FakeProcess:
+        returncode = 0
+        stdout = io.StringIO("scenario run\n")
+        stderr = io.StringIO("")
+
+        def poll(self) -> int:
+            return 0
+
+    def _fake_popen(command: list[str], **_kwargs: object) -> _FakeProcess:
+        popen_commands.append(command)
+        return _FakeProcess()
+
+    monkeypatch.setattr("app.cli.interactive_shell.action_executor.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_synthetic_test(
+        "rds_postgres:005-failover",
+        session,
+        console,
+        confirm_fn=lambda _prompt: "y",
+        is_tty=True,
+    )
+
+    assert popen_commands[0][-2:] == ["--scenario", "005-failover"]
+    assert "opensre tests synthetic --scenario 005-failover" in buf.getvalue()

--- a/tests/cli/interactive_shell/test_action_planner.py
+++ b/tests/cli/interactive_shell/test_action_planner.py
@@ -26,6 +26,28 @@ def test_plan_terminal_tasks_returns_kinds() -> None:
     assert plan_terminal_tasks(msg) == ["slash", "slash"]
 
 
+def test_plan_synthetic_test_without_scenario_uses_default() -> None:
+    msg = "run a single synthetic test"
+    actions, unhandled = plan_actions_with_unhandled(msg)
+
+    assert not unhandled
+    assert [(a.kind, a.content) for a in actions] == [
+        ("synthetic_test", "rds_postgres:001-replication-lag")
+    ]
+
+
+def test_plan_synthetic_test_with_explicit_scenario_id() -> None:
+    msg = "run synthetic test 005-failover"
+    actions, unhandled = plan_actions_with_unhandled(msg)
+
+    assert not unhandled
+    assert [(a.kind, a.content) for a in actions] == [
+        ("synthetic_test", "rds_postgres:005-failover")
+    ]
+    assert plan_terminal_tasks(msg) == ["synthetic_test"]
+    assert plan_cli_actions(msg) == []
+
+
 def test_plan_terminal_tasks_returns_implementation_action() -> None:
     msg = "please implement process auto-discovery"
     actions, unhandled = plan_actions_with_unhandled(msg)

--- a/tests/cli/interactive_shell/test_agent_actions.py
+++ b/tests/cli/interactive_shell/test_agent_actions.py
@@ -330,6 +330,11 @@ def test_compound_services_and_synthetic_rds_plans_all_actions() -> None:
     assert plan_cli_actions(message) == ["/list integrations"]
 
 
+def test_synthetic_scenario_id_plans_synthetic_action_kind() -> None:
+    assert plan_terminal_tasks("run synthetic test 005-failover") == ["synthetic_test"]
+    assert plan_cli_actions("run synthetic test 005-failover") == []
+
+
 def test_compound_prompt_executes_all_supported_tasks(monkeypatch: object) -> None:
     dispatched: list[str] = []
 
@@ -512,10 +517,13 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
     assert len(popen_calls) == 1
     assert popen_calls[0][0] == [
         sys.executable,
+        "-u",
         "-m",
         "app.cli",
         "tests",
         "synthetic",
+        "--scenario",
+        "001-replication-lag",
     ]
 
     assert session.history[:2] == [
@@ -547,8 +555,30 @@ def test_execute_cli_actions_lists_all_actions_before_synthetic_rds(monkeypatch:
     output = buf.getvalue()
     assert output.index("1.") < output.index("$ /list integrations")
     assert output.index("2.") < output.index("$ /list integrations")
+    assert "synthetic test rds_postgres:001-replication-lag" in output
     assert output.index("synthetic test") < output.index("$ opensre tests synthetic")
     assert output.index("$ /list integrations") < output.index("$ opensre tests synthetic")
+
+
+def test_execute_cli_actions_runs_requested_synthetic_scenario(monkeypatch: object) -> None:
+    popen_calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _fake_popen(command: list[str], **kwargs: object) -> MagicMock:
+        popen_calls.append((command, kwargs))
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        return proc
+
+    monkeypatch.setattr(action_executor.subprocess, "Popen", _fake_popen)
+
+    session = ReplSession()
+    console, buf = _capture()
+    handled = execute_cli_actions("run synthetic test 005-failover", session, console)
+
+    assert handled is True
+    assert popen_calls[0][0][-2:] == ["--scenario", "005-failover"]
+    assert "$ opensre tests synthetic --scenario 005-failover" in buf.getvalue()
 
 
 def test_execute_cli_actions_cancels_single_running_synthetic_task() -> None:

--- a/tests/cli/interactive_shell/test_execution_policy.py
+++ b/tests/cli/interactive_shell/test_execution_policy.py
@@ -148,12 +148,12 @@ def test_tty_ask_when_action_already_listed_omits_repeat_of_summary() -> None:
     assert "configuration" in out
 
 
-def test_tty_ask_accepts_empty_confirmation_by_default() -> None:
+def test_tty_ask_rejects_empty_confirmation_by_default() -> None:
     session = ReplSession()
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=False)
     r = evaluate_slash_tier(ExecutionTier.ELEVATED)
-    assert execution_allowed(
+    assert not execution_allowed(
         r,
         session=session,
         console=console,

--- a/tests/cli/interactive_shell/test_execution_policy.py
+++ b/tests/cli/interactive_shell/test_execution_policy.py
@@ -146,3 +146,18 @@ def test_tty_ask_when_action_already_listed_omits_repeat_of_summary() -> None:
     assert "/integrations verify foo" not in out
     assert "Confirm:" in out
     assert "configuration" in out
+
+
+def test_tty_ask_accepts_empty_confirmation_by_default() -> None:
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    r = evaluate_slash_tier(ExecutionTier.ELEVATED)
+    assert execution_allowed(
+        r,
+        session=session,
+        console=console,
+        action_summary="/integrations verify foo",
+        confirm_fn=lambda _: "",
+        is_tty=True,
+    )

--- a/tests/cli/interactive_shell/test_tasks.py
+++ b/tests/cli/interactive_shell/test_tasks.py
@@ -193,6 +193,28 @@ class TestTaskRegistry:
         assert loaded.status == TaskStatus.CANCELLED
         assert (12345, 15) not in calls
 
+    def test_session_reset_does_not_truncate_persistent_task_store(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import app.constants as const_module
+
+        monkeypatch.setattr(const_module, "OPENSRE_HOME_DIR", tmp_path)
+        session = ReplSession()
+        session.task_registry = TaskRegistry.persistent()
+        task = session.task_registry.create(TaskKind.SYNTHETIC_TEST, command="opensre tests")
+        task.mark_running()
+        task.mark_completed(result="ok")
+
+        session.clear()
+
+        reloaded = TaskRegistry.persistent()
+        [loaded] = reloaded.list_recent()
+        assert loaded.task_id == task.task_id
+        assert loaded.command == "opensre tests"
+        assert session.task_registry.list_recent() == []
+
 
 class TestSlashTaskCommands:
     def test_tasks_empty_message(self) -> None:

--- a/tests/cli/test_tests_command_synthetic_flags.py
+++ b/tests/cli/test_tests_command_synthetic_flags.py
@@ -1,5 +1,29 @@
 from __future__ import annotations
 
+import sys
+import types
+import unittest.mock
+from pathlib import Path
+
+from click.testing import CliRunner
+
+# ``app.cli.commands`` imports ``app.agents.probe`` via command registration.
+# ``probe`` depends on optional ``psutil``; provide a tiny stub so this
+# focused CLI argv-plumbing test remains hermetic in minimal environments.
+if "psutil" not in sys.modules:
+    psutil_stub = types.ModuleType("psutil")
+    psutil_stub.Process = object
+    psutil_stub.pid_exists = lambda _pid: False
+
+    class _PsutilStubError(Exception):
+        pass
+
+    psutil_stub.NoSuchProcess = _PsutilStubError
+    psutil_stub.ZombieProcess = _PsutilStubError
+    psutil_stub.AccessDenied = _PsutilStubError
+    sys.modules["psutil"] = psutil_stub
+
+from app.cli.__main__ import cli
 from app.cli.commands.tests import _build_synthetic_argv
 
 
@@ -30,3 +54,86 @@ def test_build_synthetic_argv_with_json_and_no_report() -> None:
         observations_dir="",
     )
     assert argv == ["--json", "--no-report"]
+
+
+def test_tests_synthetic_cli_forwards_flags_to_run_suite_main(tmp_path: Path) -> None:
+    runner = CliRunner()
+    observations_dir = tmp_path / "obs"
+    scenarios_dir = tmp_path / "rds_postgres"
+    (scenarios_dir / "001-replication-lag").mkdir(parents=True)
+
+    seen_argv: list[str] = []
+
+    def _fake_main(argv: list[str]) -> int:
+        seen_argv[:] = argv
+        return 3
+
+    fake_run_suite = types.ModuleType("tests.synthetic.rds_postgres.run_suite")
+    fake_run_suite.main = _fake_main
+
+    with (
+        unittest.mock.patch("app.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch.dict(
+            sys.modules,
+            {"tests.synthetic.rds_postgres.run_suite": fake_run_suite},
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "tests",
+                "synthetic",
+                "--scenario",
+                "001-replication-lag",
+                "--json",
+                "--report",
+                "--observations-dir",
+                str(observations_dir),
+            ],
+        )
+
+    assert result.exit_code == 3
+    assert seen_argv == [
+        "--scenario",
+        "001-replication-lag",
+        "--json",
+        "--mock-grafana",
+        "--report",
+        "--observations-dir",
+        str(observations_dir),
+    ]
+
+
+def test_tests_synthetic_cli_does_not_pass_observations_dir_when_unset(tmp_path: Path) -> None:
+    runner = CliRunner()
+    scenarios_dir = tmp_path / "rds_postgres"
+    (scenarios_dir / "001-replication-lag").mkdir(parents=True)
+
+    seen_argv: list[str] = []
+
+    def _fake_main(argv: list[str]) -> int:
+        seen_argv[:] = argv
+        return 0
+
+    fake_run_suite = types.ModuleType("tests.synthetic.rds_postgres.run_suite")
+    fake_run_suite.main = _fake_main
+
+    with (
+        unittest.mock.patch("app.cli.tests.discover.SYNTHETIC_SCENARIOS_DIR", scenarios_dir),
+        unittest.mock.patch.dict(
+            sys.modules,
+            {"tests.synthetic.rds_postgres.run_suite": fake_run_suite},
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "tests",
+                "synthetic",
+                "--json",
+                "--no-report",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert seen_argv == ["--json", "--mock-grafana", "--no-report"]

--- a/tests/cli/test_tests_command_synthetic_flags.py
+++ b/tests/cli/test_tests_command_synthetic_flags.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from app.cli.commands.tests import _build_synthetic_argv
+
+
+def test_build_synthetic_argv_with_explicit_report_and_observations_dir() -> None:
+    argv = _build_synthetic_argv(
+        scenario="001-replication-lag",
+        output_json=False,
+        mock_grafana=True,
+        report=True,
+        observations_dir="/tmp/obs",
+    )
+    assert argv == [
+        "--scenario",
+        "001-replication-lag",
+        "--mock-grafana",
+        "--report",
+        "--observations-dir",
+        "/tmp/obs",
+    ]
+
+
+def test_build_synthetic_argv_with_json_and_no_report() -> None:
+    argv = _build_synthetic_argv(
+        scenario="",
+        output_json=True,
+        mock_grafana=False,
+        report=False,
+        observations_dir="",
+    )
+    assert argv == ["--json", "--no-report"]

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -149,6 +149,45 @@ def _resolved_evidence_sources(
     return observed_sources, required_evidence_sources, missing_required_sources
 
 
+def _process_metrics_summary(trajectory: TrajectoryMetrics) -> dict[str, Any]:
+    """Human-readable process metrics surfaced at the top of ``score``."""
+    return {
+        "loops_used": trajectory.loops_used,
+        "max_loops": trajectory.max_loops,
+        "strict_match": trajectory.strict_match,
+        "lcs_ratio": trajectory.lcs_ratio,
+        "edit_distance": trajectory.edit_distance,
+        "coverage": trajectory.coverage,
+        "extra_actions_count": len(trajectory.extra_actions),
+        "missing_actions_count": len(trajectory.missing_actions),
+        "redundancy_count": trajectory.redundancy_count,
+        "failed_action_count": trajectory.failed_action_count,
+        "definitions": {
+            "extra_actions_count": (
+                "Actions executed but not present in the evaluated golden trajectory."
+            ),
+            "missing_actions_count": (
+                "Golden-trajectory actions that never appeared in execution."
+            ),
+            "redundancy_count": (
+                "Duplicate action executions (same action run more than once). "
+                "This is different from extra actions."
+            ),
+            "strict_match": (
+                "True only when executed actions exactly match golden order and membership."
+            ),
+        },
+    }
+
+
+def _score_with_process_metrics(
+    score: dict[str, Any],
+    trajectory: TrajectoryMetrics,
+) -> dict[str, Any]:
+    """Return score payload with process metrics first for readability."""
+    return {"process_metrics": _process_metrics_summary(trajectory), **score}
+
+
 def evaluate_trajectory_policy(
     metrics: TrajectoryMetrics,
     golden_actions: list[str],
@@ -178,9 +217,7 @@ def evaluate_trajectory_policy(
         if extra_count > policy.max_extra_actions:
             violations.append(f"extra_actions={extra_count} > {policy.max_extra_actions}")
     if policy.max_redundancy is not None and metrics.redundancy_count > policy.max_redundancy:
-        violations.append(
-            f"redundancy_count={metrics.redundancy_count} > {policy.max_redundancy}"
-        )
+        violations.append(f"redundancy_count={metrics.redundancy_count} > {policy.max_redundancy}")
     if policy.max_loops is not None and metrics.loops_used > policy.max_loops:
         violations.append(f"loops_used={metrics.loops_used} > {policy.max_loops}")
 
@@ -262,6 +299,7 @@ def build_observation(
         available_evidence_sources=available_evidence_sources,
         required_evidence_sources=required_evidence_sources,
     )
+    score_payload = _score_with_process_metrics(score, trajectory)
 
     return RunObservation(
         scenario_id=scenario_id,
@@ -269,7 +307,7 @@ def build_observation(
         wall_time_s=round(wall_time_s, 3),
         suite=suite,
         backend=backend,
-        score=score,
+        score=score_payload,
         trajectory=trajectory,
         evaluated_golden_actions=evaluated_golden_actions,
         trajectory_policy=trajectory_policy,

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -49,6 +49,8 @@ class TrajectoryPolicyResult:
 
 @dataclass(frozen=True)
 class RunObservation:
+    report_schema_version: str
+    scoring_formula_version: str
     scenario_id: str
     started_at: str
     wall_time_s: float
@@ -58,7 +60,9 @@ class RunObservation:
     trajectory: TrajectoryMetrics
     evaluated_golden_actions: list[str]
     trajectory_policy: TrajectoryPolicyResult | None
+    trajectory_policy_version: str
     reasoning: dict[str, Any] | None
+    reasoning_status: str
     observed_evidence_sources: list[str]
     required_evidence_sources: list[str]
     missing_required_evidence_sources: list[str]
@@ -138,23 +142,6 @@ def _unique_in_order(items: list[str]) -> list[str]:
     return ordered
 
 
-def _resolved_evidence_sources(
-    evidence: dict[str, Any],
-    available_evidence_sources: list[str],
-    required_evidence_sources: list[str],
-) -> tuple[list[str], list[str], list[str]]:
-    coverage = _source_aware_evidence_coverage(
-        evidence=evidence,
-        available_evidence_sources=available_evidence_sources,
-        required_evidence_sources=required_evidence_sources,
-    )
-    return (
-        list(coverage["observed_sources"]),
-        list(coverage["required_sources"]),
-        list(coverage["missing_required_sources"]),
-    )
-
-
 def _source_aware_evidence_coverage(
     evidence: dict[str, Any],
     available_evidence_sources: list[str],
@@ -207,10 +194,23 @@ def _canonical_report_payload(
             "violations": list(trajectory_policy.violations),
         }
 
+    failure_reasons = score.get("failure_reasons") or []
+    gates = score.get("gates") or {}
     return {
+        "report_schema_version": "report_v2",
+        "scoring_formula_version": "v2_gated_semantic",
         "status": "pass" if bool(score.get("passed")) else "fail",
         "category": score.get("actual_category"),
-        "failure_reason": score.get("failure_reason"),
+        "failure_reasons": list(failure_reasons),
+        "gates": dict(gates),
+        "verdict_definitions": {
+            "strict_match": (
+                "Strict trajectory match requires exact action order and membership equality."
+            ),
+            "sequencing_ok": (
+                "Sequencing checks expected action coverage only; order is ignored due to parallelism."
+            ),
+        },
         "evidence": {
             "observed_sources": list(evidence_source_coverage["observed_sources"]),
             "required_sources": list(evidence_source_coverage["required_sources"]),
@@ -250,6 +250,8 @@ def _process_metrics_summary(trajectory: TrajectoryMetrics) -> dict[str, Any]:
         "missing_actions_count": len(trajectory.missing_actions),
         "redundancy_count": trajectory.redundancy_count,
         "failed_action_count": trajectory.failed_action_count,
+        "action_loops_detected": len(trajectory.actions_per_loop),
+        "loop_count_consistent": trajectory.loops_used == len(trajectory.actions_per_loop),
         "definitions": {
             "extra_actions_count": (
                 "Actions executed but not present in the evaluated golden trajectory."
@@ -263,6 +265,9 @@ def _process_metrics_summary(trajectory: TrajectoryMetrics) -> dict[str, Any]:
             ),
             "strict_match": (
                 "True only when executed actions exactly match golden order and membership."
+            ),
+            "sequencing_ok": (
+                "Coverage-only trajectory check: expected actions appear at least once; order not required."
             ),
         },
     }
@@ -387,14 +392,14 @@ def build_observation(
         available_evidence_sources=available_evidence_sources,
         required_evidence_sources=required_evidence_sources,
     )
-    observed_sources, required_sources, missing_required_sources = _resolved_evidence_sources(
-        evidence=evidence,
-        available_evidence_sources=available_evidence_sources,
-        required_evidence_sources=required_evidence_sources,
-    )
+    observed_sources = list(evidence_source_coverage["observed_sources"])
+    required_sources = list(evidence_source_coverage["required_sources"])
+    missing_required_sources = list(evidence_source_coverage["missing_required_sources"])
     score_payload = _score_with_process_metrics(score, trajectory)
 
     return RunObservation(
+        report_schema_version="report_v2",
+        scoring_formula_version="v2_gated_semantic",
         scenario_id=scenario_id,
         started_at=started_at.astimezone(UTC).isoformat(),
         wall_time_s=round(wall_time_s, 3),
@@ -404,7 +409,9 @@ def build_observation(
         trajectory=trajectory,
         evaluated_golden_actions=evaluated_golden_actions,
         trajectory_policy=trajectory_policy,
+        trajectory_policy_version="default_v1",
         reasoning=reasoning,
+        reasoning_status="captured" if reasoning is not None else "not_captured",
         observed_evidence_sources=observed_sources,
         required_evidence_sources=required_sources,
         missing_required_evidence_sources=missing_required_sources,
@@ -428,7 +435,7 @@ def write_observation(observation: RunObservation, observations_dir: Path) -> Pa
     stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
     target = scenario_dir / f"{stamp}__{status}.json"
 
-    payload = asdict(observation)
+    payload = _drop_none_fields(asdict(observation))
     payload["observation_path"] = str(target.relative_to(observations_dir))
     canonical_payload = dict(payload.get("canonical_report_payload") or {})
     canonical_payload["observation_path"] = payload["observation_path"]
@@ -438,6 +445,18 @@ def write_observation(observation: RunObservation, observations_dir: Path) -> Pa
     latest = scenario_dir / "latest.json"
     latest.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return target
+
+
+def _drop_none_fields(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _drop_none_fields(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, list):
+        return [_drop_none_fields(item) for item in value if item is not None]
+    return value
 
 
 def _fmt_ratio(value: float | None) -> str:
@@ -466,15 +485,20 @@ def render_report_to_console(observation: RunObservation, console: Console) -> N
     missing_keywords = score.get("missing_keywords") or []
     matched_keywords = score.get("matched_keywords") or []
     total_keywords = len(matched_keywords) + len(missing_keywords)
+    gates = score.get("gates") or {}
 
     correctness.add_row("Required keywords", f"{len(matched_keywords)}/{total_keywords} matched")
     correctness.add_row(
         "Forbidden keywords",
-        "clear" if not score.get("failure_reason", "").startswith("forbidden keywords") else "hit",
+        "clear"
+        if (gates.get("forbidden_keyword_clear") or {}).get("status") != "fail"
+        else "hit",
     )
     correctness.add_row(
         "Forbidden categories",
-        "clear" if not score.get("failure_reason", "").startswith("forbidden category") else "hit",
+        "clear"
+        if (gates.get("forbidden_category_clear") or {}).get("status") != "fail"
+        else "hit",
     )
     correctness.add_row("Observed evidence", _fmt_list(observation.observed_evidence_sources))
     if observation.required_evidence_sources:

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -62,6 +62,8 @@ class RunObservation:
     observed_evidence_sources: list[str]
     required_evidence_sources: list[str]
     missing_required_evidence_sources: list[str]
+    evidence_source_coverage: dict[str, Any]
+    canonical_report_payload: dict[str, Any]
     final_state_digest: str
     observation_path: str = ""
 
@@ -141,12 +143,98 @@ def _resolved_evidence_sources(
     available_evidence_sources: list[str],
     required_evidence_sources: list[str],
 ) -> tuple[list[str], list[str], list[str]]:
-    candidate_sources = _unique_in_order([*available_evidence_sources, *required_evidence_sources])
-    observed_sources = [source for source in candidate_sources if evidence.get(source)]
+    coverage = _source_aware_evidence_coverage(
+        evidence=evidence,
+        available_evidence_sources=available_evidence_sources,
+        required_evidence_sources=required_evidence_sources,
+    )
+    return (
+        list(coverage["observed_sources"]),
+        list(coverage["required_sources"]),
+        list(coverage["missing_required_sources"]),
+    )
+
+
+def _source_aware_evidence_coverage(
+    evidence: dict[str, Any],
+    available_evidence_sources: list[str],
+    required_evidence_sources: list[str],
+) -> dict[str, Any]:
+    available_sources = _unique_in_order(available_evidence_sources)
+    required_sources = _unique_in_order(required_evidence_sources)
+    candidate_sources = _unique_in_order([*available_sources, *required_sources])
+    source_presence = {source: bool(evidence.get(source)) for source in candidate_sources}
+    observed_sources = [source for source, present in source_presence.items() if present]
+
     missing_required_sources = [
-        source for source in required_evidence_sources if source not in observed_sources
+        source for source in required_sources if not source_presence.get(source, False)
     ]
-    return observed_sources, required_evidence_sources, missing_required_sources
+
+    required_observed = sum(1 for source in required_sources if source_presence.get(source, False))
+    available_observed = sum(1 for source in available_sources if source_presence.get(source, False))
+
+    required_coverage = (
+        required_observed / len(required_sources) if required_sources else 1.0
+    )
+    available_coverage = (
+        available_observed / len(available_sources) if available_sources else 1.0
+    )
+
+    return {
+        "available_sources": available_sources,
+        "required_sources": required_sources,
+        "observed_sources": observed_sources,
+        "missing_required_sources": missing_required_sources,
+        "source_presence": source_presence,
+        "required_coverage": required_coverage,
+        "available_coverage": available_coverage,
+    }
+
+
+def _canonical_report_payload(
+    *,
+    score: dict[str, Any],
+    trajectory: TrajectoryMetrics,
+    evaluated_golden_actions: list[str],
+    trajectory_policy: TrajectoryPolicyResult | None,
+    evidence_source_coverage: dict[str, Any],
+) -> dict[str, Any]:
+    policy_payload: dict[str, Any] | None = None
+    if trajectory_policy is not None:
+        policy_payload = {
+            "passed": trajectory_policy.passed,
+            "matching": trajectory_policy.matching,
+            "violations": list(trajectory_policy.violations),
+        }
+
+    return {
+        "status": "pass" if bool(score.get("passed")) else "fail",
+        "category": score.get("actual_category"),
+        "failure_reason": score.get("failure_reason"),
+        "evidence": {
+            "observed_sources": list(evidence_source_coverage["observed_sources"]),
+            "required_sources": list(evidence_source_coverage["required_sources"]),
+            "missing_required_sources": list(
+                evidence_source_coverage["missing_required_sources"]
+            ),
+            "source_presence": dict(evidence_source_coverage["source_presence"]),
+            "required_coverage": evidence_source_coverage["required_coverage"],
+            "available_coverage": evidence_source_coverage["available_coverage"],
+        },
+        "trajectory": {
+            "golden": list(evaluated_golden_actions),
+            "actual": list(trajectory.flat_actions),
+            "strict_match": trajectory.strict_match,
+            "lcs_ratio": trajectory.lcs_ratio,
+            "edit_distance": trajectory.edit_distance,
+            "coverage": trajectory.coverage,
+            "extra_actions": list(trajectory.extra_actions),
+            "missing_actions": list(trajectory.missing_actions),
+            "redundancy_count": trajectory.redundancy_count,
+            "failed_action_count": trajectory.failed_action_count,
+            "policy": policy_payload,
+        },
+    }
 
 
 def evaluate_trajectory_policy(
@@ -257,6 +345,11 @@ def build_observation(
     wall_time_s: float,
 ) -> RunObservation:
     evidence = final_state.get("evidence") or {}
+    evidence_source_coverage = _source_aware_evidence_coverage(
+        evidence=evidence,
+        available_evidence_sources=available_evidence_sources,
+        required_evidence_sources=required_evidence_sources,
+    )
     observed_sources, required_sources, missing_required_sources = _resolved_evidence_sources(
         evidence=evidence,
         available_evidence_sources=available_evidence_sources,
@@ -277,6 +370,14 @@ def build_observation(
         observed_evidence_sources=observed_sources,
         required_evidence_sources=required_sources,
         missing_required_evidence_sources=missing_required_sources,
+        evidence_source_coverage=evidence_source_coverage,
+        canonical_report_payload=_canonical_report_payload(
+            score=score,
+            trajectory=trajectory,
+            evaluated_golden_actions=evaluated_golden_actions,
+            trajectory_policy=trajectory_policy,
+            evidence_source_coverage=evidence_source_coverage,
+        ),
         final_state_digest=final_state_digest(final_state),
     )
 
@@ -291,6 +392,9 @@ def write_observation(observation: RunObservation, observations_dir: Path) -> Pa
 
     payload = asdict(observation)
     payload["observation_path"] = str(target.relative_to(observations_dir))
+    canonical_payload = dict(payload.get("canonical_report_payload") or {})
+    canonical_payload["observation_path"] = payload["observation_path"]
+    payload["canonical_report_payload"] = canonical_payload
     target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
     latest = scenario_dir / "latest.json"

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -158,14 +158,12 @@ def _source_aware_evidence_coverage(
     ]
 
     required_observed = sum(1 for source in required_sources if source_presence.get(source, False))
-    available_observed = sum(1 for source in available_sources if source_presence.get(source, False))
+    available_observed = sum(
+        1 for source in available_sources if source_presence.get(source, False)
+    )
 
-    required_coverage = (
-        required_observed / len(required_sources) if required_sources else 1.0
-    )
-    available_coverage = (
-        available_observed / len(available_sources) if available_sources else 1.0
-    )
+    required_coverage = required_observed / len(required_sources) if required_sources else 1.0
+    available_coverage = available_observed / len(available_sources) if available_sources else 1.0
 
     return {
         "available_sources": available_sources,
@@ -214,9 +212,7 @@ def _canonical_report_payload(
         "evidence": {
             "observed_sources": list(evidence_source_coverage["observed_sources"]),
             "required_sources": list(evidence_source_coverage["required_sources"]),
-            "missing_required_sources": list(
-                evidence_source_coverage["missing_required_sources"]
-            ),
+            "missing_required_sources": list(evidence_source_coverage["missing_required_sources"]),
             "source_presence": dict(evidence_source_coverage["source_presence"]),
             "required_coverage": evidence_source_coverage["required_coverage"],
             "available_coverage": evidence_source_coverage["available_coverage"],
@@ -449,11 +445,7 @@ def write_observation(observation: RunObservation, observations_dir: Path) -> Pa
 
 def _drop_none_fields(value: Any) -> Any:
     if isinstance(value, dict):
-        return {
-            key: _drop_none_fields(item)
-            for key, item in value.items()
-            if item is not None
-        }
+        return {key: _drop_none_fields(item) for key, item in value.items() if item is not None}
     if isinstance(value, list):
         return [_drop_none_fields(item) for item in value if item is not None]
     return value
@@ -490,15 +482,11 @@ def render_report_to_console(observation: RunObservation, console: Console) -> N
     correctness.add_row("Required keywords", f"{len(matched_keywords)}/{total_keywords} matched")
     correctness.add_row(
         "Forbidden keywords",
-        "clear"
-        if (gates.get("forbidden_keyword_clear") or {}).get("status") != "fail"
-        else "hit",
+        "clear" if (gates.get("forbidden_keyword_clear") or {}).get("status") != "fail" else "hit",
     )
     correctness.add_row(
         "Forbidden categories",
-        "clear"
-        if (gates.get("forbidden_category_clear") or {}).get("status") != "fail"
-        else "hit",
+        "clear" if (gates.get("forbidden_category_clear") or {}).get("status") != "fail" else "hit",
     )
     correctness.add_row("Observed evidence", _fmt_list(observation.observed_evidence_sources))
     if observation.required_evidence_sources:

--- a/tests/synthetic/rds_postgres/observations.py
+++ b/tests/synthetic/rds_postgres/observations.py
@@ -32,6 +32,22 @@ class TrajectoryMetrics:
 
 
 @dataclass(frozen=True)
+class TrajectoryPolicy:
+    matching: str
+    max_edit_distance: int | None = None
+    max_extra_actions: int | None = None
+    max_redundancy: int | None = None
+    max_loops: int | None = None
+
+
+@dataclass(frozen=True)
+class TrajectoryPolicyResult:
+    passed: bool
+    matching: str
+    violations: list[str]
+
+
+@dataclass(frozen=True)
 class RunObservation:
     scenario_id: str
     started_at: str
@@ -40,8 +56,12 @@ class RunObservation:
     backend: str
     score: dict[str, Any]
     trajectory: TrajectoryMetrics
+    evaluated_golden_actions: list[str]
+    trajectory_policy: TrajectoryPolicyResult | None
     reasoning: dict[str, Any] | None
-    evidence_keys_present: list[str]
+    observed_evidence_sources: list[str]
+    required_evidence_sources: list[str]
+    missing_required_evidence_sources: list[str]
     final_state_digest: str
     observation_path: str = ""
 
@@ -116,6 +136,61 @@ def _unique_in_order(items: list[str]) -> list[str]:
     return ordered
 
 
+def _resolved_evidence_sources(
+    evidence: dict[str, Any],
+    available_evidence_sources: list[str],
+    required_evidence_sources: list[str],
+) -> tuple[list[str], list[str], list[str]]:
+    candidate_sources = _unique_in_order([*available_evidence_sources, *required_evidence_sources])
+    observed_sources = [source for source in candidate_sources if evidence.get(source)]
+    missing_required_sources = [
+        source for source in required_evidence_sources if source not in observed_sources
+    ]
+    return observed_sources, required_evidence_sources, missing_required_sources
+
+
+def evaluate_trajectory_policy(
+    metrics: TrajectoryMetrics,
+    golden_actions: list[str],
+    policy: TrajectoryPolicy | None,
+) -> TrajectoryPolicyResult | None:
+    if not golden_actions or policy is None:
+        return None
+
+    violations: list[str] = []
+    matching = policy.matching
+
+    if matching == "strict" and metrics.strict_match is not True:
+        violations.append("strict sequence mismatch")
+    elif matching == "lcs" and metrics.lcs_ratio != 1.0:
+        violations.append(f"lcs_ratio={_fmt_ratio(metrics.lcs_ratio)} < 1.00")
+    elif matching == "set" and metrics.missing_actions:
+        violations.append(f"missing actions: {', '.join(metrics.missing_actions)}")
+
+    if (
+        policy.max_edit_distance is not None
+        and metrics.edit_distance is not None
+        and metrics.edit_distance > policy.max_edit_distance
+    ):
+        violations.append(f"edit_distance={metrics.edit_distance} > {policy.max_edit_distance}")
+    if policy.max_extra_actions is not None:
+        extra_count = len(metrics.extra_actions)
+        if extra_count > policy.max_extra_actions:
+            violations.append(f"extra_actions={extra_count} > {policy.max_extra_actions}")
+    if policy.max_redundancy is not None and metrics.redundancy_count > policy.max_redundancy:
+        violations.append(
+            f"redundancy_count={metrics.redundancy_count} > {policy.max_redundancy}"
+        )
+    if policy.max_loops is not None and metrics.loops_used > policy.max_loops:
+        violations.append(f"loops_used={metrics.loops_used} > {policy.max_loops}")
+
+    return TrajectoryPolicyResult(
+        passed=not violations,
+        matching=matching,
+        violations=violations,
+    )
+
+
 def compute_trajectory_metrics(
     executed_hypotheses: list[dict[str, Any]],
     golden: list[str],
@@ -173,12 +248,20 @@ def build_observation(
     score: dict[str, Any],
     reasoning: dict[str, Any] | None,
     trajectory: TrajectoryMetrics,
+    evaluated_golden_actions: list[str],
+    trajectory_policy: TrajectoryPolicyResult | None,
     final_state: dict[str, Any],
+    available_evidence_sources: list[str],
+    required_evidence_sources: list[str],
     started_at: datetime,
     wall_time_s: float,
 ) -> RunObservation:
     evidence = final_state.get("evidence") or {}
-    evidence_keys = sorted(str(key) for key in evidence if evidence.get(key))
+    observed_sources, required_sources, missing_required_sources = _resolved_evidence_sources(
+        evidence=evidence,
+        available_evidence_sources=available_evidence_sources,
+        required_evidence_sources=required_evidence_sources,
+    )
 
     return RunObservation(
         scenario_id=scenario_id,
@@ -188,8 +271,12 @@ def build_observation(
         backend=backend,
         score=score,
         trajectory=trajectory,
+        evaluated_golden_actions=evaluated_golden_actions,
+        trajectory_policy=trajectory_policy,
         reasoning=reasoning,
-        evidence_keys_present=evidence_keys,
+        observed_evidence_sources=observed_sources,
+        required_evidence_sources=required_sources,
+        missing_required_evidence_sources=missing_required_sources,
         final_state_digest=final_state_digest(final_state),
     )
 
@@ -247,15 +334,20 @@ def render_report_to_console(observation: RunObservation, console: Console) -> N
         "Forbidden categories",
         "clear" if not score.get("failure_reason", "").startswith("forbidden category") else "hit",
     )
-    correctness.add_row("Evidence sources", _fmt_list(observation.evidence_keys_present))
+    correctness.add_row("Observed evidence", _fmt_list(observation.observed_evidence_sources))
+    if observation.required_evidence_sources:
+        correctness.add_row("Required evidence", _fmt_list(observation.required_evidence_sources))
+        correctness.add_row(
+            "Missing evidence",
+            _fmt_list(observation.missing_required_evidence_sources),
+        )
 
     trajectory = observation.trajectory
     trajectory_table = Table.grid(padding=(0, 2))
     trajectory_table.add_column(style="cyan", no_wrap=True)
     trajectory_table.add_column()
 
-    score_trajectory = score.get("trajectory") or {}
-    golden = score_trajectory.get("expected_sequence") or []
+    golden = observation.evaluated_golden_actions
     trajectory_table.add_row("golden", " -> ".join(golden) if golden else "-")
     trajectory_table.add_row("actual", _fmt_list(trajectory.flat_actions))
     if trajectory.lcs_ratio is not None:
@@ -269,6 +361,12 @@ def render_report_to_console(observation: RunObservation, console: Console) -> N
     trajectory_table.add_row("redundant", str(trajectory.redundancy_count))
     trajectory_table.add_row("per-loop", str(trajectory.actions_per_loop))
     trajectory_table.add_row("failed", str(trajectory.failed_action_count))
+    if observation.trajectory_policy is not None:
+        policy = observation.trajectory_policy
+        policy_status = "pass" if policy.passed else "fail"
+        trajectory_table.add_row("policy", f"{policy_status} ({policy.matching})")
+        if policy.violations:
+            trajectory_table.add_row("violations", "; ".join(policy.violations))
 
     body = Group(
         status_line,

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -345,9 +345,7 @@ def score_trajectory(
     calibration_ok = action_loops_used <= max_loops
     extra_actions_count = len([action for action in actual_sequence if action not in set(expected)])
     trajectory_budget_ok = extra_actions_count == 0
-    efficiency_score = (
-        int(sequencing_ok) + int(calibration_ok) + int(trajectory_budget_ok)
-    ) / 3.0
+    efficiency_score = (int(sequencing_ok) + int(calibration_ok) + int(trajectory_budget_ok)) / 3.0
 
     return TrajectoryScore(
         actual_sequence=actual_sequence,
@@ -445,7 +443,9 @@ def score_result(
     semantic_missing_keywords: list[str] = []
     normalization_used: set[str] = {"casefold_whitespace_normalization"}
     for keyword in fixture.answer_key.required_keywords:
-        semantic_match, match_mode, _matched_alias = _keyword_match_details(normalized_output, keyword)
+        semantic_match, match_mode, _matched_alias = _keyword_match_details(
+            normalized_output, keyword
+        )
         if semantic_match:
             semantic_matched_keywords.append(keyword)
             normalization_used.add(match_mode)
@@ -503,10 +503,7 @@ def score_result(
         "required_keyword_match",
         semantic_keyword_match,
         "all required keywords matched (semantic)",
-        (
-            f"missing_semantic={semantic_missing_keywords}, "
-            f"missing_exact={exact_missing_keywords}"
-        ),
+        (f"missing_semantic={semantic_missing_keywords}, missing_exact={exact_missing_keywords}"),
     )
 
     _mark_gate(

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -15,13 +15,16 @@ from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.rds_postgres.observations import (
+    TrajectoryPolicy,
     build_observation,
     compute_trajectory_metrics,
+    evaluate_trajectory_policy,
     render_report_to_console,
     write_observation,
 )
 from tests.synthetic.rds_postgres.scenario_loader import (
     SUITE_DIR,
+    GoldenTrajectoryConfig,
     ScenarioFixture,
     load_all_scenarios,
 )
@@ -497,15 +500,19 @@ def run_scenario(
     return state_dict, score_result(fixture, state_dict, queried_metrics=queried_metrics)
 
 
-def _resolved_golden_trajectory(fixture: ScenarioFixture) -> tuple[list[str], int | None]:
-    golden_cfg = fixture.answer_key.golden_trajectory or {}
-    ordered = golden_cfg.get("ordered_actions")
-    if isinstance(ordered, list) and ordered:
-        max_loops = golden_cfg.get("max_loops")
-        if isinstance(max_loops, int):
-            return [str(action) for action in ordered], max_loops
-        return [str(action) for action in ordered], fixture.answer_key.max_investigation_loops
-    return list(fixture.answer_key.optimal_trajectory), fixture.answer_key.max_investigation_loops
+def _resolved_golden_trajectory(
+    fixture: ScenarioFixture,
+) -> tuple[list[str], int | None, GoldenTrajectoryConfig | None]:
+    golden_cfg = fixture.answer_key.golden_trajectory
+    if golden_cfg is not None and golden_cfg.ordered_actions:
+        if golden_cfg.max_loops is not None:
+            return list(golden_cfg.ordered_actions), golden_cfg.max_loops, golden_cfg
+        return (
+            list(golden_cfg.ordered_actions),
+            fixture.answer_key.max_investigation_loops,
+            golden_cfg,
+        )
+    return list(fixture.answer_key.optimal_trajectory), fixture.answer_key.max_investigation_loops, None
 
 
 def _print_gap_report(
@@ -568,19 +575,43 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
         final_state, score = run_scenario(fixture, use_mock_grafana=args.mock_grafana)
         wall_time_s = time.monotonic() - started_monotonic
 
-        results.append(score)
-
         executed_hypotheses = final_state.get("executed_hypotheses") or []
-        loops_used = int(
-            final_state.get("investigation_loop_count") or len(executed_hypotheses)
-        )
-        golden_trajectory, max_loops = _resolved_golden_trajectory(fixture)
+        loops_used = int(final_state.get("investigation_loop_count") or len(executed_hypotheses))
+        golden_trajectory, max_loops, golden_cfg = _resolved_golden_trajectory(fixture)
         trajectory_metrics = compute_trajectory_metrics(
             executed_hypotheses=executed_hypotheses,
             golden=golden_trajectory,
             loops_used=loops_used,
             max_loops=max_loops,
         )
+        trajectory_policy = (
+            evaluate_trajectory_policy(
+                metrics=trajectory_metrics,
+                golden_actions=golden_trajectory,
+                policy=TrajectoryPolicy(
+                    matching=golden_cfg.matching,
+                    max_edit_distance=golden_cfg.max_edit_distance,
+                    max_extra_actions=golden_cfg.max_extra_actions,
+                    max_redundancy=golden_cfg.max_redundancy,
+                    max_loops=golden_cfg.max_loops,
+                ),
+            )
+            if golden_cfg is not None
+            else None
+        )
+
+        if score.passed and trajectory_policy is not None and not trajectory_policy.passed:
+            score = replace(
+                score,
+                passed=False,
+                failure_reason=(
+                    "trajectory policy failed: "
+                    + "; ".join(trajectory_policy.violations or ["unknown violation"])
+                ),
+            )
+
+        results.append(score)
+
         observation = build_observation(
             scenario_id=fixture.scenario_id,
             suite="axis1",
@@ -588,7 +619,11 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
             score=asdict(score),
             reasoning=asdict(score.reasoning) if score.reasoning is not None else None,
             trajectory=trajectory_metrics,
+            evaluated_golden_actions=golden_trajectory,
+            trajectory_policy=trajectory_policy,
             final_state=final_state,
+            available_evidence_sources=list(fixture.metadata.available_evidence),
+            required_evidence_sources=list(fixture.answer_key.required_evidence_sources),
             started_at=started_at,
             wall_time_s=wall_time_s,
         )

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from rich.console import Console
 
-from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.rds_postgres.observations import (
@@ -472,6 +471,8 @@ def run_scenario(
     use_mock_grafana: bool = False,
     grafana_backend: Any = None,
 ) -> tuple[dict[str, Any], ScenarioScore]:
+    from app.pipeline.runners import run_investigation
+
     alert = fixture.alert
     labels = alert.get("commonLabels", {}) or {}
 
@@ -513,6 +514,48 @@ def _resolved_golden_trajectory(
             golden_cfg,
         )
     return list(fixture.answer_key.optimal_trajectory), fixture.answer_key.max_investigation_loops, None
+
+
+def _trajectory_policy_for_fixture(
+    *,
+    max_loops: int | None,
+    golden_cfg: GoldenTrajectoryConfig | None,
+) -> TrajectoryPolicy | None:
+    if golden_cfg is None:
+        return None
+    return TrajectoryPolicy(
+        matching=golden_cfg.matching,
+        max_edit_distance=golden_cfg.max_edit_distance,
+        max_extra_actions=golden_cfg.max_extra_actions,
+        max_redundancy=golden_cfg.max_redundancy,
+        # Enforce the resolved loop threshold even if golden_trajectory omits max_loops.
+        max_loops=max_loops,
+    )
+
+
+def _apply_trajectory_policy_to_score(
+    score: ScenarioScore,
+    trajectory_policy: Any,
+) -> ScenarioScore:
+    if trajectory_policy is None or trajectory_policy.passed:
+        return score
+
+    policy_reason = "trajectory policy failed: " + "; ".join(
+        trajectory_policy.violations or ["unknown violation"]
+    )
+    if score.failure_reason:
+        if "trajectory policy failed:" in score.failure_reason:
+            combined_reason = score.failure_reason
+        else:
+            combined_reason = f"{score.failure_reason}; {policy_reason}"
+    else:
+        combined_reason = policy_reason
+
+    return replace(
+        score,
+        passed=False,
+        failure_reason=combined_reason,
+    )
 
 
 def _print_gap_report(
@@ -588,27 +631,16 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
             evaluate_trajectory_policy(
                 metrics=trajectory_metrics,
                 golden_actions=golden_trajectory,
-                policy=TrajectoryPolicy(
-                    matching=golden_cfg.matching,
-                    max_edit_distance=golden_cfg.max_edit_distance,
-                    max_extra_actions=golden_cfg.max_extra_actions,
-                    max_redundancy=golden_cfg.max_redundancy,
-                    max_loops=golden_cfg.max_loops,
+                policy=_trajectory_policy_for_fixture(
+                    max_loops=max_loops,
+                    golden_cfg=golden_cfg,
                 ),
             )
             if golden_cfg is not None
             else None
         )
 
-        if score.passed and trajectory_policy is not None and not trajectory_policy.passed:
-            score = replace(
-                score,
-                passed=False,
-                failure_reason=(
-                    "trajectory policy failed: "
-                    + "; ".join(trajectory_policy.violations or ["unknown violation"])
-                ),
-            )
+        score = _apply_trajectory_policy_to_score(score, trajectory_policy)
 
         results.append(score)
 

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -512,7 +512,11 @@ def _resolved_golden_trajectory(
             fixture.answer_key.max_investigation_loops,
             golden_cfg,
         )
-    return list(fixture.answer_key.optimal_trajectory), fixture.answer_key.max_investigation_loops, None
+    return (
+        list(fixture.answer_key.optimal_trajectory),
+        fixture.answer_key.max_investigation_loops,
+        None,
+    )
 
 
 def _print_gap_report(
@@ -629,9 +633,10 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
         )
         observation_path = write_observation(observation, observations_dir)
         relative_observation_path = str(observation_path.relative_to(observations_dir))
+        display_observation_path = str(observation_path.resolve())
         observation_for_report = replace(
             observation,
-            observation_path=relative_observation_path,
+            observation_path=f"{relative_observation_path} ({display_observation_path})",
         )
 
         if should_report:

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from rich.console import Console
 
+from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.rds_postgres.observations import (
@@ -471,8 +472,6 @@ def run_scenario(
     use_mock_grafana: bool = False,
     grafana_backend: Any = None,
 ) -> tuple[dict[str, Any], ScenarioScore]:
-    from app.pipeline.runners import run_investigation
-
     alert = fixture.alert
     labels = alert.get("commonLabels", {}) or {}
 

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -4,10 +4,11 @@ import argparse
 import json
 import re
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from rich.console import Console
 

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -7,11 +7,10 @@ import time
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from rich.console import Console
 
-from app.pipeline.runners import run_investigation
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.rds_postgres.observations import (
@@ -35,6 +34,17 @@ _EVIDENCE_KEY_MAP: dict[str, str] = {
     "aws_rds_events": "grafana_logs",
     "aws_performance_insights": "grafana_metrics",
 }
+
+
+def _run_investigation_lazy(**kwargs: Any) -> Any:
+    from app.pipeline.runners import run_investigation as _run_investigation
+
+    return _run_investigation(**kwargs)
+
+
+# Keep this as a module symbol so tests can monkeypatch it without importing
+# heavy optional dependencies during test collection.
+run_investigation: Callable[..., Any] = _run_investigation_lazy
 
 
 @dataclass(frozen=True)

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -5,7 +5,7 @@ import json
 import re
 import time
 from collections.abc import Callable
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -16,6 +16,7 @@ from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
 from tests.synthetic.rds_postgres.observations import (
     TrajectoryPolicy,
+    TrajectoryPolicyResult,
     build_observation,
     compute_trajectory_metrics,
     evaluate_trajectory_policy,
@@ -53,10 +54,28 @@ class TrajectoryScore:
     actual_sequence: list[str]  # flattened actions from executed_hypotheses
     expected_sequence: list[str]  # from answer_key.optimal_trajectory
     loops_used: int
+    reported_loops_used: int
+    loop_count_consistent: bool
+    actions_per_loop: list[int]
     max_loops: int
     sequencing_ok: bool  # all expected actions appear in actual (set membership)
     calibration_ok: bool  # loops_used <= max_loops
-    efficiency_score: float  # mean(sequencing_ok, calibration_ok)
+    trajectory_budget_ok: bool  # no extra actions beyond expected trajectory
+    extra_actions_count: int
+    efficiency_score: float  # mean(sequencing_ok, calibration_ok, trajectory_budget_ok)
+
+
+@dataclass(frozen=True)
+class FailureDetail:
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class GateResult:
+    status: str
+    threshold: str
+    actual: str
 
 
 @dataclass(frozen=True)
@@ -84,10 +103,40 @@ class ScenarioScore:
     actual_category: str
     missing_keywords: list[str]
     matched_keywords: list[str]
-    root_cause: str
+    exact_missing_keywords: list[str] = field(default_factory=list)
+    exact_matched_keywords: list[str] = field(default_factory=list)
+    semantic_missing_keywords: list[str] = field(default_factory=list)
+    semantic_matched_keywords: list[str] = field(default_factory=list)
+    exact_keyword_match: bool = False
+    semantic_keyword_match: bool = False
+    normalization_used: list[str] = field(default_factory=list)
+    gates: dict[str, GateResult] = field(default_factory=dict)
+    failure_reasons: list[FailureDetail] = field(default_factory=list)
+    root_cause: str = ""
     failure_reason: str = ""
     trajectory: TrajectoryScore | None = None
     reasoning: ReasoningScore | None = None
+
+
+_REQUIRED_GATE_NAMES = {
+    "category_match",
+    "required_keyword_match",
+    "required_evidence_sources",
+    "trajectory_budget",
+    "forbidden_category_clear",
+    "forbidden_keyword_clear",
+    "failover_event_reasoning",
+    "trajectory_policy",
+}
+
+
+def _all_required_gates_pass(gates: dict[str, GateResult]) -> bool:
+    for gate_name, gate in gates.items():
+        if gate_name not in _REQUIRED_GATE_NAMES:
+            continue
+        if gate.status != "pass":
+            return False
+    return True
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -180,9 +229,19 @@ def _normalize_query_token(value: str) -> str:
 
 
 def _matches_required_keyword(normalized_output: str, keyword: str) -> bool:
+    semantic_match, _, _ = _keyword_match_details(normalized_output, keyword)
+    return semantic_match
+
+
+def _matches_required_keyword_exact(normalized_output: str, keyword: str) -> bool:
+    normalized_keyword = _normalize_text(keyword)
+    return bool(normalized_keyword) and normalized_keyword in normalized_output
+
+
+def _keyword_match_details(normalized_output: str, keyword: str) -> tuple[bool, str, str | None]:
     normalized_keyword = _normalize_text(keyword)
     if normalized_keyword in normalized_output:
-        return True
+        return True, "exact_phrase", None
 
     keyword_aliases = {
         "max_connections": (
@@ -209,17 +268,29 @@ def _matches_required_keyword(normalized_output: str, keyword: str) -> bool:
             "sessions remain open",
             "open sessions",
         ),
+        "write-heavyworkload": (
+            "write heavy workload",
+            "write-heavy update",
+            "update-heavy workload",
+            "heavy update workload",
+        ),
+        "replicationlag": (
+            "replica lag",
+            "replication delay",
+        ),
     }
     for alias in keyword_aliases.get(normalized_keyword.replace(" ", ""), ()):
         if _normalize_text(alias) in normalized_output:
-            return True
+            return True, "alias_lookup", alias
 
     keyword_tokens = set(re.findall(r"[a-z0-9]+", normalized_keyword))
     if not keyword_tokens:
-        return False
+        return False, "none", None
 
     output_tokens = set(re.findall(r"[a-z0-9]+", normalized_output))
-    return keyword_tokens.issubset(output_tokens)
+    if keyword_tokens.issubset(output_tokens):
+        return True, "token_subset", None
+    return False, "none", None
 
 
 def _scored_output_text(final_state: dict[str, Any]) -> str:
@@ -255,11 +326,15 @@ def score_trajectory(
     # Flatten all actions across every investigation loop (order preserved)
     executed_hypotheses: list[dict[str, Any]] = final_state.get("executed_hypotheses") or []
     actual_sequence: list[str] = []
+    actions_per_loop: list[int] = []
     for hyp in executed_hypotheses:
-        for action in hyp.get("actions", []):
-            actual_sequence.append(action)
+        actions = [str(action) for action in hyp.get("actions", [])]
+        actions_per_loop.append(len(actions))
+        actual_sequence.extend(actions)
 
-    loops_used: int = int(final_state.get("investigation_loop_count") or len(executed_hypotheses))
+    action_loops_used = len(executed_hypotheses)
+    reported_loops_used = int(final_state.get("investigation_loop_count") or action_loops_used)
+    loop_count_consistent = reported_loops_used == action_loops_used
 
     # Sequencing: all expected actions must appear in the actual sequence.
     # Actions run in parallel so completion order is non-deterministic; we check
@@ -267,16 +342,25 @@ def score_trajectory(
     # it may skip actions entirely — that will surface as sequencing_ok=False.
     sequencing_ok = set(expected) <= set(actual_sequence)
 
-    calibration_ok = loops_used <= max_loops
-    efficiency_score = (int(sequencing_ok) + int(calibration_ok)) / 2.0
+    calibration_ok = action_loops_used <= max_loops
+    extra_actions_count = len([action for action in actual_sequence if action not in set(expected)])
+    trajectory_budget_ok = extra_actions_count == 0
+    efficiency_score = (
+        int(sequencing_ok) + int(calibration_ok) + int(trajectory_budget_ok)
+    ) / 3.0
 
     return TrajectoryScore(
         actual_sequence=actual_sequence,
         expected_sequence=expected,
-        loops_used=loops_used,
+        loops_used=action_loops_used,
+        reported_loops_used=reported_loops_used,
+        loop_count_consistent=loop_count_consistent,
+        actions_per_loop=actions_per_loop,
         max_loops=max_loops,
         sequencing_ok=sequencing_ok,
         calibration_ok=calibration_ok,
+        trajectory_budget_ok=trajectory_budget_ok,
+        extra_actions_count=extra_actions_count,
         efficiency_score=efficiency_score,
     )
 
@@ -347,43 +431,140 @@ def score_result(
     evidence_text = _scored_output_text(final_state)
     normalized_output = _normalize_text(evidence_text)
 
-    matched_keywords = [
+    exact_matched_keywords = [
         keyword
         for keyword in fixture.answer_key.required_keywords
-        if _matches_required_keyword(normalized_output, keyword)
+        if _matches_required_keyword_exact(normalized_output, keyword)
     ]
-    missing_keywords = [
+    exact_missing_keywords = [
         keyword
         for keyword in fixture.answer_key.required_keywords
-        if keyword not in matched_keywords
+        if keyword not in exact_matched_keywords
     ]
+    semantic_matched_keywords: list[str] = []
+    semantic_missing_keywords: list[str] = []
+    normalization_used: set[str] = {"casefold_whitespace_normalization"}
+    for keyword in fixture.answer_key.required_keywords:
+        semantic_match, match_mode, _matched_alias = _keyword_match_details(normalized_output, keyword)
+        if semantic_match:
+            semantic_matched_keywords.append(keyword)
+            normalization_used.add(match_mode)
+        else:
+            semantic_missing_keywords.append(keyword)
+
+    # Backward-compatible aggregate aliases retained for existing consumers.
+    matched_keywords = list(semantic_matched_keywords)
+    missing_keywords = list(semantic_missing_keywords)
+    exact_keyword_match = not exact_missing_keywords
+    semantic_keyword_match = not semantic_missing_keywords
 
     answer_key = fixture.answer_key
-    failure_reason = ""
+    trajectory = score_trajectory(fixture, final_state)
+    reasoning = score_reasoning(fixture, final_state, queried_metrics)
+    failures: list[FailureDetail] = []
+
+    gates: dict[str, GateResult] = {}
+
+    def _mark_gate(name: str, passed: bool, threshold: str, actual: str) -> None:
+        gates[name] = GateResult(
+            status="pass" if passed else "fail",
+            threshold=threshold,
+            actual=actual,
+        )
 
     # 1. Category match
     if not root_cause_present:
-        failure_reason = "no root cause in output"
+        failures.append(FailureDetail(code="NO_ROOT_CAUSE", detail="no root cause in output"))
     elif actual_category != answer_key.root_cause_category:
-        failure_reason = (
-            f"wrong category: got {actual_category!r}, expected {answer_key.root_cause_category!r}"
+        failures.append(
+            FailureDetail(
+                code="WRONG_CATEGORY",
+                detail=(
+                    f"wrong category: got {actual_category!r}, expected "
+                    f"{answer_key.root_cause_category!r}"
+                ),
+            )
         )
-    elif missing_keywords:
-        failure_reason = f"missing required keywords: {missing_keywords}"
+    _mark_gate(
+        "category_match",
+        root_cause_present and actual_category == answer_key.root_cause_category,
+        f"actual_category == {answer_key.root_cause_category!r}",
+        f"root_cause_present={root_cause_present}, actual_category={actual_category!r}",
+    )
+
+    if semantic_missing_keywords:
+        failures.append(
+            FailureDetail(
+                code="MISSING_REQUIRED_KEYWORD",
+                detail=f"missing required keywords: {semantic_missing_keywords}",
+            )
+        )
+    _mark_gate(
+        "required_keyword_match",
+        semantic_keyword_match,
+        "all required keywords matched (semantic)",
+        (
+            f"missing_semantic={semantic_missing_keywords}, "
+            f"missing_exact={exact_missing_keywords}"
+        ),
+    )
+
+    _mark_gate(
+        "exact_keyword_match",
+        exact_keyword_match,
+        "all required keywords matched verbatim",
+        f"missing_exact={exact_missing_keywords}",
+    )
+    _mark_gate(
+        "semantic_keyword_match",
+        semantic_keyword_match,
+        "all required keywords matched semantically",
+        f"missing_semantic={semantic_missing_keywords}",
+    )
+
     # 2. Forbidden category check (level 2+ adversarial)
-    elif answer_key.forbidden_categories and actual_category in answer_key.forbidden_categories:
-        failure_reason = f"forbidden category in output: {actual_category!r}"
+    forbidden_category_hit = bool(
+        answer_key.forbidden_categories and actual_category in answer_key.forbidden_categories
+    )
+    if forbidden_category_hit:
+        failures.append(
+            FailureDetail(
+                code="FORBIDDEN_CATEGORY_PRESENT",
+                detail=f"forbidden category in output: {actual_category!r}",
+            )
+        )
+    _mark_gate(
+        "forbidden_category_clear",
+        not forbidden_category_hit,
+        "actual_category not in forbidden_categories",
+        f"actual_category={actual_category!r}, forbidden={answer_key.forbidden_categories}",
+    )
+
     # 3. Forbidden keyword check — none of these may appear in evidence_text
-    elif answer_key.forbidden_keywords:
+    forbidden_hits: list[str] = []
+    if answer_key.forbidden_keywords:
         forbidden_hits = [
             kw for kw in answer_key.forbidden_keywords if _normalize_text(kw) in normalized_output
         ]
         if forbidden_hits:
-            failure_reason = f"forbidden keywords in output: {forbidden_hits}"
+            failures.append(
+                FailureDetail(
+                    code="FORBIDDEN_KEYWORD_PRESENT",
+                    detail=f"forbidden keywords in output: {forbidden_hits}",
+                )
+            )
+    _mark_gate(
+        "forbidden_keyword_clear",
+        not forbidden_hits,
+        "no forbidden keywords appear in graded output text",
+        f"forbidden_hits={forbidden_hits}",
+    )
+
     # 4. Evidence path check — required sources must be non-empty in final_state["evidence"].
     # Fixture schema keys (aws_cloudwatch_metrics, aws_rds_events, aws_performance_insights) map to the agent's
     # internal evidence keys (grafana_metrics, grafana_logs) set by _map_grafana_*.
-    if not failure_reason and answer_key.required_evidence_sources:
+    missing_required_evidence: list[str] = []
+    if answer_key.required_evidence_sources:
         evidence = final_state.get("evidence") or {}
         performance_insights_tokens = (
             "top sql activity",
@@ -404,15 +585,38 @@ def score_result(
                 )
 
                 if not (has_state_evidence and has_pi_signal):
-                    failure_reason = f"required evidence not gathered: {source_key!r}"
-                    break
+                    missing_required_evidence.append(source_key)
 
                 continue
 
             state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
             if not evidence.get(state_key):
-                failure_reason = f"required evidence not gathered: {source_key!r}"
-                break
+                missing_required_evidence.append(source_key)
+
+    if missing_required_evidence:
+        failures.append(
+            FailureDetail(
+                code="MISSING_REQUIRED_EVIDENCE_SOURCE",
+                detail=f"required evidence not gathered: {missing_required_evidence}",
+            )
+        )
+    _mark_gate(
+        "required_evidence_sources",
+        not missing_required_evidence,
+        "all required evidence sources populated",
+        f"missing_required_evidence={missing_required_evidence}",
+    )
+
+    _mark_gate(
+        "trajectory_budget",
+        trajectory.trajectory_budget_ok if trajectory is not None else True,
+        "extra_actions_count == 0",
+        (
+            f"extra_actions_count={trajectory.extra_actions_count}"
+            if trajectory is not None
+            else "not_applicable"
+        ),
+    )
 
     # 5. Primary evidence + explicit sequence check — only for scenarios that
     # explicitly require the failover event timeline wording.
@@ -430,7 +634,7 @@ def score_result(
         normalized_required_keywords
     )
 
-    if not failure_reason and requires_failover_event_reasoning:
+    if requires_failover_event_reasoning:
         root_cause_text = _normalize_text(root_cause)
         validated_text = _normalize_text(
             " ".join(claim.get("claim", "") for claim in final_state.get("validated_claims", []))
@@ -446,7 +650,12 @@ def score_result(
         )
 
         if not mentions_event_reasoning:
-            failure_reason = "RDS events gathered but not used as primary reasoning signal"
+            failures.append(
+                FailureDetail(
+                    code="FAILOVER_REASONING_NOT_PRIMARY",
+                    detail="RDS events gathered but not used as primary reasoning signal",
+                )
+            )
 
         required_sequence_tokens = (
             "failover initiated",
@@ -457,12 +666,32 @@ def score_result(
 
         sequence_present = all(token in reasoning_text for token in required_sequence_tokens)
 
-        if not failure_reason and not sequence_present:
-            failure_reason = "RDS event sequence not explicitly listed in required form"
+        if not sequence_present:
+            failures.append(
+                FailureDetail(
+                    code="FAILOVER_SEQUENCE_INCOMPLETE",
+                    detail="RDS event sequence not explicitly listed in required form",
+                )
+            )
+        _mark_gate(
+            "failover_event_reasoning",
+            mentions_event_reasoning and sequence_present,
+            "mentions primary RDS event reasoning and full failover sequence tokens",
+            (
+                f"mentions_event_reasoning={mentions_event_reasoning}, "
+                f"sequence_present={sequence_present}"
+            ),
+        )
+    else:
+        _mark_gate(
+            "failover_event_reasoning",
+            True,
+            "not required unless failover sequence keywords are in answer key",
+            "not_applicable",
+        )
 
-    passed = not failure_reason
-    trajectory = score_trajectory(fixture, final_state)
-    reasoning = score_reasoning(fixture, final_state, queried_metrics)
+    passed = _all_required_gates_pass(gates) and not failures
+    failure_reason = "; ".join(detail.detail for detail in failures)
     return ScenarioScore(
         scenario_id=fixture.scenario_id,
         passed=passed,
@@ -471,6 +700,15 @@ def score_result(
         actual_category=actual_category,
         missing_keywords=missing_keywords,
         matched_keywords=matched_keywords,
+        exact_missing_keywords=exact_missing_keywords,
+        exact_matched_keywords=exact_matched_keywords,
+        semantic_missing_keywords=semantic_missing_keywords,
+        semantic_matched_keywords=semantic_matched_keywords,
+        exact_keyword_match=exact_keyword_match,
+        semantic_keyword_match=semantic_keyword_match,
+        normalization_used=sorted(normalization_used),
+        gates=gates,
+        failure_reasons=failures,
         root_cause=root_cause,
         failure_reason=failure_reason,
         trajectory=trajectory,
@@ -549,7 +787,7 @@ def _trajectory_policy_for_fixture(
 
 def _apply_trajectory_policy_to_score(
     score: ScenarioScore,
-    trajectory_policy: Any,
+    trajectory_policy: TrajectoryPolicyResult | None,
 ) -> ScenarioScore:
     if trajectory_policy is None or trajectory_policy.passed:
         return score
@@ -557,17 +795,23 @@ def _apply_trajectory_policy_to_score(
     policy_reason = "trajectory policy failed: " + "; ".join(
         trajectory_policy.violations or ["unknown violation"]
     )
-    if score.failure_reason:
-        if "trajectory policy failed:" in score.failure_reason:
-            combined_reason = score.failure_reason
-        else:
-            combined_reason = f"{score.failure_reason}; {policy_reason}"
-    else:
-        combined_reason = policy_reason
+    failures = list(score.failure_reasons)
+    if not any(detail.code == "TRAJECTORY_POLICY_FAILED" for detail in failures):
+        failures.append(FailureDetail(code="TRAJECTORY_POLICY_FAILED", detail=policy_reason))
+
+    gates = dict(score.gates)
+    gates["trajectory_policy"] = GateResult(
+        status="pass" if trajectory_policy.passed else "fail",
+        threshold="policy violations list must be empty",
+        actual=f"violations={trajectory_policy.violations}",
+    )
+    combined_reason = "; ".join(detail.detail for detail in failures)
 
     return replace(
         score,
-        passed=False,
+        passed=_all_required_gates_pass(gates) and not failures,
+        gates=gates,
+        failure_reasons=failures,
         failure_reason=combined_reason,
     )
 
@@ -633,7 +877,7 @@ def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
         wall_time_s = time.monotonic() - started_monotonic
 
         executed_hypotheses = final_state.get("executed_hypotheses") or []
-        loops_used = int(final_state.get("investigation_loop_count") or len(executed_hypotheses))
+        loops_used = len(executed_hypotheses)
         golden_trajectory, max_loops, golden_cfg = _resolved_golden_trajectory(fixture)
         trajectory_metrics = compute_trajectory_metrics(
             executed_hypotheses=executed_hypotheses,

--- a/tests/synthetic/rds_postgres/scenario_loader.py
+++ b/tests/synthetic/rds_postgres/scenario_loader.py
@@ -80,6 +80,27 @@ class ScenarioFixture:
     problem_md: str
 
 
+def _parse_trajectory_matching(value: Any) -> TrajectoryMatching:
+    if value in {"strict", "lcs", "set"}:
+        return cast(TrajectoryMatching, value)
+    raise ValueError(
+        "answer.yml: 'golden_trajectory.matching' must be one of "
+        "'strict', 'lcs', or 'set' when present"
+    )
+
+
+def _parse_non_negative_int(golden_trajectory: dict[str, Any], field: str) -> int | None:
+    value = golden_trajectory.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(
+            f"answer.yml: 'golden_trajectory.{field}' must be a non-negative integer "
+            "when present"
+        )
+    return value
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -242,44 +263,26 @@ def _parse_answer_yaml(path: Path) -> ScenarioAnswerKey:
     golden_trajectory_raw = validated.get("golden_trajectory")
     golden_trajectory: GoldenTrajectoryConfig | None = None
     if isinstance(golden_trajectory_raw, dict):
-        ordered_actions = [
-            str(action)
-            for action in (golden_trajectory_raw.get("ordered_actions") or [])
-            if isinstance(action, str) and action.strip()
-        ]
-        if ordered_actions:
-            matching_value = golden_trajectory_raw.get("matching")
-            matching: TrajectoryMatching = (
-                "strict"
-                if matching_value == "strict"
-                else "set"
-                if matching_value == "set"
-                else "lcs"
+        ordered_actions_raw = golden_trajectory_raw.get("ordered_actions")
+        if not isinstance(ordered_actions_raw, list) or not ordered_actions_raw:
+            raise ValueError(
+                "answer.yml: 'golden_trajectory.ordered_actions' must be a non-empty list "
+                "of strings when present"
             )
-            golden_trajectory = GoldenTrajectoryConfig(
-                ordered_actions=ordered_actions,
-                matching=matching,
-                max_edit_distance=(
-                    int(golden_trajectory_raw["max_edit_distance"])
-                    if isinstance(golden_trajectory_raw.get("max_edit_distance"), int)
-                    else None
-                ),
-                max_extra_actions=(
-                    int(golden_trajectory_raw["max_extra_actions"])
-                    if isinstance(golden_trajectory_raw.get("max_extra_actions"), int)
-                    else None
-                ),
-                max_redundancy=(
-                    int(golden_trajectory_raw["max_redundancy"])
-                    if isinstance(golden_trajectory_raw.get("max_redundancy"), int)
-                    else None
-                ),
-                max_loops=(
-                    int(golden_trajectory_raw["max_loops"])
-                    if isinstance(golden_trajectory_raw.get("max_loops"), int)
-                    else None
-                ),
-            )
+        ordered_actions = [action.strip() for action in ordered_actions_raw]
+        matching = _parse_trajectory_matching(golden_trajectory_raw.get("matching", "lcs"))
+        golden_trajectory = GoldenTrajectoryConfig(
+            ordered_actions=ordered_actions,
+            matching=matching,
+            max_edit_distance=_parse_non_negative_int(
+                golden_trajectory_raw, "max_edit_distance"
+            ),
+            max_extra_actions=_parse_non_negative_int(
+                golden_trajectory_raw, "max_extra_actions"
+            ),
+            max_redundancy=_parse_non_negative_int(golden_trajectory_raw, "max_redundancy"),
+            max_loops=_parse_non_negative_int(golden_trajectory_raw, "max_loops"),
+        )
 
     return ScenarioAnswerKey(
         root_cause_category=validated["root_cause_category"].strip(),

--- a/tests/synthetic/rds_postgres/scenario_loader.py
+++ b/tests/synthetic/rds_postgres/scenario_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import yaml
 
@@ -41,6 +41,19 @@ class ScenarioMetadata:
     depends_on: str = ""
 
 
+TrajectoryMatching = Literal["strict", "lcs", "set"]
+
+
+@dataclass(frozen=True)
+class GoldenTrajectoryConfig:
+    ordered_actions: list[str]
+    matching: TrajectoryMatching = "lcs"
+    max_edit_distance: int | None = None
+    max_extra_actions: int | None = None
+    max_redundancy: int | None = None
+    max_loops: int | None = None
+
+
 @dataclass(frozen=True)
 class ScenarioAnswerKey:
     root_cause_category: str
@@ -53,7 +66,7 @@ class ScenarioAnswerKey:
     max_investigation_loops: int = 1
     ruling_out_keywords: list[str] = ()  # type: ignore[assignment]
     required_queries: list[str] = ()  # type: ignore[assignment]
-    golden_trajectory: dict[str, Any] | None = None
+    golden_trajectory: GoldenTrajectoryConfig | None = None
 
 
 @dataclass(frozen=True)
@@ -226,6 +239,48 @@ def _parse_scenario_yaml(path: Path) -> tuple[ScenarioMetadata, Path | None]:
 def _parse_answer_yaml(path: Path) -> ScenarioAnswerKey:
     payload = _read_yaml(path)
     validated = validate_answer_key(payload)
+    golden_trajectory_raw = validated.get("golden_trajectory")
+    golden_trajectory: GoldenTrajectoryConfig | None = None
+    if isinstance(golden_trajectory_raw, dict):
+        ordered_actions = [
+            str(action)
+            for action in (golden_trajectory_raw.get("ordered_actions") or [])
+            if isinstance(action, str) and action.strip()
+        ]
+        if ordered_actions:
+            matching_value = golden_trajectory_raw.get("matching")
+            matching: TrajectoryMatching = (
+                "strict"
+                if matching_value == "strict"
+                else "set"
+                if matching_value == "set"
+                else "lcs"
+            )
+            golden_trajectory = GoldenTrajectoryConfig(
+                ordered_actions=ordered_actions,
+                matching=matching,
+                max_edit_distance=(
+                    int(golden_trajectory_raw["max_edit_distance"])
+                    if isinstance(golden_trajectory_raw.get("max_edit_distance"), int)
+                    else None
+                ),
+                max_extra_actions=(
+                    int(golden_trajectory_raw["max_extra_actions"])
+                    if isinstance(golden_trajectory_raw.get("max_extra_actions"), int)
+                    else None
+                ),
+                max_redundancy=(
+                    int(golden_trajectory_raw["max_redundancy"])
+                    if isinstance(golden_trajectory_raw.get("max_redundancy"), int)
+                    else None
+                ),
+                max_loops=(
+                    int(golden_trajectory_raw["max_loops"])
+                    if isinstance(golden_trajectory_raw.get("max_loops"), int)
+                    else None
+                ),
+            )
+
     return ScenarioAnswerKey(
         root_cause_category=validated["root_cause_category"].strip(),
         required_keywords=[k.strip() for k in validated["required_keywords"]],
@@ -237,11 +292,7 @@ def _parse_answer_yaml(path: Path) -> ScenarioAnswerKey:
         max_investigation_loops=int(validated.get("max_investigation_loops") or 1),
         ruling_out_keywords=list(validated.get("ruling_out_keywords") or []),
         required_queries=list(validated.get("required_queries") or []),
-        golden_trajectory=(
-            dict(validated["golden_trajectory"])
-            if isinstance(validated.get("golden_trajectory"), dict)
-            else None
-        ),
+        golden_trajectory=golden_trajectory,
     )
 
 

--- a/tests/synthetic/rds_postgres/scenario_loader.py
+++ b/tests/synthetic/rds_postgres/scenario_loader.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, cast
 import yaml
 
 from tests.synthetic.schemas import (
+    GoldenTrajectorySchema,
     ScenarioEvidence,
     ScenarioMetadataSchema,
     validate_alert,
@@ -89,7 +90,9 @@ def _parse_trajectory_matching(value: Any) -> TrajectoryMatching:
     )
 
 
-def _parse_non_negative_int(golden_trajectory: dict[str, Any], field: str) -> int | None:
+def _parse_non_negative_int(
+    golden_trajectory: GoldenTrajectorySchema | dict[str, Any], field: str
+) -> int | None:
     value = golden_trajectory.get(field)
     if value is None:
         return None
@@ -97,7 +100,7 @@ def _parse_non_negative_int(golden_trajectory: dict[str, Any], field: str) -> in
         raise ValueError(
             f"answer.yml: 'golden_trajectory.{field}' must be a non-negative integer when present"
         )
-    return value
+    return cast(int, value)
 
 
 def _read_json(path: Path) -> dict[str, Any]:

--- a/tests/synthetic/rds_postgres/scenario_loader.py
+++ b/tests/synthetic/rds_postgres/scenario_loader.py
@@ -95,8 +95,7 @@ def _parse_non_negative_int(golden_trajectory: dict[str, Any], field: str) -> in
         return None
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(
-            f"answer.yml: 'golden_trajectory.{field}' must be a non-negative integer "
-            "when present"
+            f"answer.yml: 'golden_trajectory.{field}' must be a non-negative integer when present"
         )
     return value
 
@@ -274,12 +273,8 @@ def _parse_answer_yaml(path: Path) -> ScenarioAnswerKey:
         golden_trajectory = GoldenTrajectoryConfig(
             ordered_actions=ordered_actions,
             matching=matching,
-            max_edit_distance=_parse_non_negative_int(
-                golden_trajectory_raw, "max_edit_distance"
-            ),
-            max_extra_actions=_parse_non_negative_int(
-                golden_trajectory_raw, "max_extra_actions"
-            ),
+            max_edit_distance=_parse_non_negative_int(golden_trajectory_raw, "max_edit_distance"),
+            max_extra_actions=_parse_non_negative_int(golden_trajectory_raw, "max_extra_actions"),
             max_redundancy=_parse_non_negative_int(golden_trajectory_raw, "max_redundancy"),
             max_loops=_parse_non_negative_int(golden_trajectory_raw, "max_loops"),
         )

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -50,6 +50,51 @@ def _sample_score_payload() -> dict[str, Any]:
         "actual_category": "resource_exhaustion",
         "missing_keywords": [],
         "matched_keywords": ["replication lag", "wal"],
+        "exact_matched_keywords": ["replication lag", "wal"],
+        "exact_missing_keywords": [],
+        "semantic_matched_keywords": ["replication lag", "wal"],
+        "semantic_missing_keywords": [],
+        "exact_keyword_match": True,
+        "semantic_keyword_match": True,
+        "normalization_used": ["casefold_whitespace_normalization", "exact_phrase"],
+        "gates": {
+            "category_match": {
+                "status": "pass",
+                "threshold": "actual_category == 'resource_exhaustion'",
+                "actual": "root_cause_present=True, actual_category='resource_exhaustion'",
+            },
+            "required_keyword_match": {
+                "status": "pass",
+                "threshold": "all required keywords matched (semantic)",
+                "actual": "missing_semantic=[], missing_exact=[]",
+            },
+            "required_evidence_sources": {
+                "status": "pass",
+                "threshold": "all required evidence sources populated",
+                "actual": "missing_required_evidence=[]",
+            },
+            "trajectory_budget": {
+                "status": "pass",
+                "threshold": "extra_actions_count == 0",
+                "actual": "extra_actions_count=0",
+            },
+            "forbidden_category_clear": {
+                "status": "pass",
+                "threshold": "actual_category not in forbidden_categories",
+                "actual": "actual_category='resource_exhaustion', forbidden=[]",
+            },
+            "forbidden_keyword_clear": {
+                "status": "pass",
+                "threshold": "no forbidden keywords appear in graded output text",
+                "actual": "forbidden_hits=[]",
+            },
+            "failover_event_reasoning": {
+                "status": "pass",
+                "threshold": "not required unless failover sequence keywords are in answer key",
+                "actual": "not_applicable",
+            },
+        },
+        "failure_reasons": [],
         "failure_reason": "",
         "trajectory": {
             "expected_sequence": [
@@ -133,8 +178,11 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
     output_path = write_observation(observation, tmp_path)
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["scenario_id"] == "001-replication-lag"
+    assert payload["report_schema_version"] == "report_v2"
+    assert payload["scoring_formula_version"] == "v2_gated_semantic"
     assert "process_metrics" in payload["score"]
     assert payload["score"]["process_metrics"]["redundancy_count"] == 0
+    assert payload["score"]["process_metrics"]["loop_count_consistent"] is True
     assert (
         "Duplicate action executions"
         in payload["score"]["process_metrics"]["definitions"]["redundancy_count"]
@@ -153,6 +201,10 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
         "aws_rds_events": False,
     }
     assert payload["canonical_report_payload"]["status"] == "pass"
+    assert payload["canonical_report_payload"]["report_schema_version"] == "report_v2"
+    assert payload["canonical_report_payload"]["scoring_formula_version"] == "v2_gated_semantic"
+    assert "failure_reason" not in payload["canonical_report_payload"]
+    assert payload["canonical_report_payload"]["failure_reasons"] == []
     assert payload["canonical_report_payload"]["trajectory"]["golden"] == [
         "query_grafana_metrics",
         "query_grafana_logs",
@@ -171,6 +223,9 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
         payload["canonical_report_payload"]["observation_path"]
         == payload["observation_path"]
     )
+    assert payload["reasoning_status"] == "not_captured"
+    assert "reasoning" not in payload
+    assert payload["trajectory_policy_version"] == "default_v1"
     assert (tmp_path / "001-replication-lag" / "latest.json").exists()
 
     report_text = render_report_to_string(observation)

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -29,9 +29,7 @@ def _sample_final_state() -> dict[str, Any]:
                 "observations": ["CPU is elevated"],
             },
             "aws_performance_insights": {
-                "observations": [
-                    "Top SQL Activity: select 1 | Avg Load: 2.0 AAS | Waits: CPU"
-                ],
+                "observations": ["Top SQL Activity: select 1 | Avg Load: 2.0 AAS | Waits: CPU"],
                 "top_sql": [{"sql": "select 1", "db_load": 2.0, "wait_event": "CPU"}],
                 "wait_events": [],
             },
@@ -135,6 +133,12 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
     output_path = write_observation(observation, tmp_path)
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["scenario_id"] == "001-replication-lag"
+    assert "process_metrics" in payload["score"]
+    assert payload["score"]["process_metrics"]["redundancy_count"] == 0
+    assert (
+        "Duplicate action executions"
+        in payload["score"]["process_metrics"]["definitions"]["redundancy_count"]
+    )
     assert payload["score"]["actual_category"] == "resource_exhaustion"
     assert payload["observed_evidence_sources"] == [
         "aws_cloudwatch_metrics",

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -215,14 +215,10 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
         "matching": "lcs",
         "violations": ["lcs_ratio=0.67 < 1.00"],
     }
-    assert (
-        payload["canonical_report_payload"]["evidence"]["missing_required_sources"]
-        == ["aws_rds_events"]
-    )
-    assert (
-        payload["canonical_report_payload"]["observation_path"]
-        == payload["observation_path"]
-    )
+    assert payload["canonical_report_payload"]["evidence"]["missing_required_sources"] == [
+        "aws_rds_events"
+    ]
+    assert payload["canonical_report_payload"]["observation_path"] == payload["observation_path"]
     assert payload["reasoning_status"] == "not_captured"
     assert "reasoning" not in payload
     assert payload["trajectory_policy_version"] == "default_v1"

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from typing import Any
 
 from tests.synthetic.rds_postgres.observations import (
+    TrajectoryPolicy,
     build_observation,
     compute_trajectory_metrics,
     edit_distance,
+    evaluate_trajectory_policy,
     lcs_length,
     render_report_to_string,
     write_observation,
@@ -21,6 +23,18 @@ def _sample_final_state() -> dict[str, Any]:
         "evidence": {
             "grafana_metrics": [{"metric_name": "CPUUtilization"}],
             "grafana_logs": [{"message": "replica lag detected"}],
+            "aws_cloudwatch_metrics": {
+                "db_instance_identifier": "db-1",
+                "metrics": [{"metric_name": "CPUUtilization"}],
+                "observations": ["CPU is elevated"],
+            },
+            "aws_performance_insights": {
+                "observations": [
+                    "Top SQL Activity: select 1 | Avg Load: 2.0 AAS | Waits: CPU"
+                ],
+                "top_sql": [{"sql": "select 1", "db_load": 2.0, "wait_event": "CPU"}],
+                "wait_events": [],
+            },
         },
         "executed_hypotheses": [
             {"actions": ["query_grafana_metrics", "query_grafana_logs"], "failed_actions": []}
@@ -101,7 +115,19 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
         score=score,
         reasoning=None,
         trajectory=trajectory,
+        evaluated_golden_actions=list(score["trajectory"]["expected_sequence"]),
+        trajectory_policy=evaluate_trajectory_policy(
+            metrics=trajectory,
+            golden_actions=list(score["trajectory"]["expected_sequence"]),
+            policy=TrajectoryPolicy(matching="lcs"),
+        ),
         final_state=final_state,
+        available_evidence_sources=[
+            "aws_cloudwatch_metrics",
+            "aws_performance_insights",
+            "aws_rds_events",
+        ],
+        required_evidence_sources=["aws_performance_insights", "aws_rds_events"],
         started_at=datetime.now(UTC),
         wall_time_s=1.2,
     )
@@ -110,11 +136,20 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["scenario_id"] == "001-replication-lag"
     assert payload["score"]["actual_category"] == "resource_exhaustion"
+    assert payload["observed_evidence_sources"] == [
+        "aws_cloudwatch_metrics",
+        "aws_performance_insights",
+    ]
+    assert payload["missing_required_evidence_sources"] == ["aws_rds_events"]
     assert (tmp_path / "001-replication-lag" / "latest.json").exists()
 
     report_text = render_report_to_string(observation)
     assert "Synthetic RDS Run - 001-replication-lag" in report_text
     assert "PASS" in report_text
+    assert "Observed evidence" in report_text
+    assert "aws_performance_insights" in report_text
+    assert "Missing evidence" in report_text
+    assert "policy" in report_text
     assert "Trajectory" in report_text
     assert "lcs=0.67" in report_text
     assert "Observation:" in report_text

--- a/tests/synthetic/rds_postgres/test_observation_metrics.py
+++ b/tests/synthetic/rds_postgres/test_observation_metrics.py
@@ -141,6 +141,32 @@ def test_observation_roundtrip_and_report_rendering(tmp_path: Path) -> None:
         "aws_performance_insights",
     ]
     assert payload["missing_required_evidence_sources"] == ["aws_rds_events"]
+    assert payload["evidence_source_coverage"]["required_coverage"] == 0.5
+    assert payload["evidence_source_coverage"]["available_coverage"] == 2 / 3
+    assert payload["evidence_source_coverage"]["source_presence"] == {
+        "aws_cloudwatch_metrics": True,
+        "aws_performance_insights": True,
+        "aws_rds_events": False,
+    }
+    assert payload["canonical_report_payload"]["status"] == "pass"
+    assert payload["canonical_report_payload"]["trajectory"]["golden"] == [
+        "query_grafana_metrics",
+        "query_grafana_logs",
+        "query_grafana_alert_rules",
+    ]
+    assert payload["canonical_report_payload"]["trajectory"]["policy"] == {
+        "passed": False,
+        "matching": "lcs",
+        "violations": ["lcs_ratio=0.67 < 1.00"],
+    }
+    assert (
+        payload["canonical_report_payload"]["evidence"]["missing_required_sources"]
+        == ["aws_rds_events"]
+    )
+    assert (
+        payload["canonical_report_payload"]["observation_path"]
+        == payload["observation_path"]
+    )
     assert (tmp_path / "001-replication-lag" / "latest.json").exists()
 
     report_text = render_report_to_string(observation)

--- a/tests/synthetic/rds_postgres/test_run_suite_observations.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_observations.py
@@ -33,6 +33,28 @@ def _fake_final_state() -> dict[str, Any]:
     }
 
 
+def _fake_final_state_with_two_loops() -> dict[str, Any]:
+    return {
+        "root_cause": "Replication lag due to write pressure.",
+        "root_cause_category": "resource_exhaustion",
+        "validated_claims": [],
+        "non_validated_claims": [],
+        "causal_chain": [],
+        "evidence": {
+            "aws_cloudwatch_metrics": {
+                "db_instance_identifier": "payments-prod",
+                "metrics": [{"metric_name": "CPUUtilization"}],
+                "observations": ["CPU elevated"],
+            }
+        },
+        "executed_hypotheses": [
+            {"actions": ["query_grafana_metrics"], "failed_actions": []},
+            {"actions": ["query_grafana_logs"], "failed_actions": []},
+        ],
+        "investigation_loop_count": 2,
+    }
+
+
 def _fake_write_observation(
     _observation: Any,
     observations_dir: Path,
@@ -99,6 +121,69 @@ def test_run_suite_applies_trajectory_policy_failure(
     assert results[0].passed is False
     assert "trajectory policy failed" in results[0].failure_reason
     assert render_calls == ["called"]
+
+
+def test_run_suite_enforces_resolved_loop_threshold_and_persists_score_consistency(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fixture = load_scenario(SUITE_DIR / "001-replication-lag")
+    fixture = replace(
+        fixture,
+        answer_key=replace(
+            fixture.answer_key,
+            max_investigation_loops=1,
+            golden_trajectory=GoldenTrajectoryConfig(
+                ordered_actions=["query_grafana_metrics"],
+                matching="set",
+            ),
+        ),
+    )
+
+    score = run_suite_module.ScenarioScore(
+        scenario_id=fixture.scenario_id,
+        passed=True,
+        root_cause_present=True,
+        expected_category=fixture.answer_key.root_cause_category,
+        actual_category=fixture.answer_key.root_cause_category,
+        missing_keywords=[],
+        matched_keywords=list(fixture.answer_key.required_keywords),
+        root_cause="Replication lag due to write pressure.",
+    )
+
+    persisted_scores: list[dict[str, Any]] = []
+
+    def _capture_write_observation(observation: Any, observations_dir: Path) -> Path:
+        persisted_scores.append(dict(observation.score))
+        target = observations_dir / "001-replication-lag" / "latest.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}", encoding="utf-8")
+        return target
+
+    monkeypatch.setattr(run_suite_module, "load_all_scenarios", lambda _suite_dir: [fixture])
+    monkeypatch.setattr(
+        run_suite_module,
+        "run_scenario",
+        lambda *_args, **_kwargs: (_fake_final_state_with_two_loops(), score),
+    )
+    monkeypatch.setattr(run_suite_module, "write_observation", _capture_write_observation)
+
+    results = run_suite_module.run_suite(
+        [
+            "--scenario",
+            fixture.scenario_id,
+            "--observations-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert "trajectory policy failed" in results[0].failure_reason
+    assert "loops_used=2 > 1" in results[0].failure_reason
+    assert len(persisted_scores) == 1
+    assert persisted_scores[0]["passed"] is False
+    assert persisted_scores[0]["failure_reason"] == results[0].failure_reason
 
 
 def test_run_suite_json_mode_suppresses_report_render(

--- a/tests/synthetic/rds_postgres/test_run_suite_observations.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_observations.py
@@ -99,7 +99,9 @@ def test_run_suite_applies_trajectory_policy_failure(
     render_calls: list[str] = []
 
     monkeypatch.setattr(run_suite_module, "load_all_scenarios", lambda _suite_dir: [fixture])
-    monkeypatch.setattr(run_suite_module, "run_scenario", lambda *_args, **_kwargs: (_fake_final_state(), score))
+    monkeypatch.setattr(
+        run_suite_module, "run_scenario", lambda *_args, **_kwargs: (_fake_final_state(), score)
+    )
     monkeypatch.setattr(run_suite_module, "write_observation", _fake_write_observation)
     monkeypatch.setattr(
         run_suite_module,
@@ -206,7 +208,9 @@ def test_run_suite_json_mode_suppresses_report_render(
     render_calls: list[str] = []
 
     monkeypatch.setattr(run_suite_module, "load_all_scenarios", lambda _suite_dir: [fixture])
-    monkeypatch.setattr(run_suite_module, "run_scenario", lambda *_args, **_kwargs: (_fake_final_state(), score))
+    monkeypatch.setattr(
+        run_suite_module, "run_scenario", lambda *_args, **_kwargs: (_fake_final_state(), score)
+    )
     monkeypatch.setattr(run_suite_module, "write_observation", _fake_write_observation)
     monkeypatch.setattr(
         run_suite_module,

--- a/tests/synthetic/rds_postgres/test_run_suite_observations.py
+++ b/tests/synthetic/rds_postgres/test_run_suite_observations.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import tests.synthetic.rds_postgres.run_suite as run_suite_module
+from tests.synthetic.rds_postgres.scenario_loader import (
+    SUITE_DIR,
+    GoldenTrajectoryConfig,
+    load_scenario,
+)
+
+
+def _fake_final_state() -> dict[str, Any]:
+    return {
+        "root_cause": "Replication lag due to write pressure.",
+        "root_cause_category": "resource_exhaustion",
+        "validated_claims": [],
+        "non_validated_claims": [],
+        "causal_chain": [],
+        "evidence": {
+            "aws_cloudwatch_metrics": {
+                "db_instance_identifier": "payments-prod",
+                "metrics": [{"metric_name": "CPUUtilization"}],
+                "observations": ["CPU elevated"],
+            }
+        },
+        "executed_hypotheses": [
+            {"actions": ["query_grafana_metrics"], "failed_actions": []},
+        ],
+        "investigation_loop_count": 1,
+    }
+
+
+def _fake_write_observation(
+    _observation: Any,
+    observations_dir: Path,
+) -> Path:
+    target = observations_dir / "001-replication-lag" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{}", encoding="utf-8")
+    return target
+
+
+def test_run_suite_applies_trajectory_policy_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fixture = load_scenario(SUITE_DIR / "001-replication-lag")
+    fixture = replace(
+        fixture,
+        answer_key=replace(
+            fixture.answer_key,
+            golden_trajectory=GoldenTrajectoryConfig(
+                ordered_actions=[
+                    "query_grafana_metrics",
+                    "query_grafana_logs",
+                ],
+                matching="strict",
+                max_extra_actions=0,
+            ),
+        ),
+    )
+
+    score = run_suite_module.ScenarioScore(
+        scenario_id=fixture.scenario_id,
+        passed=True,
+        root_cause_present=True,
+        expected_category=fixture.answer_key.root_cause_category,
+        actual_category=fixture.answer_key.root_cause_category,
+        missing_keywords=[],
+        matched_keywords=list(fixture.answer_key.required_keywords),
+        root_cause="Replication lag due to write pressure.",
+    )
+
+    render_calls: list[str] = []
+
+    monkeypatch.setattr(run_suite_module, "load_all_scenarios", lambda _suite_dir: [fixture])
+    monkeypatch.setattr(run_suite_module, "run_scenario", lambda *_args, **_kwargs: (_fake_final_state(), score))
+    monkeypatch.setattr(run_suite_module, "write_observation", _fake_write_observation)
+    monkeypatch.setattr(
+        run_suite_module,
+        "render_report_to_console",
+        lambda *_args, **_kwargs: render_calls.append("called"),
+    )
+
+    results = run_suite_module.run_suite(
+        [
+            "--scenario",
+            fixture.scenario_id,
+            "--report",
+            "--observations-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert "trajectory policy failed" in results[0].failure_reason
+    assert render_calls == ["called"]
+
+
+def test_run_suite_json_mode_suppresses_report_render(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fixture = load_scenario(SUITE_DIR / "001-replication-lag")
+
+    score = run_suite_module.ScenarioScore(
+        scenario_id=fixture.scenario_id,
+        passed=True,
+        root_cause_present=True,
+        expected_category=fixture.answer_key.root_cause_category,
+        actual_category=fixture.answer_key.root_cause_category,
+        missing_keywords=[],
+        matched_keywords=list(fixture.answer_key.required_keywords),
+        root_cause="Replication lag due to write pressure.",
+    )
+
+    render_calls: list[str] = []
+
+    monkeypatch.setattr(run_suite_module, "load_all_scenarios", lambda _suite_dir: [fixture])
+    monkeypatch.setattr(run_suite_module, "run_scenario", lambda *_args, **_kwargs: (_fake_final_state(), score))
+    monkeypatch.setattr(run_suite_module, "write_observation", _fake_write_observation)
+    monkeypatch.setattr(
+        run_suite_module,
+        "render_report_to_console",
+        lambda *_args, **_kwargs: render_calls.append("called"),
+    )
+
+    _ = run_suite_module.run_suite(
+        [
+            "--scenario",
+            fixture.scenario_id,
+            "--report",
+            "--json",
+            "--observations-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert render_calls == []

--- a/tests/synthetic/rds_postgres/test_suite.py
+++ b/tests/synthetic/rds_postgres/test_suite.py
@@ -9,6 +9,7 @@ import pytest
 from tests.synthetic.rds_postgres.run_suite import run_scenario, score_result
 from tests.synthetic.rds_postgres.scenario_loader import (
     SUITE_DIR,
+    GoldenTrajectoryConfig,
     load_all_scenarios,
     load_scenario,
 )
@@ -439,3 +440,50 @@ class TestScenarioInheritance:
         assert fixture.metadata.scenario_id == "000-healthy"
         assert fixture.metadata.failure_mode == "healthy"
         assert fixture.evidence.aws_cloudwatch_metrics is not None
+
+    def test_golden_trajectory_is_loaded_as_typed_config(self) -> None:
+        """golden_trajectory is normalized into a typed config object."""
+        real_dir = SUITE_DIR / "999-test-golden-trajectory"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(
+                textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-golden-trajectory
+                failure_mode: replication_lag
+                severity: critical
+            """)
+            )
+            (real_dir / "answer.yml").write_text(
+                textwrap.dedent("""\
+                root_cause_category: resource_exhaustion
+                required_keywords:
+                  - replication lag
+                model_response: "Replication lag from write pressure."
+                golden_trajectory:
+                  ordered_actions:
+                    - query_grafana_metrics
+                    - query_grafana_logs
+                  matching: strict
+                  max_edit_distance: 1
+                  max_extra_actions: 0
+                  max_redundancy: 0
+                  max_loops: 2
+            """)
+            )
+
+            fixture = load_scenario(real_dir)
+            expected = GoldenTrajectoryConfig(
+                ordered_actions=["query_grafana_metrics", "query_grafana_logs"],
+                matching="strict",
+                max_edit_distance=1,
+                max_extra_actions=0,
+                max_redundancy=0,
+                max_loops=2,
+            )
+
+            assert fixture.answer_key.golden_trajectory == expected
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()

--- a/tests/synthetic/rds_postgres/test_suite.py
+++ b/tests/synthetic/rds_postgres/test_suite.py
@@ -487,3 +487,74 @@ class TestScenarioInheritance:
             for f in real_dir.iterdir():
                 f.unlink()
             real_dir.rmdir()
+
+    def test_golden_trajectory_requires_ordered_actions(self) -> None:
+        """golden_trajectory block must include a non-empty ordered_actions list."""
+        real_dir = SUITE_DIR / "999-test-golden-trajectory-missing-actions"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(
+                textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-golden-trajectory-missing-actions
+                failure_mode: replication_lag
+                severity: critical
+            """)
+            )
+            (real_dir / "answer.yml").write_text(
+                textwrap.dedent("""\
+                root_cause_category: resource_exhaustion
+                required_keywords:
+                  - replication lag
+                model_response: "Replication lag from write pressure."
+                golden_trajectory:
+                  matching: strict
+            """)
+            )
+
+            with pytest.raises(
+                ValueError,
+                match="golden_trajectory.ordered_actions",
+            ):
+                load_scenario(real_dir)
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()
+
+    def test_golden_trajectory_rejects_boolean_numeric_fields(self) -> None:
+        """Boolean values are rejected for numeric golden_trajectory limits."""
+        real_dir = SUITE_DIR / "999-test-golden-trajectory-bool-limit"
+        real_dir.mkdir(exist_ok=True)
+        try:
+            (real_dir / "scenario.yml").write_text(
+                textwrap.dedent("""\
+                base: 000-healthy
+                scenario_id: 999-test-golden-trajectory-bool-limit
+                failure_mode: replication_lag
+                severity: critical
+            """)
+            )
+            (real_dir / "answer.yml").write_text(
+                textwrap.dedent("""\
+                root_cause_category: resource_exhaustion
+                required_keywords:
+                  - replication lag
+                model_response: "Replication lag from write pressure."
+                golden_trajectory:
+                  ordered_actions:
+                    - query_grafana_metrics
+                    - query_grafana_logs
+                  max_loops: true
+            """)
+            )
+
+            with pytest.raises(
+                ValueError,
+                match="golden_trajectory.max_loops",
+            ):
+                load_scenario(real_dir)
+        finally:
+            for f in real_dir.iterdir():
+                f.unlink()
+            real_dir.rmdir()

--- a/tests/synthetic/rds_postgres/test_suite.py
+++ b/tests/synthetic/rds_postgres/test_suite.py
@@ -176,6 +176,45 @@ def test_score_result_accepts_failover_event_reasoning() -> None:
     assert score.passed is True
 
 
+def test_score_result_uses_semantic_keyword_matching_for_write_heavy_workload() -> None:
+    fixture = load_scenario(SUITE_DIR / "001-replication-lag")
+
+    final_state = {
+        "root_cause": (
+            "Replication lag is driven by a write-heavy UPDATE on the orders table, "
+            "which increases WAL generation faster than the replica can replay; "
+            "Top SQL Activity and Avg Load confirm replay pressure."
+        ),
+        "root_cause_category": "resource_exhaustion",
+        "validated_claims": [
+            {"claim": "Replica lag and WAL replay pressure are both elevated."},
+        ],
+        "non_validated_claims": [],
+        "causal_chain": [],
+        "evidence": {
+            "grafana_metrics": [{"metric_name": "ReplicaLag"}],
+            "grafana_logs": [{"message": "replica lag spike observed"}],
+        },
+        "executed_hypotheses": [
+            {
+                "actions": [
+                    "query_grafana_metrics",
+                    "query_grafana_logs",
+                    "query_grafana_alert_rules",
+                ]
+            }
+        ],
+    }
+
+    score = score_result(fixture, final_state)
+
+    assert score.semantic_keyword_match is True
+    assert score.exact_keyword_match is False
+    assert score.gates["required_keyword_match"].status == "pass"
+    assert "write-heavy workload" in score.semantic_matched_keywords
+    assert score.passed is True
+
+
 _ALL_SCENARIOS = load_all_scenarios()
 _LLM_ATTEMPTS = 2
 


### PR DESCRIPTION
## What this PR does
- aggregates the four parallel agent branches (schema, observation payload/report, trajectory policy, tests/CLI)
- fixes evidence coverage granularity by introducing source-aware coverage fields in persisted observations
- tightens golden trajectory parsing/validation (required ordered actions, non-boolean numeric policy fields)
- enforces trajectory policy consistently in scoring, including resolved loop thresholds
- extends CLI forwarding and observation metric tests for new behavior
- keeps run_suite import path monkeypatch-friendly via lazy run_investigation loader to avoid optional dependency import failures during unit-style collection

## Validation run
- uv run pytest tests/synthetic/rds_postgres/test_suite.py::TestScenarioInheritance::test_golden_trajectory_requires_ordered_actions tests/synthetic/rds_postgres/test_suite.py::TestScenarioInheritance::test_golden_trajectory_rejects_boolean_numeric_fields tests/synthetic/rds_postgres/test_observation_metrics.py tests/synthetic/rds_postgres/test_run_suite_observations.py tests/cli/test_tests_command_synthetic_flags.py

## Note
- full synthetic scenario execution tests in tests/synthetic/rds_postgres/test_suite.py still require runtime dependencies/environment not present in this local run.