### PR TITLE
fix(agents): move cpu_percent() outside oneshot() to return accurate values (#1950)

### DIFF
--- a/app/agents/probe.py
+++ b/app/agents/probe.py
@@ -88,8 +88,9 @@ def probe(pid: int, *, cpu_interval: float = 0.1) -> ProcessSnapshot | None:
         return None
 
     try:
+        cpu = proc.cpu_percent(interval=cpu_interval)
+
         with proc.oneshot():
-            cpu = proc.cpu_percent(interval=cpu_interval)
             rss_mb = proc.memory_info().rss / _BYTES_PER_MIB
             num_fds = _safe_num_fds(proc)
             num_connections = _safe_num_connections(proc)

--- a/tests/agents/test_probe.py
+++ b/tests/agents/test_probe.py
@@ -4,16 +4,44 @@ from __future__ import annotations
 
 import os
 import pathlib
+import subprocess
 import sys
+import time
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from unittest.mock import patch
 
 import psutil
+import pytest
 
 from app.agents.probe import ProcessSnapshot, probe
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 _PROBE_MODULE = _REPO_ROOT / "app" / "agents" / "probe.py"
+
+
+@pytest.fixture
+def busy_process() -> Iterator[int]:
+    """Spawn a subprocess burning CPU in a tight loop; yields its PID.
+    The warmup sleep ensures the process has accumulated enough CPU time for
+    psutil.cpu_percent(interval>0) to measure a non-zero delta.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "while True: pass"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    time.sleep(0.1)
+
+    yield proc.pid
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
 
 
 def test_probe_returns_snapshot_for_self() -> None:
@@ -75,3 +103,15 @@ def test_psutil_is_not_imported_outside_probe_module() -> None:
     assert not leaks, (
         "psutil leaked into modules other than app/agents/probe.py:\n  " + "\n  ".join(leaks)
     )
+
+
+def test_probe_returns_nonzero_cpu_for_busy_process(busy_process: int) -> None:
+    """Regression: cpu_percent(interval>0) returned 0.0 when called inside proc.oneshot()
+    because both internal readings hit the same cache (#1950). Probing a busy subprocess
+    with a positive interval must yield a non-zero value now that the call lives
+    outside the oneshot block.
+    """
+    snap = probe(busy_process, cpu_interval=0.1)
+
+    assert snap is not None
+    assert snap.cpu_percent > 0.0


### PR DESCRIPTION
Fixes #1950 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR

cpu_percent(interval>0) always returned 0.0 because it was called inside proc.oneshot(), which caches both internal readings from a single snapshot — making the delta always zero.

Moved proc.cpu_percent() outside the oneshot() block in app/agents/probe.py. All other calls (memory_info, status, create_time, num_fds, net_connections) remain inside oneshot() for their caching benefit. Added a regression test that spawns a CPU-burning subprocess and asserts non-zero CPU%.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

This bug was surfaced during #1905 (wire probe into REPL), where the demo was recorded with cpu_percent() already moved outside oneshot() as a workaround. That PR's demo shows the fix working end-to-end in the agents view.

This PR formalizes the fix in isolation. Since probe() is an internal collector that requires the wiring in #1905 (not yet merged) to surface in the UI, here is the test output:
<img width="998" height="354" alt="Screenshot 2026-05-13 at 22 35 39" src="https://github.com/user-attachments/assets/faa9dff6-350d-4568-920d-a248a58cdfc2" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

Problem: psutil.Process.oneshot() caches all process attributes from a single syscall. cpu_percent(interval>0) needs two separate readings separated in time to compute a delta — inside oneshot, both readings return the same cached value, so the result is always 0.0.
Alternative: Could have called cpu_percent(interval=0) and managed baseline state externally in the sampler — rejected because it adds complexity to the consumer for no benefit.
Why this approach: Moving the single call outside the with block is the minimal fix. It preserves the oneshot optimization for all other fields while letting cpu_percent take real measurements.
Key change: One line moved in probe(), one regression test added with a busy-subprocess fixture.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
