### PR TITLE
fix: silence langgraph allowed_objects deprecation at app import time

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,11 @@
 """Agentic AI for Data Pipeline Incident Resolution Demo."""
 
-from app.entrypoints.sdk import run_investigation
+# Install third-party warning filters before any submodule (transitively)
+# imports ``langgraph`` — see issue #1779.
+from app.utils.warning_filters import install_known_filters
+
+install_known_filters()
+
+from app.entrypoints.sdk import run_investigation  # noqa: E402
 
 __all__ = ["run_investigation"]

--- a/app/utils/warning_filters.py
+++ b/app/utils/warning_filters.py
@@ -1,0 +1,56 @@
+"""Process-wide third-party warning filters.
+
+Some upstream packages emit deprecation warnings during ordinary
+``import`` of one of their submodules. Filtering those at call time
+(e.g. inside ``init_sentry``) is too late, because the import — and
+therefore the ``warnings.warn`` call — has already happened by the time
+``init_sentry`` runs.
+
+The filters here are intentionally narrow: they target a single, exact
+upstream warning that we have already triaged and decided to silence
+until the upstream packages expose a configuration hook. Adding a
+filter here should always be paired with a comment naming the upstream
+issue or change that motivates the filter.
+"""
+
+from __future__ import annotations
+
+import warnings
+from contextlib import suppress
+
+_LANGGRAPH_ALLOWED_OBJECTS_PATTERN = (
+    r"The default value of `allowed_objects` will change in a future version\..*"
+)
+
+_filters_installed = False
+
+
+def install_known_filters() -> None:
+    """Register the project-wide warning filters once per process.
+
+    Safe to call from multiple entry points; subsequent calls are no-ops.
+    Call this as early as possible — before any module that transitively
+    imports ``langgraph`` — otherwise the filtered warning has already
+    fired by the time the filter is in place.
+    """
+    global _filters_installed
+    if _filters_installed:
+        return
+
+    # langgraph.checkpoint.serde.jsonplus imports langchain_core.load.dump,
+    # which currently emits a LangChainPendingDeprecationWarning about the
+    # default value of ``allowed_objects`` (see issue #1779). The runtime
+    # behaviour does not change, so silence only this exact warning until
+    # the upstream packages expose an explicit configuration hook.
+    category: type[Warning] = Warning
+    with suppress(Exception):
+        from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
+
+        category = LangChainPendingDeprecationWarning
+    warnings.filterwarnings(
+        "ignore",
+        message=_LANGGRAPH_ALLOWED_OBJECTS_PATTERN,
+        category=category,
+    )
+
+    _filters_installed = True

--- a/tests/utils/test_warning_filters.py
+++ b/tests/utils/test_warning_filters.py
@@ -1,0 +1,70 @@
+"""Tests for ``app.utils.warning_filters``."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from app.utils import warning_filters
+
+
+@pytest.fixture(autouse=True)
+def _reset_filter_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force ``install_known_filters`` to run fresh in each test."""
+    monkeypatch.setattr(warning_filters, "_filters_installed", False)
+
+
+def test_install_known_filters_silences_langgraph_allowed_objects_warning() -> None:
+    """Regression coverage for issue #1779.
+
+    The default value of ``allowed_objects`` deprecation warning is emitted
+    when ``langgraph.checkpoint.serde.jsonplus`` is imported (transitively
+    via ``app.state.agent_state``). The runtime behaviour is unchanged, so
+    we silence only this exact warning until the upstream packages expose
+    a configuration hook.
+    """
+    from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
+
+    warning_filters.install_known_filters()
+
+    with warnings.catch_warnings(record=True) as caught:
+        # Ensure user-side ``simplefilter("always")`` does not unmask filters
+        # installed via ``warnings.filterwarnings`` — we want the project
+        # filter to take precedence over the test harness default.
+        warnings.warn(
+            (
+                "The default value of `allowed_objects` will change in a future version. "
+                "Pass an explicit value (e.g., allowed_objects='messages' or "
+                "allowed_objects='core') to suppress this warning."
+            ),
+            category=LangChainPendingDeprecationWarning,
+            stacklevel=1,
+        )
+
+    assert not [w for w in caught if isinstance(w.message, LangChainPendingDeprecationWarning)]
+
+
+def test_install_known_filters_is_idempotent() -> None:
+    """Calling ``install_known_filters`` twice must not duplicate filter entries."""
+    warning_filters.install_known_filters()
+    filters_after_first = list(warnings.filters)
+
+    warning_filters.install_known_filters()
+    filters_after_second = list(warnings.filters)
+
+    assert filters_after_first == filters_after_second
+
+
+def test_install_known_filters_does_not_silence_unrelated_warnings() -> None:
+    """The filter must be narrow — unrelated DeprecationWarnings still surface."""
+    warning_filters.install_known_filters()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.warn("unrelated deprecation", category=DeprecationWarning, stacklevel=1)
+
+    assert any(
+        isinstance(w.message, DeprecationWarning) and "unrelated deprecation" in str(w.message)
+        for w in caught
+    )


### PR DESCRIPTION
### Summary

Closes #1779.

Importing `app` (transitively via `app.entrypoints.sdk` -> `app.pipeline.runners` -> `app.state.agent_state`) loads `langgraph.checkpoint.serde.jsonplus`, which currently emits a `LangChainPendingDeprecationWarning`:

```
LangChainPendingDeprecationWarning: The default value of `allowed_objects` will change in a future version. Pass an explicit value (e.g., allowed_objects='messages' or allowed_objects='core') to suppress this warning.
  from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
```

OpenSRE already filters this exact warning inside `init_sentry` via `_suppress_langgraph_allowed_objects_warning`, but every entry point that runs an RCA fixture (`tests.e2e.rca.run_rca_test`, `app.pipeline.runners.run_investigation`) imports the LangGraph modules **before** `init_sentry` ever runs, so the filter is installed too late and the warning has already fired by the time the user sees the first line of investigation output. The reporter in #1779 hits this on every RCA run on Windows.

### Change

- New `app/utils/warning_filters.py` exposes an idempotent `install_known_filters()` that registers the same single, narrow filter (same message regex, same `LangChainPendingDeprecationWarning` category — no behaviour change beyond when it's installed).
- `app/__init__.py` calls `install_known_filters()` before importing `app.entrypoints.sdk`, so the filter is in place before any submodule transitively imports `langgraph`.
- The existing `_suppress_langgraph_allowed_objects_warning` context manager in `app/utils/sentry_sdk.py` is left in place as a belt-and-suspenders guard, so the existing `test_init_sentry_suppresses_langgraph_allowed_objects_warning` still passes.

Filter scope deliberately stays narrow: same exact message, same exact category. Unrelated DeprecationWarnings continue to surface.

### Test plan

- `pytest tests/utils/test_warning_filters.py -vv` — 3 new tests:
  - silences the LangGraph `allowed_objects` warning
  - calling `install_known_filters()` twice does not duplicate filter entries
  - unrelated `DeprecationWarning`s still surface
- `pytest tests/test_sentry_init.py -k langgraph` — existing context-manager test still passes
- End-to-end smoke:
  ```
  python -W default -c "import warnings; warnings.simplefilter('default'); ...; import app; import app.pipeline.runners; import app.state.agent_state"
  ```
  reports `relevant deprecation warnings: []` (was 1 before).