### PR TITLE
fix(cli): /cancel stops the spinner when worker is parked on a confirmation

### DIFF
--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -154,6 +154,26 @@ def _looks_like_cancel_request(text: str | None) -> bool:
     return (text or "").strip().lower() in _CANCEL_REQUEST_TOKENS
 
 
+class DispatchCancelled(Exception):
+    """Raised in the dispatch worker thread when the user interrupts
+    (Esc / ``/cancel`` / ``/stop`` / ``/abort``) and the worker is
+    parked on a ``Proceed? [y/N]`` confirmation prompt.
+
+    Closes a real footgun in the cancel path: ``execution_policy``
+    treats an empty answer as **YES** (the upstream prompt is
+    ``[Y/n]``, capital Y), so if the cancel handler returned ``""``
+    the worker would happily run the action it was supposed to
+    interrupt — only the spinner would stop, the agent would keep
+    going. Raising propagates out of ``execution_allowed`` and the
+    surrounding action loop, so the in-flight action never runs and
+    any remaining actions in the same plan are skipped.
+
+    Caught by :func:`_run_one_dispatch` so the user just sees the
+    standard ``· interrupted`` line and the prompt becomes responsive
+    again, identical to a clean Esc on a streaming response.
+    """
+
+
 def _looks_like_correction(text: str) -> bool:
     """True when text begins with a short correction cue (intervention signal)."""
     stripped = text.lstrip()
@@ -744,6 +764,17 @@ async def _run_interactive(
         except asyncio.CancelledError:
             console.print(f"[{WARNING}]· interrupted[/]")
             raise
+        except DispatchCancelled:
+            # Worker raised mid-confirmation because the user pressed
+            # Esc / typed ``/cancel``. The exception already short-
+            # circuited the in-flight action and the surrounding action
+            # loop, so there's nothing left to do besides match the
+            # ``Esc``-on-streaming UX. Do NOT re-raise: the asyncio
+            # task completed via the worker's exception, not via
+            # ``Task.cancel`` (the two race), and re-raising here would
+            # surface this as a generic dispatch error rather than the
+            # clean ``· interrupted`` line.
+            console.print(f"[{WARNING}]· interrupted[/]")
         except Exception as exc:
             report_exception(exc, context="interactive_shell.dispatch_async")
             console.print(f"[{ERROR}]dispatch error:[/] {escape(str(exc))}")
@@ -920,8 +951,11 @@ def _route_confirm_through_prompt(state: _ReplState, prompt_text: str) -> str:
 
     Prints the confirmation prompt above the input, parks itself
     on a ``threading.Event``, and waits for the next text the user
-    submits. Esc cancels and returns ``""`` (which execution_policy
-    treats as "decline").
+    submits. Esc / ``/cancel`` raises :class:`DispatchCancelled` so
+    the surrounding ``execution_allowed`` call (and the dispatch as
+    a whole) bails out without running the pending action — returning
+    a sentinel string would be silently confirmed by
+    ``execution_policy`` because ``[Y/n]`` treats empty as YES.
 
     Module-level (with explicit ``state``) rather than a closure inside
     :func:`_run_interactive` so the threaded happy-path / cancel-path
@@ -951,9 +985,19 @@ def _route_confirm_through_prompt(state: _ReplState, prompt_text: str) -> str:
         while not response_event.is_set():
             cancel = state.current_cancel_event
             if cancel is not None and cancel.is_set():
-                return ""
+                raise DispatchCancelled("cancelled while awaiting confirmation")
             response_event.wait(timeout=_PROMPT_REFRESH_INTERVAL_S)
-        return state.confirm_response[0] if state.confirm_response else ""
+        # ``response_event`` was set. Real answers reach here via
+        # ``deliver_confirmation``, which appends to ``confirm_response``
+        # *before* setting the event. An empty list here therefore
+        # means the event was set by ``cancel_current_dispatch`` (which
+        # publishes the event without delivering an answer) — treat
+        # that as a cancel rather than the empty string, otherwise
+        # ``execution_policy`` would silently confirm the pending
+        # ``[Y/n]`` action.
+        if not state.confirm_response:
+            raise DispatchCancelled("cancelled while awaiting confirmation")
+        return state.confirm_response[0]
     finally:
         state.confirm_event = None
         state.confirm_response = []

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -129,6 +129,31 @@ def _looks_like_confirmation_answer(text: str | None) -> bool:
     return (text or "").strip().lower() in _CONFIRMATION_TOKENS
 
 
+# Bare slash commands that mean "stop whatever is currently pondering",
+# matching the user's mental model when they reach for the obvious
+# cancel command after seeing the spinner stuck. ``/cancel <task_id>``
+# (with arguments) is intentionally excluded — that's a targeted
+# background-task cancel handled by the existing slash command in the
+# worker thread.
+_CANCEL_REQUEST_TOKENS: frozenset[str] = frozenset({"/cancel", "/stop", "/abort"})
+
+
+def _looks_like_cancel_request(text: str | None) -> bool:
+    """True when ``text`` reads as a deliberate request to interrupt the
+    currently-active dispatch.
+
+    Used by the prompt loop to intercept bare ``/cancel`` (and friends)
+    before they're queued. Without this intercept, ``/cancel`` typed
+    while the worker is parked on a ``Proceed? [y/N]`` confirmation
+    sits behind the parked dispatch in the queue and never runs — the
+    spinner keeps spinning and the user gets no feedback. Routing the
+    intent through :meth:`_ReplState.cancel_current_dispatch` mirrors
+    what ``Esc`` already does and gives ``/cancel`` discoverable parity
+    with that keystroke.
+    """
+    return (text or "").strip().lower() in _CANCEL_REQUEST_TOKENS
+
+
 def _looks_like_correction(text: str) -> bool:
     """True when text begins with a short correction cue (intervention signal)."""
     stripped = text.lstrip()
@@ -823,6 +848,25 @@ async def _run_interactive(
 
                 if state.exit_requested:
                     return
+
+                # Bare ``/cancel``/``/stop``/``/abort`` while a dispatch
+                # is active: route through the same path as ``Esc``
+                # (``state.cancel_current_dispatch()``) instead of
+                # queueing the slash. Queueing a cancel behind the
+                # dispatch that's *causing* the spinner to spin is a
+                # deadlock from the user's perspective — the queued
+                # ``/cancel`` only runs once the parked dispatch
+                # finishes, which is exactly what they're trying to
+                # interrupt. ``/cancel <task_id>`` with arguments is
+                # intentionally NOT matched by the recognizer so the
+                # existing targeted background-task cancel still flows
+                # through the normal slash-dispatch path.
+                if state.is_dispatch_running() and _looks_like_cancel_request(text):
+                    stripped = (text or "").strip()
+                    if stripped:
+                        render_submitted_prompt(echo_console, session, stripped)
+                    state.cancel_current_dispatch()
+                    continue
 
                 # If a worker thread is parked on a confirmation prompt,
                 # the next text the user submits *might* be the answer

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -894,8 +894,7 @@ async def _run_interactive(
                 # through the normal slash-dispatch path.
                 if state.is_dispatch_running() and _looks_like_cancel_request(text):
                     stripped = (text or "").strip()
-                    if stripped:
-                        render_submitted_prompt(echo_console, session, stripped)
+                    render_submitted_prompt(echo_console, session, stripped)
                     state.cancel_current_dispatch()
                     continue
 

--- a/app/cli/interactive_shell/orchestration/agent_actions.py
+++ b/app/cli/interactive_shell/orchestration/agent_actions.py
@@ -32,7 +32,7 @@ from app.cli.interactive_shell.orchestration.execution_policy import (
     resolve_slash_execution_tier,
 )
 from app.cli.interactive_shell.runtime import ReplSession, TaskKind, TaskRecord, TaskStatus
-from app.cli.interactive_shell.ui import print_planned_actions
+from app.cli.interactive_shell.ui import DIM, print_planned_actions
 from app.cli.interactive_shell.ui.streaming import render_response_header
 
 
@@ -175,6 +175,16 @@ def execute_cli_actions(
         session.record("cli_agent", message)
 
     for action in actions:
+        # Multi-action plans: if the user pressed Esc / typed
+        # ``/cancel`` between actions, the per-dispatch cancel event
+        # is set on the ``_StreamingConsole``. Skip the rest of the
+        # plan so a "run all of these" plan doesn't keep marching
+        # through after an explicit cancel. ``getattr`` with a default
+        # keeps non-streaming consoles (used by the seeded-input
+        # test path) working unchanged.
+        if getattr(console, "cancel_requested", False):
+            console.print(f"[{DIM}](remaining actions cancelled)[/]")
+            break
         console.print()
         if action.kind == "slash":
             stripped = action.content.strip()

--- a/tests/cli/interactive_shell/orchestration/test_agent_actions.py
+++ b/tests/cli/interactive_shell/orchestration/test_agent_actions.py
@@ -119,6 +119,72 @@ def test_execute_cli_actions_dispatches_planned_commands(monkeypatch: object) ->
     assert "ran /list integrations" in output
 
 
+def test_execute_cli_actions_skips_remaining_actions_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-action plan: if the user pressed Esc / typed ``/cancel``
+    between actions, the per-dispatch cancel event is set on the
+    ``_StreamingConsole``. The action loop checks ``cancel_requested``
+    at the top of each iteration and breaks, so the remaining actions
+    in the plan are NOT dispatched.
+
+    Pre-fix, the loop ran every action regardless of cancel state, so
+    cancelling a "do A then B" plan still ran B even after the user
+    explicitly asked to stop. This pins the new contract that an
+    in-flight cancel halts the plan after the current action.
+    """
+    dispatched: list[str] = []
+
+    class _CancelAfterFirst:
+        """Console-shaped object that returns ``cancel_requested=True``
+        only AFTER the first action has been dispatched, simulating
+        the user hitting Esc / typing ``/cancel`` between actions."""
+
+        def __init__(self, inner: Console, dispatched: list[str]) -> None:
+            self._inner = inner
+            self._dispatched = dispatched
+
+        @property
+        def cancel_requested(self) -> bool:
+            return len(self._dispatched) >= 1
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._inner, name)
+
+    def _fake_dispatch(
+        command: str,
+        session: ReplSession,
+        console: Console,
+        **_kwargs: object,
+    ) -> bool:
+        dispatched.append(command)
+        session.record("slash", command, ok=True)
+        console.print(f"ran {command}")
+        return True
+
+    monkeypatch.setattr(agent_actions, "dispatch_slash", _fake_dispatch)  # type: ignore[attr-defined]
+
+    session = ReplSession()
+    inner_console, buf = _capture()
+    console = _CancelAfterFirst(inner_console, dispatched)
+    handled = agent_actions.execute_cli_actions(
+        "check the health of my opensre and then show me all connected services",
+        session,
+        console,  # type: ignore[arg-type]
+    )
+
+    assert handled is True
+    # Only the first action ran; the second was skipped because the
+    # cancel event was set between iterations.
+    assert dispatched == ["/health"], (
+        f"second action ran despite cancel between iterations: {dispatched}"
+    )
+    output = buf.getvalue()
+    assert "ran /health" in output
+    assert "ran /list integrations" not in output
+    assert "remaining actions cancelled" in output
+
+
 def test_execute_cli_actions_falls_through_for_local_llama_request(monkeypatch: object) -> None:
     dispatched: list[str] = []
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -1114,15 +1114,27 @@ class TestRouteConfirmThroughPrompt:
 
     def _run_in_thread(
         self, state: loop._ReplState, prompt_text: str
-    ) -> tuple[threading.Thread, list[str]]:
+    ) -> tuple[threading.Thread, list[str], list[BaseException]]:
+        """Run the worker in a background thread and capture both its
+        return value (``result``) and any raised exception (``exc``).
+
+        Cancellation now raises :class:`loop.DispatchCancelled` instead
+        of returning ``""``, so tests need access to both channels —
+        the happy path checks ``result``, the cancel paths check
+        ``exc``.
+        """
         result: list[str] = []
+        exc: list[BaseException] = []
 
         def target() -> None:
-            result.append(loop._route_confirm_through_prompt(state, prompt_text))
+            try:
+                result.append(loop._route_confirm_through_prompt(state, prompt_text))
+            except BaseException as e:
+                exc.append(e)
 
         t = threading.Thread(target=target, daemon=True)
         t.start()
-        return t, result
+        return t, result, exc
 
     def test_returns_delivered_response_and_clears_state(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1144,13 +1156,14 @@ class TestRouteConfirmThroughPrompt:
         # confirm_fn. Never set in this test.
         state.current_cancel_event = threading.Event()
 
-        t, result = self._run_in_thread(state, "Proceed? [y/N] ")
+        t, result, exc = self._run_in_thread(state, "Proceed? [y/N] ")
         self._wait_until_parked(state)
 
         state.deliver_confirmation("y")
         t.join(timeout=self._JOIN_TIMEOUT_S)
 
         assert not t.is_alive(), "worker did not return within timeout"
+        assert exc == [], f"happy path raised unexpectedly: {exc}"
         assert result == ["y"]
         # Finally-block invariant: state cleared for the next prompt.
         assert state.confirm_event is None
@@ -1158,58 +1171,60 @@ class TestRouteConfirmThroughPrompt:
         # Prompt text was written before parking.
         assert "Proceed? [y/N]" in captured.getvalue()
 
-    def test_returns_empty_string_when_cancel_event_fires(
+    def test_raises_dispatch_cancelled_when_cancel_event_fires(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Esc-cancel **user-facing** path: pressing Esc during an
-        active dispatch routes through the key binding to
+        """Esc / ``/cancel`` **user-facing** path: routes through
         ``state.cancel_current_dispatch()``, which sets BOTH
         ``current_cancel_event`` AND ``confirm_event``. The worker
         wakes from ``response_event.wait`` because ``confirm_event``
         is the same object as ``response_event``; the polling loop
         exits via the natural ``while not response_event.is_set()``
-        condition. With ``confirm_response`` never populated, the
-        function returns ``""`` from the else branch of its return
-        expression — ``execution_policy`` treats empty as "decline".
+        condition.
 
-        This pins the production ESC path observable behaviour. The
-        in-loop cancel-check (``if cancel.is_set(): return ""``) is
-        exercised separately by
-        ``test_returns_empty_string_when_cancel_already_set_before_park``
-        and ``test_in_loop_cancel_check_fires_after_wait_timeout``,
-        which set ``current_cancel_event`` without also setting
-        ``confirm_event``.
+        With ``confirm_response`` never populated, the function MUST
+        raise :class:`loop.DispatchCancelled` rather than returning
+        the empty string. Returning ``""`` would be silently confirmed
+        by ``execution_policy`` because ``[Y/n]`` treats empty as YES,
+        so the in-flight action would run despite the user cancelling.
+        Raising propagates out of ``execution_allowed`` and the
+        surrounding action loop instead, matching what the user
+        expects from ``Esc``.
         """
         monkeypatch.setattr(sys, "stdout", io.StringIO())
 
         state = loop._ReplState()
         state.current_cancel_event = threading.Event()
 
-        t, result = self._run_in_thread(state, "Proceed? [y/N] ")
+        t, result, exc = self._run_in_thread(state, "Proceed? [y/N] ")
         self._wait_until_parked(state)
 
         state.cancel_current_dispatch()
         t.join(timeout=self._JOIN_TIMEOUT_S)
 
         assert not t.is_alive(), "worker did not return within timeout"
-        assert result == [""]
+        assert result == [], f"cancel path returned a value: {result}"
+        assert len(exc) == 1, f"expected exactly one exception, got {exc}"
+        assert isinstance(exc[0], loop.DispatchCancelled), (
+            f"expected DispatchCancelled, got {type(exc[0]).__name__}: {exc[0]}"
+        )
         assert state.confirm_event is None
         assert state.confirm_response == []
 
-    def test_returns_empty_string_when_cancel_already_set_before_park(
+    def test_raises_dispatch_cancelled_when_cancel_already_set_before_park(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Race-safety: if the user pressed Esc *before* the worker
         reaches the poll loop, the first iteration must observe
-        ``current_cancel_event.is_set()`` and return ``""`` immediately
-        rather than waiting forever for a confirmation that won't come.
+        ``current_cancel_event.is_set()`` and raise immediately rather
+        than waiting forever for a confirmation that won't come.
 
         Isolates the **in-loop cancel-check** on the FIRST iteration:
         ``current_cancel_event`` is pre-set; ``confirm_event`` is NOT
         set; the worker enters the loop, reaches the cancel-check
-        BEFORE the first ``response_event.wait``, and returns ``""``.
-        Deleting the cancel-check would make this test hang to
-        ``_JOIN_TIMEOUT_S`` and fail.
+        BEFORE the first ``response_event.wait``, and raises
+        :class:`loop.DispatchCancelled`. Deleting the cancel-check
+        would make this test hang to ``_JOIN_TIMEOUT_S`` and fail.
         """
         monkeypatch.setattr(sys, "stdout", io.StringIO())
 
@@ -1218,29 +1233,33 @@ class TestRouteConfirmThroughPrompt:
         cancel.set()  # already cancelled
         state.current_cancel_event = cancel
 
-        t, result = self._run_in_thread(state, "Proceed? ")
+        t, result, exc = self._run_in_thread(state, "Proceed? ")
         t.join(timeout=self._JOIN_TIMEOUT_S)
 
         assert not t.is_alive(), "pre-set cancel did not unblock worker"
-        assert result == [""]
+        assert result == []
+        assert len(exc) == 1
+        assert isinstance(exc[0], loop.DispatchCancelled)
         assert state.confirm_event is None
 
-    def test_in_loop_cancel_check_fires_after_wait_timeout(
+    def test_in_loop_cancel_check_raises_after_wait_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """In-loop cancel-check on a SUBSEQUENT iteration: the worker
         is already parked in ``response_event.wait(timeout=0.1s)`` when
         cancel fires. The wait times out (because we don't touch
         ``confirm_event``), the next iteration's cancel-check sees
-        ``current_cancel_event.is_set()``, returns ``""``.
+        ``current_cancel_event.is_set()`` and raises
+        :class:`loop.DispatchCancelled`.
 
         Why this is needed: the user-facing test
-        (``test_returns_empty_string_when_cancel_event_fires``) calls
-        ``state.cancel_current_dispatch()``, which sets BOTH the
+        (``test_raises_dispatch_cancelled_when_cancel_event_fires``)
+        calls ``state.cancel_current_dispatch()``, which sets BOTH the
         cancel and confirm events — the worker exits via the
-        confirm_event-set path, NOT via the cancel-check. Deleting the
-        cancel-check would still pass that test. This test sets ONLY
-        the cancel event so the only way out is through the check.
+        confirm_event-set path (the post-wait empty-``confirm_response``
+        check), NOT via the cancel-check. Deleting the cancel-check
+        would still pass that test. This test sets ONLY the cancel
+        event so the only way out is through the check.
         """
         monkeypatch.setattr(sys, "stdout", io.StringIO())
 
@@ -1248,7 +1267,7 @@ class TestRouteConfirmThroughPrompt:
         cancel = threading.Event()
         state.current_cancel_event = cancel
 
-        t, result = self._run_in_thread(state, "Proceed? ")
+        t, result, exc = self._run_in_thread(state, "Proceed? ")
         self._wait_until_parked(state)
 
         # Set cancel directly — do NOT set confirm_event. The worker
@@ -1261,7 +1280,9 @@ class TestRouteConfirmThroughPrompt:
             "in-loop cancel-check did not return within timeout — "
             "the function ignored a cancel signal that arrived mid-wait"
         )
-        assert result == [""]
+        assert result == []
+        assert len(exc) == 1
+        assert isinstance(exc[0], loop.DispatchCancelled)
         assert state.confirm_event is None
 
     def test_confirm_response_reset_before_confirm_event_published(
@@ -1300,12 +1321,13 @@ class TestRouteConfirmThroughPrompt:
 
         monkeypatch.setattr(loop._ReplState, "__setattr__", tracking_setattr)
 
-        t, result = self._run_in_thread(state, "Proceed? ")
+        t, result, exc = self._run_in_thread(state, "Proceed? ")
         self._wait_until_parked(state)
 
         state.deliver_confirmation("answer")
         t.join(timeout=self._JOIN_TIMEOUT_S)
 
+        assert exc == [], f"happy path raised unexpectedly: {exc}"
         assert result == ["answer"]
 
         # During setup ``_route_confirm_through_prompt`` writes both
@@ -1333,21 +1355,125 @@ class TestRouteConfirmThroughPrompt:
     ) -> None:
         """User presses Enter on the confirmation prompt without typing
         anything → ``state.deliver_confirmation("")`` is called →
-        function returns ``""``. Real production case: ``y/N`` prompts
-        default to "decline" when the user just hits Enter.
+        function returns ``""``. Real production case: ``[Y/n]`` prompts
+        treat plain Enter as "yes" (capital Y default).
+
+        This is the ONLY path that legitimately yields an empty-string
+        return: ``deliver_confirmation`` populated ``confirm_response``
+        with ``""`` BEFORE setting the event, so the post-wait check
+        sees a non-empty list and returns the user's actual answer.
+        Cancellation, by contrast, sets the event WITHOUT delivering
+        an answer and is now distinguishable — that path raises
+        :class:`loop.DispatchCancelled` (see the cancel-path tests
+        above).
         """
         monkeypatch.setattr(sys, "stdout", io.StringIO())
 
         state = loop._ReplState()
         state.current_cancel_event = threading.Event()
 
-        t, result = self._run_in_thread(state, "Proceed? [y/N] ")
+        t, result, exc = self._run_in_thread(state, "Proceed? [y/N] ")
         self._wait_until_parked(state)
 
         state.deliver_confirmation("")
         t.join(timeout=self._JOIN_TIMEOUT_S)
 
         assert not t.is_alive(), "empty delivery did not unblock worker"
+        assert exc == [], f"explicit empty delivery should not raise: {exc}"
         assert result == [""]
         assert state.confirm_event is None
         assert state.confirm_response == []
+
+
+class TestExecutionAllowedRespectsDispatchCancelled:
+    """End-to-end contract: cancelling during ``Proceed? [Y/n]`` must
+    actually STOP the in-flight action — not just stop the spinner.
+
+    Pre-fix, the cancel handler returned ``""``; ``execution_allowed``
+    treated empty as YES (since ``[Y/n]`` defaults to Y) and the worker
+    happily ran the action it was supposed to interrupt — only the
+    spinner stopped, the agent kept going. This test class pins the
+    new contract: the confirm callable raises ``DispatchCancelled`` and
+    the exception propagates out of ``execution_allowed`` *without*
+    silently confirming the action. The action loop in
+    ``execute_cli_actions`` therefore exits via the exception, the
+    in-flight action never runs, and any further actions in the same
+    plan are skipped.
+    """
+
+    def test_dispatch_cancelled_propagates_through_execution_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rich.console import Console
+
+        from app.cli.interactive_shell.orchestration.execution_policy import (
+            ExecutionPolicyResult,
+            execution_allowed,
+        )
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        session = ReplSession()
+        console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+        def _cancel_confirm(_prompt: str) -> str:
+            raise loop.DispatchCancelled("cancelled while awaiting confirmation")
+
+        policy = ExecutionPolicyResult(
+            verdict="ask",
+            action_type="opensre_cli",
+            reason="this opensre subcommand may change local config or infrastructure",
+        )
+
+        with pytest.raises(loop.DispatchCancelled):
+            execution_allowed(
+                policy,
+                session=session,
+                console=console,
+                action_summary="opensre deploy ec2 --help",
+                confirm_fn=_cancel_confirm,
+                is_tty=True,
+            )
+
+    def test_empty_confirm_response_would_silently_allow_without_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard documenting WHY the raise is required.
+
+        If the confirm callable returned ``""`` instead of raising,
+        ``execution_allowed`` would treat the empty answer as YES
+        (``[Y/n]`` defaults to Y) and the action would run. This test
+        pins that footgun by demonstrating the bad outcome with an
+        empty-string return — the cancel handler MUST raise, not
+        return, to actually stop the in-flight action.
+        """
+        from rich.console import Console
+
+        from app.cli.interactive_shell.orchestration.execution_policy import (
+            ExecutionPolicyResult,
+            execution_allowed,
+        )
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        session = ReplSession()
+        console = Console(file=io.StringIO(), force_terminal=False, highlight=False)
+
+        policy = ExecutionPolicyResult(
+            verdict="ask",
+            action_type="opensre_cli",
+            reason="this opensre subcommand may change local config or infrastructure",
+        )
+
+        # Empty string answer (the pre-fix cancel return value) is
+        # silently confirmed — proving the bug existed and that we
+        # cannot rely on a sentinel string for cancellation.
+        assert (
+            execution_allowed(
+                policy,
+                session=session,
+                console=console,
+                action_summary="opensre deploy ec2 --help",
+                confirm_fn=lambda _prompt: "",
+                is_tty=True,
+            )
+            is True
+        )

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -640,6 +640,63 @@ class TestLooksLikeConfirmationAnswer:
         assert loop._looks_like_confirmation_answer(text) is False
 
 
+class TestLooksLikeCancelRequest:
+    """Unit tests for the bare-cancel slash recognizer.
+
+    The recognizer is the gate that lets the prompt loop intercept
+    ``/cancel``-style slashes typed while a dispatch is parked
+    (e.g. on a ``Proceed? [y/N]`` confirmation) and route them through
+    ``state.cancel_current_dispatch()`` instead of queueing them
+    behind the dispatch they're trying to interrupt.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "/cancel",
+            "/CANCEL",
+            "/Cancel",
+            "/stop",
+            "/STOP",
+            "/abort",
+            "  /cancel  ",
+            "/cancel\n",
+            "\t/stop\t",
+        ],
+    )
+    def test_recognised_cancel_slashes_match(self, text: str) -> None:
+        assert loop._looks_like_cancel_request(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Targeted background-task cancel — must keep flowing
+            # through the normal slash dispatch path so the existing
+            # ``_cmd_cancel`` handler resolves the task id.
+            "/cancel 8f5fe574",
+            "/cancel abc123",
+            "/stop now",
+            # Other slashes — unrelated to interrupt.
+            "/help",
+            "/tasks",
+            # Natural-language uses of the same words must NOT be
+            # intercepted; the user might be talking about cancelling
+            # a deploy or stopping a service in their environment.
+            "cancel this please",
+            "cancel",
+            "stop the deploy",
+            "stop",
+            "abort",
+            # Empty / whitespace / None — nothing to intercept.
+            "",
+            "   ",
+            None,
+        ],
+    )
+    def test_unrecognised_text_does_not_match(self, text: str | None) -> None:
+        assert loop._looks_like_cancel_request(text) is False
+
+
 # ── Spinner state tests ──────────────────────────────────────────────────────
 
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -1114,7 +1114,7 @@ class TestRouteConfirmThroughPrompt:
 
     def _run_in_thread(
         self, state: loop._ReplState, prompt_text: str
-    ) -> tuple[threading.Thread, list[str], list[BaseException]]:
+    ) -> tuple[threading.Thread, list[str], list[Exception]]:
         """Run the worker in a background thread and capture both its
         return value (``result``) and any raised exception (``exc``).
 
@@ -1124,12 +1124,12 @@ class TestRouteConfirmThroughPrompt:
         ``exc``.
         """
         result: list[str] = []
-        exc: list[BaseException] = []
+        exc: list[Exception] = []
 
         def target() -> None:
             try:
                 result.append(loop._route_confirm_through_prompt(state, prompt_text))
-            except BaseException as e:
+            except Exception as e:
                 exc.append(e)
 
         t = threading.Thread(target=target, daemon=True)


### PR DESCRIPTION
## Summary

Cancelling a dispatch (via `Esc`, `/cancel`, `/stop`, or `/abort`) now actually stops the agent's worker thread — not just the visible spinner.

### The bug

You typed `/cancel` while parked on a `Proceed? [y/N]` confirmation. After the first commit on this branch, the spinner stopped. But you correctly noticed the agent was still working on the task — `pondering…` reappeared with a higher elapsed counter. **Esc had the exact same bug.**

### Root cause

When the cancel signal fired, `_route_confirm_through_prompt` returned the empty string `""` to its caller. `execution_policy.execution_allowed` then evaluated:

```python
if answer not in {"", "y", "yes"}:
```

…and `""` IS in that set (because the upstream prompt is `[Y/n]` with capital-Y default), so the worker treated cancellation as a confirmation and ran the action. The `Task.cancel()` on the asyncio side stopped the visible spinner; the worker thread kept executing in the background, output and all.

### The fix

1. **`DispatchCancelled` exception.** `_route_confirm_through_prompt` now raises it instead of returning `""` when the cancel event fires (or when the confirm event was published without a delivered answer — that's the `cancel_current_dispatch` fingerprint). The exception propagates out of `execution_allowed` and the surrounding action loop, so the in-flight action never runs.
2. **`_run_one_dispatch` catches `DispatchCancelled`** and prints the standard `· interrupted` line, matching the `Esc`-on-streaming UX.
3. **`execute_cli_actions` checks `console.cancel_requested`** at the top of each action iteration, so multi-action plans halt after the current action when the user cancels mid-plan.
4. **Prompt-loop intercept** (kept from the first commit): bare `/cancel` / `/stop` / `/abort` while a dispatch is running routes through `state.cancel_current_dispatch()` instead of being queued behind the parked dispatch. `/cancel <task_id>` (with arguments) is intentionally unchanged — that targeted background-task cancel still flows through normal slash dispatch.

### Reproduction

1. Trigger any action plan that asks for `Proceed? [y/N]` confirmation (e.g. `opensre deploy ec2 --help`).
2. Without answering, type `/cancel` (or hit `Esc`).
3. **Before this PR:** spinner stops with `· interrupted`, but the worker thread silently runs the action anyway. With `/cancel`, the spinner doesn't even stop because the slash got queued behind the parked dispatch.
4. **After this PR:** worker raises `DispatchCancelled`, the action never runs, the dispatch ends cleanly, and the prompt becomes responsive immediately.

## Changes

- `app/cli/interactive_shell/loop.py`
  - New `DispatchCancelled(Exception)`.
  - `_route_confirm_through_prompt` raises `DispatchCancelled` on cancel (replaces the `""` return).
  - `_run_one_dispatch` catches `DispatchCancelled` alongside `asyncio.CancelledError`.
  - `_looks_like_cancel_request()` recognizer + intercept of bare `/cancel` / `/stop` / `/abort` in the prompt loop.
- `app/cli/interactive_shell/orchestration/agent_actions.py`
  - Top-of-loop `console.cancel_requested` check in `execute_cli_actions` so multi-action plans break after the current action.
- `tests/cli/interactive_shell/test_loop.py`
  - `TestLooksLikeCancelRequest` — recognizer coverage.
  - Updated three `TestRouteConfirmThroughPrompt` cancel-path tests for the new raise-based contract.
  - New `TestExecutionAllowedRespectsDispatchCancelled` pins the end-to-end contract AND documents the original footgun (an empty-string return IS silently confirmed as YES, which is exactly why the cancel path must raise).
- `tests/cli/interactive_shell/orchestration/test_agent_actions.py`
  - `test_execute_cli_actions_skips_remaining_actions_when_cancelled` pins the multi-action between-iterations break.

## Test plan

- [x] `make lint` — passes
- [x] `make format-check` — passes
- [x] `make typecheck` — passes (576 source files, no issues)
- [x] `uv run pytest tests/cli/` — 1371 passed