### PR TITLE
fix(agents): guard unix socket bus on unsupported platforms

### DIFF
--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -60,6 +60,13 @@ _MAX_FRAME_BYTES: int = 64 * 1024
 _BROADCAST_WRITE_TIMEOUT_SECONDS: float = 0.2
 
 
+def _require_unix_socket_support() -> None:
+    if not hasattr(socket, "AF_UNIX"):
+        raise OSError(
+            "agent bus requires Unix-domain socket support; this platform does not expose socket.AF_UNIX"
+        )
+
+
 @dataclass(frozen=True)
 class BusMessage:
     """A single finding published on the agent bus.
@@ -177,6 +184,8 @@ def _socket_is_live(path: Path) -> bool:
     """
     if not path.exists():
         return False
+    if not hasattr(socket, "AF_UNIX"):
+        return False
     pid = _read_broker_pid(path)
     if pid is None:
         return False
@@ -260,6 +269,7 @@ class BusServer:
         """
         if self._running.is_set():
             return
+        _require_unix_socket_support()
         _ensure_parent_dir(self._path)
         listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
@@ -515,6 +525,7 @@ def _ensure_broker(path: Path) -> BusServer | None:
 
 def _connect_client(path: Path, timeout: float) -> socket.socket:
     """Open a blocking UDS connection to the broker at ``path``."""
+    _require_unix_socket_support()
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.settimeout(timeout)
     try:

--- a/pr/pr-1850-windows-agent-bus.md
+++ b/pr/pr-1850-windows-agent-bus.md
@@ -1,0 +1,31 @@
+Fixes #1850
+
+#### Describe the changes you have made in this PR -
+
+- Added an explicit Unix-domain socket support guard in `app.agents.bus`.
+- Made liveness checks return false on platforms without `socket.AF_UNIX`.
+- Skipped Unix-socket bus tests on platforms that cannot run them.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall app\agents\bus.py tests\agents\test_bus.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+This is the conservative compatibility fix: Windows no longer crashes with `AttributeError` from `socket.AF_UNIX`; callers receive a clear unsupported-platform error. A future PR can add a TCP transport if maintainers choose that direction.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to issue
+- [x] Added platform guard
+- [x] Kept scope narrow while maintainers discuss full transport abstraction

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -14,6 +14,11 @@ import pytest
 
 _POSIX_FCNTL_AVAILABLE = importlib.util.find_spec("fcntl") is not None
 
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="agent bus currently uses Unix-domain sockets",
+)
+
 from app.agents import bus as bus_module
 from app.agents.bus import (
     BUS_SCHEMA_VERSION,


### PR DESCRIPTION
﻿Fixes #1850

#### Describe the changes you have made in this PR -

- Added an explicit Unix-domain socket support guard in `app.agents.bus`.
- Made liveness checks return false on platforms without `socket.AF_UNIX`.
- Skipped Unix-socket bus tests on platforms that cannot run them.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall app\agents\bus.py tests\agents\test_bus.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

This is the conservative compatibility fix: Windows no longer crashes with `AttributeError` from `socket.AF_UNIX`; callers receive a clear unsupported-platform error. A future PR can add a TCP transport if maintainers choose that direction.

---

## Checklist before requesting a review
- [x] Linked to issue
- [x] Added platform guard
- [x] Kept scope narrow while maintainers discuss full transport abstraction

---

