### PR TITLE
fix(aws): report service client failures

### DIFF
--- a/app/services/aws/__init__.py
+++ b/app/services/aws/__init__.py
@@ -1,0 +1,2 @@
+"""Shared AWS service-client helpers."""
+

--- a/app/services/aws/_telemetry.py
+++ b/app/services/aws/_telemetry.py
@@ -1,0 +1,61 @@
+"""AWS-specific service-client error telemetry."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.utils.errors import report_exception
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+
+    class ClientError(Exception):  # type: ignore[no-redef]
+        """Stub when botocore is not installed."""
+
+
+logger = logging.getLogger(__name__)
+
+
+def aws_error_code(exc: BaseException) -> str:
+    if isinstance(exc, ClientError):
+        return str(exc.response.get("Error", {}).get("Code", "Unknown"))
+    return type(exc).__name__
+
+
+def report_aws_service_exception(
+    exc: BaseException,
+    *,
+    service: str,
+    operation: str,
+    region: str | None = None,
+    function_name: str | None = None,
+    severity: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    """Report an AWS service-client exception with consistent tags."""
+    error_code = aws_error_code(exc)
+    effective_severity = severity or ("warning" if isinstance(exc, ClientError) else "error")
+    tags = {
+        "surface": "service_client",
+        "cloud": "aws",
+        "service": service,
+        "operation": operation,
+        "error_code": error_code,
+    }
+    if region:
+        tags["region"] = region
+    if function_name:
+        tags["function_name"] = function_name
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"[aws] {service}.{operation} failed: {error_code}",
+        severity=effective_severity,
+        tags=tags,
+        extras=extras,
+    )
+
+
+__all__ = ["aws_error_code", "report_aws_service_exception"]

--- a/app/services/aws_sdk_client.py
+++ b/app/services/aws_sdk_client.py
@@ -10,6 +10,8 @@ from typing import Any
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
 
+from app.services.aws._telemetry import report_aws_service_exception
+
 # Read-only operation patterns (allowlist)
 ALLOWED_OPERATION_PATTERNS = [
     r"^describe_.*",
@@ -238,6 +240,12 @@ def execute_aws_sdk_call(
         }
 
     except ClientError as e:
+        report_aws_service_exception(
+            e,
+            service=service_name,
+            operation=operation_name,
+            region=region,
+        )
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
         error_message = e.response.get("Error", {}).get("Message", str(e))
 
@@ -255,6 +263,12 @@ def execute_aws_sdk_call(
         }
 
     except Exception as e:
+        report_aws_service_exception(
+            e,
+            service=service_name,
+            operation=operation_name,
+            region=region,
+        )
         return {
             "success": False,
             "error": f"Unexpected error: {str(e)}",

--- a/app/services/lambda_client.py
+++ b/app/services/lambda_client.py
@@ -2,11 +2,13 @@
 
 import base64
 import json
-from contextlib import suppress
 from io import BytesIO
 from typing import Any
 from zipfile import ZipFile
 
+import requests
+
+from app.services.aws._telemetry import report_aws_service_exception
 from app.services.env import make_boto3_client, require_aws_credentials
 
 try:
@@ -23,6 +25,55 @@ def _get_lambda_client():
 
 def _get_cloudwatch_logs_client():
     return make_boto3_client("logs")
+
+
+_reported_metric_parse_failures: set[str] = set()
+
+
+def _client_region(client: Any) -> str | None:
+    return str(getattr(getattr(client, "meta", None), "region_name", "") or "") or None
+
+
+def _report_lambda_client_error(
+    exc: BaseException,
+    *,
+    operation: str,
+    function_name: str,
+    client: Any | None = None,
+    severity: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    report_aws_service_exception(
+        exc,
+        service="lambda",
+        operation=operation,
+        region=_client_region(client),
+        function_name=function_name,
+        severity=severity,
+        extras=extras,
+    )
+
+
+def _report_metric_parse_failure_once(
+    exc: BaseException,
+    *,
+    function_name: str,
+    metric_name: str,
+    message: str,
+    client: Any,
+) -> None:
+    key = f"{function_name}:{metric_name}"
+    if key in _reported_metric_parse_failures:
+        return
+    _reported_metric_parse_failures.add(key)
+    _report_lambda_client_error(
+        exc,
+        operation="parse_invocation_metric",
+        function_name=function_name,
+        client=client,
+        severity="warning",
+        extras={"metric_name": metric_name, "message": message},
+    )
 
 
 def get_function_configuration(function_name: str) -> dict[str, Any]:
@@ -69,6 +120,12 @@ def get_function_configuration(function_name: str) -> dict[str, Any]:
             },
         }
     except ClientError as e:
+        _report_lambda_client_error(
+            e,
+            operation="get_function_configuration",
+            function_name=function_name,
+            client=client,
+        )
         return {"success": False, "error": str(e)}
 
 
@@ -114,10 +171,28 @@ def get_function_code(
 
         if extract_files and code_location and code_size < 5 * 1024 * 1024:
             # Download and extract if code is under 5MB
-            import requests
-
-            zip_response = requests.get(code_location, timeout=30)
-            if zip_response.status_code == 200:
+            try:
+                zip_response = requests.get(code_location, timeout=30)
+            except requests.RequestException as e:
+                _report_lambda_client_error(
+                    e,
+                    operation="download_function_code",
+                    function_name=function_name,
+                    client=client,
+                    severity="warning",
+                    extras={"code_location": code_location},
+                )
+                zip_response = None
+            if zip_response is not None and zip_response.status_code != 200:
+                _report_lambda_client_error(
+                    RuntimeError(f"Function code download returned HTTP {zip_response.status_code}"),
+                    operation="download_function_code",
+                    function_name=function_name,
+                    client=client,
+                    severity="warning",
+                    extras={"status_code": zip_response.status_code, "code_location": code_location},
+                )
+            if zip_response is not None and zip_response.status_code == 200:
                 files: dict[str, Any] = {}
                 try:
                     with ZipFile(BytesIO(zip_response.content)) as zf:
@@ -145,10 +220,23 @@ def get_function_code(
                     result["data"]["files"] = files
                     result["data"]["file_count"] = len(files)
                 except Exception as e:
+                    _report_lambda_client_error(
+                        e,
+                        operation="extract_function_code",
+                        function_name=function_name,
+                        client=client,
+                        severity="warning",
+                    )
                     result["data"]["extract_error"] = str(e)
 
         return result
     except ClientError as e:
+        _report_lambda_client_error(
+            e,
+            operation="get_function",
+            function_name=function_name,
+            client=client,
+        )
         return {"success": False, "error": str(e)}
 
 
@@ -218,13 +306,29 @@ def get_recent_invocations(
                     current_invocation["logs"].append(message)
                     # Parse REPORT for duration and memory
                     if "Duration:" in message:
-                        with suppress(IndexError, ValueError):
+                        try:
                             duration_part = message.split("Duration: ")[1].split()[0]
                             current_invocation["duration_ms"] = float(duration_part)
+                        except (IndexError, ValueError) as e:
+                            _report_metric_parse_failure_once(
+                                e,
+                                function_name=function_name,
+                                metric_name="duration_ms",
+                                message=message,
+                                client=logs_client,
+                            )
                     if "Memory Used:" in message:
-                        with suppress(IndexError, ValueError):
+                        try:
                             memory_part = message.split("Memory Used: ")[1].split()[0]
                             current_invocation["memory_used_mb"] = int(memory_part)
+                        except (IndexError, ValueError) as e:
+                            _report_metric_parse_failure_once(
+                                e,
+                                function_name=function_name,
+                                metric_name="memory_used_mb",
+                                message=message,
+                                client=logs_client,
+                            )
                     invocations.append(current_invocation)
                     current_invocation = None
             elif current_invocation:
@@ -243,6 +347,12 @@ def get_recent_invocations(
             },
         }
     except ClientError as e:
+        _report_lambda_client_error(
+            e,
+            operation="filter_log_events",
+            function_name=function_name,
+            client=logs_client,
+        )
         error_code = e.response.get("Error", {}).get("Code", "")
         if error_code == "ResourceNotFoundException":
             return {
@@ -300,6 +410,12 @@ def get_invocation_logs_by_request_id(
             },
         }
     except ClientError as e:
+        _report_lambda_client_error(
+            e,
+            operation="filter_log_events_by_request_id",
+            function_name=function_name,
+            client=logs_client,
+        )
         return {"success": False, "error": str(e)}
 
 
@@ -337,22 +453,44 @@ def invoke_function(
         response = client.invoke(**kwargs)
 
         result_payload = None
+        payload_parse_error = None
         if "Payload" in response:
-            result_payload = json.loads(response["Payload"].read().decode())
+            raw_payload = response["Payload"].read().decode()
+            try:
+                result_payload = json.loads(raw_payload)
+            except json.JSONDecodeError as e:
+                _report_lambda_client_error(
+                    e,
+                    operation="parse_invoke_payload",
+                    function_name=function_name,
+                    client=client,
+                    extras={"payload_preview": raw_payload[:200]},
+                )
+                payload_parse_error = str(e)
+
+        data = {
+            "status_code": response.get("StatusCode"),
+            "function_error": response.get("FunctionError"),
+            "executed_version": response.get("ExecutedVersion"),
+            "log_result": base64.b64decode(response.get("LogResult", "")).decode()
+            if response.get("LogResult")
+            else None,
+            "payload": result_payload,
+        }
+        if payload_parse_error is not None:
+            data["payload_parse_error"] = payload_parse_error
 
         return {
             "success": True,
-            "data": {
-                "status_code": response.get("StatusCode"),
-                "function_error": response.get("FunctionError"),
-                "executed_version": response.get("ExecutedVersion"),
-                "log_result": base64.b64decode(response.get("LogResult", "")).decode()
-                if response.get("LogResult")
-                else None,
-                "payload": result_payload,
-            },
+            "data": data,
         }
     except ClientError as e:
+        _report_lambda_client_error(
+            e,
+            operation="invoke",
+            function_name=function_name,
+            client=client,
+        )
         return {"success": False, "error": str(e)}
 
 
@@ -406,4 +544,10 @@ def list_functions(
             },
         }
     except ClientError as e:
+        _report_lambda_client_error(
+            e,
+            operation="list_functions",
+            function_name="",
+            client=client,
+        )
         return {"success": False, "error": str(e)}

--- a/pr/1462-aws-client-error-telemetry.md
+++ b/pr/1462-aws-client-error-telemetry.md
@@ -1,0 +1,33 @@
+Fixes #1462
+
+#### Describe the changes you've made
+
+Adds AWS-specific service-client telemetry for swallowed errors in `aws_sdk_client.py` and `lambda_client.py`.
+
+The new helper tags AWS failures consistently with service, operation, region, function name, and AWS error code. `ClientError` failures are reported at warning severity, while unexpected runtime failures are reported at error severity.
+
+Lambda code download, zip extraction, CloudWatch metric parsing, and invoke-payload JSON parsing now report the previously silent failure path while preserving the existing user-facing result shape.
+
+### Demo/Screenshot
+
+N/A - telemetry and regression-test change.
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**  
+Yes.
+
+## Checklist before requesting a review
+
+- [x] I have performed a self-review of my code
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [ ] `make test-cov` passes locally
+- [ ] `make lint` passes locally
+- [ ] `make typecheck` passes locally
+
+Local verification:
+
+- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\services\aws app\services\aws_sdk_client.py app\services\lambda_client.py tests\services\test_aws_sdk_client.py tests\services\test_lambda_client.py tests\services\test_aws_telemetry.py`
+- Pytest could not be run because neither the system Python nor bundled Python has the repo test dependencies installed, and `uv` is unavailable.

--- a/tests/services/test_aws_sdk_client.py
+++ b/tests/services/test_aws_sdk_client.py
@@ -302,25 +302,45 @@ class TestExecuteAwsSdkCallParamValidation:
 
 class TestExecuteAwsSdkCallClientError:
     def test_client_error(self, mock_boto3_client) -> None:
-        mock_boto3_client.describe_instances.side_effect = ClientError(
+        error = ClientError(
             {
                 "Error": {"Code": "UnauthorizedAccess", "Message": "Not authorized"},
                 "ResponseMetadata": {"HTTPStatusCode": 403},
             },
             "DescribeInstances",
         )
-        result = execute_aws_sdk_call("ec2", "describe_instances")
+        mock_boto3_client.describe_instances.side_effect = error
+
+        with patch("app.services.aws_sdk_client.report_aws_service_exception") as report:
+            result = execute_aws_sdk_call("ec2", "describe_instances")
+
         assert result["success"] is False
         assert "UnauthorizedAccess" in result["error"]
         assert result["metadata"]["error_type"] == "client_error"
         assert result["metadata"]["error_code"] == "UnauthorizedAccess"
         assert result["metadata"]["status_code"] == 403
+        report.assert_called_once_with(
+            error,
+            service="ec2",
+            operation="describe_instances",
+            region=None,
+        )
 
 
 class TestExecuteAwsSdkCallUnexpectedError:
     def test_unexpected_runtime_error(self, mock_boto3_client) -> None:
-        mock_boto3_client.describe_instances.side_effect = RuntimeError("boom")
-        result = execute_aws_sdk_call("ec2", "describe_instances")
+        error = RuntimeError("boom")
+        mock_boto3_client.describe_instances.side_effect = error
+
+        with patch("app.services.aws_sdk_client.report_aws_service_exception") as report:
+            result = execute_aws_sdk_call("ec2", "describe_instances")
+
         assert result["success"] is False
         assert "unexpected error" in result["error"].lower()
         assert result["metadata"]["error_type"] == "unexpected"
+        report.assert_called_once_with(
+            error,
+            service="ec2",
+            operation="describe_instances",
+            region=None,
+        )

--- a/tests/services/test_aws_telemetry.py
+++ b/tests/services/test_aws_telemetry.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import ANY, patch
+
+from botocore.exceptions import ClientError
+
+from app.services.aws._telemetry import report_aws_service_exception
+
+
+def test_report_aws_service_exception_tags_client_error_as_warning() -> None:
+    error = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "denied"}},
+        "GetFunction",
+    )
+
+    with patch("app.services.aws._telemetry.report_exception") as report:
+        report_aws_service_exception(
+            error,
+            service="lambda",
+            operation="get_function",
+            region="us-east-1",
+            function_name="fn",
+        )
+
+    report.assert_called_once()
+    _, kwargs = report.call_args
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"]["error_code"] == "AccessDeniedException"
+    assert kwargs["tags"]["region"] == "us-east-1"
+    assert kwargs["tags"]["function_name"] == "fn"
+
+
+def test_report_aws_service_exception_tags_unknown_error_as_error() -> None:
+    error = RuntimeError("boom")
+
+    with patch("app.services.aws._telemetry.report_exception") as report:
+        report_aws_service_exception(
+            error,
+            service="ec2",
+            operation="describe_instances",
+        )
+
+    report.assert_called_once_with(
+        error,
+        logger=ANY,
+        message="[aws] ec2.describe_instances failed: RuntimeError",
+        severity="error",
+        tags={
+            "surface": "service_client",
+            "cloud": "aws",
+            "service": "ec2",
+            "operation": "describe_instances",
+            "error_code": "RuntimeError",
+        },
+        extras=None,
+    )

--- a/tests/services/test_lambda_client.py
+++ b/tests/services/test_lambda_client.py
@@ -71,14 +71,20 @@ def test_get_function_configuration_success(mock_lambda_client) -> None:
 
 def test_get_function_configuration_error(mock_lambda_client) -> None:
     error_response = {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}}
-    mock_lambda_client.get_function_configuration.side_effect = ClientError(
-        error_response, "GetFunctionConfiguration"
-    )
+    error = ClientError(error_response, "GetFunctionConfiguration")
+    mock_lambda_client.get_function_configuration.side_effect = error
 
-    result = get_function_configuration("missing-func")
+    with patch("app.services.lambda_client._report_lambda_client_error") as report:
+        result = get_function_configuration("missing-func")
 
     assert result["success"] is False
     assert "ResourceNotFoundException" in result["error"]
+    report.assert_called_once_with(
+        error,
+        operation="get_function_configuration",
+        function_name="missing-func",
+        client=mock_lambda_client,
+    )
 
 
 def test_get_function_code_success(mock_lambda_client) -> None:
@@ -239,11 +245,16 @@ def test_get_function_code_download_error(mock_lambda_client) -> None:
     }
     mock_response = MagicMock()
     mock_response.status_code = 404
-    with patch("requests.get", return_value=mock_response):
+    with (
+        patch("requests.get", return_value=mock_response),
+        patch("app.services.lambda_client._report_lambda_client_error") as report,
+    ):
         result = get_function_code("test-func")
 
     assert result["success"] is True  # The get_function call succeeded
     assert "files" not in result["data"]
+    assert report.call_args.kwargs["operation"] == "download_function_code"
+    assert report.call_args.kwargs["severity"] == "warning"
 
 
 def test_get_function_code_corrupt_zip(mock_lambda_client) -> None:
@@ -255,11 +266,30 @@ def test_get_function_code_corrupt_zip(mock_lambda_client) -> None:
     mock_response.status_code = 200
     mock_response.content = b"not a zip file"
 
-    with patch("requests.get", return_value=mock_response):
+    with (
+        patch("requests.get", return_value=mock_response),
+        patch("app.services.lambda_client._report_lambda_client_error") as report,
+    ):
         result = get_function_code("test-func")
 
     assert result["success"] is True
     assert "extract_error" in result["data"]
+    assert report.call_args.kwargs["operation"] == "extract_function_code"
+
+
+def test_invoke_function_reports_invalid_json_payload(mock_lambda_client) -> None:
+    mock_lambda_client.invoke.return_value = {
+        "StatusCode": 200,
+        "Payload": BytesIO(b"not-json"),
+    }
+
+    with patch("app.services.lambda_client._report_lambda_client_error") as report:
+        result = invoke_function("test-func")
+
+    assert result["success"] is True
+    assert result["data"]["payload"] is None
+    assert "payload_parse_error" in result["data"]
+    assert report.call_args.kwargs["operation"] == "parse_invoke_payload"
 
 
 def test_get_recent_invocations_multiple(mock_logs_client) -> None:


### PR DESCRIPTION
Fixes #1462

#### Describe the changes you've made

Adds AWS-specific service-client telemetry for swallowed errors in `aws_sdk_client.py` and `lambda_client.py`.

The new helper tags AWS failures consistently with service, operation, region, function name, and AWS error code. `ClientError` failures are reported at warning severity, while unexpected runtime failures are reported at error severity.

Lambda code download, zip extraction, CloudWatch metric parsing, and invoke-payload JSON parsing now report the previously silent failure path while preserving the existing user-facing result shape.

### Demo/Screenshot

N/A - telemetry and regression-test change.

---

## Code Understanding and AI Usage

**Did you use AI assistance?**  
Yes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] `make test-cov` passes locally
- [ ] `make lint` passes locally
- [ ] `make typecheck` passes locally

Local verification:

- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\services\aws app\services\aws_sdk_client.py app\services\lambda_client.py tests\services\test_aws_sdk_client.py tests\services\test_lambda_client.py tests\services\test_aws_telemetry.py`
- Pytest could not be run because neither the system Python nor bundled Python has the repo test dependencies installed, and `uv` is unavailable.
