### PR TITLE
fix(ci): router sample_alert fast-path + streaming non-TTY Live skip

### DIFF
--- a/app/cli/interactive_shell/routing/router.py
+++ b/app/cli/interactive_shell/routing/router.py
@@ -52,7 +52,9 @@ InputKind = Literal["slash", "cli_help", "cli_agent", "new_alert", "follow_up"]
 
 # Rule names that are part of the deterministic fast-path and must never be
 # handed to the LLM classifier (they are always correct by definition).
-_FAST_PATH_RULE_NAMES: frozenset[str] = frozenset({"slash_prefix", "bare_command_alias"})
+_FAST_PATH_RULE_NAMES: frozenset[str] = frozenset(
+    {"slash_prefix", "bare_command_alias", "sample_alert_launch"}
+)
 
 
 def _is_slash_prefix(text: str, _session: RoutingSession) -> bool:

--- a/app/cli/interactive_shell/ui/streaming.py
+++ b/app/cli/interactive_shell/ui/streaming.py
@@ -240,11 +240,11 @@ def stream_to_console(
             # as a static block so the user — and any error label printed by
             # the caller — sees what was produced before the failure.
             try:
-                wrap_patch_stdout = _console_file_is_a_tty(console)
-                try:
-                    _run_throttled_with_live(wrap_patch_stdout=wrap_patch_stdout)
-                except NoConsoleScreenBufferError:
-                    if wrap_patch_stdout:
+                is_real_tty = _console_file_is_a_tty(console)
+                if is_real_tty:
+                    try:
+                        _run_throttled_with_live(wrap_patch_stdout=True)
+                    except NoConsoleScreenBufferError:
                         try:
                             _run_throttled_with_live(wrap_patch_stdout=False)
                         except NoConsoleScreenBufferError:
@@ -254,13 +254,16 @@ def stream_to_console(
                                 buffer=buffer,
                                 next_chunk=_next_chunk,
                             )
-                    else:
-                        _run_throttled_markdown_loop(
-                            preview=_noop_preview,
-                            chunks_iter=chunks_iter,
-                            buffer=buffer,
-                            next_chunk=_next_chunk,
-                        )
+                else:
+                    # force_terminal=True but backed by a non-TTY file (StringIO
+                    # in tests, piped output): skip Live to avoid cursor-positioning
+                    # sequences writing raw intermediate markdown into the buffer.
+                    _run_throttled_markdown_loop(
+                        preview=_noop_preview,
+                        chunks_iter=chunks_iter,
+                        buffer=buffer,
+                        next_chunk=_next_chunk,
+                    )
             finally:
                 # Single authoritative render. The live preview was transient
                 # + cropped while streaming; this is what ends up in


### PR DESCRIPTION
## Summary

- **Router**: `sample_alert_launch` was not in `_FAST_PATH_RULE_NAMES`, so the LLM classifier ran before the deterministic regex rule and returned `new_alert` for phrases like `"try a sample alert"`. Added `sample_alert_launch` to the fast-path so it's evaluated before the LLM (3 failing tests fixed).

- **Streaming**: `TestTtyLiveRender::test_renders_label_and_streamed_content_as_markdown` asserted that literal `**` delimiters are absent after Markdown rendering. When the console is `force_terminal=True` but backed by `StringIO` (test env), Rich `Live` with `transient=True` writes cursor-positioning sequences to the buffer — `\r` does not erase bytes in `StringIO`, leaving `**opensre` visible. Fixed by skipping `Live` when `_console_file_is_a_tty()` is `False` and going directly to `_noop_preview`, relying on the single final flush for rendering.

## Test plan

- [ ] All 4 previously failing tests now pass locally
- [ ] Full `tests/cli/interactive_shell/routing/` and `tests/cli/interactive_shell/ui/` suites pass (151 tests)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)