### PR TITLE
fix(sentry): strip pydantic boilerplate from ValidationError RuntimeError message

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -999,6 +999,10 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
     try:
         settings = LLMSettings.from_env()
     except ValidationError as exc:
+        errors = exc.errors()
+        if len(errors) == 1:
+            msg = re.sub(r"^[Vv]alue error,\s*", "", errors[0].get("msg", "")).strip()
+            raise RuntimeError(msg or str(exc)) from exc
         raise RuntimeError(str(exc)) from exc
     provider = settings.provider
     if provider == "openai":

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1032,6 +1032,21 @@ def test_create_llm_client_missing_api_key_raises_runtime_error(monkeypatch) -> 
         llm_client.reset_llm_singletons()
 
 
+def test_create_llm_client_missing_api_key_omits_pydantic_boilerplate(monkeypatch) -> None:
+    """Sentry #1815: the RuntimeError message must not include pydantic boilerplate."""
+    monkeypatch.setenv("LLM_PROVIDER", "minimax")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    llm_client.reset_llm_singletons()
+    try:
+        with pytest.raises(RuntimeError) as exc_info:
+            llm_client._create_llm_client("reasoning")
+        msg = str(exc_info.value)
+        assert "1 validation error for LLMSettings" not in msg
+        assert "MINIMAX_API_KEY" in msg
+    finally:
+        llm_client.reset_llm_singletons()
+
+
 # ---------------------------------------------------------------------------
 # LLMClient.invoke / invoke_stream — NotFoundError handling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Sentry issue PYTHON-2P (#1815) surfaced with title `RuntimeError: 1 validation error for LLMSettings` — the pydantic boilerplate prefix rather than the actionable message.
- `_create_llm_client` was wrapping the full `str(ValidationError)` which, for a single-field failure, looks like `"1 validation error for LLMSettings\n  Value error, LLM provider 'minimax' requires MINIMAX_API_KEY to be set. ..."`.
- Fix: when only one validation error is present, extract `errors[0]["msg"]` and strip pydantic's `"Value error, "` prefix, so the RuntimeError message is simply `"LLM provider 'minimax' requires MINIMAX_API_KEY to be set."`.

## Test plan

- [ ] `uv run pytest tests/services/test_llm_client.py -x -q` — all 66 tests pass including new `test_create_llm_client_missing_api_key_omits_pydantic_boilerplate`
- [ ] Existing `test_create_llm_client_missing_api_key_raises_runtime_error` still matches `"ANTHROPIC_API_KEY"` ✓

Closes #1815

https://claude.ai/code/session_01EhKTUZ1jm2Z7SHj8F27Zn6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhKTUZ1jm2Z7SHj8F27Zn6)_