### PR TITLE
feat(agent): /agents graph dependency rendering

### DIFF
--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -75,6 +75,7 @@ class AgentRegistry:
     def forget(self, pid: int) -> AgentRecord | None:
         removed = self._records.pop(pid, None)
         if removed is not None:
+            self._scrub_waits_on({pid})
             self._rewrite()
         return removed
 
@@ -94,8 +95,18 @@ class AgentRegistry:
             if record is not None:
                 removed.append(record)
         if removed:
+            self._scrub_waits_on({r.pid for r in removed})
             self._rewrite()
         return removed
+
+    def _scrub_waits_on(self, removed_pids: set[int]) -> None:
+        """Drop ``removed_pids`` from every remaining record's ``waits_on``."""
+        for pid, record in self._records.items():
+            if not record.waits_on:
+                continue
+            left = tuple(p for p in record.waits_on if p not in removed_pids)
+            if len(left) != len(record.waits_on):
+                self._records[pid] = replace(record, waits_on=left)
 
     def list(self) -> list[AgentRecord]:
         return list(self._records.values())

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -25,7 +25,7 @@ class AgentRecord:
     command: str
     registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     source: str = "registered"
-    waits_on: list[int] = field(default_factory=list)
+    waits_on: tuple[int, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -35,7 +35,7 @@ class AgentRecord:
         raw_pid = data["pid"]
         raw_waits = data.get("waits_on", [])
         pid = int(str(raw_pid))
-        waits_on = [int(str(p)) for p in raw_waits] if isinstance(raw_waits, list) else []
+        waits_on = tuple(int(str(p)) for p in raw_waits) if isinstance(raw_waits, list) else ()
         return cls(
             name=str(data["name"]),
             pid=pid,
@@ -49,7 +49,7 @@ class AgentRecord:
         """Create a new record instead mutating to maintain the immutable contract."""
         if record.pid in self.waits_on:
             return self
-        return replace(self, waits_on=[*self.waits_on, record.pid])
+        return replace(self, waits_on=(*self.waits_on, record.pid))
 
 
 class AgentRegistry:

--- a/app/agents/registry.py
+++ b/app/agents/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Iterable
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -25,6 +25,7 @@ class AgentRecord:
     command: str
     registered_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     source: str = "registered"
+    waits_on: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -32,14 +33,23 @@ class AgentRecord:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> AgentRecord:
         raw_pid = data["pid"]
+        raw_waits = data.get("waits_on", [])
         pid = int(str(raw_pid))
+        waits_on = [int(str(p)) for p in raw_waits] if isinstance(raw_waits, list) else []
         return cls(
             name=str(data["name"]),
             pid=pid,
             command=str(data["command"]),
             registered_at=str(data.get("registered_at", datetime.now(UTC).isoformat())),
             source=str(data.get("source", "registered")),
+            waits_on=waits_on,
         )
+
+    def add_waits_on(self, record: AgentRecord) -> AgentRecord:
+        """Create a new record instead mutating to maintain the immutable contract."""
+        if record.pid in self.waits_on:
+            return self
+        return replace(self, waits_on=[*self.waits_on, record.pid])
 
 
 class AgentRegistry:

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import math
 import os
 import time
+from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from rich.console import Console
 from rich.live import Live
 from rich.markup import escape
 from rich.text import Text
+from rich.tree import Tree
 
 from app.agents.bus import BusMessage, subscribe
 from app.agents.config import (
@@ -59,6 +61,8 @@ _AGENTS_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("kill", "SIGTERM → SIGKILL a local agent by PID"),
     ("release", "release a branch claim"),
     ("trace", "live tail of an agent's stdout by pid"),
+    ("graph", "render the wait-on dependency graph as a tree"),
+    ("wait", "mark <pid> as waiting on another pid: /agent wait <pid> --on <other-pid>"),
 )
 
 _TRACE_REFRESH_PER_SECOND = 10
@@ -519,6 +523,121 @@ def _cmd_agents_trace(session: ReplSession, console: Console, args: list[str]) -
     return True
 
 
+def _cmd_agents_wait(session: ReplSession, console: Console, args: list[str]) -> bool:
+    """Handle ``/agents wait <pid> --on <other-pid>``.
+
+    Parse the two pids out of ``args``, registers the dependency in the agent registry.
+    """
+    if len(args) != 3 or args[1] != "--on":
+        console.print(f"[{ERROR}]usage:[/] /agents wait <pid> --on <other-pid>")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    try:
+        pid = int(args[0])
+    except ValueError:
+        console.print(f"[{ERROR}]invalid pid:[/] {escape(args[0])}")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    try:
+        on_pid = int(args[2])
+    except ValueError:
+        console.print(f"[{ERROR}]invalid other-pid:[/] {escape(args[2])}")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    if pid == on_pid:
+        console.print(f"[{ERROR}]invalid pid:[/] {pid} waiting for itself")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    registry = AgentRegistry()
+    waiter = registry.get(pid)
+    if waiter is None:
+        console.print(f"[{ERROR}]pid {pid} is not in the agent registry[/]")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    target = registry.get(on_pid)
+    if target is None:
+        console.print(f"[{ERROR}]pid {on_pid} is not in the agent registry[/]")
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    waiter = waiter.add_waits_on(target)
+    registry.register(waiter)
+    console.print(
+        f"[{HIGHLIGHT}]{escape(waiter.name)} (pid {pid}) now waits on "
+        f"{escape(target.name)} (pid {on_pid}).[/]"
+    )
+    return True
+
+
+def _cmd_agents_graph(console: Console) -> bool:
+    """Render the ``waits_on`` dependency graph as a Rich tree.
+
+    Single-pass DFS over the inverse ``waits_on`` edges (depended-on
+    -> waiter), building the Rich tree as it descends. A back edge — a
+    pid re-encountered while still in the active path — is the
+    canonical cycle witness for a directed graph; a warning naming the agents
+    in the loop is emitted instead.
+    """
+
+    def _label(pid: int) -> str:
+        r = records[pid]
+        if not r.waits_on:
+            return f"{escape(r.name)} ({pid}) \\[active]"
+
+        names = ", ".join(records[w].name if w in records else f"pid {w}" for w in r.waits_on)
+        return f"{escape(r.name)} ({pid}) \\[waiting on {escape(names)}]"
+
+    def _walk(pid: int, parent: Tree, path: list[int], visited: set[int]) -> list[int] | None:
+        if pid in visited:
+            return path[path.index(pid) :] + [pid]
+
+        path.append(pid)
+        visited.add(pid)
+        node = parent.add(_label(pid))
+        try:
+            for child in waiters_of.get(pid, []):
+                cycle = _walk(child, node, path, visited)
+                if cycle is not None:
+                    return cycle
+            return None
+        finally:
+            path.pop()
+            visited.remove(pid)
+
+    registry = AgentRegistry()
+    records = {r.pid: r for r in registry.list()}
+    if not records:
+        console.print(f"[{DIM}]no registered agents[/]")
+        return True
+
+    waiters_of: dict[int, list[int]] = defaultdict(list)
+    for record in records.values():
+        for on_pid in record.waits_on:
+            waiters_of[on_pid].append(record.pid)
+
+    # Roots are pids that wait on nothing. If every pid waits on
+    # something the graph is fully covered by a cycle — fall back to
+    # all pids so the walker enters somewhere and surfaces the back
+    # edge instead of silently exiting on an empty root list.
+    roots = [pid for pid, r in records.items() if not r.waits_on] or list(records)
+
+    tree = Tree(label="")
+    for root in roots:
+        cycle = _walk(root, tree, [], set())
+        if cycle is not None:
+            chain = " -> ".join(f"{records[p].name} ({p})" for p in cycle)
+            console.print(f"[{WARNING}]: agent dependency cycle detected: {escape(chain)}.[/]")
+            return True
+
+    console.print(tree)
+    return True
+
+
 def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool:
     if not args:
         return _cmd_agents_list(console)
@@ -544,12 +663,19 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
     if sub == "trace":
         return _cmd_agents_trace(session, console, args[1:])
 
+    if sub == "wait":
+        return _cmd_agents_wait(session, console, args[1:])
+
+    if sub == "graph":
+        return _cmd_agents_graph(console)
+
     console.print(
         f"[{ERROR}]unknown subcommand:[/] {escape(sub)}  "
         "(try [bold]/agents[/bold], [bold]/agents budget[/bold], "
         "[bold]/agents bus[/bold], [bold]/agents claim[/bold], "
         "[bold]/agents conflicts[/bold], [bold]/agents kill[/bold], "
-        "[bold]/agents release[/bold], or [bold]/agents trace[/bold])"
+        "[bold]/agents release[/bold], [bold]/agents trace[/bold], "
+        "[bold]/agents wait[/bold] or [bold]/agents graph[/bold])"
     )
     session.mark_latest(ok=False, kind="slash")
     return True
@@ -559,7 +685,7 @@ COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/agents",
         "show registered local AI agents (subcommands: budget, bus, claim, conflicts, kill, "
-        "release, trace)",
+        "release, trace, wait, graph)",
         _cmd_agents,
         first_arg_completions=_AGENTS_FIRST_ARGS,
     ),

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -626,19 +626,22 @@ def _cmd_agents_graph(console: Console) -> bool:
     roots = [pid for pid, r in records.items() if not r.waits_on] or list(records)
 
     trees: list[Tree] = []
+    chain: str | None = None
     for root in roots:
         tree = Tree(label=_label(root))
         cycle = _walk(root, tree, [root], {root})
         if cycle is not None:
             chain = " -> ".join(f"{records[p].name} ({p})" for p in cycle)
-            console.print(f"[{WARNING}]: agent dependency cycle detected: {escape(chain)}.[/]")
-            return True
+            break
         trees.append(tree)
 
     for i, tree in enumerate(trees):
         console.print(tree)
-        if i != len(trees) - 1:
+        if i != len(trees) - 1 and chain is None:
             console.line()
+
+    if chain is not None:
+        console.print(f"[{WARNING}]: agent dependency cycle detected: {escape(chain)}.[/]")
     return True
 
 

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -584,30 +584,29 @@ def _cmd_agents_graph(console: Console) -> bool:
     in the loop is emitted instead.
     """
 
-    def _label(pid: int) -> str:
+    def _label(pid: int, ppid: int | None = None) -> str:
         r = records[pid]
-        if not r.waits_on:
+        if ppid is None:
             return f"{escape(r.name)} ({pid}) \\[active]"
 
-        names = ", ".join(records[w].name if w in records else f"pid {w}" for w in r.waits_on)
-        return f"{escape(r.name)} ({pid}) \\[waiting on {escape(names)}]"
+        pr = records[ppid]
+        return f"{escape(r.name)} ({pid}) \\[waiting on {escape(pr.name)}]"
 
     def _walk(pid: int, parent: Tree, path: list[int], visited: set[int]) -> list[int] | None:
-        if pid in visited:
-            return path[path.index(pid) :] + [pid]
+        for child in waiters_of.get(pid, []):
+            if child in visited:
+                return path[path.index(child) :] + [child]
 
-        path.append(pid)
-        visited.add(pid)
-        node = parent.add(_label(pid))
-        try:
-            for child in waiters_of.get(pid, []):
-                cycle = _walk(child, node, path, visited)
-                if cycle is not None:
-                    return cycle
-            return None
-        finally:
+            path.append(child)
+            visited.add(child)
+            node = parent.add(_label(child, pid))
+            c = _walk(child, node, path, visited)
+            if c is not None:
+                return c
+
             path.pop()
-            visited.remove(pid)
+            visited.remove(child)
+        return None
 
     registry = AgentRegistry()
     records = {r.pid: r for r in registry.list()}
@@ -626,15 +625,20 @@ def _cmd_agents_graph(console: Console) -> bool:
     # edge instead of silently exiting on an empty root list.
     roots = [pid for pid, r in records.items() if not r.waits_on] or list(records)
 
-    tree = Tree(label="")
+    trees: list[Tree] = []
     for root in roots:
-        cycle = _walk(root, tree, [], set())
+        tree = Tree(label=_label(root))
+        cycle = _walk(root, tree, [root], {root})
         if cycle is not None:
             chain = " -> ".join(f"{records[p].name} ({p})" for p in cycle)
             console.print(f"[{WARNING}]: agent dependency cycle detected: {escape(chain)}.[/]")
             return True
+        trees.append(tree)
 
-    console.print(tree)
+    for i, tree in enumerate(trees):
+        console.print(tree)
+        if i != len(trees) - 1:
+            console.line()
     return True
 
 

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -162,3 +162,55 @@ class TestAgentRegistry:
         parsed = json.loads(lines[0])
         assert parsed["name"] == "claude-code"
         assert parsed["pid"] == 8421
+
+    def test_forget_scrubs_stale_waits_on(self, registry: AgentRegistry) -> None:
+        target = AgentRecord(name="claude-code", pid=8421, command="claude")
+        waiter = AgentRecord(name="aider", pid=7702, command="aider", waits_on=(8421,))
+        registry.register(target)
+        registry.register(waiter)
+
+        registry.forget(8421)
+
+        remaining = registry.get(7702)
+        assert remaining is not None
+        assert remaining.waits_on == ()
+
+    def test_forget_preserves_other_waits_on_entries(self, registry: AgentRegistry) -> None:
+        a = AgentRecord(name="a", pid=1001, command="a")
+        b = AgentRecord(name="b", pid=1002, command="b")
+        waiter = AgentRecord(name="c", pid=2001, command="c", waits_on=(1001, 1002))
+        registry.register(a)
+        registry.register(b)
+        registry.register(waiter)
+
+        registry.forget(1001)
+
+        remaining = registry.get(2001)
+        assert remaining is not None
+        assert remaining.waits_on == (1002,)
+
+    def test_forget_many_scrubs_stale_waits_on(self, registry: AgentRegistry) -> None:
+        dep1 = AgentRecord(name="a", pid=1001, command="a")
+        dep2 = AgentRecord(name="b", pid=1002, command="b")
+        waiter = AgentRecord(name="c", pid=2001, command="c", waits_on=(1001, 1002))
+        registry.register(dep1)
+        registry.register(dep2)
+        registry.register(waiter)
+
+        registry.forget_many([1001, 1002])
+
+        remaining = registry.get(2001)
+        assert remaining is not None
+        assert remaining.waits_on == ()
+
+    def test_forget_scrub_persists_to_disk(self, tmp_path: Path) -> None:
+        path = tmp_path / "agents.jsonl"
+        reg1 = AgentRegistry(path=path)
+        reg1.register(AgentRecord(name="dep", pid=8421, command="claude"))
+        reg1.register(AgentRecord(name="waiter", pid=7702, command="aider", waits_on=(8421,)))
+        reg1.forget(8421)
+
+        reg2 = AgentRegistry(path=path)
+        rehydrated = reg2.get(7702)
+        assert rehydrated is not None
+        assert rehydrated.waits_on == ()

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -674,7 +674,7 @@ class TestAgentsWait:
 
         reloaded = AgentRegistry(path=registry_path).get(7702)
         assert reloaded is not None
-        assert reloaded.waits_on == [8421]
+        assert reloaded.waits_on == (8421,)
 
     def test_repeated_wait_is_idempotent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -694,7 +694,7 @@ class TestAgentsWait:
 
         reloaded = AgentRegistry(path=registry_path).get(7702)
         assert reloaded is not None
-        assert reloaded.waits_on == [8421]
+        assert reloaded.waits_on == (8421,)
 
 
 class TestAgentsGraph:
@@ -716,9 +716,9 @@ class TestAgentsGraph:
         #       └── cursor-tab (9133) [waiting on aider]
         registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
         registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
-        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421]))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=(8421,)))
         registry.register(
-            AgentRecord(name="cursor-tab", pid=9133, command="cursor", waits_on=[7702])
+            AgentRecord(name="cursor-tab", pid=9133, command="cursor", waits_on=(7702,))
         )
 
         session = ReplSession()
@@ -736,8 +736,8 @@ class TestAgentsGraph:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
-        registry.register(AgentRecord(name="alpha", pid=1, command="a", waits_on=[2]))
-        registry.register(AgentRecord(name="beta", pid=2, command="b", waits_on=[1]))
+        registry.register(AgentRecord(name="alpha", pid=1, command="a", waits_on=(2,)))
+        registry.register(AgentRecord(name="beta", pid=2, command="b", waits_on=(1,)))
 
         session = ReplSession()
         console, buf = _capture()
@@ -754,9 +754,9 @@ class TestAgentsGraph:
     ) -> None:
         registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
         registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
-        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421]))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=(8421,)))
         registry.register(AgentRecord(name="cursor-tab", pid=9133, command="cursor"))
-        registry.register(AgentRecord(name="aider", pid=8491, command="aider", waits_on=[9133]))
+        registry.register(AgentRecord(name="aider", pid=8491, command="aider", waits_on=(9133,)))
 
         session = ReplSession()
         console, buf = _capture()
@@ -772,12 +772,12 @@ class TestAgentsGraph:
     ) -> None:
         registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
         registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
-        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421]))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=(8421,)))
         registry.register(
-            AgentRecord(name="cursor-tab", pid=9133, command="cursor", waits_on=[8421])
+            AgentRecord(name="cursor-tab", pid=9133, command="cursor", waits_on=(8421,))
         )
         registry.register(
-            AgentRecord(name="aider", pid=8491, command="aider", waits_on=[9133, 7702])
+            AgentRecord(name="aider", pid=8491, command="aider", waits_on=(9133, 7702))
         )
         session = ReplSession()
         console, buf = _capture()
@@ -794,12 +794,12 @@ class TestAgentsGraph:
         registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
         registry.register(AgentRecord(name="cursor-tab", pid=9133, command="cursor"))
         registry.register(
-            AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421, 9133])
+            AgentRecord(name="aider", pid=7702, command="aider", waits_on=(8421, 9133))
         )
         registry.register(
-            AgentRecord(name="cursor-tab", pid=9134, command="cursor", waits_on=[9133, 8421])
+            AgentRecord(name="cursor-tab", pid=9134, command="cursor", waits_on=(9133, 8421))
         )
-        registry.register(AgentRecord(name="aider", pid=8491, command="aider", waits_on=[9134]))
+        registry.register(AgentRecord(name="aider", pid=8491, command="aider", waits_on=(9134,)))
         session = ReplSession()
         console, buf = _capture()
         assert dispatch_slash("/agents graph", session, console) is True

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -732,9 +732,7 @@ class TestAgentsGraph:
         assert "aider (7702) [waiting on claude-code]" in out
         assert "cursor-tab (9133) [waiting on aider]" in out.lower()
 
-    def test_cycle_skips_tree_and_prints_warning(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_cycle_prints_warning(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
         registry.register(AgentRecord(name="alpha", pid=1, command="a", waits_on=(2,)))
         registry.register(AgentRecord(name="beta", pid=2, command="b", waits_on=(1,)))

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -71,6 +71,12 @@ class TestAgentsRegistration:
         keywords = [pair[0] for pair in cmd.first_arg_completions]
         assert "trace" in keywords
 
+    def test_agents_first_arg_completions_include_wait_and_graph(self) -> None:
+        cmd = SLASH_COMMANDS["/agents"]
+        keywords = [pair[0] for pair in cmd.first_arg_completions]
+        assert "wait" in keywords
+        assert "graph" in keywords
+
     def test_default_window_constant_is_ten_seconds(self) -> None:
         assert DEFAULT_WINDOW_SECONDS == 10.0
 
@@ -604,3 +610,201 @@ class TestAgentsTrace:
         out = buf.getvalue()
         assert "process exited" not in out
         assert "trace ended" in out
+
+
+class TestAgentsWait:
+    def test_usage_when_missing_on_flag(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait 1234 5678", session, console) is True
+        assert "usage:" in buf.getvalue().lower()
+
+    def test_rejects_non_numeric_pid(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait abc --on 5678", session, console) is True
+        assert "invalid pid" in buf.getvalue().lower()
+
+    def test_rejects_non_numeric_on_pid(self) -> None:
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait 1234 --on xyz", session, console) is True
+        assert "invalid other-pid" in buf.getvalue().lower()
+
+    def test_rejects_self_wait(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait 1234 --on 1234", session, console) is True
+        assert "waiting for itself" in buf.getvalue()
+
+    def test_rejects_unknown_waiter(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait 9999 --on 8421", session, console) is True
+        assert "pid 9999 is not in the agent registry" in buf.getvalue()
+
+    def test_rejects_unknown_target(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider"))
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait 7702 --on 9999", session, console) is True
+        assert "pid 9999 is not in the agent registry" in buf.getvalue()
+
+    def test_happy_path_persists_dependency(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End-to-end: wait announces the edge in output AND survives a
+        # fresh AgentRegistry load (i.e. the rewrite step actually fired).
+        registry_path = tmp_path / "agents.jsonl"
+        registry = _isolate_registry(monkeypatch, registry_path)
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider"))
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents wait 7702 --on 8421", session, console) is True
+        out = buf.getvalue()
+        assert "aider" in out
+        assert "claude-code" in out
+        assert "now waits on" in out
+
+        reloaded = AgentRegistry(path=registry_path).get(7702)
+        assert reloaded is not None
+        assert reloaded.waits_on == [8421]
+
+    def test_repeated_wait_is_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Two wait calls with the same pair must not produce [8421, 8421].
+        # Guards against a regression where `add_waits_on`'s membership
+        # check is removed and duplicates leak into the JSONL.
+        registry_path = tmp_path / "agents.jsonl"
+        registry = _isolate_registry(monkeypatch, registry_path)
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider"))
+
+        session = ReplSession()
+        for _ in range(2):
+            console, _ = _capture()
+            assert dispatch_slash("/agents wait 7702 --on 8421", session, console) is True
+
+        reloaded = AgentRegistry(path=registry_path).get(7702)
+        assert reloaded is not None
+        assert reloaded.waits_on == [8421]
+
+
+class TestAgentsGraph:
+    def test_empty_registry_renders_empty_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents graph", session, console) is True
+        assert "no registered agents" in buf.getvalue()
+
+    def test_acyclic_chain_renders_all_agents(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The issue's example tree:
+        #   claude-code (8421) [active]
+        #   └── aider (7702) [waiting on claude-code]
+        #       └── cursor-tab (9133) [waiting on aider]
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421]))
+        registry.register(
+            AgentRecord(name="cursor-tab", pid=9133, command="cursor", waits_on=[7702])
+        )
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents graph", session, console) is True
+        out = buf.getvalue()
+        assert "claude-code" in out
+        assert "aider" in out
+        assert "cursor-tab" in out
+        assert "claude-code (8421) [active]" in out
+        assert "aider (7702) [waiting on claude-code]" in out
+        assert "cursor-tab (9133) [waiting on aider]" in out.lower()
+
+    def test_cycle_skips_tree_and_prints_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="alpha", pid=1, command="a", waits_on=[2]))
+        registry.register(AgentRecord(name="beta", pid=2, command="b", waits_on=[1]))
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents graph", session, console) is True
+        out = buf.getvalue()
+
+        assert "agent dependency cycle detected" in out
+        assert "alpha" in out
+        assert "beta" in out
+        assert "alpha (1) -> beta (2) -> alpha (1)" in out
+
+    def test_acyclic_chain_multiple_roots(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421]))
+        registry.register(AgentRecord(name="cursor-tab", pid=9133, command="cursor"))
+        registry.register(AgentRecord(name="aider", pid=8491, command="aider", waits_on=[9133]))
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents graph", session, console) is True
+        out = buf.getvalue()
+        assert "cursor-tab (9133) [active]" in out
+        assert "claude-code (8421) [active]" in out
+        assert "aider (7702) [waiting on claude-code]" in out
+        assert "aider (8491) [waiting on cursor-tab]" in out
+
+    def test_acyclic_chain_multiple_blockers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421]))
+        registry.register(
+            AgentRecord(name="cursor-tab", pid=9133, command="cursor", waits_on=[8421])
+        )
+        registry.register(
+            AgentRecord(name="aider", pid=8491, command="aider", waits_on=[9133, 7702])
+        )
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents graph", session, console) is True
+        out = buf.getvalue()
+        assert "claude-code (8421) [active]" in out
+        assert "aider (8491) [waiting on aider]" in out
+        assert "aider (8491) [waiting on cursor-tab]" in out
+
+    def test_acyclic_chain_multiple_roots_blockers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = _isolate_registry(monkeypatch, tmp_path / "agents.jsonl")
+        registry.register(AgentRecord(name="claude-code", pid=8421, command="claude"))
+        registry.register(AgentRecord(name="cursor-tab", pid=9133, command="cursor"))
+        registry.register(
+            AgentRecord(name="aider", pid=7702, command="aider", waits_on=[8421, 9133])
+        )
+        registry.register(
+            AgentRecord(name="cursor-tab", pid=9134, command="cursor", waits_on=[9133, 8421])
+        )
+        registry.register(AgentRecord(name="aider", pid=8491, command="aider", waits_on=[9134]))
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents graph", session, console) is True
+        out = buf.getvalue()
+        assert "claude-code (8421) [active]" in out
+        assert "cursor-tab (9133) [active]" in out
+        assert "cursor-tab (9134) [waiting on claude-code]" in out
+        assert "cursor-tab (9134) [waiting on cursor-tab]" in out


### PR DESCRIPTION
Fixes #1504 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
Adds two new subcommands to `/agents` for tracking and visualizing wait-on dependencies between local AI agents:
- `/agents wait <pid> --on <other-pid>` — records that <pid> is blocked on <other-pid>.
- `/agents graph` — renders the dependency graph as a Rich tree. 


### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

---
<img width="1581" height="1152" alt="Screenshot from 2026-05-11 17-50-19" src="https://github.com/user-attachments/assets/27fb9086-8c24-45de-94af-b6ecbe2ad391" />


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
- `/agents wait <pid> --on <other-pid>` 
  Persists to the JSONL registry via a new AgentRecord.waits_on: list[int] field and add an immutable `add_waits_on(...)` helper that returns a new record. Unknown pids are rejected with explicit error messages.

- `/agents graph` 
  Roots (agents with no waits_on) are labelled [active]; descendants annotate the agent they're waiting on. The walker does a child-centric DFS over the inverse-edge graph (depended-on -> waiter) and detects back-edges as cycles; Trees are buffered and only flushed once every root completes cycle-free. For better visibility, each tree is separated by a new line.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
