### PR TITLE
fix(telegram): format RCA with HTML for Telegram delivery

### DIFF
--- a/app/nodes/publish_findings/formatters/base.py
+++ b/app/nodes/publish_findings/formatters/base.py
@@ -1,5 +1,7 @@
 """Base formatting utilities for report generation."""
 
+import html
+
 
 def shorten_text(text: str, max_chars: int = 120, suffix: str = "...") -> str:
     """Shorten text to a maximum length.
@@ -28,3 +30,11 @@ def format_slack_link(label: str, url: str | None) -> str:
 
     safe_label = label.replace("|", "¦").strip() or url
     return f"<{url}|{safe_label}>"
+
+
+def format_html_link(label: str, url: str | None) -> str:
+    """Return a Telegram HTML <a> tag, or escaped plain label without a URL."""
+    if not url:
+        return html.escape(label)
+    safe_label = label.replace("|", "¦").strip() or url
+    return f'<a href="{html.escape(url, quote=True)}">{html.escape(safe_label)}</a>'

--- a/app/nodes/publish_findings/formatters/evidence.py
+++ b/app/nodes/publish_findings/formatters/evidence.py
@@ -1,8 +1,11 @@
 """Evidence formatting and citation for RCA reports."""
 
+import html
+from collections.abc import Callable
 from typing import Any
 
 from app.nodes.publish_findings.formatters.base import (
+    format_html_link,
     format_slack_link,
     shorten_text,
 )
@@ -13,7 +16,11 @@ from app.nodes.publish_findings.urls.aws import (
 )
 
 
-def _format_tool_calls_line(ctx: ReportContext) -> str:
+def _format_tool_calls_line(
+    ctx: ReportContext,
+    *,
+    link_fn: Callable[[str, str | None], str] = format_slack_link,
+) -> str:
     """Summarize tool calls made during investigation from executed_hypotheses.
 
     Returns a compact line like: "Queries: cloudwatch logs (12 events), <Grafana Loki|url> (5 logs)"
@@ -227,7 +234,7 @@ def _format_tool_calls_line(ctx: ReportContext) -> str:
             label, count_fn, url_fn = defn
             count_str = count_fn(evidence)
             url = url_fn(evidence) if url_fn else None
-            display = format_slack_link(label, url) if url else label
+            display = link_fn(label, url or None)
             if count_str:
                 parts.append(f"{display} ({count_str})")
             else:
@@ -265,7 +272,7 @@ def format_cited_evidence_section(ctx: ReportContext) -> str:
             summary = entry.get("summary")
             snippet = entry.get("snippet")
             provenance = entry.get("provenance")
-            link = format_slack_link(label, url) if url else label
+            link = format_slack_link(label, url or None)
             line = f"- {display_id} — {link}"
             if summary:
                 line += f" — {summary}"
@@ -283,3 +290,43 @@ def format_cited_evidence_section(ctx: ReportContext) -> str:
         return ""
 
     return "\n*Cited Evidence:*\n" + "\n".join(lines) + "\n"
+
+
+def format_cited_evidence_section_html(ctx: ReportContext) -> str:
+    """Like :func:`format_cited_evidence_section` but Telegram HTML with consistent bullets."""
+    catalog = ctx.get("evidence_catalog") or {}
+    lines: list[str] = []
+
+    if catalog:
+
+        def _sort_key(eid: str) -> str:
+            return str(catalog[eid].get("display_id", eid))
+
+        for evidence_id in sorted(catalog.keys(), key=_sort_key):
+            if evidence_id.startswith("evidence/datadog/failed_pod/"):
+                continue
+            entry = catalog[evidence_id] or {}
+            display_id = entry.get("display_id", evidence_id)
+            label = entry.get("label") or evidence_id
+            url = entry.get("url")
+            summary = entry.get("summary")
+            snippet = entry.get("snippet")
+            provenance = entry.get("provenance")
+            link = format_html_link(label, url or None)
+            line = f"• {html.escape(str(display_id))} — {link}"
+            if summary:
+                line += f" — {html.escape(str(summary))}"
+            if provenance:
+                line += f" — provenance: {html.escape(str(provenance))}"
+            if snippet:
+                line += f" — {html.escape(shorten_text(snippet, max_chars=100))}"
+            lines.append(line)
+
+    tool_calls_line = _format_tool_calls_line(ctx, link_fn=format_html_link)
+    if tool_calls_line:
+        lines.append(f"• {tool_calls_line}")
+
+    if not lines:
+        return ""
+
+    return "\n<b>Cited Evidence</b>\n" + "\n".join(lines) + "\n"

--- a/app/nodes/publish_findings/formatters/report.py
+++ b/app/nodes/publish_findings/formatters/report.py
@@ -140,6 +140,29 @@ def _to_telegram_html_body(text: str) -> str:
     return merged
 
 
+def _norm_banner_key(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def _telegram_baseline_repeats_header(ctx: ReportContext, root_cause_sentence: str) -> bool:
+    """True when the derived root-cause line only repeats alert metadata already in the header."""
+    alert = (ctx.get("alert_name") or "").strip()
+    pipeline = (ctx.get("pipeline_name") or "").strip()
+    if not alert or not pipeline:
+        return False
+    s = root_cause_sentence.strip()
+    if len(s) > 220:
+        return False
+    rc = _norm_banner_key(s)
+    if _norm_banner_key(alert) not in rc or _norm_banner_key(pipeline) not in rc:
+        return False
+    if "because" in rc or "due to" in rc or "caused" in rc:
+        return False
+    if "severity" in rc:
+        return True
+    return len(s) < 120
+
+
 def _severity_telegram_header(ctx: ReportContext) -> str:
     """Severity emoji row aligned with Hermes Telegram sink conventions."""
     raw = (ctx.get("severity") or "").strip()
@@ -456,18 +479,26 @@ def format_telegram_message(ctx: ReportContext) -> str:
     """
     duration_seconds = ctx.get("investigation_duration_seconds")
     alert_id = ctx.get("alert_id")
-    root_cause_sentence = _derive_root_cause_sentence(ctx)
-
-    if not root_cause_sentence:
-        root_cause_sentence = "Not determined (insufficient evidence)."
+    derived_rc = _derive_root_cause_sentence(ctx)
+    root_cause_sentence = derived_rc or "Not determined (insufficient evidence)."
 
     parts: list[str] = [_severity_telegram_header(ctx)]
 
-    rc = _to_telegram_html_body(root_cause_sentence)
     top_log = _get_top_error_log(ctx.get("evidence") or {})
-    if top_log:
-        rc += "\n<code>" + html.escape(top_log) + "</code>"
-    parts.append(rc)
+    baseline_noise = (
+        derived_rc
+        and _telegram_baseline_repeats_header(ctx, derived_rc)
+        and root_cause_sentence != "Not determined (insufficient evidence)."
+    )
+    if baseline_noise and not top_log:
+        pass
+    elif baseline_noise and top_log:
+        parts.append("<code>" + html.escape(top_log) + "</code>")
+    else:
+        rc = _to_telegram_html_body(root_cause_sentence)
+        if top_log:
+            rc += "\n<code>" + html.escape(top_log) + "</code>"
+        parts.append(rc)
 
     validated_lines, non_validated_lines = _render_claim_lines_telegram(ctx)
     if validated_lines:

--- a/app/nodes/publish_findings/formatters/report.py
+++ b/app/nodes/publish_findings/formatters/report.py
@@ -1,9 +1,13 @@
-"""Main report formatting and assembly for Slack messages."""
+"""RCA report formatting for Slack (mrkdwn / Block Kit) and Telegram (HTML)."""
 
+import html
 import re
 
-from app.nodes.publish_findings.formatters.base import format_slack_link
-from app.nodes.publish_findings.formatters.evidence import format_cited_evidence_section
+from app.nodes.publish_findings.formatters.base import format_html_link, format_slack_link
+from app.nodes.publish_findings.formatters.evidence import (
+    format_cited_evidence_section,
+    format_cited_evidence_section_html,
+)
 from app.nodes.publish_findings.formatters.infrastructure import (
     build_investigation_trace,
     format_pod_line,
@@ -94,6 +98,123 @@ def _sanitize_for_slack(text: str) -> str:
     result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
     result = re.sub(r"__(.+?)__", r"*\1*", result)
     return result
+
+
+_SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
+
+
+def _to_telegram_html_body(text: str) -> str:
+    """Convert mixed Slack-style text (headers, *bold*, `code`, <url|label>) to Telegram HTML."""
+    placeholders: dict[str, str] = {}
+
+    def _put(chunk: str) -> str:
+        token = f"«{len(placeholders)}»"
+        placeholders[token] = chunk
+        return token
+
+    s = text
+    s = re.sub(r"`([^`]+)`", lambda m: _put("<code>" + html.escape(m.group(1)) + "</code>"), s)
+    s = _SLACK_LINK_RE.sub(
+        lambda m: _put(format_html_link(m.group(2) or m.group(1), m.group(1))),
+        s,
+    )
+
+    out_lines: list[str] = []
+    for line in s.splitlines():
+        hdr = re.match(r"^#{1,6}\s+(.+)$", line)
+        if hdr:
+            out_lines.append("<b>" + html.escape(hdr.group(1).strip()) + "</b>")
+            continue
+        parts = line.split("*")
+        segs: list[str] = []
+        for i, part in enumerate(parts):
+            if i % 2 == 0:
+                segs.append(html.escape(part))
+            else:
+                segs.append("<b>" + html.escape(part) + "</b>")
+        out_lines.append("".join(segs))
+
+    merged = "\n".join(out_lines)
+    for token, chunk in sorted(placeholders.items(), key=lambda kv: -len(kv[0])):
+        merged = merged.replace(token, chunk)
+    return merged
+
+
+def _severity_telegram_header(ctx: ReportContext) -> str:
+    """Severity emoji row aligned with Hermes Telegram sink conventions."""
+    raw = (ctx.get("severity") or "").strip()
+    lower = raw.lower()
+    emoji = {
+        "critical": "🔴",
+        "crit": "🔴",
+        "high": "🟠",
+        "error": "🟠",
+        "medium": "🟡",
+        "warning": "🟡",
+        "warn": "🟡",
+        "low": "🟢",
+        "info": "🟢",
+        "none": "⚪",
+        "healthy": "🟢",
+        "normal": "🟢",
+    }.get(lower, "⚠️")
+    display_sev = raw.upper() if raw else "UNKNOWN"
+    alert = html.escape(str(ctx.get("alert_name") or "Alert"))
+    pipeline = html.escape(str(ctx.get("pipeline_name") or "unknown"))
+    return f"{emoji} <b>{alert}</b> · {pipeline}\n<i>severity: {html.escape(display_sev)}</i>"
+
+
+def _render_claim_lines_telegram(ctx: ReportContext) -> tuple[list[str], list[str]]:
+    catalog = ctx.get("evidence_catalog") or {}
+    evidence = ctx.get("evidence") or {}
+
+    validated_lines: list[str] = []
+    for claim_data in ctx.get("validated_claims", []):
+        claim = claim_data.get("claim", "")
+        claim = _resolve_evidence_tags(claim, evidence)
+        claim = _sanitize_for_slack(claim)
+        evidence_ids = claim_data.get("evidence_ids", [])
+        evidence_labels = claim_data.get("evidence_labels", [])
+        evidence_list: list[str] = []
+        if evidence_ids:
+            for eid in evidence_ids:
+                entry = catalog.get(eid, {})
+                disp = entry.get("display_id", eid)
+                url = entry.get("url")
+                evidence_list.append(format_html_link(str(disp), url or None))
+        elif evidence_labels:
+            evidence_list = [html.escape(str(x)) for x in evidence_labels]
+        ev_str = f" [{', '.join(evidence_list)}]" if evidence_list else ""
+        validated_lines.append(f"• {_to_telegram_html_body(claim)}{ev_str}")
+
+    non_validated_lines: list[str] = []
+    for cd in ctx.get("non_validated_claims", []):
+        raw = _sanitize_for_slack(cd.get("claim", ""))
+        non_validated_lines.append(f"• {_to_telegram_html_body(raw)}")
+
+    return validated_lines, non_validated_lines
+
+
+def render_cloudwatch_link_html(ctx: ReportContext) -> str:
+    """Telegram-HTML CloudWatch deep link, mirroring :func:`render_cloudwatch_link`."""
+    cw_url = ctx.get("cloudwatch_logs_url")
+    cw_group = ctx.get("cloudwatch_log_group")
+    cw_stream = ctx.get("cloudwatch_log_stream")
+
+    if cw_url:
+        safe = html.escape(str(cw_url), quote=True)
+        return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
+    if cw_group and cw_stream:
+        url = build_cloudwatch_url(ctx)
+        if url:
+            safe = html.escape(str(url), quote=True)
+            return f'\n<b>CloudWatch</b>: <a href="{safe}">View logs</a>\n'
+        return (
+            f"\n<b>CloudWatch Logs</b>\n"
+            f"Log Group: {html.escape(str(cw_group))}\n"
+            f"Log Stream: {html.escape(str(cw_stream))}\n"
+        )
+    return ""
 
 
 def _mrkdwn_section(text: str) -> "dict | None":
@@ -324,6 +445,74 @@ def format_slack_message(ctx: ReportContext) -> str:
 {cited_section}
 {cloudwatch_link}{meta_block}
 """
+
+
+def format_telegram_message(ctx: ReportContext) -> str:
+    """Format an HTML RCA message for Telegram (:meth:`parse_mode` ``HTML``).
+
+    Uses Telegram-supported tags and a Hermes-style severity emoji header, instead
+    of Slack mrkdwn (``<url|label>``, ``##`` headings) which render as plain text
+    without ``parse_mode``.
+    """
+    duration_seconds = ctx.get("investigation_duration_seconds")
+    alert_id = ctx.get("alert_id")
+    root_cause_sentence = _derive_root_cause_sentence(ctx)
+
+    if not root_cause_sentence:
+        root_cause_sentence = "Not determined (insufficient evidence)."
+
+    parts: list[str] = [_severity_telegram_header(ctx)]
+
+    rc = _to_telegram_html_body(root_cause_sentence)
+    top_log = _get_top_error_log(ctx.get("evidence") or {})
+    if top_log:
+        rc += "\n<code>" + html.escape(top_log) + "</code>"
+    parts.append(rc)
+
+    validated_lines, non_validated_lines = _render_claim_lines_telegram(ctx)
+    if validated_lines:
+        parts.append("<b>Findings</b>\n" + "\n".join(validated_lines))
+    if non_validated_lines:
+        parts.append("<b>Non-Validated Claims (Inferred)</b>\n" + "\n".join(non_validated_lines))
+
+    provenance_lines = _format_provenance_lines(ctx)
+    if provenance_lines:
+        prov = "\n".join(
+            "• " + _to_telegram_html_body(_sanitize_for_slack(pl.lstrip("• ").strip()))
+            for pl in provenance_lines
+        )
+        parts.append("<b>Provenance</b>\n" + prov)
+
+    remediation_steps = ctx.get("remediation_steps", [])
+    if remediation_steps:
+        ra = "\n".join(
+            "• " + _to_telegram_html_body(_sanitize_for_slack(str(step)))
+            for step in remediation_steps
+        )
+        parts.append("<b>Recommended Actions</b>\n" + ra)
+
+    trace_steps = build_investigation_trace(ctx)
+    if trace_steps:
+        tr = "\n".join(_to_telegram_html_body(step) for step in trace_steps)
+        parts.append("<b>Investigation Trace</b>\n" + tr)
+
+    cited_block = format_cited_evidence_section_html(ctx).strip()
+    if cited_block:
+        parts.append(cited_block)
+
+    cw_block = render_cloudwatch_link_html(ctx).strip()
+    if cw_block:
+        parts.append(cw_block)
+
+    meta_bits: list[str] = []
+    if duration_seconds is not None:
+        meta_bits.append(f"Timing: {duration_seconds}s")
+    if alert_id:
+        meta_bits.append(f"Alert ID: {alert_id}")
+    if meta_bits:
+        parts.append("<i>" + html.escape(" | ".join(meta_bits)) + "</i>")
+
+    return "\n\n".join(p for p in parts if p)
 
 
 # ---------------------------------------------------------------------------

--- a/app/nodes/publish_findings/formatters/report.py
+++ b/app/nodes/publish_findings/formatters/report.py
@@ -103,6 +103,19 @@ def _sanitize_for_slack(text: str) -> str:
 _SLACK_LINK_RE = re.compile(r"<(https?://[^|>]+)(?:\|([^>]+))?>")
 
 
+def _star_pairs_to_bold_placeholders(line: str, bold_ph: dict[str, str]) -> str:
+    """Replace only paired ``*inner*`` spans (inner has no ``*``); lone ``*`` stay literal."""
+    out = line
+    while True:
+        m = re.search(r"\*([^*\n]+)\*", out)
+        if not m:
+            break
+        tok = f"«B{len(bold_ph)}»"
+        bold_ph[tok] = "<b>" + html.escape(m.group(1)) + "</b>"
+        out = out[: m.start()] + tok + out[m.end() :]
+    return out
+
+
 def _to_telegram_html_body(text: str) -> str:
     """Convert mixed Slack-style text (headers, *bold*, `code`, <url|label>) to Telegram HTML."""
     placeholders: dict[str, str] = {}
@@ -125,14 +138,12 @@ def _to_telegram_html_body(text: str) -> str:
         if hdr:
             out_lines.append("<b>" + html.escape(hdr.group(1).strip()) + "</b>")
             continue
-        parts = line.split("*")
-        segs: list[str] = []
-        for i, part in enumerate(parts):
-            if i % 2 == 0:
-                segs.append(html.escape(part))
-            else:
-                segs.append("<b>" + html.escape(part) + "</b>")
-        out_lines.append("".join(segs))
+        bold_ph: dict[str, str] = {}
+        starred = _star_pairs_to_bold_placeholders(line, bold_ph)
+        escaped = html.escape(starred)
+        for token, inner in sorted(bold_ph.items(), key=lambda kv: -len(kv[0])):
+            escaped = escaped.replace(token, inner)
+        out_lines.append(escaped)
 
     merged = "\n".join(out_lines)
     for token, chunk in sorted(placeholders.items(), key=lambda kv: -len(kv[0])):

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -1,11 +1,16 @@
 """Main orchestration node for report generation and publishing."""
 
 import logging
+from typing import Any
 
 from langsmith import traceable
 
 from app.masking import MaskingContext
-from app.nodes.publish_findings.formatters.report import build_slack_blocks, format_slack_message
+from app.nodes.publish_findings.formatters.report import (
+    build_slack_blocks,
+    format_slack_message,
+    format_telegram_message,
+)
 from app.nodes.publish_findings.gitlab_writeback import post_gitlab_mr_writeback
 from app.nodes.publish_findings.renderers.editor import open_in_editor
 from app.nodes.publish_findings.renderers.terminal import render_report
@@ -37,6 +42,8 @@ def generate_report(state: InvestigationState) -> dict:
         slack_message,
         short_summary,
     )
+
+    telegram_message = masking_ctx.unmask(format_telegram_message(ctx))
 
     all_blocks = build_slack_blocks(ctx) + build_action_blocks(investigation_url, investigation_id)
     all_blocks = masking_ctx.unmask_value(all_blocks)
@@ -135,9 +142,16 @@ def generate_report(state: InvestigationState) -> dict:
             bool(bot_token),
         )
         if bot_token and chat_id:
+            inv_url = masking_ctx.unmask(investigation_url) if investigation_url else None
+            reply_markup: dict[str, Any] | None = None
+            if inv_url:
+                reply_markup = {
+                    "inline_keyboard": [[{"text": "View investigation", "url": inv_url}]]
+                }
             tg_posted, tg_error = send_telegram_report(
-                slack_message,
+                telegram_message,
                 {"bot_token": bot_token, "chat_id": chat_id, "reply_to_message_id": reply_to},
+                reply_markup=reply_markup,
             )
             logger.debug("[publish] telegram delivery: posted=%s error=%s", tg_posted, tg_error)
             if not tg_posted:

--- a/app/nodes/publish_findings/node.py
+++ b/app/nodes/publish_findings/node.py
@@ -1,7 +1,6 @@
 """Main orchestration node for report generation and publishing."""
 
 import logging
-from typing import Any
 
 from langsmith import traceable
 
@@ -142,16 +141,9 @@ def generate_report(state: InvestigationState) -> dict:
             bool(bot_token),
         )
         if bot_token and chat_id:
-            inv_url = masking_ctx.unmask(investigation_url) if investigation_url else None
-            reply_markup: dict[str, Any] | None = None
-            if inv_url:
-                reply_markup = {
-                    "inline_keyboard": [[{"text": "View investigation", "url": inv_url}]]
-                }
             tg_posted, tg_error = send_telegram_report(
                 telegram_message,
                 {"bot_token": bot_token, "chat_id": chat_id, "reply_to_message_id": reply_to},
-                reply_markup=reply_markup,
             )
             logger.debug("[publish] telegram delivery: posted=%s error=%s", tg_posted, tg_error)
             if not tg_posted:

--- a/app/nodes/publish_findings/report_context.py
+++ b/app/nodes/publish_findings/report_context.py
@@ -90,6 +90,9 @@ class ReportContext(TypedDict, total=False):
     # Concrete source provenance, keyed by source name (grafana, eks, github, ...)
     source_provenance: dict[str, dict[str, str]]
 
+    # Alert severity (e.g. critical, high) for channel-specific formatting (Telegram, etc.)
+    severity: str | None
+
     kube_pod_name: str | None
     kube_container_name: str | None
     kube_namespace: str | None
@@ -947,6 +950,7 @@ def build_report_context(state: InvestigationState) -> ReportContext:
         "grafana_endpoint": ns.grafana_endpoint,
         "datadog_site": ns.datadog_site,
         "source_provenance": source_provenance,
+        "severity": (state.get("severity") or None),
         # Kubernetes pod details — from Datadog evidence first, then alert annotations
         "kube_pod_name": (
             ns.evidence.get("datadog_pod_name")

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -58,6 +58,7 @@ def post_telegram_message(
     bot_token: str,
     parse_mode: str = "",
     reply_to_message_id: str = "",
+    reply_markup: dict[str, Any] | None = None,
 ) -> tuple[bool, str, str]:
     """Call Telegram Bot API sendMessage endpoint.
 
@@ -67,6 +68,8 @@ def post_telegram_message(
     payload: dict[str, Any] = {"chat_id": chat_id, "text": text}
     if parse_mode:
         payload["parse_mode"] = parse_mode
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
     if reply_to_message_id and reply_to_message_id != "0":
         with contextlib.suppress(ValueError, TypeError):
             payload["reply_to_message_id"] = int(reply_to_message_id)
@@ -93,7 +96,13 @@ def post_telegram_message(
     return True, "", message_id
 
 
-def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[bool, str]:
+def send_telegram_report(
+    report: str,
+    telegram_ctx: dict[str, Any],
+    *,
+    parse_mode: str = "HTML",
+    reply_markup: dict[str, Any] | None = None,
+) -> tuple[bool, str]:
     """Send a truncated report to Telegram. Returns (success, error)."""
     bot_token: str = str(telegram_ctx.get("bot_token") or "")
     chat_id: str = str(telegram_ctx.get("chat_id") or "")
@@ -102,6 +111,11 @@ def send_telegram_report(report: str, telegram_ctx: dict[str, Any]) -> tuple[boo
     reply_to_message_id: str = str(telegram_ctx.get("reply_to_message_id") or "")
     text = truncate(report, _MESSAGE_LIMIT, suffix="…")
     post_success, error, _ = post_telegram_message(
-        chat_id, text, bot_token, reply_to_message_id=reply_to_message_id
+        chat_id,
+        text,
+        bot_token,
+        parse_mode=parse_mode,
+        reply_to_message_id=reply_to_message_id,
+        reply_markup=reply_markup,
     )
     return (True, "") if post_success else (False, error)

--- a/app/utils/telegram_delivery.py
+++ b/app/utils/telegram_delivery.py
@@ -14,6 +14,79 @@ logger = logging.getLogger(__name__)
 
 _MESSAGE_LIMIT = 4096
 _BOT_TOKEN_RE = re.compile(r"(bot)[^/]+(/)")
+_SIMPLE_TAG_NAMES = frozenset({"b", "i", "u", "code"})
+
+
+def _strip_trailing_incomplete_tag(chunk: str) -> str:
+    """Drop a trailing ``<``… fragment with no closing ``>``."""
+    while True:
+        last_lt = chunk.rfind("<")
+        if last_lt == -1:
+            return chunk
+        if ">" in chunk[last_lt:]:
+            return chunk
+        chunk = chunk[:last_lt].rstrip()
+
+
+def _strip_trailing_partial_entity(chunk: str) -> str:
+    """Remove a trailing ``&``… suffix that is not a complete character reference."""
+    amp = chunk.rfind("&")
+    if amp == -1:
+        return chunk
+    tail = chunk[amp:]
+    if ";" in tail:
+        return chunk
+    return chunk[:amp].rstrip()
+
+
+def _balance_telegram_markup_tags(fragment: str) -> str:
+    """Append closing tags for open ``b``/``i``/``u``/``code``/``a`` elements at end of *fragment*."""
+    stack: list[str] = []
+    pos = 0
+    while pos < len(fragment):
+        if fragment[pos] != "<":
+            pos += 1
+            continue
+        end = fragment.find(">", pos)
+        if end == -1:
+            break
+        raw = fragment[pos : end + 1]
+        low = raw.lower()
+        if low.startswith("<a ") and not low.startswith("</"):
+            stack.append("a")
+        elif low == "</a>":
+            if stack and stack[-1] == "a":
+                stack.pop()
+        elif low.startswith("</"):
+            name = low[2:-1].strip().lower()
+            if name in _SIMPLE_TAG_NAMES and stack and stack[-1] == name:
+                stack.pop()
+        elif not low.startswith("<a ") and low[1] != "/":
+            name = low[1:-1].strip().lower().split()[0]
+            if name in _SIMPLE_TAG_NAMES:
+                stack.append(name)
+        pos = end + 1
+
+    return fragment + "".join(f"</{t}>" for t in reversed(stack))
+
+
+def truncate_for_telegram_html(text: str, max_len: int, suffix: str = "…") -> str:
+    """Truncate *text* for Telegram ``parse_mode=HTML`` without breaking markup at the cut."""
+    if len(text) <= max_len:
+        return text
+    if max_len <= len(suffix):
+        return suffix[:max_len]
+    room = max_len - len(suffix)
+    while room > 0:
+        chunk = text[:room]
+        chunk = _strip_trailing_incomplete_tag(chunk)
+        chunk = _strip_trailing_partial_entity(chunk)
+        chunk = _balance_telegram_markup_tags(chunk)
+        candidate = chunk + suffix
+        if len(candidate) <= max_len:
+            return candidate
+        room -= 1
+    return suffix[:max_len]
 
 
 def _redact_arg(a: object) -> object:
@@ -109,7 +182,10 @@ def send_telegram_report(
     if not bot_token or not chat_id:
         return False, "Missing bot_token or chat_id"
     reply_to_message_id: str = str(telegram_ctx.get("reply_to_message_id") or "")
-    text = truncate(report, _MESSAGE_LIMIT, suffix="…")
+    if parse_mode.upper() == "HTML":
+        text = truncate_for_telegram_html(report, _MESSAGE_LIMIT, suffix="…")
+    else:
+        text = truncate(report, _MESSAGE_LIMIT, suffix="…")
     post_success, error, _ = post_telegram_message(
         chat_id,
         text,

--- a/tests/nodes/publish_findings/test_masking_unmask.py
+++ b/tests/nodes/publish_findings/test_masking_unmask.py
@@ -43,6 +43,7 @@ def test_slack_message_is_unmasked_before_delivery() -> None:
     with (
         patch.object(pub_node, "build_report_context", return_value=MagicMock()),
         patch.object(pub_node, "format_slack_message", return_value=masked_message),
+        patch.object(pub_node, "format_telegram_message", return_value="tg"),
         patch.object(pub_node, "build_slack_blocks", return_value=[]),
         patch.object(pub_node, "render_report"),
         patch.object(pub_node, "open_in_editor"),
@@ -72,6 +73,7 @@ def test_empty_masking_map_is_passthrough() -> None:
     with (
         patch.object(pub_node, "build_report_context", return_value=MagicMock()),
         patch.object(pub_node, "format_slack_message", return_value=message_without_placeholders),
+        patch.object(pub_node, "format_telegram_message", return_value="tg"),
         patch.object(pub_node, "build_slack_blocks", return_value=[]),
         patch.object(pub_node, "render_report"),
         patch.object(pub_node, "open_in_editor"),

--- a/tests/nodes/publish_findings/test_node.py
+++ b/tests/nodes/publish_findings/test_node.py
@@ -78,6 +78,10 @@ def _patch_generate_report_deps(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda _ctx: "slack report text",
     )
     monkeypatch.setattr(
+        "app.nodes.publish_findings.node.format_telegram_message",
+        lambda _ctx: "telegram report text",
+    )
+    monkeypatch.setattr(
         "app.nodes.publish_findings.node.build_slack_blocks",
         lambda _ctx: [],
     )

--- a/tests/nodes/publish_findings/test_report_provenance.py
+++ b/tests/nodes/publish_findings/test_report_provenance.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from app.nodes.publish_findings.formatters.report import build_slack_blocks, format_slack_message
+from app.nodes.publish_findings.formatters.report import (
+    build_slack_blocks,
+    format_slack_message,
+    format_telegram_message,
+)
 from app.nodes.publish_findings.report_context import build_report_context
 
 
@@ -49,6 +53,19 @@ def test_build_report_context_adds_source_provenance() -> None:
     assert ctx["evidence_catalog"]["evidence/grafana/loki"]["provenance"] == (
         "instance=myorg.grafana.net, service=checkout-api, pipeline=checkout-service"
     )
+
+
+def test_format_telegram_message_uses_html_and_severity_header() -> None:
+    state = _make_state()
+    state["severity"] = "critical"
+    state["alert_name"] = "KubernetesJobFailed"
+    ctx = build_report_context(state)
+    body = format_telegram_message(ctx)
+    assert "🔴" in body
+    assert "<b>KubernetesJobFailed</b>" in body
+    assert "CRITICAL" in body
+    assert "##" not in body
+    assert "*Cited Evidence" not in body
 
 
 def test_format_slack_message_shows_provenance() -> None:

--- a/tests/nodes/publish_findings/test_report_provenance.py
+++ b/tests/nodes/publish_findings/test_report_provenance.py
@@ -55,6 +55,24 @@ def test_build_report_context_adds_source_provenance() -> None:
     )
 
 
+def test_format_telegram_message_omits_banner_only_root_cause() -> None:
+    state = _make_state()
+    state["severity"] = "info"
+    state["alert_name"] = "[synthetic-k8s] Scheduled Health Check — payments-api"
+    state["pipeline_name"] = "k8s-eks-synthetic"
+    state["root_cause"] = (
+        "[synthetic-k8s] Scheduled Health Check — payments-api on k8s-eks-synthetic "
+        "(severity: info)"
+    )
+    ctx = build_report_context(state)
+    body = format_telegram_message(ctx)
+    assert body.count("k8s-eks-synthetic") == 1
+    assert (
+        "Scheduled Health Check — payments-api on k8s-eks-synthetic (severity: info)"
+        not in body
+    )
+
+
 def test_format_telegram_message_uses_html_and_severity_header() -> None:
     state = _make_state()
     state["severity"] = "critical"

--- a/tests/nodes/publish_findings/test_report_provenance.py
+++ b/tests/nodes/publish_findings/test_report_provenance.py
@@ -55,6 +55,18 @@ def test_build_report_context_adds_source_provenance() -> None:
     )
 
 
+def test_format_telegram_message_does_not_treat_lonely_asterisk_as_bold() -> None:
+    state = _make_state()
+    state["severity"] = "warning"
+    state["alert_name"] = "Unit"
+    state["pipeline_name"] = "pipe"
+    state["root_cause"] = "Check 2 * 3 = 6 before scaling"
+    ctx = build_report_context(state)
+    body = format_telegram_message(ctx)
+    assert "2 * 3" in body
+    assert "<b>3</b>" not in body
+
+
 def test_format_telegram_message_omits_banner_only_root_cause() -> None:
     state = _make_state()
     state["severity"] = "info"
@@ -67,10 +79,7 @@ def test_format_telegram_message_omits_banner_only_root_cause() -> None:
     ctx = build_report_context(state)
     body = format_telegram_message(ctx)
     assert body.count("k8s-eks-synthetic") == 1
-    assert (
-        "Scheduled Health Check — payments-api on k8s-eks-synthetic (severity: info)"
-        not in body
-    )
+    assert "Scheduled Health Check — payments-api on k8s-eks-synthetic (severity: info)" not in body
 
 
 def test_format_telegram_message_uses_html_and_severity_header() -> None:

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -13,6 +13,7 @@ from app.utils.telegram_delivery import (
     _TelegramTokenFilter,
     post_telegram_message,
     send_telegram_report,
+    truncate_for_telegram_html,
 )
 
 # ---------------------------------------------------------------------------
@@ -313,6 +314,29 @@ def test_send_telegram_report_truncates_to_4096(monkeypatch: pytest.MonkeyPatch)
     send_telegram_report(long_report, {"bot_token": "tok", "chat_id": "chat-1"})
     assert len(captured["text"]) == 4096
     assert captured["text"].endswith("…")
+
+
+def test_truncate_for_telegram_html_strips_incomplete_trailing_tag() -> None:
+    # Narrow limit so slice lands after ``<b>`` opens but well before ``</b>``.
+    src = "<b>" + ("m" * 80)
+    out = truncate_for_telegram_html(src, 18, suffix="…")
+    assert len(out) <= 18
+    assert out.endswith("…")
+    assert not out[:-1].replace("…", "").endswith("<")
+
+
+def test_truncate_for_telegram_html_balances_open_tags_within_limit() -> None:
+    long_inner = "z" * 6000
+    src = f"<b>start {long_inner}</b>"
+    out = truncate_for_telegram_html(src, 4096, suffix="…")
+    assert len(out) == 4096
+    assert out.endswith("…")
+    assert out.count("<b>") == out.count("</b>")
+
+
+def test_truncate_for_telegram_html_noop_when_under_limit() -> None:
+    s = "<i>ok</i>"
+    assert truncate_for_telegram_html(s, 50) == s
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_telegram_delivery.py
+++ b/tests/utils/test_telegram_delivery.py
@@ -130,6 +130,7 @@ def test_send_telegram_report_posts_to_chat(monkeypatch: pytest.MonkeyPatch) -> 
     assert "tok" in captured["url"]
     assert captured["json"]["chat_id"] == "chat-1"
     assert captured["json"]["text"] == "Report text"
+    assert captured["json"]["parse_mode"] == "HTML"
 
 
 def test_send_telegram_report_uses_reply_to_message_id(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -145,6 +146,25 @@ def test_send_telegram_report_uses_reply_to_message_id(monkeypatch: pytest.Monke
         {"bot_token": "tok", "chat_id": "chat-1", "reply_to_message_id": "77"},
     )
     assert captured["json"].get("reply_to_message_id") == 77
+
+
+def test_send_telegram_report_passes_reply_markup(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, *, json: dict[str, Any], **_kw: Any) -> MagicMock:
+        captured["json"] = json
+        return _mock_response(200, {"ok": True, "result": {"message_id": 7}})
+
+    monkeypatch.setattr("app.utils.delivery_transport.httpx.post", _fake_post)
+    markup = {"inline_keyboard": [[{"text": "Open", "url": "https://x"}]]}
+    ok, err = send_telegram_report(
+        "Hi",
+        {"bot_token": "tok", "chat_id": "c1"},
+        reply_markup=markup,
+    )
+    assert ok is True
+    assert err == ""
+    assert captured["json"]["reply_markup"] == markup
 
 
 def test_send_telegram_report_returns_false_on_api_error(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Telegram Bot API does not interpret Slack-style `mrkdwn` (`##`, `*`, `<url|label>`). This change builds a **Telegram-specific HTML** RCA body for delivery, sets `parse_mode=HTML` where appropriate, adds a **Hermes-style severity line** in the header, and supports an optional **View investigation** button when a URL is available.

Fixes #1889

## New format

<img width="498" height="335" alt="image" src="https://github.com/user-attachments/assets/e1a51ef2-5b0f-4906-9272-0d2edc0da5d0" />
