### PR TITLE
Fix agents trace rendering in headless Windows tests

### DIFF
--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -11,6 +11,7 @@ import math
 import os
 import time
 from collections.abc import Callable
+from contextlib import nullcontext
 from pathlib import Path
 
 from prompt_toolkit.patch_stdout import patch_stdout
@@ -438,9 +439,11 @@ def _render_live_tail(console: Console, label: str, sess: AttachSession) -> None
     is the canonical "stop" signal.
     """
     console.print(f"[{BOLD_BRAND}]trace {escape(label)}[/]  [{DIM}]Ctrl+C to stop[/]")
+    isatty = getattr(console.file, "isatty", None)
+    stdout_context = patch_stdout(raw=True) if callable(isatty) and isatty() else nullcontext()
     try:
         with (
-            patch_stdout(raw=True),
+            stdout_context,
             Live(
                 Text(""),
                 console=console,


### PR DESCRIPTION
Fixes #1851 

#### Describe the changes you have made in this PR -

Fixes `/agents trace` test failures on Windows.

`/agents trace` now only uses `patch_stdout` when output is a real terminal. Captured or headless output skips it, so prompt_toolkit does not require a Windows console buffer.

### Demo/Screenshot for feature changes and bug fixes -

```powershell
uv run pytest tests\cli\interactive_shell\test_agents_commands.py::TestAgentsTrace -v
