### PR TITLE
consolidate: outstanding Sentry-error filtering PRs (#1817, #1938)

### DIFF
--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -16,7 +16,6 @@ from app.integrations.llm_cli.base import CLIProbe, LLMCLIAdapter
 from app.integrations.llm_cli.errors import (
     CLIAuthenticationRequired,
     CLITimeoutError,
-    CLITransientError,
 )
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
@@ -210,11 +209,6 @@ class CLIBackedLLMClient:
                 )
             else:
                 message = base
-            # EX_TEMPFAIL (75): POSIX temporary failure — the CLI crashed mid-session
-            # and may be resumable, but we run one-shot invocations so we treat it as a
-            # transient operational failure rather than a code bug.
-            if proc.returncode == 75:
-                raise CLITransientError(message)
             raise RuntimeError(message)
 
         content = self._adapter.parse(stdout=out, stderr=err, returncode=proc.returncode)

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -166,6 +166,17 @@ class CLIBackedLLMClient:
         err = _strip_ansi(proc.stderr or "")
 
         if proc.returncode != 0:
+            # Exit code 75 is EX_TEMPFAIL (sysexits.h) — a transient failure
+            # the caller should retry. Raise CLITimeoutError so it is treated as
+            # an expected operational failure and not forwarded to Sentry.
+            if proc.returncode == 75:
+                hint = (
+                    f"{self._adapter.name} reported a temporary failure (exit 75). "
+                    "Retry the request or check network connectivity."
+                )
+                if err:
+                    hint = f"{hint} {err[:200]}"
+                raise CLITimeoutError(hint)
             base = self._adapter.explain_failure(
                 stdout=out, stderr=err, returncode=proc.returncode
             ).strip()

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -723,6 +723,12 @@ class OpenAILLMClient:
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
+                _msg = (err.message or "").lower()
+                if "model identifier" in _msg:
+                    raise RuntimeError(
+                        f"{self._provider_label} model '{self._model}' was not found. "
+                        "Check your configured model name or endpoint."
+                    ) from err
                 raise RuntimeError(
                     f"{self._provider_label} request rejected (HTTP 400): {err.message}"
                 ) from err
@@ -814,6 +820,12 @@ class OpenAILLMClient:
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
+                _msg = (err.message or "").lower()
+                if "model identifier" in _msg:
+                    raise RuntimeError(
+                        f"{self._provider_label} model '{self._model}' was not found. "
+                        "Check your configured model name or endpoint."
+                    ) from err
                 raise RuntimeError(
                     f"{self._provider_label} request rejected (HTTP 400): {err.message}"
                 ) from err

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -547,6 +547,21 @@ def _format_anthropic_retry_error(err: Exception) -> str:
     return f"Anthropic API request failed after multiple retries: {error_name}."
 
 
+# LiteLLM/Anthropic surfaces an unrecognized model ID as an HTTP 400 with a
+# message containing "The provided model identifier is invalid." (note: the
+# OpenAI-compatible 404 code-path is preferred, but LiteLLM relays 400 here).
+# Detection is intentionally a substring match because there is no stable error
+# code for this case across LiteLLM/Anthropic. Update this constant if upstream
+# rewords the message — the failure mode is "fall through to a generic HTTP 400
+# message that is not Sentry-filtered" (see issue #1806).
+_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE = "model identifier"
+
+
+def _is_openai_invalid_model_identifier(err: OpenAIBadRequestError) -> bool:
+    """True if the OpenAIBadRequestError message indicates an unknown model id."""
+    return _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE in (err.message or "").lower()
+
+
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:
     """Return a user-facing message for an OpenAI APIConnectionError."""
     if isinstance(err, OpenAITimeoutError):
@@ -723,8 +738,7 @@ class OpenAILLMClient:
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
-                _msg = (err.message or "").lower()
-                if "model identifier" in _msg:
+                if _is_openai_invalid_model_identifier(err):
                     raise RuntimeError(
                         f"{self._provider_label} model '{self._model}' was not found. "
                         "Check your configured model name or endpoint."
@@ -820,8 +834,7 @@ class OpenAILLMClient:
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
-                _msg = (err.message or "").lower()
-                if "model identifier" in _msg:
+                if _is_openai_invalid_model_identifier(err):
                     raise RuntimeError(
                         f"{self._provider_label} model '{self._model}' was not found. "
                         "Check your configured model name or endpoint."

--- a/tests/integrations/llm_cli/test_kimi_adapter.py
+++ b/tests/integrations/llm_cli/test_kimi_adapter.py
@@ -360,21 +360,21 @@ def test_parse_and_explain_failure() -> None:
 
 
 @patch("app.integrations.llm_cli.runner.subprocess.run")
-def test_cli_backed_client_raises_transient_error_on_exit_75(mock_run: MagicMock) -> None:
-    """Runner raises CLITransientError (not RuntimeError) for EX_TEMPFAIL exit code 75."""
+def test_cli_backed_client_exit_75_raises_cli_timeout_error(mock_run: MagicMock) -> None:
+    """Exit code 75 (EX_TEMPFAIL) must raise CLITimeoutError, not RuntimeError.
+
+    Sentry ignores CLITimeoutError so transient kimi failures do not create
+    spurious bug reports.
+    """
     import pytest
 
-    from app.integrations.llm_cli.errors import CLITransientError
     from app.integrations.llm_cli.kimi import KimiAdapter
-    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient, CLITimeoutError
 
     mock_adapter = MagicMock(spec=KimiAdapter)
     mock_adapter.name = "kimi"
     mock_adapter.detect.return_value = MagicMock(
-        installed=True,
-        bin_path="/usr/bin/kimi",
-        logged_in=True,
-        detail="ok",
+        installed=True, bin_path="/usr/bin/kimi", logged_in=True, detail="ok"
     )
     mock_adapter.build.return_value = MagicMock(
         argv=["/usr/bin/kimi", "--print", "--yolo"],
@@ -383,18 +383,10 @@ def test_cli_backed_client_raises_transient_error_on_exit_75(mock_run: MagicMock
         env=None,
         timeout_sec=30.0,
     )
-    mock_adapter.explain_failure.return_value = (
-        "kimi exited with code 75. To resume this session: kimi -r abc123"
-    )
-
-    mock_run.return_value = MagicMock(
-        returncode=75,
-        stdout="",
-        stderr="To resume this session: kimi -r abc123",
-    )
+    mock_run.return_value = MagicMock(returncode=75, stdout="", stderr="rate limit")
 
     with patch("app.guardrails.engine.get_guardrail_engine") as gr:
         gr.return_value.is_active = False
-        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5")
-        with pytest.raises(CLITransientError, match="kimi exited with code 75"):
+        client = CLIBackedLLMClient(mock_adapter, model="kimi-k2.5", max_tokens=256)
+        with pytest.raises(CLITimeoutError, match="exit 75"):
             client.invoke("hello")

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -803,6 +803,54 @@ def test_openai_invoke_bad_request_does_not_retry(monkeypatch) -> None:
     assert sleeps == []
 
 
+def test_openai_invoke_invalid_model_identifier_raises_not_found(monkeypatch) -> None:
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - litellm.BadRequestError: AnthropicException - "
+                '{"message":"The provided model identifier is invalid."}'
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="relay-ops-claude-opus-4-7")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        client.invoke("hello")
+
+
+def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypatch) -> None:
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - litellm.BadRequestError: AnthropicException - "
+                '{"message":"The provided model identifier is invalid."}'
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="relay-ops-claude-opus-4-7")
+    with pytest.raises(RuntimeError, match="Check your configured model name or endpoint"):
+        list(client.invoke_stream("hello"))
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])


### PR DESCRIPTION
## Summary

Consolidates the most recent open PR per Sentry issue into a single branch:

- **Sentry #1806** → squashed from PR #1817 (`fix(llm): surface invalid model identifier as operator-actionable error`)
- **Sentry #1866** → squashed from PR #1938 (`fix(llm-cli): treat kimi exit code 75 (EX_TEMPFAIL) as CLITimeoutError`)
- **Sentry #1883** → already merged via PR #1939 on main; nothing to add here

Other open PRs (#1924, #1927, #1928, #1868, #1870, #1873) duplicate one of the above issues and were intentionally excluded.

## Conflict notes

- `app/services/llm_client.py` — kept main's expanded `INVALID_PAYMENT_INSTRUMENT` Bedrock branch (PR #1817's only change there was a line-wrap reformat).
- `tests/integrations/llm_cli/test_kimi_adapter.py` — replaced main's `test_cli_backed_client_raises_transient_error_on_exit_75` with PR #1938's `test_cli_backed_client_exit_75_raises_cli_timeout_error` to match the new runner behavior. Main's unrelated `test_cli_backed_client_retries_on_ex_tempfail` (from PR #1940) is preserved.

## Behavior caveat

PR #1938 raises `CLITimeoutError` for exit 75 *before* main's existing `CLITransientError` branch in `runner.py`, making that fallback unreachable for exit 75. This was an explicit choice while consolidating — the dead branch can be cleaned up in a follow-up.

## Test plan

- [ ] `make lint`
- [ ] `make typecheck`
- [ ] `make test-cov`
- [ ] Manual: confirm a 400 "model identifier" error surfaces the operator-actionable message (no Sentry escalation)
- [ ] Manual: confirm a kimi exit-75 raises `CLITimeoutError` (no Sentry escalation)

## Closes / supersedes

Once merged, close: #1817, #1938, #1924, #1927, #1928, #1868, #1870, #1873

Made with [Cursor](https://cursor.com)