### PR TITLE
fix(e2e): resolve deploy helper asset paths from repo root

### DIFF
--- a/pr/pr-1418-e2e-deploy-helper-paths.md
+++ b/pr/pr-1418-e2e-deploy-helper-paths.md
@@ -1,0 +1,31 @@
+Fixes #1418
+
+#### Describe the changes you have made in this PR -
+
+- Corrected three E2E deploy helpers to resolve the repository root with `parents[4]`.
+- Fixed scenario asset paths to include `tests/e2e/...` where needed.
+- Added regression tests that assert shared and scenario assets resolve to existing paths.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall tests\e2e\test_deploy_helper_paths.py tests\e2e\upstream_lambda\infrastructure_sdk\deploy.py tests\e2e\upstream_prefect_ecs_fargate\infrastructure_sdk\deploy.py tests\e2e\upstream_apache_flink_ecs\infrastructure_sdk\deploy.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+Files under `tests/e2e/<scenario>/infrastructure_sdk/deploy.py` need four parent hops to reach the repo root. Once that base is correct, shared assets stay under `tests/shared`, while scenario assets are under `tests/e2e/<scenario>`.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to issue
+- [x] Added regression tests
+- [x] Verified syntax compilation

--- a/tests/e2e/test_deploy_helper_paths.py
+++ b/tests/e2e/test_deploy_helper_paths.py
@@ -1,0 +1,41 @@
+"""Regression tests for E2E deploy helper repository-root paths."""
+
+from __future__ import annotations
+
+from tests.e2e.upstream_apache_flink_ecs.infrastructure_sdk import deploy as flink_deploy
+from tests.e2e.upstream_lambda.infrastructure_sdk import deploy as lambda_deploy
+from tests.e2e.upstream_prefect_ecs_fargate.infrastructure_sdk import deploy as prefect_deploy
+
+
+def test_e2e_deploy_helpers_resolve_repo_root() -> None:
+    for module in (lambda_deploy, prefect_deploy, flink_deploy):
+        assert (module.project_root / "pyproject.toml").exists()
+        assert module.project_root.name == "opensre"
+
+
+def test_upstream_lambda_asset_paths_exist() -> None:
+    root = lambda_deploy.project_root
+    assert (root / "tests" / "shared" / "external_vendor_api").exists()
+    assert (root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code").exists()
+
+
+def test_upstream_prefect_asset_paths_exist() -> None:
+    assert prefect_deploy.MOCK_API_CODE.exists()
+    assert prefect_deploy.TRIGGER_LAMBDA_CODE.exists()
+    assert prefect_deploy.PREFECT_DOCKERFILE.exists()
+
+
+def test_upstream_flink_asset_paths_exist() -> None:
+    root = flink_deploy.project_root
+    assert (
+        root
+        / "tests"
+        / "e2e"
+        / "upstream_apache_flink_ecs"
+        / "infrastructure_code"
+        / "flink_image"
+        / "Dockerfile"
+    ).exists()
+    assert (
+        root / "tests" / "e2e" / "upstream_apache_flink_ecs" / "pipeline_code" / "trigger_lambda"
+    ).exists()

--- a/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from tests.shared.infrastructure_sdk import save_outputs
 from tests.shared.infrastructure_sdk.resources import (
@@ -154,6 +154,7 @@ def deploy() -> dict:
     dockerfile_path = (
         project_root
         / "tests"
+        / "e2e"
         / "upstream_apache_flink_ecs"
         / "infrastructure_code"
         / "flink_image"

--- a/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
@@ -27,7 +27,7 @@ from tests.shared.infrastructure_sdk.resources import api_gateway, iam, lambda_,
 from tests.shared.infrastructure_sdk.resources.iam import get_account_id, put_role_policy
 from tests.shared.infrastructure_sdk.resources.secrets import get_secret_value
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 STACK_NAME = "tracer-lambda"
 REGION = "us-east-1"
@@ -186,7 +186,7 @@ def create_lambda_functions(
 
     # Paths
     shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = project_root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"
 
     # Bundle code
     print("  Bundling MockApi Lambda code...")
@@ -431,7 +431,7 @@ def deploy() -> dict:
 
     # 4. Create pipeline Lambdas with correct URLs
     print("Creating pipeline Lambda functions...")
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = project_root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"
 
     print("  Bundling pipeline code (dependencies already vendored)...")
     # Use custom bundling that puts vendored deps at root level

--- a/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
@@ -23,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from app.utils.config import load_env
 from tests.shared.infrastructure_sdk import save_outputs
@@ -58,8 +58,9 @@ TRIGGER_LAMBDA_NAME = "tracer-prefect-ecs-trigger"
 
 # Paths
 TESTS_DIR = project_root / "tests"
+E2E_DIR = TESTS_DIR / "e2e"
 PREFECT_DOCKERFILE = (
-    TESTS_DIR
+    E2E_DIR
     / "upstream_prefect_ecs_fargate"
     / "infrastructure_code"
     / "prefect_image"
@@ -68,7 +69,7 @@ PREFECT_DOCKERFILE = (
 ALLOY_CONFIG_DIR = TESTS_DIR / "shared" / "infrastructure_code" / "alloy_config"
 MOCK_API_CODE = TESTS_DIR / "shared" / "external_vendor_api"
 TRIGGER_LAMBDA_CODE = (
-    TESTS_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
+    E2E_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
 )
 
 GRAFANA_ENV_KEYS = [


### PR DESCRIPTION
﻿Fixes #1418

#### Describe the changes you have made in this PR -

- Corrected three E2E deploy helpers to resolve the repository root with `parents[4]`.
- Fixed scenario asset paths to include `tests/e2e/...` where needed.
- Added regression tests that assert shared and scenario assets resolve to existing paths.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall tests\e2e\test_deploy_helper_paths.py tests\e2e\upstream_lambda\infrastructure_sdk\deploy.py tests\e2e\upstream_prefect_ecs_fargate\infrastructure_sdk\deploy.py tests\e2e\upstream_apache_flink_ecs\infrastructure_sdk\deploy.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

Files under `tests/e2e/<scenario>/infrastructure_sdk/deploy.py` need four parent hops to reach the repo root. Once that base is correct, shared assets stay under `tests/shared`, while scenario assets are under `tests/e2e/<scenario>`.

---

## Checklist before requesting a review
- [x] Linked to issue
- [x] Added regression tests
- [x] Verified syntax compilation

---

