### PR TITLE
add EmbeddingsClient with provider factory

### DIFF
--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -39,22 +39,24 @@ _LLM_PROVIDER_TO_EMBEDDINGS_PROVIDER: dict[str, str] = {
 }
 
 # Providers that don't support embeddings — return None from the factory.
-_NON_EMBEDDING_PROVIDERS: frozenset[str] = frozenset({
-    "anthropic",
-    "openrouter",
-    "requesty",
-    "gemini",
-    "nvidia",
-    "minimax",
-    "bedrock",
-    "codex",
-    "cursor",
-    "claude-code",
-    "gemini-cli",
-    "opencode",
-    "kimi",
-    "copilot",
-})
+_NON_EMBEDDING_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "anthropic",
+        "openrouter",
+        "requesty",
+        "gemini",
+        "nvidia",
+        "minimax",
+        "bedrock",
+        "codex",
+        "cursor",
+        "claude-code",
+        "gemini-cli",
+        "opencode",
+        "kimi",
+        "copilot",
+    }
+)
 
 _EMBEDDINGS_TIMEOUT_SEC = 30.0
 
@@ -166,9 +168,7 @@ class NoOpEmbeddingsClient:
         for text in texts:
             digest = hashlib.sha256(text.encode("utf-8")).digest()
             # Expand the 32-byte digest to ``dim`` floats in [-1, 1].
-            floats_from_bytes = [
-                (digest[i % 32] / 127.5) - 1.0 for i in range(self.dim)
-            ]
+            floats_from_bytes = [(digest[i % 32] / 127.5) - 1.0 for i in range(self.dim)]
             result.append(floats_from_bytes)
         return result
 
@@ -196,8 +196,10 @@ def get_embeddings_client() -> EmbeddingsClient | None:
     credentials are missing, so callers can skip RAG features gracefully.
     """
     raw_provider = (
-        os.getenv("OPENSRE_EMBEDDINGS_PROVIDER", "") or os.getenv("LLM_PROVIDER", "") or ""
-    ).strip().lower()
+        (os.getenv("OPENSRE_EMBEDDINGS_PROVIDER", "") or os.getenv("LLM_PROVIDER", "") or "")
+        .strip()
+        .lower()
+    )
 
     if not raw_provider or raw_provider in _NON_EMBEDDING_PROVIDERS:
         return None

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -106,7 +106,7 @@ class OpenAIEmbeddingsClient:
         self.model_name = model
         self.dim = _DEFAULT_EMBEDDINGS_DIMS.get(model, 1536)
 
-     def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, texts: list[str]) -> list[list[float]]:
         if not texts:
             return []
         response = self._client.embeddings.create(model=self.model_name, input=texts)

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -32,7 +32,7 @@ _DEFAULT_EMBEDDINGS_DIMS: dict[str, int] = {
     "text-embedding-3-large": 3072,
     "text-embedding-ada-002": 1536,
     # Voyage
-    "voyage-3-lite": 1024,
+    "voyage-3-lite": 512,
     "voyage-3": 1024,
     "voyage-3-large": 1024,
     "voyage-code-3": 2048,

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -27,9 +27,19 @@ _DEFAULT_EMBEDDINGS_MODELS: dict[str, str] = {
 }
 
 _DEFAULT_EMBEDDINGS_DIMS: dict[str, int] = {
+    # OpenAI
     "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+    # Voyage
     "voyage-3-lite": 1024,
+    "voyage-3": 1024,
+    "voyage-3-large": 1024,
+    "voyage-code-3": 2048,
+    # Ollama / popular open-source
     "nomic-embed-text": 768,
+    "mxbai-embed-large": 1024,
+    "all-minilm": 384,
 }
 
 # Embedding providers that are derived from ``LLM_PROVIDER``.
@@ -78,7 +88,7 @@ class EmbeddingsClient(Protocol):
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed a list of texts into a list of vectors."""
-        ...
+        pass
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -134,17 +144,16 @@ class OllamaEmbeddingsClient:
         self._base_url = host.rstrip("/")
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        vectors: list[list[float]] = []
-        for text in texts:
-            response = httpx.post(
-                f"{self._base_url}/api/embed",
-                json={"model": self.model_name, "input": text},
-                timeout=_EMBEDDINGS_TIMEOUT_SEC,
-            )
-            response.raise_for_status()
-            data = response.json()
-            vectors.append(data["embeddings"][0])
-        return vectors
+        if not texts:
+            return []
+        response = httpx.post(
+            f"{self._base_url}/api/embed",
+            json={"model": self.model_name, "input": texts},
+            timeout=_EMBEDDINGS_TIMEOUT_SEC,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return list(data["embeddings"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -177,9 +186,23 @@ class NoOpEmbeddingsClient:
 # Factory
 # ─────────────────────────────────────────────────────────────────────────────
 
+_embeddings_client: EmbeddingsClient | None = None
+_embeddings_client_initialized: bool = False
+
+
+def reset_embeddings_client_singleton() -> None:
+    """Clear the cached embeddings client (tests, config reloads)."""
+    global _embeddings_client, _embeddings_client_initialized
+    _embeddings_client = None
+    _embeddings_client_initialized = False
+
 
 def get_embeddings_client() -> EmbeddingsClient | None:
-    """Resolve and return an :class:`EmbeddingsClient`, or ``None``.
+    """Resolve and return a cached :class:`EmbeddingsClient`, or ``None``.
+
+    The client is constructed once and cached as a module-level singleton.
+    Call :func:`reset_embeddings_client_singleton` to clear the cache
+    (e.g. in tests or after config changes).
 
     Resolution order:
 
@@ -195,6 +218,10 @@ def get_embeddings_client() -> EmbeddingsClient | None:
     Returns ``None`` (silent no-op) for CLI-backed LLM providers or when
     credentials are missing, so callers can skip RAG features gracefully.
     """
+    global _embeddings_client, _embeddings_client_initialized
+    if _embeddings_client_initialized:
+        return _embeddings_client
+
     raw_provider = (
         (os.getenv("OPENSRE_EMBEDDINGS_PROVIDER", "") or os.getenv("LLM_PROVIDER", "") or "")
         .strip()
@@ -202,6 +229,8 @@ def get_embeddings_client() -> EmbeddingsClient | None:
     )
 
     if not raw_provider or raw_provider in _NON_EMBEDDING_PROVIDERS:
+        _embeddings_client_initialized = True
+        _embeddings_client = None
         return None
 
     # Map LLM_PROVIDER to the actual embeddings provider.
@@ -216,8 +245,12 @@ def get_embeddings_client() -> EmbeddingsClient | None:
         api_key = resolve_llm_api_key("OPENAI_API_KEY")
         if not api_key:
             logger.warning("OpenAI API key not found; embeddings disabled.")
+            _embeddings_client_initialized = True
+            _embeddings_client = None
             return None
-        return OpenAIEmbeddingsClient(model=model, api_key=api_key)
+        _embeddings_client = OpenAIEmbeddingsClient(model=model, api_key=api_key)
+        _embeddings_client_initialized = True
+        return _embeddings_client
 
     if provider == "voyage":
         from app.llm_credentials import resolve_llm_api_key
@@ -225,11 +258,19 @@ def get_embeddings_client() -> EmbeddingsClient | None:
         api_key = resolve_llm_api_key("VOYAGE_API_KEY")
         if not api_key:
             logger.warning("Voyage API key not found; embeddings disabled.")
+            _embeddings_client_initialized = True
+            _embeddings_client = None
             return None
-        return VoyageEmbeddingsClient(model=model, api_key=api_key)
+        _embeddings_client = VoyageEmbeddingsClient(model=model, api_key=api_key)
+        _embeddings_client_initialized = True
+        return _embeddings_client
 
     if provider == "ollama":
         host = os.getenv("OLLAMA_HOST", "http://localhost:11434").strip()
-        return OllamaEmbeddingsClient(model=model, host=host)
+        _embeddings_client = OllamaEmbeddingsClient(model=model, host=host)
+        _embeddings_client_initialized = True
+        return _embeddings_client
 
+    _embeddings_client_initialized = True
+    _embeddings_client = None
     return None

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -1,0 +1,233 @@
+"""Embeddings client with provider factory and graceful no-op fallback.
+
+Provides a ``EmbeddingsClient`` protocol with a factory function
+:func:`get_embeddings_client` that returns a provider-specific
+implementation or ``None`` when no provider/credentials are configured.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────────────
+
+_DEFAULT_EMBEDDINGS_MODELS: dict[str, str] = {
+    "openai": "text-embedding-3-small",
+    "voyage": "voyage-3-lite",
+    "ollama": "nomic-embed-text",
+}
+
+_DEFAULT_EMBEDDINGS_DIMS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "voyage-3-lite": 1024,
+    "nomic-embed-text": 768,
+}
+
+# Embedding providers that are derived from ``LLM_PROVIDER``.
+_LLM_PROVIDER_TO_EMBEDDINGS_PROVIDER: dict[str, str] = {
+    "openai": "openai",
+    "ollama": "ollama",
+}
+
+# Providers that don't support embeddings — return None from the factory.
+_NON_EMBEDDING_PROVIDERS: frozenset[str] = frozenset({
+    "anthropic",
+    "openrouter",
+    "requesty",
+    "gemini",
+    "nvidia",
+    "minimax",
+    "bedrock",
+    "codex",
+    "cursor",
+    "claude-code",
+    "gemini-cli",
+    "opencode",
+    "kimi",
+    "copilot",
+})
+
+_EMBEDDINGS_TIMEOUT_SEC = 30.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Protocol
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class EmbeddingsClient(Protocol):
+    """Protocol for embedding providers.
+
+    Implementations must provide ``embed``, ``model_name``, and ``dim``.
+    """
+
+    model_name: str
+    dim: int
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a list of texts into a list of vectors."""
+        ...
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Provider implementations
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class OpenAIEmbeddingsClient:
+    """Embeddings client backed by the OpenAI API."""
+
+    def __init__(self, *, model: str, api_key: str) -> None:
+        from openai import OpenAI
+
+        self._client = OpenAI(api_key=api_key, timeout=_EMBEDDINGS_TIMEOUT_SEC)
+        self.model_name = model
+        self.dim = _DEFAULT_EMBEDDINGS_DIMS.get(model, 1536)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        response = self._client.embeddings.create(model=self.model_name, input=texts)
+        response.data.sort(key=lambda d: d.index)
+        return [d.embedding for d in response.data]
+
+
+class VoyageEmbeddingsClient:
+    """Embeddings client backed by the Voyage AI API (via httpx)."""
+
+    BASE_URL = "https://api.voyageai.com/v1/embeddings"
+
+    def __init__(self, *, model: str, api_key: str) -> None:
+        self.model_name = model
+        self.dim = _DEFAULT_EMBEDDINGS_DIMS.get(model, 1024)
+        self._api_key = api_key
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        response = httpx.post(
+            self.BASE_URL,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+            json={"input": texts, "model": self.model_name},
+            timeout=_EMBEDDINGS_TIMEOUT_SEC,
+        )
+        response.raise_for_status()
+        data = response.json()
+        data["data"].sort(key=lambda d: d["index"])
+        return [d["embedding"] for d in data["data"]]
+
+
+class OllamaEmbeddingsClient:
+    """Embeddings client backed by a local Ollama instance."""
+
+    def __init__(self, *, model: str, host: str = "http://localhost:11434") -> None:
+        self.model_name = model
+        self.dim = _DEFAULT_EMBEDDINGS_DIMS.get(model, 768)
+        self._base_url = host.rstrip("/")
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        vectors: list[list[float]] = []
+        for text in texts:
+            response = httpx.post(
+                f"{self._base_url}/api/embed",
+                json={"model": self.model_name, "input": text},
+                timeout=_EMBEDDINGS_TIMEOUT_SEC,
+            )
+            response.raise_for_status()
+            data = response.json()
+            vectors.append(data["embeddings"][0])
+        return vectors
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# No-op / test client
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class NoOpEmbeddingsClient:
+    """Deterministic embeddings client for tests.
+
+    Returns vectors derived from a hash of each input text so that the
+    output is predictable across runs.
+    """
+
+    def __init__(self, dim: int = 768) -> None:
+        self.model_name = "no-op"
+        self.dim = dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        result: list[list[float]] = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode("utf-8")).digest()
+            # Expand the 32-byte digest to ``dim`` floats in [-1, 1].
+            floats_from_bytes = [
+                (digest[i % 32] / 127.5) - 1.0 for i in range(self.dim)
+            ]
+            result.append(floats_from_bytes)
+        return result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Factory
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def get_embeddings_client() -> EmbeddingsClient | None:
+    """Resolve and return an :class:`EmbeddingsClient`, or ``None``.
+
+    Resolution order:
+
+    1. ``OPENSRE_EMBEDDINGS_PROVIDER`` env var (when set).
+    2. ``LLM_PROVIDER`` env var — only providers in
+       :data:`_LLM_PROVIDER_TO_EMBEDDINGS_PROVIDER` produce a client.
+    3. Returns ``None`` when no suitable provider is configured.
+
+    The embedding model can be overridden via ``OPENSRE_EMBEDDINGS_MODEL``
+    — if unset, a sensible per-provider default is chosen
+    (:data:`_DEFAULT_EMBEDDINGS_MODELS`).
+
+    Returns ``None`` (silent no-op) for CLI-backed LLM providers or when
+    credentials are missing, so callers can skip RAG features gracefully.
+    """
+    raw_provider = (
+        os.getenv("OPENSRE_EMBEDDINGS_PROVIDER", "") or os.getenv("LLM_PROVIDER", "") or ""
+    ).strip().lower()
+
+    if not raw_provider or raw_provider in _NON_EMBEDDING_PROVIDERS:
+        return None
+
+    # Map LLM_PROVIDER to the actual embeddings provider.
+    provider = _LLM_PROVIDER_TO_EMBEDDINGS_PROVIDER.get(raw_provider, raw_provider)
+
+    model_override = os.getenv("OPENSRE_EMBEDDINGS_MODEL", "").strip()
+    model = model_override or _DEFAULT_EMBEDDINGS_MODELS.get(provider, "text-embedding-3-small")
+
+    if provider == "openai":
+        from app.llm_credentials import resolve_llm_api_key
+
+        api_key = resolve_llm_api_key("OPENAI_API_KEY")
+        if not api_key:
+            logger.warning("OpenAI API key not found; embeddings disabled.")
+            return None
+        return OpenAIEmbeddingsClient(model=model, api_key=api_key)
+
+    if provider == "voyage":
+        from app.llm_credentials import resolve_llm_api_key
+
+        api_key = resolve_llm_api_key("VOYAGE_API_KEY")
+        if not api_key:
+            logger.warning("Voyage API key not found; embeddings disabled.")
+            return None
+        return VoyageEmbeddingsClient(model=model, api_key=api_key)
+
+    if provider == "ollama":
+        host = os.getenv("OLLAMA_HOST", "http://localhost:11434").strip()
+        return OllamaEmbeddingsClient(model=model, host=host)
+
+    return None

--- a/app/services/embeddings_client.py
+++ b/app/services/embeddings_client.py
@@ -106,7 +106,9 @@ class OpenAIEmbeddingsClient:
         self.model_name = model
         self.dim = _DEFAULT_EMBEDDINGS_DIMS.get(model, 1536)
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+     def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
         response = self._client.embeddings.create(model=self.model_name, input=texts)
         response.data.sort(key=lambda d: d.index)
         return [d.embedding for d in response.data]
@@ -123,6 +125,8 @@ class VoyageEmbeddingsClient:
         self._api_key = api_key
 
     def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
         response = httpx.post(
             self.BASE_URL,
             headers={"Authorization": f"Bearer {self._api_key}"},

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -155,7 +155,7 @@ class TestProviderSelection:
             assert client is not None
             assert isinstance(client, ec.VoyageEmbeddingsClient)
             assert client.model_name == "voyage-3-lite"
-            assert client.dim == 1024
+            assert client.dim == 512
 
     def test_opensre_embeddings_provider_overrides_llm_provider(self) -> None:
         """OPENSRE_EMBEDDINGS_PROVIDER takes precedence over LLM_PROVIDER."""

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -1,0 +1,249 @@
+"""Tests for the embeddings client module."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+from app.services import embeddings_client as ec
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NoOpEmbeddingsClient
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNoOpEmbeddingsClient:
+    def test_deterministic_output(self) -> None:
+        client = ec.NoOpEmbeddingsClient(dim=4)
+        v1 = client.embed(["hello world"])
+        v2 = client.embed(["hello world"])
+        assert v1 == v2
+
+    def test_different_inputs_different_vectors(self) -> None:
+        client = ec.NoOpEmbeddingsClient(dim=4)
+        v1 = client.embed(["hello"])
+        v2 = client.embed(["world"])
+        assert v1 != v2
+
+    def test_dim_property(self) -> None:
+        client = ec.NoOpEmbeddingsClient(dim=768)
+        assert client.dim == 768
+        assert len(client.embed(["test"])[0]) == 768
+
+    def test_model_name(self) -> None:
+        client = ec.NoOpEmbeddingsClient()
+        assert client.model_name == "no-op"
+
+    def test_multiple_texts(self) -> None:
+        client = ec.NoOpEmbeddingsClient(dim=4)
+        texts = ["a", "b", "c"]
+        result = client.embed(texts)
+        assert len(result) == 3
+        assert all(len(v) == 4 for v in result)
+
+    def test_protocol_conformance(self) -> None:
+        client = ec.NoOpEmbeddingsClient()
+        assert isinstance(client, ec.EmbeddingsClient)
+
+    def test_empty_input(self) -> None:
+        client = ec.NoOpEmbeddingsClient(dim=4)
+        assert client.embed([]) == []
+
+    def test_value_range(self) -> None:
+        """Verify that all values are in [-1, 1]."""
+        client = ec.NoOpEmbeddingsClient(dim=32)
+        vec = client.embed(["some text"])[0]
+        assert all(-1.0 <= v <= 1.0 for v in vec)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Factory — provider selection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestProviderSelection:
+    def test_no_provider_returns_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert ec.get_embeddings_client() is None
+
+    def test_anthropic_provider_returns_none(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "anthropic"}, clear=True):
+            assert ec.get_embeddings_client() is None
+
+    def test_bedrock_provider_returns_none(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "bedrock"}, clear=True):
+            assert ec.get_embeddings_client() is None
+
+    def test_cli_providers_return_none(self) -> None:
+        for provider in ("codex", "cursor", "claude-code", "gemini-cli", "opencode", "kimi", "copilot"):
+            with patch.dict(os.environ, {"LLM_PROVIDER": provider}, clear=True):
+                assert ec.get_embeddings_client() is None, f"{provider} should return None"
+
+    def test_non_embedding_providers_return_none(self) -> None:
+        for provider in ("openrouter", "requesty", "gemini", "nvidia", "minimax"):
+            with patch.dict(os.environ, {"LLM_PROVIDER": provider}, clear=True):
+                assert ec.get_embeddings_client() is None, f"{provider} should return None"
+
+    def test_openai_provider_no_key_returns_none(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True):
+            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value=""):
+                assert ec.get_embeddings_client() is None
+
+    def test_openai_provider_with_key(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True):
+            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value="sk-test"):
+                with patch("app.services.embeddings_client.OpenAI") as mock_openai:
+                    client = ec.get_embeddings_client()
+                    assert client is not None
+                    assert client.model_name == "text-embedding-3-small"
+                    assert client.dim == 1536
+                    mock_openai.assert_called_once_with(api_key="sk-test", timeout=30.0)
+
+    def test_ollama_provider(self) -> None:
+        with patch.dict(os.environ, {"LLM_PROVIDER": "ollama", "OLLAMA_HOST": "http://localhost:11434"}, clear=True):
+            client = ec.get_embeddings_client()
+            assert client is not None
+            assert isinstance(client, ec.OllamaEmbeddingsClient)
+            assert client.model_name == "nomic-embed-text"
+            assert client.dim == 768
+
+    def test_voyage_provider_no_key_returns_none(self) -> None:
+        with patch.dict(os.environ, {"OPENSRE_EMBEDDINGS_PROVIDER": "voyage"}, clear=True):
+            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value=""):
+                assert ec.get_embeddings_client() is None
+
+    def test_voyage_provider_with_key(self) -> None:
+        with patch.dict(os.environ, {"OPENSRE_EMBEDDINGS_PROVIDER": "voyage"}, clear=True):
+            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value="vo-test-key"):
+                client = ec.get_embeddings_client()
+                assert client is not None
+                assert isinstance(client, ec.VoyageEmbeddingsClient)
+                assert client.model_name == "voyage-3-lite"
+                assert client.dim == 1024
+
+    def test_opensre_embeddings_provider_overrides_llm_provider(self) -> None:
+        """OPENSRE_EMBEDDINGS_PROVIDER takes precedence over LLM_PROVIDER."""
+        with patch.dict(
+            os.environ,
+            {
+                "OPENSRE_EMBEDDINGS_PROVIDER": "openai",
+                "LLM_PROVIDER": "anthropic",
+            },
+            clear=True,
+        ), patch("app.services.embeddings_client.resolve_llm_api_key", return_value="sk-test"):
+            with patch("app.services.embeddings_client.OpenAI"):
+                client = ec.get_embeddings_client()
+                assert client is not None
+
+    def test_opensre_embeddings_model_override(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "LLM_PROVIDER": "openai",
+                "OPENSRE_EMBEDDINGS_MODEL": "text-embedding-3-large",
+            },
+            clear=True,
+        ), patch("app.services.embeddings_client.resolve_llm_api_key", return_value="sk-test"):
+            with patch("app.services.embeddings_client.OpenAI"):
+                client = ec.get_embeddings_client()
+                assert client is not None
+                assert client.model_name == "text-embedding-3-large"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OpenAIEmbeddingsClient — happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIEmbeddingsHappyPath:
+    def test_batched_embed(self) -> None:
+        fake_embeddings = MagicMock()
+        fake_embeddings.create.return_value = MagicMock(
+            data=[
+                MagicMock(index=0, embedding=[0.1, 0.2]),
+                MagicMock(index=1, embedding=[0.3, 0.4]),
+            ]
+        )
+
+        fake_openai = MagicMock()
+        fake_openai.return_value.embeddings = fake_embeddings
+
+        with patch("app.services.embeddings_client.OpenAI", fake_openai):
+            client = ec.OpenAIEmbeddingsClient(model="text-embedding-3-small", api_key="sk-test")
+            result = client.embed(["hello", "world"])
+
+        assert len(result) == 2
+        assert result[0] == [0.1, 0.2]
+        assert result[1] == [0.3, 0.4]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OllamaEmbeddingsClient — happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestOllamaEmbeddingsHappyPath:
+    def test_embed(self) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"embeddings": [[0.5, 0.6]]}
+        mock_response.raise_for_status.return_value = None
+
+        with patch("app.services.embeddings_client.httpx.post", return_value=mock_response) as mock_post:
+            client = ec.OllamaEmbeddingsClient(model="nomic-embed-text", host="http://localhost:11434")
+            result = client.embed(["test"])
+
+        assert result == [[0.5, 0.6]]
+        mock_post.assert_called_once_with(
+            "http://localhost:11434/api/embed",
+            json={"model": "nomic-embed-text", "input": "test"},
+            timeout=30.0,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VoyageEmbeddingsClient — happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVoyageEmbeddingsHappyPath:
+    def test_embed(self) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"index": 0, "embedding": [0.7, 0.8]},
+                {"index": 1, "embedding": [0.9, 1.0]},
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+
+        with patch("app.services.embeddings_client.httpx.post", return_value=mock_response) as mock_post:
+            client = ec.VoyageEmbeddingsClient(model="voyage-3-lite", api_key="vo-test")
+            result = client.embed(["a", "b"])
+
+        assert result == [[0.7, 0.8], [0.9, 1.0]]
+        mock_post.assert_called_once_with(
+            "https://api.voyageai.com/v1/embeddings",
+            headers={"Authorization": "Bearer vo-test"},
+            json={"input": ["a", "b"], "model": "voyage-3-lite"},
+            timeout=30.0,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Protocol conformance
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestProtocolConformance:
+    def test_openai_conforms(self) -> None:
+        with patch("app.services.embeddings_client.OpenAI"):
+            client = ec.OpenAIEmbeddingsClient(model="text-embedding-3-small", api_key="sk-test")
+            assert isinstance(client, ec.EmbeddingsClient)
+
+    def test_voyage_conforms(self) -> None:
+        client = ec.VoyageEmbeddingsClient(model="voyage-3-lite", api_key="vo-test")
+        assert isinstance(client, ec.EmbeddingsClient)
+
+    def test_ollama_conforms(self) -> None:
+        client = ec.OllamaEmbeddingsClient(model="nomic-embed-text")
+        assert isinstance(client, ec.EmbeddingsClient)

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -93,11 +93,13 @@ class TestProviderSelection:
             "kimi",
             "copilot",
         ):
+            ec.reset_embeddings_client_singleton()
             with patch.dict(os.environ, {"LLM_PROVIDER": provider}, clear=True):
                 assert ec.get_embeddings_client() is None, f"{provider} should return None"
 
     def test_non_embedding_providers_return_none(self) -> None:
         for provider in ("openrouter", "requesty", "gemini", "nvidia", "minimax"):
+            ec.reset_embeddings_client_singleton()
             with patch.dict(os.environ, {"LLM_PROVIDER": provider}, clear=True):
                 assert ec.get_embeddings_client() is None, f"{provider} should return None"
 

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.services import embeddings_client as ec
+
+
+@pytest.fixture(autouse=True)
+def _reset_embeddings_singleton() -> None:
+    """Reset the cached singleton before each test."""
+    ec.reset_embeddings_client_singleton()
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # NoOpEmbeddingsClient
@@ -110,6 +119,14 @@ class TestProviderSelection:
             assert client.model_name == "text-embedding-3-small"
             assert client.dim == 1536
 
+    def test_openai_embedding_model_large_dim(self) -> None:
+        """text-embedding-3-large should report dim=3072."""
+        assert ec._DEFAULT_EMBEDDINGS_DIMS["text-embedding-3-large"] == 3072
+
+    def test_voyage_code_3_dim(self) -> None:
+        """voyage-code-3 should report dim=2048."""
+        assert ec._DEFAULT_EMBEDDINGS_DIMS["voyage-code-3"] == 2048
+
     def test_ollama_provider(self) -> None:
         with patch.dict(
             os.environ,
@@ -156,6 +173,35 @@ class TestProviderSelection:
         ):
             client = ec.get_embeddings_client()
             assert client is not None
+
+    def test_singleton_caching(self) -> None:
+        """Second call returns the same cached instance."""
+        with (
+            patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value="sk-test"),
+            patch("openai.OpenAI"),
+        ):
+            c1 = ec.get_embeddings_client()
+            c2 = ec.get_embeddings_client()
+            assert c1 is c2
+
+    def test_singleton_caches_none(self) -> None:
+        """None result is also cached."""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "anthropic"}, clear=True):
+            assert ec.get_embeddings_client() is None
+            assert ec.get_embeddings_client() is None
+
+    def test_reset_singleton(self) -> None:
+        """After reset, a new call creates a fresh instance."""
+        with (
+            patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value="sk-test"),
+            patch("openai.OpenAI"),
+        ):
+            c1 = ec.get_embeddings_client()
+            ec.reset_embeddings_client_singleton()
+            c2 = ec.get_embeddings_client()
+            assert c1 is not c2
 
     def test_opensre_embeddings_model_override(self) -> None:
         with (
@@ -208,7 +254,7 @@ class TestOpenAIEmbeddingsHappyPath:
 
 
 class TestOllamaEmbeddingsHappyPath:
-    def test_embed(self) -> None:
+    def test_single_text(self) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {"embeddings": [[0.5, 0.6]]}
         mock_response.raise_for_status.return_value = None
@@ -224,9 +270,36 @@ class TestOllamaEmbeddingsHappyPath:
         assert result == [[0.5, 0.6]]
         mock_post.assert_called_once_with(
             "http://localhost:11434/api/embed",
-            json={"model": "nomic-embed-text", "input": "test"},
+            json={"model": "nomic-embed-text", "input": ["test"]},
             timeout=30.0,
         )
+
+    def test_batched_texts(self) -> None:
+        """Multiple texts are sent in a single HTTP request."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]]
+        }
+        mock_response.raise_for_status.return_value = None
+
+        with patch(
+            "app.services.embeddings_client.httpx.post", return_value=mock_response
+        ) as mock_post:
+            client = ec.OllamaEmbeddingsClient(
+                model="nomic-embed-text", host="http://localhost:11434"
+            )
+            result = client.embed(["hello", "world"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+        mock_post.assert_called_once_with(
+            "http://localhost:11434/api/embed",
+            json={"model": "nomic-embed-text", "input": ["hello", "world"]},
+            timeout=30.0,
+        )
+
+    def test_empty_input(self) -> None:
+        client = ec.OllamaEmbeddingsClient(model="nomic-embed-text")
+        assert client.embed([]) == []
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/services/test_embeddings_client.py
+++ b/tests/services/test_embeddings_client.py
@@ -75,7 +75,15 @@ class TestProviderSelection:
             assert ec.get_embeddings_client() is None
 
     def test_cli_providers_return_none(self) -> None:
-        for provider in ("codex", "cursor", "claude-code", "gemini-cli", "opencode", "kimi", "copilot"):
+        for provider in (
+            "codex",
+            "cursor",
+            "claude-code",
+            "gemini-cli",
+            "opencode",
+            "kimi",
+            "copilot",
+        ):
             with patch.dict(os.environ, {"LLM_PROVIDER": provider}, clear=True):
                 assert ec.get_embeddings_client() is None, f"{provider} should return None"
 
@@ -85,22 +93,29 @@ class TestProviderSelection:
                 assert ec.get_embeddings_client() is None, f"{provider} should return None"
 
     def test_openai_provider_no_key_returns_none(self) -> None:
-        with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True):
-            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value=""):
-                assert ec.get_embeddings_client() is None
+        with (
+            patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value=""),
+        ):
+            assert ec.get_embeddings_client() is None
 
     def test_openai_provider_with_key(self) -> None:
-        with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True):
-            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value="sk-test"):
-                with patch("app.services.embeddings_client.OpenAI") as mock_openai:
-                    client = ec.get_embeddings_client()
-                    assert client is not None
-                    assert client.model_name == "text-embedding-3-small"
-                    assert client.dim == 1536
-                    mock_openai.assert_called_once_with(api_key="sk-test", timeout=30.0)
+        with (
+            patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value="sk-test"),
+            patch("openai.OpenAI"),
+        ):
+            client = ec.get_embeddings_client()
+            assert client is not None
+            assert client.model_name == "text-embedding-3-small"
+            assert client.dim == 1536
 
     def test_ollama_provider(self) -> None:
-        with patch.dict(os.environ, {"LLM_PROVIDER": "ollama", "OLLAMA_HOST": "http://localhost:11434"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"LLM_PROVIDER": "ollama", "OLLAMA_HOST": "http://localhost:11434"},
+            clear=True,
+        ):
             client = ec.get_embeddings_client()
             assert client is not None
             assert isinstance(client, ec.OllamaEmbeddingsClient)
@@ -108,46 +123,56 @@ class TestProviderSelection:
             assert client.dim == 768
 
     def test_voyage_provider_no_key_returns_none(self) -> None:
-        with patch.dict(os.environ, {"OPENSRE_EMBEDDINGS_PROVIDER": "voyage"}, clear=True):
-            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value=""):
-                assert ec.get_embeddings_client() is None
+        with (
+            patch.dict(os.environ, {"OPENSRE_EMBEDDINGS_PROVIDER": "voyage"}, clear=True),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value=""),
+        ):
+            assert ec.get_embeddings_client() is None
 
     def test_voyage_provider_with_key(self) -> None:
-        with patch.dict(os.environ, {"OPENSRE_EMBEDDINGS_PROVIDER": "voyage"}, clear=True):
-            with patch("app.services.embeddings_client.resolve_llm_api_key", return_value="vo-test-key"):
-                client = ec.get_embeddings_client()
-                assert client is not None
-                assert isinstance(client, ec.VoyageEmbeddingsClient)
-                assert client.model_name == "voyage-3-lite"
-                assert client.dim == 1024
+        with (
+            patch.dict(os.environ, {"OPENSRE_EMBEDDINGS_PROVIDER": "voyage"}, clear=True),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value="vo-test-key"),
+        ):
+            client = ec.get_embeddings_client()
+            assert client is not None
+            assert isinstance(client, ec.VoyageEmbeddingsClient)
+            assert client.model_name == "voyage-3-lite"
+            assert client.dim == 1024
 
     def test_opensre_embeddings_provider_overrides_llm_provider(self) -> None:
         """OPENSRE_EMBEDDINGS_PROVIDER takes precedence over LLM_PROVIDER."""
-        with patch.dict(
-            os.environ,
-            {
-                "OPENSRE_EMBEDDINGS_PROVIDER": "openai",
-                "LLM_PROVIDER": "anthropic",
-            },
-            clear=True,
-        ), patch("app.services.embeddings_client.resolve_llm_api_key", return_value="sk-test"):
-            with patch("app.services.embeddings_client.OpenAI"):
-                client = ec.get_embeddings_client()
-                assert client is not None
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "OPENSRE_EMBEDDINGS_PROVIDER": "openai",
+                    "LLM_PROVIDER": "anthropic",
+                },
+                clear=True,
+            ),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value="sk-test"),
+            patch("openai.OpenAI"),
+        ):
+            client = ec.get_embeddings_client()
+            assert client is not None
 
     def test_opensre_embeddings_model_override(self) -> None:
-        with patch.dict(
-            os.environ,
-            {
-                "LLM_PROVIDER": "openai",
-                "OPENSRE_EMBEDDINGS_MODEL": "text-embedding-3-large",
-            },
-            clear=True,
-        ), patch("app.services.embeddings_client.resolve_llm_api_key", return_value="sk-test"):
-            with patch("app.services.embeddings_client.OpenAI"):
-                client = ec.get_embeddings_client()
-                assert client is not None
-                assert client.model_name == "text-embedding-3-large"
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "LLM_PROVIDER": "openai",
+                    "OPENSRE_EMBEDDINGS_MODEL": "text-embedding-3-large",
+                },
+                clear=True,
+            ),
+            patch("app.llm_credentials.resolve_llm_api_key", return_value="sk-test"),
+            patch("openai.OpenAI"),
+        ):
+            client = ec.get_embeddings_client()
+            assert client is not None
+            assert client.model_name == "text-embedding-3-large"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -168,7 +193,7 @@ class TestOpenAIEmbeddingsHappyPath:
         fake_openai = MagicMock()
         fake_openai.return_value.embeddings = fake_embeddings
 
-        with patch("app.services.embeddings_client.OpenAI", fake_openai):
+        with patch("openai.OpenAI", fake_openai):
             client = ec.OpenAIEmbeddingsClient(model="text-embedding-3-small", api_key="sk-test")
             result = client.embed(["hello", "world"])
 
@@ -188,8 +213,12 @@ class TestOllamaEmbeddingsHappyPath:
         mock_response.json.return_value = {"embeddings": [[0.5, 0.6]]}
         mock_response.raise_for_status.return_value = None
 
-        with patch("app.services.embeddings_client.httpx.post", return_value=mock_response) as mock_post:
-            client = ec.OllamaEmbeddingsClient(model="nomic-embed-text", host="http://localhost:11434")
+        with patch(
+            "app.services.embeddings_client.httpx.post", return_value=mock_response
+        ) as mock_post:
+            client = ec.OllamaEmbeddingsClient(
+                model="nomic-embed-text", host="http://localhost:11434"
+            )
             result = client.embed(["test"])
 
         assert result == [[0.5, 0.6]]
@@ -216,7 +245,9 @@ class TestVoyageEmbeddingsHappyPath:
         }
         mock_response.raise_for_status.return_value = None
 
-        with patch("app.services.embeddings_client.httpx.post", return_value=mock_response) as mock_post:
+        with patch(
+            "app.services.embeddings_client.httpx.post", return_value=mock_response
+        ) as mock_post:
             client = ec.VoyageEmbeddingsClient(model="voyage-3-lite", api_key="vo-test")
             result = client.embed(["a", "b"])
 
@@ -236,7 +267,7 @@ class TestVoyageEmbeddingsHappyPath:
 
 class TestProtocolConformance:
     def test_openai_conforms(self) -> None:
-        with patch("app.services.embeddings_client.OpenAI"):
+        with patch("openai.OpenAI"):
             client = ec.OpenAIEmbeddingsClient(model="text-embedding-3-small", api_key="sk-test")
             assert isinstance(client, ec.EmbeddingsClient)
 


### PR DESCRIPTION
Fixes #1444 

Describe the changes you have made in this PR -
Add a standalone EmbeddingsClient primitive (app/services/embeddings_client.py) with a provider factory and graceful no-op fallback, modeled on the existing app/services/llm_client.py pattern. Ships with no consumers — ready for future RAG work.

Key components:

EmbeddingsClient Protocol with embed(texts), model_name, and dim
get_embeddings_client() factory reading LLM_PROVIDER / OPENSRE_EMBEDDINGS_PROVIDER, with OPENSRE_EMBEDDINGS_MODEL override
OpenAIEmbeddingsClient — uses existing openai SDK dep
VoyageEmbeddingsClient — via httpx (no new top-level dep)
OllamaEmbeddingsClient — via httpx
NoOpEmbeddingsClient — deterministic SHA-256-based vectors for tests
Returns None for non-embedding providers / missing credentials (graceful skip)
28 tests in tests/services/test_embeddings_client.py
Demo/Screenshot
Code Understanding and AI Usage
Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?

 No, I wrote all the code myself
 Yes, I used AI assistance (continue below)
If  you used AI assistance:

 I have reviewed every single line of the AI-generated code
 I can explain the purpose and logic of each function/component I added
 I have tested edge cases and understand how the code handles them
 I have modified the AI output to follow this project's coding standards and conventions
Explain your implementation approach:

The codebase had no embeddings infrastructure — app/services/llm_client.py wraps chat models only. This PR adds an embeddings primitive in isolation so future RAG / codebase-awareness work can consume it.

I followed the same conventions as the existing SupportsLLMInvoke protocol pattern (Protocol over ABC, module-level factory functions). For provider resolution, I added OPENSRE_EMBEDDINGS_PROVIDER to allow decoupling the embedding provider from the LLM provider, with LLM_PROVIDER as fallback. Voyage uses straight httpx calls (no new dependency), matching the project's existing httpx usage.

Checklist before requesting a review
 I have added proper PR title and linked to the issue
 I have performed a self-review of my code
 I can explain the purpose of every function, class, and logic block I added
 I understand why my changes work and have tested them thoroughly
 I have considered potential edge cases and how my code handles them
 If it is a core feature, I have added thorough tests
 My code follows the project's style guidelines and conventions