### PR TITLE
Added Alert Inbox by exposing an endpoint for posting alerts into the memory

### DIFF
--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -48,10 +48,11 @@ class AlertInbox:
         return True
 
     def pop_nowait(self) -> IncomingAlert | None:
-        try:
-            return self._queue.popleft()
-        except IndexError:
-            return None
+        with self._lock:
+            try:
+                return self._queue.popleft()
+            except IndexError:
+                return None
 
     def iter_pending(self) -> list[IncomingAlert]:
         with self._lock:

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -169,10 +169,10 @@ def start_alert_listener(
                     self._respond(
                         503,
                         {
-                            "queued": False,
+                            "queued": True,
                             "queue_depth": inbox.qsize,
                             "dropped": inbox.dropped,
-                            "error": "inbox full, alert dropped",
+                            "warning": "inbox full, oldest alert dropped",
                         },
                     )
                 else:

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import threading
@@ -124,7 +125,7 @@ def start_alert_listener(
                 if token is None:
                     return True
                 auth = self.headers.get("Authorization", "")
-                if auth == f"Bearer {token}":
+                if hmac.compare_digest(auth, f"Bearer {token}"):
                     return True
                 self.send_response(401)
                 self.send_header("Content-Type", "application/json")

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -1,0 +1,222 @@
+"""In-process alert inbox — tiny HTTP receiver for external alert pushes."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from queue import Empty, SimpleQueue
+from threading import Thread
+from typing import Any
+from urllib.parse import urlparse
+
+from app.cli.support.errors import OpenSREError
+from app.strict_config import StrictConfigModel
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_MAX_INBOX = 256
+
+
+class IncomingAlert(StrictConfigModel):
+    text: str
+    alert_name: str | None = None
+    severity: str | None = None
+    source: str | None = None
+    received_at: datetime | None = None
+
+
+class AlertInbox:
+    def __init__(self, maxsize: int = _DEFAULT_MAX_INBOX) -> None:
+        self._queue: SimpleQueue[IncomingAlert] = SimpleQueue()
+        self._maxsize = maxsize
+        self._dropped: int = 0
+        self._lock = threading.Lock()
+
+    def put(self, alert: IncomingAlert) -> bool:
+        with self._lock:
+            if self._queue.qsize() >= self._maxsize:
+                self._queue.get_nowait()
+                self._dropped += 1
+            self._queue.put_nowait(alert)
+        return True
+
+    def pop_nowait(self) -> IncomingAlert | None:
+        try:
+            return self._queue.get_nowait()
+        except Empty:
+            return None
+
+    def iter_pending(self) -> list[IncomingAlert]:
+        with self._lock:
+            items: list[IncomingAlert] = []
+            while True:
+                try:
+                    items.append(self._queue.get_nowait())
+                except Empty:
+                    break
+            return items
+
+    @property
+    def qsize(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def dropped(self) -> int:
+        return self._dropped
+
+
+@dataclass
+class AlertListenerHandle:
+    server: HTTPServer
+    thread: Thread
+    _inbox: AlertInbox
+    _bound_host: str = ""
+    _bound_port: int = 0
+
+    def stop(self) -> None:
+        if not getattr(self, "_stopped", False):
+            self.server.shutdown()
+            self.server.server_close()
+            self.thread.join(timeout=5)
+            self._stopped = True
+
+    @property
+    def bound_address(self) -> str:
+        return f"{self._bound_host}:{self._bound_port}"
+
+    @property
+    def inbox(self) -> AlertInbox:
+        return self._inbox
+
+
+def start_alert_listener(
+    inbox: AlertInbox,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    token: str | None = None,
+) -> AlertListenerHandle:
+    if host != "127.0.0.1" and token is None:
+        raise OpenSREError(
+            "Refusing to bind alert listener to non-loopback address without a token.",
+            suggestion="Set OPENSRE_ALERT_LISTENER_TOKEN or use 127.0.0.1.",
+        )
+
+    def _make_handler(token: str | None) -> type[BaseHTTPRequestHandler]:
+        class _AlertHandler(BaseHTTPRequestHandler):
+            def log_message(self, fmt: str, *args: Any) -> None:
+                log.debug(fmt, *args)
+
+            def _check_auth(self) -> bool:
+                if token is None:
+                    return True
+                auth = self.headers.get("Authorization", "")
+                if auth == f"Bearer {token}":
+                    return True
+                self.send_response(401)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "unauthorized"}).encode())
+                return False
+
+            def do_GET(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path == "/healthz":
+                    self._respond(200, {"status": "ok"})
+                else:
+                    self._respond(404, {"error": "not found"})
+
+            def do_POST(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path != "/alerts":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                if not self._check_auth():
+                    return
+                length = int(self.headers.get("Content-Length", 0))
+                raw = self.rfile.read(length)
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    self._respond(400, {"error": "invalid json"})
+                    return
+                try:
+                    if "received_at" not in data or data.get("received_at") is None:
+                        data["received_at"] = datetime.now(UTC)
+                    alert = IncomingAlert.model_validate(data)
+                except Exception as exc:
+                    self._respond(400, {"error": str(exc)})
+                    return
+
+                inbox.put(alert)
+
+                dropped = inbox.dropped
+                if dropped > 0:
+                    status = 503
+                    self._respond(
+                        status,
+                        {
+                            "queued": False,
+                            "queue_depth": inbox.qsize,
+                            "dropped": dropped,
+                            "error": "inbox full, alert dropped",
+                        },
+                    )
+                else:
+                    self._respond(
+                        202,
+                        {
+                            "queued": True,
+                            "queue_depth": inbox.qsize,
+                        },
+                    )
+
+            def _respond(self, code: int, body: dict[str, Any]) -> None:
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(body).encode())
+
+        return _AlertHandler
+
+    handler_cls = _make_handler(token)
+    server = HTTPServer((host, port), handler_cls)
+    addr = server.server_address
+    bound_host = str(addr[0])
+    bound_port = int(addr[1])
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return AlertListenerHandle(
+        server=server,
+        thread=thread,
+        _inbox=inbox,
+        _bound_host=bound_host,
+        _bound_port=bound_port,
+    )
+
+
+_current_inbox: AlertInbox | None = None
+
+
+def set_current_inbox(inbox: AlertInbox | None) -> None:
+    global _current_inbox
+    _current_inbox = inbox
+
+
+def get_current_inbox() -> AlertInbox | None:
+    return _current_inbox
+
+
+__all__ = [
+    "AlertInbox",
+    "AlertListenerHandle",
+    "IncomingAlert",
+    "get_current_inbox",
+    "set_current_inbox",
+    "start_alert_listener",
+]

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -37,10 +37,13 @@ class AlertInbox:
         self._lock = threading.Lock()
 
     def put(self, alert: IncomingAlert) -> bool:
+        """Return True if queued without eviction, False if an old alert was dropped."""
         with self._lock:
             if self._queue.qsize() >= self._maxsize:
                 self._queue.get_nowait()
                 self._dropped += 1
+                self._queue.put_nowait(alert)
+                return False
             self._queue.put_nowait(alert)
         return True
 

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -8,7 +8,7 @@ import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from queue import Empty, SimpleQueue
+from collections import deque
 from threading import Thread
 from typing import Any
 from urllib.parse import urlparse
@@ -31,7 +31,7 @@ class IncomingAlert(StrictConfigModel):
 
 class AlertInbox:
     def __init__(self, maxsize: int = _DEFAULT_MAX_INBOX) -> None:
-        self._queue: SimpleQueue[IncomingAlert] = SimpleQueue()
+        self._queue: deque[IncomingAlert] = deque()
         self._maxsize = maxsize
         self._dropped: int = 0
         self._lock = threading.Lock()
@@ -39,18 +39,18 @@ class AlertInbox:
     def put(self, alert: IncomingAlert) -> bool:
         """Return True if queued without eviction, False if an old alert was dropped."""
         with self._lock:
-            if self._queue.qsize() >= self._maxsize:
-                self._queue.get_nowait()
+            if len(self._queue) >= self._maxsize:
+                self._queue.popleft()
                 self._dropped += 1
-                self._queue.put_nowait(alert)
+                self._queue.append(alert)
                 return False
-            self._queue.put_nowait(alert)
+            self._queue.append(alert)
         return True
 
     def pop_nowait(self) -> IncomingAlert | None:
         try:
-            return self._queue.get_nowait()
-        except Empty:
+            return self._queue.popleft()
+        except IndexError:
             return None
 
     def iter_pending(self) -> list[IncomingAlert]:
@@ -58,14 +58,19 @@ class AlertInbox:
             items: list[IncomingAlert] = []
             while True:
                 try:
-                    items.append(self._queue.get_nowait())
-                except Empty:
+                    items.append(self._queue.popleft())
+                except IndexError:
                     break
             return items
 
+    def peek_last(self, n: int) -> list[IncomingAlert]:
+        with self._lock:
+            items = list(self._queue)
+            return items[-n:]
+
     @property
     def qsize(self) -> int:
-        return self._queue.qsize()
+        return len(self._queue)
 
     @property
     def dropped(self) -> int:

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -156,17 +156,15 @@ def start_alert_listener(
                     self._respond(400, {"error": str(exc)})
                     return
 
-                inbox.put(alert)
+                accepted = inbox.put(alert)
 
-                dropped = inbox.dropped
-                if dropped > 0:
-                    status = 503
+                if not accepted:
                     self._respond(
-                        status,
+                        503,
                         {
                             "queued": False,
                             "queue_depth": inbox.qsize,
-                            "dropped": dropped,
+                            "dropped": inbox.dropped,
                             "error": "inbox full, alert dropped",
                         },
                     )

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -167,7 +167,7 @@ def start_alert_listener(
 
                 if not accepted:
                     self._respond(
-                        503,
+                        202,
                         {
                             "queued": True,
                             "queue_depth": inbox.qsize,

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import json
 import logging
 import threading
+from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from collections import deque
 from threading import Thread
 from typing import Any
 from urllib.parse import urlparse

--- a/app/cli/interactive_shell/command_registry/__init__.py
+++ b/app/cli/interactive_shell/command_registry/__init__.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.command_registry.agents import COMMANDS as AGENTS_COMMANDS
+from app.cli.interactive_shell.command_registry.alerts import COMMANDS as ALERTS_COMMANDS
 from app.cli.interactive_shell.command_registry.cli_parity import (
     COMMANDS as PARITY_COMMANDS,
 )
@@ -52,6 +53,7 @@ _MERGED_SEQUENCE = tuple(
         TASK_COMMANDS,
         PRIVACY_COMMANDS,
         AGENTS_COMMANDS,
+        ALERTS_COMMANDS,
         PARITY_COMMANDS,
         SYSTEM_COMMANDS,
     )

--- a/app/cli/interactive_shell/command_registry/alerts.py
+++ b/app/cli/interactive_shell/command_registry/alerts.py
@@ -24,8 +24,7 @@ def _cmd_alerts(_session: ReplSession, console: Console, _args: list[str]) -> bo
     table.add_row("queue depth", str(inbox.qsize))
     table.add_row("dropped", str(inbox.dropped))
 
-    pending = inbox.iter_pending()
-    for alert in pending[-5:]:
+    for alert in inbox.peek_last(5):
         table.add_row(f"[{DIM}]recent[/]", f"{alert.alert_name or 'untitled'} — {alert.text[:80]}")
 
     console.print(table)

--- a/app/cli/interactive_shell/command_registry/alerts.py
+++ b/app/cli/interactive_shell/command_registry/alerts.py
@@ -1,0 +1,41 @@
+"""Slash command: /alerts — show alert listener status."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.table import Table
+
+from app.cli.interactive_shell.alert_inbox import get_current_inbox
+from app.cli.interactive_shell.command_registry.types import ExecutionTier, SlashCommand
+from app.cli.interactive_shell.runtime import ReplSession
+from app.cli.interactive_shell.ui.theme import BOLD_BRAND, DIM, HIGHLIGHT, WARNING
+
+
+def _cmd_alerts(_session: ReplSession, console: Console, _args: list[str]) -> bool:
+    inbox = get_current_inbox()
+    if inbox is None:
+        console.print(f"[{WARNING}]alert listener is not active.[/]")
+        return True
+
+    table = Table(title="Alert Inbox", title_style=BOLD_BRAND, show_header=False)
+    table.add_column("key", style="bold")
+    table.add_column("value")
+    table.add_row("status", f"[{HIGHLIGHT}]listening[/]")
+    table.add_row("queue depth", str(inbox.qsize))
+    table.add_row("dropped", str(inbox.dropped))
+
+    pending = inbox.iter_pending()
+    for alert in pending[-5:]:
+        table.add_row(f"[{DIM}]recent[/]", f"{alert.alert_name or 'untitled'} — {alert.text[:80]}")
+
+    console.print(table)
+    return True
+
+
+COMMANDS: list[SlashCommand] = [
+    SlashCommand(
+        "/alerts", "show alert listener status", _cmd_alerts, execution_tier=ExecutionTier.SAFE
+    ),
+]
+
+__all__ = ["COMMANDS"]

--- a/app/cli/interactive_shell/command_registry/help.py
+++ b/app/cli/interactive_shell/command_registry/help.py
@@ -11,6 +11,7 @@ from app.cli.interactive_shell.ui import BOLD_BRAND, DIM, HIGHLIGHT, repl_table
 
 def _cmd_help(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     from app.cli.interactive_shell.command_registry.agents import COMMANDS as AGENTS_CMDS
+    from app.cli.interactive_shell.command_registry.alerts import COMMANDS as ALERTS_CMDS
     from app.cli.interactive_shell.command_registry.cli_parity import (
         COMMANDS as PARITY_COMMANDS,
     )
@@ -30,6 +31,7 @@ def _cmd_help(_session: ReplSession, console: Console, _args: list[str]) -> bool
         ("Privacy", list(PRIVACY_CMDS)),
         ("Tasks", list(TASK_CMDS)),
         ("Agents", list(AGENTS_CMDS)),
+        ("Alerts", list(ALERTS_CMDS)),
         ("CLI (parity)", list(PARITY_COMMANDS)),
         ("System", list(SYS_CMDS)),
     ]

--- a/app/cli/interactive_shell/config/repl_config.py
+++ b/app/cli/interactive_shell/config/repl_config.py
@@ -76,6 +76,10 @@ class ReplConfig:
     enabled: bool = True
     layout: str = "classic"
     reload: bool = True
+    alert_listener_enabled: bool = False
+    alert_listener_host: str = "127.0.0.1"
+    alert_listener_port: int = 0
+    alert_listener_token: str | None = None
 
     @staticmethod
     def _coerce_bool(value: Any, *, default: bool) -> bool:
@@ -130,7 +134,41 @@ class ReplConfig:
         else:
             reload = cls._coerce_bool(file_conf.get("reload"), default=True)
 
-        return cls(enabled=enabled, layout=layout, reload=reload)
+        # --- alert_listener_enabled ---
+        if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_ENABLED")) is not None:
+            alert_listener_enabled = cls._coerce_bool(env_val, default=False)
+        else:
+            alert_listener_enabled = cls._coerce_bool(
+                file_conf.get("alert_listener_enabled"), default=False
+            )
+
+        # --- alert_listener_host ---
+        if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_HOST")) is not None:
+            alert_listener_host = env_val.strip()
+        else:
+            alert_listener_host = str(file_conf.get("alert_listener_host", "127.0.0.1"))
+
+        # --- alert_listener_port ---
+        if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_PORT")) is not None:
+            alert_listener_port = int(env_val.strip())
+        else:
+            alert_listener_port = int(file_conf.get("alert_listener_port", 0))
+
+        # --- alert_listener_token ---
+        if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_TOKEN")) is not None:
+            alert_listener_token = env_val.strip() or None
+        else:
+            alert_listener_token = file_conf.get("alert_listener_token")
+
+        return cls(
+            enabled=enabled,
+            layout=layout,
+            reload=reload,
+            alert_listener_enabled=alert_listener_enabled,
+            alert_listener_host=alert_listener_host,
+            alert_listener_port=alert_listener_port,
+            alert_listener_token=alert_listener_token,
+        )
 
     @classmethod
     def from_env(cls) -> ReplConfig:

--- a/app/cli/interactive_shell/config/repl_config.py
+++ b/app/cli/interactive_shell/config/repl_config.py
@@ -162,7 +162,14 @@ class ReplConfig:
                 )
                 alert_listener_port = 0
         else:
-            alert_listener_port = int(file_conf.get("alert_listener_port", 0))
+            try:
+                alert_listener_port = int(file_conf.get("alert_listener_port", 0))
+            except ValueError:
+                log.warning(
+                    "config.yml interactive.alert_listener_port=%r is not a valid port number; defaulting to 0 (random).",
+                    file_conf.get("alert_listener_port"),
+                )
+                alert_listener_port = 0
 
         # --- alert_listener_token ---
         if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_TOKEN")) is not None:

--- a/app/cli/interactive_shell/config/repl_config.py
+++ b/app/cli/interactive_shell/config/repl_config.py
@@ -175,7 +175,7 @@ class ReplConfig:
         if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_TOKEN")) is not None:
             alert_listener_token = env_val.strip() or None
         else:
-            alert_listener_token = file_conf.get("alert_listener_token")
+            alert_listener_token = file_conf.get("alert_listener_token") or None
 
         return cls(
             enabled=enabled,

--- a/app/cli/interactive_shell/config/repl_config.py
+++ b/app/cli/interactive_shell/config/repl_config.py
@@ -150,7 +150,14 @@ class ReplConfig:
 
         # --- alert_listener_port ---
         if (env_val := os.getenv("OPENSRE_ALERT_LISTENER_PORT")) is not None:
-            alert_listener_port = int(env_val.strip())
+            try:
+                alert_listener_port = int(env_val.strip())
+            except ValueError:
+                log.warning(
+                    "OPENSRE_ALERT_LISTENER_PORT=%r is not a valid port number; defaulting to 0 (random).",
+                    env_val,
+                )
+                alert_listener_port = 0
         else:
             alert_listener_port = int(file_conf.get("alert_listener_port", 0))
 

--- a/app/cli/interactive_shell/config/repl_config.py
+++ b/app/cli/interactive_shell/config/repl_config.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any
 
 _VALID_LAYOUTS = ("classic", "pinned")
 _FALSE_VALUES = ("", "0", "false", "off", "no")
+
+log = logging.getLogger(__name__)
 
 # ── Release notes ─────────────────────────────────────────────────────────────
 # Shown in the "What's new" panel on startup. Update this each release with

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -48,6 +48,7 @@ from app.agents.sweep import run_startup_sweep
 from app.analytics.cli import capture_terminal_turn_summarized
 from app.analytics.events import Event
 from app.analytics.provider import get_analytics
+from app.cli.interactive_shell import alert_inbox as _alert_inbox
 from app.cli.interactive_shell import commands as _commands
 from app.cli.interactive_shell.chat import cli_agent as _cli_agent
 from app.cli.interactive_shell.chat import cli_help as _cli_help
@@ -403,11 +404,32 @@ async def _repl_main(
     if initial_input:
         return _run_initial_input(initial_input, session, hot_reloader)
 
-    # Pass the already-built ``pt_session`` so ``_run_interactive``
-    # doesn't allocate a second one. ``session.prompt_history_backend``
-    # is already wired above.
-    await _run_interactive(session, hot_reloader, pt_session=pt_session)
-    return 0
+    alert_listener_handle: _alert_inbox.AlertListenerHandle | None = None
+    if cfg.alert_listener_enabled:
+        inbox = _alert_inbox.AlertInbox()
+        alert_listener_handle = _alert_inbox.start_alert_listener(
+            inbox,
+            host=cfg.alert_listener_host,
+            port=cfg.alert_listener_port,
+            token=cfg.alert_listener_token,
+        )
+        _alert_inbox.set_current_inbox(inbox)
+        console = Console(
+            highlight=False,
+            force_terminal=True,
+            color_system="truecolor",
+            legacy_windows=False,
+        )
+        console.print(
+            f"[{DIM}]listening for alerts on http://{alert_listener_handle.bound_address}/alerts[/]"
+        )
+
+    try:
+        await _run_interactive(session, hot_reloader, pt_session=pt_session)
+        return 0
+    finally:
+        if alert_listener_handle is not None:
+            alert_listener_handle.stop()
 
 
 def run_repl(initial_input: str | None = None, config: ReplConfig | None = None) -> int:

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -430,6 +430,7 @@ async def _repl_main(
     finally:
         if alert_listener_handle is not None:
             alert_listener_handle.stop()
+            _alert_inbox.set_current_inbox(None)
 
 
 def run_repl(initial_input: str | None = None, config: ReplConfig | None = None) -> int:

--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -25,6 +25,7 @@ conventions: input pinned at bottom, history scrolls naturally.
 from __future__ import annotations
 
 import asyncio
+import logging
 import random
 import re
 import sys
@@ -74,6 +75,8 @@ from app.cli.support.errors import OpenSREError
 from app.cli.support.exception_reporting import report_exception
 from app.cli.support.prompt_support import repl_prompt_note_ctrl_c, repl_reset_ctrl_c_gate
 from app.llm_reasoning_effort import apply_reasoning_effort
+
+log = logging.getLogger(__name__)
 
 # Module-alias pattern (introduced by main for testability + hot-reload).
 # Local rebindings expose the same names the rest of this module uses.
@@ -406,23 +409,26 @@ async def _repl_main(
 
     alert_listener_handle: _alert_inbox.AlertListenerHandle | None = None
     if cfg.alert_listener_enabled:
-        inbox = _alert_inbox.AlertInbox()
-        alert_listener_handle = _alert_inbox.start_alert_listener(
-            inbox,
-            host=cfg.alert_listener_host,
-            port=cfg.alert_listener_port,
-            token=cfg.alert_listener_token,
-        )
-        _alert_inbox.set_current_inbox(inbox)
-        console = Console(
-            highlight=False,
-            force_terminal=True,
-            color_system="truecolor",
-            legacy_windows=False,
-        )
-        console.print(
-            f"[{DIM}]listening for alerts on http://{alert_listener_handle.bound_address}/alerts[/]"
-        )
+        try:
+            inbox = _alert_inbox.AlertInbox()
+            alert_listener_handle = _alert_inbox.start_alert_listener(
+                inbox,
+                host=cfg.alert_listener_host,
+                port=cfg.alert_listener_port,
+                token=cfg.alert_listener_token,
+            )
+            _alert_inbox.set_current_inbox(inbox)
+            console = Console(
+                highlight=False,
+                force_terminal=True,
+                color_system="truecolor",
+                legacy_windows=False,
+            )
+            console.print(
+                f"[{DIM}]listening for alerts on http://{alert_listener_handle.bound_address}/alerts[/]"
+            )
+        except Exception as exc:
+            log.warning("Alert listener could not start: %s — continuing without it.", exc)
 
     try:
         await _run_interactive(session, hot_reloader, pt_session=pt_session)

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -152,11 +152,12 @@ class TestHttpListener:
         finally:
             handle.stop()
 
-    def test_overflow_returns_503(self, listener: AlertListenerHandle) -> None:
+    def test_overflow_returns_503_with_queued(self, listener: AlertListenerHandle) -> None:
         for i in range(3):
             _post("127.0.0.1", listener._bound_port, {"text": f"alert {i}"})
         status, body = _post("127.0.0.1", listener._bound_port, {"text": "overflow"})
         assert status == 503
+        assert body["queued"] is True
         assert body["dropped"] == 1
 
     def test_unknown_path_returns_404(self, listener: AlertListenerHandle) -> None:

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -1,0 +1,186 @@
+"""Tests for the alert inbox module."""
+
+from __future__ import annotations
+
+import json
+import socket
+from datetime import UTC, datetime
+from http.client import HTTPConnection
+
+import pytest
+
+from app.cli.interactive_shell.alert_inbox import (
+    AlertInbox,
+    AlertListenerHandle,
+    IncomingAlert,
+    start_alert_listener,
+)
+from app.cli.support.errors import OpenSREError
+
+
+class TestIncomingAlert:
+    def test_valid_minimal(self) -> None:
+        alert = IncomingAlert(text="CPU spike")
+        assert alert.text == "CPU spike"
+
+    def test_valid_full(self) -> None:
+        alert = IncomingAlert.model_validate(
+            {
+                "text": "disk full",
+                "alert_name": "DiskAlert",
+                "severity": "critical",
+                "source": "datadog",
+                "received_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        assert alert.alert_name == "DiskAlert"
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValueError, match="Unexpected field"):
+            IncomingAlert.model_validate({"text": "x", "unknown": "y"})
+
+    def test_text_is_required(self) -> None:
+        with pytest.raises(ValueError, match="Field required"):
+            IncomingAlert.model_validate({})
+
+
+class TestAlertInbox:
+    def test_put_and_pop(self) -> None:
+        inbox = AlertInbox(maxsize=3)
+        inbox.put(IncomingAlert(text="a"))
+        inbox.put(IncomingAlert(text="b"))
+        assert inbox.qsize == 2
+        assert inbox.pop_nowait() is not None
+        assert inbox.qsize == 1
+
+    def test_iter_pending_drains(self) -> None:
+        inbox = AlertInbox(maxsize=5)
+        for i in range(3):
+            inbox.put(IncomingAlert(text=f"alert {i}"))
+        items = inbox.iter_pending()
+        assert len(items) == 3
+        assert inbox.qsize == 0
+
+    def test_pop_nowait_returns_none_when_empty(self) -> None:
+        assert AlertInbox().pop_nowait() is None
+
+    def test_drop_oldest_on_overflow(self) -> None:
+        inbox = AlertInbox(maxsize=2)
+        inbox.put(IncomingAlert(text="a"))
+        inbox.put(IncomingAlert(text="b"))
+        inbox.put(IncomingAlert(text="c"))
+        assert inbox.qsize == 2
+        assert inbox.dropped == 1
+        assert [a.text for a in inbox.iter_pending()] == ["b", "c"]
+
+
+def _post(
+    host: str, port: int, body: object, token: str | None = None
+) -> tuple[int, dict[str, object]]:
+    conn = HTTPConnection(host, port, timeout=5)
+    headers = {"Content-Type": "application/json"}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    conn.request("POST", "/alerts", json.dumps(body), headers)
+    resp = conn.getresponse()
+    data = json.loads(resp.read())
+    conn.close()
+    return resp.status, data
+
+
+def _get(host: str, port: int, path: str) -> tuple[int, dict[str, object]]:
+    conn = HTTPConnection(host, port, timeout=5)
+    conn.request("GET", path)
+    resp = conn.getresponse()
+    raw = resp.read()
+    data = json.loads(raw) if raw else {}
+    conn.close()
+    return resp.status, data
+
+
+@pytest.fixture
+def inbox() -> AlertInbox:
+    return AlertInbox(maxsize=3)
+
+
+@pytest.fixture
+def listener(inbox: AlertInbox) -> AlertListenerHandle:
+    h = start_alert_listener(inbox, host="127.0.0.1", port=0)
+    yield h
+    h.stop()
+
+
+class TestHttpListener:
+    def test_healthcheck(self, listener: AlertListenerHandle) -> None:
+        status, body = _get("127.0.0.1", listener._bound_port, "/healthz")
+        assert status == 200
+        assert body == {"status": "ok"}
+
+    def test_post_alert_returns_202(self, listener: AlertListenerHandle) -> None:
+        status, body = _post("127.0.0.1", listener._bound_port, {"text": "test"})
+        assert status == 202
+        assert body["queued"] is True
+
+    def test_post_alert_queued(self, listener: AlertListenerHandle, inbox: AlertInbox) -> None:
+        _post("127.0.0.1", listener._bound_port, {"text": "hello"})
+        assert inbox.pop_nowait() is not None
+
+    def test_invalid_json_returns_400(self, listener: AlertListenerHandle) -> None:
+        conn = HTTPConnection("127.0.0.1", listener._bound_port, timeout=5)
+        conn.request("POST", "/alerts", b"not json", {"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        conn.close()
+        assert resp.status == 400
+
+    def test_missing_text_returns_400(self, listener: AlertListenerHandle) -> None:
+        status, _ = _post("127.0.0.1", listener._bound_port, {})
+        assert status == 400
+
+    def test_auth(self) -> None:
+        inbox = AlertInbox()
+        handle = start_alert_listener(inbox, host="127.0.0.1", port=0, token="sekret")
+        try:
+            status, body = _post("127.0.0.1", handle._bound_port, {"text": "x"})
+            assert status == 401
+            assert body["error"] == "unauthorized"
+
+            status, body = _post("127.0.0.1", handle._bound_port, {"text": "x"}, token="wrong")
+            assert status == 401
+
+            status, body = _post("127.0.0.1", handle._bound_port, {"text": "x"}, token="sekret")
+            assert status == 202
+        finally:
+            handle.stop()
+
+    def test_overflow_returns_503(self, listener: AlertListenerHandle) -> None:
+        for i in range(3):
+            _post("127.0.0.1", listener._bound_port, {"text": f"alert {i}"})
+        status, body = _post("127.0.0.1", listener._bound_port, {"text": "overflow"})
+        assert status == 503
+        assert body["dropped"] == 1
+
+    def test_unknown_path_returns_404(self, listener: AlertListenerHandle) -> None:
+        status, _ = _get("127.0.0.1", listener._bound_port, "/unknown")
+        assert status == 404
+
+    def test_port_zero_selects_free_port(self) -> None:
+        inbox = AlertInbox()
+        handle = start_alert_listener(inbox, host="127.0.0.1", port=0)
+        try:
+            assert handle._bound_port > 0
+        finally:
+            handle.stop()
+
+    def test_stop_shuts_down_server(self, listener: AlertListenerHandle) -> None:
+        port = listener._bound_port
+        listener.stop()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(3)
+        try:
+            assert sock.connect_ex(("127.0.0.1", port)) != 0
+        finally:
+            sock.close()
+
+    def test_bind_non_loopback_without_token_raises(self) -> None:
+        with pytest.raises(OpenSREError, match="non-loopback"):
+            start_alert_listener(AlertInbox(), host="0.0.0.0", port=0, token=None)

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -152,11 +152,11 @@ class TestHttpListener:
         finally:
             handle.stop()
 
-    def test_overflow_returns_503_with_queued(self, listener: AlertListenerHandle) -> None:
+    def test_overflow_returns_202_with_dropped(self, listener: AlertListenerHandle) -> None:
         for i in range(3):
             _post("127.0.0.1", listener._bound_port, {"text": f"alert {i}"})
         status, body = _post("127.0.0.1", listener._bound_port, {"text": "overflow"})
-        assert status == 503
+        assert status == 202
         assert body["queued"] is True
         assert body["dropped"] == 1
 


### PR DESCRIPTION
Fixes #1448

<!-- Add issue number above -->
I have an early phase of the Alert box functionality. We can call an http server endpoint to to post alerts. 
These alerts are stored in a queue data structure.

When the /alerts command is run in the interactive shell we can see an UI that represents their presence in memory induced by the endpoints

Proof And Showcase of the UI
```
### 1. Authentication (Unauthorized Access)
- **Objective:** Test the endpoint's security by attempting to post an alert without providing the required bearer token.

- **Request:**
```bash
curl -X POST http://127.0.0.1:9999/alerts \
  -H "Content-Type: application/json" \
  -d '{"text": "test"}'
- Response:
{"error": "unauthorized"}
- Status: PASS. The endpoint correctly blocked unauthenticated access (Expected HTTP 401).

2. Payload Schema Validation
- Objective: Test the endpoint's error handling when provided with a malformed or unrecognized payload structure.
- Request:
curl -X POST http://127.0.0.1:9999/alerts \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer my-secret" \
  -d '{"bad": "data"}'
- Response:
{"error": "1 validation error for IncomingAlert\n  Value error, Unexpected field 'bad'..."}
- Status: PASS. The Pydantic data model successfully caught the unexpected field and rejected the payload (Expected HTTP 400/422).

3. Queue Overflow & Load Testing
- Objective: Evaluate system behavior under heavy request volume to verify rate limiting or maximum queue depth constraints.
- Request: 
  Sent 300 consecutive automated requests.
for i in $(seq 1 300); do 
  curl -s -X POST http://127.0.0.1:9999/alerts \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer my-secret" \
    -d "{\"text\": \"alert $i\"}" \
    -w "\n%{http_code}" | tail -1
done

- Response Sequence (HTTP Status Codes):
  - Initial requests returned 202 (Accepted).
  - Subsequent requests shifted to returning 503 (Service Unavailable).
- Status: PASS. The system gracefully handled the flood of requests. It accepted items until the queue reached its configured maximum capacity, after which it actively rejected new requests with a 503 status to prevent system degradation or memory exhaustion.
```
---

```
❯ /alerts
             Alert Inbox              
┌─────────────┬──────────────────────┐
│ status      │ listening            │
│ queue depth │ 256                  │
│ dropped     │ 45                   │
│ recent      │ untitled — alert 296 │
│ recent      │ untitled — alert 297 │
│ recent      │ untitled — alert 298 │
│ recent      │ untitled — alert 299 │
│ recent      │ untitled — alert 300 │
└─────────────┴──────────────────────┘
[Screencast from 2026-05-12 23-43-45.webm](https://github.com/user-attachments/assets/2cc2380e-0924-42db-ad13-c5c2807b7789)

```

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
What I did is an implementation of the Alert Inbox, now we can host a local server with respect to the env variables or default variables. We can post alerts into it that are stored in the memory as a queue data structure. Which can be fetched and displayed using the /alerts commands. 
This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

*Video Demo*

[Screencast from 2026-05-12 23-43-45.webm](https://github.com/user-attachments/assets/13a6395c-9b8b-4009-9432-db7d7e5847f4)
