### PR TITLE
feat(analytics): unify investigation source tracking across entrypoints

### DIFF
--- a/app/analytics/cli.py
+++ b/app/analytics/cli.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Final
+from uuid import uuid4
 
 from app.analytics.events import Event
 from app.analytics.provider import Properties, get_analytics
+from app.analytics.source import EntrypointSource, TriggerMode, build_source_properties
 from app.utils.sentry_sdk import capture_exception
 
 EVAL_AND_TERMINAL_KPI_QUERIES: Final[dict[str, str]] = {
@@ -113,6 +118,21 @@ EVAL_AND_TERMINAL_EVENT_CONTRACT: Final[dict[Event, frozenset[str]]] = {
     ),
 }
 
+_INVESTIGATION_TRACKING_DEPTH: ContextVar[int] = ContextVar(
+    "investigation_tracking_depth",
+    default=0,
+)
+
+
+@dataclass
+class InvestigationTracker:
+    """Holds shared context for investigation lifecycle captures."""
+
+    shared_properties: Properties
+    enabled: bool
+    completed: bool = False
+    failed: bool = False
+
 
 def _string_value(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
@@ -154,8 +174,10 @@ def _investigation_started_properties(
     input_json: str | None,
     interactive: bool,
     evaluate_requested: bool,
+    shared_properties: Properties,
 ) -> Properties:
     properties: Properties = {
+        **shared_properties,
         "has_input_file": input_path is not None,
         "has_inline_json": input_json is not None,
         "interactive": interactive,
@@ -169,6 +191,21 @@ def _investigation_started_properties(
         properties["llm_provider"] = llm_provider
     if llm_model is not None:
         properties["llm_model"] = llm_model
+    return properties
+
+
+def _investigation_completed_properties(*, shared_properties: Properties) -> Properties:
+    return {**shared_properties}
+
+
+def _investigation_failed_properties(
+    *,
+    shared_properties: Properties,
+    failure_type: str | None = None,
+) -> Properties:
+    properties: Properties = {**shared_properties}
+    if failure_type:
+        properties["failure_type"] = failure_type
     return properties
 
 
@@ -284,8 +321,16 @@ def capture_investigation_started(
     input_path: str | None,
     input_json: str | None,
     interactive: bool,
+    entrypoint: EntrypointSource = EntrypointSource.CLI_COMMAND,
+    trigger_mode: TriggerMode = TriggerMode.FILE,
+    investigation_id: str | None = None,
     evaluate_requested: bool = False,
 ) -> None:
+    shared_properties = build_source_properties(
+        entrypoint=entrypoint,
+        trigger_mode=trigger_mode,
+        investigation_id=investigation_id or str(uuid4()),
+    )
     _capture(
         Event.INVESTIGATION_STARTED,
         _investigation_started_properties(
@@ -293,16 +338,101 @@ def capture_investigation_started(
             input_json=input_json,
             interactive=interactive,
             evaluate_requested=evaluate_requested,
+            shared_properties=shared_properties,
         ),
     )
 
 
-def capture_investigation_completed() -> None:
-    _capture(Event.INVESTIGATION_COMPLETED)
+def capture_investigation_completed(*, tracker: InvestigationTracker | None = None) -> None:
+    if tracker is None:
+        _capture(Event.INVESTIGATION_COMPLETED)
+        return
+    if tracker.completed or tracker.failed or not tracker.enabled:
+        tracker.completed = True
+        return
+    _capture(
+        Event.INVESTIGATION_COMPLETED,
+        _investigation_completed_properties(shared_properties=tracker.shared_properties),
+    )
+    tracker.completed = True
 
 
-def capture_investigation_failed() -> None:
-    _capture(Event.INVESTIGATION_FAILED)
+def capture_investigation_failed(
+    *,
+    tracker: InvestigationTracker | None = None,
+    failure_type: str | None = None,
+) -> None:
+    if tracker is None:
+        _capture(
+            Event.INVESTIGATION_FAILED,
+            _investigation_failed_properties(
+                shared_properties={},
+                failure_type=failure_type,
+            ),
+        )
+        return
+    if tracker.failed or not tracker.enabled:
+        tracker.failed = True
+        return
+    _capture(
+        Event.INVESTIGATION_FAILED,
+        _investigation_failed_properties(
+            shared_properties=tracker.shared_properties,
+            failure_type=failure_type,
+        ),
+    )
+    tracker.failed = True
+
+
+@contextmanager
+def track_investigation(
+    *,
+    entrypoint: EntrypointSource,
+    trigger_mode: TriggerMode,
+    input_path: str | None = None,
+    input_json: str | None = None,
+    interactive: bool = False,
+    evaluate_requested: bool = False,
+    investigation_id: str | None = None,
+):
+    """Capture investigation lifecycle once, with nested-call dedupe."""
+    depth = _INVESTIGATION_TRACKING_DEPTH.get()
+    token = _INVESTIGATION_TRACKING_DEPTH.set(depth + 1)
+    tracker: InvestigationTracker
+    if depth > 0:
+        tracker = InvestigationTracker(shared_properties={}, enabled=False)
+    else:
+        shared_properties = build_source_properties(
+            entrypoint=entrypoint,
+            trigger_mode=trigger_mode,
+            investigation_id=investigation_id or str(uuid4()),
+        )
+        _capture(
+            Event.INVESTIGATION_STARTED,
+            _investigation_started_properties(
+                input_path=input_path,
+                input_json=input_json,
+                interactive=interactive,
+                evaluate_requested=evaluate_requested,
+                shared_properties=shared_properties,
+            ),
+        )
+        tracker = InvestigationTracker(shared_properties=shared_properties, enabled=True)
+
+    try:
+        yielded = tracker
+        yield yielded
+    except Exception as exc:
+        capture_investigation_failed(
+            tracker=yielded,
+            failure_type=type(exc).__name__,
+        )
+        raise
+    else:
+        if not yielded.failed and not yielded.completed:
+            capture_investigation_completed(tracker=yielded)
+    finally:
+        _INVESTIGATION_TRACKING_DEPTH.reset(token)
 
 
 def capture_integration_setup_started(service: str) -> None:

--- a/app/analytics/source.py
+++ b/app/analytics/source.py
@@ -1,0 +1,103 @@
+"""Investigation source and classification helpers for analytics events."""
+
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+from typing import Final
+
+from app.analytics.provider import Properties
+
+INVESTIGATION_EVENT_SCHEMA_VERSION: Final[int] = 1
+
+
+class EntrypointSource(StrEnum):
+    """Canonical origin for an investigation invocation."""
+
+    SDK = "sdk"
+    MCP = "mcp"
+    REMOTE_HTTP = "remote_http"
+    CLI_COMMAND = "cli_command"
+    CLI_PASTE = "cli_paste"
+    CLI_REPL_FILE = "cli_repl_file"
+
+
+class TriggerMode(StrEnum):
+    """How the alert payload was supplied by the caller."""
+
+    PASTE = "paste"
+    FILE = "file"
+    INLINE_JSON = "inline_json"
+    SERVICE_RUNTIME = "service_runtime"
+
+
+_API_SOURCES: Final[frozenset[EntrypointSource]] = frozenset(
+    {
+        EntrypointSource.SDK,
+        EntrypointSource.MCP,
+        EntrypointSource.REMOTE_HTTP,
+    }
+)
+
+
+def is_test_run() -> bool:
+    """Return True when the current process should be tagged as test traffic."""
+    if os.getenv("OPENSRE_INVESTIGATION_SOURCE", "").strip().lower() == "test":
+        return True
+
+    if os.getenv("OPENSRE_IS_TEST", "0").strip() == "1":
+        return True
+
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return True
+
+    if os.getenv("GITHUB_ACTIONS", "").strip().lower() == "true":
+        return True
+
+    ci_value = os.getenv("CI", "").strip().lower()
+    return ci_value in {"1", "true", "yes"}
+
+
+def resolve_environment_tag() -> str:
+    """Resolve coarse environment classification for analytics slicing."""
+    raw = (
+        (os.getenv("OPENSRE_ANALYTICS_ENV") or os.getenv("ENV") or os.getenv("ENVIRONMENT") or "")
+        .strip()
+        .lower()
+    )
+    if raw in {"prod", "production"}:
+        return "prod"
+    if raw in {"stage", "staging"}:
+        return "staging"
+    if raw in {"dev", "development", "local"}:
+        return "dev"
+    return "unknown"
+
+
+def _category_for(entrypoint: EntrypointSource, *, test: bool) -> str:
+    if test:
+        return "test"
+    if entrypoint in _API_SOURCES:
+        return "api"
+    return "cli"
+
+
+def build_source_properties(
+    *,
+    entrypoint: EntrypointSource,
+    trigger_mode: TriggerMode,
+    investigation_id: str,
+) -> Properties:
+    """Return standardized source properties for investigation lifecycle events."""
+    test = is_test_run()
+    source = "test" if test else entrypoint.value
+    return {
+        "source": source,
+        "entrypoint_source": entrypoint.value,
+        "category": _category_for(entrypoint, test=test),
+        "trigger_mode": trigger_mode.value,
+        "is_test": test,
+        "environment": resolve_environment_tag(),
+        "investigation_id": investigation_id,
+        "investigation_event_schema_version": INVESTIGATION_EVENT_SCHEMA_VERSION,
+    }

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -10,13 +10,12 @@ import time
 import click
 
 from app.analytics.cli import (
-    capture_investigation_completed,
-    capture_investigation_failed,
-    capture_investigation_started,
     capture_update_completed,
     capture_update_failed,
     capture_update_started,
+    track_investigation,
 )
+from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.support.constants import ALERT_TEMPLATE_CHOICES
 from app.cli.support.context import is_json_output, is_yes
 from app.cli.support.exit_codes import ERROR, SUCCESS
@@ -216,33 +215,36 @@ def investigate_command(
             input_json=input_json,
             interactive=interactive,
         )
-        capture_investigation_started(
+        trigger_mode = (
+            TriggerMode.PASTE
+            if interactive
+            else (TriggerMode.INLINE_JSON if input_json is not None else TriggerMode.FILE)
+        )
+        with track_investigation(
+            entrypoint=EntrypointSource.CLI_COMMAND,
+            trigger_mode=trigger_mode,
             input_path=input_path,
             input_json=input_json,
             interactive=interactive,
             evaluate_requested=evaluate,
-        )
-        # Only stream the live UI when the user is interactively watching stdout
-        # and hasn't asked for machine-readable JSON. Otherwise the spinner and
-        # ANSI control codes corrupt the JSON payload that consumers expect on
-        # stdout (pipes, redirection, --json, CI logs).
-        # --evaluate forces the non-streaming path because the streaming runner
-        # does not yet wire opensre_evaluate scoring through the renderer.
-        stream_to_stdout = (
-            sys.stdout.isatty() and not is_json_output() and output is None and not evaluate
-        )
-        if stream_to_stdout:
-            run_investigation_cli_streaming(raw_alert=payload)
-        else:
-            result = run_investigation_cli(raw_alert=payload, opensre_evaluate=evaluate)
-            write_json(result, output)
+        ):
+            # Only stream the live UI when the user is interactively watching stdout
+            # and hasn't asked for machine-readable JSON. Otherwise the spinner and
+            # ANSI control codes corrupt the JSON payload that consumers expect on
+            # stdout (pipes, redirection, --json, CI logs).
+            # --evaluate forces the non-streaming path because the streaming runner
+            # does not yet wire opensre_evaluate scoring through the renderer.
+            stream_to_stdout = (
+                sys.stdout.isatty() and not is_json_output() and output is None and not evaluate
+            )
+            if stream_to_stdout:
+                run_investigation_cli_streaming(raw_alert=payload)
+            else:
+                result = run_investigation_cli(raw_alert=payload, opensre_evaluate=evaluate)
+                write_json(result, output)
     except SystemExit:
         raise
-    except Exception:
-        capture_investigation_failed()
-        raise
 
-    capture_investigation_completed()
     raise SystemExit(SUCCESS)
 
 
@@ -284,19 +286,20 @@ def _run_service_investigation(
             suggestion="Export SLACK_BOT_TOKEN=xoxb-... in your environment and retry.",
         )
 
-    try:
-        raw_alert = build_runtime_alert_payload(
-            service,
-            slack_thread_ref=slack_thread,
-            slack_bot_token=slack_bot_token or None,
-        )
-        _eval = bool(other_inputs.get("evaluate"))
-        capture_investigation_started(
-            input_path=None,
-            input_json=None,
-            interactive=False,
-            evaluate_requested=_eval,
-        )
+    raw_alert = build_runtime_alert_payload(
+        service,
+        slack_thread_ref=slack_thread,
+        slack_bot_token=slack_bot_token or None,
+    )
+    _eval = bool(other_inputs.get("evaluate"))
+    with track_investigation(
+        entrypoint=EntrypointSource.CLI_COMMAND,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+        input_path=None,
+        input_json=None,
+        interactive=False,
+        evaluate_requested=_eval,
+    ):
         result = run_investigation_cli(
             raw_alert=raw_alert,
             alert_name=raw_alert.get("alert_name"),
@@ -304,10 +307,5 @@ def _run_service_investigation(
             severity=raw_alert.get("severity"),
             opensre_evaluate=_eval,
         )
-    except Exception:
-        capture_investigation_failed()
-        raise
-
-    capture_investigation_completed()
     write_json(result, output)
     raise SystemExit(SUCCESS)

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -104,12 +104,15 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
     task = session.task_registry.create(TaskKind.INVESTIGATION, command=f"/investigate {path}")
     task.mark_running()
     try:
-        with track_investigation(
-            entrypoint=EntrypointSource.CLI_REPL_FILE,
-            trigger_mode=TriggerMode.FILE,
-            input_path=str(path),
-            interactive=True,
-        ), apply_reasoning_effort(session.reasoning_effort):
+        with (
+            track_investigation(
+                entrypoint=EntrypointSource.CLI_REPL_FILE,
+                trigger_mode=TriggerMode.FILE,
+                input_path=str(path),
+                interactive=True,
+            ),
+            apply_reasoning_effort(session.reasoning_effort),
+        ):
             final_state = run_investigation_for_session(
                 alert_text=text,
                 context_overrides=session.accumulated_context or None,

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -84,6 +84,8 @@ def _validate_save_args(args: list[str]) -> str | None:
 
 
 def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str]) -> bool:
+    from app.analytics.cli import track_investigation
+    from app.analytics.source import EntrypointSource, TriggerMode
     from app.cli.investigation import run_investigation_for_session
 
     path = Path(args[0])
@@ -102,7 +104,12 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
     task = session.task_registry.create(TaskKind.INVESTIGATION, command=f"/investigate {path}")
     task.mark_running()
     try:
-        with apply_reasoning_effort(session.reasoning_effort):
+        with track_investigation(
+            entrypoint=EntrypointSource.CLI_REPL_FILE,
+            trigger_mode=TriggerMode.FILE,
+            input_path=str(path),
+            interactive=True,
+        ), apply_reasoning_effort(session.reasoning_effort):
             final_state = run_investigation_for_session(
                 alert_text=text,
                 context_overrides=session.accumulated_context or None,

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -170,11 +170,14 @@ def _run_new_alert(
     task = session.task_registry.create(TaskKind.INVESTIGATION, command="free-text investigation")
     task.mark_running()
     try:
-        with track_investigation(
-            entrypoint=EntrypointSource.CLI_PASTE,
-            trigger_mode=TriggerMode.PASTE,
-            interactive=True,
-        ), apply_reasoning_effort(session.reasoning_effort):
+        with (
+            track_investigation(
+                entrypoint=EntrypointSource.CLI_PASTE,
+                trigger_mode=TriggerMode.PASTE,
+                interactive=True,
+            ),
+            apply_reasoning_effort(session.reasoning_effort),
+        ):
             final_state = run_investigation_for_session(
                 alert_text=text,
                 context_overrides=session.accumulated_context or None,

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -146,6 +146,8 @@ def _run_new_alert(
     is_tty: bool | None = None,
 ) -> None:
     """Dispatch a free-text alert description to the streaming pipeline."""
+    from app.analytics.cli import track_investigation
+    from app.analytics.source import EntrypointSource, TriggerMode
     from app.cli.interactive_shell.orchestration.execution_policy import (
         evaluate_investigation_launch,
         execution_allowed,
@@ -168,7 +170,11 @@ def _run_new_alert(
     task = session.task_registry.create(TaskKind.INVESTIGATION, command="free-text investigation")
     task.mark_running()
     try:
-        with apply_reasoning_effort(session.reasoning_effort):
+        with track_investigation(
+            entrypoint=EntrypointSource.CLI_PASTE,
+            trigger_mode=TriggerMode.PASTE,
+            interactive=True,
+        ), apply_reasoning_effort(session.reasoning_effort):
             final_state = run_investigation_for_session(
                 alert_text=text,
                 context_overrides=session.accumulated_context or None,

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -6,6 +6,8 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field, ValidationError
 
+from app.analytics.cli import track_investigation
+from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.investigation import run_investigation_cli
 from app.cli.support.errors import OpenSREError
 from app.utils.sentry_sdk import capture_exception, init_sentry
@@ -57,12 +59,16 @@ def _run_cli(
     pipeline_name: str | None = None,
     severity: str | None = None,
 ) -> dict[str, Any]:
-    return run_investigation_cli(
-        raw_alert=payload,
-        alert_name=alert_name,
-        pipeline_name=pipeline_name,
-        severity=severity,
-    )
+    with track_investigation(
+        entrypoint=EntrypointSource.MCP,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+    ):
+        return run_investigation_cli(
+            raw_alert=payload,
+            alert_name=alert_name,
+            pipeline_name=pipeline_name,
+            severity=severity,
+        )
 
 
 @mcp.tool(name="run_rca")

--- a/app/entrypoints/sdk.py
+++ b/app/entrypoints/sdk.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.analytics.cli import track_investigation
+from app.analytics.source import EntrypointSource, TriggerMode
+
 
 def run_investigation(*args: Any, **kwargs: Any) -> Any:
     """Lazily import the full runner stack to avoid optional dependency churn at import time."""
     from app.pipeline.runners import run_investigation as _run_investigation
 
-    return _run_investigation(*args, **kwargs)
+    with track_investigation(
+        entrypoint=EntrypointSource.SDK,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+    ):
+        return _run_investigation(*args, **kwargs)

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -26,6 +26,7 @@ from rich.text import Text
 
 from app.analytics.events import Event
 from app.analytics.provider import get_analytics
+from app.analytics.source import EntrypointSource
 from app.cli.interactive_shell.ui.theme import (
     ANSI_BOLD,
     ANSI_DIM,
@@ -85,6 +86,10 @@ _DIAGNOSE_LIVE_REFRESH = 20
 _DIAGNOSE_RENDER_INTERVAL_S = 1.0 / _DIAGNOSE_LIVE_REFRESH
 _DIAGNOSE_SPINNER_NAME = "dots12"
 _DIAGNOSE_SPINNER_COLOR = "orange1"
+
+
+def _render_source(*, local: bool) -> str:
+    return EntrypointSource.CLI_PASTE.value if local else EntrypointSource.REMOTE_HTTP.value
 
 
 class _DiagnoseStreamRenderer:
@@ -193,7 +198,7 @@ class _DiagnoseStreamRenderer:
                 {
                     "latency_ms": int(latency_ms),
                     "stage": _DIAGNOSE_NODE,
-                    "source": "interactive_shell" if self._local else "remote_api",
+                    "source": _render_source(local=self._local),
                 },
             )
         if self._live is None:
@@ -371,7 +376,7 @@ class StreamRenderer:
                 Event.INVESTIGATION_ABANDONED,
                 {
                     "stage": self._active_node or "unstarted",
-                    "source": "interactive_shell" if self._local else "remote_api",
+                    "source": _render_source(local=self._local),
                 },
             )
             raise

--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -44,6 +44,8 @@ from nacl.signing import VerifyKey
 from pydantic import BaseModel
 from starlette.responses import JSONResponse, StreamingResponse
 
+from app.analytics.cli import capture_investigation_failed, track_investigation
+from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.support.cli_error_mapping import reraise_cli_runtime_error
 from app.cli.support.errors import OpenSREError
 from app.remote.vercel_poller import (
@@ -421,48 +423,56 @@ async def investigate_stream(req: InvestigateRequest) -> Response:
     accumulated_state: dict[str, Any] = {}
 
     async def _event_generator() -> AsyncIterator[str]:
-        try:
-            async for event in astream_investigation(
-                alert_name,
-                pipeline_name,
-                severity,
-                raw_alert=raw_alert,
-            ):
-                if event.kind == "on_chain_end":
-                    output = event.data.get("data", {}).get("output", {})
-                    if isinstance(output, dict):
-                        accumulated_state.update(output)
-
-                payload = _json.dumps(event.data, default=str)
-                yield f"event: {event.event_type}\ndata: {payload}\n\n"
-            yield "event: end\ndata: {}\n\n"
-        except Exception as exc:
+        with track_investigation(
+            entrypoint=EntrypointSource.REMOTE_HTTP,
+            trigger_mode=TriggerMode.SERVICE_RUNTIME,
+        ) as tracker:
             try:
-                reraise_cli_runtime_error(exc)
-            except OpenSREError as mapped:
-                logger.warning(
-                    "Streaming investigation failed due to CLI runtime error: %s",
-                    mapped,
+                async for event in astream_investigation(
+                    alert_name,
+                    pipeline_name,
+                    severity,
+                    raw_alert=raw_alert,
+                ):
+                    if event.kind == "on_chain_end":
+                        output = event.data.get("data", {}).get("output", {})
+                        if isinstance(output, dict):
+                            accumulated_state.update(output)
+
+                    payload = _json.dumps(event.data, default=str)
+                    yield f"event: {event.event_type}\ndata: {payload}\n\n"
+                yield "event: end\ndata: {}\n\n"
+            except Exception as exc:
+                capture_investigation_failed(
+                    tracker=tracker,
+                    failure_type=type(exc).__name__,
                 )
-                error_payload = {
-                    "detail": str(mapped),
-                    "suggestion": mapped.suggestion,
-                }
-                yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
-                return
-            except Exception as inner_exc:
-                capture_exception(inner_exc)
-                logger.exception("Streaming investigation failed")
-                yield 'event: error\ndata: {"detail": "internal error"}\n\n'
-                return
-        finally:
-            _persist_streamed_result(
-                alert_name=alert_name,
-                pipeline_name=pipeline_name,
-                severity=severity,
-                state=accumulated_state,
-                logger=logger,
-            )
+                try:
+                    reraise_cli_runtime_error(exc)
+                except OpenSREError as mapped:
+                    logger.warning(
+                        "Streaming investigation failed due to CLI runtime error: %s",
+                        mapped,
+                    )
+                    error_payload = {
+                        "detail": str(mapped),
+                        "suggestion": mapped.suggestion,
+                    }
+                    yield f"event: error\ndata: {_json.dumps(error_payload)}\n\n"
+                    return
+                except Exception as inner_exc:
+                    capture_exception(inner_exc)
+                    logger.exception("Streaming investigation failed")
+                    yield 'event: error\ndata: {"detail": "internal error"}\n\n'
+                    return
+            finally:
+                _persist_streamed_result(
+                    alert_name=alert_name,
+                    pipeline_name=pipeline_name,
+                    severity=severity,
+                    state=accumulated_state,
+                    logger=logger,
+                )
 
     return StreamingResponse(  # type: ignore[return-value]
         _event_generator(),
@@ -772,10 +782,14 @@ def _execute_investigation(
         pipeline_name=pipeline_name,
         severity=severity,
     )
-    result = run_investigation_cli(
-        raw_alert=raw_alert,
-        alert_name=resolved_alert_name,
-        pipeline_name=resolved_pipeline_name,
-        severity=resolved_severity,
-    )
+    with track_investigation(
+        entrypoint=EntrypointSource.REMOTE_HTTP,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+    ):
+        result = run_investigation_cli(
+            raw_alert=raw_alert,
+            alert_name=resolved_alert_name,
+            pipeline_name=resolved_pipeline_name,
+            severity=resolved_severity,
+        )
     return result, resolved_alert_name, resolved_pipeline_name, resolved_severity

--- a/app/tools/utils/log_compaction.py
+++ b/app/tools/utils/log_compaction.py
@@ -94,10 +94,12 @@ def deduplicate_logs(
     for log in logs:
         message = log.get("message", "")
         log_level = str(log.get("log_level", "") or "").upper()
+        source_type = str(log.get("source_type", "") or "")
         timestamp = str(log.get("timestamp", "") or "")
 
-        # Build grouping key from normalized message + level
-        key = f"{log_level}::{_normalize_message(message)}"
+        # Preserve semantic source boundaries (for example k8s_events vs db-instance)
+        # so post-process mappers can still infer evidence categories from compacted logs.
+        key = f"{source_type}::{log_level}::{_normalize_message(message)}"
 
         if key in groups:
             entry = groups[key]
@@ -107,13 +109,21 @@ def deduplicate_logs(
             if timestamp and (not entry["last_seen"] or timestamp > entry["last_seen"]):
                 entry["last_seen"] = timestamp
         else:
-            groups[key] = {
-                "message": message,
-                "log_level": log_level,
-                "count": 1,
-                "first_seen": timestamp,
-                "last_seen": timestamp,
+            entry = {
+                key: value
+                for key, value in log.items()
+                if key not in {"count", "first_seen", "last_seen", "timestamp"}
             }
+            entry.update(
+                {
+                    "message": message,
+                    "log_level": log_level,
+                    "count": 1,
+                    "first_seen": timestamp,
+                    "last_seen": timestamp,
+                }
+            )
+            groups[key] = entry
 
     # Sort groups: errors first, then by first_seen ascending
     result = sorted(groups.values(), key=_log_sort_key)

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.analytics import cli
 from app.analytics.events import Event
+from app.analytics.source import EntrypointSource, TriggerMode
 
 
 class _StubAnalytics:
@@ -164,3 +165,61 @@ def test_eval_and_terminal_kpi_queries_cover_core_metrics() -> None:
     assert expected_keys.issubset(cli.EVAL_AND_TERMINAL_KPI_QUERIES.keys())
     for query in cli.EVAL_AND_TERMINAL_KPI_QUERIES.values():
         assert "FROM events" in query
+
+
+def test_track_investigation_emits_lifecycle_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+
+    with cli.track_investigation(
+        entrypoint=EntrypointSource.CLI_COMMAND,
+        trigger_mode=TriggerMode.FILE,
+        input_path="alert.json",
+    ):
+        pass
+
+    emitted_events = [event for event, _ in stub.events]
+    assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_COMPLETED]
+    started_props = stub.events[0][1] or {}
+    completed_props = stub.events[1][1] or {}
+    assert started_props["source"] == "test"
+    assert started_props["entrypoint_source"] == "cli_command"
+    assert started_props["category"] == "test"
+    assert started_props["trigger_mode"] == "file"
+    assert started_props["is_test"] is True
+    assert started_props["investigation_id"] == completed_props["investigation_id"]
+
+
+def test_track_investigation_emits_failed_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+
+    with pytest.raises(RuntimeError, match="boom"), cli.track_investigation(
+        entrypoint=EntrypointSource.MCP,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+    ):
+        raise RuntimeError("boom")
+
+    emitted_events = [event for event, _ in stub.events]
+    assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_FAILED]
+    failed_props = stub.events[1][1] or {}
+    assert failed_props["failure_type"] == "RuntimeError"
+
+
+def test_track_investigation_nested_context_dedupes(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubAnalytics()
+    monkeypatch.setattr(cli, "get_analytics", lambda: stub)
+
+    with cli.track_investigation(
+        entrypoint=EntrypointSource.SDK,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+    ), cli.track_investigation(
+        entrypoint=EntrypointSource.CLI_COMMAND,
+        trigger_mode=TriggerMode.FILE,
+    ):
+        pass
+
+    emitted_events = [event for event, _ in stub.events]
+    assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_COMPLETED]

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -196,14 +196,12 @@ def test_track_investigation_emits_failed_on_exception(
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    with (
-        pytest.raises(RuntimeError, match="boom"),
-        cli.track_investigation(
+    with pytest.raises(RuntimeError, match="boom"):  # noqa: SIM117
+        with cli.track_investigation(
             entrypoint=EntrypointSource.MCP,
             trigger_mode=TriggerMode.SERVICE_RUNTIME,
-        ),
-    ):
-        raise RuntimeError("boom")
+        ):
+            raise RuntimeError("boom")
 
     emitted_events = [event for event, _ in stub.events]
     assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_FAILED]

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -196,9 +196,12 @@ def test_track_investigation_emits_failed_on_exception(
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    with pytest.raises(RuntimeError, match="boom"), cli.track_investigation(
-        entrypoint=EntrypointSource.MCP,
-        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        cli.track_investigation(
+            entrypoint=EntrypointSource.MCP,
+            trigger_mode=TriggerMode.SERVICE_RUNTIME,
+        ),
     ):
         raise RuntimeError("boom")
 
@@ -212,12 +215,15 @@ def test_track_investigation_nested_context_dedupes(monkeypatch: pytest.MonkeyPa
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    with cli.track_investigation(
-        entrypoint=EntrypointSource.SDK,
-        trigger_mode=TriggerMode.SERVICE_RUNTIME,
-    ), cli.track_investigation(
-        entrypoint=EntrypointSource.CLI_COMMAND,
-        trigger_mode=TriggerMode.FILE,
+    with (
+        cli.track_investigation(
+            entrypoint=EntrypointSource.SDK,
+            trigger_mode=TriggerMode.SERVICE_RUNTIME,
+        ),
+        cli.track_investigation(
+            entrypoint=EntrypointSource.CLI_COMMAND,
+            trigger_mode=TriggerMode.FILE,
+        ),
     ):
         pass
 

--- a/tests/analytics/test_source.py
+++ b/tests/analytics/test_source.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from app.analytics.source import (
+    INVESTIGATION_EVENT_SCHEMA_VERSION,
+    EntrypointSource,
+    TriggerMode,
+    build_source_properties,
+    is_test_run,
+    resolve_environment_tag,
+)
+
+
+def test_is_test_run_true_for_explicit_source_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_INVESTIGATION_SOURCE", "test")
+    monkeypatch.delenv("OPENSRE_IS_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    assert is_test_run() is True
+
+
+def test_is_test_run_true_for_explicit_boolean_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENSRE_INVESTIGATION_SOURCE", raising=False)
+    monkeypatch.setenv("OPENSRE_IS_TEST", "1")
+
+    assert is_test_run() is True
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("PYTEST_CURRENT_TEST", "tests/suite.py::test_case"),
+        ("GITHUB_ACTIONS", "true"),
+        ("CI", "true"),
+    ],
+)
+def test_is_test_run_true_for_auto_detected_env(
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+    env_value: str,
+) -> None:
+    monkeypatch.delenv("OPENSRE_INVESTIGATION_SOURCE", raising=False)
+    monkeypatch.delenv("OPENSRE_IS_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv(env_name, env_value)
+
+    assert is_test_run() is True
+
+
+def test_is_test_run_false_without_signals(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENSRE_INVESTIGATION_SOURCE", raising=False)
+    monkeypatch.delenv("OPENSRE_IS_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    assert is_test_run() is False
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("production", "prod"),
+        ("prod", "prod"),
+        ("staging", "staging"),
+        ("stage", "staging"),
+        ("development", "dev"),
+        ("dev", "dev"),
+        ("local", "dev"),
+        ("preview", "unknown"),
+    ],
+)
+def test_resolve_environment_tag_maps_known_values(
+    monkeypatch: pytest.MonkeyPatch,
+    env_value: str,
+    expected: str,
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_ENV", raising=False)
+    monkeypatch.setenv("ENV", env_value)
+
+    assert resolve_environment_tag() == expected
+
+
+def test_build_source_properties_for_api_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENSRE_INVESTIGATION_SOURCE", raising=False)
+    monkeypatch.delenv("OPENSRE_IS_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("ENV", "production")
+
+    properties = build_source_properties(
+        entrypoint=EntrypointSource.SDK,
+        trigger_mode=TriggerMode.SERVICE_RUNTIME,
+        investigation_id="inv-123",
+    )
+
+    assert properties == {
+        "source": "sdk",
+        "entrypoint_source": "sdk",
+        "category": "api",
+        "trigger_mode": "service_runtime",
+        "is_test": False,
+        "environment": "prod",
+        "investigation_id": "inv-123",
+        "investigation_event_schema_version": INVESTIGATION_EVENT_SCHEMA_VERSION,
+    }
+
+
+def test_build_source_properties_for_test_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_INVESTIGATION_SOURCE", "test")
+    monkeypatch.setenv("ENV", "development")
+
+    properties = build_source_properties(
+        entrypoint=EntrypointSource.CLI_PASTE,
+        trigger_mode=TriggerMode.PASTE,
+        investigation_id="inv-abc",
+    )
+
+    assert properties["source"] == "test"
+    assert properties["entrypoint_source"] == "cli_paste"
+    assert properties["category"] == "test"
+    assert properties["is_test"] is True
+    assert properties["trigger_mode"] == "paste"
+    assert properties["environment"] == "dev"

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -913,6 +913,39 @@ class TestInvestigateFileCommand:
         assert session.last_state == {"root_cause": "test cause"}
         assert '{"alert_name": "test"}' in captured[0]
 
+    def test_investigate_file_tracks_cli_repl_file_source(
+        self, tmp_path: object, monkeypatch: object
+    ) -> None:
+        alert_file = tmp_path / "alert.json"  # type: ignore[operator]
+        alert_file.write_text('{"alert_name": "test"}', encoding="utf-8")  # type: ignore[union-attr]
+
+        track_calls: list[tuple[str, str]] = []
+
+        class _TrackContext:
+            def __enter__(self) -> None:
+                return None
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                _ = (exc_type, exc, tb)
+                return False
+
+        def _fake_track(*, entrypoint, trigger_mode, **kwargs):  # type: ignore[no-untyped-def]
+            _ = kwargs
+            track_calls.append((entrypoint.value, trigger_mode.value))
+            return _TrackContext()
+
+        monkeypatch.setattr("app.analytics.cli.track_investigation", _fake_track)
+        monkeypatch.setattr(
+            "app.cli.investigation.run_investigation_for_session",
+            lambda **_kwargs: {"root_cause": "test cause"},
+        )
+        session = ReplSession()
+        console, _ = _capture()
+
+        dispatch_slash(f"/investigate {alert_file}", session, console)
+
+        assert track_calls == [("cli_repl_file", "file")]
+
     def test_investigate_accumulates_infra_context(
         self, tmp_path: object, monkeypatch: object
     ) -> None:

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -308,6 +308,37 @@ def test_run_new_alert_marks_task_failed_on_opensre_error(monkeypatch: pytest.Mo
     assert inv_tasks[0].error == "integration misconfigured"
 
 
+def test_run_new_alert_tracks_cli_paste_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    from rich.console import Console
+
+    track_calls: list[tuple[str, str]] = []
+
+    class _TrackContext:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            _ = (exc_type, exc, tb)
+            return False
+
+    def fake_track_investigation(*, entrypoint, trigger_mode, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        track_calls.append((entrypoint.value, trigger_mode.value))
+        return _TrackContext()
+
+    monkeypatch.setattr("app.analytics.cli.track_investigation", fake_track_investigation)
+    monkeypatch.setattr(
+        "app.cli.investigation.run_investigation_for_session",
+        lambda **_kwargs: {"root_cause": "handled"},
+    )
+    session = ReplSession()
+    console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+    loop._run_new_alert("High CPU alert", session, console)
+
+    assert track_calls == [("cli_paste", "paste")]
+
+
 def test_run_new_alert_reports_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
     from rich.console import Console
 

--- a/tests/cli/test_investigate_service_flag.py
+++ b/tests/cli/test_investigate_service_flag.py
@@ -110,7 +110,7 @@ def test_service_flag_surfaces_errors_from_payload_builder() -> None:
 
     runner = CliRunner()
     with (
-        patch("app.cli.commands.general.capture_investigation_started") as mock_started,
+        patch("app.cli.commands.general.track_investigation") as mock_tracking,
         patch(
             "app.remote.runtime_alert.build_runtime_alert_payload",
             side_effect=OpenSREError("unknown service", suggestion="add it"),
@@ -120,21 +120,17 @@ def test_service_flag_surfaces_errors_from_payload_builder() -> None:
         result = runner.invoke(investigate_command, ["--service", "missing"])
 
     assert result.exit_code != 0
-    mock_started.assert_not_called()
+    mock_tracking.assert_not_called()
 
 
 def test_print_template_does_not_count_as_investigation() -> None:
     runner = CliRunner()
 
-    with (
-        patch("app.cli.commands.general.capture_investigation_started") as mock_started,
-        patch("app.cli.commands.general.capture_investigation_completed") as mock_completed,
-    ):
+    with patch("app.cli.commands.general.track_investigation") as mock_tracking:
         result = runner.invoke(investigate_command, ["--print-template", "generic"])
 
     assert result.exit_code == 0
-    mock_started.assert_not_called()
-    mock_completed.assert_not_called()
+    mock_tracking.assert_not_called()
 
 
 def test_slack_thread_without_service_is_rejected() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,14 @@ def _disable_sentry() -> None:
     os.environ["OPENSRE_SENTRY_DISABLED"] = "1"
 
 
+def _mark_tests_for_analytics() -> None:
+    os.environ["OPENSRE_NO_TELEMETRY"] = "1"
+    os.environ["OPENSRE_INVESTIGATION_SOURCE"] = "test"
+
+
 _load_env()
 _disable_sentry()
+_mark_tests_for_analytics()
 
 
 @pytest.fixture(autouse=True)
@@ -34,3 +40,4 @@ def pytest_configure(config):
     """Pytest hook — keep env available for collection and execution."""
     _load_env()
     _disable_sentry()
+    _mark_tests_for_analytics()

--- a/tests/entrypoints/test_mcp.py
+++ b/tests/entrypoints/test_mcp.py
@@ -133,3 +133,29 @@ def test_run_rca_output_model_has_error_type_field() -> None:
 def test_run_rca_output_model_error_type_defaults_to_none() -> None:
     out = RunRCAOutput(ok=True)
     assert out.error_type is None
+
+
+def test_run_rca_tracks_investigation_source(monkeypatch: MonkeyPatch) -> None:
+    track_calls: list[tuple[str, str]] = []
+
+    class _TrackContext:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            _ = (exc_type, exc, tb)
+            return False
+
+    def fake_track_investigation(*, entrypoint, trigger_mode, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        track_calls.append((entrypoint.value, trigger_mode.value))
+        return _TrackContext()
+
+    monkeypatch.setattr("app.entrypoints.mcp.track_investigation", fake_track_investigation)
+    monkeypatch.setattr("app.entrypoints.mcp.run_investigation_cli", lambda **_kwargs: {"ok": True})
+
+    payload: dict[str, Any] = {"title": "test", "state": "firing", "alert_source": "grafana"}
+    result = run_rca(alert_payload=payload)
+
+    assert result["ok"] is True
+    assert track_calls == [("mcp", "service_runtime")]

--- a/tests/entrypoints/test_sdk.py
+++ b/tests/entrypoints/test_sdk.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def test_run_investigation_wraps_runner_with_tracking(monkeypatch) -> None:
+    track_calls: list[tuple[str, str]] = []
+
+    class _TrackContext:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            _ = (exc_type, exc, tb)
+            return False
+
+    def fake_track_investigation(*, entrypoint, trigger_mode, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        track_calls.append((entrypoint.value, trigger_mode.value))
+        return _TrackContext()
+
+    captured_kwargs: dict[str, Any] = {}
+
+    def fake_runner(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        captured_kwargs["args"] = args
+        captured_kwargs["kwargs"] = kwargs
+        return {"ok": True}
+
+    monkeypatch.setattr("app.entrypoints.sdk.track_investigation", fake_track_investigation)
+    monkeypatch.setattr("app.pipeline.runners.run_investigation", fake_runner)
+
+    from app.entrypoints.sdk import run_investigation
+
+    result = run_investigation("alert-name", raw_alert={"foo": "bar"})
+
+    assert result == {"ok": True}
+    assert captured_kwargs["args"] == ("alert-name",)
+    assert captured_kwargs["kwargs"] == {"raw_alert": {"foo": "bar"}}
+    assert track_calls == [("sdk", "service_runtime")]

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -167,6 +167,46 @@ def test_investigate_captures_unexpected_exception(monkeypatch: pytest.MonkeyPat
     assert captured_errors == [expected_error]
 
 
+def test_execute_investigation_tracks_remote_http_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    track_calls: list[tuple[str, str]] = []
+
+    class _TrackContext:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            _ = (exc_type, exc, tb)
+            return False
+
+    def fake_track(*, entrypoint, trigger_mode, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        track_calls.append((entrypoint.value, trigger_mode.value))
+        return _TrackContext()
+
+    monkeypatch.setattr("app.remote.server.track_investigation", fake_track)
+    monkeypatch.setattr(
+        "app.cli.investigation.resolve_investigation_context",
+        lambda **_kwargs: ("alert-name", "pipeline-name", "critical"),
+    )
+    monkeypatch.setattr(
+        "app.cli.investigation.run_investigation_cli",
+        lambda **_kwargs: {"root_cause": "ok"},
+    )
+
+    result, alert_name, pipeline_name, severity = remote_server._execute_investigation(
+        raw_alert={"alert_name": "PayloadAlert"},
+        alert_name=None,
+        pipeline_name=None,
+        severity=None,
+    )
+
+    assert result == {"root_cause": "ok"}
+    assert (alert_name, pipeline_name, severity) == ("alert-name", "pipeline-name", "critical")
+    assert track_calls == [("remote_http", "service_runtime")]
+
+
 @pytest.mark.asyncio
 async def test_investigate_stream_persists_state_on_disconnect(
     monkeypatch: pytest.MonkeyPatch,
@@ -222,6 +262,7 @@ async def test_investigate_stream_captures_streaming_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_errors: list[BaseException] = []
+    captured_failures: list[str] = []
     expected_error = RuntimeError("stream failed")
 
     async def fake_astream_investigation(*args: object, **kwargs: object):
@@ -239,6 +280,14 @@ async def test_investigate_stream_captures_streaming_exception(
         fake_astream_investigation,
     )
     monkeypatch.setattr(remote_server, "capture_exception", captured_errors.append)
+    monkeypatch.setattr(
+        remote_server,
+        "capture_investigation_failed",
+        lambda *, tracker, failure_type=None: (
+            captured_failures.append(failure_type or ""),
+            tracker,
+        )[0],
+    )
     monkeypatch.setattr(remote_server, "_persist_streamed_result", lambda **_kwargs: None)
 
     response = await investigate_stream(
@@ -248,6 +297,7 @@ async def test_investigate_stream_captures_streaming_exception(
 
     assert any("event: error" in chunk for chunk in chunks)
     assert captured_errors == [expected_error]
+    assert captured_failures == ["RuntimeError"]
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_log_compaction.py
+++ b/tests/tools/test_log_compaction.py
@@ -143,6 +143,35 @@ class TestDeduplicateLogs:
         assert len(result) == 1
         assert result[0]["count"] == 2
 
+    def test_preserves_source_metadata_for_downstream_evidence_mapping(self):
+        logs = [
+            {
+                "message": "FailedScheduling: 0/3 nodes are available",
+                "log_level": "WARN",
+                "timestamp": "2026-04-10T02:00:00Z",
+                "source_type": "k8s_events",
+                "namespace": "billing",
+                "cluster": "prod-1",
+                "service": "billing-worker",
+            },
+            {
+                "message": "FailedScheduling: 0/3 nodes are available",
+                "log_level": "WARN",
+                "timestamp": "2026-04-10T02:01:00Z",
+                "source_type": "k8s_events",
+                "namespace": "billing",
+                "cluster": "prod-1",
+                "service": "billing-worker",
+            },
+        ]
+        result = deduplicate_logs(logs)
+        assert len(result) == 1
+        assert result[0]["count"] == 2
+        assert result[0]["source_type"] == "k8s_events"
+        assert result[0]["namespace"] == "billing"
+        assert result[0]["cluster"] == "prod-1"
+        assert result[0]["service"] == "billing-worker"
+
 
 # ===========================================================================
 # Phase 2: build_error_taxonomy


### PR DESCRIPTION
## Summary
- add a unified investigation telemetry contract (`source`, `entrypoint_source`, `category`, `trigger_mode`, `is_test`, `environment`, `investigation_id`, schema version)
- instrument investigation lifecycle tracking across CLI, interactive shell (paste + `/investigate`), SDK, MCP, and remote server flows
- add dedupe-safe `track_investigation(...)` context manager and tests for lifecycle emissions, source tagging, and nested-call deduplication
- keep the existing log-compaction fix in this PR so compaction preserves source metadata used by downstream evidence mapping

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run pytest tests/analytics/test_source.py tests/analytics/test_cli.py tests/entrypoints/test_mcp.py tests/entrypoints/test_sdk.py tests/cli/test_investigate_service_flag.py tests/cli/interactive_shell/test_loop.py tests/cli/interactive_shell/test_commands.py tests/remote/test_server.py`
- [ ] `make test-cov` (locally fails in `tests/agents/test_bus.py` with AF_UNIX path too long for this workspace path; appears environment/path-length specific)
