### PR TITLE
fix(cli): improve quickstart and provider error UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,17 @@ pipx install opensre
 Configure once, then pick how you want to run investigations:
 
 ```bash
+opensre onboard local_llm   # local Ollama path, no API key required
 opensre onboard
+```
+
+If the binary install fails on an older Linux host, run from source:
+
+```bash
+git clone https://github.com/Tracer-Cloud/opensre
+cd opensre
+uv sync --frozen --extra dev
+uv run opensre --version
 ```
 
 **Interactive shell** — with no subcommand, `opensre` starts a REPL (TTY required). Describe incidents in plain language, stream investigations, and use slash commands such as `/help`, `/status`, `/clear`, `/reset`, `/trust`, `/effort`, `/exit`. `/effort` sets reasoning depth for **OpenAI** and **Codex** providers (`low`, `medium`, `high`, `xhigh`, or `max`; other providers ignore it). Ctrl+C cancels an in-flight investigation without losing session state.

--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -28,5 +28,17 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
                 str(exc),
                 suggestion="Verify your model name in ANTHROPIC_REASONING_MODEL or ANTHROPIC_TOOLCALL_MODEL environment variables.",
             ) from exc
+        if "anthropic" in msg and "usage limits" in msg:
+            raise OpenSREError(
+                "Anthropic API usage limit reached.",
+                suggestion="Wait for the provider quota reset or switch LLM_PROVIDER to another configured provider.",
+            ) from exc
+        if "cannot connect to ollama api" in msg or (
+            "ollama" in msg and "connection" in msg
+        ):
+            raise OpenSREError(
+                "Cannot connect to Ollama API.",
+                suggestion="Start Ollama, then run `opensre onboard local_llm` or set LLM_PROVIDER to a reachable provider.",
+            ) from exc
 
     raise exc

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -17,6 +17,15 @@ slug: "quickstart"
         ```bash
         curl -fsSL https://install.opensre.com | bash
         ```
+
+        If the binary install fails on an older Linux host, run from source:
+
+        ```bash
+        git clone https://github.com/Tracer-Cloud/opensre
+        cd opensre
+        uv sync --frozen --extra dev
+        uv run opensre --version
+        ```
       </Tab>
       <Tab title="Windows">
         ```powershell
@@ -28,7 +37,13 @@ slug: "quickstart"
   </Step>
 
   <Step title="Onboard">
-    Run the onboarding wizard to configure your LLM provider and connect your integrations (Grafana, Datadog, Honeycomb, Coralogix, Slack, AWS, GitHub MCP, Sentry):
+    For a no-API-key trial, configure a local Ollama-backed model first:
+
+    ```bash
+    opensre onboard local_llm
+    ```
+
+    To configure a hosted provider and connect integrations (Grafana, Datadog, Honeycomb, Coralogix, Slack, AWS, GitHub MCP, Sentry), run:
 
     ```bash
     opensre onboard

--- a/pr/pr-1876-quickstart-provider-errors.md
+++ b/pr/pr-1876-quickstart-provider-errors.md
@@ -1,0 +1,31 @@
+Fixes #1876
+
+#### Describe the changes you have made in this PR -
+
+- Promoted `opensre onboard local_llm` in the quickstart and README.
+- Added a source-install fallback for older Linux hosts where the binary may not run.
+- Mapped Ollama connectivity failures to `OpenSREError` so CLI users get a clean actionable message instead of a traceback.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall app\cli\support\cli_error_mapping.py tests\cli\test_investigate.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+The docs change makes the no-key local path visible before hosted-provider onboarding. The runtime change reuses the existing CLI error mapping boundary so provider connectivity errors render like other setup issues.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to issue
+- [x] Docs updated with behavior change
+- [x] Added unit coverage for the error mapping

--- a/pr/pr-1883-1885-anthropic-usage-limit.md
+++ b/pr/pr-1883-1885-anthropic-usage-limit.md
@@ -1,0 +1,31 @@
+Fixes #1883
+Fixes #1885
+
+#### Describe the changes you have made in this PR -
+
+- Mapped Anthropic usage-limit runtime errors to `OpenSREError`.
+- Added a test that verifies quota errors render as operator-actionable configuration/provider state.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall app\cli\support\cli_error_mapping.py tests\cli\test_investigate.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+The underlying provider rejection is not an OpenSRE crash. The CLI should tell the user to wait for quota reset or switch provider instead of surfacing a raw traceback.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to both duplicate Sentry-created issues
+- [x] Added regression test
+- [x] Verified syntax compilation

--- a/tests/cli/test_investigate.py
+++ b/tests/cli/test_investigate.py
@@ -242,6 +242,31 @@ def test_reraise_cli_runtime_error_maps_cli_not_found() -> None:
     assert raised.value.suggestion == "codex CLI not found on PATH"
 
 
+def test_reraise_cli_runtime_error_maps_ollama_connectivity() -> None:
+    exc = RuntimeError("Cannot connect to Ollama API")
+
+    with pytest.raises(OpenSREError) as raised:
+        reraise_cli_runtime_error(exc)
+
+    assert str(raised.value) == "Cannot connect to Ollama API."
+    assert raised.value.suggestion is not None
+    assert "opensre onboard local_llm" in raised.value.suggestion
+
+
+def test_reraise_cli_runtime_error_maps_anthropic_usage_limit() -> None:
+    exc = RuntimeError(
+        "Anthropic request rejected (HTTP 400): Error code: 400 - "
+        "{'error': {'message': 'You have reached your specified API usage limits.'}}"
+    )
+
+    with pytest.raises(OpenSREError) as raised:
+        reraise_cli_runtime_error(exc)
+
+    assert str(raised.value) == "Anthropic API usage limit reached."
+    assert raised.value.suggestion is not None
+    assert "LLM_PROVIDER" in raised.value.suggestion
+
+
 def test_reraise_cli_runtime_error_reraises_unknown_runtime_error() -> None:
     exc = RuntimeError("some unrelated runtime failure")
 


### PR DESCRIPTION
﻿Fixes #1876

#### Describe the changes you have made in this PR -

- Promoted `opensre onboard local_llm` in the quickstart and README.
- Added a source-install fallback for older Linux hosts where the binary may not run.
- Mapped Ollama connectivity failures to `OpenSREError` so CLI users get a clean actionable message instead of a traceback.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall app\cli\support\cli_error_mapping.py tests\cli\test_investigate.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

The docs change makes the no-key local path visible before hosted-provider onboarding. The runtime change reuses the existing CLI error mapping boundary so provider connectivity errors render like other setup issues.

---

## Checklist before requesting a review
- [x] Linked to issue
- [x] Docs updated with behavior change
- [x] Added unit coverage for the error mapping

---

Fixes #1883
Fixes #1885

#### Describe the changes you have made in this PR -

- Mapped Anthropic usage-limit runtime errors to `OpenSREError`.
- Added a test that verifies quota errors render as operator-actionable configuration/provider state.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall app\cli\support\cli_error_mapping.py tests\cli\test_investigate.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

The underlying provider rejection is not an OpenSRE crash. The CLI should tell the user to wait for quota reset or switch provider instead of surfacing a raw traceback.

---

## Checklist before requesting a review
- [x] Linked to both duplicate Sentry-created issues
- [x] Added regression test
- [x] Verified syntax compilation

---

