### PR TITLE
fix(sentry): filter OpenAI timeout operator errors

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -59,6 +59,10 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bLLM API request failed after multiple retries\b", re.I),
     # Provider endpoint unreachable (Ollama down, bad URL, SSL misconfiguration).
     re.compile(r"\bcannot connect to .+ api\b", re.I),
+    re.compile(
+        r"\bapi request timed out\.\s+Check that the service is running and responsive\b",
+        re.I,
+    ),
 )
 
 

--- a/pr/1934-openai-timeout-sentry-filter.md
+++ b/pr/1934-openai-timeout-sentry-filter.md
@@ -1,0 +1,29 @@
+Fixes #1934
+
+#### Describe the changes you've made
+
+Adds OpenAI-compatible provider timeout messages to the existing operator-actionable LLM Sentry filter. These errors already surface to the CLI user with clear remediation text, but they should not create high-priority Sentry issues because they usually indicate endpoint/network availability rather than an OpenSRE defect.
+
+### Demo/Screenshot
+
+N/A - Sentry filtering regression.
+
+---
+
+## Code Understanding and AI Usage
+
+**Did you use AI assistance?**  
+Yes.
+
+## Checklist before requesting a review
+
+- [x] I have performed a self-review of my code
+- [x] I have added tests that prove my fix is effective
+- [ ] `make test-cov` passes locally
+- [ ] `make lint` passes locally
+- [ ] `make typecheck` passes locally
+
+Local verification:
+
+- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\utils\sentry_sdk.py tests\test_sentry_init.py`
+- Pytest could not be run because neither the system Python nor bundled Python has the repo test dependencies installed, and `uv` is unavailable.

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -667,6 +667,10 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "RuntimeError",
             "Cannot connect to Openrouter API. Check your network connection and that the endpoint URL is reachable.",
         ),
+        (
+            "RuntimeError",
+            "Openai API request timed out. Check that the service is running and responsive at the configured endpoint.",
+        ),
     ],
 )
 def test_before_send_drops_operator_actionable_llm_errors(


### PR DESCRIPTION
Fixes #1934

#### Describe the changes you've made

Adds OpenAI-compatible provider timeout messages to the existing operator-actionable LLM Sentry filter. These errors already surface to the CLI user with clear remediation text, but they should not create high-priority Sentry issues because they usually indicate endpoint/network availability rather than an OpenSRE defect.

### Demo/Screenshot

N/A - Sentry filtering regression.

---

## Code Understanding and AI Usage

**Did you use AI assistance?**  
Yes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [ ] `make test-cov` passes locally
- [ ] `make lint` passes locally
- [ ] `make typecheck` passes locally

Local verification:

- `C:\Users\11301\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m compileall app\utils\sentry_sdk.py tests\test_sentry_init.py`
- Pytest could not be run because neither the system Python nor bundled Python has the repo test dependencies installed, and `uv` is unavailable.
