### PR TITLE
fix(tools): report registry import failures to sentry

### DIFF
--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -6,12 +6,14 @@ import importlib
 import inspect
 import logging
 import pkgutil
+from contextlib import suppress
 from functools import lru_cache
 from types import ModuleType
 
 from app import tools as tools_package
 from app.tools.base import BaseTool
 from app.tools.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool, ToolSurface
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +61,25 @@ def _iter_tool_module_names() -> list[str]:
 
 def _import_tool_module(module_name: str) -> ModuleType:
     return importlib.import_module(f"{tools_package.__name__}.{module_name}")
+
+
+def _classify_import_failure(exc: BaseException) -> tuple[str, dict[str, str]]:
+    if isinstance(exc, ModuleNotFoundError) and exc.name and not exc.name.startswith("app."):
+        return (
+            "warning",
+            {
+                "event": "optional_dependency_missing",
+                "missing_module": exc.name,
+            },
+        )
+    return "error", {"event": "tool_module_import_failed"}
+
+
+def _set_sentry_tag(key: str, value: int | str | bool) -> None:
+    with suppress(Exception):
+        import sentry_sdk
+
+        sentry_sdk.set_tag(key, value)
 
 
 def _candidate_belongs_to_module(candidate: object, module_name: str) -> bool:
@@ -121,19 +142,24 @@ def _collect_registered_tools_from_module(module: ModuleType) -> list[Registered
 @lru_cache(maxsize=1)
 def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
     tools_by_name: dict[str, RegisteredTool] = {}
+    import_failures = 0
 
     for module_name in _iter_tool_module_names():
         try:
             module = _import_tool_module(module_name)
-        except ModuleNotFoundError as exc:
-            logger.warning("[tools] Skipping %s: %s", module_name, exc)
-            continue
         except Exception as exc:
-            logger.warning(
-                "[tools] Skipping %s due to import failure: %s",
-                module_name,
+            import_failures += 1
+            severity, extra_tags = _classify_import_failure(exc)
+            report_exception(
                 exc,
-                exc_info=True,
+                logger=logger,
+                message=f"[tools] Skipping {module_name} due to import failure",
+                severity=severity,
+                tags={
+                    "surface": "tool",
+                    "component": f"app.tools.{module_name}",
+                    **extra_tags,
+                },
             )
             continue
 
@@ -146,6 +172,7 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
                 continue
             tools_by_name[tool.name] = tool
 
+    _set_sentry_tag("tools.import_failures", import_failures)
     return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
 
 

--- a/pr/1464-tool-registry-import-sentry.md
+++ b/pr/1464-tool-registry-import-sentry.md
@@ -1,0 +1,31 @@
+Fixes #1464
+
+#### Describe the changes you've made
+
+Reports tool-registry import failures through the shared Sentry error helper instead of only logging warnings. Internal `app.*` missing modules and non-import exceptions are tagged as registry bugs, while external optional dependency misses remain warning-level events.
+
+The registry now also sets a best-effort `tools.import_failures` Sentry tag after loading, so process events can show how many tool modules failed to import.
+
+### Demo/Screenshot
+
+N/A - telemetry and regression-test change.
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**  
+Yes.
+
+## Checklist before requesting a review
+
+- [x] I have performed a self-review of my code
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [ ] `make test-cov` passes locally
+- [ ] `make lint` passes locally
+- [ ] `make typecheck` passes locally
+
+Local verification:
+
+- `python -m compileall app/tools/registry.py tests/tools/test_registry.py`
+- `python -m pytest tests/tools/test_registry.py -q` could not run in this local Python because the repo uses newer Python syntax in `app/analytics/provider.py` (`type PropertyValue = ...`).

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -355,7 +355,7 @@ def test_registry_regression_duplicate_tool_names_across_modules(
 def test_registry_regression_import_failures(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that registry gracefully skips modules with import failures."""
+    """Test that registry reports and gracefully skips modules with import failures."""
     module: Any = ModuleType("app.tools.valid_tool")
 
     @tool(
@@ -385,7 +385,25 @@ def test_registry_regression_import_failures(
         mock_import,
     )
 
-    with caplog.at_level(logging.WARNING, logger="app.tools.registry"):
+    reported: list[tuple[BaseException, str, dict[str, str]]] = []
+
+    def fake_report_exception(
+        exc: BaseException,
+        *,
+        logger: logging.Logger,
+        message: str,
+        severity: str = "error",
+        tags: dict[str, str] | None = None,
+        extras: dict[str, Any] | None = None,
+    ) -> None:
+        reported.append((exc, severity, tags or {}))
+        getattr(logger, severity)("%s", message, exc_info=exc)
+
+    sentry_tags: dict[str, int | str | bool] = {}
+    monkeypatch.setattr(registry_module, "report_exception", fake_report_exception)
+    monkeypatch.setattr(registry_module, "_set_sentry_tag", sentry_tags.__setitem__)
+
+    with caplog.at_level(logging.ERROR, logger="app.tools.registry"):
         tools = registry_module.get_registered_tools()
 
     tool_names = [t.name for t in tools]
@@ -394,6 +412,91 @@ def test_registry_regression_import_failures(
     assert registry_module.get_registered_tool_map()["valid_tool"].run() == {"status": "ok"}
 
     assert any(
-        "Skipping broken_module" in record.message and record.levelname == "WARNING"
+        "Skipping broken_module" in record.message and record.levelname == "ERROR"
         for record in caplog.records
     )
+    assert len(reported) == 1
+    _, severity, tags = reported[0]
+    assert severity == "error"
+    assert tags["surface"] == "tool"
+    assert tags["component"] == "app.tools.broken_module"
+    assert tags["event"] == "tool_module_import_failed"
+    assert sentry_tags["tools.import_failures"] == 1
+
+
+def test_registry_import_failure_classifies_external_optional_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_import(_name: str) -> ModuleType:
+        raise ModuleNotFoundError("No module named 'psycopg2'", name="psycopg2")
+
+    reported: list[tuple[str, dict[str, str]]] = []
+
+    def fake_report_exception(
+        exc: BaseException,
+        *,
+        logger: logging.Logger,
+        message: str,
+        severity: str = "error",
+        tags: dict[str, str] | None = None,
+        extras: dict[str, Any] | None = None,
+    ) -> None:
+        reported.append((severity, tags or {}))
+
+    monkeypatch.setattr(registry_module, "_iter_tool_module_names", lambda: ["optional_tool"])
+    monkeypatch.setattr(registry_module, "_import_tool_module", mock_import)
+    monkeypatch.setattr(registry_module, "report_exception", fake_report_exception)
+    monkeypatch.setattr(registry_module, "_set_sentry_tag", lambda _key, _value: None)
+
+    assert registry_module.get_registered_tools() == []
+    assert reported == [
+        (
+            "warning",
+            {
+                "surface": "tool",
+                "component": "app.tools.optional_tool",
+                "event": "optional_dependency_missing",
+                "missing_module": "psycopg2",
+            },
+        )
+    ]
+
+
+def test_registry_import_failure_classifies_internal_missing_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_import(_name: str) -> ModuleType:
+        raise ModuleNotFoundError(
+            "No module named 'app.services.missing'",
+            name="app.services.missing",
+        )
+
+    reported: list[tuple[str, dict[str, str]]] = []
+
+    def fake_report_exception(
+        exc: BaseException,
+        *,
+        logger: logging.Logger,
+        message: str,
+        severity: str = "error",
+        tags: dict[str, str] | None = None,
+        extras: dict[str, Any] | None = None,
+    ) -> None:
+        reported.append((severity, tags or {}))
+
+    monkeypatch.setattr(registry_module, "_iter_tool_module_names", lambda: ["broken_tool"])
+    monkeypatch.setattr(registry_module, "_import_tool_module", mock_import)
+    monkeypatch.setattr(registry_module, "report_exception", fake_report_exception)
+    monkeypatch.setattr(registry_module, "_set_sentry_tag", lambda _key, _value: None)
+
+    assert registry_module.get_registered_tools() == []
+    assert reported == [
+        (
+            "error",
+            {
+                "surface": "tool",
+                "component": "app.tools.broken_tool",
+                "event": "tool_module_import_failed",
+            },
+        )
+    ]


### PR DESCRIPTION
Fixes #1464

#### Describe the changes you've made

Reports tool-registry import failures through the shared Sentry error helper instead of only logging warnings. Internal `app.*` missing modules and non-import exceptions are tagged as registry bugs, while external optional dependency misses remain warning-level events.

The registry now also sets a best-effort `tools.import_failures` Sentry tag after loading, so process events can show how many tool modules failed to import.

### Demo/Screenshot

N/A - telemetry and regression-test change.

---

## Code Understanding and AI Usage

**Did you use AI assistance?**  
Yes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] `make test-cov` passes locally
- [ ] `make lint` passes locally
- [ ] `make typecheck` passes locally

Local verification:

- `python -m compileall app/tools/registry.py tests/tools/test_registry.py`
- `python -m pytest tests/tools/test_registry.py -q` could not run in this local Python because the repo uses newer Python syntax in `app/analytics/provider.py` (`type PropertyValue = ...`).
