### PR TITLE
fix(llm): handle embedded code fences in _extract_json_payload

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -929,6 +929,15 @@ def _extract_json_payload(text: str) -> Any:
         cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
         cleaned = re.sub(r"\s*```$", "", cleaned)
         cleaned = cleaned.strip()
+    else:
+        # LLM may prefix the code block with prose ("Here is the JSON:")
+        fence_match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
+        if fence_match:
+            candidate = fence_match.group(1).strip()
+            try:
+                return _safe_json_loads(candidate)
+            except json.JSONDecodeError:
+                pass
 
     try:
         return _safe_json_loads(cleaned)

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1822,10 +1822,7 @@ def test_extract_json_payload_embedded_fence_with_preamble() -> None:
 
 def test_extract_json_payload_embedded_fence_trailing_braces_in_prose() -> None:
     """Greedy regex would over-capture {key} in trailing prose; fence path must win."""
-    text = (
-        "Sure!\n\n```json\n{\"key\": \"value\"}\n```\n\n"
-        "The {key} field represents the identifier."
-    )
+    text = 'Sure!\n\n```json\n{"key": "value"}\n```\n\nThe {key} field represents the identifier.'
     assert llm_client._extract_json_payload(text) == {"key": "value"}
 
 

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1798,3 +1798,37 @@ def test_format_openai_connection_error_non_ssl_returns_generic_message() -> Non
     assert "SSL" not in msg
     assert "network connection" in msg
     assert "NVIDIA" in msg
+
+
+# ---------------------------------------------------------------------------
+# _extract_json_payload — embedded code-fence handling (Sentry #1861)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_json_payload_bare_json() -> None:
+    assert llm_client._extract_json_payload('{"a": 1}') == {"a": 1}
+
+
+def test_extract_json_payload_leading_fence() -> None:
+    text = '```json\n{"a": 1}\n```'
+    assert llm_client._extract_json_payload(text) == {"a": 1}
+
+
+def test_extract_json_payload_embedded_fence_with_preamble() -> None:
+    """LLM returns prose before the code block — Sentry #1861 root cause."""
+    text = 'Here is the JSON:\n\n```json\n{"location": "node.py"}\n```'
+    assert llm_client._extract_json_payload(text) == {"location": "node.py"}
+
+
+def test_extract_json_payload_embedded_fence_trailing_braces_in_prose() -> None:
+    """Greedy regex would over-capture {key} in trailing prose; fence path must win."""
+    text = (
+        "Sure!\n\n```json\n{\"key\": \"value\"}\n```\n\n"
+        "The {key} field represents the identifier."
+    )
+    assert llm_client._extract_json_payload(text) == {"key": "value"}
+
+
+def test_extract_json_payload_raises_when_no_json() -> None:
+    with pytest.raises(ValueError, match="LLM did not return valid JSON payload"):
+        llm_client._extract_json_payload("This is plain text with no JSON.")


### PR DESCRIPTION
## Summary

- **Root cause:** `_extract_json_payload` only stripped code fences when the LLM response started with ` ``` `. When an LLM prepends prose (e.g. _"Here is the JSON:"_) before the code block, the fence-stripping branch was skipped. The fallback greedy regex `\{.*\}` (DOTALL) then over-captured when explanatory trailing text contained `{...}` patterns, producing an unparseable string and raising `ValueError`.
- **Fix:** Added an `else` branch that searches for a ` ``` ` fence _anywhere_ in the response and parses its contents before falling through to the existing regex paths. No change to the existing leading-fence or regex paths.
- 5 focused regression tests covering: bare JSON, leading fence, embedded-fence-with-preamble (the exact failure mode), the greedy-regex trap case, and the plain-no-JSON error path.

Closes #1861

## Test plan

- [x] `uv run python -c "from app.services import llm_client; ..."` — all 5 new cases pass locally
- [x] New tests added to `tests/services/test_llm_client.py`
- [ ] CI green on this PR

https://claude.ai/code/session_01K1gPyjXgsNhvdFhmaJKCng

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1gPyjXgsNhvdFhmaJKCng)_