### PR TITLE
fix(pipeline): guard call_soon_threadsafe against closed event loop in astream_investigation

### DIFF
--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -207,7 +207,8 @@ async def astream_investigation(
             )
 
             if state_any.get("is_noise"):
-                loop.call_soon_threadsafe(event_queue.put_nowait, None)
+                with contextlib.suppress(RuntimeError):  # loop closed (consumer cancelled)
+                    loop.call_soon_threadsafe(event_queue.put_nowait, None)
                 return
 
             # --- investigation agent (with real tool events) ---

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import queue
 import threading
@@ -119,7 +120,8 @@ async def astream_investigation(
     loop = asyncio.get_running_loop()
 
     def _put(evt: StreamEvent) -> None:
-        loop.call_soon_threadsafe(event_queue.put_nowait, evt)
+        with contextlib.suppress(RuntimeError):  # loop already closed; consumer is gone
+            loop.call_soon_threadsafe(event_queue.put_nowait, evt)
 
     def _make_node_event(kind: str, node: str, data: dict[str, Any]) -> StreamEvent:
         return StreamEvent(
@@ -255,9 +257,11 @@ async def astream_investigation(
             from app.utils.sentry_sdk import capture_exception
 
             capture_exception(exc)
-            loop.call_soon_threadsafe(event_queue.put_nowait, exc)
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(event_queue.put_nowait, exc)
         finally:
-            loop.call_soon_threadsafe(event_queue.put_nowait, None)
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(event_queue.put_nowait, None)
 
     thread = threading.Thread(target=_run_pipeline, daemon=True)
     thread.start()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When the consumer of `astream_investigation` cancels (client disconnect, Ctrl+C) while the background thread is still running, `loop.call_soon_threadsafe()` raises `RuntimeError: Event loop is closed`.
- Wraps all three call sites — `_put()`, the exception handler, and the `finally` sentinel — with `contextlib.suppress(RuntimeError)` so the background thread exits cleanly.
- Adds `import contextlib` to the module imports.

**Root cause** (Sentry #1970 / PYTHON-3N): the pre-LangGraph-migration code called `compiled_graph.astream_events()` inline and hit `RuntimeError: cannot schedule new futures after shutdown` when the asyncio executor was torn down mid-stream. The post-migration thread-based implementation has the same failure mode via `call_soon_threadsafe` — this PR closes it.

## Test plan

- [ ] `ruff check app/pipeline/runners.py` passes
- [ ] `ruff format --check app/pipeline/runners.py` passes
- [ ] Existing unit suite (`make test-cov`) unaffected — no logic change, only exception suppression on an already-closed loop

Closes #1970

https://claude.ai/code/session_01PdNgC7WLtSwQfQ977b8yNc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdNgC7WLtSwQfQ977b8yNc)_