### PR TITLE
fix(sentry): add logging integration kill switch

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -3,6 +3,9 @@
 Initialises Sentry using the project DSN constant.  Call ``init_sentry()`` once
 early in each process entry-point (CLI, LangGraph worker, etc.).  Repeated calls
 are safe — the function is idempotent.
+Set ``OPENSRE_SENTRY_LOGGING_DISABLED=1`` to keep direct
+``capture_exception`` calls enabled while disabling Sentry's logging
+integration for noisy deployments.
 """
 
 from __future__ import annotations
@@ -316,11 +319,16 @@ def _build_sentry_integrations() -> list[Any]:
     from sentry_sdk.integrations.httpx import HttpxIntegration
     from sentry_sdk.integrations.logging import LoggingIntegration
 
-    return [
-        LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+    integrations: list[Any] = [
         AsyncioIntegration(),
         HttpxIntegration(),
     ]
+    if os.getenv("OPENSRE_SENTRY_LOGGING_DISABLED", "0") != "1":
+        integrations.insert(
+            0,
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+        )
+    return integrations
 
 
 @contextmanager
@@ -430,6 +438,8 @@ def init_sentry(entrypoint: str | None = None) -> None:
     ``DO_NOT_TRACK=1`` to disable both Sentry and PostHog product analytics.
     ``OPENSRE_SENTRY_DISABLED=1`` disables Sentry only;
     ``OPENSRE_ANALYTICS_DISABLED=1`` disables PostHog only.
+    ``OPENSRE_SENTRY_LOGGING_DISABLED=1`` disables automatic logger
+    capture without disabling direct ``capture_exception`` calls.
 
     ``entrypoint`` identifies the calling surface (``cli``, ``webapp``,
     ``remote``, ``mcp``, ``integrations``, ``wizard``, ``graph_pipeline``)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -107,6 +107,7 @@ A random install ID is stored under `~/.config/opensre/anonymous_id`. PostHog `d
 | `DO_NOT_TRACK=1`               | disabled   | disabled   |
 | `OPENSRE_ANALYTICS_DISABLED=1` | disabled   | unaffected |
 | `OPENSRE_SENTRY_DISABLED=1`    | unaffected | disabled   |
+| `OPENSRE_SENTRY_LOGGING_DISABLED=1` | unaffected | disables automatic logger capture only |
 
 Full opt-out:
 

--- a/pr/pr-1455-sentry-logging-kill-switch.md
+++ b/pr/pr-1455-sentry-logging-kill-switch.md
@@ -1,0 +1,32 @@
+Fixes #1455
+
+#### Describe the changes you have made in this PR -
+
+- Added `OPENSRE_SENTRY_LOGGING_DISABLED=1` support.
+- Kept direct `capture_exception` behavior enabled when only logger auto-capture is disabled.
+- Documented the new env var in the telemetry kill-switch matrix.
+- Added a unit test for the integration builder.
+
+### Demo/Screenshot for feature changes and bug fixes -
+
+```bash
+python -m compileall app\utils\sentry_sdk.py tests\test_sentry_init.py
+```
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**
+- [x] Yes, reviewed line by line
+
+**Explain your implementation approach:**
+
+`LoggingIntegration` was already wired. This completes the requested opt-out switch so noisy deployments can disable logger-derived Sentry events without disabling explicit exception capture.
+
+---
+
+## Checklist before requesting a review
+- [x] Linked to issue
+- [x] Added test
+- [x] Updated docs

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -375,6 +375,17 @@ def test_init_sentry_passes_explicit_integrations(monkeypatch) -> None:
     assert "HttpxIntegration" in integration_names
 
 
+def test_build_sentry_integrations_respects_logging_kill_switch(monkeypatch) -> None:
+    monkeypatch.setenv("OPENSRE_SENTRY_LOGGING_DISABLED", "1")
+
+    integrations = sentry_mod._build_sentry_integrations()
+
+    integration_names = {type(integration).__name__ for integration in integrations}
+    assert "LoggingIntegration" not in integration_names
+    assert "AsyncioIntegration" in integration_names
+    assert "HttpxIntegration" in integration_names
+
+
 def test_init_sentry_suppresses_langgraph_allowed_objects_warning(monkeypatch) -> None:
     from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
 


### PR DESCRIPTION
﻿Fixes #1455

#### Describe the changes you have made in this PR -

- Added `OPENSRE_SENTRY_LOGGING_DISABLED=1` support.
- Kept direct `capture_exception` behavior enabled when only logger auto-capture is disabled.
- Documented the new env var in the telemetry kill-switch matrix.
- Added a unit test for the integration builder.

### Demo/Screenshot for feature changes and bug fixes -

```bash
python -m compileall app\utils\sentry_sdk.py tests\test_sentry_init.py
```

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] Yes, reviewed line by line

**Explain your implementation approach:**

`LoggingIntegration` was already wired. This completes the requested opt-out switch so noisy deployments can disable logger-derived Sentry events without disabling explicit exception capture.

---

## Checklist before requesting a review
- [x] Linked to issue
- [x] Added test
- [x] Updated docs

---

