### PR TITLE
fix(sentry): filter transient LLM errors from Sentry reporting

### DIFF
--- a/app/integrations/llm_cli/errors.py
+++ b/app/integrations/llm_cli/errors.py
@@ -23,3 +23,11 @@ class CLIAuthenticationRequired(RuntimeError):
         self.auth_hint = auth_hint
         self.detail = detail
         super().__init__(f"{provider} is not authenticated. {auth_hint} ({detail})")
+
+
+class CLITransientError(RuntimeError):
+    """CLI subprocess exited with a transient failure code (e.g. EX_TEMPFAIL = 75).
+
+    Treated as an expected operational failure (not a bug), so callers should
+    not forward it to error-tracking services like Sentry.
+    """

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -13,7 +13,11 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
-from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+from app.integrations.llm_cli.errors import (
+    CLIAuthenticationRequired,
+    CLITimeoutError,
+    CLITransientError,
+)
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
 from app.llm_reasoning_effort import get_active_reasoning_effort
@@ -173,6 +177,11 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
+            # EX_TEMPFAIL (75): POSIX temporary failure — the CLI crashed mid-session
+            # and may be resumable, but we run one-shot invocations so we treat it as a
+            # transient operational failure rather than a code bug.
+            if proc.returncode == 75:
+                raise CLITransientError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -59,6 +59,10 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bLLM API request failed after multiple retries\b", re.I),
     # Provider endpoint unreachable (Ollama down, bad URL, SSL misconfiguration).
     re.compile(r"\bcannot connect to .+ api\b", re.I),
+    # Provider read timeout after retries — transient network/infra condition.
+    re.compile(r"\bapi request timed out\b", re.I),
+    # Anthropic / provider account-level usage-limit enforcement (HTTP 400).
+    re.compile(r"\byou have reached your specified api usage limits\b", re.I),
 )
 
 
@@ -367,7 +371,11 @@ def _init_sentry_once(
     """
     import sentry_sdk
 
-    from app.integrations.llm_cli.errors import CLIAuthenticationRequired, CLITimeoutError
+    from app.integrations.llm_cli.errors import (
+        CLIAuthenticationRequired,
+        CLITimeoutError,
+        CLITransientError,
+    )
 
     with _suppress_langgraph_allowed_objects_warning():
         sentry_sdk.init(
@@ -383,7 +391,7 @@ def _init_sentry_once(
             integrations=_build_sentry_integrations(),
             before_send=_before_send,
             before_breadcrumb=_before_breadcrumb,
-            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError],
+            ignore_errors=[CLIAuthenticationRequired, CLITimeoutError, CLITransientError],
         )
 
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -59,8 +59,9 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bLLM API request failed after multiple retries\b", re.I),
     # Provider endpoint unreachable (Ollama down, bad URL, SSL misconfiguration).
     re.compile(r"\bcannot connect to .+ api\b", re.I),
-    # Provider read timeout after retries — transient network/infra condition.
-    re.compile(r"\bapi request timed out\b", re.I),
+    # Provider read timeout after retries — anchored to the suffix produced by
+    # _format_openai_connection_error so generic non-LLM timeout messages are unaffected.
+    re.compile(r"\bapi request timed out\. check that the service is running\b", re.I),
     # Anthropic / provider account-level usage-limit enforcement (HTTP 400).
     re.compile(r"\byou have reached your specified api usage limits\b", re.I),
 )

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -271,3 +271,44 @@ def test_parse_and_explain_failure() -> None:
     # Test explain_failure: empty output with code 0
     fail_empty = adapter.explain_failure(stdout="", stderr="", returncode=0)
     assert fail_empty == "kimi returned no output"
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_raises_transient_error_on_exit_75(mock_run: MagicMock) -> None:
+    """Runner raises CLITransientError (not RuntimeError) for EX_TEMPFAIL exit code 75."""
+    import pytest
+
+    from app.integrations.llm_cli.errors import CLITransientError
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/kimi",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = (
+        "kimi exited with code 75. To resume this session: kimi -r abc123"
+    )
+
+    mock_run.return_value = MagicMock(
+        returncode=75,
+        stdout="",
+        stderr="To resume this session: kimi -r abc123",
+    )
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5")
+        with pytest.raises(CLITransientError, match="kimi exited with code 75"):
+            client.invoke("hello")

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -667,6 +667,20 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "RuntimeError",
             "Cannot connect to Openrouter API. Check your network connection and that the endpoint URL is reachable.",
         ),
+        # Provider read timeout after retries (issue #1934).
+        (
+            "RuntimeError",
+            "Openai API request timed out. Check that the service is running and responsive at the configured endpoint.",
+        ),
+        (
+            "RuntimeError",
+            "Minimax API request timed out. Check that the service is running and responsive at the configured endpoint.",
+        ),
+        # Anthropic account-level usage limit enforcement via HTTP 400 (issues #1883, #1885).
+        (
+            "RuntimeError",
+            "Anthropic request rejected (HTTP 400): Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'You have reached your specified API usage limits. You will regain access on 2026-06-01 at 00:00 UTC.'}, 'request_id': 'req_011CaxxMA8NCSdDvaM2LaRm6'}",
+        ),
     ],
 )
 def test_before_send_drops_operator_actionable_llm_errors(

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -637,7 +637,7 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
         ),
         (
             "RuntimeError",
-            "Openai request rejected (HTTP 400): Error code: 400 - {'error': {'message': 'litellm.BadRequestError: AnthropicException - {\"message\":\"The provided model identifier is invalid.\"}. Received Model Group=relay-ops-claude-opus-4-7'}}",
+            "Openai request rejected (HTTP 400): Error code: 400 - {'error': {'message': 'litellm.BadRequestError: AnthropicException - {\"message\":\"The provided model identifier is invalid.\"}.  Received Model Group=relay-ops-claude-opus-4-7'}}",
         ),
         (
             "RuntimeError",
@@ -780,3 +780,15 @@ def test_apply_scope_tags_is_first_wins(monkeypatch) -> None:
         call.args[1] for call in tag_mock.call_args_list if call.args[0] == "entrypoint"
     ]
     assert entrypoint_tags == ["webapp"]
+
+
+def test_init_sentry_ignore_errors_includes_cli_transient_error(monkeypatch) -> None:
+    from app.integrations.llm_cli.errors import CLITransientError
+
+    _clear_kill_switches(monkeypatch)
+    init_mock, _ = _install_full_sentry_mock(monkeypatch)
+
+    sentry_mod.init_sentry(entrypoint="cli")
+
+    ignore_errors = init_mock.call_args.kwargs["ignore_errors"]
+    assert CLITransientError in ignore_errors


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three categories of operational (non-bug) errors were incorrectly reaching Sentry as high-priority issues because they fell through the existing operator-actionable filter:

- **Provider read timeout** (#1934): the message `"… API request timed out. Check that the service is running…"` matched no existing pattern in `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS`.
- **Anthropic account usage limits** (#1883, #1885): HTTP 400 errors with `"You have reached your specified API usage limits"` were caught by the generic `AnthropicBadRequestError` handler and raised as bare `RuntimeError`, bypassing all filters.
- **kimi EX_TEMPFAIL (exit 75)** (#1866, #1867): when kimi exits with POSIX code 75 (temporary failure / session crash), the CLI runner raised a bare `RuntimeError` so Sentry filed it as a code bug.

## Changes

| File | Change |
|------|--------|
| `app/utils/sentry_sdk.py` | Add two regex patterns for timeout and usage-limit messages; add `CLITransientError` to `ignore_errors` |
| `app/integrations/llm_cli/errors.py` | New `CLITransientError` (documented as non-bug, like `CLITimeoutError`) |
| `app/integrations/llm_cli/runner.py` | Raise `CLITransientError` instead of `RuntimeError` when subprocess exits with code 75 |
| `tests/test_sentry_init.py` | Parametrized tests covering the two new filter patterns |

## Test plan

- [x] `make test-cov` — 7076 passed, 7 skipped
- [x] `make lint` — no issues
- [x] `make typecheck` — no issues

Closes #1934
Closes #1885
Closes #1883
Closes #1867
Closes #1866
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7iE8de69L9zKYTynUmqxF)_