### PR TITLE
fix(grafana): report soft-fail paths

### DIFF
--- a/app/services/grafana/_telemetry.py
+++ b/app/services/grafana/_telemetry.py
@@ -1,0 +1,57 @@
+"""Grafana service-client error telemetry."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from app.utils.errors import report_exception
+
+logger = logging.getLogger(__name__)
+
+
+def _status_code(exc: BaseException) -> int | None:
+    response = getattr(exc, "response", None)
+    value = getattr(response, "status_code", None)
+    return value if isinstance(value, int) else None
+
+
+def report_grafana_failure(
+    exc: BaseException,
+    *,
+    component: str,
+    method: str,
+    datasource_uid: str | None = None,
+    severity: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    """Report a Grafana soft-fail path with consistent tags."""
+    status_code = _status_code(exc)
+    likely_config_or_network = isinstance(exc, requests.RequestException) and (
+        status_code is None or 400 <= status_code < 500
+    )
+    effective_severity = severity or ("warning" if likely_config_or_network else "error")
+    tags = {
+        "surface": "service_client",
+        "integration": "grafana",
+        "component": f"app.services.grafana.{component}",
+        "method": method,
+    }
+    if datasource_uid:
+        tags["datasource_uid"] = datasource_uid
+    if status_code is not None:
+        tags["status_code"] = str(status_code)
+
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"[grafana] {component}.{method} failed",
+        severity=effective_severity,
+        tags=tags,
+        extras=extras,
+    )
+
+
+__all__ = ["report_grafana_failure"]

--- a/app/services/grafana/base.py
+++ b/app/services/grafana/base.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 import requests
 
 from app.services.grafana.config import GrafanaAccountConfig
+from app.services.grafana._telemetry import report_grafana_failure
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +237,7 @@ class GrafanaClientBase:
             logger.info("[grafana] Discovered datasource UIDs: %s", result)
             return result
         except Exception as e:
-            logger.warning("[grafana] Failed to discover datasource UIDs: %s", e)
+            report_grafana_failure(e, component="base", method="discover_datasource_uids")
             return {}
 
     def query_loki_label_values(self, label: str = "service_name") -> list[str]:
@@ -251,8 +252,14 @@ class GrafanaClientBase:
             data = self._make_request(url)
             values: list[str] = data.get("data", [])
             return values
-        except Exception:
-            logger.debug("Failed to fetch Loki label values for %s", label, exc_info=True)
+        except Exception as e:
+            report_grafana_failure(
+                e,
+                component="base",
+                method="query_loki_label_values",
+                datasource_uid=self.loki_datasource_uid,
+                extras={"label": label},
+            )
             return []
 
     def query_alert_rules(self, folder: str | None = None) -> list[dict[str, Any]]:
@@ -289,7 +296,7 @@ class GrafanaClientBase:
                         )
             return rules
         except Exception as e:
-            logger.warning("[grafana] Failed to query alert rules: %s", e)
+            report_grafana_failure(e, component="base", method="query_alert_rules")
             return []
 
     def _get_auth_headers(self) -> dict[str, str]:

--- a/app/services/grafana/loki.py
+++ b/app/services/grafana/loki.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any
 
+from app.services.grafana._telemetry import report_grafana_failure
+
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
 
@@ -82,6 +84,13 @@ class LokiMixin:
             if hasattr(e, "response") and e.response is not None:
                 response_text = e.response.text[:300]
                 error_msg = f"Loki query failed: {e.response.status_code}"
+            report_grafana_failure(
+                e,
+                component="loki",
+                method="query_loki",
+                datasource_uid=self.loki_datasource_uid,
+                extras={"query": query},
+            )
 
             return {
                 "success": False,

--- a/app/services/grafana/mimir.py
+++ b/app/services/grafana/mimir.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from app.services.grafana._telemetry import report_grafana_failure
+
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
 
@@ -69,6 +71,13 @@ class MimirMixin:
             if hasattr(e, "response") and e.response is not None:
                 response_text = e.response.text[:300]
                 error_msg = f"Mimir query failed: {e.response.status_code}"
+            report_grafana_failure(
+                e,
+                component="mimir",
+                method="query_mimir",
+                datasource_uid=self.mimir_datasource_uid,
+                extras={"query": query},
+            )
 
             return {
                 "success": False,

--- a/app/services/grafana/tempo.py
+++ b/app/services/grafana/tempo.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 
+from app.services.grafana._telemetry import report_grafana_failure
+
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
 
@@ -79,6 +81,13 @@ class TempoMixin:
             if hasattr(e, "response") and e.response is not None:
                 response_text = e.response.text[:300]
                 error_msg = f"Tempo query failed: {e.response.status_code}"
+            report_grafana_failure(
+                e,
+                component="tempo",
+                method="query_tempo",
+                datasource_uid=self.tempo_datasource_uid,
+                extras={"service_name": service_name},
+            )
 
             return {
                 "success": False,
@@ -130,8 +139,22 @@ class TempoMixin:
                                         )
 
                 return {"spans": spans}
-        except Exception:
-            logger.debug("Failed to fetch Tempo trace spans", exc_info=True)
+            report_grafana_failure(
+                RuntimeError(f"Tempo trace detail returned HTTP {response.status_code}"),
+                component="tempo",
+                method="_get_trace_details",
+                datasource_uid=self.tempo_datasource_uid,
+                severity="warning" if response.status_code < 500 else "error",
+                extras={"trace_id": trace_id, "status_code": response.status_code},
+            )
+        except Exception as e:
+            report_grafana_failure(
+                e,
+                component="tempo",
+                method="_get_trace_details",
+                datasource_uid=self.tempo_datasource_uid,
+                extras={"trace_id": trace_id},
+            )
             return {"spans": []}
 
         return {"spans": []}

--- a/pr/1461-grafana-soft-fail-telemetry.md
+++ b/pr/1461-grafana-soft-fail-telemetry.md
@@ -1,0 +1,31 @@
+Fixes #1461
+
+#### Describe the changes you've made
+
+Adds a shared Grafana service-client telemetry helper and wires it into the soft-fail paths in `base.py`, `loki.py`, `mimir.py`, and `tempo.py`.
+
+The existing fallback return values are preserved, but datasource discovery, label values, alert rules, Loki queries, Mimir queries, Tempo queries, and Tempo trace-detail non-200 responses now report a tagged Sentry event.
+
+### Demo/Screenshot
+
+N/A - telemetry and regression-test change.
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**  
+Yes.
+
+## Checklist before requesting a review
+
+- [x] I have performed a self-review of my code
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [ ] `make test-cov` passes locally
+- [ ] `make lint` passes locally
+- [ ] `make typecheck` passes locally
+
+Local verification:
+
+- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\services\grafana tests\services\test_grafana_loki.py tests\services\test_grafana_mimir.py tests\services\test_grafana_tempo.py`
+- Pytest could not be run because neither the system Python nor bundled Python has the repo test dependencies installed, and `uv` is unavailable.

--- a/tests/services/test_grafana_loki.py
+++ b/tests/services/test_grafana_loki.py
@@ -180,9 +180,11 @@ class TestQueryLokiExceptions:
 
     def test_plain_exception_returns_str_error_and_empty_response(self) -> None:
         host = _FakeLokiHost()
-        host.make_request_mock.side_effect = RuntimeError("connection refused")
+        error = RuntimeError("connection refused")
+        host.make_request_mock.side_effect = error
 
-        result = host.query_loki(_QUERY)
+        with patch("app.services.grafana.loki.report_grafana_failure") as report:
+            result = host.query_loki(_QUERY)
 
         assert result == {
             "success": False,
@@ -190,6 +192,13 @@ class TestQueryLokiExceptions:
             "response": "",
             "logs": [],
         }
+        report.assert_called_once_with(
+            error,
+            component="loki",
+            method="query_loki",
+            datasource_uid="loki-uid",
+            extras={"query": _QUERY},
+        )
 
     def test_exception_with_response_includes_status_and_truncated_text(self) -> None:
         host = _FakeLokiHost()

--- a/tests/services/test_grafana_mimir.py
+++ b/tests/services/test_grafana_mimir.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.services.grafana.mimir import MimirMixin
 
@@ -97,14 +97,23 @@ def test_query_mimir_exception_handling():
     """Test that network exceptions are caught and wrapped in a safe error envelope."""
     client = DummyMimirClient()
 
-    client._make_request.side_effect = Exception("Network timeout")
+    error = Exception("Network timeout")
+    client._make_request.side_effect = error
 
-    result = client.query_mimir("cpu_usage_total")
+    with patch("app.services.grafana.mimir.report_grafana_failure") as report:
+        result = client.query_mimir("cpu_usage_total")
 
     # Requirement: Exception cases / error envelope
     assert result["success"] is False
     assert "Network timeout" in result["error"]
     assert result["metrics"] == []
+    report.assert_called_once_with(
+        error,
+        component="mimir",
+        method="query_mimir",
+        datasource_uid="mimir_uid_456",
+        extras={"query": "cpu_usage_total"},
+    )
 
 
 def test_query_mimir_http_exception_handling():

--- a/tests/services/test_grafana_tempo.py
+++ b/tests/services/test_grafana_tempo.py
@@ -42,14 +42,23 @@ class TestTempoMixin:
     def test_query_tempo_general_exception(self):
         """Test general exception handling during a query."""
         client = FakeGrafanaClient()
-        client._make_request = Mock(side_effect=Exception("Connection timeout"))
+        error = Exception("Connection timeout")
+        client._make_request = Mock(side_effect=error)
 
-        result = client.query_tempo(service_name="auth-service")
+        with patch("app.services.grafana.tempo.report_grafana_failure") as report:
+            result = client.query_tempo(service_name="auth-service")
 
         assert result["success"] is False
         assert result["error"] == "Connection timeout"
         assert result["response"] == ""
         assert result["traces"] == []
+        report.assert_called_once_with(
+            error,
+            component="tempo",
+            method="query_tempo",
+            datasource_uid="tempo-uid-abc",
+            extras={"service_name": "auth-service"},
+        )
 
     def test_query_tempo_http_exception_with_response(self):
         """Test exception handling when the exception contains a response object."""
@@ -182,7 +191,15 @@ class TestTempoMixin:
         mock_response.status_code = 404
         mock_requests_get.return_value = mock_response
 
-        result = client._get_trace_details(trace_id="trace-123")
+        with patch("app.services.grafana.tempo.report_grafana_failure") as report:
+            result = client._get_trace_details(trace_id="trace-123")
 
         # Assert it safely falls back to empty spans
         assert result == {"spans": []}
+        assert report.call_args.kwargs == {
+            "component": "tempo",
+            "method": "_get_trace_details",
+            "datasource_uid": "tempo-uid-abc",
+            "severity": "warning",
+            "extras": {"trace_id": "trace-123", "status_code": 404},
+        }


### PR DESCRIPTION
Fixes #1461

#### Describe the changes you've made

Adds a shared Grafana service-client telemetry helper and wires it into the soft-fail paths in `base.py`, `loki.py`, `mimir.py`, and `tempo.py`.

The existing fallback return values are preserved, but datasource discovery, label values, alert rules, Loki queries, Mimir queries, Tempo queries, and Tempo trace-detail non-200 responses now report a tagged Sentry event.

### Demo/Screenshot

N/A - telemetry and regression-test change.

---

## Code Understanding and AI Usage

**Did you use AI assistance?**  
Yes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] `make test-cov` passes locally
- [ ] `make lint` passes locally
- [ ] `make typecheck` passes locally

Local verification:

- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\services\grafana tests\services\test_grafana_loki.py tests\services\test_grafana_mimir.py tests\services\test_grafana_tempo.py`
- Pytest could not be run because neither the system Python nor bundled Python has the repo test dependencies installed, and `uv` is unavailable.
