### PR TITLE
fix(e2e): resolve repo root correctly in deploy helpers

### DIFF
--- a/tests/e2e/test_infrastructure_deploy_paths.py
+++ b/tests/e2e/test_infrastructure_deploy_paths.py
@@ -1,0 +1,83 @@
+"""Regression coverage for repo-root resolution in e2e infrastructure deploy helpers.
+
+These deploy modules build Lambda zips and Docker contexts from on-disk asset
+directories. Drifting the `parents[N]` index (or re-introducing a `tests/`
+double-prefix) silently breaks the bundling step at `iterdir()` time, well
+after CI has spent minutes provisioning cloud resources. The checks below
+catch that locally.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEPLOY_HELPERS: list[tuple[str, Path, list[str]]] = [
+    (
+        "upstream_lambda",
+        REPO_ROOT / "tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py",
+        [
+            "tests/shared/external_vendor_api",
+            "tests/e2e/upstream_lambda/pipeline_code",
+        ],
+    ),
+    (
+        "upstream_prefect_ecs_fargate",
+        REPO_ROOT / "tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py",
+        [
+            "tests/shared/external_vendor_api",
+            "tests/shared/infrastructure_code/alloy_config",
+            "tests/e2e/upstream_prefect_ecs_fargate/infrastructure_code/prefect_image/Dockerfile",
+            "tests/e2e/upstream_prefect_ecs_fargate/pipeline_code/trigger_lambda",
+        ],
+    ),
+    (
+        "upstream_apache_flink_ecs",
+        REPO_ROOT / "tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py",
+        [
+            "tests/shared/external_vendor_api",
+            "tests/e2e/upstream_apache_flink_ecs/infrastructure_code/flink_image/Dockerfile",
+            "tests/e2e/upstream_apache_flink_ecs/pipeline_code/trigger_lambda",
+        ],
+    ),
+]
+
+
+def _load_deploy_module(scenario: str, deploy_file: Path) -> ModuleType:
+    module_name = f"_deploy_helper_under_test_{scenario}"
+    spec = importlib.util.spec_from_file_location(module_name, deploy_file)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+@pytest.mark.parametrize(
+    ("scenario", "deploy_file", "expected_assets"),
+    DEPLOY_HELPERS,
+    ids=[scenario for scenario, _, _ in DEPLOY_HELPERS],
+)
+def test_deploy_helper_resolves_repo_root(
+    scenario: str, deploy_file: Path, expected_assets: list[str]
+) -> None:
+    assert deploy_file.exists(), f"deploy helper missing: {deploy_file}"
+    module = _load_deploy_module(scenario, deploy_file)
+
+    assert module.project_root == REPO_ROOT, (
+        f"{deploy_file} resolves project_root to {module.project_root}, expected {REPO_ROOT}"
+    )
+
+    for relative in expected_assets:
+        asset = REPO_ROOT / relative
+        assert asset.exists(), f"{scenario}: expected asset path missing on disk: {asset}"

--- a/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from tests.shared.infrastructure_sdk import save_outputs
 from tests.shared.infrastructure_sdk.resources import (
@@ -154,6 +154,7 @@ def deploy() -> dict:
     dockerfile_path = (
         project_root
         / "tests"
+        / "e2e"
         / "upstream_apache_flink_ecs"
         / "infrastructure_code"
         / "flink_image"

--- a/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py
@@ -27,7 +27,7 @@ from tests.shared.infrastructure_sdk.resources import api_gateway, iam, lambda_,
 from tests.shared.infrastructure_sdk.resources.iam import get_account_id, put_role_policy
 from tests.shared.infrastructure_sdk.resources.secrets import get_secret_value
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 STACK_NAME = "tracer-lambda"
 REGION = "us-east-1"
@@ -186,7 +186,7 @@ def create_lambda_functions(
 
     # Paths
     shared_dir = project_root / "tests" / "shared" / "external_vendor_api"
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = project_root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"
 
     # Bundle code
     print("  Bundling MockApi Lambda code...")
@@ -431,7 +431,7 @@ def deploy() -> dict:
 
     # 4. Create pipeline Lambdas with correct URLs
     print("Creating pipeline Lambda functions...")
-    pipeline_dir = project_root / "tests" / "upstream_lambda" / "pipeline_code"
+    pipeline_dir = project_root / "tests" / "e2e" / "upstream_lambda" / "pipeline_code"
 
     print("  Bundling pipeline code (dependencies already vendored)...")
     # Use custom bundling that puts vendored deps at root level

--- a/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
+++ b/tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py
@@ -23,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-project_root = Path(__file__).resolve().parents[3]
+project_root = Path(__file__).resolve().parents[4]
 
 from app.utils.config import load_env
 from tests.shared.infrastructure_sdk import save_outputs
@@ -58,8 +58,9 @@ TRIGGER_LAMBDA_NAME = "tracer-prefect-ecs-trigger"
 
 # Paths
 TESTS_DIR = project_root / "tests"
+E2E_DIR = TESTS_DIR / "e2e"
 PREFECT_DOCKERFILE = (
-    TESTS_DIR
+    E2E_DIR
     / "upstream_prefect_ecs_fargate"
     / "infrastructure_code"
     / "prefect_image"
@@ -67,9 +68,7 @@ PREFECT_DOCKERFILE = (
 )
 ALLOY_CONFIG_DIR = TESTS_DIR / "shared" / "infrastructure_code" / "alloy_config"
 MOCK_API_CODE = TESTS_DIR / "shared" / "external_vendor_api"
-TRIGGER_LAMBDA_CODE = (
-    TESTS_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
-)
+TRIGGER_LAMBDA_CODE = E2E_DIR / "upstream_prefect_ecs_fargate" / "pipeline_code" / "trigger_lambda"
 
 GRAFANA_ENV_KEYS = [
     "GCLOUD_HOSTED_METRICS_URL",


### PR DESCRIPTION
Fixes #1418

#### Describe the changes you have made in this PR -

Three E2E AWS deploy helpers were computing `project_root` as `Path(__file__).resolve().parents[3]`, which lands on `<repo>/tests` instead of the actual repo root. Subsequent asset paths then double-stacked into `<repo>/tests/tests/upstream_lambda/pipeline_code` and similar nonexistent locations, breaking Lambda code bundling and Docker build-context resolution before any cloud resources were provisioned.

This PR:

- Corrects `parents[3]` → `parents[4]` in all three deploy helpers:
  - `tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py`
  - `tests/e2e/upstream_prefect_ecs_fargate/infrastructure_sdk/deploy.py`
  - `tests/e2e/upstream_apache_flink_ecs/infrastructure_sdk/deploy.py`
- Repoints scenario-specific assets so they resolve under `tests/e2e/<scenario>/...` (Lambda `pipeline_code`, Prefect Dockerfile + trigger lambda, Flink Dockerfile).
- Keeps shared assets resolving from `tests/shared/...` unchanged.
- Adds an explicit `E2E_DIR` alongside `TESTS_DIR` in the Prefect helper so the shared-vs-scenario split is obvious from the path table.
- Adds `tests/e2e/test_infrastructure_deploy_paths.py` — a regression test that imports each deploy helper via importlib, asserts `module.project_root` equals the actual repository root, and verifies the bundled asset paths (Lambda code, Dockerfiles, Alloy config) exist on disk. Catches `parents[N]` drift locally before CI burns minutes on cloud provisioning that will fail at `iterdir()`.

Acceptance criteria from #1418:

- [x] All three deploy helpers resolve the repository root correctly.
- [x] Shared assets still resolve from `tests/shared/...`.
- [x] Scenario-specific assets resolve from their correct `tests/e2e/...` directories.
- [x] A regression test covers the path resolution so these helpers do not drift again.

### Demo/Screenshot for feature changes and bug fixes -

Before (current main, `parents[3]`):

```
$ python3 -c "from pathlib import Path; p=Path('tests/e2e/upstream_lambda/infrastructure_sdk/deploy.py'); print(p.resolve().parents[3])"
/Users/.../opensre/tests
```

Composed pipeline_dir then resolves to `/Users/.../opensre/tests/tests/upstream_lambda/pipeline_code` — does not exist, `iterdir()` raises during bundling.

After (this PR):

```
$ uv run pytest tests/e2e/test_infrastructure_deploy_paths.py -v
tests/e2e/test_infrastructure_deploy_paths.py::test_deploy_helper_resolves_repo_root[upstream_lambda] PASSED
tests/e2e/test_infrastructure_deploy_paths.py::test_deploy_helper_resolves_repo_root[upstream_prefect_ecs_fargate] PASSED
tests/e2e/test_infrastructure_deploy_paths.py::test_deploy_helper_resolves_repo_root[upstream_apache_flink_ecs] PASSED
=========== 3 passed in 0.11s ===========
```

Full `make test-cov`: **6512 passed, 6 skipped** in 92s on this branch.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

The bug is a single-character index drift compounded by a string-concatenation mistake. Each deploy helper lives at depth 4 from the repo root (`tests/e2e/<scenario>/infrastructure_sdk/deploy.py`), so `Path(__file__).resolve().parents[N]` must use `N=4` to reach the repo, not `N=3`. Once that is correct, the asset-path strings still need to include the `e2e/` segment for scenario-specific files (Lambda zips, Docker contexts) while leaving shared paths (`tests/shared/...`) alone.

I considered two alternatives before settling on this one:

1. **Inline `Path(__file__).resolve().parents[N]` with a smaller `N` and rebase asset paths off the helper directory directly.** Rejected because it makes shared-asset paths read `../../../shared/...` from inside the helper, which is harder to grep for and inconsistent with the existing pattern.
2. **Walk upwards searching for a sentinel (`pyproject.toml`).** Rejected because it adds runtime cost and a layer of indirection for a fix that should be a one-line index change.

The regression test loads each helper via `importlib.util.spec_from_file_location` rather than a normal `from tests.e2e... import` because the per-scenario directories do not have `__init__.py` files. Loading by file path keeps the test self-contained and avoids touching package layout.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
