### PR TITLE
feat(analytics): classify investigation entry sources across surfaces

### DIFF
--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -347,8 +347,9 @@ def capture_investigation_completed(*, tracker: InvestigationTracker | None = No
     if tracker is None:
         _capture(Event.INVESTIGATION_COMPLETED)
         return
-    if tracker.completed or tracker.failed or not tracker.enabled:
-        tracker.completed = True
+    if tracker.completed:
+        return
+    if tracker.failed or not tracker.enabled:
         return
     _capture(
         Event.INVESTIGATION_COMPLETED,
@@ -394,7 +395,7 @@ def track_investigation(
     interactive: bool = False,
     evaluate_requested: bool = False,
     investigation_id: str | None = None,
-):
+) -> Generator[InvestigationTracker]:
     """Capture investigation lifecycle once, with nested-call dedupe."""
     depth = _INVESTIGATION_TRACKING_DEPTH.get()
     token = _INVESTIGATION_TRACKING_DEPTH.set(depth + 1)

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -423,56 +423,57 @@ async def investigate_stream(req: InvestigateRequest) -> Response:
     accumulated_state: dict[str, Any] = {}
 
     async def _event_generator() -> AsyncIterator[str]:
-        with track_investigation(
-            entrypoint=EntrypointSource.REMOTE_HTTP,
-            trigger_mode=TriggerMode.SERVICE_RUNTIME,
-        ) as tracker:
-            try:
-                async for event in astream_investigation(
-                    alert_name,
-                    pipeline_name,
-                    severity,
-                    raw_alert=raw_alert,
-                ):
-                    if event.kind == "on_chain_end":
-                        output = event.data.get("data", {}).get("output", {})
-                        if isinstance(output, dict):
-                            accumulated_state.update(output)
-
-                    payload = _json.dumps(event.data, default=str)
-                    yield f"event: {event.event_type}\ndata: {payload}\n\n"
-                yield "event: end\ndata: {}\n\n"
-            except Exception as exc:
-                capture_investigation_failed(
-                    tracker=tracker,
-                    failure_type=type(exc).__name__,
-                )
+        try:
+            with track_investigation(
+                entrypoint=EntrypointSource.REMOTE_HTTP,
+                trigger_mode=TriggerMode.SERVICE_RUNTIME,
+            ) as tracker:
                 try:
-                    reraise_cli_runtime_error(exc)
-                except OpenSREError as mapped:
-                    logger.warning(
-                        "Streaming investigation failed due to CLI runtime error: %s",
-                        mapped,
+                    async for event in astream_investigation(
+                        alert_name,
+                        pipeline_name,
+                        severity,
+                        raw_alert=raw_alert,
+                    ):
+                        if event.kind == "on_chain_end":
+                            output = event.data.get("data", {}).get("output", {})
+                            if isinstance(output, dict):
+                                accumulated_state.update(output)
+
+                        payload = _json.dumps(event.data, default=str)
+                        yield f"event: {event.event_type}\ndata: {payload}\n\n"
+                    yield "event: end\ndata: {}\n\n"
+                except Exception as exc:
+                    capture_investigation_failed(
+                        tracker=tracker,
+                        failure_type=type(exc).__name__,
                     )
-                    error_payload = {
-                        "detail": str(mapped),
-                        "suggestion": mapped.suggestion,
-                    }
-                    yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
-                    return
-                except Exception as inner_exc:
-                    capture_exception(inner_exc)
-                    logger.exception("Streaming investigation failed")
-                    yield 'event: error\ndata: {"detail": "internal error"}\n\n'
-                    return
-            finally:
-                _persist_streamed_result(
-                    alert_name=alert_name,
-                    pipeline_name=pipeline_name,
-                    severity=severity,
-                    state=accumulated_state,
-                    logger=logger,
-                )
+                    try:
+                        reraise_cli_runtime_error(exc)
+                    except OpenSREError as mapped:
+                        logger.warning(
+                            "Streaming investigation failed due to CLI runtime error: %s",
+                            mapped,
+                        )
+                        error_payload = {
+                            "detail": str(mapped),
+                            "suggestion": mapped.suggestion,
+                        }
+                        yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
+                        return
+                    except Exception as inner_exc:
+                        capture_exception(inner_exc)
+                        logger.exception("Streaming investigation failed")
+                        yield 'event: error\ndata: {"detail": "internal error"}\n\n'
+                        return
+        finally:
+            _persist_streamed_result(
+                alert_name=alert_name,
+                pipeline_name=pipeline_name,
+                severity=severity,
+                state=accumulated_state,
+                logger=logger,
+            )
 
     return StreamingResponse(  # type: ignore[return-value]
         _event_generator(),

--- a/app/tools/utils/log_compaction.py
+++ b/app/tools/utils/log_compaction.py
@@ -82,6 +82,9 @@ def deduplicate_logs(
     - ``count``        — number of occurrences in the input
     - ``first_seen``   — earliest timestamp in the group
     - ``last_seen``    — latest timestamp in the group
+    - plus preserved first-seen metadata fields from the source record
+      (for example ``source_type``, ``namespace``, ``cluster``), excluding
+      per-event timestamp/count bookkeeping keys.
 
     If *max_output* is given the result is truncated **after** grouping so that
     high-count bursts no longer steal slots from unique messages.

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -196,16 +196,14 @@ def test_track_investigation_emits_failed_on_exception(
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    try:
+    with pytest.raises(RuntimeError, match="boom"):  # noqa: SIM117
+        # Keep nested (not combined) so CodeQL can prove control flow past the
+        # raise via pytest.raises is reachable (see PR #1846 review threads).
         with cli.track_investigation(
             entrypoint=EntrypointSource.MCP,
             trigger_mode=TriggerMode.SERVICE_RUNTIME,
         ):
             raise RuntimeError("boom")
-    except RuntimeError as exc:
-        assert str(exc) == "boom"
-    else:
-        pytest.fail("Expected RuntimeError")
 
     emitted_events = [event for event, _ in stub.events]
     assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_FAILED]

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -196,12 +196,16 @@ def test_track_investigation_emits_failed_on_exception(
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    with pytest.raises(RuntimeError, match="boom"):  # noqa: SIM117
+    try:
         with cli.track_investigation(
             entrypoint=EntrypointSource.MCP,
             trigger_mode=TriggerMode.SERVICE_RUNTIME,
         ):
             raise RuntimeError("boom")
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+    else:
+        pytest.fail("Expected RuntimeError")
 
     emitted_events = [event for event, _ in stub.events]
     assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_FAILED]


### PR DESCRIPTION
## Summary
- add a shared analytics source module to normalize investigation source/category/trigger metadata across CLI, SDK, MCP, and remote HTTP entrypoints
- wire investigation lifecycle tracking through entrypoint wrappers and CLI command flows so source attribution is consistent for service-runtime and interactive modes
- extend log compaction and analytics tests to validate source tagging, lifecycle event emission, and remote/server integration behavior

## Test plan
- [x] `uv run ruff check app tests`
- [x] `uv run pytest tests/analytics/test_source.py tests/analytics/test_cli.py tests/entrypoints/test_mcp.py tests/tools/test_log_compaction.py`
- [x] `uv run pytest tests/entrypoints/test_sdk.py` *(assertion behavior verified; full run can require optional `psutil` in some local Python setups)*
- [ ] `uv run pytest tests/remote/test_server.py tests/cli/test_investigate_service_flag.py tests/cli/interactive_shell/test_commands.py tests/cli/interactive_shell/test_loop.py` *(locally blocked in this clean worktree by missing optional `pynacl`/`psutil` in externally managed Homebrew Python; expected in CI image)*


Made with [Cursor](https://cursor.com)