### PR TITLE
Fix Sentry issue searches for exception signatures

### DIFF
--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -14,6 +14,9 @@ from app.strict_config import StrictConfigModel
 
 DEFAULT_SENTRY_URL = "https://sentry.io"
 DEFAULT_SENTRY_STATS_PERIOD = "24h"
+_EXCEPTION_QUERY_PREFIX_RE = re.compile(
+    r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s+"
+)
 _STRUCTURED_QUERY_TOKEN_RE = re.compile(r"(?:^|\s)[a-z][a-z0-9_.-]*:")
 
 
@@ -110,6 +113,8 @@ def _normalize_issue_search_query(query: str) -> str:
     stripped = query.strip()
     if not stripped or _is_quoted_search_query(stripped):
         return stripped
+    if _starts_like_exception_signature(stripped):
+        return _quote_search_phrase(stripped)
     if _STRUCTURED_QUERY_TOKEN_RE.search(stripped):
         return stripped
     if _looks_like_exception_signature(stripped):
@@ -119,6 +124,10 @@ def _normalize_issue_search_query(query: str) -> str:
 
 def _is_quoted_search_query(query: str) -> bool:
     return len(query) >= 2 and query[0] == '"' and query[-1] == '"'
+
+
+def _starts_like_exception_signature(query: str) -> bool:
+    return bool(_EXCEPTION_QUERY_PREFIX_RE.search(query))
 
 
 def _looks_like_exception_signature(query: str) -> bool:

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -15,13 +15,13 @@ from app.strict_config import StrictConfigModel
 DEFAULT_SENTRY_URL = "https://sentry.io"
 DEFAULT_SENTRY_STATS_PERIOD = "24h"
 _EXCEPTION_QUERY_PREFIX_RE = re.compile(
-    r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s*"
+    r"^(?:[A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)|panic|error|runtime error|fatal error):\s*"
 )
 _BARE_EXCEPTION_QUERY_PREFIX_RE = re.compile(
-    r"^(?P<name>[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s*$"
+    r"^(?P<name>[A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)|panic|error|runtime error|fatal error):\s*$"
 )
 _BARE_EXCEPTION_QUERY_NAME_RE = re.compile(
-    r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error)$"
+    r"^(?:[A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)|panic|error|runtime error|fatal error)$"
 )
 _STRUCTURED_QUERY_KEY_RE = re.compile(r"(?<!\S)!?(?P<key>[A-Za-z][A-Za-z0-9_.-]*):")
 _STRUCTURED_QUERY_KEYS = frozenset(
@@ -169,15 +169,11 @@ def _normalize_issue_search_query(query: str) -> str:
         normalized_free_text = (
             _quote_search_phrase(free_text)
             if not _is_quoted_search_query(free_text)
-            and (
-                _starts_like_exception_signature(free_text)
-                or _is_bare_exception_name(free_text)
-                or _looks_like_exception_signature(free_text)
-            )
+            and (_starts_like_exception_signature(free_text) or _is_bare_exception_name(free_text))
             else free_text
         )
         return " ".join([*leading_filters, normalized_free_text, *trailing_filters])
-    if _starts_like_exception_signature(stripped) or _looks_like_exception_signature(stripped):
+    if _starts_like_exception_signature(stripped):
         return _quote_search_phrase(stripped)
     return stripped
 
@@ -269,10 +265,6 @@ def _structured_query_value_end(query: str, value_start: int) -> int:
     while index < len(query) and not query[index].isspace():
         index += 1
     return index
-
-
-def _looks_like_exception_signature(query: str) -> bool:
-    return ":" in query and any(char in query for char in (" ", "(", ")", "/", "\\"))
 
 
 def _quote_search_phrase(query: str) -> str:

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -15,9 +15,51 @@ from app.strict_config import StrictConfigModel
 DEFAULT_SENTRY_URL = "https://sentry.io"
 DEFAULT_SENTRY_STATS_PERIOD = "24h"
 _EXCEPTION_QUERY_PREFIX_RE = re.compile(
-    r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s+"
+    r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s*"
 )
-_STRUCTURED_QUERY_TOKEN_RE = re.compile(r"(?:^|\s)[a-z][a-z0-9_.-]*:")
+_STRUCTURED_QUERY_TOKEN_RE = re.compile(r"(?:^|\s)([A-Za-z][A-Za-z0-9_.-]*):")
+_STRUCTURED_QUERY_KEYS = frozenset(
+    {
+        "age",
+        "assigned",
+        "browser.name",
+        "browser.version",
+        "culprit",
+        "device.family",
+        "device.model",
+        "dist",
+        "environment",
+        "error.handled",
+        "error.type",
+        "error.unhandled",
+        "event.type",
+        "firstSeen",
+        "has",
+        "is",
+        "issue.category",
+        "issue.type",
+        "lastSeen",
+        "level",
+        "logger",
+        "message",
+        "os.name",
+        "os.version",
+        "project",
+        "release",
+        "server_name",
+        "stack.filename",
+        "stack.function",
+        "status",
+        "timesSeen",
+        "title",
+        "transaction",
+        "url",
+        "user",
+        "user.email",
+        "user.id",
+        "user.ip",
+    }
+)
 
 
 class SentryConfig(StrictConfigModel):
@@ -115,7 +157,7 @@ def _normalize_issue_search_query(query: str) -> str:
         return stripped
     if _starts_like_exception_signature(stripped):
         return _quote_search_phrase(stripped)
-    if _STRUCTURED_QUERY_TOKEN_RE.search(stripped):
+    if _has_structured_query_token(stripped):
         return stripped
     if _looks_like_exception_signature(stripped):
         return _quote_search_phrase(stripped)
@@ -128,6 +170,13 @@ def _is_quoted_search_query(query: str) -> bool:
 
 def _starts_like_exception_signature(query: str) -> bool:
     return bool(_EXCEPTION_QUERY_PREFIX_RE.search(query))
+
+
+def _has_structured_query_token(query: str) -> bool:
+    return any(
+        match.group(1) in _STRUCTURED_QUERY_KEYS
+        for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query)
+    )
 
 
 def _looks_like_exception_signature(query: str) -> bool:

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -17,6 +17,12 @@ DEFAULT_SENTRY_STATS_PERIOD = "24h"
 _EXCEPTION_QUERY_PREFIX_RE = re.compile(
     r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s*"
 )
+_BARE_EXCEPTION_QUERY_PREFIX_RE = re.compile(
+    r"^(?P<name>[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s*$"
+)
+_BARE_EXCEPTION_QUERY_NAME_RE = re.compile(
+    r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error)$"
+)
 _STRUCTURED_QUERY_TOKEN_RE = re.compile(
     r"(?<!\S)(?P<key>[A-Za-z][A-Za-z0-9_.-]*):(?P<value>\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|\S+)"
 )
@@ -167,6 +173,7 @@ def _normalize_issue_search_query(query: str) -> str:
             if not _is_quoted_search_query(free_text)
             and (
                 _starts_like_exception_signature(free_text)
+                or _is_bare_exception_name(free_text)
                 or _looks_like_exception_signature(free_text)
             )
             else free_text
@@ -185,24 +192,43 @@ def _starts_like_exception_signature(query: str) -> bool:
     return bool(_EXCEPTION_QUERY_PREFIX_RE.search(query))
 
 
+def _is_bare_exception_name(query: str) -> bool:
+    return bool(_BARE_EXCEPTION_QUERY_NAME_RE.fullmatch(query))
+
+
 def _split_structured_query_filters(query: str) -> tuple[str, list[str]]:
-    filters: list[str] = []
-    free_text_parts: list[str] = []
-    cursor = 0
-
-    for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query):
-        if match.group("key") not in _STRUCTURED_QUERY_KEYS:
-            continue
-        free_text_parts.append(query[cursor : match.start()])
-        filters.append(match.group(0))
-        cursor = match.end()
-
-    if not filters:
+    matches = [
+        match
+        for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query)
+        if match.group("key") in _STRUCTURED_QUERY_KEYS
+    ]
+    if not matches:
         return query, []
 
-    free_text_parts.append(query[cursor:])
-    free_text = " ".join(part.strip() for part in free_text_parts if part.strip())
-    return free_text, filters
+    trailing_filters: list[str] = []
+    suffix_start = len(query)
+    match_index = len(matches) - 1
+
+    while match_index >= 0:
+        match = matches[match_index]
+        if query[match.end() : suffix_start].strip():
+            break
+        trailing_filters.insert(0, match.group(0))
+        suffix_start = match.start()
+        match_index -= 1
+
+    if not trailing_filters:
+        return query, []
+
+    free_text = query[:suffix_start].strip()
+    if not free_text:
+        return "", trailing_filters
+
+    bare_exception_prefix = _BARE_EXCEPTION_QUERY_PREFIX_RE.fullmatch(free_text)
+    if bare_exception_prefix:
+        free_text = bare_exception_prefix.group("name")
+
+    return free_text, trailing_filters
 
 
 def _looks_like_exception_signature(query: str) -> bool:

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -23,7 +23,7 @@ _BARE_EXCEPTION_QUERY_PREFIX_RE = re.compile(
 _BARE_EXCEPTION_QUERY_NAME_RE = re.compile(
     r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error)$"
 )
-_STRUCTURED_QUERY_KEY_RE = re.compile(r"(?<!\S)(?P<key>[A-Za-z][A-Za-z0-9_.-]*):")
+_STRUCTURED_QUERY_KEY_RE = re.compile(r"(?<!\S)!?(?P<key>[A-Za-z][A-Za-z0-9_.-]*):")
 _STRUCTURED_QUERY_KEYS = frozenset(
     {
         "age",

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -164,10 +164,10 @@ def _normalize_issue_search_query(query: str) -> str:
     if not stripped or _is_quoted_search_query(stripped):
         return stripped
 
-    free_text, filters = _split_structured_query_filters(stripped)
-    if filters and not free_text:
+    free_text, leading_filters, trailing_filters = _split_structured_query_filters(stripped)
+    if (leading_filters or trailing_filters) and not free_text:
         return stripped
-    if filters:
+    if leading_filters or trailing_filters:
         normalized_free_text = (
             _quote_search_phrase(free_text)
             if not _is_quoted_search_query(free_text)
@@ -178,7 +178,7 @@ def _normalize_issue_search_query(query: str) -> str:
             )
             else free_text
         )
-        return " ".join([normalized_free_text, *filters])
+        return " ".join([*leading_filters, normalized_free_text, *trailing_filters])
     if _starts_like_exception_signature(stripped) or _looks_like_exception_signature(stripped):
         return _quote_search_phrase(stripped)
     return stripped
@@ -196,20 +196,32 @@ def _is_bare_exception_name(query: str) -> bool:
     return bool(_BARE_EXCEPTION_QUERY_NAME_RE.fullmatch(query))
 
 
-def _split_structured_query_filters(query: str) -> tuple[str, list[str]]:
+def _split_structured_query_filters(query: str) -> tuple[str, list[str], list[str]]:
     matches = [
         match
         for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query)
         if match.group("key") in _STRUCTURED_QUERY_KEYS
     ]
     if not matches:
-        return query, []
+        return query, [], []
+
+    leading_filters: list[str] = []
+    prefix_end = 0
+    match_index = 0
+
+    while match_index < len(matches):
+        match = matches[match_index]
+        if query[prefix_end : match.start()].strip():
+            break
+        leading_filters.append(match.group(0))
+        prefix_end = match.end()
+        match_index += 1
 
     trailing_filters: list[str] = []
     suffix_start = len(query)
     match_index = len(matches) - 1
 
-    while match_index >= 0:
+    while match_index >= len(leading_filters):
         match = matches[match_index]
         if query[match.end() : suffix_start].strip():
             break
@@ -217,18 +229,18 @@ def _split_structured_query_filters(query: str) -> tuple[str, list[str]]:
         suffix_start = match.start()
         match_index -= 1
 
-    if not trailing_filters:
-        return query, []
+    if not leading_filters and not trailing_filters:
+        return query, [], []
 
-    free_text = query[:suffix_start].strip()
+    free_text = query[prefix_end:suffix_start].strip()
     if not free_text:
-        return "", trailing_filters
+        return "", leading_filters, trailing_filters
 
     bare_exception_prefix = _BARE_EXCEPTION_QUERY_PREFIX_RE.fullmatch(free_text)
     if bare_exception_prefix:
         free_text = bare_exception_prefix.group("name")
 
-    return free_text, trailing_filters
+    return free_text, leading_filters, trailing_filters
 
 
 def _looks_like_exception_signature(query: str) -> bool:

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -242,11 +242,13 @@ def _structured_query_tokens(query: str) -> list[tuple[int, int, str]]:
         if value_start >= len(query) or query[value_start].isspace():
             continue
         end = _structured_query_value_end(query, value_start)
+        if end is None:
+            continue
         tokens.append((match.start(), end, query[match.start() : end]))
     return tokens
 
 
-def _structured_query_value_end(query: str, value_start: int) -> int:
+def _structured_query_value_end(query: str, value_start: int) -> int | None:
     quote = query[value_start]
     if quote in {'"', "'"}:
         index = value_start + 1
@@ -260,6 +262,7 @@ def _structured_query_value_end(query: str, value_start: int) -> int:
             elif char == quote:
                 return index + 1
             index += 1
+        return None
 
     index = value_start
     while index < len(query) and not query[index].isspace():

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -23,9 +23,7 @@ _BARE_EXCEPTION_QUERY_PREFIX_RE = re.compile(
 _BARE_EXCEPTION_QUERY_NAME_RE = re.compile(
     r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error)$"
 )
-_STRUCTURED_QUERY_TOKEN_RE = re.compile(
-    r"(?<!\S)(?P<key>[A-Za-z][A-Za-z0-9_.-]*):(?P<value>\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|\S+)"
-)
+_STRUCTURED_QUERY_KEY_RE = re.compile(r"(?<!\S)(?P<key>[A-Za-z][A-Za-z0-9_.-]*):")
 _STRUCTURED_QUERY_KEYS = frozenset(
     {
         "age",
@@ -197,37 +195,33 @@ def _is_bare_exception_name(query: str) -> bool:
 
 
 def _split_structured_query_filters(query: str) -> tuple[str, list[str], list[str]]:
-    matches = [
-        match
-        for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query)
-        if match.group("key") in _STRUCTURED_QUERY_KEYS
-    ]
-    if not matches:
+    tokens = _structured_query_tokens(query)
+    if not tokens:
         return query, [], []
 
     leading_filters: list[str] = []
     prefix_end = 0
-    match_index = 0
+    token_index = 0
 
-    while match_index < len(matches):
-        match = matches[match_index]
-        if query[prefix_end : match.start()].strip():
+    while token_index < len(tokens):
+        start, end, text = tokens[token_index]
+        if query[prefix_end:start].strip():
             break
-        leading_filters.append(match.group(0))
-        prefix_end = match.end()
-        match_index += 1
+        leading_filters.append(text)
+        prefix_end = end
+        token_index += 1
 
     trailing_filters: list[str] = []
     suffix_start = len(query)
-    match_index = len(matches) - 1
+    token_index = len(tokens) - 1
 
-    while match_index >= len(leading_filters):
-        match = matches[match_index]
-        if query[match.end() : suffix_start].strip():
+    while token_index >= len(leading_filters):
+        start, end, text = tokens[token_index]
+        if query[end:suffix_start].strip():
             break
-        trailing_filters.insert(0, match.group(0))
-        suffix_start = match.start()
-        match_index -= 1
+        trailing_filters.insert(0, text)
+        suffix_start = start
+        token_index -= 1
 
     if not leading_filters and not trailing_filters:
         return query, [], []
@@ -241,6 +235,40 @@ def _split_structured_query_filters(query: str) -> tuple[str, list[str], list[st
         free_text = bare_exception_prefix.group("name")
 
     return free_text, leading_filters, trailing_filters
+
+
+def _structured_query_tokens(query: str) -> list[tuple[int, int, str]]:
+    tokens: list[tuple[int, int, str]] = []
+    for match in _STRUCTURED_QUERY_KEY_RE.finditer(query):
+        if match.group("key") not in _STRUCTURED_QUERY_KEYS:
+            continue
+        value_start = match.end()
+        if value_start >= len(query) or query[value_start].isspace():
+            continue
+        end = _structured_query_value_end(query, value_start)
+        tokens.append((match.start(), end, query[match.start() : end]))
+    return tokens
+
+
+def _structured_query_value_end(query: str, value_start: int) -> int:
+    quote = query[value_start]
+    if quote in {'"', "'"}:
+        index = value_start + 1
+        escaped = False
+        while index < len(query):
+            char = query[index]
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                return index + 1
+            index += 1
+
+    index = value_start
+    while index < len(query) and not query[index].isspace():
+        index += 1
+    return index
 
 
 def _looks_like_exception_signature(query: str) -> bool:

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -164,8 +164,11 @@ def _normalize_issue_search_query(query: str) -> str:
     if filters:
         normalized_free_text = (
             _quote_search_phrase(free_text)
-            if _starts_like_exception_signature(free_text)
-            or _looks_like_exception_signature(free_text)
+            if not _is_quoted_search_query(free_text)
+            and (
+                _starts_like_exception_signature(free_text)
+                or _looks_like_exception_signature(free_text)
+            )
             else free_text
         )
         return " ".join([normalized_free_text, *filters])

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,6 +14,7 @@ from app.strict_config import StrictConfigModel
 
 DEFAULT_SENTRY_URL = "https://sentry.io"
 DEFAULT_SENTRY_STATS_PERIOD = "24h"
+_STRUCTURED_QUERY_TOKEN_RE = re.compile(r"(?:^|\s)[a-z][a-z0-9_.-]*:")
 
 
 class SentryConfig(StrictConfigModel):
@@ -93,14 +95,39 @@ def _build_issue_list_params(
     limit: int,
     query: str,
 ) -> list[tuple[str, str | int | float | bool | None]]:
+    normalized_query = _normalize_issue_search_query(query)
     params: list[tuple[str, str | int | float | bool | None]] = [
         ("limit", str(limit)),
         ("statsPeriod", DEFAULT_SENTRY_STATS_PERIOD),
-        ("query", query),
+        ("query", normalized_query),
     ]
     if config.project_slug:
         params.append(("project", config.project_slug))
     return params
+
+
+def _normalize_issue_search_query(query: str) -> str:
+    stripped = query.strip()
+    if not stripped or _is_quoted_search_query(stripped):
+        return stripped
+    if _STRUCTURED_QUERY_TOKEN_RE.search(stripped):
+        return stripped
+    if _looks_like_exception_signature(stripped):
+        return _quote_search_phrase(stripped)
+    return stripped
+
+
+def _is_quoted_search_query(query: str) -> bool:
+    return len(query) >= 2 and query[0] == '"' and query[-1] == '"'
+
+
+def _looks_like_exception_signature(query: str) -> bool:
+    return ":" in query and any(char in query for char in (" ", "(", ")", "/", "\\"))
+
+
+def _quote_search_phrase(query: str) -> str:
+    escaped = query.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
 
 
 def _request_json(

--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -17,7 +17,9 @@ DEFAULT_SENTRY_STATS_PERIOD = "24h"
 _EXCEPTION_QUERY_PREFIX_RE = re.compile(
     r"^(?:[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Interrupt|Warning)?|panic|error|runtime error|fatal error):\s*"
 )
-_STRUCTURED_QUERY_TOKEN_RE = re.compile(r"(?:^|\s)([A-Za-z][A-Za-z0-9_.-]*):")
+_STRUCTURED_QUERY_TOKEN_RE = re.compile(
+    r"(?<!\S)(?P<key>[A-Za-z][A-Za-z0-9_.-]*):(?P<value>\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|\S+)"
+)
 _STRUCTURED_QUERY_KEYS = frozenset(
     {
         "age",
@@ -155,11 +157,19 @@ def _normalize_issue_search_query(query: str) -> str:
     stripped = query.strip()
     if not stripped or _is_quoted_search_query(stripped):
         return stripped
-    if _starts_like_exception_signature(stripped):
-        return _quote_search_phrase(stripped)
-    if _has_structured_query_token(stripped):
+
+    free_text, filters = _split_structured_query_filters(stripped)
+    if filters and not free_text:
         return stripped
-    if _looks_like_exception_signature(stripped):
+    if filters:
+        normalized_free_text = (
+            _quote_search_phrase(free_text)
+            if _starts_like_exception_signature(free_text)
+            or _looks_like_exception_signature(free_text)
+            else free_text
+        )
+        return " ".join([normalized_free_text, *filters])
+    if _starts_like_exception_signature(stripped) or _looks_like_exception_signature(stripped):
         return _quote_search_phrase(stripped)
     return stripped
 
@@ -172,11 +182,24 @@ def _starts_like_exception_signature(query: str) -> bool:
     return bool(_EXCEPTION_QUERY_PREFIX_RE.search(query))
 
 
-def _has_structured_query_token(query: str) -> bool:
-    return any(
-        match.group(1) in _STRUCTURED_QUERY_KEYS
-        for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query)
-    )
+def _split_structured_query_filters(query: str) -> tuple[str, list[str]]:
+    filters: list[str] = []
+    free_text_parts: list[str] = []
+    cursor = 0
+
+    for match in _STRUCTURED_QUERY_TOKEN_RE.finditer(query):
+        if match.group("key") not in _STRUCTURED_QUERY_KEYS:
+            continue
+        free_text_parts.append(query[cursor : match.start()])
+        filters.append(match.group(0))
+        cursor = match.end()
+
+    if not filters:
+        return query, []
+
+    free_text_parts.append(query[cursor:])
+    free_text = " ".join(part.strip() for part in free_text_parts if part.strip())
+    return free_text, filters
 
 
 def _looks_like_exception_signature(query: str) -> bool:

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -73,6 +73,17 @@ def test_list_sentry_issues_preserves_negated_structured_queries(
     assert ("query", query) in captured["params"]
 
 
+def test_list_sentry_issues_preserves_plain_colon_text_queries(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "team: backend rollout"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", query) in captured["params"]
+
+
 def test_list_sentry_issues_escapes_quotes_in_exception_signatures(
     monkeypatch: Any,
 ) -> None:
@@ -102,6 +113,17 @@ def test_list_sentry_issues_quotes_lowercase_panic_signatures(
     captured = _capture_sentry_issue_params(monkeypatch)
 
     query = "panic: runtime error: invalid memory address or nil pointer dereference"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", f'"{query}"') in captured["params"]
+
+
+def test_list_sentry_issues_quotes_package_qualified_exception_signatures(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "java.lang.NullPointerException: Cannot invoke getName()"
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     assert ("query", f'"{query}"') in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -62,6 +62,17 @@ def test_list_sentry_issues_preserves_quoted_structured_filter_values(
     assert ("query", query) in captured["params"]
 
 
+def test_list_sentry_issues_preserves_negated_structured_queries(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "!is:resolved !level:info"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", query) in captured["params"]
+
+
 def test_list_sentry_issues_escapes_quotes_in_exception_signatures(
     monkeypatch: Any,
 ) -> None:
@@ -187,4 +198,28 @@ def test_list_sentry_issues_preserves_filters_around_exception_text(
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     expected_query = 'is:unresolved "panic: nil pointer" level:fatal'
+    assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_preserves_negated_filters_with_exception_text(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "TypeError: cannot read property !is:resolved !level:info"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = '"TypeError: cannot read property" !is:resolved !level:info'
+    assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_preserves_leading_negated_filters(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "!is:resolved !level:info TypeError: cannot read property"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = '!is:resolved !level:info "TypeError: cannot read property"'
     assert ("query", expected_query) in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -94,3 +94,27 @@ def test_list_sentry_issues_quotes_bare_colon_exception_signatures(
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     assert ("query", f'"{query}"') in captured["params"]
+
+
+def test_list_sentry_issues_preserves_filters_after_exception_text(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "TypeError: cannot read property 'x' is:unresolved level:error"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = "\"TypeError: cannot read property 'x'\" is:unresolved level:error"
+    assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_preserves_filters_after_lowercase_panic(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "panic: nil pointer is:unresolved level:fatal"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = '"panic: nil pointer" is:unresolved level:fatal'
+    assert ("query", expected_query) in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -153,3 +153,27 @@ def test_list_sentry_issues_drops_bare_exception_separator_before_filters(
 
     expected_query = '"TypeError" is:unresolved level:error'
     assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_preserves_filters_before_exception_text(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "is:unresolved level:error TypeError: cannot read property"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = 'is:unresolved level:error "TypeError: cannot read property"'
+    assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_preserves_filters_around_exception_text(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "is:unresolved panic: nil pointer level:fatal"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = 'is:unresolved "panic: nil pointer" level:fatal'
+    assert ("query", expected_query) in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -118,3 +118,14 @@ def test_list_sentry_issues_preserves_filters_after_lowercase_panic(
 
     expected_query = '"panic: nil pointer" is:unresolved level:fatal'
     assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_preserves_prequoted_exception_text_with_filters(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = '"TypeError: cannot read property" is:unresolved'
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", query) in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -51,6 +51,17 @@ def test_list_sentry_issues_preserves_structured_queries(monkeypatch: Any) -> No
     assert ("query", query) in captured["params"]
 
 
+def test_list_sentry_issues_preserves_quoted_structured_filter_values(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = 'is:unresolved title:"Cannot read properties" level:error'
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", query) in captured["params"]
+
+
 def test_list_sentry_issues_escapes_quotes_in_exception_signatures(
     monkeypatch: Any,
 ) -> None:

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -1,0 +1,63 @@
+"""Tests for shared Sentry integration helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.integrations.sentry import SentryConfig, list_sentry_issues
+
+
+def _config() -> SentryConfig:
+    return SentryConfig(organization_slug="ide-zy", auth_token="tok_test")
+
+
+def _capture_sentry_issue_params(monkeypatch: Any) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def fake_request(
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: list[tuple[str, object]],
+        timeout: float,
+    ) -> httpx.Response:
+        captured["params"] = params
+        return httpx.Response(200, json=[], request=httpx.Request(method, url))
+
+    monkeypatch.setattr("app.integrations.sentry.httpx.request", fake_request)
+    return captured
+
+
+def test_list_sentry_issues_quotes_exception_signature_queries(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "TypeError: Cannot read properties of null (reading mailapi) at src/mail/sync.ts:142"
+    assert list_sentry_issues(config=_config(), query=query, limit=10) == []
+
+    assert ("query", f'"{query}"') in captured["params"]
+
+
+def test_list_sentry_issues_preserves_structured_queries(monkeypatch: Any) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "is:unresolved level:error"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", query) in captured["params"]
+
+
+def test_list_sentry_issues_escapes_quotes_in_exception_signatures(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = 'TypeError: Cannot read "mailapi" at src/mail/sync.ts:142'
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = '"TypeError: Cannot read \\"mailapi\\" at src/mail/sync.ts:142"'
+    assert ("query", expected_query) in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -62,6 +62,17 @@ def test_list_sentry_issues_preserves_quoted_structured_filter_values(
     assert ("query", query) in captured["params"]
 
 
+def test_list_sentry_issues_ignores_unclosed_quoted_structured_values(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = 'title:"Cannot read TypeError: boom'
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", query) in captured["params"]
+
+
 def test_list_sentry_issues_preserves_negated_structured_queries(
     monkeypatch: Any,
 ) -> None:

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -129,3 +129,27 @@ def test_list_sentry_issues_preserves_prequoted_exception_text_with_filters(
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     assert ("query", query) in captured["params"]
+
+
+def test_list_sentry_issues_keeps_filter_tokens_inside_exception_messages(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "TypeError: unexpected level:error state is:unresolved"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = '"TypeError: unexpected level:error state" is:unresolved'
+    assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_drops_bare_exception_separator_before_filters(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "TypeError: is:unresolved level:error"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    expected_query = '"TypeError" is:unresolved level:error'
+    assert ("query", expected_query) in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -45,7 +45,7 @@ def test_list_sentry_issues_quotes_exception_signature_queries(
 def test_list_sentry_issues_preserves_structured_queries(monkeypatch: Any) -> None:
     captured = _capture_sentry_issue_params(monkeypatch)
 
-    query = "is:unresolved level:error url:http://example.test/login"
+    query = "is:unresolved level:error error.type:TypeError url:http://example.test/login"
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     assert ("query", query) in captured["params"]
@@ -80,6 +80,17 @@ def test_list_sentry_issues_quotes_lowercase_panic_signatures(
     captured = _capture_sentry_issue_params(monkeypatch)
 
     query = "panic: runtime error: invalid memory address or nil pointer dereference"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", f'"{query}"') in captured["params"]
+
+
+def test_list_sentry_issues_quotes_bare_colon_exception_signatures(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "KeyError:missing_key"
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     assert ("query", f'"{query}"') in captured["params"]

--- a/tests/integrations/test_sentry.py
+++ b/tests/integrations/test_sentry.py
@@ -45,7 +45,7 @@ def test_list_sentry_issues_quotes_exception_signature_queries(
 def test_list_sentry_issues_preserves_structured_queries(monkeypatch: Any) -> None:
     captured = _capture_sentry_issue_params(monkeypatch)
 
-    query = "is:unresolved level:error"
+    query = "is:unresolved level:error url:http://example.test/login"
     list_sentry_issues(config=_config(), query=query, limit=10)
 
     assert ("query", query) in captured["params"]
@@ -61,3 +61,25 @@ def test_list_sentry_issues_escapes_quotes_in_exception_signatures(
 
     expected_query = '"TypeError: Cannot read \\"mailapi\\" at src/mail/sync.ts:142"'
     assert ("query", expected_query) in captured["params"]
+
+
+def test_list_sentry_issues_quotes_os_errors_with_word_colons(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "OSError: No such file or directory: '/tmp/cache/index.json'"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", f'"{query}"') in captured["params"]
+
+
+def test_list_sentry_issues_quotes_lowercase_panic_signatures(
+    monkeypatch: Any,
+) -> None:
+    captured = _capture_sentry_issue_params(monkeypatch)
+
+    query = "panic: runtime error: invalid memory address or nil pointer dereference"
+    list_sentry_issues(config=_config(), query=query, limit=10)
+
+    assert ("query", f'"{query}"') in captured["params"]


### PR DESCRIPTION
## Summary
- Quote exception-like Sentry issue search queries before sending them to the issues API.
- Preserve structured Sentry filters such as `is:unresolved level:error`.
- Add integration tests covering the #1965 failure shape and quote escaping.

## Validation
- `uv run --extra dev python -m pytest tests/integrations/test_sentry.py tests/tools/test_sentry_search_issues_tool.py -q`
- `uv run --extra dev ruff check app/integrations/sentry.py tests/integrations/test_sentry.py tests/tools/test_sentry_search_issues_tool.py`
- `uv run --extra dev ruff format --check app/integrations/sentry.py tests/integrations/test_sentry.py tests/tools/test_sentry_search_issues_tool.py`
- `uv run --extra dev mypy app/integrations/sentry.py`
- `git diff --check`

Closes #1965