### PR TITLE
fix(integrations): add alicloud field to EffectiveIntegrations

### DIFF
--- a/app/integrations/effective_models.py
+++ b/app/integrations/effective_models.py
@@ -95,3 +95,4 @@ class EffectiveIntegrations(StrictConfigModel):
     argocd: EffectiveIntegrationEntry | None = None
     helm: EffectiveIntegrationEntry | None = None
     victoria_logs: EffectiveIntegrationEntry | None = None
+    alicloud: EffectiveIntegrationEntry | None = None

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -319,23 +319,22 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(service="google_docs", verifier=_verify_google_docs, verify_order=19),
     IntegrationSpec(service="kafka", verifier=_verify_kafka, verify_order=22),
     IntegrationSpec(service="clickhouse", verifier=_verify_clickhouse, verify_order=23),
+    IntegrationSpec(service="alicloud", direct_effective=True),
     IntegrationSpec(service="notion"),
     IntegrationSpec(service="prefect"),
     IntegrationSpec(service="posthog"),
     IntegrationSpec(service="trello"),
     IntegrationSpec(service="rds", setup_order=11),
-    IntegrationSpec(service="alicloud", direct_effective=True),
 )
 
 INTEGRATION_SPECS_BY_SERVICE = {spec.service: spec for spec in INTEGRATION_SPECS}
 
-SERVICE_KEY_MAP: dict[str, str] = {}
+SERVICE_KEY_MAP: dict[str, str] = {spec.service: spec.service for spec in INTEGRATION_SPECS}
 for _spec in INTEGRATION_SPECS:
-    SERVICE_KEY_MAP[_spec.service] = _spec.service
     for _alias in _spec.aliases:
         SERVICE_KEY_MAP[_alias] = _spec.service
 
-SKIP_CLASSIFIED_SERVICES = frozenset(
+SKIP_CLASSIFIED_SERVICES: frozenset[str] = frozenset(
     spec.service for spec in INTEGRATION_SPECS if spec.skip_classification
 )
 

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -324,6 +324,7 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     IntegrationSpec(service="posthog"),
     IntegrationSpec(service="trello"),
     IntegrationSpec(service="rds", setup_order=11),
+    IntegrationSpec(service="alicloud", direct_effective=True),
 )
 
 INTEGRATION_SPECS_BY_SERVICE = {spec.service: spec for spec in INTEGRATION_SPECS}

--- a/tests/integrations/test_alicloud.py
+++ b/tests/integrations/test_alicloud.py
@@ -1,0 +1,36 @@
+"""Regression test for Sentry issue PYTHON-2G.
+
+EffectiveIntegrations was missing the ``alicloud`` field, causing a
+ValidationError when a user had an alicloud integration in their store.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def test_effective_integrations_field_exists() -> None:
+    """``alicloud`` must be a declared field on EffectiveIntegrations."""
+    from app.integrations.effective_models import (
+        EffectiveIntegrationEntry,
+        EffectiveIntegrations,
+    )
+
+    entry = EffectiveIntegrationEntry(
+        source="local env",
+        config={"credentials": {}, "integration_id": "env-alicloud"},
+    )
+    effective: dict[str, Any] = {"alicloud": entry.model_dump()}
+    # Should not raise (EffectiveIntegrations uses extra='forbid').
+    result = EffectiveIntegrations.model_validate(effective)
+    assert result.alicloud is not None
+
+
+def test_registry_spec_present() -> None:
+    """alicloud must be registered with direct_effective=True."""
+    from app.integrations.registry import DIRECT_CLASSIFIED_EFFECTIVE_SERVICES, INTEGRATION_SPECS
+
+    spec = next((s for s in INTEGRATION_SPECS if s.service == "alicloud"), None)
+    assert spec is not None
+    assert spec.direct_effective is True
+    assert "alicloud" in DIRECT_CLASSIFIED_EFFECTIVE_SERVICES


### PR DESCRIPTION
## Summary

- `EffectiveIntegrations` (`app/integrations/effective_models.py`) was missing the `alicloud` field
- `StrictConfigModel` uses `extra="forbid"` and a `_reject_unknown_fields` model validator, so passing a dict with `alicloud` raised a `ValidationError` immediately
- Added `alicloud: EffectiveIntegrationEntry | None = None` to `EffectiveIntegrations`
- Registered `alicloud` in `INTEGRATION_SPECS` with `direct_effective=True` so the catalog loop picks up any stored alicloud record

## Root cause (Sentry PYTHON-2G)

```
ValidationError: 1 validation error for EffectiveIntegrations
  Value error, Unexpected field 'alicloud'.
  File "app/integrations/_catalog_impl.py", line 1912, in resolve_effective_integrations
    return EffectiveIntegrations.model_validate(effective).model_dump(exclude_none=True)
```

The deployed runtime had an alicloud integration record in the store. `resolve_effective_integrations` placed it into the `effective` dict, but `EffectiveIntegrations` had no `alicloud` field, causing every call to `verify_integrations` (and the full RCA pipeline) to crash.

## Test plan

- [x] `tests/integrations/test_alicloud.py` — new regression test: verifies `alicloud` is a valid field on `EffectiveIntegrations` and present in `DIRECT_CLASSIFIED_EFFECTIVE_SERVICES`
- [x] `make lint` passes
- [x] `make format-check` passes
- [x] `make typecheck` passes

Closes #1801

https://claude.ai/code/session_01DNvvGTLUciFkniK1S1HkDf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNvvGTLUciFkniK1S1HkDf)_