### PR TITLE
fix(sentry): filter provider API connectivity errors from Sentry reports

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -57,6 +57,8 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Relay/proxy forwarding an invalid model group to Anthropic.
     re.compile(r"\bprovided model identifier is invalid\b", re.I),
     re.compile(r"\bLLM API request failed after multiple retries\b", re.I),
+    # Provider endpoint unreachable (Ollama down, bad URL, SSL misconfiguration).
+    re.compile(r"\bcannot connect to .+ api\b", re.I),
 )
 
 

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -655,6 +655,18 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "RuntimeError",
             "LLM API request failed after multiple retries. Try again in a few seconds.",
         ),
+        (
+            "RuntimeError",
+            "Cannot connect to Ollama API. Check your network connection and that the endpoint URL is reachable.",
+        ),
+        (
+            "RuntimeError",
+            "Cannot connect to Ollama API (SSL/TLS error). Verify the endpoint URL uses HTTPS and that no proxy is stripping TLS.",
+        ),
+        (
+            "RuntimeError",
+            "Cannot connect to Openrouter API. Check your network connection and that the endpoint URL is reachable.",
+        ),
     ],
 )
 def test_before_send_drops_operator_actionable_llm_errors(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS` in `app/utils/sentry_sdk.py` was missing a pattern for provider endpoint connectivity failures (connection refused, read timeout, SSL errors).
- Ollama-down errors (`Cannot connect to Ollama API. Check your network connection…`) were reaching Sentry as high-priority bugs instead of being silently dropped as operator-actionable configuration issues.
- The existing filter already covered auth failures, rate limits, model-not-found, and relay model-identifier errors — this patch closes the gap for the connection class.

**Root cause (stack traces from Sentry issues):**
```
ConnectError: [Errno 111] Connection refused
→ APIConnectionError: Connection error.
→ RuntimeError: Cannot connect to Ollama API. Check your network connection and that the endpoint URL is reachable.
```

**Fix:** add `re.compile(r"\bcannot connect to .+ api\b", re.I)` — covers Ollama, OpenRouter, OpenAI, and any other OpenAI-compatible provider going through `_format_openai_connection_error`.

Closes #1839, #1840, #1821, #1822

## Test plan

- [x] 3 new parametrised cases added to `test_before_send_drops_operator_actionable_llm_errors` covering connection-refused, SSL/TLS, and non-Ollama provider variants
- [x] All 54 tests in `tests/test_sentry_init.py` pass
- [x] `ruff check` and `ruff format --check` pass on changed files

https://claude.ai/code/session_015hGzzxZzTWGAmg2UmT1psu
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015hGzzxZzTWGAmg2UmT1psu)_