### PR TITLE
fix(agents/bus): guard AF_UNIX usage on Windows

### DIFF
--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -42,6 +42,12 @@ except ImportError:
 else:
     _fcntl = _fcntl_impl
 
+# ``socket.AF_UNIX`` is absent on stock Windows Python builds. Probe once so
+# callers see a clear ``OSError`` instead of an ``AttributeError`` from inside
+# ``socket.socket(...)``.
+BUS_AVAILABLE: bool = hasattr(socket, "AF_UNIX")
+_BUS_UNAVAILABLE_MSG = "agent bus requires AF_UNIX sockets; not available on this platform"
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BUS_SOCKET_PATH: Path = OPENSRE_HOME_DIR / "agents-bus.sock"
@@ -260,6 +266,8 @@ class BusServer:
         """
         if self._running.is_set():
             return
+        if not BUS_AVAILABLE:
+            raise OSError(_BUS_UNAVAILABLE_MSG)
         _ensure_parent_dir(self._path)
         listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
@@ -515,6 +523,8 @@ def _ensure_broker(path: Path) -> BusServer | None:
 
 def _connect_client(path: Path, timeout: float) -> socket.socket:
     """Open a blocking UDS connection to the broker at ``path``."""
+    if not BUS_AVAILABLE:
+        raise OSError(_BUS_UNAVAILABLE_MSG)
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.settimeout(timeout)
     try:
@@ -734,6 +744,7 @@ def subscribe(
 
 
 __all__ = [
+    "BUS_AVAILABLE",
     "BUS_SCHEMA_VERSION",
     "BusMessage",
     "BusServer",

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -23,7 +23,7 @@ from rich.markup import escape
 from rich.text import Text
 from rich.tree import Tree
 
-from app.agents.bus import BusMessage, subscribe
+from app.agents.bus import BUS_AVAILABLE, BusMessage, subscribe
 from app.agents.config import (
     agents_config_path,
     load_agents_config,
@@ -160,6 +160,13 @@ def _cmd_agents_bus(console: Console) -> bool:
     ``KeyboardInterrupt`` (user detached), broker disconnect (e.g. the
     publishing process exited), or socket error.
     """
+    if not BUS_AVAILABLE:
+        # AF_UNIX is POSIX-only; the rest of the REPL still works on Windows.
+        console.print(
+            f"[{WARNING}]/agents bus is not available on this platform "
+            "(requires AF_UNIX sockets — POSIX only).[/]"
+        )
+        return True
     console.print(
         f"[{DIM}]tailing /agents bus — Ctrl-C to exit[/]",
     )

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -13,6 +13,15 @@ from pathlib import Path
 import pytest
 
 _POSIX_FCNTL_AVAILABLE = importlib.util.find_spec("fcntl") is not None
+_AF_UNIX_AVAILABLE = hasattr(socket, "AF_UNIX")
+
+# Class-level marker for the socket-bound tests. The ``BusMessage`` and
+# slash-command formatter tests are pure-Python and don't carry this marker,
+# so they still run on Windows.
+_requires_af_unix = pytest.mark.skipif(
+    not _AF_UNIX_AVAILABLE,
+    reason="agent bus requires AF_UNIX sockets (POSIX only)",
+)
 
 from app.agents import bus as bus_module
 from app.agents.bus import (
@@ -141,6 +150,7 @@ class TestBusMessage:
         assert msg.data["k"] == 1
 
 
+@_requires_af_unix
 class TestBusServerLifecycle:
     def test_start_binds_socket_and_stop_unlinks(self, sock_path: Path) -> None:
         server = BusServer(sock_path)
@@ -217,6 +227,7 @@ class TestBusServerLifecycle:
             bus_module._ensure_broker(sock_path)
 
 
+@_requires_af_unix
 class TestLivenessProbe:
     def test_socket_is_live_does_not_create_phantom_subscriber(self, sock_path: Path) -> None:
         # _socket_is_live used to make a real connection on every probe; under
@@ -246,6 +257,7 @@ class TestLivenessProbe:
         assert not _socket_is_live(sock_path)
 
 
+@_requires_af_unix
 class TestPublisherCache:
     def test_burst_of_publishes_reuses_one_connection(self, sock_path: Path) -> None:
         # Each publish() previously opened a fresh UDS connection, which the
@@ -407,6 +419,7 @@ class TestPublisherCache:
         assert len(seen) == total, f"frame loss or corruption: got {len(seen)} unique of {total}"
 
 
+@_requires_af_unix
 class TestPublishSubscribe:
     def test_round_trip_one_publisher_one_subscriber(self, sock_path: Path) -> None:
         received: queue.Queue[BusMessage] = queue.Queue()
@@ -671,6 +684,7 @@ class TestPublishSubscribe:
             server.stop()
 
 
+@_requires_af_unix
 class TestBrokerElectionRace:
     def test_concurrent_cold_start_election_does_not_orphan_a_broker(self, sock_path: Path) -> None:
         # Cold-start race: two processes both observe ``_socket_is_live``
@@ -821,6 +835,7 @@ class TestBrokerElectionRace:
             child.wait(timeout=5.0)
 
 
+@_requires_af_unix
 class TestBrokerSelfElection:
     def test_stale_socket_file_is_unlinked_and_rebound(self, sock_path: Path) -> None:
         sock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -883,3 +898,39 @@ class TestSlashCommandFormatter:
         msg = BusMessage(agent="a:1", topic="finding", summary="x")
         out = _format_bus_message(msg)
         assert "—" not in out
+
+
+class TestPlatformGuards:
+    def test_bus_server_start_raises_clear_error_when_unavailable(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bus_module, "BUS_AVAILABLE", False)
+        server = BusServer(sock_path)
+        with pytest.raises(OSError, match="AF_UNIX"):
+            server.start()
+        assert not server.is_running
+
+    def test_connect_client_raises_clear_error_when_unavailable(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bus_module, "BUS_AVAILABLE", False)
+        with pytest.raises(OSError, match="AF_UNIX"):
+            bus_module._connect_client(sock_path, timeout=0.1)
+
+    def test_slash_command_degrades_gracefully_when_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        from app.cli.interactive_shell.command_registry import agents as agents_cmd
+
+        monkeypatch.setattr(agents_cmd, "BUS_AVAILABLE", False)
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False, width=120)
+        result = agents_cmd._cmd_agents_bus(console)
+        assert result is True
+        out = buf.getvalue()
+        assert "not available on this platform" in out
+        assert "AF_UNIX" in out


### PR DESCRIPTION
Fixes #1850.

`socket.AF_UNIX` is missing on stock Windows Python builds, which made `/agents bus` crash with `AttributeError: module 'socket' has no attribute 'AF_UNIX'` and broke `tests/agents/test_bus.py` collection on Windows test-cov runs.

Same shape as the existing `_POSIX_FCNTL_AVAILABLE` skip already in this file:

- `app/agents/bus.py`: probe `hasattr(socket, "AF_UNIX")` once at import as `BUS_AVAILABLE`. `BusServer.start` and `_connect_client` raise `OSError("agent bus requires AF_UNIX sockets; ...")` early so the `AttributeError` never leaves the call.
- `app/cli/interactive_shell/command_registry/agents.py`: `_cmd_agents_bus` checks the flag up front and prints a short "not available on this platform" line. The rest of the REPL is unaffected.
- `tests/agents/test_bus.py`: socket-bound classes get `@pytest.mark.skipif(not _AF_UNIX_AVAILABLE, ...)`. Added a small `TestPlatformGuards` class (3 tests) that monkeypatches `BUS_AVAILABLE = False` so the guard paths are covered on every host.

`BusMessage` round-trip tests and the slash-command formatter tests stay unconditionally enabled; they don't touch sockets.

### Verified

- `uv run pytest tests/agents/test_bus.py` on macOS: 41 passed.
- Same command on macOS with `socket.AF_UNIX` deleted before collection (simulates Windows): 14 passed, 27 skipped, no errors.
- `tests/cli_smoke_test.py`: clean.
- `ruff check` and `ruff format --check` on the three touched files: clean.

I don't have a Windows box, so a final `make test-cov` on Windows still needs a maintainer with one. Happy to iterate if anything else pops up there.