### PR TITLE
fix(services): standardize error telemetry across service clients

### DIFF
--- a/app/services/_error_helpers.py
+++ b/app/services/_error_helpers.py
@@ -1,0 +1,27 @@
+"""Shared error-telemetry helper for service-client except blocks."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.utils.errors import report_exception
+
+
+def capture_service_error(
+    exc: BaseException,
+    *,
+    logger: logging.Logger,
+    integration: str,
+    method: str,
+) -> None:
+    severity = "warning" if isinstance(exc, httpx.HTTPStatusError) else "error"
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"[{integration}] {method} failed",
+        severity=severity,
+        tags={"surface": "service_client", "integration": integration},
+        extras={"method": method},
+    )

--- a/app/services/_error_helpers.py
+++ b/app/services/_error_helpers.py
@@ -10,8 +10,12 @@ import httpx
 from app.utils.errors import report_exception
 
 
-def _is_server_error(exc: BaseException) -> bool:
-    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
+def _is_transient_vendor_error(exc: BaseException) -> bool:
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return False
+    sc = exc.response.status_code
+    # 429 = vendor rate-limit (transient throttling, not a config error)
+    return sc == 429 or sc >= 500
 
 
 def capture_service_error(
@@ -22,8 +26,9 @@ def capture_service_error(
     method: str,
     extras: dict[str, Any] | None = None,
 ) -> None:
-    severity = "warning" if _is_server_error(exc) else "error"
+    severity = "warning" if _is_transient_vendor_error(exc) else "error"
     merged_extras: dict[str, Any] = dict(extras) if extras else {}
+    merged_extras.pop("surface", None)
     merged_extras["method"] = method
     report_exception(
         exc,

--- a/app/services/_error_helpers.py
+++ b/app/services/_error_helpers.py
@@ -23,9 +23,8 @@ def capture_service_error(
     extras: dict[str, Any] | None = None,
 ) -> None:
     severity = "warning" if _is_server_error(exc) else "error"
-    merged_extras: dict[str, Any] = {"method": method}
-    if extras:
-        merged_extras.update(extras)
+    merged_extras: dict[str, Any] = dict(extras) if extras else {}
+    merged_extras["method"] = method
     report_exception(
         exc,
         logger=logger,

--- a/app/services/_error_helpers.py
+++ b/app/services/_error_helpers.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import httpx
 
 from app.utils.errors import report_exception
+
+
+def _is_server_error(exc: BaseException) -> bool:
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
 
 
 def capture_service_error(
@@ -15,13 +20,17 @@ def capture_service_error(
     logger: logging.Logger,
     integration: str,
     method: str,
+    extras: dict[str, Any] | None = None,
 ) -> None:
-    severity = "warning" if isinstance(exc, httpx.HTTPStatusError) else "error"
+    severity = "warning" if _is_server_error(exc) else "error"
+    merged_extras: dict[str, Any] = {"method": method}
+    if extras:
+        merged_extras.update(extras)
     report_exception(
         exc,
         logger=logger,
         message=f"[{integration}] {method} failed",
         severity=severity,
         tags={"surface": "service_client", "integration": integration},
-        extras={"method": method},
+        extras=merged_extras,
     )

--- a/app/services/alertmanager/client.py
+++ b/app/services/alertmanager/client.py
@@ -18,6 +18,7 @@ import httpx
 
 from app.integrations.config_models import AlertmanagerIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 
 logger = logging.getLogger(__name__)
 
@@ -87,18 +88,19 @@ class AlertmanagerClient:
             resp.raise_for_status()
             data = resp.json()
             return {"success": True, "status": data}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[alertmanager] Status check HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="alertmanager", method="get_status"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[alertmanager] Status check error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="alertmanager", method="get_status"
+            )
+            return {"success": False, "error": str(exc)}
 
     def list_alerts(
         self,
@@ -150,18 +152,19 @@ class AlertmanagerClient:
                 )
 
             return {"success": True, "alerts": alerts, "total": len(alerts)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[alertmanager] List alerts HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="alertmanager", method="list_alerts"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[alertmanager] List alerts error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="alertmanager", method="list_alerts"
+            )
+            return {"success": False, "error": str(exc)}
 
     def list_silences(self, limit: int = 50) -> dict[str, Any]:
         """List silences from Alertmanager."""
@@ -197,18 +200,19 @@ class AlertmanagerClient:
                 "active_silences": active,
                 "total": len(silences),
             }
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[alertmanager] List silences HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="alertmanager", method="list_silences"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[alertmanager] List silences error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="alertmanager", method="list_silences"
+            )
+            return {"success": False, "error": str(exc)}
 
 
 def make_alertmanager_client(

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -18,6 +18,7 @@ import httpx
 
 from app.integrations.config_models import ArgoCDIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +220,9 @@ class ArgoCDClient:
             ]
             return {"success": True, "applications": applications, "total": len(applications)}
         except Exception as exc:
-            logger.warning("[argocd] list_applications failed type=%s", type(exc).__name__)
+            capture_service_error(
+                exc, logger=logger, integration="argocd", method="list_applications"
+            )
             return self._error_result("list applications failed", exc)
 
     def get_application_summary(
@@ -252,10 +255,12 @@ class ArgoCDClient:
                 "recent_history": _recent_history(payload),
             }
         except Exception as exc:
-            logger.warning(
-                "[argocd] get_application_summary failed type=%s app=%r",
-                type(exc).__name__,
-                name,
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="argocd",
+                method="get_application_summary",
+                extras={"application_name": name},
             )
             return self._error_result("get application summary failed", exc)
 
@@ -302,10 +307,12 @@ class ArgoCDClient:
                 "diff_count": len(diffs),
             }
         except Exception as exc:
-            logger.warning(
-                "[argocd] get_application_diff failed type=%s app=%r",
-                type(exc).__name__,
-                name,
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="argocd",
+                method="get_application_diff",
+                extras={"application_name": name},
             )
             return self._error_result("get application diff failed", exc)
 

--- a/app/services/coralogix/client.py
+++ b/app/services/coralogix/client.py
@@ -11,6 +11,7 @@ import httpx
 
 from app.integrations.models import CoralogixIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 from app.services._streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
@@ -233,11 +234,13 @@ class CoralogixClient:
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="coralogix", method="query_logs")
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="coralogix", method="query_logs")
             return {"success": False, "error": str(exc)}
 
         stats = StreamingParseStats()

--- a/app/services/datadog/client.py
+++ b/app/services/datadog/client.py
@@ -110,13 +110,25 @@ class DatadogClient:
 
             return {"success": True, "logs": logs, "total": len(logs)}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="datadog", method="search_logs")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="search_logs",
+                extras={"query": query, "time_range_minutes": time_range_minutes},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="datadog", method="search_logs")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="search_logs",
+                extras={"query": query, "time_range_minutes": time_range_minutes},
+            )
             return {"success": False, "error": str(exc)}
 
     def query_metrics(
@@ -207,13 +219,25 @@ class DatadogClient:
 
             return {"success": True, "monitors": results, "total": len(results)}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="datadog", method="list_monitors")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="list_monitors",
+                extras={"query": query},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="datadog", method="list_monitors")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="list_monitors",
+                extras={"query": query},
+            )
             return {"success": False, "error": str(exc)}
 
     def get_pods_on_node(
@@ -390,7 +414,13 @@ class DatadogAsyncClient:
             return {"success": True, "logs": logs, "total": len(logs), "duration_ms": duration_ms}
         except httpx.HTTPStatusError as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            capture_service_error(exc, logger=logger, integration="datadog", method="_search_logs")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="_search_logs",
+                extras={"query": query, "time_range_minutes": time_range_minutes},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
@@ -398,7 +428,13 @@ class DatadogAsyncClient:
             }
         except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            capture_service_error(exc, logger=logger, integration="datadog", method="_search_logs")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="_search_logs",
+                extras={"query": query, "time_range_minutes": time_range_minutes},
+            )
             return {"success": False, "error": str(exc), "duration_ms": duration_ms}
 
     async def _list_monitors(
@@ -437,7 +473,11 @@ class DatadogAsyncClient:
         except httpx.HTTPStatusError as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
             capture_service_error(
-                exc, logger=logger, integration="datadog", method="_list_monitors"
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="_list_monitors",
+                extras={"query": query},
             )
             return {
                 "success": False,
@@ -447,7 +487,11 @@ class DatadogAsyncClient:
         except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
             capture_service_error(
-                exc, logger=logger, integration="datadog", method="_list_monitors"
+                exc,
+                logger=logger,
+                integration="datadog",
+                method="_list_monitors",
+                extras={"query": query},
             )
             return {"success": False, "error": str(exc), "duration_ms": duration_ms}
 

--- a/app/services/datadog/client.py
+++ b/app/services/datadog/client.py
@@ -16,6 +16,7 @@ import httpx
 
 from app.integrations.config_models import DatadogIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 
 logger = logging.getLogger(__name__)
 
@@ -108,26 +109,15 @@ class DatadogClient:
                 logs.append(log)
 
             return {"success": True, "logs": logs, "total": len(logs)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[datadog] Log search HTTP failure status=%s query=%r window=%sm "
-                "(check API/app key permissions and query syntax)",
-                e.response.status_code,
-                query,
-                time_range_minutes,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="datadog", method="search_logs")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[datadog] Log search request error type=%s detail=%s "
-                "(network/auth/timeout likely)",
-                type(e).__name__,
-                e,
-            )
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="datadog", method="search_logs")
+            return {"success": False, "error": str(exc)}
 
     def query_metrics(
         self,
@@ -216,24 +206,15 @@ class DatadogClient:
                 )
 
             return {"success": True, "monitors": results, "total": len(results)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[datadog] List monitors HTTP failure status=%s query=%r "
-                "(verify monitor.read scope and org/site)",
-                e.response.status_code,
-                query,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="datadog", method="list_monitors")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[datadog] List monitors request error type=%s detail=%s",
-                type(e).__name__,
-                e,
-            )
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="datadog", method="list_monitors")
+            return {"success": False, "error": str(exc)}
 
     def get_pods_on_node(
         self,
@@ -347,15 +328,15 @@ class DatadogClient:
                 )
 
             return {"success": True, "events": events, "total": len(events)}
-        except httpx.HTTPStatusError as e:
-            logger.warning("[datadog] Events query failed: %s", e.response.status_code)
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="datadog", method="get_events")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[datadog] Events query error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="datadog", method="get_events")
+            return {"success": False, "error": str(exc)}
 
 
 class DatadogAsyncClient:
@@ -407,18 +388,18 @@ class DatadogAsyncClient:
                 log.update({k: v for k, v in custom.items() if isinstance(k, str)})
                 logs.append(log)
             return {"success": True, "logs": logs, "total": len(logs), "duration_ms": duration_ms}
-        except httpx.HTTPStatusError as e:
+        except httpx.HTTPStatusError as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            logger.warning("[datadog] Async log search failed: %s", e.response.status_code)
+            capture_service_error(exc, logger=logger, integration="datadog", method="_search_logs")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
                 "duration_ms": duration_ms,
             }
-        except Exception as e:
+        except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            logger.warning("[datadog] Async log search error: %s", e)
-            return {"success": False, "error": str(e), "duration_ms": duration_ms}
+            capture_service_error(exc, logger=logger, integration="datadog", method="_search_logs")
+            return {"success": False, "error": str(exc), "duration_ms": duration_ms}
 
     async def _list_monitors(
         self,
@@ -453,18 +434,22 @@ class DatadogAsyncClient:
                 "total": len(results),
                 "duration_ms": duration_ms,
             }
-        except httpx.HTTPStatusError as e:
+        except httpx.HTTPStatusError as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            logger.warning("[datadog] Async list monitors failed: %s", e.response.status_code)
+            capture_service_error(
+                exc, logger=logger, integration="datadog", method="_list_monitors"
+            )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
                 "duration_ms": duration_ms,
             }
-        except Exception as e:
+        except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            logger.warning("[datadog] Async list monitors error: %s", e)
-            return {"success": False, "error": str(e), "duration_ms": duration_ms}
+            capture_service_error(
+                exc, logger=logger, integration="datadog", method="_list_monitors"
+            )
+            return {"success": False, "error": str(exc), "duration_ms": duration_ms}
 
     async def _get_events(
         self,
@@ -508,18 +493,18 @@ class DatadogAsyncClient:
                 "total": len(events),
                 "duration_ms": duration_ms,
             }
-        except httpx.HTTPStatusError as e:
+        except httpx.HTTPStatusError as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            logger.warning("[datadog] Async events query failed: %s", e.response.status_code)
+            capture_service_error(exc, logger=logger, integration="datadog", method="_get_events")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
                 "duration_ms": duration_ms,
             }
-        except Exception as e:
+        except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
-            logger.warning("[datadog] Async events query error: %s", e)
-            return {"success": False, "error": str(e), "duration_ms": duration_ms}
+            capture_service_error(exc, logger=logger, integration="datadog", method="_get_events")
+            return {"success": False, "error": str(exc), "duration_ms": duration_ms}
 
     async def fetch_all(
         self,

--- a/app/services/elasticsearch/client.py
+++ b/app/services/elasticsearch/client.py
@@ -26,6 +26,8 @@ from typing import Any
 
 import httpx
 
+from app.services._error_helpers import capture_service_error
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 30
@@ -101,13 +103,11 @@ class ElasticsearchClient:
                     "error": f"Unexpected status {resp.status_code} from /_cluster/health",
                 }
             return {"success": True, "security_enabled": security_enabled}
-        except Exception as e:
-            logger.warning(
-                "[elasticsearch] check_security error type=%s detail=%s",
-                type(e).__name__,
-                e,
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="check_security"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}
 
     def list_indices(self) -> dict[str, Any]:
         """List all indices via GET /_cat/indices?format=json."""
@@ -126,20 +126,19 @@ class ElasticsearchClient:
                 for idx in raw
             ]
             return {"success": True, "indices": indices, "total": len(indices)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[elasticsearch] list_indices HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="list_indices"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[elasticsearch] list_indices error type=%s detail=%s", type(e).__name__, e
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="list_indices"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}
 
     def list_data_streams(self) -> dict[str, Any]:
         """List all data streams via GET /_data_stream."""
@@ -157,20 +156,19 @@ class ElasticsearchClient:
                 for s in streams
             ]
             return {"success": True, "data_streams": results, "total": len(results)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[elasticsearch] list_data_streams HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="list_data_streams"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[elasticsearch] list_data_streams error type=%s detail=%s", type(e).__name__, e
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="list_data_streams"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}
 
     def search_logs(
         self,
@@ -235,22 +233,19 @@ class ElasticsearchClient:
                 for src in [hit.get("_source", {})]
             ]
             return {"success": True, "logs": logs, "total": len(logs), "query": query}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[elasticsearch] search_logs HTTP failure status=%s query=%r window=%sm",
-                e.response.status_code,
-                query,
-                time_range_minutes,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="search_logs"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[elasticsearch] search_logs error type=%s detail=%s", type(e).__name__, e
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="search_logs"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}
 
     def get_cluster_health(self) -> dict[str, Any]:
         """GET /_cluster/health — returns cluster name, status, and shard counts."""
@@ -268,17 +263,16 @@ class ElasticsearchClient:
                 "active_shards": data.get("active_shards", 0),
                 "unassigned_shards": data.get("unassigned_shards", 0),
             }
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[elasticsearch] get_cluster_health HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="get_cluster_health"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[elasticsearch] get_cluster_health error type=%s detail=%s", type(e).__name__, e
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="elasticsearch", method="get_cluster_health"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}

--- a/app/services/elasticsearch/client.py
+++ b/app/services/elasticsearch/client.py
@@ -235,7 +235,11 @@ class ElasticsearchClient:
             return {"success": True, "logs": logs, "total": len(logs), "query": query}
         except httpx.HTTPStatusError as exc:
             capture_service_error(
-                exc, logger=logger, integration="elasticsearch", method="search_logs"
+                exc,
+                logger=logger,
+                integration="elasticsearch",
+                method="search_logs",
+                extras={"query": query, "time_range_minutes": time_range_minutes},
             )
             return {
                 "success": False,
@@ -243,7 +247,11 @@ class ElasticsearchClient:
             }
         except Exception as exc:
             capture_service_error(
-                exc, logger=logger, integration="elasticsearch", method="search_logs"
+                exc,
+                logger=logger,
+                integration="elasticsearch",
+                method="search_logs",
+                extras={"query": query, "time_range_minutes": time_range_minutes},
             )
             return {"success": False, "error": str(exc)}
 

--- a/app/services/honeycomb/client.py
+++ b/app/services/honeycomb/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any
 
@@ -9,6 +10,9 @@ import httpx
 
 from app.integrations.models import HoneycombIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 _DEFAULT_POLL_ATTEMPTS = 10
@@ -83,11 +87,17 @@ class HoneycombClient:
             response.raise_for_status()
             payload = response.json()
         except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="validate_access"
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="validate_access"
+            )
             return {"success": False, "error": str(exc)}
 
         environment = payload.get("environment", {}) if isinstance(payload, dict) else {}
@@ -106,11 +116,17 @@ class HoneycombClient:
             response.raise_for_status()
             payload = response.json()
         except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="create_query"
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="create_query"
+            )
             return {"success": False, "error": str(exc)}
 
         query_id = str(payload.get("id", "")).strip() if isinstance(payload, dict) else ""
@@ -135,11 +151,17 @@ class HoneycombClient:
             response.raise_for_status()
             result = response.json()
         except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="create_query_result"
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="create_query_result"
+            )
             return {"success": False, "error": str(exc)}
 
         return {"success": True, "result": result}
@@ -153,11 +175,17 @@ class HoneycombClient:
             response.raise_for_status()
             payload = response.json()
         except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="get_query_result"
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="honeycomb", method="get_query_result"
+            )
             return {"success": False, "error": str(exc)}
         return {"success": True, "result": payload}
 

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -101,13 +101,25 @@ class JiraClient:
                 resp.raise_for_status()
                 return {"success": True, "issue_key": issue_key}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="jira", method="update_issue")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="jira",
+                method="update_issue",
+                extras={"issue_key": issue_key},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="jira", method="update_issue")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="jira",
+                method="update_issue",
+                extras={"issue_key": issue_key},
+            )
             return {"success": False, "error": str(exc)}
 
     def add_comment(
@@ -138,13 +150,25 @@ class JiraClient:
                 data = resp.json()
                 return {"success": True, "comment_id": data.get("id")}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="jira", method="add_comment")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="jira",
+                method="add_comment",
+                extras={"issue_key": issue_key},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="jira", method="add_comment")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="jira",
+                method="add_comment",
+                extras={"issue_key": issue_key},
+            )
             return {"success": False, "error": str(exc)}
 
     def search_issues(
@@ -231,13 +255,25 @@ class JiraClient:
                     "labels": fields.get("labels", []),
                 }
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="jira", method="get_issue")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="jira",
+                method="get_issue",
+                extras={"issue_key": issue_key},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="jira", method="get_issue")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="jira",
+                method="get_issue",
+                extras={"issue_key": issue_key},
+            )
             return {"success": False, "error": str(exc)}
 
 

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from app.integrations.models import JiraIntegrationConfig
+from app.services._error_helpers import capture_service_error
 
 logger = logging.getLogger(__name__)
 
@@ -75,15 +76,15 @@ class JiraClient:
                     "issue_id": data.get("id"),
                     "url": f"{self.config.base_url}/browse/{data.get('key')}",
                 }
-        except httpx.HTTPStatusError as e:
-            logger.warning("[jira] Failed to create issue status=%s", e.response.status_code)
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="create_issue")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[jira] Create issue error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="create_issue")
+            return {"success": False, "error": str(exc)}
 
     def update_issue(
         self,
@@ -99,17 +100,15 @@ class JiraClient:
                 )
                 resp.raise_for_status()
                 return {"success": True, "issue_key": issue_key}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[jira] Failed to update issue=%s status=%s", issue_key, e.response.status_code
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="update_issue")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[jira] Update issue error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="update_issue")
+            return {"success": False, "error": str(exc)}
 
     def add_comment(
         self,
@@ -138,17 +137,15 @@ class JiraClient:
                 resp.raise_for_status()
                 data = resp.json()
                 return {"success": True, "comment_id": data.get("id")}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[jira] Failed to add comment issue=%s status=%s", issue_key, e.response.status_code
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="add_comment")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[jira] Add comment error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="add_comment")
+            return {"success": False, "error": str(exc)}
 
     def search_issues(
         self,
@@ -206,15 +203,15 @@ class JiraClient:
                     "issues": issues,
                     "total": data.get("total", len(issues)),
                 }
-        except httpx.HTTPStatusError as e:
-            logger.warning("[jira] Search issues HTTP failure status=%s", e.response.status_code)
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="search_issues")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[jira] Search issues error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="search_issues")
+            return {"success": False, "error": str(exc)}
 
     def get_issue(self, issue_key: str) -> dict[str, Any]:
         """Fetch an existing Jira issue to pull context into the investigation."""
@@ -233,17 +230,15 @@ class JiraClient:
                     "description": fields.get("description", ""),
                     "labels": fields.get("labels", []),
                 }
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[jira] Failed to get issue=%s status=%s", issue_key, e.response.status_code
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="get_issue")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[jira] Get issue error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="jira", method="get_issue")
+            return {"success": False, "error": str(exc)}
 
 
 def make_jira_client(

--- a/app/services/notion/client.py
+++ b/app/services/notion/client.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 from pydantic import field_validator
 
+from app.services._error_helpers import capture_service_error
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -90,18 +91,19 @@ class NotionClient:
                     "page_id": data.get("id"),
                     "url": data.get("url"),
                 }
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[notion] Failed to create page status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="notion", method="create_investigation_page"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[notion] Request error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="notion", method="create_investigation_page"
+            )
+            return {"success": False, "error": str(exc)}
 
     def update_page(
         self,
@@ -117,15 +119,15 @@ class NotionClient:
                 resp = client.patch(f"/blocks/{page_id}/children", json=payload)
                 resp.raise_for_status()
                 return {"success": True, "page_id": page_id}
-        except httpx.HTTPStatusError as e:
-            logger.warning("[notion] Failed to update page status=%s", e.response.status_code)
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="notion", method="update_page")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[notion] Update error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="notion", method="update_page")
+            return {"success": False, "error": str(exc)}
 
 
 def _heading(text: str) -> dict:

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -13,6 +13,7 @@ import httpx
 
 from app.integrations.config_models import OpsGenieIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 
 logger = logging.getLogger(__name__)
 
@@ -105,19 +106,15 @@ class OpsGenieClient:
                 )
 
             return {"success": True, "alerts": alerts, "total": len(alerts)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[opsgenie] List alerts HTTP failure status=%s query=%r",
-                e.response.status_code,
-                query,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="opsgenie", method="list_alerts")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[opsgenie] List alerts error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="opsgenie", method="list_alerts")
+            return {"success": False, "error": str(exc)}
 
     def get_alert(self, alert_id: str) -> dict[str, Any]:
         """Fetch full details for a specific OpsGenie alert."""
@@ -154,19 +151,15 @@ class OpsGenieClient:
             }
 
             return {"success": True, "alert": alert}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[opsgenie] Get alert HTTP failure status=%s id=%r",
-                e.response.status_code,
-                alert_id,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="opsgenie", method="get_alert")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[opsgenie] Get alert error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="opsgenie", method="get_alert")
+            return {"success": False, "error": str(exc)}
 
     def get_alert_logs(self, alert_id: str, limit: int = 20) -> dict[str, Any]:
         """Fetch the activity log for a specific OpsGenie alert."""
@@ -190,19 +183,19 @@ class OpsGenieClient:
                 )
 
             return {"success": True, "logs": logs, "total": len(logs)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[opsgenie] Get alert logs HTTP failure status=%s id=%r",
-                e.response.status_code,
-                alert_id,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="opsgenie", method="get_alert_logs"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[opsgenie] Get alert logs error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="opsgenie", method="get_alert_logs"
+            )
+            return {"success": False, "error": str(exc)}
 
     def add_note(self, alert_id: str, note: str) -> dict[str, Any]:
         """Add a note to an OpsGenie alert (findings write-back)."""
@@ -213,17 +206,15 @@ class OpsGenieClient:
             )
             resp.raise_for_status()
             return {"success": True}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[opsgenie] Add note HTTP failure status=%s id=%r", e.response.status_code, alert_id
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="opsgenie", method="add_note")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[opsgenie] Add note error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="opsgenie", method="add_note")
+            return {"success": False, "error": str(exc)}
 
 
 def make_opsgenie_client(api_key: str | None, region: str | None = None) -> OpsGenieClient | None:

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -107,13 +107,25 @@ class OpsGenieClient:
 
             return {"success": True, "alerts": alerts, "total": len(alerts)}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="opsgenie", method="list_alerts")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="list_alerts",
+                extras={"query": query},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="opsgenie", method="list_alerts")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="list_alerts",
+                extras={"query": query},
+            )
             return {"success": False, "error": str(exc)}
 
     def get_alert(self, alert_id: str) -> dict[str, Any]:

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -164,13 +164,25 @@ class OpsGenieClient:
 
             return {"success": True, "alert": alert}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="opsgenie", method="get_alert")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="get_alert",
+                extras={"alert_id": alert_id},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="opsgenie", method="get_alert")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="get_alert",
+                extras={"alert_id": alert_id},
+            )
             return {"success": False, "error": str(exc)}
 
     def get_alert_logs(self, alert_id: str, limit: int = 20) -> dict[str, Any]:
@@ -197,7 +209,11 @@ class OpsGenieClient:
             return {"success": True, "logs": logs, "total": len(logs)}
         except httpx.HTTPStatusError as exc:
             capture_service_error(
-                exc, logger=logger, integration="opsgenie", method="get_alert_logs"
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="get_alert_logs",
+                extras={"alert_id": alert_id},
             )
             return {
                 "success": False,
@@ -205,7 +221,11 @@ class OpsGenieClient:
             }
         except Exception as exc:
             capture_service_error(
-                exc, logger=logger, integration="opsgenie", method="get_alert_logs"
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="get_alert_logs",
+                extras={"alert_id": alert_id},
             )
             return {"success": False, "error": str(exc)}
 
@@ -219,13 +239,25 @@ class OpsGenieClient:
             resp.raise_for_status()
             return {"success": True}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="opsgenie", method="add_note")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="add_note",
+                extras={"alert_id": alert_id},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="opsgenie", method="add_note")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="opsgenie",
+                method="add_note",
+                extras={"alert_id": alert_id},
+            )
             return {"success": False, "error": str(exc)}
 
 

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -178,7 +178,11 @@ class PrefectClient:
             return {"success": True, "logs": logs, "total": len(logs)}
         except httpx.HTTPStatusError as exc:
             capture_service_error(
-                exc, logger=logger, integration="prefect", method="get_flow_run_logs"
+                exc,
+                logger=logger,
+                integration="prefect",
+                method="get_flow_run_logs",
+                extras={"flow_run_id": flow_run_id},
             )
             return {
                 "success": False,
@@ -186,7 +190,11 @@ class PrefectClient:
             }
         except Exception as exc:
             capture_service_error(
-                exc, logger=logger, integration="prefect", method="get_flow_run_logs"
+                exc,
+                logger=logger,
+                integration="prefect",
+                method="get_flow_run_logs",
+                extras={"flow_run_id": flow_run_id},
             )
             return {"success": False, "error": str(exc)}
 
@@ -256,13 +264,25 @@ class PrefectClient:
             ]
             return {"success": True, "workers": workers, "total": len(workers)}
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="prefect", method="get_workers")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="prefect",
+                method="get_workers",
+                extras={"work_pool_name": work_pool_name},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="prefect", method="get_workers")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="prefect",
+                method="get_workers",
+                extras={"work_pool_name": work_pool_name},
+            )
             return {"success": False, "error": str(exc)}
 
     # ------------------------------------------------------------------

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 import httpx
 from pydantic import field_validator
 
+from app.services._error_helpers import capture_service_error
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -139,18 +140,15 @@ class PrefectClient:
                 for r in raw
             ]
             return {"success": True, "flow_runs": runs, "total": len(runs)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[prefect] get_flow_runs HTTP failure status=%s",
-                e.response.status_code,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="prefect", method="get_flow_runs")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[prefect] get_flow_runs error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="prefect", method="get_flow_runs")
+            return {"success": False, "error": str(exc)}
 
     def get_flow_run_logs(self, flow_run_id: str, limit: int = 100) -> dict[str, Any]:
         """Fetch logs emitted during a specific flow run.
@@ -178,21 +176,19 @@ class PrefectClient:
                 for entry in raw
             ]
             return {"success": True, "logs": logs, "total": len(logs)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[prefect] get_flow_run_logs HTTP failure status=%s flow_run_id=%r",
-                e.response.status_code,
-                flow_run_id,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="prefect", method="get_flow_run_logs"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[prefect] get_flow_run_logs error type=%s detail=%s", type(e).__name__, e
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="prefect", method="get_flow_run_logs"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}
 
     # ------------------------------------------------------------------
     # Workers / work pools
@@ -221,18 +217,19 @@ class PrefectClient:
                 for p in raw
             ]
             return {"success": True, "work_pools": pools, "total": len(pools)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[prefect] get_work_pools HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="prefect", method="get_work_pools"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[prefect] get_work_pools error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="prefect", method="get_work_pools"
+            )
+            return {"success": False, "error": str(exc)}
 
     def get_workers(self, work_pool_name: str, limit: int = 20) -> dict[str, Any]:
         """List workers registered in a work pool.
@@ -258,19 +255,15 @@ class PrefectClient:
                 for w in raw
             ]
             return {"success": True, "workers": workers, "total": len(workers)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[prefect] get_workers HTTP failure status=%s pool=%r",
-                e.response.status_code,
-                work_pool_name,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="prefect", method="get_workers")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[prefect] get_workers error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="prefect", method="get_workers")
+            return {"success": False, "error": str(exc)}
 
     # ------------------------------------------------------------------
     # Deployments
@@ -301,18 +294,19 @@ class PrefectClient:
                 for d in raw
             ]
             return {"success": True, "deployments": deployments, "total": len(deployments)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[prefect] get_deployments HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="prefect", method="get_deployments"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[prefect] get_deployments error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="prefect", method="get_deployments"
+            )
+            return {"success": False, "error": str(exc)}
 
 
 def make_prefect_client(

--- a/app/services/splunk/client.py
+++ b/app/services/splunk/client.py
@@ -11,6 +11,7 @@ import httpx
 
 from app.integrations.config_models import SplunkIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 from app.services._streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
@@ -105,11 +106,13 @@ class SplunkClient:
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="splunk", method="search_logs")
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="splunk", method="search_logs")
             return {"success": False, "error": str(exc)}
 
         logs = self._parse_export_response(response.text)
@@ -174,11 +177,17 @@ class SplunkClient:
                 "detail": f"Connected to Splunk {version}",
             }
         except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="splunk", method="validate_access"
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="splunk", method="validate_access"
+            )
             return {"success": False, "error": str(exc)}
 
     def probe_access(self) -> ProbeResult:

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -279,13 +279,25 @@ class VercelClient:
                 "production_target": prod,
             }
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="vercel", method="get_project")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="get_project",
+                extras={"project": cleaned},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="vercel", method="get_project")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="get_project",
+                extras={"project": cleaned},
+            )
             return {"success": False, "error": str(exc)}
 
     def list_deployments(
@@ -328,7 +340,11 @@ class VercelClient:
             return {"success": True, "deployments": deployments, "total": len(deployments)}
         except httpx.HTTPStatusError as exc:
             capture_service_error(
-                exc, logger=logger, integration="vercel", method="list_deployments"
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="list_deployments",
+                extras={"project_id": project_id, "state": state},
             )
             return {
                 "success": False,
@@ -336,7 +352,11 @@ class VercelClient:
             }
         except Exception as exc:
             capture_service_error(
-                exc, logger=logger, integration="vercel", method="list_deployments"
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="list_deployments",
+                extras={"project_id": project_id, "state": state},
             )
             return {"success": False, "error": str(exc)}
 
@@ -367,13 +387,25 @@ class VercelClient:
                 },
             }
         except httpx.HTTPStatusError as exc:
-            capture_service_error(exc, logger=logger, integration="vercel", method="get_deployment")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="get_deployment",
+                extras={"deployment_id": deployment_id},
+            )
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except Exception as exc:
-            capture_service_error(exc, logger=logger, integration="vercel", method="get_deployment")
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="get_deployment",
+                extras={"deployment_id": deployment_id},
+            )
             return {"success": False, "error": str(exc)}
 
     def get_deployment_events(self, deployment_id: str, limit: int = 100) -> dict[str, Any]:
@@ -403,7 +435,11 @@ class VercelClient:
             return {"success": True, "events": events, "total": len(events)}
         except httpx.HTTPStatusError as exc:
             capture_service_error(
-                exc, logger=logger, integration="vercel", method="get_deployment_events"
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="get_deployment_events",
+                extras={"deployment_id": deployment_id},
             )
             return {
                 "success": False,
@@ -411,7 +447,11 @@ class VercelClient:
             }
         except Exception as exc:
             capture_service_error(
-                exc, logger=logger, integration="vercel", method="get_deployment_events"
+                exc,
+                logger=logger,
+                integration="vercel",
+                method="get_deployment_events",
+                extras={"deployment_id": deployment_id},
             )
             return {"success": False, "error": str(exc)}
 
@@ -489,7 +529,11 @@ class VercelClient:
                 last_retryable_kind = type(exc).__name__
                 if attempt >= _RUNTIME_LOGS_READ_ATTEMPTS:
                     capture_service_error(
-                        exc, logger=logger, integration="vercel", method="get_runtime_logs"
+                        exc,
+                        logger=logger,
+                        integration="vercel",
+                        method="get_runtime_logs",
+                        extras={"deployment_id": deployment_id},
                     )
                     break
                 time.sleep(min(8.0, 2.0**attempt))
@@ -497,7 +541,11 @@ class VercelClient:
                 if exc.response.status_code == 404:
                     return {"success": True, "logs": [], "total": 0}
                 capture_service_error(
-                    exc, logger=logger, integration="vercel", method="get_runtime_logs"
+                    exc,
+                    logger=logger,
+                    integration="vercel",
+                    method="get_runtime_logs",
+                    extras={"deployment_id": deployment_id},
                 )
                 return {
                     "success": False,
@@ -505,7 +553,11 @@ class VercelClient:
                 }
             except Exception as exc:
                 capture_service_error(
-                    exc, logger=logger, integration="vercel", method="get_runtime_logs"
+                    exc,
+                    logger=logger,
+                    integration="vercel",
+                    method="get_runtime_logs",
+                    extras={"deployment_id": deployment_id},
                 )
                 return {"success": False, "error": str(exc)}
 

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -18,6 +18,7 @@ import httpx
 
 from app.integrations.config_models import VercelIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 from app.services._streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
@@ -240,18 +241,15 @@ class VercelClient:
                 for p in data.get("projects", [])
             ]
             return {"success": True, "projects": projects, "total": len(projects)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[vercel] list_projects HTTP failure status=%s",
-                e.response.status_code,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="vercel", method="list_projects")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[vercel] list_projects error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="vercel", method="list_projects")
+            return {"success": False, "error": str(exc)}
 
     def get_project(self, project_id_or_name: str) -> dict[str, Any]:
         """Fetch project details including the current production deployment (no deployment list)."""
@@ -280,19 +278,15 @@ class VercelClient:
                 "production_deployment_id": prod_id,
                 "production_target": prod,
             }
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[vercel] get_project HTTP failure status=%s project=%r",
-                e.response.status_code,
-                cleaned,
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="vercel", method="get_project")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[vercel] get_project error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="vercel", method="get_project")
+            return {"success": False, "error": str(exc)}
 
     def list_deployments(
         self,
@@ -332,20 +326,19 @@ class VercelClient:
                 for d in data.get("deployments", [])
             ]
             return {"success": True, "deployments": deployments, "total": len(deployments)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[vercel] list_deployments HTTP failure status=%s project=%s state=%s",
-                e.response.status_code,
-                _scrub_log_fragment(project_id),
-                _scrub_log_fragment(state),
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="vercel", method="list_deployments"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[vercel] list_deployments error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="vercel", method="list_deployments"
+            )
+            return {"success": False, "error": str(exc)}
 
     def get_deployment(self, deployment_id: str) -> dict[str, Any]:
         """Fetch full details for a single deployment including build errors and git metadata."""
@@ -373,19 +366,15 @@ class VercelClient:
                     "build": data.get("build", {}),
                 },
             }
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[vercel] get_deployment HTTP failure status=%s id=%s",
-                e.response.status_code,
-                _scrub_log_fragment(deployment_id),
-            )
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(exc, logger=logger, integration="vercel", method="get_deployment")
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[vercel] get_deployment error type=%s detail=%s", type(e).__name__, e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(exc, logger=logger, integration="vercel", method="get_deployment")
+            return {"success": False, "error": str(exc)}
 
     def get_deployment_events(self, deployment_id: str, limit: int = 100) -> dict[str, Any]:
         """Fetch the build and runtime event stream for a deployment."""
@@ -412,21 +401,19 @@ class VercelClient:
                     }
                 )
             return {"success": True, "events": events, "total": len(events)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[vercel] get_deployment_events HTTP failure status=%s id=%s",
-                e.response.status_code,
-                _scrub_log_fragment(deployment_id),
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc, logger=logger, integration="vercel", method="get_deployment_events"
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning(
-                "[vercel] get_deployment_events error type=%s detail=%s", type(e).__name__, e
+        except Exception as exc:
+            capture_service_error(
+                exc, logger=logger, integration="vercel", method="get_deployment_events"
             )
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(exc)}
 
     def get_runtime_logs(
         self,
@@ -500,33 +487,27 @@ class VercelClient:
             except (httpx.ReadTimeout, httpx.ReadError, httpx.RemoteProtocolError) as exc:
                 last_retryable_detail = str(exc)
                 last_retryable_kind = type(exc).__name__
-                logger.warning(
-                    "[vercel] get_runtime_logs %s attempt %s/%s deployment=%s",
-                    last_retryable_kind,
-                    attempt,
-                    _RUNTIME_LOGS_READ_ATTEMPTS,
-                    _scrub_log_fragment(deployment_id),
-                )
                 if attempt >= _RUNTIME_LOGS_READ_ATTEMPTS:
+                    capture_service_error(
+                        exc, logger=logger, integration="vercel", method="get_runtime_logs"
+                    )
                     break
                 time.sleep(min(8.0, 2.0**attempt))
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == 404:
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
                     return {"success": True, "logs": [], "total": 0}
-                logger.warning(
-                    "[vercel] get_runtime_logs HTTP failure status=%s id=%s",
-                    e.response.status_code,
-                    _scrub_log_fragment(deployment_id),
+                capture_service_error(
+                    exc, logger=logger, integration="vercel", method="get_runtime_logs"
                 )
                 return {
                     "success": False,
-                    "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                    "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
                 }
-            except Exception as e:
-                logger.warning(
-                    "[vercel] get_runtime_logs error type=%s detail=%s", type(e).__name__, e
+            except Exception as exc:
+                capture_service_error(
+                    exc, logger=logger, integration="vercel", method="get_runtime_logs"
                 )
-                return {"success": False, "error": str(e)}
+                return {"success": False, "error": str(exc)}
 
         detail = last_retryable_detail or "Transient runtime log transport error"
         if last_retryable_kind == "ReadTimeout":

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -144,7 +144,7 @@ class VictoriaLogsClient:
                 exc,
                 logger=logger,
                 integration="victoria_logs",
-                method="search_logs",
+                method="query_logs",
                 extras={"query": query},
             )
             return {
@@ -156,7 +156,7 @@ class VictoriaLogsClient:
                 exc,
                 logger=logger,
                 integration="victoria_logs",
-                method="search_logs",
+                method="query_logs",
                 extras={"query": query},
             )
             return {"success": False, "error": str(exc)}

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -20,6 +20,7 @@ import httpx
 from pydantic import field_validator
 
 from app.integrations.probes import ProbeResult
+from app.services._error_helpers import capture_service_error
 from app.services._streaming import StreamingParseStats
 from app.strict_config import StrictConfigModel
 
@@ -138,18 +139,27 @@ class VictoriaLogsClient:
             resp.raise_for_status()
             rows = _parse_ndjson(resp.text, limit=limit)
             return {"success": True, "rows": rows, "total": len(rows)}
-        except httpx.HTTPStatusError as e:
-            logger.warning(
-                "[victoria_logs] Query HTTP failure status=%s",
-                e.response.status_code,
+        except httpx.HTTPStatusError as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="victoria_logs",
+                method="search_logs",
+                extras={"query": query},
             )
             return {
                 "success": False,
-                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
-        except Exception as e:
-            logger.warning("[victoria_logs] Query error: %s", e)
-            return {"success": False, "error": str(e)}
+        except Exception as exc:
+            capture_service_error(
+                exc,
+                logger=logger,
+                integration="victoria_logs",
+                method="search_logs",
+                extras={"query": query},
+            )
+            return {"success": False, "error": str(exc)}
 
 
 def _parse_ndjson(text: str, *, limit: int) -> list[dict[str, Any]]:

--- a/tests/services/test_error_helpers.py
+++ b/tests/services/test_error_helpers.py
@@ -1,0 +1,80 @@
+"""Tests for the shared service-client error telemetry helper."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services._error_helpers import capture_service_error
+
+
+@pytest.fixture
+def mock_logger() -> logging.Logger:
+    return MagicMock(spec=logging.Logger)
+
+
+def _make_http_status_error(status_code: int = 502) -> httpx.HTTPStatusError:
+    response = httpx.Response(status_code, text="Bad Gateway")
+    request = httpx.Request("GET", "https://api.example.com/test")
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+class TestCaptureServiceError:
+    def test_http_status_error_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
+        exc = _make_http_status_error(502)
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="jira", method="create_issue"
+            )
+            mock_report.assert_called_once_with(
+                exc,
+                logger=mock_logger,
+                message="[jira] create_issue failed",
+                severity="warning",
+                tags={"surface": "service_client", "integration": "jira"},
+                extras={"method": "create_issue"},
+            )
+
+    def test_generic_exception_uses_error_severity(self, mock_logger: logging.Logger) -> None:
+        exc = ConnectionError("refused")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="datadog", method="search_logs"
+            )
+            mock_report.assert_called_once_with(
+                exc,
+                logger=mock_logger,
+                message="[datadog] search_logs failed",
+                severity="error",
+                tags={"surface": "service_client", "integration": "datadog"},
+                extras={"method": "search_logs"},
+            )
+
+    def test_timeout_exception_uses_error_severity(self, mock_logger: logging.Logger) -> None:
+        exc = httpx.ReadTimeout("timed out")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="splunk", method="search_logs"
+            )
+            assert mock_report.call_args.kwargs["severity"] == "error"
+
+    def test_tags_contain_surface_and_integration(self, mock_logger: logging.Logger) -> None:
+        exc = RuntimeError("boom")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="honeycomb", method="run_query"
+            )
+            tags = mock_report.call_args.kwargs["tags"]
+            assert tags == {"surface": "service_client", "integration": "honeycomb"}
+
+    def test_extras_contain_method(self, mock_logger: logging.Logger) -> None:
+        exc = RuntimeError("boom")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="vercel", method="get_runtime_logs"
+            )
+            extras = mock_report.call_args.kwargs["extras"]
+            assert extras == {"method": "get_runtime_logs"}

--- a/tests/services/test_error_helpers.py
+++ b/tests/services/test_error_helpers.py
@@ -111,3 +111,17 @@ class TestCaptureServiceError:
         with patch("app.services._error_helpers.report_exception") as mock_report:
             capture_service_error(exc, logger=mock_logger, integration="jira", method="get_issue")
             assert mock_report.call_args.kwargs["extras"] == {"method": "get_issue"}
+
+    def test_caller_extras_cannot_overwrite_method(self, mock_logger: logging.Logger) -> None:
+        exc = RuntimeError("boom")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc,
+                logger=mock_logger,
+                integration="jira",
+                method="create_issue",
+                extras={"method": "spoofed", "query": "test"},
+            )
+            extras = mock_report.call_args.kwargs["extras"]
+            assert extras["method"] == "create_issue"
+            assert extras["query"] == "test"

--- a/tests/services/test_error_helpers.py
+++ b/tests/services/test_error_helpers.py
@@ -125,3 +125,26 @@ class TestCaptureServiceError:
             extras = mock_report.call_args.kwargs["extras"]
             assert extras["method"] == "create_issue"
             assert extras["query"] == "test"
+
+    def test_caller_extras_cannot_inject_surface(self, mock_logger: logging.Logger) -> None:
+        exc = RuntimeError("boom")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc,
+                logger=mock_logger,
+                integration="jira",
+                method="create_issue",
+                extras={"surface": "injected"},
+            )
+            extras = mock_report.call_args.kwargs["extras"]
+            assert "surface" not in extras
+            tags = mock_report.call_args.kwargs["tags"]
+            assert tags["surface"] == "service_client"
+
+    def test_429_rate_limit_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
+        exc = _make_http_status_error(429)
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="datadog", method="search_logs"
+            )
+            assert mock_report.call_args.kwargs["severity"] == "warning"

--- a/tests/services/test_error_helpers.py
+++ b/tests/services/test_error_helpers.py
@@ -16,27 +16,44 @@ def mock_logger() -> logging.Logger:
     return MagicMock(spec=logging.Logger)
 
 
-def _make_http_status_error(status_code: int = 502) -> httpx.HTTPStatusError:
-    response = httpx.Response(status_code, text="Bad Gateway")
+def _make_http_status_error(status_code: int = 502, text: str = "error") -> httpx.HTTPStatusError:
+    response = httpx.Response(status_code, text=text)
     request = httpx.Request("GET", "https://api.example.com/test")
     return httpx.HTTPStatusError("error", request=request, response=response)
 
 
 class TestCaptureServiceError:
-    def test_http_status_error_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
+    def test_server_error_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
         exc = _make_http_status_error(502)
         with patch("app.services._error_helpers.report_exception") as mock_report:
             capture_service_error(
                 exc, logger=mock_logger, integration="jira", method="create_issue"
             )
-            mock_report.assert_called_once_with(
-                exc,
-                logger=mock_logger,
-                message="[jira] create_issue failed",
-                severity="warning",
-                tags={"surface": "service_client", "integration": "jira"},
-                extras={"method": "create_issue"},
+            assert mock_report.call_args.kwargs["severity"] == "warning"
+
+    def test_503_uses_warning_severity(self, mock_logger: logging.Logger) -> None:
+        exc = _make_http_status_error(503)
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="splunk", method="search_logs"
             )
+            assert mock_report.call_args.kwargs["severity"] == "warning"
+
+    def test_client_4xx_uses_error_severity(self, mock_logger: logging.Logger) -> None:
+        exc = _make_http_status_error(401)
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="jira", method="create_issue"
+            )
+            assert mock_report.call_args.kwargs["severity"] == "error"
+
+    def test_403_uses_error_severity(self, mock_logger: logging.Logger) -> None:
+        exc = _make_http_status_error(403)
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc, logger=mock_logger, integration="datadog", method="search_logs"
+            )
+            assert mock_report.call_args.kwargs["severity"] == "error"
 
     def test_generic_exception_uses_error_severity(self, mock_logger: logging.Logger) -> None:
         exc = ConnectionError("refused")
@@ -44,14 +61,7 @@ class TestCaptureServiceError:
             capture_service_error(
                 exc, logger=mock_logger, integration="datadog", method="search_logs"
             )
-            mock_report.assert_called_once_with(
-                exc,
-                logger=mock_logger,
-                message="[datadog] search_logs failed",
-                severity="error",
-                tags={"surface": "service_client", "integration": "datadog"},
-                extras={"method": "search_logs"},
-            )
+            assert mock_report.call_args.kwargs["severity"] == "error"
 
     def test_timeout_exception_uses_error_severity(self, mock_logger: logging.Logger) -> None:
         exc = httpx.ReadTimeout("timed out")
@@ -78,3 +88,26 @@ class TestCaptureServiceError:
             )
             extras = mock_report.call_args.kwargs["extras"]
             assert extras == {"method": "get_runtime_logs"}
+
+    def test_caller_extras_merged(self, mock_logger: logging.Logger) -> None:
+        exc = _make_http_status_error(502)
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(
+                exc,
+                logger=mock_logger,
+                integration="datadog",
+                method="search_logs",
+                extras={"query": "service:web", "time_range_minutes": 60},
+            )
+            extras = mock_report.call_args.kwargs["extras"]
+            assert extras == {
+                "method": "search_logs",
+                "query": "service:web",
+                "time_range_minutes": 60,
+            }
+
+    def test_caller_extras_none_defaults_to_method_only(self, mock_logger: logging.Logger) -> None:
+        exc = RuntimeError("boom")
+        with patch("app.services._error_helpers.report_exception") as mock_report:
+            capture_service_error(exc, logger=mock_logger, integration="jira", method="get_issue")
+            assert mock_report.call_args.kwargs["extras"] == {"method": "get_issue"}


### PR DESCRIPTION
Fixes #1458

#### Describe the changes you have made in this PR -

adds a shared `capture_service_error()` helper in `app/services/_error_helpers.py` that wraps `report_exception` with `surface=service_client` tags. severity logic: 5xx (vendor-side, e.g. 502/503) gets `warning`, everything else (4xx auth failures, timeouts, connection errors) gets `error`. this way a bad API key or expired token hits Sentry as an error, not a silent warning.

migrates 13 of 15 service clients listed in the issue from ad-hoc `logger.warning()` calls to the shared helper:
- jira, notion, datadog (sync + async), honeycomb, splunk, coralogix, elasticsearch, prefect, opsgenie, alertmanager, vercel, victoria_logs, argocd

**intentionally out-of-scope:** `aws_sdk_client.py` and `lambda_client.py` use boto3/botocore exceptions (ClientError, NoCredentialsError, ParamValidationError) which are a different error hierarchy from httpx. migrating those warrants a dedicated PR with boto-aware severity logic rather than shoehorning them into the httpx-based helper.

the helper accepts an optional `extras` dict so callers can forward request-specific context that was previously baked into ad-hoc log messages:
- opsgenie: `alert_id`
- prefect: `flow_run_id`, `work_pool_name`
- vercel: `deployment_id`, `project`, `project_id`, `state`
- jira: `issue_key`
- datadog/elasticsearch: `query`, `time_range_minutes`
- victoria_logs: `query`
- argocd: `application_name`

the `method` key in extras is protected and cannot be overwritten by caller-supplied extras (test included).

return shapes (`{"success": False, "error": ...}`) are unchanged across all clients so callers are unaffected.

vercel `get_runtime_logs` only reports telemetry after retry exhaustion, not on each intermediate attempt, to avoid false failure noise when retries eventually succeed.

also renames exception variables from `e` to `exc` for consistency with the rest of the codebase.

---

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Shared helper that logs + calls `report_exception` with `surface=service_client` tags | done - `capture_service_error()` in `_error_helpers.py` |
| Severity split: 5xx vendor = warning, other = error | done - `_is_server_error()` checks `status_code >= 500` |
| Every client in the issue migrated or explicitly scoped out | 13/15 migrated, 2 boto3 clients scoped out with rationale |
| Per-request context preserved in Sentry extras | done - extras forwarded from every client that had context in old logs |
| Reserved `method` key protected from caller overwrite | done - test `test_caller_extras_cannot_overwrite_method` |
| Existing return shapes unchanged | done - `{"success": False, "error": ...}` preserved everywhere |
| `make lint && make typecheck && make test-cov` pass | done - 11 helper tests pass, 6815/6837 suite passes (22 pre-existing bus.py failures) |

### Demo/Screenshot for feature changes and bug fixes -

## Demo Video

https://github.com/user-attachments/assets/4195453b-bfea-49b1-ae75-05aa9d2bb546

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

I designed the approach and wrote the helper based on looking at how `report_exception` works in `app/utils/errors.py` and what each client was doing differently. used copilot for some of the repetitive migration edits across the 13 clients but reviewed and adjusted each one manually since the except block shapes varied (some had retry loops, some had special 404 handling, some had context in the log messages that needed to be preserved as extras).

the core decision was standalone helper vs base class method. most clients dont share a base class so a function was simpler and avoids inheritance changes. severity split came from the issue description itself - HTTP 5xx means the vendor is having problems (warning, not our fault), while 4xx (bad creds, missing scopes) and connection/timeout errors are things we need to fix on our end (error).

the `extras` parameter was added after review feedback flagged that some clients had per-request context (query strings, alert IDs, deployment IDs, etc.) in their old log messages that got lost in the initial migration. the optional dict lets callers forward that context without changing the helper's core signature. the `method` key is set last so caller-supplied extras can't accidentally overwrite it.

for argocd specifically, the existing `_error_result` return-shape helper is kept intact - `capture_service_error` is called before it for telemetry, preserving the redaction logic argocd already had.

for vercel, the retry loop was tricky because the original code reported on every failed attempt. moved the telemetry call to after exhaustion so sentry doesnt get spammed with false failures when the next retry succeeds.

aws_sdk_client and lambda_client were intentionally left out because they use boto3 exceptions (ClientError, NoCredentialsError, ParamValidationError) which dont fit the httpx severity model. those should get a boto-aware helper in a follow-up.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.