### PR TITLE
feat(watch_dog): add process watchdog CLI

### DIFF
--- a/app/agents/probe.py
+++ b/app/agents/probe.py
@@ -13,6 +13,7 @@ explicit import.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -23,6 +24,13 @@ import psutil
 # Datadog, Grafana) labels the same 1024² unit as "MB"; the constant
 # stays precise so the unit math is unambiguous.
 _BYTES_PER_MIB = 1024 * 1024
+
+PROCESS_NOT_FOUND: tuple[type[BaseException], ...] = (psutil.NoSuchProcess,)
+PROCESS_INACCESSIBLE_OR_GONE: tuple[type[BaseException], ...] = (
+    psutil.NoSuchProcess,
+    psutil.AccessDenied,
+)
+PROCESS_ERROR: tuple[type[BaseException], ...] = (psutil.Error,)
 
 
 @dataclass(frozen=True)
@@ -64,6 +72,16 @@ def pid_exists(pid: int) -> bool:
         return psutil.pid_exists(pid)
     except (OverflowError, ValueError):
         return False
+
+
+def process(pid: int) -> psutil.Process:
+    """Return a handle for ``pid`` while keeping psutil access local."""
+    return psutil.Process(pid)
+
+
+def process_iter(attrs: Iterable[str]) -> Iterator[psutil.Process]:
+    """Yield process handles with preloaded attrs from the local probe module."""
+    return psutil.process_iter(list(attrs))
 
 
 def probe(pid: int, *, cpu_interval: float = 0.1) -> ProcessSnapshot | None:

--- a/app/cli/commands/__init__.py
+++ b/app/cli/commands/__init__.py
@@ -21,6 +21,7 @@ from app.cli.commands.messaging import messaging
 from app.cli.commands.onboard import onboard
 from app.cli.commands.remote import remote
 from app.cli.commands.tests import tests
+from app.cli.commands.watchdog import watchdog_command
 
 _COMMANDS: tuple[click.Command, ...] = (
     investigate_command,
@@ -33,6 +34,7 @@ _COMMANDS: tuple[click.Command, ...] = (
     agents,
     messaging,
     hermes_command,
+    watchdog_command,
     health_command,
     doctor_command,
     update_command,

--- a/app/cli/commands/watchdog.py
+++ b/app/cli/commands/watchdog.py
@@ -1,0 +1,95 @@
+"""``opensre watchdog`` process-threshold monitor."""
+
+from __future__ import annotations
+
+import click
+from pydantic import ValidationError
+
+from app.cli.support.errors import OpenSREError
+from app.watch_dog.config import WatchdogConfig
+from app.watch_dog.runner import run_watchdog
+
+
+@click.command(name="watchdog")
+@click.option(
+    "--pid", type=int, default=None, help="PID to monitor. Mutually exclusive with --name."
+)
+@click.option(
+    "--name", "process_name", type=str, default=None, help="Process-name regex to monitor."
+)
+@click.option("--pick-first", is_flag=True, help="Use the lowest PID when --name matches many.")
+@click.option(
+    "--max-cpu", type=float, default=None, help="Alarm when CPU percent reaches this value."
+)
+@click.option(
+    "--cpu-window",
+    type=str,
+    default="30",
+    show_default=True,
+    help="CPU smoothing window in seconds, or with s/m/h suffix.",
+)
+@click.option(
+    "--max-runtime", type=str, default=None, help="Alarm after runtime exceeds s/m/h duration."
+)
+@click.option(
+    "--max-rss", type=str, default=None, help="Alarm when RSS exceeds bytes or K/M/G/T size."
+)
+@click.option(
+    "--interval", type=float, default=5.0, show_default=True, help="Sample period in seconds."
+)
+@click.option(
+    "--cooldown",
+    type=str,
+    default="5m",
+    show_default=True,
+    help="Minimum gap between repeated alarms per threshold.",
+)
+@click.option("--once", is_flag=True, help="Exit after the first threshold alarm.")
+@click.option("--chat-id", type=str, default=None, help="Override TELEGRAM_DEFAULT_CHAT_ID.")
+@click.option("--verbose", is_flag=True, help="Print one line per sampled process state.")
+def watchdog_command(
+    pid: int | None,
+    process_name: str | None,
+    pick_first: bool,
+    max_cpu: float | None,
+    cpu_window: str,
+    max_runtime: str | None,
+    max_rss: str | None,
+    interval: float,
+    cooldown: str,
+    once: bool,
+    chat_id: str | None,
+    verbose: bool,
+) -> None:
+    """Monitor a process and send Telegram alarms when thresholds trip."""
+    try:
+        config = WatchdogConfig.model_validate(
+            {
+                "pid": pid,
+                "name": process_name,
+                "pick_first": pick_first,
+                "max_cpu": max_cpu,
+                "cpu_window": cpu_window,
+                "max_runtime": max_runtime,
+                "max_rss": max_rss,
+                "interval": interval,
+                "cooldown": cooldown,
+                "once": once,
+                "chat_id": chat_id,
+                "verbose": verbose,
+            }
+        )
+    except ValidationError as exc:
+        raise OpenSREError(
+            "Invalid watchdog configuration.",
+            suggestion=_validation_suggestion(exc),
+        ) from exc
+
+    raise SystemExit(run_watchdog(config))
+
+
+def _validation_suggestion(exc: ValidationError) -> str:
+    first = exc.errors()[0]
+    location = ".".join(str(part) for part in first.get("loc", ()) if part != "__root__")
+    prefix = f"{location}: " if location else ""
+    return f"{prefix}{first.get('msg', 'Check the provided options.')}"

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -230,6 +230,10 @@ def _cmd_hermes(session: ReplSession, console: Console, args: list[str]) -> bool
     return run_cli_command(console, ["hermes", *args])
 
 
+def _cmd_watchdog(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    return run_cli_command(console, ["watchdog", *args])
+
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/onboard",
@@ -284,6 +288,12 @@ COMMANDS: list[SlashCommand] = [
         "/hermes",
         "live-tail Hermes logs and route incidents to Telegram ('/hermes watch')",
         _cmd_hermes,
+        execution_tier=ExecutionTier.SAFE,
+    ),
+    SlashCommand(
+        "/watchdog",
+        "monitor one process and send threshold alarms ('/watchdog --pid 123 --max-rss 1GiB')",
+        _cmd_watchdog,
         execution_tier=ExecutionTier.SAFE,
     ),
 ]

--- a/app/watch_dog/__init__.py
+++ b/app/watch_dog/__init__.py
@@ -7,9 +7,16 @@ from app.watch_dog.alarms import (
     AlarmDispatcher,
     load_credentials_from_env,
 )
+from app.watch_dog.config import Threshold, WatchdogConfig
+from app.watch_dog.process_monitor import ProcessMonitor, ProcessSample, Sampler
 
 __all__ = [
     "AlarmCredentials",
     "AlarmDispatcher",
+    "ProcessMonitor",
+    "ProcessSample",
+    "Sampler",
+    "Threshold",
+    "WatchdogConfig",
     "load_credentials_from_env",
 ]

--- a/app/watch_dog/config.py
+++ b/app/watch_dog/config.py
@@ -81,7 +81,7 @@ class WatchdogConfig(StrictConfigModel):
     max_runtime: float | None = Field(default=None, gt=0)
     max_rss: int | None = Field(default=None, gt=0)
     interval: float = Field(default=5.0, gt=0)
-    cooldown: float = Field(default=300.0, ge=0)
+    cooldown: float = Field(default=300.0, gt=0)
     once: bool = False
     chat_id: str | None = None
     verbose: bool = False

--- a/app/watch_dog/config.py
+++ b/app/watch_dog/config.py
@@ -1,0 +1,128 @@
+"""Configuration helpers for the process watchdog."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from app.strict_config import StrictConfigModel
+
+ThresholdName = Literal["max_cpu", "max_runtime", "max_rss"]
+
+_DURATION_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[smh]?)$")
+_BYTE_RE = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgt]?b?)$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Threshold:
+    """A configured watchdog threshold."""
+
+    name: ThresholdName
+    limit: float
+
+
+def parse_duration_seconds(value: float | int | str) -> float:
+    """Parse a duration in seconds, or with s/m/h suffix, into seconds."""
+    if isinstance(value, int | float):
+        seconds = float(value)
+    else:
+        text = value.strip().lower()
+        match = _DURATION_RE.fullmatch(text)
+        if match is None:
+            raise ValueError("Expected a duration like 30, 30s, 5m, or 2h.")
+        amount = float(match.group("value"))
+        unit = match.group("unit") or "s"
+        multiplier = {"s": 1.0, "m": 60.0, "h": 3600.0}[unit]
+        seconds = amount * multiplier
+
+    if seconds <= 0:
+        raise ValueError("Duration must be positive.")
+    return seconds
+
+
+def parse_byte_size(value: int | float | str) -> int:
+    """Parse a byte-size value with optional K/M/G/T suffix into bytes."""
+    if isinstance(value, int):
+        size = value
+    elif isinstance(value, float):
+        size = int(value)
+    else:
+        text = value.strip().lower()
+        match = _BYTE_RE.fullmatch(text)
+        if match is None:
+            raise ValueError("Expected a byte size like 4096, 512M, or 4G.")
+        amount = float(match.group("value"))
+        unit = match.group("unit").removesuffix("b")
+        multiplier = {
+            "": 1,
+            "k": 1024,
+            "m": 1024**2,
+            "g": 1024**3,
+            "t": 1024**4,
+        }[unit]
+        size = int(amount * multiplier)
+
+    if size <= 0:
+        raise ValueError("Byte size must be positive.")
+    return size
+
+
+class WatchdogConfig(StrictConfigModel):
+    """Validated configuration for ``opensre watchdog``."""
+
+    pid: int | None = Field(default=None, ge=1)
+    name: str | None = None
+    pick_first: bool = False
+    max_cpu: float | None = Field(default=None, gt=0)
+    cpu_window: float = Field(default=30.0, gt=0)
+    max_runtime: float | None = Field(default=None, gt=0)
+    max_rss: int | None = Field(default=None, gt=0)
+    interval: float = Field(default=5.0, gt=0)
+    cooldown: float = Field(default=300.0, ge=0)
+    once: bool = False
+    chat_id: str | None = None
+    verbose: bool = False
+
+    @field_validator("cpu_window", "max_runtime", "cooldown", mode="before")
+    @classmethod
+    def _parse_duration_fields(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str | int | float):
+            return parse_duration_seconds(value)
+        return value
+
+    @field_validator("max_rss", mode="before")
+    @classmethod
+    def _parse_max_rss(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str | int | float):
+            return parse_byte_size(value)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_process_selector_and_thresholds(self) -> WatchdogConfig:
+        has_pid = self.pid is not None
+        has_name = bool(self.name)
+        if has_pid == has_name:
+            raise ValueError("Provide exactly one of pid or name.")
+
+        if self.max_cpu is None and self.max_runtime is None and self.max_rss is None:
+            raise ValueError("Configure at least one threshold.")
+
+        return self
+
+    def thresholds(self) -> tuple[Threshold, ...]:
+        """Return thresholds in stable evaluation order."""
+        thresholds: list[Threshold] = []
+        if self.max_cpu is not None:
+            thresholds.append(Threshold("max_cpu", self.max_cpu))
+        if self.max_runtime is not None:
+            thresholds.append(Threshold("max_runtime", self.max_runtime))
+        if self.max_rss is not None:
+            thresholds.append(Threshold("max_rss", float(self.max_rss)))
+        return tuple(thresholds)

--- a/app/watch_dog/process_monitor.py
+++ b/app/watch_dog/process_monitor.py
@@ -1,0 +1,161 @@
+"""Process sampling primitives for the watchdog CLI."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from app.agents import probe as process_probe
+from app.cli.support.errors import OpenSREError
+from app.watch_dog.config import WatchdogConfig
+
+
+@dataclass(frozen=True)
+class ProcessSample:
+    """A point-in-time process resource sample."""
+
+    pid: int
+    name: str
+    cmdline: tuple[str, ...]
+    cpu_percent: float
+    rss_bytes: int
+    runtime_seconds: float
+    alive: bool
+    started_at: float | None = None
+
+    @property
+    def command(self) -> str:
+        """Return a display-friendly command string."""
+        return " ".join(self.cmdline)
+
+
+class Sampler(Protocol):
+    """Protocol used by the runner so tests can inject fake samples."""
+
+    def sample(self) -> ProcessSample:
+        """Return the next process sample."""
+
+
+class ProcessMonitor:
+    """Resolve and sample one process."""
+
+    def __init__(self, config: WatchdogConfig) -> None:
+        self._process = _resolve_process(config)
+        self._pid = self._process.pid
+        self._name = _safe_process_name(self._process)
+        self._cmdline = _safe_cmdline(self._process)
+        self._started_at = _safe_create_time(self._process)
+        self._warm_cpu_percent()
+
+    def sample(self) -> ProcessSample:
+        """Capture CPU, RSS, runtime, and liveness for the target process."""
+        try:
+            if not self._process.is_running():
+                return self._dead_sample()
+            name = self._process.name()
+            cmdline = tuple(self._process.cmdline())
+            cpu_percent = float(self._process.cpu_percent(interval=None))
+            rss_bytes = int(self._process.memory_info().rss)
+            started_at = float(self._process.create_time())
+        except process_probe.PROCESS_INACCESSIBLE_OR_GONE:
+            return self._dead_sample()
+
+        return ProcessSample(
+            pid=self._pid,
+            name=name,
+            cmdline=cmdline,
+            cpu_percent=cpu_percent,
+            rss_bytes=rss_bytes,
+            runtime_seconds=max(0.0, time.time() - started_at),
+            alive=True,
+            started_at=started_at,
+        )
+
+    def _warm_cpu_percent(self) -> None:
+        try:
+            self._process.cpu_percent(interval=None)
+        except process_probe.PROCESS_ERROR:
+            return
+
+    def _dead_sample(self) -> ProcessSample:
+        return ProcessSample(
+            pid=self._pid,
+            name=self._name,
+            cmdline=self._cmdline,
+            cpu_percent=0.0,
+            rss_bytes=0,
+            runtime_seconds=0.0,
+            alive=False,
+            started_at=self._started_at,
+        )
+
+
+def _resolve_process(config: WatchdogConfig) -> Any:
+    if config.pid is not None:
+        try:
+            return process_probe.process(config.pid)
+        except process_probe.PROCESS_NOT_FOUND as exc:
+            raise OpenSREError(
+                f"No process found for PID {config.pid}.",
+                suggestion="Check the PID and retry while the process is still running.",
+            ) from exc
+
+    assert config.name is not None
+    return _resolve_process_by_name(config.name, pick_first=config.pick_first)
+
+
+def _resolve_process_by_name(pattern: str, *, pick_first: bool) -> Any:
+    try:
+        compiled = re.compile(pattern)
+    except re.error as exc:
+        raise OpenSREError(
+            f"Invalid --name regex: {exc}",
+            suggestion="Pass a valid Python regular expression, for example --name claude.",
+        ) from exc
+
+    matches: list[Any] = []
+    for process in process_probe.process_iter(["pid", "name", "cmdline", "create_time"]):
+        try:
+            name = str(process.info.get("name") or "")
+        except process_probe.PROCESS_INACCESSIBLE_OR_GONE:
+            continue
+        if compiled.search(name):
+            matches.append(process)
+
+    matches.sort(key=lambda proc: proc.pid)
+    if not matches:
+        raise OpenSREError(
+            f"No running process name matched {pattern!r}.",
+            suggestion="Run `ps aux` to confirm the process name, then retry.",
+        )
+    if len(matches) > 1 and not pick_first:
+        preview = ", ".join(f"{proc.pid}:{_safe_process_name(proc)}" for proc in matches[:5])
+        raise OpenSREError(
+            f"Multiple processes matched {pattern!r}: {preview}",
+            suggestion="Pass --pid for the exact process or --pick-first to use the lowest PID.",
+        )
+    return matches[0]
+
+
+def _safe_process_name(process: Any) -> str:
+    try:
+        return str(process.name())
+    except process_probe.PROCESS_ERROR:
+        return str(getattr(process, "info", {}).get("name") or "")
+
+
+def _safe_cmdline(process: Any) -> tuple[str, ...]:
+    try:
+        return tuple(process.cmdline())
+    except process_probe.PROCESS_ERROR:
+        return tuple(getattr(process, "info", {}).get("cmdline") or ())
+
+
+def _safe_create_time(process: Any) -> float | None:
+    try:
+        return float(process.create_time())
+    except process_probe.PROCESS_ERROR:
+        value = getattr(process, "info", {}).get("create_time")
+        return float(value) if value is not None else None

--- a/app/watch_dog/runner.py
+++ b/app/watch_dog/runner.py
@@ -45,7 +45,7 @@ def run_watchdog(
 ) -> int:
     """Run the watchdog loop until target exit, SIGINT, or --once alarm."""
     active_sampler = sampler or ProcessMonitor(config)
-    active_dispatcher = dispatcher
+    active_dispatcher = dispatcher or _build_dispatcher(config)
     cpu_window = _CpuWindow()
 
     try:
@@ -61,11 +61,7 @@ def run_watchdog(
             if config.verbose:
                 click.echo(_format_sample_log(sample, breaches))
 
-            if breaches and active_dispatcher is None:
-                active_dispatcher = _build_dispatcher(config)
-
             for breach in breaches:
-                assert active_dispatcher is not None
                 active_dispatcher.dispatch(
                     breach.name,
                     _format_alarm_message(sample, breach),

--- a/app/watch_dog/runner.py
+++ b/app/watch_dog/runner.py
@@ -1,0 +1,217 @@
+"""Foreground watchdog loop and alarm formatting."""
+
+from __future__ import annotations
+
+import socket
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+import click
+
+from app.cli.support.exit_codes import ERROR, SUCCESS
+from app.watch_dog.alarms import AlarmDispatcher, load_credentials_from_env
+from app.watch_dog.config import WatchdogConfig
+from app.watch_dog.process_monitor import ProcessMonitor, ProcessSample, Sampler
+
+
+class Dispatcher(Protocol):
+    """Minimal alarm dispatcher protocol used by the runner tests."""
+
+    def dispatch(self, threshold_name: str, message: str) -> bool:
+        """Dispatch one threshold alarm."""
+
+
+@dataclass(frozen=True)
+class ThresholdBreach:
+    """A threshold violation observed for a sample."""
+
+    name: str
+    limit: float
+    observed: float
+    window_seconds: float | None = None
+
+
+def run_watchdog(
+    config: WatchdogConfig,
+    *,
+    sampler: Sampler | None = None,
+    dispatcher: Dispatcher | None = None,
+    _sleep: Callable[[float], None] = time.sleep,
+    _clock: Callable[[], float] = time.monotonic,
+) -> int:
+    """Run the watchdog loop until target exit, SIGINT, or --once alarm."""
+    active_sampler = sampler or ProcessMonitor(config)
+    active_dispatcher = dispatcher
+    cpu_window = _CpuWindow()
+
+    try:
+        while True:
+            sample = active_sampler.sample()
+            if not sample.alive:
+                if config.verbose:
+                    click.echo(f"watchdog: target exited pid={sample.pid}")
+                return SUCCESS
+
+            now = _clock()
+            breaches = _evaluate_thresholds(config, sample, cpu_window=cpu_window, now=now)
+            if config.verbose:
+                click.echo(_format_sample_log(sample, breaches))
+
+            if breaches and active_dispatcher is None:
+                active_dispatcher = _build_dispatcher(config)
+
+            for breach in breaches:
+                assert active_dispatcher is not None
+                active_dispatcher.dispatch(
+                    breach.name,
+                    _format_alarm_message(sample, breach),
+                )
+
+            if breaches and config.once:
+                return ERROR
+
+            _sleep(config.interval)
+    except KeyboardInterrupt:
+        return SUCCESS
+
+
+def _build_dispatcher(config: WatchdogConfig) -> AlarmDispatcher:
+    creds = load_credentials_from_env(chat_id_override=config.chat_id)
+    return AlarmDispatcher(creds, cooldown_seconds=config.cooldown)
+
+
+def _evaluate_thresholds(
+    config: WatchdogConfig,
+    sample: ProcessSample,
+    *,
+    cpu_window: _CpuWindow,
+    now: float,
+) -> tuple[ThresholdBreach, ...]:
+    breaches: list[ThresholdBreach] = []
+
+    if config.max_cpu is not None:
+        observed_cpu = cpu_window.add(now, sample.cpu_percent, window_seconds=config.cpu_window)
+        if observed_cpu >= config.max_cpu:
+            breaches.append(
+                ThresholdBreach(
+                    name="max_cpu",
+                    limit=config.max_cpu,
+                    observed=observed_cpu,
+                    window_seconds=config.cpu_window,
+                )
+            )
+
+    if config.max_runtime is not None and sample.runtime_seconds >= config.max_runtime:
+        breaches.append(
+            ThresholdBreach(
+                name="max_runtime",
+                limit=config.max_runtime,
+                observed=sample.runtime_seconds,
+            )
+        )
+
+    if config.max_rss is not None and sample.rss_bytes >= config.max_rss:
+        breaches.append(
+            ThresholdBreach(
+                name="max_rss",
+                limit=float(config.max_rss),
+                observed=float(sample.rss_bytes),
+            )
+        )
+
+    return tuple(breaches)
+
+
+class _CpuWindow:
+    """Rolling CPU average over a time window."""
+
+    def __init__(self) -> None:
+        self._samples: deque[tuple[float, float]] = deque()
+
+    def add(self, now: float, value: float, *, window_seconds: float) -> float:
+        self._samples.append((now, value))
+        oldest_allowed = now - window_seconds
+        while len(self._samples) > 1 and self._samples[0][0] < oldest_allowed:
+            self._samples.popleft()
+        return sum(cpu for _, cpu in self._samples) / len(self._samples)
+
+
+def _format_sample_log(
+    sample: ProcessSample,
+    breaches: tuple[ThresholdBreach, ...],
+) -> str:
+    status = "alarm" if breaches else "ok"
+    return (
+        "watchdog: "
+        f"status={status} pid={sample.pid} name={sample.name} "
+        f"cpu={sample.cpu_percent:.1f}% rss={_format_bytes(sample.rss_bytes)} "
+        f"runtime={_format_duration(sample.runtime_seconds)}"
+    )
+
+
+def _format_alarm_message(sample: ProcessSample, breach: ThresholdBreach) -> str:
+    started = "-"
+    if sample.started_at is not None:
+        started = datetime.fromtimestamp(sample.started_at, tz=UTC).isoformat()
+        started = started.replace("+00:00", "Z")
+
+    command = sample.command or "-"
+    if len(command) > 180:
+        command = f"{command[:177]}..."
+
+    return "\n".join(
+        [
+            "[opensre watchdog] ALARM",
+            f"host       {socket.gethostname()}",
+            f"pid        {sample.pid}  ({sample.name or '-'})",
+            f"cmd        {command}",
+            f"threshold  {_format_threshold_breach(breach)}",
+            f"runtime    {_format_duration(sample.runtime_seconds)}",
+            f"started    {started}",
+        ]
+    )
+
+
+def _format_threshold_breach(breach: ThresholdBreach) -> str:
+    if breach.name == "max_cpu":
+        window = f"  window={_format_duration(breach.window_seconds or 0)}"
+        return f"max_cpu  limit={breach.limit:.1f}%  observed={breach.observed:.1f}%{window}"
+    if breach.name == "max_runtime":
+        return (
+            "max_runtime  "
+            f"limit={_format_duration(breach.limit)}  "
+            f"observed={_format_duration(breach.observed)}"
+        )
+    if breach.name == "max_rss":
+        return (
+            "max_rss  "
+            f"limit={_format_bytes(breach.limit)}  "
+            f"observed={_format_bytes(breach.observed)}"
+        )
+    return f"{breach.name}  limit={breach.limit}  observed={breach.observed}"
+
+
+def _format_duration(seconds: float) -> str:
+    remaining = max(0, int(round(seconds)))
+    hours, remaining = divmod(remaining, 3600)
+    minutes, secs = divmod(remaining, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m{secs:02d}s"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+def _format_bytes(value: float) -> str:
+    amount = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(amount) < 1024.0 or unit == "TiB":
+            if unit == "B":
+                return f"{int(amount)}B"
+            return f"{amount:.1f}{unit}"
+        amount /= 1024.0
+    return f"{amount:.1f}TiB"

--- a/tests/watch_dog/test_cli.py
+++ b/tests/watch_dog/test_cli.py
@@ -1,0 +1,94 @@
+"""Tests for the ``opensre watchdog`` CLI command."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from app.cli.__main__ import cli
+from app.cli.commands.watchdog import watchdog_command
+from app.watch_dog.config import WatchdogConfig
+
+
+def test_watchdog_help_lists_expected_flags() -> None:
+    result = CliRunner().invoke(watchdog_command, ["--help"])
+
+    assert result.exit_code == 0
+    for flag in (
+        "--pid",
+        "--name",
+        "--pick-first",
+        "--max-cpu",
+        "--cpu-window",
+        "--max-runtime",
+        "--max-rss",
+        "--interval",
+        "--cooldown",
+        "--once",
+        "--chat-id",
+        "--verbose",
+    ):
+        assert flag in result.output
+
+
+def test_watchdog_cli_maps_flags_to_config(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, WatchdogConfig] = {}
+
+    def _fake_run(config: WatchdogConfig) -> int:
+        captured["config"] = config
+        return 0
+
+    monkeypatch.setattr("app.cli.commands.watchdog.run_watchdog", _fake_run)
+
+    result = CliRunner().invoke(
+        watchdog_command,
+        [
+            "--pid",
+            "123",
+            "--max-cpu",
+            "90",
+            "--cpu-window",
+            "30",
+            "--max-runtime",
+            "30m",
+            "--max-rss",
+            "4G",
+            "--interval",
+            "5",
+            "--cooldown",
+            "5m",
+            "--once",
+            "--chat-id",
+            "chat-1",
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0
+    config = captured["config"]
+    assert config.pid == 123
+    assert config.max_cpu == 90
+    assert config.cpu_window == 30
+    assert config.max_runtime == 1800
+    assert config.max_rss == 4 * 1024**3
+    assert config.interval == 5
+    assert config.cooldown == 300
+    assert config.once is True
+    assert config.chat_id == "chat-1"
+    assert config.verbose is True
+
+
+def test_watchdog_cli_rejects_invalid_selector() -> None:
+    result = CliRunner().invoke(
+        watchdog_command,
+        ["--pid", "123", "--name", "python", "--max-cpu", "90"],
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid watchdog configuration" in result.output
+
+
+def test_root_cli_registers_watchdog_command() -> None:
+    result = CliRunner().invoke(cli, ["watchdog", "--help"])
+
+    assert result.exit_code == 0
+    assert "--max-runtime" in result.output

--- a/tests/watch_dog/test_cli.py
+++ b/tests/watch_dog/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from click.testing import CliRunner
 
 from app.cli.__main__ import cli
@@ -30,7 +31,7 @@ def test_watchdog_help_lists_expected_flags() -> None:
         assert flag in result.output
 
 
-def test_watchdog_cli_maps_flags_to_config(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_watchdog_cli_maps_flags_to_config(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, WatchdogConfig] = {}
 
     def _fake_run(config: WatchdogConfig) -> int:

--- a/tests/watch_dog/test_config.py
+++ b/tests/watch_dog/test_config.py
@@ -1,0 +1,69 @@
+"""Tests for watchdog configuration parsing and validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.watch_dog.config import (
+    WatchdogConfig,
+    parse_byte_size,
+    parse_duration_seconds,
+)
+
+
+def test_parse_duration_seconds_accepts_suffixes() -> None:
+    assert parse_duration_seconds("30m") == 1800.0
+    assert parse_duration_seconds("2h") == 7200.0
+    assert parse_duration_seconds("15s") == 15.0
+    assert parse_duration_seconds(5) == 5.0
+
+
+def test_parse_byte_size_accepts_binary_suffixes() -> None:
+    assert parse_byte_size("4G") == 4 * 1024**3
+    assert parse_byte_size("512M") == 512 * 1024**2
+    assert parse_byte_size("1K") == 1024
+    assert parse_byte_size(4096) == 4096
+
+
+def test_watchdog_config_requires_pid_or_name_xor() -> None:
+    with pytest.raises(ValidationError, match="exactly one"):
+        WatchdogConfig(pid=123, name="python", max_cpu=90)
+
+    with pytest.raises(ValidationError, match="exactly one"):
+        WatchdogConfig(max_cpu=90)
+
+
+def test_watchdog_config_requires_at_least_one_threshold() -> None:
+    with pytest.raises(ValidationError, match="at least one threshold"):
+        WatchdogConfig(pid=123)
+
+
+def test_watchdog_config_parses_runtime_rss_and_cooldown() -> None:
+    config = WatchdogConfig(
+        name="claude",
+        max_runtime="30m",
+        max_rss="4G",
+        cooldown="5m",
+        cpu_window="45s",
+    )
+
+    assert config.max_runtime == 1800.0
+    assert config.max_rss == 4 * 1024**3
+    assert config.cooldown == 300.0
+    assert config.cpu_window == 45.0
+
+
+def test_thresholds_are_returned_in_stable_order() -> None:
+    config = WatchdogConfig(
+        pid=123,
+        max_rss="1G",
+        max_cpu=90,
+        max_runtime="2h",
+    )
+
+    assert [threshold.name for threshold in config.thresholds()] == [
+        "max_cpu",
+        "max_runtime",
+        "max_rss",
+    ]

--- a/tests/watch_dog/test_monitor.py
+++ b/tests/watch_dog/test_monitor.py
@@ -1,0 +1,150 @@
+"""Tests for the psutil-backed process monitor."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import cast
+
+import psutil
+import pytest
+
+from app.cli.support.errors import OpenSREError
+from app.watch_dog.config import WatchdogConfig
+from app.watch_dog.process_monitor import ProcessMonitor
+
+
+@dataclass
+class _MemoryInfo:
+    rss: int
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        pid: int,
+        name: str,
+        *,
+        cmdline: tuple[str, ...] = ("python", "worker.py"),
+        rss: int = 1024,
+        cpu_values: tuple[float, ...] = (0.0, 17.5),
+        create_time: float | None = None,
+    ) -> None:
+        self.pid = pid
+        self.info = {
+            "pid": pid,
+            "name": name,
+            "cmdline": list(cmdline),
+            "create_time": create_time or (time.time() - 60),
+        }
+        self._name = name
+        self._cmdline = cmdline
+        self._rss = rss
+        self._cpu_values = list(cpu_values)
+        self.cpu_calls = 0
+
+    def is_running(self) -> bool:
+        return True
+
+    def name(self) -> str:
+        return self._name
+
+    def cmdline(self) -> list[str]:
+        return list(self._cmdline)
+
+    def cpu_percent(self, interval: float | None = None) -> float:
+        _ = interval
+        self.cpu_calls += 1
+        if self._cpu_values:
+            return self._cpu_values.pop(0)
+        return 0.0
+
+    def memory_info(self) -> _MemoryInfo:
+        return _MemoryInfo(rss=self._rss)
+
+    def create_time(self) -> float:
+        return float(cast(float, self.info["create_time"]))
+
+
+class _GoneProcess(_FakeProcess):
+    def is_running(self) -> bool:
+        return False
+
+
+class _AccessDeniedProcess(_FakeProcess):
+    def memory_info(self) -> _MemoryInfo:
+        raise psutil.AccessDenied(self.pid)
+
+
+def test_process_monitor_resolves_by_pid_and_warms_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(123, "python", cpu_values=(0.0, 22.0))
+    monkeypatch.setattr("app.watch_dog.process_monitor.process_probe.process", lambda _pid: process)
+
+    monitor = ProcessMonitor(WatchdogConfig(pid=123, max_cpu=90))
+    sample = monitor.sample()
+
+    assert process.cpu_calls == 2
+    assert sample.pid == 123
+    assert sample.name == "python"
+    assert sample.cpu_percent == 22.0
+    assert sample.rss_bytes == 1024
+    assert sample.alive is True
+
+
+def test_process_monitor_resolves_name_regex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _FakeProcess(20, "python")
+    second = _FakeProcess(10, "claude")
+    monkeypatch.setattr(
+        "app.watch_dog.process_monitor.process_probe.process_iter",
+        lambda _attrs: iter([first, second]),
+    )
+
+    monitor = ProcessMonitor(WatchdogConfig(name="claude", max_cpu=90))
+
+    assert monitor.sample().pid == 10
+
+
+def test_process_monitor_requires_pick_first_for_multiple_name_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.watch_dog.process_monitor.process_probe.process_iter",
+        lambda _attrs: iter([_FakeProcess(20, "claude"), _FakeProcess(10, "claude")]),
+    )
+
+    with pytest.raises(OpenSREError, match="Multiple processes"):
+        ProcessMonitor(WatchdogConfig(name="claude", max_cpu=90))
+
+    monitor = ProcessMonitor(WatchdogConfig(name="claude", pick_first=True, max_cpu=90))
+    assert monitor.sample().pid == 10
+
+
+def test_process_monitor_returns_dead_sample_on_no_such_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _GoneProcess(123, "python")
+    monkeypatch.setattr("app.watch_dog.process_monitor.process_probe.process", lambda _pid: process)
+
+    monitor = ProcessMonitor(WatchdogConfig(pid=123, max_cpu=90))
+    sample = monitor.sample()
+
+    assert sample.pid == 123
+    assert sample.alive is False
+    assert sample.cpu_percent == 0.0
+
+
+def test_process_monitor_returns_dead_sample_on_access_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _AccessDeniedProcess(123, "python")
+    monkeypatch.setattr("app.watch_dog.process_monitor.process_probe.process", lambda _pid: process)
+
+    monitor = ProcessMonitor(WatchdogConfig(pid=123, max_cpu=90))
+    sample = monitor.sample()
+
+    assert sample.pid == 123
+    assert sample.alive is False

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from app.cli.support.errors import OpenSREError
 from app.cli.support.exit_codes import ERROR, SUCCESS
 from app.watch_dog.config import WatchdogConfig
 from app.watch_dog.process_monitor import ProcessSample
@@ -25,6 +28,11 @@ class _FakeDispatcher:
     def dispatch(self, threshold_name: str, message: str) -> bool:
         self.calls.append((threshold_name, message))
         return True
+
+
+class _ExplodingSampler:
+    def sample(self) -> ProcessSample:
+        raise AssertionError("watchdog sampled before credentials were validated")
 
 
 def _sample(
@@ -98,6 +106,26 @@ def test_target_exit_before_alarm_does_not_dispatch() -> None:
 
     assert code == SUCCESS
     assert dispatcher.calls == []
+
+
+def test_missing_credentials_fail_fast_before_sampling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_missing_credentials(*, chat_id_override: str | None = None) -> object:
+        raise OpenSREError("missing telegram credentials")
+
+    monkeypatch.setattr(
+        "app.watch_dog.runner.load_credentials_from_env",
+        _raise_missing_credentials,
+    )
+
+    with pytest.raises(OpenSREError, match="missing telegram credentials"):
+        run_watchdog(
+            WatchdogConfig(pid=123, max_cpu=90),
+            sampler=_ExplodingSampler(),
+            _sleep=lambda _seconds: None,
+            _clock=lambda: 100.0,
+        )
 
 
 def test_rss_threshold_formats_alarm_message() -> None:

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -1,0 +1,116 @@
+"""Tests for the watchdog foreground loop."""
+
+from __future__ import annotations
+
+from app.cli.support.exit_codes import ERROR, SUCCESS
+from app.watch_dog.config import WatchdogConfig
+from app.watch_dog.process_monitor import ProcessSample
+from app.watch_dog.runner import run_watchdog
+
+
+class _FakeSampler:
+    def __init__(self, samples: list[ProcessSample]) -> None:
+        self.samples = samples
+
+    def sample(self) -> ProcessSample:
+        if not self.samples:
+            raise AssertionError("sample called too many times")
+        return self.samples.pop(0)
+
+
+class _FakeDispatcher:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def dispatch(self, threshold_name: str, message: str) -> bool:
+        self.calls.append((threshold_name, message))
+        return True
+
+
+def _sample(
+    *,
+    cpu: float = 0.0,
+    rss: int = 1024,
+    runtime: float = 10.0,
+    alive: bool = True,
+) -> ProcessSample:
+    return ProcessSample(
+        pid=123,
+        name="python",
+        cmdline=("python", "worker.py"),
+        cpu_percent=cpu,
+        rss_bytes=rss,
+        runtime_seconds=runtime,
+        alive=alive,
+        started_at=1_700_000_000.0,
+    )
+
+
+def test_once_exits_after_first_threshold_trip() -> None:
+    dispatcher = _FakeDispatcher()
+    code = run_watchdog(
+        WatchdogConfig(pid=123, max_cpu=90, once=True),
+        sampler=_FakeSampler([_sample(cpu=95)]),
+        dispatcher=dispatcher,
+        _sleep=lambda _seconds: None,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == ERROR
+    assert len(dispatcher.calls) == 1
+    assert dispatcher.calls[0][0] == "max_cpu"
+    assert "[opensre watchdog] ALARM" in dispatcher.calls[0][1]
+
+
+def test_default_mode_keeps_polling_until_target_exits() -> None:
+    dispatcher = _FakeDispatcher()
+    sleeps: list[float] = []
+
+    code = run_watchdog(
+        WatchdogConfig(pid=123, max_runtime="30s", interval=2),
+        sampler=_FakeSampler(
+            [
+                _sample(runtime=10),
+                _sample(runtime=31),
+                _sample(alive=False),
+            ]
+        ),
+        dispatcher=dispatcher,
+        _sleep=sleeps.append,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == SUCCESS
+    assert sleeps == [2.0, 2.0]
+    assert [name for name, _message in dispatcher.calls] == ["max_runtime"]
+
+
+def test_target_exit_before_alarm_does_not_dispatch() -> None:
+    dispatcher = _FakeDispatcher()
+
+    code = run_watchdog(
+        WatchdogConfig(pid=123, max_cpu=90),
+        sampler=_FakeSampler([_sample(alive=False)]),
+        dispatcher=dispatcher,
+        _sleep=lambda _seconds: None,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == SUCCESS
+    assert dispatcher.calls == []
+
+
+def test_rss_threshold_formats_alarm_message() -> None:
+    dispatcher = _FakeDispatcher()
+
+    code = run_watchdog(
+        WatchdogConfig(pid=123, max_rss="4G", once=True),
+        sampler=_FakeSampler([_sample(rss=5 * 1024**3)]),
+        dispatcher=dispatcher,
+        _sleep=lambda _seconds: None,
+        _clock=lambda: 100.0,
+    )
+
+    assert code == ERROR
+    assert "max_rss" in dispatcher.calls[0][1]
+    assert "5.0GiB" in dispatcher.calls[0][1]

--- a/tests/watch_dog/test_runner.py
+++ b/tests/watch_dog/test_runner.py
@@ -75,7 +75,7 @@ def test_default_mode_keeps_polling_until_target_exits() -> None:
     sleeps: list[float] = []
 
     code = run_watchdog(
-        WatchdogConfig(pid=123, max_runtime="30s", interval=2),
+        WatchdogConfig.model_validate({"pid": 123, "max_runtime": "30s", "interval": 2}),
         sampler=_FakeSampler(
             [
                 _sample(runtime=10),
@@ -132,7 +132,7 @@ def test_rss_threshold_formats_alarm_message() -> None:
     dispatcher = _FakeDispatcher()
 
     code = run_watchdog(
-        WatchdogConfig(pid=123, max_rss="4G", once=True),
+        WatchdogConfig.model_validate({"pid": 123, "max_rss": "4G", "once": True}),
         sampler=_FakeSampler([_sample(rss=5 * 1024**3)]),
         dispatcher=dispatcher,
         _sleep=lambda _seconds: None,


### PR DESCRIPTION
Fixes #1451

#### Describe the changes you have made in this PR -

- Add a validated `opensre watchdog` CLI for PID/name process selection, CPU/RSS/runtime thresholds, cooldowns, `--once`, and verbose sampling.
- Add watchdog CLI config, process sampler, foreground runner, and Telegram alarm dispatch integration with focused config/CLI/monitor/runner tests.
- Register `/watchdog` in the interactive shell CLI parity registry.
- Keep process sampling access routed through `app.agents.probe` so the existing psutil dependency boundary remains intact.
- Rebase onto current `main` and keep the existing REPL watchdog `app.watch_dog.monitor` module intact by placing the CLI sampler in `app.watch_dog.process_monitor`.

### Demo/Screenshot for feature changes and bug fixes -

E2E CLI demo against a real local process. I used a dummy Telegram token plus a refused local proxy so no real message was sent, while still exercising CLI -> process sampler -> threshold evaluation -> dispatcher path:

```console
$ uv run --extra dev python -m app.cli watchdog --pid 55393 --max-rss 1 --once --verbose
exit_code=1
--- stdout ---
watchdog: status=alarm pid=55393 name=Python cpu=0.0% rss=11.1MiB runtime=1s
--- stderr ---
[telegram] post message exception: [Errno 61] Connection refused
[watchdog] alarm delivery failed: name=max_rss error=[Errno 61] Connection refused
```

Real Telegram delivery was not verified in my local environment because no real `TELEGRAM_BOT_TOKEN` / `TELEGRAM_DEFAULT_CHAT_ID` credentials are configured.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The command turns a single process selector (`--pid` or `--name`) plus one or more threshold options into a `WatchdogConfig`, resolves the target process, samples CPU/RSS/runtime in a foreground loop, and sends Telegram alarms through the existing delivery helper when thresholds trip. The monitor handles exited or inaccessible processes without crashing, and `--once` exits after the first alarm for scripting.

The follow-up fix keeps process-library usage confined to `app.agents.probe`, matching the project boundary enforced by `tests/agents/test_probe.py`, and adds `/watchdog` to the REPL slash-command registry so the root CLI and shell stay in parity. The latest rebase keeps `app.watch_dog.monitor` for the existing REPL watchdog loop and uses `app.watch_dog.process_monitor` for this foreground CLI sampler.

Validation run locally:

- `uv run --extra dev python -m pytest tests/cli/interactive_shell/test_parity.py tests/agents/test_probe.py tests/watch_dog -q` -> 43 passed
- `uv run --extra dev python -m ruff check app/agents/probe.py app/watch_dog/process_monitor.py app/watch_dog/runner.py app/cli/interactive_shell/command_registry/cli_parity.py tests/watch_dog/test_monitor.py tests/watch_dog/test_runner.py` -> passed
- `uv run --extra dev python -m mypy app/agents/probe.py app/watch_dog/process_monitor.py app/watch_dog/runner.py app/cli/interactive_shell/command_registry/cli_parity.py tests/watch_dog/test_monitor.py tests/watch_dog/test_runner.py` -> passed
- `uv run --extra dev python -m app.cli watchdog --help` -> passed
- `git diff --check` -> passed
- `uv run --extra dev python -m pytest -q` -> environment-gated synthetic failures due missing `ANTHROPIC_API_KEY`; watchdog/parity/probe target tests passed before the synthetic suite reached those unrelated credential failures

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.