### PR TITLE
Show investigation progress for running synthetic tests

### DIFF
--- a/app/cli/interactive_shell/command_registry/tasks_cmds.py
+++ b/app/cli/interactive_shell/command_registry/tasks_cmds.py
@@ -9,15 +9,14 @@ from rich.markup import escape
 
 from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
 from app.cli.interactive_shell.history import load_command_history_entries
-from app.cli.interactive_shell.rendering import repl_table
-from app.cli.interactive_shell.session import ReplSession
-from app.cli.interactive_shell.tasks import TaskKind, TaskRecord, TaskStatus
-from app.cli.interactive_shell.theme import (
+from app.cli.interactive_shell.runtime import ReplSession, TaskKind, TaskRecord, TaskStatus
+from app.cli.interactive_shell.ui import (
     BOLD_BRAND,
     DIM,
     ERROR,
     HIGHLIGHT,
     WARNING,
+    repl_table,
 )
 
 
@@ -37,6 +36,10 @@ def _task_detail_label(task: TaskRecord) -> str:
         return str(task.error)
     if task.result:
         return str(task.result)
+    if task.command:
+        return str(task.command)
+    if task.progress:
+        return str(task.progress)
     return "—"
 
 
@@ -100,13 +103,13 @@ def _cmd_stop(session: ReplSession, console: Console, args: list[str]) -> bool: 
     return True
 
 
-def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool:
+def _validate_cancel_args(args: list[str]) -> str | None:
     if not args:
-        console.print(
-            f"[{ERROR}]usage:[/] /cancel <task_id>  — use [{HIGHLIGHT}]/tasks[/] to list ids"
-        )
-        return True
+        return f"[{ERROR}]usage:[/] /cancel <task_id>  — use [{HIGHLIGHT}]/tasks[/] to list ids"
+    return None
 
+
+def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool:
     needle = args[0]
     candidates = session.task_registry.candidates(needle)
     if not candidates:
@@ -135,7 +138,8 @@ def _cmd_cancel(session: ReplSession, console: Console, args: list[str]) -> bool
         )
     else:
         console.print(
-            f"[{HIGHLIGHT}]stop requested[/] [{DIM}]for synthetic test {escape(task.task_id)}.[/] "
+            f"[{HIGHLIGHT}]stop requested[/] "
+            f"[{DIM}]for {escape(task.kind.value)} {escape(task.task_id)}.[/] "
             f"[{DIM}]use[/] [{HIGHLIGHT}]/tasks[/] [{DIM}]to confirm status.[/]"
         )
     return True
@@ -149,6 +153,7 @@ COMMANDS: list[SlashCommand] = [
         "cancel a running task by id ('/cancel <task_id>' — see /tasks)",
         _cmd_cancel,
         execution_tier=ExecutionTier.ELEVATED,
+        validate_args=_validate_cancel_args,
     ),
     SlashCommand(
         "/stop",

--- a/app/cli/interactive_shell/orchestration/action_executor.py
+++ b/app/cli/interactive_shell/orchestration/action_executor.py
@@ -1,0 +1,1232 @@
+"""Execute planned shell, sample alert, and synthetic test actions."""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import IO, Any
+
+from rich.console import Console
+from rich.markup import escape
+from rich.text import Text
+
+import app.cli.interactive_shell.intent.intent_parser as _intent_parser
+from app.cli.interactive_shell.orchestration.action_planner import (
+    DEFAULT_SYNTHETIC_SCENARIO,
+    SYNTHETIC_UNKNOWN_PREFIX,
+    _list_rds_postgres_scenarios,
+)
+from app.cli.interactive_shell.orchestration.execution_policy import (
+    evaluate_code_agent_launch,
+    evaluate_investigation_launch,
+    evaluate_shell_from_parsed,
+    evaluate_synthetic_test_launch,
+    execution_allowed,
+)
+from app.cli.interactive_shell.runtime import ReplSession, TaskKind, TaskRecord
+from app.cli.interactive_shell.runtime.session import (
+    SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST,
+)
+from app.cli.interactive_shell.shell import (
+    argv_for_repl_builtin_routing,
+    execute_shell_command,
+    parse_shell_command,
+)
+from app.cli.interactive_shell.ui import DIM, ERROR, HIGHLIGHT, WARNING, print_command_output
+from app.cli.support.errors import OpenSREError
+from app.cli.support.exception_reporting import report_exception
+from app.integrations.llm_cli.claude_code import ClaudeCodeAdapter
+from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
+
+SHELL_COMMAND_TIMEOUT_SECONDS = 120
+SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
+CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS = 1800
+_SYNTHETIC_POLL_SECONDS = 0.25
+_MAX_COMMAND_OUTPUT_CHARS = 24_000
+_SYNTHETIC_DIAG_CHARS = 2_000  # max stderr bytes captured from a failing synthetic run
+_SIGTERM_GRACE_SECONDS = 10  # wait for clean exit after SIGTERM before escalating to SIGKILL
+_TASK_OUTPUT_JOIN_TIMEOUT_SECONDS = 2
+_SYNTHETIC_SCENARIO_ID_RE = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*$")
+_IMPLEMENT_PERMISSION_MODE_ENV = "CLAUDE_CODE_IMPLEMENT_PERMISSION_MODE"
+_DEFAULT_IMPLEMENT_PERMISSION_MODE = "acceptEdits"
+
+
+def terminate_child_process(proc: subprocess.Popen[Any]) -> None:
+    """Best-effort SIGTERM → wait → SIGKILL → wait without blocking forever."""
+    if proc.poll() is not None:
+        return
+    with contextlib.suppress(OSError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=_SIGTERM_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(OSError):
+            proc.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+
+def read_diag(buf: tempfile.SpooledTemporaryFile[bytes]) -> str:  # type: ignore[type-arg]
+    """Read up to ``_SYNTHETIC_DIAG_CHARS`` bytes from a captured stderr buffer."""
+    buf.seek(0)
+    return buf.read(_SYNTHETIC_DIAG_CHARS).decode("utf-8", errors="replace").strip()
+
+
+def read_tail(buf: tempfile.SpooledTemporaryFile[bytes], n: int) -> str:  # type: ignore[type-arg]
+    """Read the last ``n`` characters from a captured buffer."""
+    buf.seek(0, 2)
+    size = buf.tell()
+    if size == 0:
+        return ""
+    read_start = max(0, size - n)
+    buf.seek(read_start)
+    return buf.read(size - read_start).decode("utf-8", errors="replace").strip()
+
+
+class _ThreadSafeCapture:
+    """Thread-safe wrapper around SpooledTemporaryFile for concurrent write/read."""
+    def __init__(self) -> None:
+        self._buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile()  # type: ignore[type-arg]
+        self._lock = threading.Lock()
+
+    def write(self, data: bytes) -> None:
+        with self._lock:
+            self._buf.write(data)
+
+    def read_tail(self, n: int) -> str:
+        with self._lock:
+            return read_tail(self._buf, n)
+
+    def close(self) -> None:
+        self._buf.close()
+
+
+# Width of the ``<task_id> <stream> │ `` prefix that ``_print_task_output_line``
+# prepends to every relayed subprocess line. Used to align the subprocess's own
+# Rich rendering width via ``COLUMNS`` so panels and tables don't wrap mid-row
+# in the user's narrower terminal once the prefix has been added.
+#   task_id (8 hex) + " " + stream ("stdout"/"stderr", 6) + " │ " (3) = 18
+_TASK_OUTPUT_PREFIX_WIDTH = 18
+
+# Below this many columns Rich panels and tables degrade past usefulness. We
+# keep the subprocess at this minimum even if the user's terminal is tiny —
+# wrapping the borders is no worse than crushing them.
+_MIN_SUBPROCESS_TERMINAL_WIDTH = 60
+
+
+def _print_task_output_line(
+    console: Console,
+    task: TaskRecord,
+    stream_name: str,
+    line: str,
+    *,
+    style: str | None = None,
+) -> None:
+    text = Text()
+    text.append(f"{task.task_id} {stream_name} │ ", style=DIM)
+    text.append(line.rstrip("\r\n"), style=style)
+    console.print(text)
+
+
+def _subprocess_env_with_aligned_width(console: Console) -> dict[str, str]:
+    """Return ``os.environ`` patched so a piped Rich subprocess wraps to fit.
+
+    Background: ``_print_task_output_line`` prepends ``<task_id> <stream> │ ``
+    (a fixed 18-char prefix) to every relayed subprocess line before printing
+    into the user's terminal. The subprocess itself sees a piped stdout, so
+    Rich inside the subprocess falls back to a default 80-column rendering.
+    The combined ``80 + 18 = 98`` chars then overflow narrower user terminals,
+    breaking Rich's panel borders and table headers mid-row.
+
+    We forward the user's actual terminal width minus the prefix overhead via
+    the ``COLUMNS`` env var (and ``LINES`` for completeness). Rich and most
+    POSIX tools honour ``COLUMNS`` via ``shutil.get_terminal_size``, so the
+    subprocess renders narrow enough that the relayed line fits inside the
+    user's terminal once the prefix is applied. A floor of 60 columns keeps
+    rendering usable when the user's terminal is unusually narrow.
+    """
+    user_width = console.size.width or _MIN_SUBPROCESS_TERMINAL_WIDTH + _TASK_OUTPUT_PREFIX_WIDTH
+    available = max(
+        _MIN_SUBPROCESS_TERMINAL_WIDTH,
+        user_width - _TASK_OUTPUT_PREFIX_WIDTH - 1,
+    )
+    env = dict(os.environ)
+    env["COLUMNS"] = str(available)
+    # LINES is less critical (Rich pagination is rare here) but we keep
+    # the pair consistent so ``shutil.get_terminal_size`` agrees with itself.
+    env.setdefault("LINES", str(max(20, console.size.height or 24)))
+    return env
+
+
+def _pump_task_stream(
+    *,
+    task: TaskRecord,
+    stream_name: str,
+    stream: IO[str],
+    console: Console,
+    style: str | None = None,
+    capture: tempfile.SpooledTemporaryFile[bytes] | None = None,  # type: ignore[type-arg]
+) -> None:
+    try:
+        for line in stream:
+            if capture is not None:
+                capture.write(line.encode("utf-8", errors="replace"))
+            if line.strip():
+                _print_task_output_line(console, task, stream_name, line, style=style)
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[{DIM}]task output stream ended unexpectedly:[/] {escape(str(exc))}")
+
+
+def _start_task_output_streams(
+    *,
+    task: TaskRecord,
+    proc: subprocess.Popen[Any],
+    console: Console,
+    stdout_capture: tempfile.SpooledTemporaryFile[bytes] | None = None,  # type: ignore[type-arg]
+    stderr_capture: tempfile.SpooledTemporaryFile[bytes] | None = None,  # type: ignore[type-arg]
+) -> list[threading.Thread]:
+    threads: list[threading.Thread] = []
+    streams: tuple[tuple[str, IO[str] | None, str | None, Any], ...] = (
+        ("stdout", proc.stdout, None, stdout_capture),
+        ("stderr", proc.stderr, ERROR, stderr_capture),
+    )
+    for stream_name, stream, style, capture in streams:
+        if stream is None:
+            continue
+        thread = threading.Thread(
+            target=_pump_task_stream,
+            kwargs={
+                "task": task,
+                "stream_name": stream_name,
+                "stream": stream,
+                "console": console,
+                "style": style,
+                "capture": capture,
+            },
+            daemon=True,
+            name=f"task-output-{task.task_id}-{stream_name}",
+        )
+        thread.start()
+        threads.append(thread)
+    return threads
+
+
+def _join_task_output_streams(threads: list[threading.Thread]) -> None:
+    for thread in threads:
+        thread.join(timeout=_TASK_OUTPUT_JOIN_TIMEOUT_SECONDS)
+
+
+def _console_file_is_tty(console: Console) -> bool:
+    isatty = getattr(console.file, "isatty", None)
+    return bool(isatty and isatty())
+
+
+def _should_use_pty(console: Console, requested: bool) -> bool:
+    return requested and hasattr(os, "openpty") and _console_file_is_tty(console)
+
+
+def _pump_task_pty(
+    *,
+    master_fd: int,
+    console: Console,
+    capture: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+) -> None:
+    try:
+        while True:
+            try:
+                chunk = os.read(master_fd, 4096)
+            except OSError as exc:
+                # BSD/macOS PTYs raise EIO at EOF; Linux commonly returns b"".
+                if exc.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            capture.write(chunk)
+            console.file.write(chunk.decode("utf-8", errors="replace"))
+            console.file.flush()
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[{DIM}]task terminal stream ended unexpectedly:[/] {escape(str(exc))}")
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(master_fd)
+
+
+def start_background_cli_task(
+    *,
+    display_command: str,
+    argv_list: list[str],
+    session: ReplSession,
+    console: Console,
+    timeout_seconds: int = SHELL_COMMAND_TIMEOUT_SECONDS,
+    kind: TaskKind = TaskKind.CLI_COMMAND,
+    use_pty: bool = False,
+) -> TaskRecord | None:
+    """Start a subprocess as a REPL task while streaming output above the prompt."""
+    console.print(f"[bold]$ {display_command}[/bold]")
+    task = session.task_registry.create(kind, command=display_command)
+    task.mark_running()
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+        max_size=_SYNTHETIC_DIAG_CHARS * 2
+    )
+    pty_fds: tuple[int, int] | None = None
+    if _should_use_pty(console, use_pty):
+        try:
+            pty_fds = os.openpty()
+        except OSError:
+            pty_fds = None
+    stdout_buf: tempfile.SpooledTemporaryFile[bytes] | None = None  # type: ignore[type-arg]
+    if pty_fds is None:
+        stdout_buf = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg] # noqa: SIM115
+            max_size=_MAX_COMMAND_OUTPUT_CHARS
+        )
+    subprocess_env = _subprocess_env_with_aligned_width(console)
+    proc: subprocess.Popen[Any]
+    try:
+        if pty_fds is None:
+            proc = subprocess.Popen(
+                argv_list,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                start_new_session=True,
+                env=subprocess_env,
+            )
+        else:
+            _master_fd, slave_fd = pty_fds
+            proc = subprocess.Popen(
+                argv_list,
+                stdin=subprocess.DEVNULL,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                close_fds=True,
+                start_new_session=True,
+                env=subprocess_env,
+            )
+    except Exception as exc:  # noqa: BLE001
+        if pty_fds is not None:
+            for fd in pty_fds:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+        if stdout_buf is not None:
+            stdout_buf.close()
+        stderr_buf.close()
+        task.mark_failed(str(exc))
+        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+        return None
+
+    task.attach_process(proc)
+    started_at = time.monotonic()
+    if pty_fds is None:
+        output_threads = _start_task_output_streams(
+            task=task,
+            proc=proc,
+            console=console,
+            stdout_capture=stdout_buf,
+            stderr_capture=stderr_buf,
+        )
+    else:
+        master_fd, slave_fd = pty_fds
+        with contextlib.suppress(OSError):
+            os.close(slave_fd)
+        output_thread = threading.Thread(
+            target=_pump_task_pty,
+            kwargs={"master_fd": master_fd, "console": console, "capture": stderr_buf},
+            daemon=True,
+            name=f"task-terminal-{task.task_id}",
+        )
+        output_thread.start()
+        output_threads = [output_thread]
+
+    def _watch() -> None:
+        terminated_by_watcher = False
+        timed_out = False
+        while proc.poll() is None:
+            if time.monotonic() - started_at > timeout_seconds:
+                timed_out = True
+                task.request_cancel()
+                terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            if task.cancel_requested.is_set():
+                terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            time.sleep(_SYNTHETIC_POLL_SECONDS)
+
+        try:
+            if timed_out:
+                task.mark_failed(f"timed out after {timeout_seconds}s")
+                return
+            if terminated_by_watcher and task.cancel_requested.is_set():
+                task.mark_cancelled()
+                return
+
+            _join_task_output_streams(output_threads)
+            code = proc.returncode
+            if code == 0:
+                task.mark_completed()
+            else:
+                diag = read_diag(stderr_buf)
+                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+                task.mark_failed(error_msg)
+                console.print(f"[{ERROR}]command failed (exit {code}):[/]")
+        except Exception as exc:  # noqa: BLE001
+            task.mark_failed(str(exc))
+            console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
+        finally:
+            _join_task_output_streams(output_threads)
+            if stdout_buf is not None:
+                stdout_buf.close()
+            stderr_buf.close()
+
+    thread = threading.Thread(target=_watch, daemon=True)
+    thread.start()
+    console.print(
+        f"[{DIM}]started — task[/] [bold]{escape(task.task_id)}[/bold]. "
+        f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "
+        f"[{HIGHLIGHT}]/cancel {escape(task.task_id)}[/] [{DIM}]to stop.[/]"
+    )
+    return task
+
+
+def _scenario_id_from_synthetic_suite_name(suite_name: str) -> str:
+    if ":" not in suite_name:
+        return ""
+    return suite_name.split(":", 1)[1].strip()
+
+
+def _try_bind_synthetic_observation(session: ReplSession, suite_name: str) -> None:
+    """Point session at ``_observations/<scenario>/latest.json`` after a failed run."""
+    scenario_id = _scenario_id_from_synthetic_suite_name(suite_name)
+    if not scenario_id:
+        return
+    try:
+        from app.cli.tests.discover import SYNTHETIC_SCENARIOS_DIR
+    except Exception:
+        session.last_synthetic_observation_path = None
+        return
+    latest = SYNTHETIC_SCENARIOS_DIR / "_observations" / scenario_id / "latest.json"
+    for _ in range(8):
+        if latest.is_file():
+            session.last_synthetic_observation_path = str(latest.resolve())
+            return
+        time.sleep(0.06)
+    session.last_synthetic_observation_path = None
+
+
+def watch_synthetic_subprocess(
+    task: TaskRecord,
+    proc: subprocess.Popen[Any],
+    session: ReplSession,
+    suite_name: str,
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes],  # type: ignore[type-arg]
+    console: Console | None = None,
+) -> None:
+    def _history_text() -> str:
+        return f"{suite_name} task:{task.task_id}"
+
+    history_gen_when_watch_started = session.history_generation
+
+    def _suggest_follow_up_on_failure() -> None:
+        if session.history_generation != history_gen_when_watch_started:
+            return
+        session.pending_prompt_default = SUGGESTED_PROMPT_AFTER_FAILED_SYNTHETIC_TEST
+        _try_bind_synthetic_observation(session, suite_name)
+
+    def _record_synthetic_if_current_session(ok: bool) -> None:
+        if session.history_generation != history_gen_when_watch_started:
+            return
+        session.record("synthetic_test", _history_text(), ok=ok)
+
+    def _run() -> None:
+        stdout_capture: _ThreadSafeCapture = _ThreadSafeCapture()
+        output_threads = (
+            _start_task_output_streams(
+                task=task,
+                proc=proc,
+                console=console,
+                stdout_capture=stdout_capture,
+                stderr_capture=stderr_buf,
+            )
+            if console is not None
+            else []
+        )
+        started = time.monotonic()
+        timed_out = False
+        terminated_by_watcher = False
+        _last_progress_read = 0.0
+        _progress_interval = 2.0
+        while proc.poll() is None:
+            if time.monotonic() - started > SYNTHETIC_TEST_TIMEOUT_SECONDS:
+                timed_out = True
+                task.request_cancel()
+                terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            if task.cancel_requested.is_set():
+                terminate_child_process(proc)
+                terminated_by_watcher = True
+                break
+            now = time.monotonic()
+            if now - _last_progress_read >= _progress_interval:
+                tail = stdout_capture.read_tail(200)
+                if tail:
+                    task.update_progress(tail)
+                _last_progress_read = now
+            time.sleep(_SYNTHETIC_POLL_SECONDS)
+
+        try:
+            if timed_out:
+                task.mark_failed(f"timed out after {SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
+                _record_synthetic_if_current_session(ok=False)
+                _suggest_follow_up_on_failure()
+                return
+
+            _join_task_output_streams(output_threads)
+            tail = stdout_capture.read_tail(200)
+            if tail:
+                task.update_progress(tail)
+            code = proc.returncode
+            if code is None:
+                task.mark_failed("subprocess did not report exit code")
+                _record_synthetic_if_current_session(ok=False)
+                _suggest_follow_up_on_failure()
+                return
+
+            # Honour the real exit code when the process exited on its own.
+            # Only treat as CANCELLED when *we* killed it after a cancel request;
+            # a natural exit that races with /cancel should be recorded by its code.
+            if terminated_by_watcher and task.cancel_requested.is_set():
+                task.mark_cancelled()
+                _record_synthetic_if_current_session(ok=False)
+                return
+
+            if code == 0:
+                task.mark_completed(result="ok")
+                _record_synthetic_if_current_session(ok=True)
+            else:
+                diag = read_diag(stderr_buf)
+                error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+                task.mark_failed(error_msg)
+                _record_synthetic_if_current_session(ok=False)
+                _suggest_follow_up_on_failure()
+        finally:
+            _join_task_output_streams(output_threads)
+            stderr_buf.close()
+            stdout_capture.close()
+
+    threading.Thread(target=_run, daemon=True, name=f"synthetic-{task.task_id}").start()
+
+
+def _recent_cli_agent_context(session: ReplSession, *, limit: int = 6) -> str:
+    recent = session.cli_agent_messages[-limit:]
+    if not recent:
+        return ""
+    return "\n".join(f"{role}: {text}" for role, text in recent)
+
+
+def _is_context_dependent_implementation_request(request: str) -> bool:
+    normalized = " ".join(request.strip().lower().split())
+    return normalized in {
+        "implement",
+        "please implement",
+        "code",
+        "make the change",
+        "make those changes",
+    }
+
+
+def _build_claude_code_implementation_prompt(request: str, session: ReplSession) -> str:
+    context = _recent_cli_agent_context(session)
+    context_block = (
+        f"--- Recent OpenSRE terminal assistant context ---\n{context}\n\n" if context else ""
+    )
+    return (
+        "You are Claude Code working in the current OpenSRE repository.\n\n"
+        f"{context_block}"
+        f"--- User implementation request ---\n{request.strip()}\n\n"
+        "--- Rules ---\n"
+        "- Implement the requested change in this repository.\n"
+        "- Follow AGENTS.md, existing project conventions, and local code style.\n"
+        "- Do not create a git commit or push changes.\n"
+        "- Do not run destructive git commands such as reset --hard or checkout --.\n"
+        "- Preserve unrelated user changes in the working tree.\n"
+        "- Run focused tests or lint checks when practical.\n"
+        "- Finish with a concise summary of changed files and verification performed.\n"
+    )
+
+
+def _implementation_argv(argv: tuple[str, ...]) -> list[str]:
+    exec_argv = list(argv)
+    permission_mode = os.environ.get(
+        _IMPLEMENT_PERMISSION_MODE_ENV,
+        _DEFAULT_IMPLEMENT_PERMISSION_MODE,
+    ).strip()
+    if permission_mode and permission_mode.lower() not in {"default", "none", "off"}:
+        exec_argv.extend(["--permission-mode", permission_mode])
+    return exec_argv
+
+
+def run_claude_code_implementation(
+    request: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    action_already_listed: bool = False,
+) -> None:
+    policy = evaluate_code_agent_launch()
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"Claude Code implementation: {request}",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=action_already_listed,
+    ):
+        session.record("implementation", request, ok=False)
+        return
+
+    if _is_context_dependent_implementation_request(request) and not session.cli_agent_messages:
+        console.print(
+            f"[{ERROR}]implementation request is too vague:[/] "
+            "describe what Claude Code should change."
+        )
+        session.record("implementation", request, ok=False)
+        return
+
+    adapter = ClaudeCodeAdapter()
+    probe = adapter.detect()
+    if not probe.installed or not probe.bin_path:
+        console.print(f"[{ERROR}]Claude Code CLI not available:[/] {escape(probe.detail)}")
+        session.record("implementation", request, ok=False)
+        return
+    if probe.logged_in is False:
+        console.print(f"[{ERROR}]Claude Code is not authenticated:[/] {escape(probe.detail)}")
+        session.record("implementation", request, ok=False)
+        return
+
+    prompt = _build_claude_code_implementation_prompt(request, session)
+    try:
+        invocation = adapter.build(
+            prompt=prompt,
+            model=os.environ.get("CLAUDE_CODE_MODEL"),
+            workspace=str(Path.cwd()),
+        )
+    except Exception as exc:
+        report_exception(exc, context="interactive_shell.claude_code.build")
+        console.print(f"[{ERROR}]Claude Code failed to prepare:[/] {escape(str(exc))}")
+        session.record("implementation", request, ok=False)
+        return
+
+    display_command = "claude -p"
+    console.print(f"[bold]$ {display_command}[/bold]")
+    task = session.task_registry.create(TaskKind.CODE_AGENT, command=display_command)
+    task.mark_running()
+    history_gen_when_started = session.history_generation
+
+    try:
+        proc = subprocess.Popen(
+            _implementation_argv(invocation.argv),
+            stdin=subprocess.PIPE if invocation.stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=invocation.cwd,
+            env=build_cli_subprocess_env(invocation.env),
+            start_new_session=True,
+        )
+    except Exception as exc:
+        task.mark_failed(str(exc))
+        report_exception(exc, context="interactive_shell.claude_code.start")
+        console.print(f"[{ERROR}]Claude Code failed to start:[/] {escape(str(exc))}")
+        session.record("implementation", request, ok=False)
+        return
+
+    task.attach_process(proc)
+    session.record("implementation", request, ok=True)
+
+    def _watch() -> None:
+        try:
+            timed_out = False
+            try:
+                stdout, stderr = proc.communicate(
+                    input=invocation.stdin,
+                    timeout=CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                task.request_cancel()
+                terminate_child_process(proc)
+                stdout, stderr = proc.communicate()
+
+            out = (stdout or "")[:_MAX_COMMAND_OUTPUT_CHARS]
+            err = (stderr or "")[:_MAX_COMMAND_OUTPUT_CHARS]
+            if timed_out:
+                task.mark_failed(f"timed out after {CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS}s")
+                console.print(
+                    f"[{ERROR}]Claude Code timed out after "
+                    f"{CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS} seconds[/]"
+                )
+                return
+
+            code = proc.returncode
+            if task.cancel_requested.is_set() and code != 0:
+                task.mark_cancelled()
+                if session.history_generation == history_gen_when_started:
+                    session.mark_latest(ok=False, kind="implementation")
+                console.print(f"[{WARNING}]Claude Code task cancelled.[/]")
+                return
+
+            if code == 0:
+                task.mark_completed(result="ok")
+                console.print(f"[{HIGHLIGHT}]Claude Code completed[/] task {task.task_id}")
+                print_command_output(console, out)
+                if err:
+                    print_command_output(console, err, style=DIM)
+                return
+
+            diag = (err or out).strip()[:_SYNTHETIC_DIAG_CHARS]
+            error_msg = f"exit code {code}" + (f": {diag}" if diag else "")
+            task.mark_failed(error_msg)
+            if session.history_generation == history_gen_when_started:
+                session.mark_latest(ok=False, kind="implementation")
+            console.print(f"[{ERROR}]Claude Code failed (exit {code}):[/]")
+            print_command_output(console, out)
+            print_command_output(console, err, style=ERROR)
+        except Exception as exc:  # noqa: BLE001
+            task.mark_failed(str(exc))
+            report_exception(exc, context="interactive_shell.claude_code.watch")
+            if session.history_generation == history_gen_when_started:
+                session.mark_latest(ok=False, kind="implementation")
+            console.print(f"[{ERROR}]Claude Code watcher failed:[/] {escape(str(exc))}")
+
+    threading.Thread(target=_watch, daemon=True, name=f"claude-code-{task.task_id}").start()
+    console.print(
+        f"[{DIM}]Claude Code started — task[/] [bold]{escape(task.task_id)}[/bold]. "
+        f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "
+        f"[{HIGHLIGHT}]/cancel {escape(task.task_id)}[/] [{DIM}]to stop.[/]"
+    )
+
+
+def run_shell_command(
+    command: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    argv: list[str] | None = None,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    action_already_listed: bool = False,
+) -> None:
+    parsed = parse_shell_command(command, is_windows=_intent_parser.IS_WINDOWS)
+    policy = evaluate_shell_from_parsed(parsed)
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"$ {command}",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=action_already_listed,
+    ):
+        session.record("shell", command, ok=False)
+        return
+
+    console.print(f"[bold]$ {escape(command)}[/bold]")
+
+    argv_builtin = argv_for_repl_builtin_routing(
+        parsed=parsed, is_windows=_intent_parser.IS_WINDOWS
+    )
+
+    if argv_builtin is not None and argv_builtin[0].lower() == "cd":
+        run_cd_command(parsed.command, session, console)
+        return
+    if argv_builtin is not None and argv_builtin[0].lower() == "pwd":
+        run_pwd_command(parsed.command, session, console)
+        return
+
+    use_shell = parsed.passthrough
+    if use_shell:
+        console.print(f"[{DIM}]explicit shell passthrough enabled[/]")
+
+    exec_argv = argv if argv is not None else parsed.argv
+
+    try:
+        result = execute_shell_command(
+            command=parsed.command,
+            argv=exec_argv,
+            use_shell=use_shell,
+            timeout_seconds=SHELL_COMMAND_TIMEOUT_SECONDS,
+            max_output_chars=_MAX_COMMAND_OUTPUT_CHARS,
+        )
+    except Exception as exc:
+        report_exception(exc, context="interactive_shell.shell_command.start")
+        console.print(f"[{ERROR}]command failed to start:[/] {escape(str(exc))}")
+        session.record("shell", command, ok=False)
+        return
+
+    print_command_output(console, result.stdout)
+    print_command_output(console, result.stderr, style=ERROR)
+    if result.timed_out:
+        console.print(
+            f"[{ERROR}]command timed out after {SHELL_COMMAND_TIMEOUT_SECONDS} seconds[/]"
+        )
+        session.record("shell", command, ok=False)
+        return
+    ok = result.exit_code == 0
+    had_stdout = bool((result.stdout or "").strip())
+    had_stderr = bool((result.stderr or "").strip())
+    if ok:
+        if not had_stdout and not had_stderr:
+            console.print(f"[{HIGHLIGHT}]✓[/]")
+    else:
+        code = result.exit_code if result.exit_code is not None else "?"
+        console.print(f"[{ERROR}]✗[/] exit {code}")
+    session.record("shell", command, ok=ok)
+
+
+def run_cd_command(command: str, session: ReplSession, console: Console) -> None:
+    def _strip_outer_quotes(value: str) -> str:
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            return value[1:-1]
+        return value
+
+    try:
+        tokens = shlex.split(command, posix=not _intent_parser.IS_WINDOWS)
+        if _intent_parser.IS_WINDOWS and len(tokens) > 1:
+            tokens = [tokens[0], *(_strip_outer_quotes(token) for token in tokens[1:])]
+    except ValueError as exc:
+        console.print(f"[{ERROR}]cd failed:[/] {escape(str(exc))}")
+        session.record("shell", command, ok=False)
+        return
+
+    if len(tokens) > 2:
+        console.print(f"[{ERROR}]cd failed:[/] too many arguments")
+        session.record("shell", command, ok=False)
+        return
+
+    target = Path(tokens[1]).expanduser() if len(tokens) == 2 else Path.home()
+    try:
+        os.chdir(target)
+    except Exception as exc:
+        console.print(f"[{ERROR}]cd failed:[/] {escape(str(exc))}")
+        session.record("shell", command, ok=False)
+        return
+
+    console.print(Text(str(Path.cwd())))
+    session.record("shell", command)
+
+
+def run_pwd_command(command: str, session: ReplSession, console: Console) -> None:
+    try:
+        tokens = shlex.split(command, posix=not _intent_parser.IS_WINDOWS)
+    except ValueError as exc:
+        console.print(f"[{ERROR}]pwd failed:[/] {escape(str(exc))}")
+        session.record("shell", command, ok=False)
+        return
+
+    if len(tokens) != 1:
+        console.print(f"[{ERROR}]pwd failed:[/] too many arguments")
+        session.record("shell", command, ok=False)
+        return
+
+    console.print(Text(str(Path.cwd())))
+    session.record("shell", command)
+
+
+_OPENSRE_BLOCKED_SUBCOMMANDS: frozenset[str] = frozenset({"agent"})
+
+_READ_ONLY_OPENSRE_SUBCOMMANDS: frozenset[str] = frozenset(
+    {
+        "health",
+        "version",
+        "list",
+        "status",
+        "show",
+    }
+)
+
+
+def _classify_opensre_command(tokens: list[str]) -> str:
+    first_token = tokens[0].lower()
+    if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS:
+        return "read_only"
+    if first_token == "agents":
+        subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
+        if subcommand in {"list"}:
+            return "read_only"
+        if subcommand == "scan" and "--register" not in tokens[2:]:
+            return "read_only"
+    return "mutating"
+
+
+def _opensre_confirmation_reason(tokens: list[str]) -> str:
+    if tokens[:2] == ["agents", "scan"] and "--register" in tokens[2:]:
+        return "register discovered local AI-agent processes"
+    if tokens and tokens[0] == "agents":
+        return "this updates the local AI-agent registry"
+    return "this opensre subcommand may change local config or infrastructure"
+
+
+def _should_run_opensre_in_foreground(tokens: list[str]) -> bool:
+    first_token = tokens[0].lower()
+    if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS:
+        return True
+    if first_token == "agents":
+        subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
+        return subcommand in {"list", "register", "forget", "scan", "watch"}
+    return False
+
+
+def _run_opensre_foreground(
+    argv_list: list[str],
+    display_command: str,
+    session: ReplSession,
+    console: Console,
+) -> None:
+    console.print(f"[bold]$ {escape(display_command)}[/bold]")
+    try:
+        result = subprocess.run(
+            argv_list,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=SHELL_COMMAND_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        print_command_output(console, str(exc.output or ""))
+        print_command_output(console, str(exc.stderr or ""), style=ERROR)
+        console.print(
+            f"[{ERROR}]command timed out after {SHELL_COMMAND_TIMEOUT_SECONDS} seconds[/]"
+        )
+        session.record("cli_command", display_command, ok=False)
+        return
+    except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="interactive_shell.opensre_cli.start")
+        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+        session.record("cli_command", display_command, ok=False)
+        return
+
+    print_command_output(console, result.stdout)
+    print_command_output(console, result.stderr, style=ERROR)
+    ok = result.returncode == 0
+    if not ok:
+        console.print(f"[{ERROR}]command failed (exit {result.returncode}):[/]")
+    session.record("cli_command", display_command, ok=ok)
+
+
+def _run_opensre_foreground_streaming(
+    argv_list: list[str],
+    display_command: str,
+    session: ReplSession,
+    console: Console,
+) -> None:
+    console.print(f"[bold]$ {escape(display_command)}[/bold]")
+    try:
+        proc = subprocess.Popen(
+            argv_list,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="interactive_shell.opensre_cli.start")
+        console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
+        session.record("cli_command", display_command, ok=False)
+        return
+
+    if proc.stdout is not None:
+        for line in proc.stdout:
+            print_command_output(console, line)
+    code = proc.wait()
+    ok = code == 0
+    if not ok:
+        console.print(f"[{ERROR}]command failed (exit {code}):[/]")
+    session.record("cli_command", display_command, ok=ok)
+
+
+def run_opensre_cli_command(
+    args: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> bool:
+    """Run an opensre subcommand (not agent).
+
+    Returns True if the command was attempted (regardless of success),
+    False if the subcommand is blocked or args are empty.
+    """
+    try:
+        tokens = shlex.split(args)
+    except ValueError:
+        tokens = args.split()
+    if not tokens:
+        return False
+
+    first_token = tokens[0].lower()
+    if first_token in _OPENSRE_BLOCKED_SUBCOMMANDS:
+        console.print(f"[{ERROR}]Cannot run `opensre {first_token}`: subcommand is blocked.[/]")
+        return False
+
+    command_classification = _classify_opensre_command(tokens)
+    from app.cli.interactive_shell.orchestration.execution_policy import (
+        ExecutionPolicyResult,
+        execution_allowed,
+    )
+
+    if command_classification == "read_only":
+        policy_result = ExecutionPolicyResult(
+            verdict="allow",
+            action_type="cli_command",
+            reason=None,
+            hint=None,
+            shell_classification=command_classification,
+        )
+    else:
+        policy_result = ExecutionPolicyResult(
+            verdict="ask",
+            action_type="cli_command",
+            reason=_opensre_confirmation_reason([token.lower() for token in tokens]),
+            hint="Use a read-only subcommand (health, version, list, status, show)",
+            shell_classification=command_classification,
+        )
+
+    if not execution_allowed(
+        policy_result,
+        session=session,
+        console=console,
+        action_summary=f"$ opensre {' '.join(tokens)}",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=True,
+    ):
+        session.record("cli_command", f"opensre {' '.join(tokens)}", ok=False)
+        return True
+
+    argv_list = [sys.executable, "-m", "app.cli"] + tokens
+    display_command = f"opensre {' '.join(tokens)}"
+    if _should_run_opensre_in_foreground(tokens):
+        if [token.lower() for token in tokens[:2]] == ["agents", "watch"]:
+            _run_opensre_foreground_streaming(argv_list, display_command, session, console)
+            return True
+        _run_opensre_foreground(argv_list, display_command, session, console)
+        return True
+
+    session.record("cli_command", display_command)
+    start_background_cli_task(
+        display_command=display_command,
+        argv_list=argv_list,
+        session=session,
+        console=console,
+    )
+    return True
+
+
+def run_sample_alert(
+    template_name: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    action_already_listed: bool = False,
+) -> None:
+    from app.cli.investigation import run_sample_alert_for_session
+
+    policy = evaluate_investigation_launch(action_type="sample_alert")
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"sample alert investigation ({template_name})",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=action_already_listed,
+    ):
+        session.record("alert", f"sample:{template_name}", ok=False)
+        return
+
+    console.print(f"[bold]sample alert:[/bold] {escape(template_name)}")
+    task = session.task_registry.create(
+        TaskKind.INVESTIGATION, command=f"sample alert:{template_name}"
+    )
+    task.mark_running()
+    try:
+        final_state = run_sample_alert_for_session(
+            template_name=template_name,
+            context_overrides=session.accumulated_context or None,
+            cancel_requested=task.cancel_requested,
+        )
+    except KeyboardInterrupt:
+        task.mark_cancelled()
+        console.print(f"[{WARNING}]investigation cancelled.[/]")
+        session.record("alert", f"sample:{template_name}", ok=False)
+        return
+    except OpenSREError as exc:
+        task.mark_failed(str(exc))
+        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+        if exc.suggestion:
+            console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
+        session.record("alert", f"sample:{template_name}", ok=False)
+        return
+    except Exception as exc:
+        task.mark_failed(str(exc))
+        report_exception(exc, context="interactive_shell.sample_alert")
+        console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+        session.record("alert", f"sample:{template_name}", ok=False)
+        return
+
+    root = final_state.get("root_cause")
+    task.mark_completed(result=str(root) if root is not None else "")
+    session.last_state = final_state
+    session.accumulate_from_state(final_state)
+    session.record("alert", f"sample:{template_name}")
+
+
+def run_synthetic_test(
+    suite_name: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+    action_already_listed: bool = False,
+) -> None:
+    suite_spec = suite_name.strip().lower()
+
+    # The planner emits this sentinel when the user explicitly named a numeric
+    # scenario ID that isn't in the on-disk suite (e.g. "test 016" when only
+    # 000-015 exist). Surface the error before any execution-policy / subprocess
+    # work so we never silently launch the default scenario in its place.
+    if suite_spec.startswith(SYNTHETIC_UNKNOWN_PREFIX):
+        hint = suite_spec[len(SYNTHETIC_UNKNOWN_PREFIX) :]
+        console.print(f"[{ERROR}]no synthetic scenario matches[/] '{escape(hint)}'.")
+        available = _list_rds_postgres_scenarios()
+        if available:
+            console.print(f"Available scenarios ({len(available)}):")
+            for name in available:
+                console.print(f"  • {name}")
+        session.record("synthetic_test", suite_name, ok=False)
+        return
+
+    resolved_suite_name = ""
+    resolved_scenario = DEFAULT_SYNTHETIC_SCENARIO
+    if suite_spec == "rds_postgres":
+        resolved_suite_name = "rds_postgres"
+    elif suite_spec.startswith("rds_postgres:"):
+        requested_scenario = suite_spec.split(":", 1)[1].strip()
+        if requested_scenario and _SYNTHETIC_SCENARIO_ID_RE.fullmatch(requested_scenario):
+            resolved_suite_name = "rds_postgres"
+            resolved_scenario = requested_scenario
+    if resolved_suite_name != "rds_postgres":
+        console.print(f"[{ERROR}]unknown synthetic suite:[/] {escape(suite_name)}")
+        session.record("synthetic_test", suite_name, ok=False)
+        return
+
+    policy = evaluate_synthetic_test_launch()
+    if not execution_allowed(
+        policy,
+        session=session,
+        console=console,
+        action_summary=f"opensre tests synthetic --scenario {resolved_scenario}",
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+        action_already_listed=action_already_listed,
+    ):
+        session.record("synthetic_test", suite_name, ok=False)
+        return
+
+    display_command = f"opensre tests synthetic --scenario {resolved_scenario}"
+    console.print(f"[bold]$ {display_command}[/bold]")
+    session.last_synthetic_observation_path = None
+    task = session.task_registry.create(TaskKind.SYNTHETIC_TEST, command=display_command)
+    task.mark_running()
+    # Lifetime managed by the watcher thread's finally block; SIM115 ignored
+    # for this file in ruff.toml.
+    stderr_buf: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # type: ignore[type-arg]
+        max_size=_SYNTHETIC_DIAG_CHARS * 2
+    )
+    try:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-u",
+                "-m",
+                "app.cli",
+                "tests",
+                "synthetic",
+                "--scenario",
+                resolved_scenario,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            start_new_session=True,
+            env=_subprocess_env_with_aligned_width(console),
+        )
+    except Exception as exc:
+        stderr_buf.close()
+        task.mark_failed(str(exc))
+        report_exception(exc, context="interactive_shell.synthetic_test.start")
+        console.print(f"[{ERROR}]synthetic test failed to start:[/] {escape(str(exc))}")
+        session.record("synthetic_test", suite_name, ok=False)
+        return
+
+    task.attach_process(proc)
+    watch_synthetic_subprocess(
+        task,
+        proc,
+        session,
+        f"{resolved_suite_name}:{resolved_scenario}",
+        stderr_buf,
+        console,
+    )
+    console.print(
+        f"[{DIM}]synthetic test started — task[/] [bold]{escape(task.task_id)}[/bold]. "
+        f"[{HIGHLIGHT}]/tasks[/] [{DIM}]to monitor,[/] "
+        f"[{HIGHLIGHT}]/cancel {escape(task.task_id)}[/] [{DIM}]to stop.[/]"
+    )
+
+
+__all__ = [
+    "SHELL_COMMAND_TIMEOUT_SECONDS",
+    "SYNTHETIC_TEST_TIMEOUT_SECONDS",
+    "read_diag",
+    "read_tail",
+    "run_claude_code_implementation",
+    "run_cd_command",
+    "run_opensre_cli_command",
+    "run_pwd_command",
+    "run_sample_alert",
+    "run_shell_command",
+    "run_synthetic_test",
+    "start_background_cli_task",
+    "terminate_child_process",
+    "watch_synthetic_subprocess",
+]

--- a/app/cli/interactive_shell/runtime/tasks.py
+++ b/app/cli/interactive_shell/runtime/tasks.py
@@ -1,0 +1,344 @@
+"""In-flight task bookkeeping for the interactive shell (REPL tasks + cancellation)."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import secrets
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from subprocess import Popen
+from typing import Any
+
+import app.constants as const_module
+
+_TASK_ID_BYTES = 4
+_MAX_REGISTRY = 100
+_MAX_PROGRESS_CHARS = 500
+_TASKS_STORE_FILENAME = "interactive_tasks.json"
+
+
+class TaskStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class TaskKind(StrEnum):
+    INVESTIGATION = "investigation"
+    SYNTHETIC_TEST = "synthetic_test"
+    CLI_COMMAND = "cli_command"
+    CODE_AGENT = "code_agent"
+
+
+@dataclass
+class TaskRecord:
+    """One shell task (investigation pipeline run or subprocess-backed suite)."""
+
+    task_id: str
+    kind: TaskKind
+    status: TaskStatus = TaskStatus.PENDING
+    started_at: float = field(default_factory=time.time)
+    ended_at: float | None = None
+    result: str | None = None
+    error: str | None = None
+    pid: int | None = None
+    command: str | None = None
+    progress: str | None = None
+    _cancel_requested: threading.Event = field(
+        default_factory=threading.Event, repr=False, init=False
+    )
+    _process: Popen[Any] | None = field(default=None, repr=False, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, init=False)
+    _on_change: Callable[[], None] | None = field(default=None, repr=False, init=False)
+    _rehydrated: bool = field(default=False, repr=False, init=False)
+
+    def _notify_changed(self) -> None:
+        if self._on_change is not None:
+            self._on_change()
+
+    @property
+    def cancel_requested(self) -> threading.Event:
+        """Set by :meth:`request_cancel`; polled by cooperative cancellation paths."""
+        return self._cancel_requested
+
+    def attach_process(self, proc: Popen[Any]) -> None:
+        """Bind a child process so :meth:`request_cancel` can terminate it."""
+        with self._lock:
+            self._process = proc
+            pid = getattr(proc, "pid", None)
+            self.pid = pid if isinstance(pid, int) else None
+        self._notify_changed()
+
+    def attach_pid(self, pid: int | None) -> None:
+        """Bind a previously-started process id without a live ``Popen`` object."""
+        with self._lock:
+            self.pid = pid
+        self._notify_changed()
+
+    def mark_running(self) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.RUNNING
+        self._notify_changed()
+
+    def mark_completed(self, *, result: str | None = None) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.COMPLETED
+            self.result = result
+            self.ended_at = time.time()
+        self._notify_changed()
+
+    def mark_cancelled(self) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.CANCELLED
+            self.ended_at = time.time()
+        self._notify_changed()
+
+    def mark_failed(self, message: str) -> None:
+        with self._lock:
+            if self.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED, TaskStatus.FAILED):
+                return
+            self.status = TaskStatus.FAILED
+            self.error = message
+            self.ended_at = time.time()
+        self._notify_changed()
+
+    def update_progress(self, text: str) -> None:
+        with self._lock:
+            if self.status != TaskStatus.RUNNING:
+                return
+            if self.progress is None:
+                self.progress = text[-_MAX_PROGRESS_CHARS:]
+            else:
+                self.progress = (self.progress + "\n" + text)[-_MAX_PROGRESS_CHARS:]
+
+    def request_cancel(self) -> bool:
+        """Signal cancellation and kill a bound subprocess. Returns True if task was running."""
+        mark_cancelled_without_watcher = False
+        with self._lock:
+            was_active = self.status == TaskStatus.RUNNING
+            self._cancel_requested.set()
+            proc = self._process
+            pid = self.pid
+        if proc is not None and proc.poll() is None:
+            with contextlib.suppress(OSError):
+                proc.terminate()
+        elif was_active and pid is not None:
+            mark_cancelled_without_watcher = True
+        if mark_cancelled_without_watcher:
+            self.mark_cancelled()
+        else:
+            self._notify_changed()
+        return was_active
+
+    def duration_seconds(self) -> float | None:
+        if self.ended_at is None:
+            return None
+        return self.ended_at - self.started_at
+
+    def refresh_rehydrated_status(self) -> None:
+        """Mark persisted running tasks as finished once their PID disappears."""
+        with self._lock:
+            if (
+                not self._rehydrated
+                or self.status != TaskStatus.RUNNING
+                or self._process is not None
+            ):
+                return
+            if self.pid is not None and _process_alive(self.pid):
+                return
+            self.status = TaskStatus.COMPLETED
+            self.result = self.result or "process exited while shell was closed"
+            self.ended_at = time.time()
+        self._notify_changed()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "task_id": self.task_id,
+            "kind": self.kind.value,
+            "status": self.status.value,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "result": self.result,
+            "error": self.error,
+            "pid": self.pid,
+            "command": self.command,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> TaskRecord | None:
+        try:
+            task_id = str(data["task_id"])
+            kind = TaskKind(str(data["kind"]))
+            status = TaskStatus(str(data["status"]))
+            started_at_value = data["started_at"]
+            if not isinstance(started_at_value, int | float | str):
+                return None
+            started_at = float(started_at_value)
+        except (KeyError, TypeError, ValueError):
+            return None
+
+        ended_at_value = data.get("ended_at")
+        pid_value = data.get("pid")
+        record = cls(
+            task_id=task_id,
+            kind=kind,
+            status=status,
+            started_at=started_at,
+            ended_at=float(ended_at_value) if isinstance(ended_at_value, int | float) else None,
+            result=str(data["result"]) if data.get("result") is not None else None,
+            error=str(data["error"]) if data.get("error") is not None else None,
+            pid=int(pid_value) if isinstance(pid_value, int) else None,
+            command=str(data["command"]) if data.get("command") is not None else None,
+        )
+        record._rehydrated = True
+        return record
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _tasks_store_path() -> Path:
+    return const_module.OPENSRE_HOME_DIR / _TASKS_STORE_FILENAME
+
+
+class TaskRegistry:
+    """Recent tasks for /tasks and /cancel, optionally persisted across REPL sessions."""
+
+    def __init__(
+        self,
+        *,
+        max_tasks: int = _MAX_REGISTRY,
+        persist_path: Path | None = None,
+        load: bool = False,
+    ) -> None:
+        self._tasks: deque[TaskRecord] = deque(maxlen=max_tasks)
+        self._lock = threading.Lock()
+        self._persist_lock = threading.Lock()
+        self._persist_path = persist_path
+        self._max_tasks = max_tasks
+        if load:
+            self._load_persisted()
+
+    @classmethod
+    def persistent(cls, *, max_tasks: int = _MAX_REGISTRY) -> TaskRegistry:
+        return cls(max_tasks=max_tasks, persist_path=_tasks_store_path(), load=True)
+
+    def _attach(self, record: TaskRecord) -> TaskRecord:
+        record._on_change = self._persist
+        return record
+
+    def _load_persisted(self) -> None:
+        if self._persist_path is None or not self._persist_path.exists():
+            return
+        try:
+            payload = json.loads(self._persist_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, list):
+            return
+        records = [
+            self._attach(record)
+            for item in payload
+            if isinstance(item, dict)
+            if (record := TaskRecord.from_dict(item)) is not None
+        ]
+        for record in records[-self._max_tasks :]:
+            record.refresh_rehydrated_status()
+            self._tasks.append(record)
+        self._persist()
+
+    def _persist(self) -> None:
+        if self._persist_path is None:
+            return
+        with self._persist_lock:
+            with self._lock:
+                payload = [task.to_dict() for task in self._tasks]
+            tmp_path: Path | None = None
+            try:
+                self._persist_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                tmp_path = self._persist_path.with_name(
+                    f"{self._persist_path.name}.{threading.get_ident()}.{secrets.token_hex(4)}.tmp"
+                )
+                tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+                tmp_path.replace(self._persist_path)
+            except OSError:
+                if tmp_path is not None:
+                    with contextlib.suppress(OSError):
+                        tmp_path.unlink()
+                return
+
+    def _refresh_rehydrated(self) -> None:
+        with self._lock:
+            items = list(self._tasks)
+        for task in items:
+            task.refresh_rehydrated_status()
+
+    def create(self, kind: TaskKind, *, command: str | None = None) -> TaskRecord:
+        task_id = secrets.token_hex(_TASK_ID_BYTES)
+        record = self._attach(TaskRecord(task_id=task_id, kind=kind, command=command))
+        with self._lock:
+            self._tasks.append(record)
+        self._persist()
+        return record
+
+    def candidates(self, task_id_prefix: str) -> list[TaskRecord]:
+        self._refresh_rehydrated()
+        needle = task_id_prefix.strip().lower()
+        if not needle:
+            return []
+        with self._lock:
+            items = list(self._tasks)
+        return [t for t in items if t.task_id.lower().startswith(needle)]
+
+    def get(self, task_id_prefix: str) -> TaskRecord | None:
+        matches = self.candidates(task_id_prefix)
+        if len(matches) != 1:
+            return None
+        return matches[0]
+
+    def list_recent(self, n: int = 20) -> list[TaskRecord]:
+        """Return up to ``n`` tasks, newer tasks first (FIFO buffer end is newest)."""
+        self._refresh_rehydrated()
+        with self._lock:
+            items = list(self._tasks)
+        return list(reversed(items[-n:]))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._tasks.clear()
+        self._persist()
+
+    def __contains__(self, task_id: str) -> bool:
+        return self.get(task_id) is not None
+
+
+__all__ = [
+    "TaskKind",
+    "TaskRecord",
+    "TaskRegistry",
+    "TaskStatus",
+]

--- a/tests/synthetic/rds_postgres/run_suite.py
+++ b/tests/synthetic/rds_postgres/run_suite.py
@@ -1,68 +1,105 @@
+"""Thin orchestration entrypoint for the synthetic RDS PostgreSQL benchmark suite.
+
+Pure scoring logic lives in scoring.py.
+Rendering/cross-axis reports live in reporting.py.
+Per-scenario observation building and Rich rendering live in observations.py.
+"""
+
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
-import re
-from dataclasses import asdict, dataclass
+import os
+import textwrap
+import time
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager, nullcontext
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
-from app.pipeline.runners import run_investigation
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.table import Table
+
 from tests.synthetic.mock_aws_backend import FixtureAWSBackend
 from tests.synthetic.mock_grafana_backend.backend import FixtureGrafanaBackend
+from tests.synthetic.rds_postgres.observations import (
+    TrajectoryPolicy,
+    TrajectoryPolicyResult,
+    build_observation,
+    compute_trajectory_metrics,
+    evaluate_trajectory_policy,
+    render_report_to_console,
+    write_observation,
+)
+from tests.synthetic.rds_postgres.runner_api import (
+    LevelRunConfig,
+    LevelRunResult,
+    SuiteRunConfig,
+    SuiteRunResult,
+    group_fixtures_by_level,
+    parse_levels_csv,
+    select_fixtures,
+)
 from tests.synthetic.rds_postgres.scenario_loader import (
     SUITE_DIR,
+    GoldenTrajectoryConfig,
     ScenarioFixture,
     load_all_scenarios,
 )
 
-# Maps fixture schema evidence keys to the agent's internal state keys.
-_EVIDENCE_KEY_MAP: dict[str, str] = {
-    "aws_cloudwatch_metrics": "grafana_metrics",
-    "aws_rds_events": "grafana_logs",
-    "aws_performance_insights": "grafana_metrics",
-}
+# Re-export scoring symbols so existing import sites continue to work without
+# modification. Track removal in a follow-up once all sites are migrated.
+from tests.synthetic.rds_postgres.scoring import (
+    FailureDetail,
+    GateResult,
+    ReasoningScore,
+    ScenarioScore,
+    TrajectoryScore,
+    _all_required_gates_pass,
+    score_reasoning,
+    score_result,
+    score_trajectory,
+)
+
+__all__ = [
+    # dataclasses
+    "FailureDetail",
+    "GateResult",
+    "ReasoningScore",
+    "ScenarioScore",
+    "TrajectoryScore",
+    # functions
+    "score_result",
+    "score_reasoning",
+    "score_trajectory",
+    # orchestration
+    "run_scenario",
+    "run_synthetic_suite",
+    "run_suite",
+    "main",
+]
 
 
-@dataclass(frozen=True)
-class TrajectoryScore:
-    actual_sequence: list[str]  # flattened actions from executed_hypotheses
-    expected_sequence: list[str]  # from answer_key.optimal_trajectory
-    loops_used: int
-    max_loops: int
-    sequencing_ok: bool  # all expected actions appear in actual (set membership)
-    calibration_ok: bool  # loops_used <= max_loops
-    efficiency_score: float  # mean(sequencing_ok, calibration_ok)
+def _run_investigation_lazy(**kwargs: Any) -> Any:
+    from app.pipeline.runners import run_investigation as _run_investigation
+
+    return _run_investigation(**kwargs)
 
 
-@dataclass(frozen=True)
-class ReasoningScore:
-    """Axis 2 adversarial reasoning quality score.
-
-    ruling_out_ok: every ruling_out_keywords token was found in agent output.
-    queries_ok: every required_queries metric name was requested via query_timeseries.
-    reasoning_score: mean(ruling_out_ok, queries_ok); 1.0 = full pass.
-    """
-
-    ruling_out_ok: bool
-    queries_ok: bool
-    missing_ruling_out: list[str]
-    missing_queries: list[str]
-    reasoning_score: float
-
-
-@dataclass(frozen=True)
-class ScenarioScore:
-    scenario_id: str
-    passed: bool
-    root_cause_present: bool
-    expected_category: str
-    actual_category: str
-    missing_keywords: list[str]
-    matched_keywords: list[str]
-    root_cause: str
-    failure_reason: str = ""
-    trajectory: TrajectoryScore | None = None
-    reasoning: ReasoningScore | None = None
+# Keep as module symbol so tests can monkeypatch without importing heavy deps.
+run_investigation: Callable[..., Any] = _run_investigation_lazy
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -71,6 +108,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--scenario",
         default="",
         help="Run a single scenario directory name, e.g. 001-replication-lag.",
+    )
+    parser.add_argument(
+        "--levels",
+        default="1,2,3,4",
+        help=(
+            "Comma-separated scenario_difficulty levels to execute (1-4). "
+            "Ignored when --scenario is set."
+        ),
+    )
+    parser.add_argument(
+        "--parallel-levels",
+        type=int,
+        default=1,
+        dest="parallel_levels",
+        help="Number of scenario levels to execute in parallel (max 4).",
     )
     parser.add_argument(
         "--json",
@@ -88,7 +140,55 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Print Axis 1 vs Axis 2 gap report (requires results from both suites).",
     )
+    report_group = parser.add_mutually_exclusive_group()
+    report_group.add_argument(
+        "--report",
+        action="store_true",
+        dest="report",
+        help="Print Rich observation report per scenario.",
+    )
+    report_group.add_argument(
+        "--no-report",
+        action="store_false",
+        dest="report",
+        help="Disable Rich observation report output.",
+    )
+    parser.set_defaults(report=None)
+    parser.add_argument(
+        "--observations-dir",
+        default=str(SUITE_DIR / "_observations"),
+        help="Directory where per-run observation JSON files are written.",
+    )
+    parser.add_argument(
+        "--baseline-out",
+        default="",
+        dest="baseline_out",
+        help="Write per-scenario canonical_report_payload JSON snapshots into this directory.",
+    )
+    parser.add_argument(
+        "--baseline-check",
+        default="",
+        dest="baseline_check",
+        help=(
+            "Compare each scenario's canonical_report_payload against snapshots in this "
+            "directory. Exits non-zero on any mismatch."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def _build_run_config(args: argparse.Namespace) -> SuiteRunConfig:
+    return SuiteRunConfig(
+        scenario=str(args.scenario or "").strip(),
+        levels=parse_levels_csv(args.levels),
+        parallel_levels=max(1, int(args.parallel_levels)),
+        output_json=bool(args.json),
+        mock_grafana=bool(args.mock_grafana),
+        report=args.report,
+        observations_dir=Path(args.observations_dir),
+        baseline_out=Path(args.baseline_out) if args.baseline_out else None,
+        baseline_check=Path(args.baseline_check) if args.baseline_check else None,
+    )
 
 
 def _build_resolved_integrations(
@@ -96,22 +196,7 @@ def _build_resolved_integrations(
     use_mock_grafana: bool,
     grafana_backend: Any = None,
 ) -> dict[str, Any] | None:
-    """Build pre-resolved integrations to inject into run_investigation.
-
-    Accepts an optional pre-built grafana_backend (e.g. SelectiveGrafanaBackend)
-    so callers can instrument the backend before injection.  Falls back to a fresh
-    FixtureGrafanaBackend when use_mock_grafana=True and no backend is provided.
-
-    When the scenario declares EC2/ELB evidence, also injects a FixtureAWSBackend
-    under ``aws.ec2_backend`` so the EC2/RDS topology tools can serve fixture
-    data without colliding with the EKS ``_backend`` slot.
-    """
-    has_aws_topology = bool(
-        fixture.evidence.ec2_instances_by_tag is not None
-        or fixture.evidence.elb_target_health is not None
-    )
-    if not use_mock_grafana and grafana_backend is None and not has_aws_topology:
-        return None
+    """Build pre-resolved integrations for injection into run_investigation."""
     integrations: dict[str, Any] = {}
     if use_mock_grafana or grafana_backend is not None:
         integrations["grafana"] = {
@@ -119,318 +204,99 @@ def _build_resolved_integrations(
             "api_key": "",
             "_backend": grafana_backend or FixtureGrafanaBackend(fixture),
         }
-    if has_aws_topology:
-        integrations["aws"] = {
-            "region": fixture.metadata.region,
-            "ec2_backend": FixtureAWSBackend(fixture),
-        }
-    return integrations or None
-
-
-def _normalize_text(value: str) -> str:
-    return " ".join(value.lower().split())
-
-
-def _normalize_query_token(value: str) -> str:
-    return _normalize_text(value).replace(" ", "_").replace("-", "_")
-
-
-def _matches_required_keyword(normalized_output: str, keyword: str) -> bool:
-    normalized_keyword = _normalize_text(keyword)
-    if normalized_keyword in normalized_output:
-        return True
-
-    keyword_aliases = {
-        "max_connections": (
-            "maximum allowed connections",
-            "max allowed connections",
-            "allowed connections",
-            "connection slots",
-        ),
-        "performanceinsights": (
-            "top sql activity",
-            "avg load",
-            "aas",
-            "active sessions",
-            "db load",
-        ),
-        "client sessions": (
-            "client session",
-            "idle database sessions",
-            "database sessions",
-        ),
-        "idle": (
-            "clientread",
-            "waiting for client response",
-            "sessions remain open",
-            "open sessions",
-        ),
+    integrations["aws"] = {
+        "region": fixture.metadata.region,
+        "ec2_backend": FixtureAWSBackend(fixture),
     }
-    for alias in keyword_aliases.get(normalized_keyword.replace(" ", ""), ()):
-        if _normalize_text(alias) in normalized_output:
-            return True
-
-    keyword_tokens = set(re.findall(r"[a-z0-9]+", normalized_keyword))
-    if not keyword_tokens:
-        return False
-
-    output_tokens = set(re.findall(r"[a-z0-9]+", normalized_output))
-    return keyword_tokens.issubset(output_tokens)
+    return integrations
 
 
-def _scored_output_text(final_state: dict[str, Any]) -> str:
-    """Return the broadest textual output we should grade for synthetic scenarios."""
-    return " ".join(
-        [
-            str(final_state.get("root_cause") or ""),
-            " ".join(claim.get("claim", "") for claim in final_state.get("validated_claims", [])),
-            " ".join(
-                claim.get("claim", "") for claim in final_state.get("non_validated_claims", [])
-            ),
-            " ".join(final_state.get("causal_chain", [])),
-            str(final_state.get("report") or ""),
-            str((final_state.get("problem_report") or {}).get("report_md") or ""),
-        ]
+def _resolved_golden_trajectory(
+    fixture: ScenarioFixture,
+) -> tuple[list[str], int | None, GoldenTrajectoryConfig | None]:
+    golden_cfg = fixture.answer_key.golden_trajectory
+    if golden_cfg is not None and golden_cfg.ordered_actions:
+        if golden_cfg.max_loops is not None:
+            return list(golden_cfg.ordered_actions), golden_cfg.max_loops, golden_cfg
+        return (
+            list(golden_cfg.ordered_actions),
+            fixture.answer_key.max_investigation_loops,
+            golden_cfg,
+        )
+    return (
+        list(fixture.answer_key.optimal_trajectory),
+        fixture.answer_key.max_investigation_loops,
+        None,
     )
 
 
-def score_trajectory(
-    fixture: ScenarioFixture,
-    final_state: dict[str, Any],
-) -> TrajectoryScore | None:
-    """Score the agent's investigation trajectory against the expected sequence.
-
-    Returns None when no optimal_trajectory is declared for the scenario.
-    """
-    expected = list(fixture.answer_key.optimal_trajectory)
-    if not expected:
+def _trajectory_policy_for_fixture(
+    *,
+    max_loops: int | None,
+    golden_cfg: GoldenTrajectoryConfig | None,
+) -> TrajectoryPolicy | None:
+    if golden_cfg is None:
         return None
-
-    max_loops = fixture.answer_key.max_investigation_loops
-
-    # Flatten all actions across every investigation loop (order preserved)
-    executed_hypotheses: list[dict[str, Any]] = final_state.get("executed_hypotheses") or []
-    actual_sequence: list[str] = []
-    for hyp in executed_hypotheses:
-        for action in hyp.get("actions", []):
-            actual_sequence.append(action)
-
-    loops_used: int = int(final_state.get("investigation_loop_count") or len(executed_hypotheses))
-
-    # Sequencing: all expected actions must appear in the actual sequence.
-    # Actions run in parallel so completion order is non-deterministic; we check
-    # coverage (set membership) rather than position.  When a real LLM is used,
-    # it may skip actions entirely — that will surface as sequencing_ok=False.
-    sequencing_ok = set(expected) <= set(actual_sequence)
-
-    calibration_ok = loops_used <= max_loops
-    efficiency_score = (int(sequencing_ok) + int(calibration_ok)) / 2.0
-
-    return TrajectoryScore(
-        actual_sequence=actual_sequence,
-        expected_sequence=expected,
-        loops_used=loops_used,
+    return TrajectoryPolicy(
+        matching=golden_cfg.matching,
+        max_edit_distance=golden_cfg.max_edit_distance,
+        max_extra_actions=golden_cfg.max_extra_actions,
+        max_redundancy=golden_cfg.max_redundancy,
         max_loops=max_loops,
-        sequencing_ok=sequencing_ok,
-        calibration_ok=calibration_ok,
-        efficiency_score=efficiency_score,
     )
 
 
-def score_reasoning(
-    fixture: ScenarioFixture,
-    final_state: dict[str, Any],
-    queried_metrics: list[str] | None = None,
-) -> ReasoningScore | None:
-    """Score Axis 2 adversarial reasoning quality.
-
-    Returns None when neither ruling_out_keywords nor required_queries are
-    declared for the scenario.
-
-    Args:
-        fixture: The scenario fixture containing the answer key.
-        final_state: The agent's final investigation state dict.
-        queried_metrics: List of metric_name values the agent requested via
-            query_timeseries (from SelectiveGrafanaBackend.queried_metrics).
-            Pass None or [] when the backend does not record queries (Axis 1).
-    """
-    has_ruling_out = bool(fixture.answer_key.ruling_out_keywords)
-    has_required_queries = bool(fixture.answer_key.required_queries)
-    if not has_ruling_out and not has_required_queries:
-        return None
-
-    # --- ruling_out_keywords: check each token appears anywhere in agent output ---
-    evidence_text = _scored_output_text(final_state)
-    normalized_output = _normalize_text(evidence_text)
-
-    missing_ruling_out: list[str] = []
-    if has_ruling_out:
-        for token in fixture.answer_key.ruling_out_keywords:
-            if not _matches_required_keyword(normalized_output, token):
-                missing_ruling_out.append(token)
-
-    # --- required_queries: each token must appear in at least one queried metric name ---
-    missing_queries: list[str] = []
-    if has_required_queries:
-        audited = {_normalize_query_token(item) for item in (queried_metrics or [])}
-        for required in fixture.answer_key.required_queries:
-            token = _normalize_query_token(required)
-            if not any(token in q for q in audited):
-                missing_queries.append(required)
-
-    ruling_out_ok = not missing_ruling_out
-    queries_ok = not missing_queries
-    reasoning_score = (int(ruling_out_ok) + int(queries_ok)) / 2.0
-
-    return ReasoningScore(
-        ruling_out_ok=ruling_out_ok,
-        queries_ok=queries_ok,
-        missing_ruling_out=missing_ruling_out,
-        missing_queries=missing_queries,
-        reasoning_score=reasoning_score,
-    )
-
-
-def score_result(
-    fixture: ScenarioFixture,
-    final_state: dict[str, Any],
-    queried_metrics: list[str] | None = None,
+def _apply_trajectory_policy_to_score(
+    score: ScenarioScore,
+    trajectory_policy: TrajectoryPolicyResult | None,
 ) -> ScenarioScore:
-    root_cause = str(final_state.get("root_cause") or "").strip()
-    actual_category = str(final_state.get("root_cause_category") or "unknown").strip()
-    root_cause_present = bool(root_cause and root_cause.lower() != "unable to determine root cause")
+    """Apply the trajectory policy result to the score, always recording the gate.
 
-    evidence_text = _scored_output_text(final_state)
-    normalized_output = _normalize_text(evidence_text)
+    The gate is recorded in ALL cases (pass, fail, not-applicable) so that
+    ``_all_required_gates_pass`` acts as a true hard gate.
+    """
+    gates = dict(score.gates)
 
-    matched_keywords = [
-        keyword
-        for keyword in fixture.answer_key.required_keywords
-        if _matches_required_keyword(normalized_output, keyword)
-    ]
-    missing_keywords = [
-        keyword
-        for keyword in fixture.answer_key.required_keywords
-        if keyword not in matched_keywords
-    ]
-
-    answer_key = fixture.answer_key
-    failure_reason = ""
-
-    # 1. Category match
-    if not root_cause_present:
-        failure_reason = "no root cause in output"
-    elif actual_category != answer_key.root_cause_category:
-        failure_reason = (
-            f"wrong category: got {actual_category!r}, expected {answer_key.root_cause_category!r}"
+    if trajectory_policy is None:
+        gates["trajectory_policy"] = GateResult(
+            status="pass",
+            threshold="not_applicable — no golden trajectory configured",
+            actual="not_applicable",
         )
-    elif missing_keywords:
-        failure_reason = f"missing required keywords: {missing_keywords}"
-    # 2. Forbidden category check (level 2+ adversarial)
-    elif answer_key.forbidden_categories and actual_category in answer_key.forbidden_categories:
-        failure_reason = f"forbidden category in output: {actual_category!r}"
-    # 3. Forbidden keyword check — none of these may appear in evidence_text
-    elif answer_key.forbidden_keywords:
-        forbidden_hits = [
-            kw for kw in answer_key.forbidden_keywords if _normalize_text(kw) in normalized_output
-        ]
-        if forbidden_hits:
-            failure_reason = f"forbidden keywords in output: {forbidden_hits}"
-    # 4. Evidence path check — required sources must be non-empty in final_state["evidence"].
-    # Fixture schema keys (aws_cloudwatch_metrics, aws_rds_events, aws_performance_insights) map to the agent's
-    # internal evidence keys (grafana_metrics, grafana_logs) set by _map_grafana_*.
-    if not failure_reason and answer_key.required_evidence_sources:
-        evidence = final_state.get("evidence") or {}
-        performance_insights_tokens = (
-            "top sql activity",
-            "avg load",
-            "aas",
-            "db load",
-            "walwrite",
-            "clientread",
+        return replace(
+            score,
+            passed=_all_required_gates_pass(gates) and not score.failure_reasons,
+            gates=gates,
         )
 
-        for source_key in answer_key.required_evidence_sources:
-            if source_key == "aws_performance_insights":
-                state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
-
-                has_state_evidence = bool(evidence.get(state_key))
-                has_pi_signal = any(
-                    token in normalized_output for token in performance_insights_tokens
-                )
-
-                if not (has_state_evidence and has_pi_signal):
-                    failure_reason = f"required evidence not gathered: {source_key!r}"
-                    break
-
-                continue
-
-            state_key = _EVIDENCE_KEY_MAP.get(source_key, source_key)
-            if not evidence.get(state_key):
-                failure_reason = f"required evidence not gathered: {source_key!r}"
-                break
-
-    # 5. Primary evidence + explicit sequence check — only for scenarios that
-    # explicitly require the failover event timeline wording.
-    failover_required_tokens = {
-        "primary evidence source",
-        "failover initiated",
-        "failover in progress",
-        "failover completed",
-        "instance available",
-    }
-    normalized_required_keywords = {
-        _normalize_text(keyword) for keyword in answer_key.required_keywords
-    }
-    requires_failover_event_reasoning = failover_required_tokens.issubset(
-        normalized_required_keywords
+    gates["trajectory_policy"] = GateResult(
+        status="pass" if trajectory_policy.passed else "fail",
+        threshold="policy violations list must be empty",
+        actual=f"violations={trajectory_policy.violations}",
     )
 
-    if not failure_reason and requires_failover_event_reasoning:
-        root_cause_text = _normalize_text(root_cause)
-        validated_text = _normalize_text(
-            " ".join(claim.get("claim", "") for claim in final_state.get("validated_claims", []))
-        )
-        causal_chain_text = _normalize_text(" ".join(final_state.get("causal_chain", [])))
-
-        reasoning_text = " ".join([root_cause_text, validated_text, causal_chain_text])
-
-        mentions_event_reasoning = (
-            "rds" in reasoning_text
-            and ("event" in reasoning_text or "timeline" in reasoning_text)
-            and "primary evidence source" in reasoning_text
+    if trajectory_policy.passed:
+        return replace(
+            score,
+            passed=_all_required_gates_pass(gates) and not score.failure_reasons,
+            gates=gates,
         )
 
-        if not mentions_event_reasoning:
-            failure_reason = "RDS events gathered but not used as primary reasoning signal"
+    policy_reason = "trajectory policy failed: " + "; ".join(
+        trajectory_policy.violations or ["unknown violation"]
+    )
+    failures = list(score.failure_reasons)
+    if not any(detail.code == "TRAJECTORY_POLICY_FAILED" for detail in failures):
+        failures.append(FailureDetail(code="TRAJECTORY_POLICY_FAILED", detail=policy_reason))
 
-        required_sequence_tokens = (
-            "failover initiated",
-            "failover in progress",
-            "failover completed",
-            "instance available",
-        )
+    combined_reason = "; ".join(detail.detail for detail in failures)
 
-        sequence_present = all(token in reasoning_text for token in required_sequence_tokens)
-
-        if not failure_reason and not sequence_present:
-            failure_reason = "RDS event sequence not explicitly listed in required form"
-
-    passed = not failure_reason
-    trajectory = score_trajectory(fixture, final_state)
-    reasoning = score_reasoning(fixture, final_state, queried_metrics)
-    return ScenarioScore(
-        scenario_id=fixture.scenario_id,
-        passed=passed,
-        root_cause_present=root_cause_present,
-        expected_category=fixture.answer_key.root_cause_category,
-        actual_category=actual_category,
-        missing_keywords=missing_keywords,
-        matched_keywords=matched_keywords,
-        root_cause=root_cause,
-        failure_reason=failure_reason,
-        trajectory=trajectory,
-        reasoning=reasoning,
+    return replace(
+        score,
+        passed=_all_required_gates_pass(gates) and not failures,
+        gates=gates,
+        failure_reasons=failures,
+        failure_reason=combined_reason,
     )
 
 
@@ -459,7 +325,6 @@ def run_scenario(
     )
     state_dict = dict(final_state)
 
-    # Extract query audit log from SelectiveGrafanaBackend if one was injected.
     queried_metrics: list[str] | None = None
     if grafana_backend is not None and hasattr(grafana_backend, "queried_metrics"):
         queried_metrics = list(grafana_backend.queried_metrics)
@@ -467,72 +332,388 @@ def run_scenario(
     return state_dict, score_result(fixture, state_dict, queried_metrics=queried_metrics)
 
 
-def _print_gap_report(
-    axis1_results: list[ScenarioScore],
-    axis2_results: list[ScenarioScore],
-    all_fixtures: list[ScenarioFixture],
-) -> None:
-    """Print Axis 1 vs Axis 2 pass-rate gap, overall and per difficulty level."""
-    difficulty_map = {f.scenario_id: f.metadata.scenario_difficulty for f in all_fixtures}
+@dataclass(frozen=True)
+class _ScenarioExecution:
+    fixture: ScenarioFixture
+    score: ScenarioScore
+    canonical_report_payload: dict[str, Any]
+    observation_for_report: Any
+    wall_time_s: float
 
-    def _pass_rate(results: list[ScenarioScore]) -> float:
-        return sum(1 for r in results if r.passed) / len(results) * 100 if results else 0.0
 
-    ax1_pct = _pass_rate(axis1_results)
-    ax2_pct = _pass_rate(axis2_results)
-    gap = ax1_pct - ax2_pct
+def _execute_fixture(
+    fixture: ScenarioFixture,
+    *,
+    config: SuiteRunConfig,
+    progress_hook: Callable[[str, int], None] | None = None,
+) -> _ScenarioExecution:
+    if progress_hook is not None:
+        progress_hook(fixture.scenario_id, 1)
+    started_at = datetime.now(UTC)
+    started_monotonic = time.monotonic()
+    final_state, score = run_scenario(fixture, use_mock_grafana=config.mock_grafana)
+    wall_time_s = time.monotonic() - started_monotonic
+    if progress_hook is not None:
+        progress_hook(fixture.scenario_id, 2)
 
-    print("\n=== Axis 1 vs Axis 2 Gap Report ===")
-    print(
-        f"  Axis 1 (all scenarios, full data):  {ax1_pct:.0f}%  ({sum(r.passed for r in axis1_results)}/{len(axis1_results)})"
+    executed_hypotheses = final_state.get("executed_hypotheses") or []
+    loops_used = len(executed_hypotheses)
+    golden_trajectory, max_loops, golden_cfg = _resolved_golden_trajectory(fixture)
+    trajectory_metrics = compute_trajectory_metrics(
+        executed_hypotheses=executed_hypotheses,
+        golden=golden_trajectory,
+        loops_used=loops_used,
+        max_loops=max_loops,
     )
-    print(
-        f"  Axis 2 (adversarial, selective):    {ax2_pct:.0f}%  ({sum(r.passed for r in axis2_results)}/{len(axis2_results)})"
-    )
-    print(f"  Gap:                                {gap:+.0f}pp")
-
-    print("\n  Per difficulty level:")
-    for level in sorted(
-        {difficulty_map.get(r.scenario_id, 0) for r in axis1_results + axis2_results}
-    ):
-        ax1_level = [r for r in axis1_results if difficulty_map.get(r.scenario_id, 0) == level]
-        ax2_level = [r for r in axis2_results if difficulty_map.get(r.scenario_id, 0) == level]
-        ax1_pct_l = _pass_rate(ax1_level)
-        ax2_pct_l = _pass_rate(ax2_level)
-        gap_l = ax1_pct_l - ax2_pct_l
-        print(
-            f"    Difficulty {level}: Axis1={ax1_pct_l:.0f}% ({len(ax1_level)} scenarios)  "
-            f"Axis2={ax2_pct_l:.0f}% ({len(ax2_level)} scenarios)  gap={gap_l:+.0f}pp"
+    trajectory_policy = (
+        evaluate_trajectory_policy(
+            metrics=trajectory_metrics,
+            golden_actions=golden_trajectory,
+            policy=_trajectory_policy_for_fixture(
+                max_loops=max_loops,
+                golden_cfg=golden_cfg,
+            ),
         )
+        if golden_cfg is not None
+        else None
+    )
+
+    score = _apply_trajectory_policy_to_score(score, trajectory_policy)
+    if progress_hook is not None:
+        progress_hook(fixture.scenario_id, 3)
+
+    observation = build_observation(
+        scenario_id=fixture.scenario_id,
+        suite="axis1",
+        backend="FixtureGrafanaBackend" if config.mock_grafana else "LiveGrafanaBackend",
+        score=asdict(score),
+        reasoning=asdict(score.reasoning) if score.reasoning is not None else None,
+        trajectory=trajectory_metrics,
+        evaluated_golden_actions=golden_trajectory,
+        trajectory_policy=trajectory_policy,
+        final_state=final_state,
+        available_evidence_sources=list(fixture.metadata.available_evidence),
+        required_evidence_sources=list(fixture.answer_key.required_evidence_sources),
+        started_at=started_at,
+        wall_time_s=wall_time_s,
+    )
+
+    observation_path = write_observation(observation, config.observations_dir)
+    relative_observation_path = str(observation_path.relative_to(config.observations_dir))
+    display_observation_path = str(observation_path.resolve())
+    observation_for_report = replace(
+        observation,
+        observation_path=f"{relative_observation_path} ({display_observation_path})",
+    )
+    if progress_hook is not None:
+        progress_hook(fixture.scenario_id, 4)
+
+    return _ScenarioExecution(
+        fixture=fixture,
+        score=score,
+        canonical_report_payload=observation.canonical_report_payload,
+        observation_for_report=observation_for_report,
+        wall_time_s=wall_time_s,
+    )
+
+
+def _run_level(
+    level_config: LevelRunConfig,
+    *,
+    config: SuiteRunConfig,
+    progress_hook: Callable[[str, int], None] | None = None,
+) -> tuple[list[_ScenarioExecution], LevelRunResult]:
+    started = time.monotonic()
+    executions: list[_ScenarioExecution] = []
+    for fixture in level_config.fixtures:
+        executions.append(_execute_fixture(fixture, config=config, progress_hook=progress_hook))
+
+    passed = sum(1 for execution in executions if execution.score.passed)
+    level_result = LevelRunResult(
+        level=level_config.level,
+        scenario_ids=tuple(execution.fixture.scenario_id for execution in executions),
+        passed=passed,
+        failed=len(executions) - passed,
+        wall_time_s=time.monotonic() - started,
+    )
+    return executions, level_result
+
+
+@contextmanager
+def _suppress_investigation_rendering(enabled: bool) -> Iterator[None]:
+    """Temporarily disable node-level investigation rendering."""
+    if not enabled:
+        yield
+        return
+
+    previous_output_format = os.environ.get("TRACER_OUTPUT_FORMAT")
+    os.environ["TRACER_OUTPUT_FORMAT"] = "none"
+
+    from app import output as output_module
+
+    output_module.get_tracker(reset=True)
+    try:
+        yield
+    finally:
+        if previous_output_format is None:
+            os.environ.pop("TRACER_OUTPUT_FORMAT", None)
+        else:
+            os.environ["TRACER_OUTPUT_FORMAT"] = previous_output_format
+        output_module.get_tracker(reset=True)
+
+
+def _render_suite_overview(
+    console: Console,
+    *,
+    config: SuiteRunConfig,
+    level_configs: tuple[LevelRunConfig, ...],
+) -> None:
+    total = sum(len(level.fixtures) for level in level_configs)
+    overview = Table(title="Synthetic Suite Overview", show_header=True)
+    overview.add_column("Level", justify="right")
+    overview.add_column("Scenarios", justify="right")
+    overview.add_column("IDs")
+    for level in level_configs:
+        scenario_ids = ", ".join(fixture.scenario_id for fixture in level.fixtures)
+        overview.add_row(str(level.level), str(len(level.fixtures)), scenario_ids)
+    console.print(overview)
+    console.print(
+        "Run config: "
+        f"total={total}, parallel_levels={config.parallel_levels}, "
+        f"mock_grafana={config.mock_grafana}, observations_dir={config.observations_dir}"
+    )
+
+
+def _render_suite_summary(
+    console: Console,
+    *,
+    executions: list[_ScenarioExecution],
+    level_results: tuple[LevelRunResult, ...],
+) -> None:
+    summary = Table(title="Synthetic Suite Report", show_header=True)
+    summary.add_column("Scenario")
+    summary.add_column("Level", justify="right")
+    summary.add_column("Status")
+    summary.add_column("Category")
+    summary.add_column("Wall(s)", justify="right")
+    summary.add_column("Detail")
+
+    for execution in executions:
+        status = "PASS" if execution.score.passed else "FAIL"
+        detail = execution.score.failure_reason or "-"
+        summary.add_row(
+            execution.fixture.scenario_id,
+            str(execution.fixture.metadata.scenario_difficulty),
+            status,
+            execution.score.actual_category,
+            f"{execution.wall_time_s:.2f}",
+            detail,
+        )
+    console.print(summary)
+
+    level_table = Table(title="Level Summary", show_header=True)
+    level_table.add_column("Level", justify="right")
+    level_table.add_column("Passed", justify="right")
+    level_table.add_column("Failed", justify="right")
+    level_table.add_column("Wall(s)", justify="right")
+    for level_result in level_results:
+        level_table.add_row(
+            str(level_result.level),
+            str(level_result.passed),
+            str(level_result.failed),
+            f"{level_result.wall_time_s:.2f}",
+        )
+    console.print(level_table)
+
+
+def _write_baseline(canonical_payloads: dict[str, Any], baseline_out_dir: Path) -> None:
+    """Write per-scenario canonical_report_payload snapshots to *baseline_out_dir*."""
+    baseline_out_dir.mkdir(parents=True, exist_ok=True)
+    for scenario_id, payload in canonical_payloads.items():
+        target = baseline_out_dir / f"{scenario_id}.json"
+        target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _check_baseline(
+    canonical_payloads: dict[str, Any],
+    baseline_check_dir: Path,
+) -> list[str]:
+    """Compare canonical payloads against committed baseline snapshots.
+
+    Returns a list of human-readable mismatch descriptions (empty if all match).
+    """
+    mismatches: list[str] = []
+    for scenario_id, actual_payload in canonical_payloads.items():
+        baseline_file = baseline_check_dir / f"{scenario_id}.json"
+        if not baseline_file.exists():
+            mismatches.append(f"{scenario_id}: baseline file missing at {baseline_file}")
+            continue
+        expected = json.loads(baseline_file.read_text(encoding="utf-8"))
+        actual_canonical = json.loads(
+            json.dumps(actual_payload, sort_keys=True, separators=(",", ":"))
+        )
+        expected_canonical = json.loads(json.dumps(expected, sort_keys=True, separators=(",", ":")))
+        if actual_canonical != expected_canonical:
+            actual_str = json.dumps(actual_payload, indent=2, sort_keys=True)
+            expected_str = json.dumps(expected, indent=2, sort_keys=True)
+            diff_lines: list[str] = []
+            for line in difflib.unified_diff(
+                expected_str.splitlines(),
+                actual_str.splitlines(),
+                fromfile=f"{scenario_id} (baseline)",
+                tofile=f"{scenario_id} (actual)",
+                lineterm="",
+            ):
+                diff_lines.append(line)
+            mismatches.append(
+                f"{scenario_id}: canonical payload differs from baseline\n"
+                + "\n".join(diff_lines[:60])
+            )
+    return mismatches
+
+
+def run_synthetic_suite(config: SuiteRunConfig) -> SuiteRunResult:
+    fixtures = load_all_scenarios(SUITE_DIR)
+    try:
+        selected_fixtures = select_fixtures(fixtures, config)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    level_order = (
+        tuple(sorted({fixture.metadata.scenario_difficulty for fixture in selected_fixtures}))
+        if config.scenario
+        else config.levels
+    )
+    level_configs = group_fixtures_by_level(selected_fixtures, level_order)
+    interactive_console = Console(highlight=False, soft_wrap=True)
+    show_interactive = not config.output_json
+    bulk_run = len(selected_fixtures) > 1
+    show_overview_only = show_interactive and bulk_run
+    if show_interactive and level_configs:
+        _render_suite_overview(interactive_console, config=config, level_configs=level_configs)
+
+    level_executions: dict[int, list[_ScenarioExecution]] = {}
+    level_results_map: dict[int, LevelRunResult] = {}
+    task_map: dict[str, TaskID] = {}
+    progress: Progress | None = None
+    if show_interactive and level_configs and not show_overview_only:
+        progress = Progress(
+            TextColumn("[bold blue]{task.fields[level]}[/bold blue]"),
+            TextColumn("{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TimeElapsedColumn(),
+            console=interactive_console,
+            transient=False,
+        )
+        for level_config in level_configs:
+            for fixture in level_config.fixtures:
+                task_id = progress.add_task(
+                    description=fixture.scenario_id,
+                    total=4,
+                    completed=0,
+                    level=f"L{level_config.level}",
+                )
+                task_map[fixture.scenario_id] = task_id
+
+    def _progress_hook(scenario_id: str, step: int) -> None:
+        if progress is None:
+            return
+        task_id = task_map.get(scenario_id)
+        if task_id is None:
+            return
+        progress.update(task_id, completed=step)
+
+    max_workers = min(config.parallel_levels, len(level_configs)) if level_configs else 1
+    progress_context = progress if progress is not None else nullcontext()
+    suppress_investigation_rendering = bulk_run or config.output_json
+    with (
+        _suppress_investigation_rendering(suppress_investigation_rendering),
+        progress_context,
+    ):
+        if max_workers > 1:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {
+                    level_config.level: executor.submit(
+                        _run_level,
+                        level_config,
+                        config=config,
+                        progress_hook=_progress_hook,
+                    )
+                    for level_config in level_configs
+                }
+                for level, future in futures.items():
+                    executions, level_result = future.result()
+                    level_executions[level] = executions
+                    level_results_map[level] = level_result
+        else:
+            for level_config in level_configs:
+                executions, level_result = _run_level(
+                    level_config,
+                    config=config,
+                    progress_hook=_progress_hook,
+                )
+                level_executions[level_config.level] = executions
+                level_results_map[level_config.level] = level_result
+
+    ordered_executions: list[_ScenarioExecution] = []
+    ordered_level_results: list[LevelRunResult] = []
+    for level in level_order:
+        if level in level_results_map:
+            ordered_executions.extend(level_executions[level])
+            ordered_level_results.append(level_results_map[level])
+
+    should_report = (
+        bool(config.report) if config.report is not None else len(selected_fixtures) == 1
+    )
+    if config.output_json:
+        should_report = False
+
+    if should_report:
+        report_console = (
+            interactive_console if show_interactive else Console(highlight=False, soft_wrap=True)
+        )
+        for execution in ordered_executions:
+            render_report_to_console(execution.observation_for_report, report_console)
+
+    if show_interactive and ordered_executions and not show_overview_only:
+        _render_suite_summary(
+            interactive_console,
+            executions=ordered_executions,
+            level_results=tuple(ordered_level_results),
+        )
+
+    return SuiteRunResult(
+        config=config,
+        level_results=tuple(ordered_level_results),
+        scores=tuple(execution.score for execution in ordered_executions),
+        canonical_payloads={
+            execution.fixture.scenario_id: execution.canonical_report_payload
+            for execution in ordered_executions
+        },
+    )
 
 
 def run_suite(argv: list[str] | None = None) -> list[ScenarioScore]:
     args = parse_args(argv)
-    fixtures = load_all_scenarios(SUITE_DIR)
-    if args.scenario:
-        fixtures = [fixture for fixture in fixtures if fixture.scenario_id == args.scenario]
-        if not fixtures:
-            raise SystemExit(f"Unknown scenario: {args.scenario}")
-
-    results: list[ScenarioScore] = []
-    for fixture in fixtures:
-        _, score = run_scenario(fixture, use_mock_grafana=args.mock_grafana)
-        results.append(score)
+    config = _build_run_config(args)
+    suite_result = run_synthetic_suite(config)
+    results = list(suite_result.scores)
+    canonical_payloads = dict(suite_result.canonical_payloads)
 
     if args.json:
         print(json.dumps([asdict(result) for result in results], indent=2))
-    else:
-        for result in results:
-            status = "PASS" if result.passed else "FAIL"
-            detail = (
-                f"reason={result.failure_reason!r}"
-                if result.failure_reason
-                else f"category={result.actual_category}"
-            )
-            print(f"{status} {result.scenario_id} {detail}")
 
-        passed_count = sum(1 for result in results if result.passed)
-        print(f"\nResults: {passed_count}/{len(results)} passed")
+    if config.baseline_out:
+        _write_baseline(canonical_payloads, config.baseline_out)
+
+    if config.baseline_check:
+        mismatches = _check_baseline(canonical_payloads, config.baseline_check)
+        if mismatches:
+            print("\n=== Baseline Check FAILED ===")
+            for msg in mismatches:
+                print(textwrap.indent(msg, "  "))
+            raise SystemExit(1)
 
     return results
 


### PR DESCRIPTION
Fixes #1526 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
I have made it so such that the progress is visible when a user runs synthetic queries

### Demo/Screenshot for feature changes and bug fixes - 

### Tasks
```
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

   ██████╗ ██████╗ ███████╗███╗   ██╗███████╗██████╗ ███████╗
  ██╔═══██╗██╔══██╗██╔════╝████╗  ██║██╔════╝██╔══██╗██╔════╝
  ██║   ██║██████╔╝█████╗  ██╔██╗ ██║███████╗██████╔╝█████╗
  ██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║╚════██║██╔══██╗██╔══╝
  ╚██████╔╝██║     ███████╗██║ ╚████║███████║██║  ██║███████╗
   ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝╚══════╝

  opensre  ·  v2026.4.5
  open-source SRE agent for automated incident investigation and root cause analysis

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  ⚠  This tool executes AI-powered commands against your infrastructure.
     Review the documentation before connecting production systems.
     Source: https://github.com/opensre-dev/opensre

  Press Enter to continue…


╭─  OpenSRE · v2026.4.5  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                             │
│  █▀█                                              │ Tips for getting started                                                                │
│  █▄█                                              │ Paste alert JSON or describe an incident                                                │
│                                                   │ Type /help to list slash commands                                                       │
│                                                   │ Run /doctor for environment diagnostics                                                 │
│  Welcome back x1vi!                               │ Use /investigate <file> for file alerts                                                 │
│                                                   │ ───                                                                                     │
│                                                   │ What's new                                                                              │
│  unknown  ·  unknown  ·                           │ Confidence scoring now shown during diagnosis                                           │
│  ~/Documents/development/opensource/sre/opensre   │ New /save command exports investigation reports                                         │
│                                                                                                                                             │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

❯ okay, run a synthetic test.

assistant:
Requested actions:
1. synthetic test rds_postgres

Confirm: synthetic tests spawn a long-running subprocess
Proceed? [y/N] y
$ opensre tests synthetic
synthetic test started — task 920854a5. /tasks to monitor, /cancel 920854a5 to stop.

[2] ❯ /tasks
                                                                     Tasks
id       │ kind           │ status │ started                 │ duration │ detail
━━━━━━━━━┿━━━━━━━━━━━━━━━━┿━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
920854a5 │ synthetic_test │ failed │ 2026-05-11 05:10:35 UTC │     5.3s │ exit code 1: run_investigation failed
         │                │        │                         │          │ Traceback (most recent call last):
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/services
         │                │        │                         │          │ /llm_client.py", line 820, in _create_llm_client
         │                │        │                         │          │     settings = LLMSettings.from_env()
         │                │        │                         │          │                ^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/config.p
         │                │        │                         │          │ y", line 241, in from_env
         │                │        │                         │          │     return cls.model_validate(
         │                │        │                         │          │            ^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/py
         │                │        │                         │          │ thon3.12/site-packages/pydantic/main.py", line 732, in model_validate
         │                │        │                         │          │     return cls.__pydantic_validator__.validate_python(
         │                │        │                         │          │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │ pydantic_core._pydantic_core.ValidationError: 1 validation error for
         │                │        │                         │          │ LLMSettings
         │                │        │                         │          │   Value error, LLM provider 'anthropic' requires ANTHROPIC_API_KEY to
         │                │        │                         │          │ be set. [type=value_error, input_value={'provider': 'anthropic',...',
         │                │        │                         │          │ 'max_tokens': '4096'}, input_type=dict]
         │                │        │                         │          │     For further information visit
         │                │        │                         │          │ https://errors.pydantic.dev/2.13/v/value_error
         │                │        │                         │          │
         │                │        │                         │          │ The above exception was the direct cause of the following exception:
         │                │        │                         │          │
         │                │        │                         │          │ Traceback (most recent call last):
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/utils/er
         │                │        │                         │          │ rors.py", line 78, in report_and_reraise
         │                │        │                         │          │     yield
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/pipeline
         │                │        │                         │          │ /runners.py", line 87, in run_investigation
         │                │        │                         │          │     compiled_graph.invoke(initial, {"recursion_limit":
         │                │        │                         │          │ _GRAPH_RECURSION_LIMIT}),
         │                │        │                         │          │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │ ^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/py
         │                │        │                         │          │ thon3.12/site-packages/sentry_sdk/integrations/langgraph.py", line
         │                │        │                         │          │ 196, in new_invoke
         │                │        │                         │          │     result = f(self, *args, **kwargs)
         │                │        │                         │          │              ^^^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/py
         │                │        │                         │          │ thon3.12/site-packages/langgraph/pregel/main.py", line 3365, in
         │                │        │                         │          │ invoke
         │                │        │                         │          │     for chunk in self.stream(
         │                │        │                         │          │   File "/home/x1vi/Documents/development/opensou
[3] ❯ /tasks
                                                                     Tasks
id       │ kind           │ status │ started                 │ duration │ detail
━━━━━━━━━┿━━━━━━━━━━━━━━━━┿━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
920854a5 │ synthetic_test │ failed │ 2026-05-11 05:10:35 UTC │     5.3s │ exit code 1: run_investigation failed
         │                │        │                         │          │ Traceback (most recent call last):
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/services
         │                │        │                         │          │ /llm_client.py", line 820, in _create_llm_client
         │                │        │                         │          │     settings = LLMSettings.from_env()
         │                │        │                         │          │                ^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/config.p
         │                │        │                         │          │ y", line 241, in from_env
         │                │        │                         │          │     return cls.model_validate(
         │                │        │                         │          │            ^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/py
         │                │        │                         │          │ thon3.12/site-packages/pydantic/main.py", line 732, in model_validate
         │                │        │                         │          │     return cls.__pydantic_validator__.validate_python(
         │                │        │                         │          │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │ pydantic_core._pydantic_core.ValidationError: 1 validation error for
         │                │        │                         │          │ LLMSettings
         │                │        │                         │          │   Value error, LLM provider 'anthropic' requires ANTHROPIC_API_KEY to
         │                │        │                         │          │ be set. [type=value_error, input_value={'provider': 'anthropic',...',
         │                │        │                         │          │ 'max_tokens': '4096'}, input_type=dict]
         │                │        │                         │          │     For further information visit
         │                │        │                         │          │ https://errors.pydantic.dev/2.13/v/value_error
         │                │        │                         │          │
         │                │        │                         │          │ The above exception was the direct cause of the following exception:
         │                │        │                         │          │
         │                │        │                         │          │ Traceback (most recent call last):
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/utils/er
         │                │        │                         │          │ rors.py", line 78, in report_and_reraise
         │                │        │                         │          │     yield
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/app/pipeline
         │                │        │                         │          │ /runners.py", line 87, in run_investigation
         │                │        │                         │          │     compiled_graph.invoke(initial, {"recursion_limit":
         │                │        │                         │          │ _GRAPH_RECURSION_LIMIT}),
         │                │        │                         │          │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │ ^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/py
         │                │        │                         │          │ thon3.12/site-packages/sentry_sdk/integrations/langgraph.py", line
         │                │        │                         │          │ 196, in new_invoke
         │                │        │                         │          │     result = f(self, *args, **kwargs)
         │                │        │                         │          │              ^^^^^^^^^^^^^^^^^^^^^^^^
         │                │        │                         │          │   File
         │                │        │                         │          │ "/home/x1vi/Documents/development/opensource/sre/opensre/.venv/lib/py
         │                │        │                         │          │ thon3.12/site-packages/langgraph/pregel/main.py", line 3365, in
         │                │        │                         │          │ invoke
         │                │        │                         │          │     for chunk in self.stream(
         │                │        │                         │          │   File "/home/x1vi/Documents/development/opensou
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[4] ❯ Type a message, /command, or paste an alert
```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

This is according to my understanding, when we running a command in interactive shell. The code spawns threads.
So I PIPE that thread that runs synthetic queries, took the context logs and put them in a queue data structure.
The I looped over this structure and rendered it into the tables.
When /task command is run the progress that is details is visible in the table.

The tests I ran after implementing the changes
```
uv run pytest tests/cli/interactive_shell/test_tasks.py -v          # task system + watcher
uv run pytest tests/cli/interactive_shell/ -v                        # all shell tests (562 tests)

```
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


<img width="939" height="309" alt="image" src="https://github.com/user-attachments/assets/c30a0373-0fd1-40c9-b363-feb09d2057cd" />


