### PR TITLE
fix: ignore KeyboardInterrupt in Sentry

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -365,7 +365,12 @@ def _init_sentry_once(
         auto_enabling_integrations=False,
         before_send=_before_send,
         before_breadcrumb=_before_breadcrumb,
-        ignore_errors=[CLIAuthenticationRequired, CLITimeoutError, CLITransientError],
+        ignore_errors=[
+            KeyboardInterrupt,
+            CLIAuthenticationRequired,
+            CLITimeoutError,
+            CLITransientError,
+        ],
     )
 
 

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -772,3 +772,13 @@ def test_init_sentry_ignore_errors_includes_cli_transient_error(monkeypatch) -> 
 
     ignore_errors = init_mock.call_args.kwargs["ignore_errors"]
     assert CLITransientError in ignore_errors
+
+
+def test_init_sentry_ignore_errors_includes_keyboard_interrupt(monkeypatch) -> None:
+    _clear_kill_switches(monkeypatch)
+    init_mock, _ = _install_full_sentry_mock(monkeypatch)
+
+    sentry_mod.init_sentry(entrypoint="cli")
+
+    ignore_errors = init_mock.call_args.kwargs["ignore_errors"]
+    assert KeyboardInterrupt in ignore_errors


### PR DESCRIPTION
## Summary
- add `KeyboardInterrupt` to Sentry `ignore_errors` so user Ctrl+C cancellations do not create high-priority Sentry crash issues
- keep existing local Ctrl+C handling unchanged; this only affects Sentry event filtering
- extend the Sentry init test to cover the new ignored exception

Closes #1961.
Closes #1956.
Closes #1952.
Refs #1951.

## Validation
- `uv run --extra dev python -m pytest tests/test_sentry_init.py -q`
- `uv run --extra dev ruff check app/utils/sentry_sdk.py tests/test_sentry_init.py`
- `uv run --extra dev ruff format --check app/utils/sentry_sdk.py tests/test_sentry_init.py`
- `uv run --extra dev mypy app/utils/sentry_sdk.py`
- `git diff --check`