### PR TITLE
fix(llm_cli): retry kimi invocation on EX_TEMPFAIL (exit 75)

### DIFF
--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -25,6 +25,12 @@ _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 # Avoid re-running `detect()` (two subprocess probes) on every invoke during long investigations.
 _PROBE_CACHE_TTL_SEC = 45.0
 
+# POSIX EX_TEMPFAIL (75): the subprocess hit a transient error and can be retried.
+# kimi uses this when a session dies mid-flight ("To resume this session: kimi -r …").
+_EX_TEMPFAIL = 75
+_TEMPFAIL_MAX_RETRIES = 2
+_TEMPFAIL_BACKOFF_SEC = 2.0
+
 # Back-compat name for tests and imports that expect this symbol on runner.
 _build_subprocess_env = build_cli_subprocess_env
 
@@ -116,25 +122,41 @@ class CLIBackedLLMClient:
         )
         merged_env = _build_subprocess_env(invocation.env)
 
-        try:
-            proc = subprocess.run(
-                list(invocation.argv),
-                input=invocation.stdin,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=invocation.cwd,
-                env=merged_env,
-                timeout=invocation.timeout_sec,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise CLITimeoutError(
-                f"{self._adapter.name} CLI timed out after {invocation.timeout_sec:.0f}s."
-            ) from exc
-        except OSError as exc:
-            raise RuntimeError(f"Failed to spawn {self._adapter.name} CLI: {exc}") from exc
+        backoff = _TEMPFAIL_BACKOFF_SEC
+        for attempt in range(_TEMPFAIL_MAX_RETRIES + 1):
+            try:
+                proc = subprocess.run(
+                    list(invocation.argv),
+                    input=invocation.stdin,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    cwd=invocation.cwd,
+                    env=merged_env,
+                    timeout=invocation.timeout_sec,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise CLITimeoutError(
+                    f"{self._adapter.name} CLI timed out after {invocation.timeout_sec:.0f}s."
+                ) from exc
+            except OSError as exc:
+                raise RuntimeError(f"Failed to spawn {self._adapter.name} CLI: {exc}") from exc
+
+            if proc.returncode == _EX_TEMPFAIL and attempt < _TEMPFAIL_MAX_RETRIES:
+                logger.warning(
+                    "cli_llm_tempfail_retry",
+                    extra={
+                        "provider": self._adapter.name,
+                        "attempt": attempt + 1,
+                        "backoff_sec": backoff,
+                    },
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            break
 
         out = _strip_ansi(proc.stdout or "")
         err = _strip_ansi(proc.stderr or "")

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -269,7 +269,9 @@ def test_cli_backed_client_retries_on_ex_tempfail(
         timeout_sec=30.0,
     )
     mock_adapter.parse.return_value = "answer"
-    mock_adapter.explain_failure.return_value = "kimi exited with code 75. To resume this session: kimi -r abc"
+    mock_adapter.explain_failure.return_value = (
+        "kimi exited with code 75. To resume this session: kimi -r abc"
+    )
 
     tempfail = MagicMock(returncode=75, stdout="To resume this session: kimi -r abc", stderr="")
     success = MagicMock(returncode=0, stdout="answer\n", stderr="")
@@ -291,10 +293,10 @@ def test_cli_backed_client_raises_after_all_tempfail_retries(
     mock_run: MagicMock, mock_sleep: MagicMock
 ) -> None:
     """EX_TEMPFAIL (75) exhausting all retries raises RuntimeError."""
-    from app.integrations.llm_cli.kimi import KimiAdapter
-    from app.integrations.llm_cli.runner import CLIBackedLLMClient, _TEMPFAIL_MAX_RETRIES
-
     import pytest
+
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import _TEMPFAIL_MAX_RETRIES, CLIBackedLLMClient
 
     mock_adapter = MagicMock(spec=KimiAdapter)
     mock_adapter.name = "kimi"
@@ -311,7 +313,9 @@ def test_cli_backed_client_raises_after_all_tempfail_retries(
         env=None,
         timeout_sec=30.0,
     )
-    mock_adapter.explain_failure.return_value = "kimi exited with code 75. To resume this session: kimi -r abc"
+    mock_adapter.explain_failure.return_value = (
+        "kimi exited with code 75. To resume this session: kimi -r abc"
+    )
 
     tempfail = MagicMock(returncode=75, stdout="To resume this session: kimi -r abc", stderr="")
     mock_run.side_effect = [tempfail] * (_TEMPFAIL_MAX_RETRIES + 1)

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -244,6 +244,88 @@ def test_cli_backed_client_invoke_forwards_kimi_env(mock_run: MagicMock) -> None
     assert "OPENAI_API_KEY" not in env
 
 
+@patch("app.integrations.llm_cli.runner.time.sleep")
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_retries_on_ex_tempfail(
+    mock_run: MagicMock, mock_sleep: MagicMock
+) -> None:
+    """EX_TEMPFAIL (75) should be retried; on final success returns the answer."""
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/kimi",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.parse.return_value = "answer"
+    mock_adapter.explain_failure.return_value = "kimi exited with code 75. To resume this session: kimi -r abc"
+
+    tempfail = MagicMock(returncode=75, stdout="To resume this session: kimi -r abc", stderr="")
+    success = MagicMock(returncode=0, stdout="answer\n", stderr="")
+    mock_run.side_effect = [tempfail, success]
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        resp = client.invoke("hello")
+
+    assert resp.content == "answer"
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("app.integrations.llm_cli.runner.time.sleep")
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_backed_client_raises_after_all_tempfail_retries(
+    mock_run: MagicMock, mock_sleep: MagicMock
+) -> None:
+    """EX_TEMPFAIL (75) exhausting all retries raises RuntimeError."""
+    from app.integrations.llm_cli.kimi import KimiAdapter
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient, _TEMPFAIL_MAX_RETRIES
+
+    import pytest
+
+    mock_adapter = MagicMock(spec=KimiAdapter)
+    mock_adapter.name = "kimi"
+    mock_adapter.detect.return_value = MagicMock(
+        installed=True,
+        bin_path="/usr/bin/kimi",
+        logged_in=True,
+        detail="ok",
+    )
+    mock_adapter.build.return_value = MagicMock(
+        argv=["/usr/bin/kimi", "--print", "--yolo"],
+        stdin="hello",
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.explain_failure.return_value = "kimi exited with code 75. To resume this session: kimi -r abc"
+
+    tempfail = MagicMock(returncode=75, stdout="To resume this session: kimi -r abc", stderr="")
+    mock_run.side_effect = [tempfail] * (_TEMPFAIL_MAX_RETRIES + 1)
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        with pytest.raises(RuntimeError):
+            client.invoke("hello")
+
+    assert mock_run.call_count == _TEMPFAIL_MAX_RETRIES + 1
+    assert mock_sleep.call_count == _TEMPFAIL_MAX_RETRIES
+
+
 def test_parse_and_explain_failure() -> None:
     adapter = KimiAdapter()
 


### PR DESCRIPTION
## Summary

- `kimi` exits with POSIX `EX_TEMPFAIL` (75) when a session dies mid-flight, producing "To resume this session: kimi -r `<id>`". Previously this propagated immediately as a bare `RuntimeError` and was filed as a Sentry bug on every occurrence.
- Added a retry loop (up to 2 retries, 2 s/4 s exponential back-off) around the subprocess call in `CLIBackedLLMClient.invoke`. Only exit code 75 triggers a retry; all other non-zero codes still fail immediately.
- Added two new tests: (1) success on second attempt after one `EX_TEMPFAIL`, and (2) `RuntimeError` after all retries are exhausted.

## Test plan

- [x] `uv run pytest tests/integrations/llm_cli/test_kimi_adapter.py -v` — 11 passed
- [x] `uv run pytest tests/integrations/llm_cli/ -v` — 202 passed

Closes #1866
Closes #1867

https://claude.ai/code/session_01U8EmDosHu51EnFM1vKNMnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8EmDosHu51EnFM1vKNMnT)_