### PR TITLE
feat(sentry): init_sentry for missing entrypoints (Sentry coverage 3/5)

### DIFF
--- a/app/analytics/install.py
+++ b/app/analytics/install.py
@@ -21,4 +21,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from app.utils.sentry_sdk import init_sentry
+
+    init_sentry(entrypoint="analytics.install")
     raise SystemExit(main())

--- a/app/cli/wizard/grafana_seed.py
+++ b/app/cli/wizard/grafana_seed.py
@@ -164,7 +164,7 @@ def seed_logs() -> None:
 
 def main() -> int:
     with suppress(ModuleNotFoundError):
-        init_sentry(entrypoint="wizard")
+        init_sentry(entrypoint="wizard.grafana_seed")
     seed_logs()
     return 0
 

--- a/app/entrypoints/sdk.py
+++ b/app/entrypoints/sdk.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.utils.sentry_sdk import init_sentry
+
+init_sentry(entrypoint="entrypoints.sdk")
+
 
 def run_investigation(*args: Any, **kwargs: Any) -> Any:
     """Lazily import the full runner stack to avoid optional dependency churn at import time."""

--- a/app/graph_pipeline.py
+++ b/app/graph_pipeline.py
@@ -8,5 +8,8 @@ Production deployment config and older internal docs still reference
 from __future__ import annotations
 
 from app.pipeline.graph import build_graph
+from app.utils.sentry_sdk import init_sentry
+
+init_sentry(entrypoint="graph_pipeline")
 
 __all__ = ["build_graph"]

--- a/app/integrations/daily_update.py
+++ b/app/integrations/daily_update.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo
 from pydantic import BaseModel, Field
 
 from app.services.llm_client import get_llm_for_reasoning
+from app.utils.sentry_sdk import init_sentry
 from app.version import get_version
 
 GITHUB_API_BASE_URL = "https://api.github.com"
@@ -732,6 +733,7 @@ def _append_github_output(name: str, value: str) -> None:
 
 def main() -> int:
     """Entrypoint used by the scheduled GitHub Actions workflow."""
+    init_sentry(entrypoint="integrations.daily_update")
     repository = _string(os.getenv("GITHUB_REPOSITORY"))
     token = _string(os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN"))
     if not repository:

--- a/app/integrations/github_issue_comments.py
+++ b/app/integrations/github_issue_comments.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 from urllib import error, request
 
+from app.utils.sentry_sdk import init_sentry
+
 MAX_COMMENT_PREVIEW_CHARS = 500
 
 
@@ -150,6 +152,7 @@ def send_slack_webhook(payload: dict[str, Any], webhook_url: str) -> None:
 
 def main() -> int:
     """Entrypoint used by the GitHub Actions workflow."""
+    init_sentry(entrypoint="integrations.github_issue_comments")
     event_path = _string(os.getenv("GITHUB_EVENT_PATH"))
     repository = _string(os.getenv("GITHUB_REPOSITORY"))
     webhook_url = _string(

--- a/tests/test_sentry_entrypoint_wiring.py
+++ b/tests/test_sentry_entrypoint_wiring.py
@@ -1,0 +1,104 @@
+"""Wiring tests for issue #1477 — init_sentry coverage on standalone entrypoints."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_init_cache() -> None:
+    from app.utils import sentry_sdk as sentry_mod
+
+    sentry_mod._init_sentry_once.cache_clear()
+
+
+def _record_init(monkeypatch: pytest.MonkeyPatch) -> list[str | None]:
+    calls: list[str | None] = []
+
+    def _stub(entrypoint: str | None = None) -> None:
+        calls.append(entrypoint)
+
+    monkeypatch.setattr("app.utils.sentry_sdk.init_sentry", _stub)
+    return calls
+
+
+def _reload(module_name: str) -> Any:
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_graph_pipeline_initializes_sentry_on_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _record_init(monkeypatch)
+    _reload("app.graph_pipeline")
+    assert "graph_pipeline" in calls
+
+
+def test_entrypoints_sdk_initializes_sentry_on_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _record_init(monkeypatch)
+    _reload("app.entrypoints.sdk")
+    assert "entrypoints.sdk" in calls
+
+
+def test_daily_update_main_initializes_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.integrations import daily_update
+
+    calls: list[str | None] = []
+    monkeypatch.setattr(
+        daily_update, "init_sentry", lambda entrypoint=None: calls.append(entrypoint)
+    )
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    assert daily_update.main() == 1
+    assert calls == ["integrations.daily_update"]
+
+
+def test_github_issue_comments_main_initializes_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.integrations import github_issue_comments
+
+    calls: list[str | None] = []
+    monkeypatch.setattr(
+        github_issue_comments, "init_sentry", lambda entrypoint=None: calls.append(entrypoint)
+    )
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    assert github_issue_comments.main() == 1
+    assert calls == ["integrations.github_issue_comments"]
+
+
+def test_grafana_seed_main_initializes_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.cli.wizard import grafana_seed
+
+    calls: list[str | None] = []
+    monkeypatch.setattr(
+        grafana_seed, "init_sentry", lambda entrypoint=None: calls.append(entrypoint)
+    )
+    monkeypatch.setattr(grafana_seed, "seed_logs", lambda: None)
+
+    assert grafana_seed.main() == 0
+    assert calls == ["wizard.grafana_seed"]
+
+
+def test_analytics_install_main_block_initializes_sentry() -> None:
+    import subprocess
+    import sys
+
+    script = (
+        "import app.utils.sentry_sdk as s\n"
+        "calls = []\n"
+        "s.init_sentry = lambda entrypoint=None: calls.append(entrypoint)\n"
+        "import app.analytics.provider as p\n"
+        "p.capture_install_detected_if_needed = lambda *a, **k: None\n"
+        "p.shutdown_analytics = lambda *a, **k: None\n"
+        "import runpy\n"
+        "try:\n"
+        "    runpy.run_module('app.analytics.install', run_name='__main__')\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        "assert calls == ['analytics.install'], calls\n"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Fixes #1477

#### Describe the changes you have made in this PR -

Adds `init_sentry()` calls to the six standalone entrypoints that were running without Sentry coverage. Each call uses the new `entrypoint=` kwarg introduced by #1475 (PR #1558) so the events get tagged with the right calling surface:

| File | Tag |
| --- | --- |
| `app/analytics/install.py` | `analytics.install` (inside `__main__` guard) |
| `app/integrations/daily_update.py` | `integrations.daily_update` |
| `app/integrations/github_issue_comments.py` | `integrations.github_issue_comments` |
| `app/cli/wizard/grafana_seed.py` | `wizard.grafana_seed` (relabel from `wizard`) |
| `app/graph_pipeline.py` | `graph_pipeline` (hosted LangGraph loader, per `langgraph.json`) |
| `app/entrypoints/sdk.py` | `entrypoints.sdk` (SDK consumers importing the runner directly) |

`_init_sentry_once` is `@cache`d on its kwargs, so the hosted-runtime path (`webapp.py` + `graph_pipeline.py` both initializing) only actually calls `sentry_sdk.init` once.

Wiring tests in `tests/test_sentry_entrypoint_wiring.py` cover all six paths:
- module-import-time inits for `graph_pipeline` / `entrypoints.sdk` via `importlib.reload`
- `main()`-call inits for `daily_update` / `github_issue_comments` / `grafana_seed`
- `__main__`-guard init for `analytics.install` via `runpy` in a subprocess

### Demo/Screenshot for feature changes and bug fixes -

`pytest tests/test_sentry_entrypoint_wiring.py tests/test_sentry_init.py`:
```
tests/test_sentry_entrypoint_wiring.py ......                            [ 11%]
tests/test_sentry_init.py .............................................. [100%]
============================== 52 passed in 1.92s ==============================
```

`make lint` and `make format-check` pass clean. `make typecheck` and `make test-cov` have the same pre-existing failures observed before this branch (clickhouse_connect stubs, kafka admin attr, AF_UNIX socket-path-too-long on local cwd) — none touched by this PR.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

The issue called out six entrypoints that ran without Sentry. The fix is mechanical — import `init_sentry` and call it with the correct `entrypoint=...` tag at the documented spot for each file:

- For standalone scripts that go through `main()` (`daily_update`, `github_issue_comments`), the call goes at the top of `main()` before any work — matches what `app/main.py` already does after `load_dotenv()`. These two run in GitHub Actions which exports env natively, so no `load_dotenv()` is needed.
- For `analytics/install.py` the issue specifically asked for the call to live inside the `if __name__ == "__main__":` block so that `from app.analytics.install import main` from other code doesn't double-init. I also moved the `init_sentry` import there to keep the module import side-effect-free.
- For `graph_pipeline.py` (the hosted LangGraph compatibility shim) and `entrypoints/sdk.py`, the call has to happen at module-import time because consumers don't go through a `main()` — they just import. The `_init_sentry_once` cache makes the double-init on hosted (webapp.py also calls it) a no-op.
- For `grafana_seed.py` the file already had `init_sentry(entrypoint="wizard")` — I relabelled it to the more specific `wizard.grafana_seed` per the tag table in the issue, since the existing `wizard` tag already covers `app/cli/wizard/__main__.py`.

Alternative I considered: a single `_init_sentry_for_module()` helper that infers the tag from `__name__`. Rejected because the existing pattern in `main.py`, `webapp.py`, `mcp.py` etc. uses explicit string tags, and the tag values were specifically prescribed by the issue — a helper would just obscure the contract.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code