### PR TITLE
fix(bedrock): surface upstream AWS reason on AccessDeniedException

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -431,8 +431,8 @@ class BedrockLLMClient:
                     # ``INVALID_PAYMENT_INSTRUMENT``). Surface the upstream
                     # AWS-provided reason so the user knows which one to fix
                     # — see issue #1808.
-                    aws_message = str(err.response.get("Error", {}).get("Message", "")).strip()
-                    detail = f" Cause: {aws_message}" if aws_message else ""
+                    aws_message = str(err.response.get("Error", {}).get("Message", "")).strip().rstrip(".")
+                    detail = f" Cause: {aws_message}." if aws_message else ""
                     raise RuntimeError(
                         f"Access denied for Bedrock model '{self._model}'.{detail} "
                         "Check Bedrock model access (per-region opt-in), your "

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -425,9 +425,19 @@ class BedrockLLMClient:
                         "Check the model ID, region, or inference profile."
                     ) from err
                 if code in ("AccessDeniedException", "UnauthorizedException"):
+                    # AccessDeniedException is overloaded on Bedrock: it can mean
+                    # missing IAM, missing per-region/per-model Bedrock access
+                    # opt-in, or an AWS Marketplace billing problem (e.g.
+                    # ``INVALID_PAYMENT_INSTRUMENT``). Surface the upstream
+                    # AWS-provided reason so the user knows which one to fix
+                    # — see issue #1808.
+                    aws_message = str(err.response.get("Error", {}).get("Message", "")).strip()
+                    detail = f" Cause: {aws_message}" if aws_message else ""
                     raise RuntimeError(
-                        f"Access denied for Bedrock model '{self._model}'. "
-                        "Check your AWS IAM permissions and account configuration."
+                        f"Access denied for Bedrock model '{self._model}'.{detail} "
+                        "Check Bedrock model access (per-region opt-in), your "
+                        "AWS Marketplace subscription / payment method, and "
+                        "IAM permissions."
                     ) from err
                 last_err = err
                 if attempt == max_attempts - 1:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1676,6 +1676,45 @@ def test_bedrock_invoke_converse_hard_client_errors_raise_immediately(
     assert sleeps == [], "non-transient errors must not be retried"
 
 
+def test_bedrock_access_denied_surfaces_upstream_aws_message(monkeypatch) -> None:
+    """``AccessDeniedException`` on Bedrock can also indicate an AWS
+    Marketplace billing problem (e.g. ``INVALID_PAYMENT_INSTRUMENT``) or a
+    missing per-model Bedrock opt-in, not just IAM. The wrapped
+    ``RuntimeError`` must include the upstream AWS ``Message`` so the user
+    knows which one to fix. Regression coverage for #1808."""
+    monkeypatch.setattr(
+        "app.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+    monkeypatch.setattr(llm_client.time, "sleep", lambda _s: None)
+
+    import botocore.exceptions
+
+    aws_message = (
+        "Model access is denied due to INVALID_PAYMENT_INSTRUMENT:"
+        "A valid payment instrument must be provided."
+    )
+    boto_err = botocore.exceptions.ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": aws_message}},
+        "Converse",
+    )
+
+    class _FailingRuntime:
+        def converse(self, **_kwargs):
+            raise boto_err
+
+    monkeypatch.setattr(llm_client.boto3, "client", lambda *_a, **_k: _FailingRuntime())
+
+    client = llm_client.BedrockLLMClient(model="some-model")
+    with pytest.raises(RuntimeError) as excinfo:
+        client.invoke("hello")
+
+    rendered = str(excinfo.value)
+    assert "INVALID_PAYMENT_INSTRUMENT" in rendered
+    assert "Bedrock model access" in rendered
+    assert "AWS Marketplace subscription" in rendered
+
+
 def test_format_openai_connection_error_ssl_via_cause() -> None:
     """SSL fingerprint in __cause__ triggers the TLS-specific message."""
     ssl_err = Exception("[SSL: WRONG_VERSION_NUMBER] wrong version number")


### PR DESCRIPTION
### Summary

Closes #1808.

The Bedrock `Converse` path translated every `AccessDeniedException` and `UnauthorizedException` from boto3 into the same wrapped `RuntimeError`:

```
Access denied for Bedrock model '<id>'.
Check your AWS IAM permissions and account configuration.
```

That message is misleading. On Bedrock, `AccessDeniedException` is overloaded across at least three real-world causes:

1. Missing IAM permissions for `bedrock:InvokeModel` / `bedrock:Converse` on the model or inference profile.
2. The model has not been opted into in this region's Bedrock console (per-model access toggle).
3. AWS Marketplace billing problem — typically surfaced as `INVALID_PAYMENT_INSTRUMENT` in the upstream message — the account has no valid payment method for paid model subscriptions.

The third case is what drove the Sentry report referenced by #1808; the user followed the suggested IAM check, found nothing wrong, and the failure stayed unactionable.

### Change

Carry the upstream AWS-provided `Error.Message` through the wrapped `RuntimeError` and broaden the suggested check to all three realistic causes. New rendered error looks like:

```
Access denied for Bedrock model '<id>'. Cause: Model access is denied due to INVALID_PAYMENT_INSTRUMENT:A valid payment instrument must be provided. Check Bedrock model access (per-region opt-in), your AWS Marketplace subscription / payment method, and IAM permissions.
```

Exception type is unchanged (still `RuntimeError` chained from the original `ClientError`), so the existing `test_bedrock_invoke_converse_hard_client_errors_raise_immediately` parametrisation continues to pass.

### Test plan

- New `test_bedrock_access_denied_surfaces_upstream_aws_message` injects a `ClientError(AccessDeniedException)` with the exact `INVALID_PAYMENT_INSTRUMENT` message from the Sentry report and asserts both the upstream reason and the Marketplace guidance appear in the rendered error.
- Existing parametrised `test_bedrock_invoke_converse_hard_client_errors_raise_immediately[AccessDeniedException]` and `[ResourceNotFoundException]` still pass.
- All 16 `bedrock`-tagged tests in `tests/services/test_llm_client.py` pass; `ruff check` clean; `ruff format --check` clean.