### PR TITLE
fix(services/aws): route AWS client errors through Sentry telemetry

### DIFF
--- a/app/services/aws_sdk_client.py
+++ b/app/services/aws_sdk_client.py
@@ -4,11 +4,16 @@ Generic AWS SDK client for executing read-only operations.
 Security-first design with operation allowlists and response sanitization.
 """
 
+import logging
 import re
 from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
+
+from app.services.aws_telemetry import report_aws_failure
+
+logger = logging.getLogger(__name__)
 
 # Read-only operation patterns (allowlist)
 ALLOWED_OPERATION_PATTERNS = [
@@ -241,6 +246,15 @@ def execute_aws_sdk_call(
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
         error_message = e.response.get("Error", {}).get("Message", str(e))
 
+        report_aws_failure(
+            e,
+            logger=logger,
+            message=f"AWS {service_name}.{operation_name} returned {error_code}",
+            service=service_name,
+            operation=operation_name,
+            region=region,
+        )
+
         return {
             "success": False,
             "error": f"AWS API error ({error_code}): {error_message}",
@@ -255,6 +269,14 @@ def execute_aws_sdk_call(
         }
 
     except Exception as e:
+        report_aws_failure(
+            e,
+            logger=logger,
+            message=f"Unexpected error executing AWS {service_name}.{operation_name}",
+            service=service_name,
+            operation=operation_name,
+            region=region,
+        )
         return {
             "success": False,
             "error": f"Unexpected error: {str(e)}",

--- a/app/services/aws_telemetry.py
+++ b/app/services/aws_telemetry.py
@@ -1,0 +1,72 @@
+"""AWS-specific Sentry/log tagging for service clients.
+
+The generic ``app.utils.errors.report_exception`` is fine for one-off
+``except`` sites, but every AWS client wants the same tag shape
+(``service``, ``operation``, ``region``, ``error_code``, ``surface=service_client``)
+and the same severity policy (vendor errors -> ``warning``, our bugs ->
+``error``). Wrapping that policy here keeps the call sites short and the
+Sentry signal consistent across ``aws_sdk_client.py`` and ``lambda_client.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.utils.errors import report_exception
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+
+    class ClientError(Exception):  # type: ignore[no-redef]
+        """Stub when botocore is not installed; preserves the helper's API."""
+
+
+def aws_error_code(exc: BaseException) -> str:
+    """Extract the AWS error code from a botocore ``ClientError``.
+
+    Returns ``"Unknown"`` for non-``ClientError`` exceptions or malformed
+    responses, so callers can use the value as a tag without further guards.
+    """
+    if not isinstance(exc, ClientError):
+        return "Unknown"
+    return str(exc.response.get("Error", {}).get("Code", "Unknown") or "Unknown")
+
+
+def report_aws_failure(
+    exc: BaseException,
+    *,
+    logger: logging.Logger,
+    message: str,
+    service: str,
+    operation: str,
+    region: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    """Log + Sentry-capture an AWS client failure with the standard tag shape.
+
+    ``ClientError`` is treated as a vendor problem (often expected: invalid
+    credentials, missing role, quota) and reported at ``warning``. Anything
+    else is treated as our own bug and reported at ``error``.
+    """
+    is_client_error = isinstance(exc, ClientError)
+    severity = "warning" if is_client_error else "error"
+    tags: dict[str, str] = {
+        "surface": "service_client",
+        "component": "aws",
+        "service": service,
+        "operation": operation,
+    }
+    if region:
+        tags["region"] = region
+    if is_client_error:
+        tags["aws_error_code"] = aws_error_code(exc)
+    report_exception(
+        exc,
+        logger=logger,
+        message=message,
+        severity=severity,
+        tags=tags,
+        extras=extras,
+    )

--- a/app/services/lambda_client.py
+++ b/app/services/lambda_client.py
@@ -2,11 +2,13 @@
 
 import base64
 import json
+import logging
 from contextlib import suppress
 from io import BytesIO
 from typing import Any
 from zipfile import ZipFile
 
+from app.services.aws_telemetry import report_aws_failure
 from app.services.env import make_boto3_client, require_aws_credentials
 
 try:
@@ -15,6 +17,9 @@ except ImportError:
 
     class ClientError(Exception):  # type: ignore[no-redef]
         """Stub when botocore is not installed; prevents over-broad except clauses."""
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_lambda_client():
@@ -116,7 +121,19 @@ def get_function_code(
             # Download and extract if code is under 5MB
             import requests
 
-            zip_response = requests.get(code_location, timeout=30)
+            try:
+                zip_response = requests.get(code_location, timeout=30)
+            except requests.RequestException as e:
+                report_aws_failure(
+                    e,
+                    logger=logger,
+                    message=f"Lambda zip download failed for {function_name}",
+                    service="lambda",
+                    operation="get_function:download_code",
+                    extras={"function_name": function_name},
+                )
+                result["data"]["extract_error"] = f"download failed: {e}"
+                return result
             if zip_response.status_code == 200:
                 files: dict[str, Any] = {}
                 try:
@@ -145,10 +162,39 @@ def get_function_code(
                     result["data"]["files"] = files
                     result["data"]["file_count"] = len(files)
                 except Exception as e:
+                    report_aws_failure(
+                        e,
+                        logger=logger,
+                        message=f"Lambda zip extraction failed for {function_name}",
+                        service="lambda",
+                        operation="get_function:extract_code",
+                        extras={"function_name": function_name},
+                    )
                     result["data"]["extract_error"] = str(e)
+            else:
+                report_aws_failure(
+                    RuntimeError(f"HTTP {zip_response.status_code}"),
+                    logger=logger,
+                    message=f"Lambda zip download returned non-200 for {function_name}",
+                    service="lambda",
+                    operation="get_function:download_code",
+                    extras={
+                        "function_name": function_name,
+                        "status_code": zip_response.status_code,
+                    },
+                )
+                result["data"]["extract_error"] = f"HTTP {zip_response.status_code}"
 
         return result
     except ClientError as e:
+        report_aws_failure(
+            e,
+            logger=logger,
+            message=f"Lambda get_function failed for {function_name}",
+            service="lambda",
+            operation="get_function",
+            extras={"function_name": function_name},
+        )
         return {"success": False, "error": str(e)}
 
 
@@ -336,9 +382,27 @@ def invoke_function(
 
         response = client.invoke(**kwargs)
 
-        result_payload = None
+        result_payload: Any = None
         if "Payload" in response:
-            result_payload = json.loads(response["Payload"].read().decode())
+            try:
+                result_payload = json.loads(response["Payload"].read().decode())
+            except json.JSONDecodeError as e:
+                report_aws_failure(
+                    e,
+                    logger=logger,
+                    message=f"Lambda invoke payload parse failed for {function_name}",
+                    service="lambda",
+                    operation="invoke:parse_payload",
+                    extras={"function_name": function_name},
+                )
+                return {
+                    "success": False,
+                    "error": f"Invalid JSON payload returned by Lambda: {e}",
+                    "data": {
+                        "status_code": response.get("StatusCode"),
+                        "function_error": response.get("FunctionError"),
+                    },
+                }
 
         return {
             "success": True,
@@ -353,6 +417,14 @@ def invoke_function(
             },
         }
     except ClientError as e:
+        report_aws_failure(
+            e,
+            logger=logger,
+            message=f"Lambda invoke failed for {function_name}",
+            service="lambda",
+            operation="invoke",
+            extras={"function_name": function_name},
+        )
         return {"success": False, "error": str(e)}
 
 

--- a/tests/services/test_aws_telemetry.py
+++ b/tests/services/test_aws_telemetry.py
@@ -1,0 +1,189 @@
+"""Tests for ``app.services.aws_telemetry`` and the AWS-client error paths
+that route through it. Regression coverage for issue #1462."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as requests_module
+from botocore.exceptions import ClientError
+
+from app.services import aws_sdk_client, aws_telemetry, lambda_client
+
+
+def _client_error(code: str = "AccessDeniedException", message: str = "denied") -> ClientError:
+    return ClientError(
+        error_response={
+            "Error": {"Code": code, "Message": message},
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        },
+        operation_name="DescribeInstances",
+    )
+
+
+class TestAwsErrorCode:
+    def test_extracts_code_from_client_error(self) -> None:
+        assert (
+            aws_telemetry.aws_error_code(_client_error("ThrottlingException"))
+            == "ThrottlingException"
+        )
+
+    def test_returns_unknown_for_non_client_error(self) -> None:
+        assert aws_telemetry.aws_error_code(RuntimeError("boom")) == "Unknown"
+
+    def test_returns_unknown_when_response_payload_missing_code(self) -> None:
+        exc = ClientError(
+            error_response={"Error": {}, "ResponseMetadata": {}},
+            operation_name="DescribeInstances",
+        )
+        assert aws_telemetry.aws_error_code(exc) == "Unknown"
+
+
+class TestReportAwsFailure:
+    def test_client_error_is_reported_as_warning_with_aws_tags(self) -> None:
+        logger = logging.getLogger("test.aws_telemetry")
+        exc = _client_error("AccessDeniedException")
+
+        with patch.object(aws_telemetry, "report_exception") as mock_report:
+            aws_telemetry.report_aws_failure(
+                exc,
+                logger=logger,
+                message="boom",
+                service="ec2",
+                operation="describe_instances",
+                region="us-east-1",
+            )
+
+        assert mock_report.call_count == 1
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["severity"] == "warning"
+        assert kwargs["tags"] == {
+            "surface": "service_client",
+            "component": "aws",
+            "service": "ec2",
+            "operation": "describe_instances",
+            "region": "us-east-1",
+            "aws_error_code": "AccessDeniedException",
+        }
+
+    def test_unexpected_exception_is_reported_as_error_without_aws_code_tag(self) -> None:
+        logger = logging.getLogger("test.aws_telemetry")
+
+        with patch.object(aws_telemetry, "report_exception") as mock_report:
+            aws_telemetry.report_aws_failure(
+                RuntimeError("boom"),
+                logger=logger,
+                message="unexpected",
+                service="ec2",
+                operation="describe_instances",
+            )
+
+        assert mock_report.call_count == 1
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["severity"] == "error"
+        assert "aws_error_code" not in kwargs["tags"]
+        assert kwargs["tags"]["surface"] == "service_client"
+        assert kwargs["tags"]["component"] == "aws"
+
+
+class TestExecuteAwsSdkCallReportsErrors:
+    """``execute_aws_sdk_call`` previously swallowed ``ClientError`` and
+    ``Exception`` without logging or capturing — see #1462."""
+
+    def test_client_error_path_calls_report_aws_failure(self) -> None:
+        with (
+            patch.object(aws_sdk_client, "boto3") as mock_boto3,
+            patch.object(aws_sdk_client, "report_aws_failure") as mock_report,
+        ):
+            client = MagicMock()
+            mock_boto3.client.return_value = client
+            client.describe_instances.side_effect = _client_error("AccessDeniedException")
+
+            result = aws_sdk_client.execute_aws_sdk_call("ec2", "describe_instances")
+
+        assert result["success"] is False
+        assert result["metadata"]["error_code"] == "AccessDeniedException"
+        assert mock_report.call_count == 1
+        assert isinstance(mock_report.call_args.args[0], ClientError)
+
+    def test_unexpected_exception_path_calls_report_aws_failure(self) -> None:
+        with (
+            patch.object(aws_sdk_client, "boto3") as mock_boto3,
+            patch.object(aws_sdk_client, "report_aws_failure") as mock_report,
+        ):
+            client = MagicMock()
+            mock_boto3.client.return_value = client
+            client.describe_instances.side_effect = RuntimeError("boom")
+
+            result = aws_sdk_client.execute_aws_sdk_call("ec2", "describe_instances")
+
+        assert result["success"] is False
+        assert result["metadata"]["error_type"] == "unexpected"
+        assert mock_report.call_count == 1
+        assert isinstance(mock_report.call_args.args[0], RuntimeError)
+
+
+@pytest.mark.parametrize(
+    "factory_name, side_effect, expect_extract_error_substring",
+    [
+        ("requests_request_exception", "download failed", "download failed"),
+        ("zip_extraction_exception", "BadZipFile", "BadZipFile"),
+    ],
+)
+def test_get_function_routes_extract_failures_through_helper(
+    factory_name: str,
+    side_effect: str,
+    expect_extract_error_substring: str,
+) -> None:
+    """``get_function_code`` previously surfaced extract failures only
+    inside the result dict — see #1462."""
+    function_name = "fn-1"
+    code_url = "https://example.invalid/code.zip"
+
+    with (
+        patch.object(lambda_client, "_get_lambda_client") as mock_get_client,
+        patch.object(lambda_client, "require_aws_credentials", return_value=None),
+        patch.object(lambda_client, "report_aws_failure") as mock_report,
+        patch("requests.get") as mock_requests_get,
+    ):
+        client = MagicMock()
+        mock_get_client.return_value = client
+        client.get_function.return_value = {
+            "Code": {"Location": code_url, "RepositoryType": "S3"},
+            "Configuration": {"CodeSize": 1024},
+        }
+        if factory_name == "requests_request_exception":
+            mock_requests_get.side_effect = requests_module.RequestException(side_effect)
+        else:
+            zip_response = MagicMock()
+            zip_response.status_code = 200
+            zip_response.content = b"not a zip"
+            mock_requests_get.return_value = zip_response
+
+        result = lambda_client.get_function_code(function_name, extract_files=True)
+
+    assert mock_report.call_count == 1
+    assert "extract_error" in result["data"]
+
+
+def test_invoke_function_captures_json_decode_error() -> None:
+    """``invoke_function`` previously let ``JSONDecodeError`` propagate
+    uncontrolled — see #1462."""
+    with (
+        patch.object(lambda_client, "_get_lambda_client") as mock_get_client,
+        patch.object(lambda_client, "require_aws_credentials", return_value=None),
+        patch.object(lambda_client, "report_aws_failure") as mock_report,
+    ):
+        client = MagicMock()
+        mock_get_client.return_value = client
+        payload_stream = MagicMock()
+        payload_stream.read.return_value = b"not json"
+        client.invoke.return_value = {"Payload": payload_stream, "StatusCode": 200}
+
+        result = lambda_client.invoke_function("fn-1")
+
+    assert result["success"] is False
+    assert "Invalid JSON payload" in result["error"]
+    assert mock_report.call_count == 1


### PR DESCRIPTION
### Summary

Closes #1462.

The AWS service clients silently dropped failures on the floor:

- `aws_sdk_client.execute_aws_sdk_call` caught both `botocore.exceptions.ClientError` and bare `Exception` and folded the error into the result dict — no `logger.*`, no Sentry event, no distinction between vendor problems (invalid credentials, missing role, throttling, quota) and our own bugs.
- `lambda_client.get_function_code` skipped non-200 zip downloads silently and let `except Exception` surface only inside `result["data"]["extract_error"]`.
- `lambda_client.invoke_function` let `json.JSONDecodeError` from `json.loads(response["Payload"].read().decode())` propagate uncontrolled.

### Change

New `app/services/aws_telemetry.py` exposes `report_aws_failure`, a thin wrapper around `app.utils.errors.report_exception` (already present from #1454) that:

- Tags every event with `surface=service_client`, `component=aws`, `service`, `operation`, optional `region`, and `aws_error_code` when the exception is a `ClientError`.
- Uses the severity policy the issue calls for: `ClientError` -> `warning` (vendor problem, often expected), anything else -> `error` (our bug).

Route every previously-silent `except` site in `aws_sdk_client.py` and `lambda_client.py` through the helper. Additionally:

- Lambda zip download: wrap `requests.get` in `try/except requests.RequestException`, and report non-200 status codes via the helper. Both now also surface a clean `extract_error` string in the response dict, so existing callers see the same shape.
- Lambda invoke: wrap `json.loads(response["Payload"].read().decode())` in `try/except json.JSONDecodeError`. Returns `{"success": False, "error": "Invalid JSON payload returned by Lambda: ..."}` instead of crashing.

The metric-parsing `with suppress(IndexError, ValueError)` block in `get_recent_invocations` is intentionally left as-is per issue body ("acceptable for normal user metrics") — the proposed once-per-process schema-break sample is a separate, larger change and is not in scope here.

### Test plan

`tests/services/test_aws_telemetry.py` (10 new tests):

- `aws_error_code` returns `"Unknown"` for non-`ClientError` and malformed responses
- `report_aws_failure` emits the right severity + tag shape for `ClientError` (warning + `aws_error_code`) and for plain `RuntimeError` (error, no `aws_error_code`)
- `execute_aws_sdk_call` calls the helper on both `ClientError` and unexpected `RuntimeError` paths
- `get_function_code` calls the helper on `RequestException` and on a corrupt zip
- `invoke_function` returns a clean error and reports the `JSONDecodeError` instead of crashing

```
$ pytest tests/services/test_aws_telemetry.py tests/services/test_aws_sdk_client.py tests/services/test_lambda_client.py -q
... 81 passed
$ ruff check app/services/aws_telemetry.py app/services/aws_sdk_client.py app/services/lambda_client.py tests/services/test_aws_telemetry.py
All checks passed!
$ ruff format --check app/services/aws_telemetry.py app/services/aws_sdk_client.py app/services/lambda_client.py tests/services/test_aws_telemetry.py
4 files already formatted
```