### PR TITLE
fix(sentry): sanitize query before sending to Sentry issues API

### DIFF
--- a/app/integrations/sentry.py
+++ b/app/integrations/sentry.py
@@ -13,6 +13,7 @@ from app.strict_config import StrictConfigModel
 
 DEFAULT_SENTRY_URL = "https://sentry.io"
 DEFAULT_SENTRY_STATS_PERIOD = "24h"
+_MAX_SENTRY_QUERY_LEN = 200
 
 
 class SentryConfig(StrictConfigModel):
@@ -88,6 +89,19 @@ def get_sentry_auth_recommendations() -> dict[str, str]:
     }
 
 
+def _sanitize_sentry_query(query: str) -> str:
+    """Reduce a raw query string to something the Sentry issues API accepts.
+
+    The agent may pass a full error message or multi-line stack trace as the
+    search term, which causes a 400 Bad Request because the Sentry search
+    grammar treats ``:`` as a field separator and rejects very long URLs.
+    Taking the first non-empty line and capping at _MAX_SENTRY_QUERY_LEN
+    characters is enough to produce a valid free-text search token.
+    """
+    first_line = query.split("\n")[0].strip()
+    return first_line[:_MAX_SENTRY_QUERY_LEN]
+
+
 def _build_issue_list_params(
     config: SentryConfig,
     limit: int,
@@ -96,7 +110,7 @@ def _build_issue_list_params(
     params: list[tuple[str, str | int | float | bool | None]] = [
         ("limit", str(limit)),
         ("statsPeriod", DEFAULT_SENTRY_STATS_PERIOD),
-        ("query", query),
+        ("query", _sanitize_sentry_query(query)),
     ]
     if config.project_slug:
         params.append(("project", config.project_slug))

--- a/tests/tools/test_sentry_search_issues_tool.py
+++ b/tests/tools/test_sentry_search_issues_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from app.integrations.sentry import _MAX_SENTRY_QUERY_LEN, _sanitize_sentry_query
 from app.tools.SentrySearchIssuesTool import search_sentry_issues
 from tests.tools.conftest import BaseToolContract, mock_agent_state
 
@@ -58,3 +59,43 @@ def test_run_empty_issues() -> None:
         result = search_sentry_issues(organization_slug="my-org", sentry_token="tok_test")
     assert result["available"] is True
     assert result["issues"] == []
+
+
+# --- _sanitize_sentry_query tests ---
+
+
+def test_sanitize_sentry_query_plain_term() -> None:
+    assert _sanitize_sentry_query("TypeError") == "TypeError"
+
+
+def test_sanitize_sentry_query_multiline_takes_first_line() -> None:
+    raw = "TypeError: Cannot read\n  at foo (bar.ts:1)\n  at baz (qux.ts:2)"
+    result = _sanitize_sentry_query(raw)
+    assert "\n" not in result
+    assert result == "TypeError: Cannot read"
+
+
+def test_sanitize_sentry_query_truncates_long_query() -> None:
+    long = "a" * (_MAX_SENTRY_QUERY_LEN + 50)
+    result = _sanitize_sentry_query(long)
+    assert len(result) == _MAX_SENTRY_QUERY_LEN
+
+
+def test_sanitize_sentry_query_strips_whitespace() -> None:
+    assert _sanitize_sentry_query("  hello world  ") == "hello world"
+
+
+def test_sanitize_sentry_query_empty_string() -> None:
+    assert _sanitize_sentry_query("") == ""
+
+
+def test_build_issue_list_params_sanitizes_multiline_query() -> None:
+    """_build_issue_list_params must collapse multi-line stack traces so the
+    Sentry API does not return a 400 Bad Request."""
+    from app.integrations.sentry import SentryConfig, _build_issue_list_params
+
+    config = SentryConfig(organization_slug="my-org", auth_token="tok")
+    multiline_query = "TypeError: Cannot read props\n  at src/foo.ts:10"
+    params = dict(_build_issue_list_params(config, limit=10, query=multiline_query))
+    assert "\n" not in str(params["query"])
+    assert params["query"] == "TypeError: Cannot read props"


### PR DESCRIPTION
## Summary

- The agent passes raw error messages or multi-line stack traces as the `query` parameter to `search_sentry_issues`. The Sentry issues API returns **400 Bad Request** because `:` in `TypeError: ...` is parsed as a field:value separator and very long stack traces exceed URL length limits.
- Add `_sanitize_sentry_query()` in `app/integrations/sentry.py`: take only the first non-empty line, strip whitespace, truncate to 200 characters.
- Apply it in `_build_issue_list_params()` so all callers benefit automatically.

## Test plan

- [ ] `test_sanitize_sentry_query_plain_term` — single-word query passes through unchanged
- [ ] `test_sanitize_sentry_query_multiline_takes_first_line` — multi-line stack trace collapsed to first line
- [ ] `test_sanitize_sentry_query_truncates_long_query` — queries longer than 200 chars are truncated
- [ ] `test_sanitize_sentry_query_strips_whitespace` — leading/trailing whitespace stripped
- [ ] `test_sanitize_sentry_query_empty_string` — empty string handled safely
- [ ] `test_build_issue_list_params_sanitizes_multiline_query` — end-to-end: `_build_issue_list_params` produces a clean single-line query

Closes #1965

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgLTbwKgEJgD38G2RPFKSB)_