### PR TITLE
fix(security): clear remaining open CodeQL alerts

### DIFF
--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -455,12 +455,45 @@ def _release_election_flock(fd: int | None) -> None:
 
 @contextmanager
 def _hold_election_flock(path: Path) -> Iterator[None]:
-    """Acquire the cross-process election flock for ``path`` for one ``with`` block."""
-    fd = _acquire_election_flock(path)
-    try:
+    """Acquire the cross-process election flock for ``path`` for one ``with`` block.
+
+    The fd lifecycle (``os.open`` → ``flock`` → ``flock LOCK_UN`` → ``os.close``)
+    lives entirely in this scope so static analyzers can verify the file is
+    always closed (CodeQL ``py/file-not-closed``). The standalone
+    ``_acquire_election_flock`` / ``_release_election_flock`` helpers are kept
+    for tests that exercise the half-paired primitive directly.
+    """
+    if _fcntl is None:
+        # No flock support (Windows, exotic FS). Matches the
+        # ``_acquire_election_flock`` → ``None`` contract: yield without
+        # holding a cross-process lock.
         yield
+        return
+
+    lock_path = _election_lock_path(path)
+    try:
+        _ensure_parent_dir(lock_path)
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    except OSError:
+        yield
+        return
+
+    try:
+        try:
+            _fcntl.flock(fd, _fcntl.LOCK_EX)
+        except OSError:
+            # Could not acquire flock; proceed without it (best-effort
+            # election, matching the original ``None``-on-failure contract).
+            yield
+            return
+        try:
+            yield
+        finally:
+            with suppress(OSError):
+                _fcntl.flock(fd, _fcntl.LOCK_UN)
     finally:
-        _release_election_flock(fd)
+        with suppress(OSError):
+            os.close(fd)
 
 
 def _ensure_broker(path: Path) -> BusServer | None:

--- a/app/hermes/poller.py
+++ b/app/hermes/poller.py
@@ -351,7 +351,11 @@ def _read_segment(
     since_queue: deque[bool] = deque()  # one entry per Traceback opener, in order
     prev_was_continuation = False  # tracks boundary for queue pop
     last_parent_passes_since = since is None  # seed when queue is empty
-    new_offset = start_offset
+    # ``new_offset`` is written exactly once per loop iteration from
+    # ``line_start`` (see comment below). ``while True`` guarantees the loop
+    # body runs at least once before any reachable return, so no module-level
+    # seed is needed — adding one would just trip CodeQL
+    # ``py/multiple-definition``.
 
     with path.open("rb") as handle:
         handle.seek(start_offset)
@@ -363,9 +367,13 @@ def _read_segment(
         while True:
             line_start = handle.tell()
             raw = handle.readline()
-            # ``line_start`` is the resume offset on EOF or when the line
-            # does not fit in ``budget``; assign once here so CodeQL does
-            # not flag redundant writes on those break paths.
+            # Single ``new_offset`` write per iteration so CodeQL does not
+            # flag redundant assignments (``py/multiple-definition``). On
+            # the EOF / budget / max_lines break paths ``line_start`` IS the
+            # resume offset; on the record-is-None ``continue`` and on the
+            # normal end-of-body path, the next iteration's ``handle.tell()``
+            # advances past the consumed line so the next write here
+            # captures the new end-of-stream cursor.
             new_offset = line_start
             if not raw:
                 break
@@ -384,15 +392,10 @@ def _read_segment(
                     truncated = max(truncated, 1)
                 break
             budget -= len(raw)
-            # Post-line offset is deterministic from line_start + raw length;
-            # no extra tell() needed and there is exactly one assignment path
-            # per iteration that reaches the loop top again.
-            line_end = line_start + len(raw)
 
             line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
             record = parse_log_line(line, prev_level=prev_level)
             if record is None:
-                new_offset = line_end
                 continue
 
             passes_level = level_filter is None or record.level in level_filter
@@ -447,7 +450,6 @@ def _read_segment(
 
             if passes_level and passes_since:
                 records.append(record)
-            new_offset = line_end
 
     return tuple(records), tuple(incidents), new_offset, parsed_count, truncated
 

--- a/tests/analytics/test_cli.py
+++ b/tests/analytics/test_cli.py
@@ -196,14 +196,20 @@ def test_track_investigation_emits_failed_on_exception(
     stub = _StubAnalytics()
     monkeypatch.setattr(cli, "get_analytics", lambda: stub)
 
-    with pytest.raises(RuntimeError, match="boom"):  # noqa: SIM117
-        # Keep nested (not combined) so CodeQL can prove control flow past the
-        # raise via pytest.raises is reachable (see PR #1846 review threads).
+    # Wrap the raise in a callable so the ``raise`` lives inside ``_trigger``
+    # rather than directly in the test body. ``pytest.raises`` then sees a
+    # plain function call as its protected expression, which lets CodeQL
+    # ``py/unreachable-statement`` prove the assertions below are reachable
+    # (the previous nested-``with`` workaround still tripped the rule).
+    def _trigger() -> None:
         with cli.track_investigation(
             entrypoint=EntrypointSource.MCP,
             trigger_mode=TriggerMode.SERVICE_RUNTIME,
         ):
             raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _trigger()
 
     emitted_events = [event for event, _ in stub.events]
     assert emitted_events == [Event.INVESTIGATION_STARTED, Event.INVESTIGATION_FAILED]


### PR DESCRIPTION
## Summary

Closes the five remaining open Code Scanning alerts on `Tracer-Cloud/opensre` ([security/code-scanning](https://github.com/Tracer-Cloud/opensre/security/code-scanning)):

| # | File | Rule |
| --- | --- | --- |
| [#889](https://github.com/Tracer-Cloud/opensre/security/code-scanning/889), [#912](https://github.com/Tracer-Cloud/opensre/security/code-scanning/912), [#913](https://github.com/Tracer-Cloud/opensre/security/code-scanning/913) | `app/hermes/poller.py` | `py/multiple-definition` |
| [#886](https://github.com/Tracer-Cloud/opensre/security/code-scanning/886) | `tests/analytics/test_cli.py` | `py/unreachable-statement` |
| [#878](https://github.com/Tracer-Cloud/opensre/security/code-scanning/878) | `app/agents/bus.py` | `py/file-not-closed` |

### Changes

- **`app/hermes/poller.py` (`py/multiple-definition`):** `new_offset` was rewritten four times per `_read_segment` iteration. Collapsed to the single canonical write right after `handle.readline()` so every break / continue / normal-end path resolves to a well-defined offset without redundant rewrites. `line_end` becomes unused and is removed along with its now-stale comment.

- **`app/agents/bus.py` (`py/file-not-closed`):** Inlined the `os.open` → `flock` → `LOCK_UN` → `os.close` lifecycle inside `_hold_election_flock` so the fd is opened and closed in the same lexical scope (CodeQL could not track the close across the `_release_election_flock` helper boundary, which is why the previous fix on alert #844 only relocated the warning to alert #878). The standalone `_acquire_election_flock` / `_release_election_flock` helpers are kept intact because `tests/agents/test_bus.py` exercises them directly.

- **`tests/analytics/test_cli.py` (`py/unreachable-statement`):** Moved the `raise RuntimeError("boom")` into a nested helper called inside `pytest.raises(...)`. CodeQL could not prove control-flow continued past the previous nested-`with` form, so it flagged the post-block assertions as unreachable; calling a function from inside `pytest.raises` is the pattern CodeQL recognises.

No behaviour change.

## Test plan

- [x] `make lint` — clean
- [x] `make format-check` — clean
- [x] `make typecheck` — clean
- [x] `pytest tests/hermes/ tests/agents/test_bus.py tests/analytics/test_cli.py` — 200/200 passing
- [ ] CodeQL re-scan on this PR closes alerts #878, #886, #889, #912, #913

Made with [Cursor](https://cursor.com)