### PR TITLE
fix(llm_client): retry OpenAI APITimeoutError instead of raising immediately

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -711,7 +711,6 @@ class OpenAILLMClient:
             except GuardrailBlockedError:
                 raise
             except OpenAITimeoutError as err:
-                last_err = err
                 if attempt == max_attempts - 1:
                     raise RuntimeError(
                         _format_openai_connection_error(err, self._provider_label)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -710,6 +710,14 @@ class OpenAILLMClient:
                 ) from err
             except GuardrailBlockedError:
                 raise
+            except OpenAITimeoutError as err:
+                last_err = err
+                if attempt == max_attempts - 1:
+                    raise RuntimeError(
+                        _format_openai_connection_error(err, self._provider_label)
+                    ) from err
+                time.sleep(backoff_seconds)
+                backoff_seconds *= 2
             except OpenAIConnectionError as err:
                 raise RuntimeError(
                     _format_openai_connection_error(err, self._provider_label)
@@ -794,6 +802,15 @@ class OpenAILLMClient:
                 ) from err
             except GuardrailBlockedError:
                 raise
+            except OpenAITimeoutError as err:
+                if emitted:
+                    raise
+                if attempt == max_attempts - 1:
+                    raise RuntimeError(
+                        _format_openai_connection_error(err, self._provider_label)
+                    ) from err
+                time.sleep(backoff_seconds)
+                backoff_seconds *= 2
             except OpenAIConnectionError as err:
                 if emitted:
                     raise

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1458,6 +1458,186 @@ def test_openai_invoke_stream_rate_limit_insufficient_quota_after_emit_is_wrappe
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# OpenAILLMClient – APITimeoutError retry handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeTimeoutError(llm_client.OpenAITimeoutError):
+    """Minimal stand-in for openai.APITimeoutError."""
+
+    def __init__(self) -> None:
+        super().__init__(request=None)  # type: ignore[arg-type]
+
+
+def test_openai_invoke_timeout_retries_and_succeeds(monkeypatch) -> None:
+    """APITimeoutError on the first attempt must be retried; success on the second."""
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.message = type("_Msg", (), {"content": content})()
+
+    class _Response:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **_kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise _FakeTimeoutError()
+            return _Response("ok")
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    result = client.invoke("hi")
+
+    assert result.content == "ok"
+    assert len(attempts) == 2
+    assert len(sleeps) == 1
+
+
+def test_openai_invoke_timeout_raises_timeout_message_after_exhaustion(monkeypatch) -> None:
+    """After all retries on APITimeoutError, raise a RuntimeError with a timeout message."""
+    sleeps: list[float] = []
+
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _FakeTimeoutError()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    with pytest.raises(RuntimeError) as exc_info:
+        client.invoke("hi")
+
+    msg = str(exc_info.value).lower()
+    assert "timed out" in msg or "timeout" in msg
+    assert "network connection" not in msg
+    assert len(sleeps) == llm_client._RETRY_MAX_ATTEMPTS - 1
+
+
+def test_openai_invoke_stream_timeout_retries_before_emit(monkeypatch) -> None:
+    """APITimeoutError before any chunk is emitted should be retried."""
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    class _Delta:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.delta = _Delta(content)
+
+    class _Chunk:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **_kwargs):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise _FakeTimeoutError()
+
+            def _stream():
+                yield _Chunk("hello")
+
+            return _stream()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    chunks = list(client.invoke_stream("hi"))
+
+    assert chunks == ["hello"]
+    assert len(attempts) == 2
+    assert len(sleeps) == 1
+
+
+def test_openai_invoke_stream_timeout_does_not_retry_after_emit(monkeypatch) -> None:
+    """APITimeoutError mid-stream (after a chunk was emitted) must not be retried."""
+    call_count = 0
+    sleeps: list[float] = []
+
+    class _Delta:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.delta = _Delta(content)
+
+    class _Chunk:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            def _stream():
+                yield _Chunk("partial")
+                raise _FakeTimeoutError()
+
+            return _stream()
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    client = llm_client.OpenAILLMClient(model="gpt-4", api_key_env="OPENAI_API_KEY")
+    stream = client.invoke_stream("hi")
+    assert next(stream) == "partial"
+    with pytest.raises(llm_client.OpenAITimeoutError):
+        next(stream)
+
+    assert call_count == 1, "mid-stream timeout must not be retried"
+    assert sleeps == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # BedrockLLMClient – non-transient error handling
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `APITimeoutError` is a subclass of `APIConnectionError` in the OpenAI SDK, so it was silently caught by the `except OpenAIConnectionError` handler in both `invoke()` and `invoke_stream()` and raised immediately as a `RuntimeError` — no retry, misleading "Check your network connection" message.
- Added an explicit `except OpenAITimeoutError` clause **before** `except OpenAIConnectionError` in both methods so transient timeouts get the same backoff-retry treatment as rate-limit errors.
- After all retries are exhausted the timeout-specific message from `_format_openai_connection_error` is surfaced instead of the generic connection error message.

## Test plan

- [ ] `test_openai_invoke_timeout_retries_and_succeeds` — first attempt times out, second succeeds
- [ ] `test_openai_invoke_timeout_raises_timeout_message_after_exhaustion` — all attempts time out → RuntimeError with "timed out" message (not "network connection")
- [ ] `test_openai_invoke_stream_timeout_retries_before_emit` — timeout before first chunk is retried
- [ ] `test_openai_invoke_stream_timeout_does_not_retry_after_emit` — timeout after a chunk has been emitted propagates immediately (no duplicate output)
- [ ] Full test suite: `make test-cov` → 6828 passed, 0 failures
- [ ] `make lint && make format-check && make typecheck` → all green

Closes #1864

https://claude.ai/code/session_01MJvuM7s5vt6eZrSCEZhzqe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJvuM7s5vt6eZrSCEZhzqe)_