### PR TITLE
fix(hermes): match pattern rules against message only

### DIFF
--- a/app/hermes/rules.py
+++ b/app/hermes/rules.py
@@ -45,7 +45,8 @@ class PatternRule:
     """Rule that emits one incident per matching log record.
 
     Patterns are matched case-insensitively against the record's
-    message. Any pattern matching causes the rule to fire.
+    message only. The raw line often contains timestamps, levels, and
+    logger names; matching that prefix can produce false positives.
     """
 
     name: str
@@ -60,7 +61,7 @@ class PatternRule:
         if record.level.severity_rank < self.min_level.severity_rank:
             return None
         for pattern in self.patterns:
-            if pattern.search(record.message) or pattern.search(record.raw):
+            if pattern.search(record.message):
                 title = self.title_template.format(
                     logger=record.logger or "unknown",
                     level=record.level.value,
@@ -85,6 +86,7 @@ class RepeatRule:
     Used for ``crash_loop`` and any other failure mode that's only
     actionable when it repeats. Each rule keeps its own bounded deque
     keyed by logger; older matches age out automatically.
+    Patterns scan the parsed message, not the raw log prefix.
     """
 
     name: str
@@ -101,7 +103,7 @@ class RepeatRule:
             return None
         if record.level.severity_rank < self.min_level.severity_rank:
             return None
-        if not any(p.search(record.message) or p.search(record.raw) for p in self.patterns):
+        if not any(p.search(record.message) for p in self.patterns):
             return None
         key = record.logger or "_unknown"
         bucket = self._hits.setdefault(key, deque())

--- a/pr/pr-1874-hermes-message-only-rules.md
+++ b/pr/pr-1874-hermes-message-only-rules.md
@@ -1,0 +1,40 @@
+Fixes #1874
+
+#### Describe the changes you have made in this PR -
+
+- Updated `PatternRule` and `RepeatRule` to match only `LogRecord.message`, not `LogRecord.raw`.
+- Added regression coverage for logger-name-only false positives.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall app\hermes\rules.py tests\hermes\test_rules.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
+- [x] Yes, I used AI assistance (continue below)
+
+**If you used AI assistance:**
+- [x] I have reviewed every single line of the AI-generated code
+- [x] I can explain the purpose and logic of each function/component I added
+- [x] I have tested edge cases and understand how the code handles them
+- [x] I have modified the AI output to follow this project's coding standards and conventions
+
+**Explain your implementation approach:**
+
+The raw log line includes structural prefixes such as timestamp, level, and logger name. Scanning it lets a logger name trigger OOM/crash-loop rules even when the message is benign. The fix keeps classification focused on parsed message text and pins both single-record and repeat-rule boundaries with tests.
+
+---
+
+## Checklist before requesting a review
+- [x] I have added proper PR title and linked to the issue
+- [x] I have performed a self-review of my code
+- [x] I can explain the purpose of every function, class, and logic block I added
+- [x] I understand why my changes work and have tested them thoroughly
+- [x] I have considered potential edge cases and how my code handles them
+- [x] If it is a core feature, I have added thorough tests
+- [x] My code follows the project's style guidelines and conventions

--- a/tests/hermes/test_rules.py
+++ b/tests/hermes/test_rules.py
@@ -77,6 +77,13 @@ def test_pattern_rules_ignore_continuation_lines() -> None:
     assert rule.evaluate(record) is None
 
 
+def test_pattern_rules_do_not_match_logger_name_only() -> None:
+    rules = {r.name: r for r in default_pattern_rules()}
+    rule = rules["oom_killed"]
+    record = _rec("benign worker heartbeat", logger_name="oom-killer.worker")
+    assert rule.evaluate(record) is None
+
+
 def test_repeat_rule_only_fires_at_threshold() -> None:
     crash = next(r for r in default_pattern_rules() if r.name == "crash_loop")
     assert isinstance(crash, RepeatRule)
@@ -99,6 +106,23 @@ def test_repeat_rule_crash_loop_ignores_info_level_restart_spam() -> None:
     msg = "agent restarted after unexpected exit"
     for i in range(5):
         assert crash.evaluate(_rec(msg, level=LogLevel.INFO, seconds=i * 5)) is None
+
+
+def test_repeat_rule_does_not_count_logger_name_only_matches() -> None:
+    crash = next(r for r in default_pattern_rules() if r.name == "crash_loop")
+    assert isinstance(crash, RepeatRule)
+    for i in range(5):
+        assert (
+            crash.evaluate(
+                _rec(
+                    "routine heartbeat",
+                    level=LogLevel.WARNING,
+                    logger_name="agent-restarting-supervisor",
+                    seconds=i * 10,
+                )
+            )
+            is None
+        )
 
 
 def test_repeat_rule_window_ages_out_old_hits() -> None:


### PR DESCRIPTION
﻿Fixes #1874

#### Describe the changes you have made in this PR -

- Updated `PatternRule` and `RepeatRule` to match only `LogRecord.message`, not `LogRecord.raw`.
- Added regression coverage for logger-name-only false positives.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall app\hermes\rules.py tests\hermes\test_rules.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The raw log line includes structural prefixes such as timestamp, level, and logger name. Scanning it lets a logger name trigger OOM/crash-loop rules even when the message is benign. The fix keeps classification focused on parsed message text and pins both single-record and repeat-rule boundaries with tests.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

