### PR TITLE
fix(repl): avoid assistant spinner for slash commands

### DIFF
--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -288,6 +288,10 @@ def _dispatch_one_turn(
         Event.INTERACTIVE_SHELL_ROUTE_DECISION,
         decision.to_event_payload(),
     )
+    if kind != "slash":
+        begin_spinner = getattr(console, "begin_assistant_spinner", None)
+        if callable(begin_spinner):
+            begin_spinner()
     if kind in ("follow_up", "new_alert") and _looks_like_correction(text):
         session.record_intervention("correction")
 
@@ -702,6 +706,9 @@ class _StreamingConsole(Console):
         # the token counter is imperceptible.
         self._spinner.bytes_in = bytes_received
 
+    def begin_assistant_spinner(self) -> None:
+        self._spinner.start()
+
     @property
     def cancel_requested(self) -> bool:
         return self._cancel_event.is_set()
@@ -780,7 +787,6 @@ async def _run_interactive(
             color_system="truecolor",
             legacy_windows=False,
         )
-        spinner.start()
         try:
             await asyncio.to_thread(
                 _dispatch_one_turn,

--- a/pr/pr-1904-repl-slash-spinner.md
+++ b/pr/pr-1904-repl-slash-spinner.md
@@ -1,0 +1,31 @@
+Fixes #1904
+
+#### Describe the changes you have made in this PR -
+
+- Moved assistant spinner startup until after routing decides the turn is not a slash command.
+- Added `begin_assistant_spinner()` on the streaming console bridge.
+- Added tests proving slash commands do not start the assistant/token spinner, while LLM routes still do.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall app\cli\interactive_shell\loop.py tests\cli\interactive_shell\test_loop.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+The spinner was started before routing, so menu slash commands inherited the assistant-token UI despite not calling an LLM. The spinner now starts only for non-slash routes after `route_input` returns.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to issue
+- [x] Added regression tests
+- [x] Verified syntax compilation

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -513,6 +513,54 @@ def test_dispatch_one_turn_calls_on_exit_when_slash_returns_false(
     assert exit_calls == [None]
 
 
+def test_dispatch_one_turn_does_not_start_assistant_spinner_for_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rich.console import Console
+
+    class _Console(Console):
+        spinner_started = False
+
+        def begin_assistant_spinner(self) -> None:
+            self.spinner_started = True
+
+    monkeypatch.setattr(
+        loop,
+        "route_input",
+        lambda *_args: RouteDecision(RouteKind.SLASH, 1.0, ("slash_command",)),
+    )
+    monkeypatch.setattr(loop, "dispatch_slash", lambda *_args, **_kwargs: True)
+
+    console = _Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    loop._dispatch_one_turn("/history", ReplSession(), console, on_exit=lambda: None)
+
+    assert console.spinner_started is False
+
+
+def test_dispatch_one_turn_starts_assistant_spinner_for_llm_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from rich.console import Console
+
+    class _Console(Console):
+        spinner_started = False
+
+        def begin_assistant_spinner(self) -> None:
+            self.spinner_started = True
+
+    monkeypatch.setattr(
+        loop,
+        "route_input",
+        lambda *_args: RouteDecision(RouteKind.CLI_HELP, 1.0, ("help",)),
+    )
+    monkeypatch.setattr(loop, "answer_cli_help", lambda *_args, **_kwargs: None)
+
+    console = _Console(file=io.StringIO(), force_terminal=False, highlight=False)
+    loop._dispatch_one_turn("explain /tests", ReplSession(), console, on_exit=lambda: None)
+
+    assert console.spinner_started is True
+
+
 class TestLooksLikeCorrection:
     """Unit tests for the ``_looks_like_correction`` heuristic.
 


### PR DESCRIPTION
﻿Fixes #1904

#### Describe the changes you have made in this PR -

- Moved assistant spinner startup until after routing decides the turn is not a slash command.
- Added `begin_assistant_spinner()` on the streaming console bridge.
- Added tests proving slash commands do not start the assistant/token spinner, while LLM routes still do.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall app\cli\interactive_shell\loop.py tests\cli\interactive_shell\test_loop.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

The spinner was started before routing, so menu slash commands inherited the assistant-token UI despite not calling an LLM. The spinner now starts only for non-slash routes after `route_input` returns.

---

## Checklist before requesting a review
- [x] Linked to issue
- [x] Added regression tests
- [x] Verified syntax compilation

---

