### PR TITLE
fix(e2e): deploy helpers resolve repo root correctly (#1418)

### DIFF
--- a/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from tests.shared.infrastructure_sdk import save_outputs
 from tests.shared.infrastructure_sdk.resources import (
@@ -154,6 +154,7 @@ def deploy() -> dict:
     dockerfile_path = (
         project_root
         / "tests"
+        / "e2e"
         / "upstream_apache_flink_ecs"
         / "infrastructure_code"
         / "flink_image"

--- a/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
@@ -27,7 +27,7 @@ from tests.shared.infrastructure_sdk.resources import api_gateway, iam, lambda_,
 from tests.shared.infrastructure_sdk.resources.iam import get_account_id, put_role_policy
 from tests.shared.infrastructure_sdk.resources.secrets import get_secret_value
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 STACK_NAME = "tracer-lambda"
 REGION = "us-east-1"
@@ -186,7 +186,7 @@ def create_lambda_functions(
 
     # Paths
     shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = project_root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"
 
     # Bundle code
     print("  Bundling MockApi Lambda code...")
@@ -431,7 +431,7 @@ def deploy() -> dict:
 
     # 4. Create pipeline Lambdas with correct URLs
     print("Creating pipeline Lambda functions...")
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = project_root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"
 
     print("  Bundling pipeline code (dependencies already vendored)...")
     # Use custom bundling that puts vendored deps at root level

--- a/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
@@ -23,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from app.utils.config import load_env
 from tests.shared.infrastructure_sdk import save_outputs
@@ -58,18 +58,13 @@ TRIGGER_LAMBDA_NAME = "tracer-prefect-ecs-trigger"
 
 # Paths
 TESTS_DIR = project_root / "tests"
+SCENARIO_DIR = TESTS_DIR / "e2e" / "upstream_prefect_ecs_fargate"
 PREFECT_DOCKERFILE = (
-    TESTS_DIR
-    / "upstream_prefect_ecs_fargate"
-    / "infrastructure_code"
-    / "prefect_image"
-    / "Dockerfile"
+    SCENARIO_DIR / "infrastructure_code" / "prefect_image" / "Dockerfile"
 )
 ALLOY_CONFIG_DIR = TESTS_DIR / "shared" / "infrastructure_code" / "alloy_config"
 MOCK_API_CODE = TESTS_DIR / "shared" / "external_vendor_api"
-TRIGGER_LAMBDA_CODE = (
-    TESTS_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
-)
+TRIGGER_LAMBDA_CODE = SCENARIO_DIR / "pipeline_code" / "trigger_lambda"
 
 GRAFANA_ENV_KEYS = [
     "GCLOUD_HOSTED_METRICS_URL",

--- a/tests/test_e2e_deploy_helpers_paths.py
+++ b/tests/test_e2e_deploy_helpers_paths.py
@@ -1,0 +1,128 @@
+"""Regression test for #1418 — e2e deploy helpers resolve repo root + asset paths.
+
+The three AWS deploy helpers under
+
+    tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
+    tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
+    tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
+
+each compute ``project_root = Path(__file__).resolve().parents[N]``. They live
+four directory levels deep, so the correct depth is ``parents[4]``. A previous
+version used ``parents[3]``, which resolved to ``<repo>/tests`` and broke every
+asset path built from it (``tests/tests/shared/...``, ``tests/tests/upstream_*/...``).
+
+This test does NOT import the deploy modules (their AWS-deploy dependencies are
+heavy and live-infrastructure-only). Instead it:
+
+- parses the ``parents[N]`` literal out of each deploy.py and asserts the
+  resolved directory equals the actual repository root;
+- asserts the asset paths the helpers reference actually exist on disk.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SCENARIOS = (
+    "upstream_lambda",
+    "upstream_prefect_ecs_fargate",
+    "upstream_apache_flink_ecs",
+)
+
+
+def _deploy_py(scenario: str) -> Path:
+    return REPO_ROOT / "tests" / "e2e" / scenario / "infrastructure_sdk" / "deploy.py"
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS)
+def test_deploy_project_root_resolves_to_repo_root(scenario: str) -> None:
+    deploy_py = _deploy_py(scenario)
+    assert deploy_py.is_file(), f"missing deploy helper: {deploy_py}"
+
+    source = deploy_py.read_text(encoding="utf-8")
+    match = re.search(
+        r"project_root\s*=\s*Path\(__file__\)\.resolve\(\)\.parents\[(\d+)\]",
+        source,
+    )
+    assert match, (
+        f"{deploy_py.relative_to(REPO_ROOT)}: expected a "
+        "`project_root = Path(__file__).resolve().parents[N]` declaration"
+    )
+
+    depth = int(match.group(1))
+    resolved = deploy_py.resolve().parents[depth]
+    assert resolved == REPO_ROOT, (
+        f"{deploy_py.relative_to(REPO_ROOT)}: parents[{depth}] resolves to "
+        f"{resolved}, expected the repo root {REPO_ROOT}. The deploy helper is "
+        "four directories deep — use parents[4]."
+    )
+
+
+def test_shared_assets_exist() -> None:
+    """Assets referenced from `tests/shared/...` by all three helpers."""
+    for rel in (
+        Path("external_vendor_api"),
+        Path("infrastructure_code") / "alloy_config",
+    ):
+        path = REPO_ROOT / "tests" / "shared" / rel
+        assert path.exists(), f"shared asset missing: {path.relative_to(REPO_ROOT)}"
+
+
+@pytest.mark.parametrize(
+    ("scenario", "rel_asset"),
+    [
+        ("upstream_lambda", "pipeline_code"),
+        (
+            "upstream_prefect_ecs_fargate",
+            "infrastructure_code/prefect_image/Dockerfile",
+        ),
+        ("upstream_prefect_ecs_fargate", "pipeline_code/trigger_lambda"),
+        (
+            "upstream_apache_flink_ecs",
+            "infrastructure_code/flink_image/Dockerfile",
+        ),
+        ("upstream_apache_flink_ecs", "pipeline_code/trigger_lambda"),
+    ],
+)
+def test_scenario_assets_exist_under_tests_e2e(scenario: str, rel_asset: str) -> None:
+    """Scenario-specific assets must live under `tests/e2e/<scenario>/...`."""
+    path = REPO_ROOT / "tests" / "e2e" / scenario / rel_asset
+    assert path.exists(), (
+        f"asset missing under tests/e2e/{scenario}/{rel_asset}: "
+        f"{path.relative_to(REPO_ROOT)}"
+    )
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS)
+def test_deploy_uses_tests_e2e_for_scenario_assets(scenario: str) -> None:
+    """Guard against re-introducing `tests/<scenario>/...` paths missing `e2e/`.
+
+    The deploy helpers must reference scenario-specific assets at
+    ``tests/e2e/<scenario>/...``. The previous (buggy) layout used
+    ``tests/<scenario>/...``, which only resolved because the wrong
+    ``parents[3]`` doubled the leading ``tests/`` segment.
+    """
+    deploy_py = _deploy_py(scenario)
+    source = deploy_py.read_text(encoding="utf-8")
+
+    pattern = rf'["\']tests/{re.escape(scenario)}/'
+    offenders = re.findall(pattern, source)
+    assert not offenders, (
+        f"{deploy_py.relative_to(REPO_ROOT)}: scenario-specific asset paths "
+        f"must use 'tests/e2e/{scenario}/...', not 'tests/{scenario}/...'."
+    )
+
+    quoted_segment_pattern = rf'["\']{re.escape(scenario)}["\']'
+    quoted_segments = re.findall(quoted_segment_pattern, source)
+    if quoted_segments:
+        e2e_quoted = re.findall(r'["\']e2e["\']', source)
+        assert e2e_quoted, (
+            f"{deploy_py.relative_to(REPO_ROOT)}: references "
+            f"{quoted_segments[0]} as a path segment without a sibling 'e2e' "
+            "segment — the scenario directory lives under tests/e2e/."
+        )

--- a/tests/test_e2e_deploy_helpers_paths.py
+++ b/tests/test_e2e_deploy_helpers_paths.py
@@ -64,7 +64,17 @@ def test_deploy_project_root_resolves_to_repo_root(scenario: str) -> None:
 
 
 def test_shared_assets_exist() -> None:
-    """Assets referenced from `tests/shared/...` by all three helpers."""
+    """Assets the deploy helpers resolve from `tests/shared/...`.
+
+    `external_vendor_api` is bundled as a Lambda by all three helpers
+    (the mock external vendor API). `infrastructure_code/alloy_config`
+    is only read by the Prefect helper's `ALLOY_CONFIG_DIR`; the Flink
+    helper embeds an equivalent Alloy config inline and the Lambda
+    helper has no Alloy sidecar. The directory is still checked here
+    because it is the canonical location for that config and the
+    Prefect helper's resolution depends on the same `tests/shared/`
+    layout this test guards.
+    """
     for rel in (
         Path("external_vendor_api"),
         Path("infrastructure_code") / "alloy_config",


### PR DESCRIPTION
Fixes #1418

#### Describe the changes you have made in this PR -

The three AWS e2e deploy helpers under `tests/e2e/upstream_*/infrastructure_sdk/deploy.py` computed `project_root` with `Path(__file__).resolve().parents[3]`, which resolves to `<repo>/tests` rather than the repo root. Subsequent path constructions then landed in `<repo>/tests/tests/...` and several deploys would fail immediately — e.g. `lambda_.bundle_code(source_dir)` calls `source_dir.iterdir()` on a non-existent path.

Per-file fix:

- `tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py`
  - `parents[3]` → `parents[4]`
  - `pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"` → `... / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"` (two call sites)
- `tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py`
  - `parents[3]` → `parents[4]`
  - Introduced `SCENARIO_DIR = TESTS_DIR / "e2e" / "upstream_prefect_ecs_fargate"` so `PREFECT_DOCKERFILE` and `TRIGGER_LAMBDA_CODE` share one source of truth.
- `tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py`
  - `parents[3]` → `parents[4]`
  - Inserted the missing `"e2e"` segment in `dockerfile_path`. The other two scenario references (`mock_api_code_dir`, `trigger_code_dir`) already used valid relative paths and just needed `project_root` to be correct.

Shared assets continue to resolve from `tests/shared/...` and scenario-specific assets now resolve from `tests/e2e/<scenario>/...`, matching the actual repo layout.

#### Regression test

New file: `tests/test_e2e_deploy_helpers_paths.py` (12 cases, all PASS in `0.06s`):

1. Parses each deploy.py and asserts the literal `Path(__file__).resolve().parents[N]` resolves to the actual repo root — catches future file-location drift.
2. Asserts each shared asset (`tests/shared/external_vendor_api`, `tests/shared/infrastructure_code/alloy_config`) exists.
3. Asserts each scenario-specific asset (`tests/e2e/<scenario>/pipeline_code`, `infrastructure_code/<image>/Dockerfile`, `pipeline_code/trigger_lambda`) exists.
4. Regex guard that rejects any future reintroduction of `tests/<scenario>/...` paths missing the `e2e/` segment.

The test does **not** import the deploy modules — their AWS SDK dependencies are live-infrastructure-only and unavailable in the regular test environment. It reads them as source instead.

I verified the negative direction too: reintroducing `parents[3]` causes `test_deploy_project_root_resolves_to_repo_root` to fail with an explicit message; reintroducing a `tests/<scenario>/` path causes `test_deploy_uses_tests_e2e_for_scenario_assets` to fail.

### Demo/Screenshot for feature changes and bug fixes -

```
$ py -m pytest tests/test_e2e_deploy_helpers_paths.py -v --no-header --noconftest
collecting ... collected 12 items

tests/test_e2e_deploy_helpers_paths.py::test_deploy_project_root_resolves_to_repo_root[upstream_lambda] PASSED [  8%]
tests/test_e2e_deploy_helpers_paths.py::test_deploy_project_root_resolves_to_repo_root[upstream_prefect_ecs_fargate] PASSED [ 16%]
tests/test_e2e_deploy_helpers_paths.py::test_deploy_project_root_resolves_to_repo_root[upstream_apache_flink_ecs] PASSED [ 25%]
tests/test_e2e_deploy_helpers_paths.py::test_shared_assets_exist PASSED  [ 33%]
tests/test_e2e_deploy_helpers_paths.py::test_scenario_assets_exist_under_tests_e2e[upstream_lambda-pipeline_code] PASSED [ 41%]
tests/test_e2e_deploy_helpers_paths.py::test_scenario_assets_exist_under_tests_e2e[upstream_prefect_ecs_fargate-infrastructure_code/prefect_image/Dockerfile] PASSED [ 50%]
tests/test_e2e_deploy_helpers_paths.py::test_scenario_assets_exist_under_tests_e2e[upstream_prefect_ecs_fargate-pipeline_code/trigger_lambda] PASSED [ 58%]
tests/test_e2e_deploy_helpers_paths.py::test_scenario_assets_exist_under_tests_e2e[upstream_apache_flink_ecs-infrastructure_code/flink_image/Dockerfile] PASSED [ 66%]
tests/test_e2e_deploy_helpers_paths.py::test_scenario_assets_exist_under_tests_e2e[upstream_apache_flink_ecs-pipeline_code/trigger_lambda] PASSED [ 75%]
tests/test_e2e_deploy_helpers_paths.py::test_deploy_uses_tests_e2e_for_scenario_assets[upstream_lambda] PASSED [ 83%]
tests/test_e2e_deploy_helpers_paths.py::test_deploy_uses_tests_e2e_for_scenario_assets[upstream_prefect_ecs_fargate] PASSED [ 91%]
tests/test_e2e_deploy_helpers_paths.py::test_deploy_uses_tests_e2e_for_scenario_assets[upstream_apache_flink_ecs] PASSED [100%]

============================ 12 passed in 0.06s ===============================
```

I did not exercise the `test-thorough` matrix itself — it is gated on live AWS credentials and on the `tracer` install — but the new regression test is what those jobs would have caught at the asset-bundling step had it existed before.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The original `parents[3]` was a one-off bug per file but the consequences leaked into the scenario subpaths (`tests/<scenario>/` instead of `tests/e2e/<scenario>/`) — so the fix had two halves per file. I considered three approaches for the helper:

1. Walk up to a `pyproject.toml` marker (most robust, but introduces a new convention).
2. Inline `parents[4]` (matches the existing style elsewhere in the test suite, minimal diff).
3. Add a shared `_repo_root.py` helper.

I went with option 2 to keep the diff narrow and consistent with `tests/test_naming_conventions.py` and the surrounding code.

For the regression test I deliberately avoided importing the deploy modules — they pull boto3/prefect/etc. and are not part of `make test-cov`. Reading them as source and asserting via regex + filesystem checks is cheap (~60ms total), runs in CI without extra deps, and would have caught the original bug.

For the Prefect file, I extracted a single `SCENARIO_DIR` so the two scenario-specific paths (`PREFECT_DOCKERFILE` and `TRIGGER_LAMBDA_CODE`) cannot drift again. The other two helpers each had ≤1 scenario path so a constant would have been ceremony.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions