### PR TITLE
fix(cli): terminate streaming investigation cleanly on Ctrl+C

### DIFF
--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -244,6 +244,8 @@ def investigate_command(
                 write_json(result, output)
     except SystemExit:
         raise
+    except KeyboardInterrupt:
+        raise SystemExit(SUCCESS) from None
 
     raise SystemExit(SUCCESS)
 

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from langsmith import traceable
@@ -148,7 +148,7 @@ def stream_investigation_cli(
     alert_name: str | None = None,
     pipeline_name: str | None = None,
     severity: str | None = None,
-) -> Iterator[StreamEvent]:
+) -> Generator[StreamEvent]:
     """Stream investigation events locally via ``astream_events``.
 
     Bridges the async LangGraph streaming API into a synchronous iterator

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import threading
 from collections.abc import Generator, Iterator
@@ -224,7 +225,9 @@ def stream_investigation_cli(
         task = pump_task_ref.get("task")
         if loop is None or task is None or loop.is_closed():
             return
-        loop.call_soon_threadsafe(task.cancel)
+        with contextlib.suppress(RuntimeError):
+            # Loop may close between `is_closed()` and scheduling cancellation.
+            loop.call_soon_threadsafe(task.cancel)
 
     try:
         while True:
@@ -233,7 +236,7 @@ def stream_investigation_cli(
             except queue.Empty:
                 continue
             if isinstance(item, BaseException):
-                thread.join()
+                thread.join(timeout=5)
                 _reraise_investigation_failure(item)
             if item is None:
                 break
@@ -345,7 +348,9 @@ def _run_session_alert_payload(
         task = pump_task_ref.get("task")
         if loop is None or task is None or loop.is_closed():
             return
-        loop.call_soon_threadsafe(task.cancel)
+        with contextlib.suppress(RuntimeError):
+            # Loop may close between `is_closed()` and scheduling cancellation.
+            loop.call_soon_threadsafe(task.cancel)
 
     def _events() -> Iterator[StreamEvent]:
         try:
@@ -358,6 +363,7 @@ def _run_session_alert_payload(
                 except queue.Empty:
                     continue
                 if isinstance(item, BaseException):
+                    thread.join(timeout=5)
                     _reraise_investigation_failure(item)
                 if item is None:
                     return

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+
+class _InvestigationPumpCancelled(Exception):
+    """Propagated when the async pump task was cancelled (distinct from Ctrl+C SIGINT)."""
+
+
 _SESSION_EVENT_POLL_S = 0.25
 
 
@@ -46,6 +51,14 @@ def _check_llm_settings() -> None:
 
 def _reraise_investigation_failure(exc: BaseException) -> NoReturn:
     """Map investigation runtime failures to structured CLI errors."""
+    if isinstance(exc, _InvestigationPumpCancelled):
+        from app.cli.support.errors import OpenSREError
+
+        raise OpenSREError(
+            "Investigation streaming stopped before completion.",
+            suggestion="The run was cancelled or closed early. Retry if you still need results.",
+        ) from exc
+
     reraise_cli_runtime_error(exc)
 
 
@@ -196,7 +209,7 @@ def stream_investigation_cli(
             try:
                 loop.run_until_complete(task)
             except asyncio.CancelledError:
-                event_queue.put(KeyboardInterrupt("investigation cancelled"))
+                event_queue.put(_InvestigationPumpCancelled())
         except Exception as exc:
             event_queue.put(exc)
         finally:
@@ -225,10 +238,8 @@ def stream_investigation_cli(
             if item is None:
                 break
             yield item
-    except KeyboardInterrupt:
-        _cancel_pump()
-        raise
     finally:
+        _cancel_pump()
         thread.join(timeout=5)
         if thread.is_alive():
             _logger.warning(
@@ -319,7 +330,7 @@ def _run_session_alert_payload(
             try:
                 loop.run_until_complete(task)
             except asyncio.CancelledError:
-                event_queue.put(KeyboardInterrupt("investigation cancelled"))
+                event_queue.put(_InvestigationPumpCancelled())
         except Exception as exc:
             event_queue.put(exc)
         finally:
@@ -351,9 +362,8 @@ def _run_session_alert_payload(
                 if item is None:
                     return
                 yield item
-        except KeyboardInterrupt:
+        finally:
             _cancel_pump()
-            raise
 
     renderer = StreamRenderer(local=True)
     try:

--- a/app/cli/investigation/investigate.py
+++ b/app/cli/investigation/investigate.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+_SESSION_EVENT_POLL_S = 0.25
+
 
 def _check_llm_settings() -> None:
     """Validate LLM settings early and surface misconfiguration as a structured error."""
@@ -153,6 +155,10 @@ def stream_investigation_cli(
     using a background thread + queue so events are yielded in real time
     (not batched).  The same ``StreamRenderer`` used for remote
     investigations can render local runs identically.
+
+    On :exc:`KeyboardInterrupt` the background asyncio task is cancelled
+    and the thread is joined so Ctrl+C terminates cleanly instead of
+    leaving an orphaned LangGraph run in flight.
     """
     import queue
     import threading
@@ -167,10 +173,13 @@ def stream_investigation_cli(
         severity=severity,
     )
 
-    event_queue: queue.Queue[StreamEvent | Exception | None] = queue.Queue()
+    event_queue: queue.Queue[StreamEvent | BaseException | None] = queue.Queue()
+    loop_ref: dict[str, asyncio.AbstractEventLoop] = {}
+    pump_task_ref: dict[str, asyncio.Task[None]] = {}
 
     def _run_async() -> None:
         loop = asyncio.new_event_loop()
+        loop_ref["loop"] = loop
         try:
 
             async def _pump() -> None:
@@ -182,7 +191,12 @@ def stream_investigation_cli(
                 ):
                     event_queue.put(evt)
 
-            loop.run_until_complete(_pump())
+            task = loop.create_task(_pump())
+            pump_task_ref["task"] = task
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError:
+                event_queue.put(KeyboardInterrupt("investigation cancelled"))
         except Exception as exc:
             event_queue.put(exc)
         finally:
@@ -192,16 +206,35 @@ def stream_investigation_cli(
     thread = threading.Thread(target=_run_async, daemon=True)
     thread.start()
 
-    while True:
-        item = event_queue.get()
-        if isinstance(item, Exception):
-            thread.join()
-            _reraise_investigation_failure(item)
-        if item is None:
-            break
-        yield item
+    def _cancel_pump() -> None:
+        loop = loop_ref.get("loop")
+        task = pump_task_ref.get("task")
+        if loop is None or task is None or loop.is_closed():
+            return
+        loop.call_soon_threadsafe(task.cancel)
 
-    thread.join()
+    try:
+        while True:
+            try:
+                item = event_queue.get(timeout=_SESSION_EVENT_POLL_S)
+            except queue.Empty:
+                continue
+            if isinstance(item, BaseException):
+                thread.join()
+                _reraise_investigation_failure(item)
+            if item is None:
+                break
+            yield item
+    except KeyboardInterrupt:
+        _cancel_pump()
+        raise
+    finally:
+        thread.join(timeout=5)
+        if thread.is_alive():
+            _logger.warning(
+                "investigation thread did not terminate within 5s after cancellation; "
+                "an LLM call may still be in flight"
+            )
 
 
 def run_investigation_cli_streaming(
@@ -225,16 +258,19 @@ def run_investigation_cli_streaming(
         severity=severity,
     )
     renderer = StreamRenderer(local=True)
-    final_state = renderer.render_stream(events)
+    try:
+        final_state = renderer.render_stream(events)
+    except KeyboardInterrupt:
+        # Force-close the generator so the background thread's finally block
+        # runs and the async task is cancelled before we re-raise.
+        events.close()
+        raise
     return {
         "report": final_state.get("slack_message", final_state.get("report", "")),
         "problem_md": final_state.get("problem_md", ""),
         "root_cause": final_state.get("root_cause", ""),
         "is_noise": final_state.get("is_noise", False),
     }
-
-
-_SESSION_EVENT_POLL_S = 0.25
 
 
 def _run_session_alert_payload(

--- a/app/remote/renderer.py
+++ b/app/remote/renderer.py
@@ -368,10 +368,12 @@ class StreamRenderer:
         if not self._local:
             _print_connection_banner()
 
+        _interrupted = False
         try:
             for event in events:
                 self._handle_event(event)
         except KeyboardInterrupt:
+            _interrupted = True
             get_analytics().capture(
                 Event.INVESTIGATION_ABANDONED,
                 {
@@ -388,7 +390,8 @@ class StreamRenderer:
             # report the user has been watching stream live would be
             # silently discarded before the exception propagates.
             self._finish_active_node()
-            self._print_report()
+            if not _interrupted:
+                self._print_report()
         return dict(self._final_state)
 
     def _handle_event(self, event: StreamEvent) -> None:

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -153,6 +153,7 @@ def test_stream_investigation_cli_closes_cleanly_on_generator_close(
 ) -> None:
     """Closing the generator must not hang and must clean up the background thread."""
     import asyncio
+    import time
 
     async def fake_astream_investigation(*args: object, **kwargs: object):
         yield StreamEvent("metadata", data={"run_id": "run-123"})
@@ -169,8 +170,10 @@ def test_stream_investigation_cli_closes_cleanly_on_generator_close(
     first = next(events)
     assert first.event_type == "metadata"
 
-    # Closing the generator should trigger cleanup without hanging
+    # Without eager pump cancellation, thread.join() would block for the full timeout (~5s).
+    t0 = time.monotonic()
     events.close()
+    assert time.monotonic() - t0 < 2.0
 
 
 def test_run_investigation_cli_maps_cli_auth_to_opensre_error(

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -148,6 +148,31 @@ def test_stream_investigation_cli_raises_queued_exception_immediately(
         next(events)
 
 
+def test_stream_investigation_cli_closes_cleanly_on_generator_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing the generator must not hang and must clean up the background thread."""
+    import asyncio
+
+    async def fake_astream_investigation(*args: object, **kwargs: object):
+        yield StreamEvent("metadata", data={"run_id": "run-123"})
+        # Simulate a long-running stream
+        await asyncio.sleep(1000)
+
+    monkeypatch.setattr("app.cli.investigation.investigate.LLMSettings.from_env", object)
+    monkeypatch.setattr(
+        "app.pipeline.runners.astream_investigation",
+        fake_astream_investigation,
+    )
+
+    events = stream_investigation_cli(raw_alert={"alert_name": "PayloadAlert"})
+    first = next(events)
+    assert first.event_type == "metadata"
+
+    # Closing the generator should trigger cleanup without hanging
+    events.close()
+
+
 def test_run_investigation_cli_maps_cli_auth_to_opensre_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/test_investigate_service_flag.py
+++ b/tests/cli/test_investigate_service_flag.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import NoReturn
 from unittest.mock import patch
 
 import pytest
@@ -185,3 +186,54 @@ def test_slack_thread_passed_to_payload_builder(monkeypatch) -> None:
         slack_thread_ref="C01234/1712345.000001",
         slack_bot_token="xoxb-fake-token",
     )
+
+
+def test_investigate_command_keyboard_interrupt_non_streaming(monkeypatch) -> None:
+    """Ctrl+C during a non-streaming investigation exits cleanly with code 0."""
+    runner = CliRunner()
+
+    def fake_run(*args: object, **kwargs: object) -> NoReturn:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("app.cli.investigation.run_investigation_cli", fake_run)
+    monkeypatch.setattr(
+        "app.cli.investigation.payload.load_payload", lambda **_: {"alert_name": "A"}
+    )
+    monkeypatch.setattr("app.cli.commands.general.is_json_output", lambda: True)
+
+    result = runner.invoke(investigate_command, ["--input", "/tmp/alert.json"])
+    assert result.exit_code == 0
+    assert result.exception is None
+
+
+def test_investigate_command_keyboard_interrupt_streaming(monkeypatch) -> None:
+    """Ctrl+C during a streaming investigation exits cleanly with code 0."""
+    import sys as real_sys
+    import types
+    from unittest.mock import MagicMock
+
+    runner = CliRunner()
+
+    def fake_streaming(*args: object, **kwargs: object) -> NoReturn:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("app.cli.investigation.run_investigation_cli_streaming", fake_streaming)
+    monkeypatch.setattr(
+        "app.cli.investigation.payload.load_payload", lambda **_: {"alert_name": "A"}
+    )
+    monkeypatch.setattr("app.cli.commands.general.is_json_output", lambda: False)
+
+    # Click's CliRunner patches the real sys.stdout, but
+    # app.cli.commands.general imported sys at module load time.
+    # Replace it with a fake module whose stdout reports isatty=True
+    # so the command takes the streaming path.
+    fake_sys = types.ModuleType("sys")
+    fake_sys.__dict__.update(real_sys.__dict__)
+    fake_sys.stdout = MagicMock()
+    fake_sys.stdout.isatty.return_value = True
+
+    with patch("app.cli.commands.general.sys", fake_sys):
+        result = runner.invoke(investigate_command, ["--input", "/tmp/alert.json"])
+
+    assert result.exit_code == 0
+    assert result.exception is None

--- a/tests/remote/test_renderer.py
+++ b/tests/remote/test_renderer.py
@@ -6,6 +6,8 @@ import os
 from collections.abc import Iterator
 from unittest.mock import patch
 
+import pytest
+
 from app.remote.renderer import StreamRenderer, _canonical_node_name
 from app.remote.stream import StreamEvent
 
@@ -359,6 +361,35 @@ class TestStreamRendererCleanupOnException:
         assert renderer.final_state.get("alert_name") == "partial-alert", (
             "accumulated state from before the failure must be retained"
         )
+
+    @patch.dict(os.environ, {"TRACER_OUTPUT_FORMAT": "text"})
+    def test_print_report_skipped_on_keyboard_interrupt(self) -> None:
+        """_print_report must NOT run when the user presses Ctrl+C."""
+
+        def stream_raises_keyboard_interrupt() -> Iterator[StreamEvent]:
+            yield _make_event("metadata", data={"run_id": "r-ki"})
+            yield _make_event(
+                "updates",
+                "extract_alert",
+                {"extract_alert": {"alert_name": "interrupted-alert"}},
+            )
+            raise KeyboardInterrupt
+
+        renderer = StreamRenderer()
+        print_report_calls: list[None] = []
+        finish_calls: list[None] = []
+
+        renderer._print_report = lambda: print_report_calls.append(None)  # type: ignore[method-assign]
+        renderer._finish_active_node = lambda: finish_calls.append(None)  # type: ignore[method-assign]
+
+        with pytest.raises(KeyboardInterrupt):
+            renderer.render_stream(stream_raises_keyboard_interrupt())
+
+        assert finish_calls, "spinner cleanup must run on Ctrl+C"
+        assert not print_report_calls, (
+            "_print_report() must be skipped when the user interrupts the stream"
+        )
+        assert renderer.final_state.get("alert_name") == "interrupted-alert"
 
 
 def _diagnose_streaming_events() -> Iterator[StreamEvent]:


### PR DESCRIPTION

## Issue

Pressing Ctrl+C during `opensre investigate --input <file>` (interactive TTY / streaming path) did not terminate the process cleanly. The main thread received `KeyboardInterrupt`, but the background LangGraph asyncio task continued running in the daemon thread, leaving an orphaned investigation in flight and printing a partial or empty RCA report after the interrupt.

## Root Cause

1. `stream_investigation_cli()` blocked on `queue.get()` without a timeout, so when Ctrl+C arrived there was no opportunity to cancel the background asyncio task.
2. `run_investigation_cli_streaming()` did not close the generator on `KeyboardInterrupt`, so the background thread's cleanup never ran.
3. `investigate_command()` did not catch `KeyboardInterrupt`, allowing an ugly traceback to propagate.
4. `StreamRenderer.render_stream()` called `_print_report()` unconditionally in its `finally` block, so even an intentionally aborted stream printed the final report panel.

## Changes

### `app/cli/investigation/investigate.py`
- `stream_investigation_cli`: adds a `_SESSION_EVENT_POLL_S` timeout to `queue.get()`, captures `loop_ref` and `pump_task_ref`, and on `KeyboardInterrupt` calls `task.cancel()` via `loop.call_soon_threadsafe()` before joining the daemon thread (5s timeout).
- `run_investigation_cli_streaming`: closes the generator on `KeyboardInterrupt` so the background task is torn down before re-raising.

### `app/cli/commands/general.py`
- `investigate_command`: catches `KeyboardInterrupt` and exits with `SystemExit(SUCCESS)` (same graceful pattern used by `health_command --watch`).

### `app/remote/renderer.py`
- `render_stream`: tracks whether the stream was interrupted (`_interrupted = True` in the `KeyboardInterrupt` handler). The `finally` block still calls `_finish_active_node()` to stop spinners / close Rich `Live` regions (preventing terminal corruption), but **skips `_print_report()`** when interrupted so the user doesn't see an incomplete / empty RCA panel.

### Tests
- `test_stream_investigation_cli_closes_cleanly_on_generator_close` — generator `.close()` cleans up thread without hanging.
- `test_investigate_command_keyboard_interrupt_non_streaming` — Ctrl+C exits 0 on non-streaming path.
- `test_investigate_command_keyboard_interrupt_streaming` — Ctrl+C exits 0 on streaming path.
- `test_print_report_skipped_on_keyboard_interrupt` — renderer skips final report on interrupt.

## Verification

```bash
uv run pytest tests/cli/test_investigate.py tests/cli/test_investigate_service_flag.py tests/remote/test_renderer.py -q
# 76 passed
```