### PR TITLE
test(repl): cover alert inbox peek snapshot behavior

### DIFF
--- a/pr/pr-1887-alert-inbox-regression.md
+++ b/pr/pr-1887-alert-inbox-regression.md
@@ -1,0 +1,29 @@
+Fixes #1887
+
+#### Describe the changes you have made in this PR -
+
+- Added a regression test proving `AlertInbox.peek_last()` uses the internal deque snapshot and does not drain the inbox.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall tests\cli\interactive_shell\test_alert_inbox.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+Current main already uses `deque`, not `SimpleQueue.queue`. This PR locks that contract with a regression test so the Sentry failure does not return.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to issue
+- [x] Added regression coverage
+- [x] Verified syntax compilation

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -73,6 +73,14 @@ class TestAlertInbox:
         assert inbox.dropped == 1
         assert [a.text for a in inbox.iter_pending()] == ["b", "c"]
 
+    def test_peek_last_uses_internal_deque_snapshot(self) -> None:
+        inbox = AlertInbox(maxsize=4)
+        for value in ("a", "b", "c"):
+            inbox.put(IncomingAlert(text=value))
+
+        assert [a.text for a in inbox.peek_last(2)] == ["b", "c"]
+        assert inbox.qsize == 3
+
 
 def _post(
     host: str, port: int, body: object, token: str | None = None


### PR DESCRIPTION
﻿Fixes #1887

#### Describe the changes you have made in this PR -

- Added a regression test proving `AlertInbox.peek_last()` uses the internal deque snapshot and does not drain the inbox.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall tests\cli\interactive_shell\test_alert_inbox.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

Current main already uses `deque`, not `SimpleQueue.queue`. This PR locks that contract with a regression test so the Sentry failure does not return.

---

## Checklist before requesting a review
- [x] Linked to issue
- [x] Added regression coverage
- [x] Verified syntax compilation

---

