### PR TITLE
fix(integrations): report verifier failures to sentry

### DIFF
--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
+from contextlib import suppress
 from typing import Any
 
 import boto3
@@ -47,10 +49,23 @@ from app.services.splunk import SplunkClient, SplunkConfig
 from app.services.tracer_client.client import TracerClient
 from app.services.vercel.client import VercelClient, VercelConfig
 from app.services.victoria_logs import VictoriaLogsClient, VictoriaLogsConfig
+from app.utils.errors import report_exception
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except Exception:  # pragma: no cover - boto3 brings botocore in supported installs.
+    BotoCoreError = ClientError = ()  # type: ignore[assignment]
 
 VerifierFn = Callable[[str, dict[str, Any]], dict[str, str]]
 
 _SUPPORTED_GRAFANA_TYPES = ("loki", "tempo", "prometheus")
+logger = logging.getLogger(__name__)
+_VENDOR_EXCEPTION_TYPES = (
+    httpx.HTTPError,
+    requests.RequestException,
+    BotoCoreError,
+    ClientError,
+)
 
 
 def result(
@@ -67,6 +82,35 @@ def result(
     }
 
 
+def _set_sentry_tag(key: str, value: int | str | bool) -> None:
+    with suppress(Exception):
+        import sentry_sdk
+
+        sentry_sdk.set_tag(key, value)
+
+
+def _report_verify_exception(
+    service: str,
+    exc: BaseException,
+    *,
+    phase: str,
+    event: str | None = None,
+) -> None:
+    is_vendor_failure = isinstance(exc, _VENDOR_EXCEPTION_TYPES)
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"[integrations] {service} verification {phase} failed",
+        severity="info" if is_vendor_failure else "error",
+        tags={
+            "surface": "integration",
+            "integration": service,
+            "event": event or ("vendor_failure" if is_vendor_failure else "verify_failed"),
+            "phase": phase,
+        },
+    )
+
+
 def _verify_with_validation_result[ConfigT](
     service: str,
     source: str,
@@ -75,8 +119,16 @@ def _verify_with_validation_result[ConfigT](
     build_config: Callable[[dict[str, Any]], ConfigT],
     validate_config: Callable[[ConfigT], Any],
 ) -> dict[str, str]:
-    normalized_config = build_config(config)
-    validation_result = validate_config(normalized_config)
+    try:
+        normalized_config = build_config(config)
+    except Exception as err:
+        _report_verify_exception(service, err, phase="build_config", event="verify_config_invalid")
+        return result(service, source, "missing", str(err))
+    try:
+        validation_result = validate_config(normalized_config)
+    except Exception as err:
+        _report_verify_exception(service, err, phase="validate_config")
+        return result(service, source, "failed", str(err))
     return result(
         service,
         source,
@@ -113,10 +165,12 @@ def build_probe_verifier[ConfigT](
         try:
             normalized_config = build_config(config)
         except Exception as err:
+            _report_verify_exception(service, err, phase="build_config", event="verify_config_invalid")
             return result(service, source, "missing", str(err))
         try:
             probe_result = client_factory(normalized_config).probe_access()
         except Exception as err:
+            _report_verify_exception(service, err, phase="probe_access")
             return result(service, source, "failed", str(err))
         return result(service, source, probe_result.status, probe_result.detail)
 
@@ -181,6 +235,7 @@ def _verify_grafana(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        _report_verify_exception("grafana", exc, phase="datasource_discovery")
         return result("grafana", source, "failed", f"Datasource discovery failed: {exc}")
 
     datasources = payload if isinstance(payload, list) else []
@@ -213,6 +268,7 @@ def _verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
         sts_client, region, mode = _build_sts_client(config)
         identity = sts_client.get_caller_identity()
     except Exception as exc:
+        _report_verify_exception("aws", exc, phase="sts_check")
         return result("aws", source, "failed", f"AWS STS check failed: {exc}")
 
     account = str(identity.get("Account", "")).strip()
@@ -237,6 +293,7 @@ def _verify_slack(
     try:
         slack_config = SlackWebhookConfig.model_validate(config)
     except Exception as err:
+        _report_verify_exception("slack", err, phase="build_config", event="verify_config_invalid")
         return result("slack", source, "missing", str(err))
 
     webhook_url = slack_config.webhook_url
@@ -255,6 +312,7 @@ def _verify_slack(
         response = httpx.post(webhook_url, json=payload, timeout=10.0)
         response.raise_for_status()
     except Exception as exc:
+        _report_verify_exception("slack", exc, phase="webhook_post")
         return result("slack", source, "failed", f"Webhook delivery failed: {exc}")
     return result("slack", source, "passed", "Webhook delivered test message successfully.")
 
@@ -268,6 +326,7 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         org_id = extract_org_id_from_jwt(tracer_config.jwt_token)
     except Exception as err:
+        _report_verify_exception("tracer", err, phase="jwt_decode")
         return result("tracer", source, "failed", f"JWT decode failed: {err}")
     if not org_id:
         return result("tracer", source, "failed", "JWT did not contain an org identifier.")
@@ -280,6 +339,7 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
         )
         integrations = tracer_client.get_all_integrations()
     except Exception as err:
+        _report_verify_exception("tracer", err, phase="api_list_integrations")
         return result("tracer", source, "failed", f"Tracer API check failed: {err}")
 
     return result(
@@ -294,6 +354,7 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         import discord  # type: ignore[import-not-found]
     except Exception:
+        _set_sentry_tag("integrations.discord.import_failed", True)
         return result("discord", source, "failed", "discord.py is not installed.")
 
     bot_token = str(config.get("bot_token", "")).strip()
@@ -306,11 +367,13 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         client.run(bot_token)
     except discord.LoginFailure as err:
+        _report_verify_exception("discord", err, phase="login")
         return result("discord", source, "failed", f"Discord login failed: {err}")
     except Exception as err:
         detail = str(err)
         if "run() cannot be called from a running event loop" in detail:
             return result("discord", source, "passed", "Discord bot token accepted.")
+        _report_verify_exception("discord", err, phase="api_check")
         return result("discord", source, "failed", f"Discord API check failed: {err}")
     return result("discord", source, "passed", "Discord bot token accepted.")
 
@@ -325,6 +388,7 @@ def _verify_telegram(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        _report_verify_exception("telegram", exc, phase="get_me")
         return result("telegram", source, "failed", f"Telegram API check failed: {exc}")
 
     if not payload.get("ok"):

--- a/pr/1469-integration-verify-sentry.md
+++ b/pr/1469-integration-verify-sentry.md
@@ -1,0 +1,31 @@
+Fixes #1469
+
+#### Describe the changes you've made
+
+Adds Sentry reporting to integration verification adapters when a verifier catches and converts an exception into a user-facing `missing` or `failed` result.
+
+The change keeps the existing verification output shape, while tagging captured failures with `surface=integration`, `integration=<service>`, `phase=<verification step>`, and either `event=vendor_failure`, `event=verify_failed`, or `event=verify_config_invalid`. Discord's optional dependency path remains non-fatal and now sets `integrations.discord.import_failed`.
+
+### Demo/Screenshot
+
+N/A - telemetry and regression-test change.
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**  
+Yes.
+
+## Checklist before requesting a review
+
+- [x] I have performed a self-review of my code
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [ ] `make test-cov` passes locally
+- [ ] `make lint` passes locally
+- [ ] `make typecheck` passes locally
+
+Local verification:
+
+- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\integrations\_verification_adapters.py tests\integrations\test_verify.py`
+- Pytest could not be run because neither the system Python nor the bundled Python has this repo's test dependencies installed, and `uv` is not available in the local shell.

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -214,6 +214,42 @@ def test_verify_grafana_passes_with_supported_datasource(monkeypatch: pytest.Mon
     assert "prometheus" in result["detail"]
 
 
+def test_verify_grafana_reports_datasource_discovery_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.integrations._verification_adapters as _adapters
+
+    reported: list[tuple[BaseException, dict[str, str]]] = []
+
+    def fake_report(
+        service: str,
+        exc: BaseException,
+        *,
+        phase: str,
+        event: str | None = None,
+    ) -> None:
+        reported.append((exc, {"service": service, "phase": phase, "event": event or ""}))
+
+    def raise_requests_error(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("datasource boom")
+
+    monkeypatch.setattr(_adapters, "_report_verify_exception", fake_report)
+    monkeypatch.setattr(_adapters.requests, "get", raise_requests_error)
+
+    result = _verify_grafana(
+        "local env",
+        {"endpoint": "https://example.grafana.net", "api_key": "token"},
+    )
+
+    assert result["status"] == "failed"
+    assert "datasource boom" in result["detail"]
+    assert reported[0][1] == {
+        "service": "grafana",
+        "phase": "datasource_discovery",
+        "event": "",
+    }
+
+
 def test_verify_datadog_reports_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     from app.integrations.probes import ProbeResult
     from app.services.datadog.client import DatadogClient
@@ -231,6 +267,84 @@ def test_verify_datadog_reports_api_failure(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert result["status"] == "failed"
     assert "403" in result["detail"]
+
+
+def test_probe_verifier_reports_probe_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.integrations._verification_adapters as _adapters
+
+    reported: list[tuple[str, str, str]] = []
+
+    class _Config:
+        pass
+
+    class _Client:
+        def __init__(self, _config: _Config) -> None:
+            return None
+
+        def probe_access(self) -> None:
+            raise RuntimeError("probe bug")
+
+    def fake_report(
+        service: str,
+        exc: BaseException,
+        *,
+        phase: str,
+        event: str | None = None,
+    ) -> None:
+        reported.append((service, phase, str(exc)))
+
+    monkeypatch.setattr(_adapters, "_report_verify_exception", fake_report)
+
+    verifier = _adapters.build_probe_verifier(
+        "fake_service",
+        build_config=lambda _raw: _Config(),
+        client_factory=_Client,
+    )
+    result = verifier("local env", {"api_key": "token"})
+
+    assert result == {
+        "service": "fake_service",
+        "source": "local env",
+        "status": "failed",
+        "detail": "probe bug",
+    }
+    assert reported == [("fake_service", "probe_access", "probe bug")]
+
+
+def test_validation_verifier_reports_build_config_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.integrations._verification_adapters as _adapters
+
+    reported: list[tuple[str, str, str | None]] = []
+
+    def fake_report(
+        service: str,
+        exc: BaseException,
+        *,
+        phase: str,
+        event: str | None = None,
+    ) -> None:
+        reported.append((service, phase, event))
+
+    def raise_build_config(_raw: dict[str, Any]) -> object:
+        raise ValueError("missing field")
+
+    monkeypatch.setattr(_adapters, "_report_verify_exception", fake_report)
+
+    verifier = _adapters.build_validation_verifier(
+        "fake_validation",
+        build_config=raise_build_config,
+        validate_config=lambda _config: object(),
+    )
+
+    assert verifier("local env", {}) == {
+        "service": "fake_validation",
+        "source": "local env",
+        "status": "missing",
+        "detail": "missing field",
+    }
+    assert reported == [("fake_validation", "build_config", "verify_config_invalid")]
 
 
 def test_verify_datadog_accepts_integration_id() -> None:
@@ -377,6 +491,31 @@ def test_verify_tracer_passes_with_env_jwt(monkeypatch: pytest.MonkeyPatch) -> N
     assert result["status"] == "passed"
     assert "org_123" in result["detail"]
     assert "2 integrations" in result["detail"]
+
+
+def test_verify_discord_import_failure_sets_sentry_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    import app.integrations._verification_adapters as _adapters
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "discord":
+            raise ImportError("discord missing")
+        return real_import(name, *args, **kwargs)
+
+    tags: dict[str, int | str | bool] = {}
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(_adapters, "_set_sentry_tag", tags.__setitem__)
+
+    result = _adapters._verify_discord("local env", {"bot_token": "token"})
+
+    assert result["status"] == "failed"
+    assert result["detail"] == "discord.py is not installed."
+    assert tags["integrations.discord.import_failed"] is True
 
 
 def test_verify_github_passes_with_valid_streamable_http_config(


### PR DESCRIPTION
Fixes #1469

#### Describe the changes you've made

Adds Sentry reporting to integration verification adapters when a verifier catches and converts an exception into a user-facing `missing` or `failed` result.

The change keeps the existing verification output shape, while tagging captured failures with `surface=integration`, `integration=<service>`, `phase=<verification step>`, and either `event=vendor_failure`, `event=verify_failed`, or `event=verify_config_invalid`. Discord's optional dependency path remains non-fatal and now sets `integrations.discord.import_failed`.

### Demo/Screenshot

N/A - telemetry and regression-test change.

---

## Code Understanding and AI Usage

**Did you use AI assistance?**  
Yes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] `make test-cov` passes locally
- [ ] `make lint` passes locally
- [ ] `make typecheck` passes locally

Local verification:

- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\integrations\_verification_adapters.py tests\integrations\test_verify.py`
- Pytest could not be run because neither the system Python nor the bundled Python has this repo's test dependencies installed, and `uv` is not available in the local shell.
