### PR TITLE
fix(shell): hide assistant spinner for slash commands

### DIFF
--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -158,6 +158,21 @@ def _looks_like_cancel_request(text: str | None) -> bool:
     return (text or "").strip().lower() in _CANCEL_REQUEST_TOKENS
 
 
+def _dispatch_should_show_spinner(text: str, session: ReplSession) -> bool:
+    """Return False for deterministic slash-command dispatches.
+
+    Slash commands often open menus or run local shell handlers. Showing the
+    assistant/token spinner for those paths makes a local menu look like an LLM
+    turn is running. Keep this in lockstep with the router's bare-alias
+    typo-tolerance so typo-corrected local commands do not briefly show the
+    assistant spinner either.
+    """
+    stripped = text.strip()
+    if stripped.startswith("/"):
+        return False
+    return not _router.is_bare_command_alias(stripped, session)
+
+
 class DispatchCancelled(Exception):
     """Raised in the dispatch worker thread when the user interrupts
     (Esc / ``/cancel`` / ``/stop`` / ``/abort``) and the worker is
@@ -780,7 +795,9 @@ async def _run_interactive(
             color_system="truecolor",
             legacy_windows=False,
         )
-        spinner.start()
+        show_spinner = _dispatch_should_show_spinner(text, session)
+        if show_spinner:
+            spinner.start()
         try:
             await asyncio.to_thread(
                 _dispatch_one_turn,
@@ -808,7 +825,8 @@ async def _run_interactive(
             report_exception(exc, context="interactive_shell.dispatch_async")
             console.print(f"[{ERROR}]dispatch error:[/] {escape(str(exc))}")
         finally:
-            spinner.stop()
+            if show_spinner:
+                spinner.stop()
             # Release the per-turn cancel event only if it's still ours.
             # A stale-but-still-running prior-turn worker keeps a strong
             # reference to its own ``dispatch_cancel``; nothing else

--- a/app/cli/interactive_shell/routing/router.py
+++ b/app/cli/interactive_shell/routing/router.py
@@ -75,6 +75,11 @@ def _is_bare_command_alias(text: str, _session: RoutingSession) -> bool:
     return is_single_edit_typo(stripped.lower(), normalized)
 
 
+def is_bare_command_alias(text: str, session: RoutingSession) -> bool:
+    """True when ``text`` is a bare slash-command alias or accepted typo."""
+    return _is_bare_command_alias(text, session)
+
+
 def _is_cli_help_rule(text: str, _session: RoutingSession) -> bool:
     return _is_cli_help_intent(text.strip())
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -700,6 +700,36 @@ class TestLooksLikeCancelRequest:
 # ── Spinner state tests ──────────────────────────────────────────────────────
 
 
+class TestDispatchSpinnerRouting:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "/history",
+            "/tests",
+            "/model show",
+            "tests",
+            "help",
+            # The router typo-corrects single-edit bare aliases before
+            # dispatch, so these are local slash-command paths too.
+            "testts",
+            "hlep",
+        ],
+    )
+    def test_slash_dispatches_do_not_show_assistant_spinner(self, text: str) -> None:
+        assert loop._dispatch_should_show_spinner(text, ReplSession()) is False
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "why did this fail?",
+            "run opensre investigate --input alert.json",
+            "explain deploy",
+        ],
+    )
+    def test_non_slash_dispatches_show_assistant_spinner(self, text: str) -> None:
+        assert loop._dispatch_should_show_spinner(text, ReplSession()) is True
+
+
 def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", text)
 


### PR DESCRIPTION
## Summary
- keep the assistant/token spinner off for deterministic slash-command dispatches
- preserve the spinner for normal assistant/help/investigation turns
- add routing helper coverage for slash and non-slash inputs

Closes #1904

## Validation
- `uv run --extra dev python -m pytest tests/cli/interactive_shell/test_loop.py -q`
- `uv run --extra dev ruff check app/cli/interactive_shell/loop.py tests/cli/interactive_shell/test_loop.py`
- `uv run --extra dev ruff format --check app/cli/interactive_shell/loop.py tests/cli/interactive_shell/test_loop.py`
- `uv run --extra dev mypy app/cli/interactive_shell/loop.py`
- `git diff --check`