### PR TITLE
fix: increase LLM timeout to 180s to prevent 504 gateway errors

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -252,7 +252,7 @@ class OpenAILLMClient:
         self._base_url = base_url
         self._api_key_env = api_key_env
         self._provider_label = api_key_env.removesuffix("_API_KEY").replace("_", " ").title()
-        self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=60.0)
+        self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=180.0)
         self._model = model
         self._max_tokens = max_tokens
         self._temperature = temperature
@@ -274,7 +274,7 @@ class OpenAILLMClient:
             )
         if api_key != self._api_key:
             self._api_key = api_key
-            self._client = OpenAI(api_key=api_key, base_url=self._base_url, timeout=60.0)
+            self._client = OpenAI(api_key=api_key, base_url=self._base_url, timeout=180.0)
 
     def invoke(self, prompt_or_messages: Any) -> LLMResponse:
         self._ensure_client()
@@ -315,7 +315,8 @@ class OpenAILLMClient:
                 last_err = err
                 if attempt == max_attempts - 1:
                     raise RuntimeError(
-                        "LLM API request failed after multiple retries. Try again in a few seconds."
+                        f"LLM API request failed after {max_attempts} retires. "
+                        f"Last error: {type(err).__name__}: {err}"
                     ) from err
                 time.sleep(backoff_seconds)
                 backoff_seconds *= 2


### PR DESCRIPTION
Fixes #1818 

#### Describe the changes you have made in this PR -
This PR increases the hardcoded LLM API timeout in app/services/llm_client.py from 60 seconds to 180 seconds. This change is designed to mitigate 504 Gateway Timeout and RuntimeError exceptions encountered during high-latency tasks, such as action planning. By extending this window, we ensure the application layer provides sufficient time for the model to process extensive context and generate a response.

### Demo/Screenshot for feature changes and bug fixes - 
```
Root Cause
  Incident on events_fact (severity: warning). Unable to determine exact root cause - insufficient evidence gathered.

  Report
  Incident on events_fact (severity: warning)
  
  *Non-Validated Claims (Inferred):*
  • Insufficient evidence available to validate root cause
  
  
  *Cited Evidence:*
  - Queries: get sre guidance
  
  
  Timing: 16s
{
  "report": "Incident on events_fact (severity: warning)\n\n*Non-Validated Claims (Inferred):*\n\u2022 Insufficient evidence available to validate root cause\n\n\n*Cited Evidence:*\n- Queries: get sre guidance\n\n\nTiming: 16s\n",
  "problem_md": "# Incident\nPipeline: events_fact | Severity: warning",
  "root_cause": "Incident on events_fact (severity: warning). Unable to determine exact root cause - insufficient evidence gathered.",
  "is_noise": false
}
```


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- What problem does your code solve: The application was throwing 504 Gateway Timeouts and RuntimeErrors during complex LLM tasks (like plan_actions). The Python LLM client was giving up after 60 seconds, which wasn't enough time for the AI to process large logs and return structured JSON.

- What alternative approaches did you consider: I considered implementing data chunking or response streaming, but simply increasing the client timeout is the most standard, direct, and least invasive fix to resolve the immediate 504 disconnects.

- Why did you choose this specific implementation: By bumping the timeout limit from 60 seconds to 180 seconds, it gives the LLM ample time to finish thinking and return the data without Python prematurely killing the connection. 
 **Note:** This change serves a dual purpose: it solves the application-side bottleneck and will help verify if additional timeout adjustments are required at the infrastructure layer (e.g., Nginx or Load Balancer) should the 504s persist. 

- Key functions/components: Updated the timeout parameter within the `LLMClient` and `OpenAILLMClient` classes in app/services/llm_client.py.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



