### PR TITLE
fix(sentry): expand operator-error filters and guard _before_send when disabled

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -45,12 +45,17 @@ _QUERY_SCRUBBING_CATEGORIES: frozenset[str] = frozenset({"http", "httpx"})
 _HEADER_SCRUBBING_CATEGORIES: frozenset[str] = frozenset({"http", "httpx", "aiohttp"})
 _HOSTED_ENTRYPOINTS: frozenset[str] = frozenset({"webapp", "remote", "mcp", "graph_pipeline"})
 _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\b(?:anthropic|openai|opensre custom)\s+authentication failed\b", re.I),
+    # Any provider auth failure: "Openrouter authentication failed. Check OPENROUTER_API_KEY …"
+    re.compile(r"\bauthentication failed\.\s+Check\s+\S+_API_KEY\b", re.I),
     re.compile(r"\bmissing\s+[A-Z0-9_]+_API_KEY\b", re.I),
+    # Pydantic validation: "LLM provider 'minimax' requires MINIMAX_API_KEY to be set."
+    re.compile(r"\brequires\s+[A-Z0-9_]+_API_KEY\s+to\s+be\s+set\b", re.I),
     re.compile(r"\brate limit exceeded\b.*\b(?:quota|billing)\b", re.I),
     re.compile(r"\bcredit balance is too low\b", re.I),
     re.compile(r"\bmodel\s+['\"][^'\"]+['\"]\s+was not found\b", re.I),
     re.compile(r"\bcheck your configured model name or endpoint\b", re.I),
+    # Relay/proxy forwarding an invalid model group to Anthropic.
+    re.compile(r"\bprovided model identifier is invalid\b", re.I),
     re.compile(r"\bLLM API request failed after multiple retries\b", re.I),
 )
 
@@ -232,9 +237,12 @@ def _event_has_operator_actionable_llm_error(event: dict[str, Any]) -> bool:
 def _before_send(event: Any, _hint: dict[str, Any]) -> Any:
     """Drop or scrub a Sentry event before transport.
 
-    Returns ``None`` to drop the event (e.g. when DSN is empty), otherwise
-    returns the same dict with sensitive bits replaced with ``[Filtered]``.
+    Returns ``None`` to drop the event (e.g. when DSN is empty or telemetry
+    is disabled), otherwise returns the same dict with sensitive bits
+    replaced with ``[Filtered]``.
     """
+    if _is_sentry_disabled():
+        return None
     if not _resolved_dsn():
         return None
     if not isinstance(event, dict):

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -20,10 +20,17 @@ def _reset_sentry_module_state(monkeypatch: pytest.MonkeyPatch) -> None:
     import Y`` because the stub is not a package. Stubbing the integrations
     builder with an empty list keeps every test working; the one test that
     asserts integrations were wired overrides this in its own body.
+
+    Also clears the global ``OPENSRE_SENTRY_DISABLED`` flag set by conftest so
+    that ``_before_send`` unit tests can exercise the scrubbing/filtering logic.
+    Tests that need the disable flag re-set it via ``monkeypatch.setenv``.
     """
     sentry_mod._init_sentry_once.cache_clear()
     sentry_mod._reset_scope_tags_state_for_tests()
     monkeypatch.setattr(sentry_mod, "_build_sentry_integrations", lambda: [])
+    monkeypatch.delenv("OPENSRE_SENTRY_DISABLED", raising=False)
+    monkeypatch.delenv("OPENSRE_NO_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
 
 
 def test_init_sentry_noops_when_disabled(monkeypatch) -> None:
@@ -246,6 +253,12 @@ def test_before_send_filters_sensitive_request_headers() -> None:
 def test_before_send_drops_event_when_dsn_is_empty(monkeypatch) -> None:
     monkeypatch.setenv("SENTRY_DSN", "")
     monkeypatch.setattr(sentry_mod, "SENTRY_DSN", "")
+
+    assert sentry_mod._before_send({"message": "boom"}, {}) is None
+
+
+def test_before_send_drops_event_when_sentry_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_SENTRY_DISABLED", "1")
 
     assert sentry_mod._before_send({"message": "boom"}, {}) is None
 
@@ -609,6 +622,22 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
         (
             "RuntimeError",
             "Openai authentication failed. Check OPENAI_API_KEY in your environment, .env, or secure local keychain.",
+        ),
+        (
+            "RuntimeError",
+            "Openrouter authentication failed. Check OPENROUTER_API_KEY in your environment, .env, or secure local keychain.",
+        ),
+        (
+            "RuntimeError",
+            "Minimax authentication failed. Check MINIMAX_API_KEY in your environment, .env, or secure local keychain.",
+        ),
+        (
+            "RuntimeError",
+            "1 validation error for LLMSettings\n  Value error, LLM provider 'minimax' requires MINIMAX_API_KEY to be set.",
+        ),
+        (
+            "RuntimeError",
+            "Openai request rejected (HTTP 400): Error code: 400 - {'error': {'message': 'litellm.BadRequestError: AnthropicException - {\"message\":\"The provided model identifier is invalid.\"}. Received Model Group=relay-ops-claude-opus-4-7'}}",
         ),
         (
             "RuntimeError",


### PR DESCRIPTION
## Summary

Fixes several Sentry issues that were creating spurious high-priority bug reports due to missing filter patterns and a gap in the `_before_send` guard.

- **#1813** — Test-triggered errors (`test_runners_sentry.py`) were reaching real Sentry in environments where `sentry_sdk` was initialized before `OPENSRE_SENTRY_DISABLED=1` took effect. `_before_send` now checks `_is_sentry_disabled()` so events are dropped even when the SDK is already initialized.
- **#1816** — "Openrouter authentication failed" was not caught by the previous pattern (only listed `anthropic`, `openai`, `opensre custom`). Pattern is now provider-agnostic: matches any `"… authentication failed. Check <X>_API_KEY …"` message.
- **#1815** — Pydantic validation errors from misconfigured providers (`LLM provider 'minimax' requires MINIMAX_API_KEY to be set`) were not caught. New pattern covers `"requires <X>_API_KEY to be set"`.
- **#1805 / #1806** — Relay/LiteLLM forwarding an invalid model group to Anthropic (`"The provided model identifier is invalid."`) was not caught. New pattern suppresses this operator-actionable noise.
- **#1804** — `NameError: _fallback_extract` is already fixed in the current codebase (`_fallback_details` is the correct function name). Closed via this PR.

## Changes

- `app/utils/sentry_sdk.py`: added `_is_sentry_disabled()` check to `_before_send`; replaced hardcoded provider list in auth-failure pattern with a generic `Check <X>_API_KEY` pattern; added two new operator-actionable patterns.
- `tests/test_sentry_init.py`: cleared telemetry kill-switches in the autouse fixture so `_before_send` unit tests can exercise scrubbing logic; added test cases for the three new patterns and for the disabled-guard.

## Test plan

- [x] `uv run --with pytest python -m pytest tests/test_sentry_init.py tests/pipeline/test_runners_sentry.py -v` — 52 passed
- [x] `ruff check app/utils/sentry_sdk.py tests/test_sentry_init.py` — all checks passed

Closes #1813, #1815, #1816
Partially addresses #1805, #1806

https://claude.ai/code/session_01YUy5nuKbnwhCtEmmwmEVys

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUy5nuKbnwhCtEmmwmEVys)_