### PR TITLE
test: skip POSIX-specific tail tests on Windows to fix CI failures

### DIFF
--- a/tests/agents/test_tail.py
+++ b/tests/agents/test_tail.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 import os
 import queue
+import sys
 import threading
 import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import sys
 
 from app.agents import tail as tail_mod
 from app.agents.tail import (

--- a/tests/agents/test_tail.py
+++ b/tests/agents/test_tail.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import sys
 
 from app.agents import tail as tail_mod
 from app.agents.tail import (
@@ -161,6 +162,7 @@ class TestParseLsofFd1:
 
 
 class TestResolveLinuxTarget:
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows uses backslashes, not POSIX paths")
     def test_regular_file_target(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         log = tmp_path / "out.log"
         log.write_text("")
@@ -215,6 +217,7 @@ class TestResolveLinuxTarget:
         with pytest.raises(AttachUnsupported, match="no such pid"):
             _resolve_linux_target(123)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows uses backslashes, not POSIX paths")
     def test_target_is_directory_rejected(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -409,6 +412,7 @@ class TestAttachSession:
             assert b"hello" in sess.buffer.snapshot()
         assert not sess._thread.is_alive()  # noqa: SLF001 (test inspecting lifecycle)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows locks open files and prevents renaming")
     def test_reader_follows_inode_through_rename(self, tmp_path: Path) -> None:
         # logrotate-style: the path is renamed away after attach, but the
         # producer keeps writing to the original inode. The reader holds

--- a/tests/agents/test_tail.py
+++ b/tests/agents/test_tail.py
@@ -412,7 +412,9 @@ class TestAttachSession:
             assert b"hello" in sess.buffer.snapshot()
         assert not sess._thread.is_alive()  # noqa: SLF001 (test inspecting lifecycle)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Windows locks open files and prevents renaming")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Windows locks open files and prevents renaming"
+    )
     def test_reader_follows_inode_through_rename(self, tmp_path: Path) -> None:
         # logrotate-style: the path is renamed away after attach, but the
         # producer keeps writing to the original inode. The reader holds


### PR DESCRIPTION
Fixes #1852 

#### Describe the changes you have made in this PR -
Added `@pytest.mark.skipif` decorators to skip POSIX-specific tail tests when running on Windows. This prevents `AttachUnsupported` (path parsing) and `WinError 32` (file-locking) errors during Windows CI runs, satisfying the host-neutral requirement mentioned in the issue.

### Demo/Screenshot for feature changes and bug fixes - 
```
======================================================= slowest 20 durations =======================================================
0.10s call     tests/agents/test_tail.py::TestAttachSession::test_does_not_replay_pre_attach_content
0.03s call     tests/agents/test_tail.py::TestAttachIntegration::test_attach_eagerly_opens_real_file
0.02s call     tests/agents/test_tail.py::TestAttachSession::test_reader_exits_when_pid_dies
0.02s call     tests/agents/test_tail.py::TestAttachSession::test_yields_chunks_written_after_attach
0.01s setup    tests/agents/test_tail.py::TestResolveMacosTarget::test_lsof_warnings_on_stderr_do_not_break_parse
0.01s setup    tests/agents/test_tail.py::TestResolveMacosTarget::test_regular_file
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_iteration_after_close_raises_stop_iteration
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_yields_chunks_written_after_attach
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_does_not_replay_pre_attach_content
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_close_is_idempotent
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_close_does_not_set_producer_exited
0.00s setup    tests/agents/test_tail.py::TestAttachIntegration::test_attach_eagerly_opens_real_file
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_reader_exits_when_pid_dies
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_publish_drops_oldest_when_queue_full
0.00s setup    tests/agents/test_tail.py::TestAttachSession::test_context_manager_closes_thread
0.00s call     tests/agents/test_tail.py::TestAttachSession::test_iteration_after_close_raises_stop_iteration
0.00s setup    tests/agents/test_tail.py::TestResolveMacosTarget::test_lsof_missing
0.00s call     tests/agents/test_tail.py::TestResolveMacosTarget::test_lsof_warnings_on_stderr_do_not_break_parse
0.00s call     tests/agents/test_tail.py::TestAttachSession::test_close_is_idempotent
0.00s call     tests/agents/test_tail.py::TestAttachSession::test_publish_drops_oldest_when_queue_full
================================================== 51 passed, 3 skipped in 0.42s ===================================================
```
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- Problem: test_tail.py assumes POSIX path formatting and Linux-style file renaming (which ignores file locks). This causes the test suite to crash on Windows.

- Approach: Rather than rewriting the core tail.py logic to handle Windows paths and lock files, I utilized `pytest.mark.skipif` to bypass the three specific Linux/macOS tests if `sys.platform == "win32"`.

- Why this implementation: It is the cleanest, least intrusive way to unblock Windows developers and fix the CI pipeline without risking regressions in the core POSIX tail logic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



**Note to Maintainers:** I went with the `@pytest.mark.skipif` method to quickly unblock the Windows CI pipeline. However, if you prefer to make app/agents/tail.py completely host-neutral so these tests can actually run on Windows, let me know! I am more than happy to rewrite the path-parsing and file-lock logic as a follow-up.
