### PR TITLE
fix(bedrock): surface payment instrument error instead of generic IAM message

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -425,6 +425,13 @@ class BedrockLLMClient:
                         "Check the model ID, region, or inference profile."
                     ) from err
                 if code in ("AccessDeniedException", "UnauthorizedException"):
+                    err_msg = str(err)
+                    if "INVALID_PAYMENT_INSTRUMENT" in err_msg or "payment instrument" in err_msg.lower():
+                        raise RuntimeError(
+                            f"Access denied for Bedrock model '{self._model}'. "
+                            "A valid AWS payment instrument is required — add a payment method "
+                            "to your AWS account or check your AWS Marketplace subscription."
+                        ) from err
                     raise RuntimeError(
                         f"Access denied for Bedrock model '{self._model}'. "
                         "Check your AWS IAM permissions and account configuration."

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -426,7 +426,10 @@ class BedrockLLMClient:
                     ) from err
                 if code in ("AccessDeniedException", "UnauthorizedException"):
                     err_msg = str(err)
-                    if "INVALID_PAYMENT_INSTRUMENT" in err_msg or "payment instrument" in err_msg.lower():
+                    if (
+                        "INVALID_PAYMENT_INSTRUMENT" in err_msg
+                        or "payment instrument" in err_msg.lower()
+                    ):
                         raise RuntimeError(
                             f"Access denied for Bedrock model '{self._model}'. "
                             "A valid AWS payment instrument is required — add a payment method "


### PR DESCRIPTION
## Summary

- When AWS Bedrock returns `AccessDeniedException` with `INVALID_PAYMENT_INSTRUMENT` in the message, the error now says to add/fix a payment method instead of misleadingly pointing users at IAM permissions.
- The fallback IAM-permissions message is preserved for all other `AccessDeniedException` / `UnauthorizedException` cases.

## Root cause (Sentry PYTHON-2M)

`BedrockLLMClient._invoke_converse` caught every `AccessDeniedException` with a single generic message: _"Check your AWS IAM permissions and account configuration."_ AWS Marketplace payment failures arrive as `AccessDeniedException` with `INVALID_PAYMENT_INSTRUMENT` in the body, so users were directed to debug the wrong thing.

## Test plan

- [ ] Confirm `uv run ruff check app/services/llm_client.py` passes (no lint errors).
- [ ] Mock a `botocore.exceptions.ClientError` with `Code=AccessDeniedException` and `Message` containing `INVALID_PAYMENT_INSTRUMENT`; assert the raised `RuntimeError` mentions "payment instrument".
- [ ] Mock the same error without the payment keyword; assert the original IAM-permissions message is raised.

Closes #1808

https://claude.ai/code/session_01PyKz2Thccp1AaHFxjV38KP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyKz2Thccp1AaHFxjV38KP)_