### PR TITLE
fix(sentry): surface specific timeout message for APITimeoutError on OpenAI-compatible clients

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -29,6 +29,7 @@ from anthropic import (
 )
 from anthropic import BadRequestError as AnthropicBadRequestError
 from openai import APIConnectionError as OpenAIConnectionError
+from openai import APITimeoutError as OpenAITimeoutError
 from openai import AuthenticationError as OpenAIAuthError
 from openai import BadRequestError as OpenAIBadRequestError
 from openai import NotFoundError as OpenAINotFoundError
@@ -530,6 +531,11 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:
     """Return a user-facing message for an OpenAI APIConnectionError."""
+    if isinstance(err, OpenAITimeoutError):
+        return (
+            f"{provider_label} API request timed out. "
+            "Check that the service is running and responsive at the configured endpoint."
+        )
     cause: BaseException | None = err
     cause_text_parts: list[str] = []
     while cause is not None:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1783,3 +1783,15 @@ def test_format_openai_connection_error_non_ssl_returns_generic_message() -> Non
     assert "SSL" not in msg
     assert "network connection" in msg
     assert "NVIDIA" in msg
+
+
+def test_format_openai_connection_error_timeout_returns_timeout_message() -> None:
+    """APITimeoutError gets a specific timeout message, not the generic network-connection one."""
+    err = llm_client.OpenAITimeoutError.__new__(llm_client.OpenAITimeoutError)
+    Exception.__init__(err, "Request timed out.")
+
+    msg = llm_client._format_openai_connection_error(err, "Ollama")
+
+    assert "timed out" in msg.lower()
+    assert "Ollama" in msg
+    assert "network connection" not in msg


### PR DESCRIPTION
## Summary

- Sentry issues PYTHON-2V / PYTHON-2T (#1822, #1821) showed the misleading message `RuntimeError: Cannot connect to Ollama API. Check your network connection and that the endpoint URL is reachable.` when the real cause was a request **timeout**, not a refused connection.
- `openai.APITimeoutError` is a subclass of `APIConnectionError`, so it was routed to `_format_openai_connection_error` — but that function had no timeout-specific branch and fell through to the generic "Check your network connection" wording.
- Fix: import `APITimeoutError as OpenAITimeoutError` and add an `isinstance` check at the top of `_format_openai_connection_error`. Timeouts now get: `"{provider} API request timed out. Check that the service is running and responsive at the configured endpoint."` Non-timeout connection errors and the SSL path are unchanged.

## Test plan

- [ ] `uv run pytest tests/services/test_llm_client.py -x -q` — all 66 tests pass including new `test_format_openai_connection_error_timeout_returns_timeout_message`
- [ ] Existing SSL and generic-connection tests still pass ✓
- [ ] Full unit suite: `6568 passed, 7 skipped` ✓

Closes #1822
Closes #1821

https://claude.ai/code/session_01EhKTUZ1jm2Z7SHj8F27Zn6


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhKTUZ1jm2Z7SHj8F27Zn6)_