### PR TITLE
fix: report interactive shell fallback errors

### DIFF
--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -97,6 +97,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
     try:
         text = path.read_text(encoding="utf-8")
     except Exception as exc:
+        report_exception(exc, context="interactive_shell.investigate_file.read")
         console.print(f"[{ERROR}]cannot read file:[/] {escape(str(exc))}")
         session.mark_latest(ok=False, kind="slash")
         return True
@@ -200,6 +201,7 @@ def _cmd_save(session: ReplSession, console: Console, args: list[str]) -> bool:
             dest.write_text("\n".join(lines) or "(no report content)", encoding="utf-8")
         console.print(f"[{HIGHLIGHT}]saved:[/] {escape(str(dest))}")
     except Exception as exc:
+        report_exception(exc, context="interactive_shell.save_report")
         console.print(f"[{ERROR}]save failed:[/] {escape(str(exc))}")
     return True
 

--- a/app/cli/interactive_shell/orchestration/action_executor.py
+++ b/app/cli/interactive_shell/orchestration/action_executor.py
@@ -158,6 +158,7 @@ def _pump_task_stream(
                 _print_task_output_line(console, task, stream_name, line, style=style)
                 task.update_progress(line)
     except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context=f"interactive_shell.task_stream.{stream_name}")
         console.print(f"[{DIM}]task output stream ended unexpectedly:[/] {escape(str(exc))}")
 
 
@@ -230,6 +231,7 @@ def _pump_task_pty(
             console.file.write(chunk.decode("utf-8", errors="replace"))
             console.file.flush()
     except Exception as exc:  # noqa: BLE001
+        report_exception(exc, context="interactive_shell.task_pty_stream")
         console.print(f"[{DIM}]task terminal stream ended unexpectedly:[/] {escape(str(exc))}")
     finally:
         with contextlib.suppress(OSError):
@@ -298,6 +300,7 @@ def start_background_cli_task(
             stdout_buf.close()
         stderr_buf.close()
         task.mark_failed(str(exc))
+        report_exception(exc, context="interactive_shell.background_cli_task.start")
         console.print(f"[{ERROR}]failed to start:[/] {escape(str(exc))}")
         return None
 
@@ -359,6 +362,7 @@ def start_background_cli_task(
                 console.print(f"[{ERROR}]command failed (exit {code}):[/]")
         except Exception as exc:  # noqa: BLE001
             task.mark_failed(str(exc))
+            report_exception(exc, context="interactive_shell.background_cli_task.watch")
             console.print(f"[{ERROR}]error:[/] {escape(str(exc))}")
         finally:
             _join_task_output_streams(output_threads)
@@ -426,36 +430,37 @@ def watch_synthetic_subprocess(
         session.record("synthetic_test", _history_text(), ok=ok)
 
     def _run() -> None:
-        output_threads = (
-            _start_task_output_streams(
-                task=task,
-                proc=proc,
-                console=console,
-                stderr_capture=stderr_buf,
-            )
-            if console is not None
-            else []
-        )
-        started = time.monotonic()
-        timed_out = False
-        # Track whether *we* explicitly terminated the process so we can
-        # distinguish a cancel-driven exit from a natural exit that happened
-        # to race with a concurrent /cancel.
-        terminated_by_watcher = False
-        while proc.poll() is None:
-            if time.monotonic() - started > SYNTHETIC_TEST_TIMEOUT_SECONDS:
-                timed_out = True
-                task.request_cancel()
-                terminate_child_process(proc)
-                terminated_by_watcher = True
-                break
-            if task.cancel_requested.is_set():
-                terminate_child_process(proc)
-                terminated_by_watcher = True
-                break
-            time.sleep(_SYNTHETIC_POLL_SECONDS)
-
+        output_threads: list[threading.Thread] = []
         try:
+            output_threads = (
+                _start_task_output_streams(
+                    task=task,
+                    proc=proc,
+                    console=console,
+                    stderr_capture=stderr_buf,
+                )
+                if console is not None
+                else []
+            )
+            started = time.monotonic()
+            timed_out = False
+            # Track whether *we* explicitly terminated the process so we can
+            # distinguish a cancel-driven exit from a natural exit that happened
+            # to race with a concurrent /cancel.
+            terminated_by_watcher = False
+            while proc.poll() is None:
+                if time.monotonic() - started > SYNTHETIC_TEST_TIMEOUT_SECONDS:
+                    timed_out = True
+                    task.request_cancel()
+                    terminate_child_process(proc)
+                    terminated_by_watcher = True
+                    break
+                if task.cancel_requested.is_set():
+                    terminate_child_process(proc)
+                    terminated_by_watcher = True
+                    break
+                time.sleep(_SYNTHETIC_POLL_SECONDS)
+
             if timed_out:
                 task.mark_failed(f"timed out after {SYNTHETIC_TEST_TIMEOUT_SECONDS}s")
                 _record_synthetic_if_current_session(ok=False)
@@ -487,6 +492,13 @@ def watch_synthetic_subprocess(
                 task.mark_failed(error_msg)
                 _record_synthetic_if_current_session(ok=False)
                 _suggest_follow_up_on_failure()
+        except Exception as exc:  # noqa: BLE001
+            task.mark_failed(str(exc))
+            report_exception(exc, context="interactive_shell.synthetic_test.watch")
+            _record_synthetic_if_current_session(ok=False)
+            _suggest_follow_up_on_failure()
+            if console is not None:
+                console.print(f"[{ERROR}]synthetic watcher failed:[/] {escape(str(exc))}")
         finally:
             _join_task_output_streams(output_threads)
             stderr_buf.close()
@@ -790,6 +802,7 @@ def run_cd_command(command: str, session: ReplSession, console: Console) -> None
     try:
         os.chdir(target)
     except Exception as exc:
+        report_exception(exc, context="interactive_shell.shell_cd")
         console.print(f"[{ERROR}]cd failed:[/] {escape(str(exc))}")
         session.record("shell", command, ok=False)
         return

--- a/tests/cli/interactive_shell/orchestration/test_action_executor.py
+++ b/tests/cli/interactive_shell/orchestration/test_action_executor.py
@@ -15,6 +15,8 @@ from rich.console import Console
 from app.cli.interactive_shell.orchestration.action_executor import (
     _MIN_SUBPROCESS_TERMINAL_WIDTH,
     _TASK_OUTPUT_PREFIX_WIDTH,
+    _pump_task_pty,
+    _pump_task_stream,
     read_diag,
     run_cd_command,
     run_claude_code_implementation,
@@ -24,6 +26,7 @@ from app.cli.interactive_shell.orchestration.action_executor import (
     run_synthetic_test,
     start_background_cli_task,
     terminate_child_process,
+    watch_synthetic_subprocess,
 )
 from app.cli.interactive_shell.runtime.session import ReplSession
 from app.cli.interactive_shell.runtime.tasks import TaskKind, TaskStatus
@@ -111,6 +114,30 @@ def test_run_cd_command_chdirs_to_target(monkeypatch: pytest.MonkeyPatch) -> Non
     run_cd_command("cd /tmp/example", session, console)
     assert directories == [Path("/tmp/example")]
     assert session.history[-1]["type"] == "shell"
+
+
+def test_run_cd_command_reports_chdir_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_errors: list[BaseException] = []
+
+    def _chdir(_target: Path) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("app.cli.interactive_shell.orchestration.action_executor.os.chdir", _chdir)
+    monkeypatch.setattr(
+        "app.cli.support.exception_reporting.capture_exception",
+        lambda exc, **_kwargs: captured_errors.append(exc),
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    run_cd_command("cd /root/blocked", session, console)
+
+    assert "cd failed" in buf.getvalue()
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], OSError)
+    assert session.history[-1] == {"type": "shell", "text": "cd /root/blocked", "ok": False}
 
 
 def test_run_shell_command_records_when_policy_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -595,6 +622,204 @@ def test_start_background_cli_task_falls_back_to_pipes_when_pty_unavailable(
     assert popen_kwargs[0]["stderr"] is subprocess.PIPE
     assert popen_kwargs[0]["text"] is True
     assert "pipe progress" in buf.getvalue()
+
+
+def test_task_output_stream_reports_unexpected_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_errors: list[BaseException] = []
+
+    class _BrokenStream:
+        def __iter__(self) -> _BrokenStream:
+            return self
+
+        def __next__(self) -> str:
+            raise RuntimeError("stream broke")
+
+    monkeypatch.setattr(
+        "app.cli.support.exception_reporting.capture_exception",
+        lambda exc, **_kwargs: captured_errors.append(exc),
+    )
+
+    session = ReplSession()
+    task = session.task_registry.create(TaskKind.CLI_COMMAND, command="demo")
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    _pump_task_stream(
+        task=task,
+        stream_name="stdout",
+        stream=_BrokenStream(),  # type: ignore[arg-type]
+        console=console,
+    )
+
+    assert "stream ended unexpectedly" in buf.getvalue()
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], RuntimeError)
+
+
+def test_task_pty_stream_reports_unexpected_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_errors: list[BaseException] = []
+    closed_fds: list[int] = []
+
+    def _raise_read(_fd: int, _size: int) -> bytes:
+        raise RuntimeError("pty broke")
+
+    monkeypatch.setattr(
+        "app.cli.support.exception_reporting.capture_exception",
+        lambda exc, **_kwargs: captured_errors.append(exc),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.os.read",
+        _raise_read,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.os.close",
+        lambda fd: closed_fds.append(fd),
+    )
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+    with tempfile.SpooledTemporaryFile() as capture:  # type: ignore[type-arg]
+        _pump_task_pty(master_fd=123, console=console, capture=capture)
+
+    assert "terminal stream ended unexpectedly" in buf.getvalue()
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], RuntimeError)
+    assert closed_fds == [123]
+
+
+def test_start_background_cli_task_reports_spawn_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_errors: list[BaseException] = []
+
+    def _fake_popen(_command: list[str], **_kwargs: object) -> object:
+        raise RuntimeError("spawn broke")
+
+    monkeypatch.setattr(
+        "app.cli.support.exception_reporting.capture_exception",
+        lambda exc, **_kwargs: captured_errors.append(exc),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.subprocess.Popen",
+        _fake_popen,
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    task = start_background_cli_task(
+        display_command="opensre tests synthetic --scenario 001-replication-lag",
+        argv_list=["python", "-m", "app.cli", "tests", "synthetic"],
+        session=session,
+        console=console,
+        kind=TaskKind.SYNTHETIC_TEST,
+    )
+
+    assert task is None
+    assert "failed to start" in buf.getvalue()
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], RuntimeError)
+    assert session.task_registry.list_recent(1)[0].status == TaskStatus.FAILED
+
+
+def test_start_background_cli_task_reports_watcher_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_errors: list[BaseException] = []
+
+    class _FakeProcess:
+        stdout = None
+        stderr = None
+        returncode = 1
+
+        def poll(self) -> int:
+            return 1
+
+    def _fake_popen(_command: list[str], **_kwargs: object) -> _FakeProcess:
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "app.cli.support.exception_reporting.capture_exception",
+        lambda exc, **_kwargs: captured_errors.append(exc),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.subprocess.Popen",
+        _fake_popen,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.read_diag",
+        lambda _buf: (_ for _ in ()).throw(RuntimeError("diag broke")),
+    )
+
+    session = ReplSession()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    task = start_background_cli_task(
+        display_command="opensre tests synthetic --scenario 001-replication-lag",
+        argv_list=["python", "-m", "app.cli", "tests", "synthetic"],
+        session=session,
+        console=console,
+        kind=TaskKind.SYNTHETIC_TEST,
+    )
+
+    assert task is not None
+    assert task.status == TaskStatus.FAILED
+    assert "error:" in buf.getvalue()
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], RuntimeError)
+
+
+def test_watch_synthetic_subprocess_reports_daemon_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_errors: list[BaseException] = []
+
+    class _FakeProcess:
+        stdout = None
+        stderr = None
+
+        def poll(self) -> int:
+            raise RuntimeError("poll broke")
+
+    monkeypatch.setattr(
+        "app.cli.support.exception_reporting.capture_exception",
+        lambda exc, **_kwargs: captured_errors.append(exc),
+    )
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.orchestration.action_executor.threading.Thread",
+        _ImmediateThread,
+    )
+
+    session = ReplSession()
+    task = session.task_registry.create(TaskKind.SYNTHETIC_TEST, command="suite")
+    task.mark_running()
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False)
+
+    with tempfile.SpooledTemporaryFile() as stderr_buf:  # type: ignore[type-arg]
+        watch_synthetic_subprocess(
+            task,
+            _FakeProcess(),  # type: ignore[arg-type]
+            session,
+            "suite:001-test",
+            stderr_buf,
+            console,
+        )
+
+    assert task.status == TaskStatus.FAILED
+    assert "synthetic watcher failed" in buf.getvalue()
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0], RuntimeError)
 
 
 def test_run_synthetic_test_unknown_suite_records_failure() -> None:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -210,6 +210,55 @@ class TestDispatchSlash:
         assert "/list integrations" in output
         assert "current session only" not in output
 
+    def test_investigate_file_read_failure_is_reported(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured_errors: list[BaseException] = []
+
+        monkeypatch.setattr(Path, "exists", lambda _self: True)
+        monkeypatch.setattr(
+            Path,
+            "read_text",
+            lambda _self, **_kwargs: (_ for _ in ()).throw(RuntimeError("read broke")),
+        )
+        monkeypatch.setattr(
+            "app.cli.support.exception_reporting.capture_exception",
+            lambda exc, **_kwargs: captured_errors.append(exc),
+        )
+
+        session = ReplSession()
+        console, buf = _capture()
+
+        assert dispatch_slash("/investigate incident.json", session, console) is True
+
+        assert "cannot read file" in buf.getvalue()
+        assert len(captured_errors) == 1
+        assert isinstance(captured_errors[0], RuntimeError)
+
+    def test_save_failure_is_reported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured_errors: list[BaseException] = []
+
+        monkeypatch.setattr(
+            Path,
+            "write_text",
+            lambda _self, *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("write broke")),
+        )
+        monkeypatch.setattr(
+            "app.cli.support.exception_reporting.capture_exception",
+            lambda exc, **_kwargs: captured_errors.append(exc),
+        )
+
+        session = ReplSession()
+        session.last_state = {"root_cause": "cache issue", "problem_md": "details"}
+        console, buf = _capture()
+
+        assert dispatch_slash("/save report.md", session, console) is True
+
+        assert "save failed" in buf.getvalue()
+        assert len(captured_errors) == 1
+        assert isinstance(captured_errors[0], RuntimeError)
+
 
 class TestListCommand:
     """Coverage for /list integrations / models / mcp and the default summary."""


### PR DESCRIPTION
## Summary
- routes remaining interactive-shell fallback failures through Sentry reporting before preserving the existing REPL UX
- covers task output stream failures, PTY stream failures, background task spawn/watch failures, synthetic watcher daemon failures, `cd` failures, `/investigate` file-read failures, and `/save` write failures
- adds focused regression tests that assert each migrated boundary captures exactly one exception while the REPL/task state continues to degrade gracefully

## Validation
- `uv run --extra dev python -m pytest tests/cli/interactive_shell/orchestration/test_action_executor.py tests/cli/interactive_shell/test_commands.py -q` -> 147 passed
- `uv run --extra dev ruff check app/cli/interactive_shell/orchestration/action_executor.py app/cli/interactive_shell/command_registry/investigation.py tests/cli/interactive_shell/orchestration/test_action_executor.py tests/cli/interactive_shell/test_commands.py`
- `uv run --extra dev ruff format --check app/cli/interactive_shell/orchestration/action_executor.py app/cli/interactive_shell/command_registry/investigation.py tests/cli/interactive_shell/orchestration/test_action_executor.py tests/cli/interactive_shell/test_commands.py`
- `uv run --extra dev mypy app/cli/interactive_shell/orchestration/action_executor.py app/cli/interactive_shell/command_registry/investigation.py`
- `git diff --check`

Closes #1473