### PR TITLE
fix(alert-inbox): Fix a race condition in the alert-inbox HTTP listener's auth path

### DIFF
--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -193,21 +193,15 @@ def start_alert_listener(
                     self.send_response(404)
                     self.end_headers()
                     return
-                # Read the body first. If we reply and close the
-                # connection while the client is still sending, the
-                # OS may drop our response before it arrives. Validate
-                # ``Content-Length`` *before* the auth check so an
-                # unauthenticated caller can't stall this single-
-                # threaded handler. Reject in two separate cases so
-                # the response status matches HTTP semantics:
-                #   - Negative values → 400. ``rfile.read(-1)`` blocks
-                #     until EOF, letting an attacker hang the handler
-                #     by not closing the connection. The header itself
-                #     is malformed; 400 names that, not 413.
-                #   - Values over ``_MAX_BODY_BYTES`` → 413. Bound the
-                #     bytes a single request can pull (see the
-                #     constant for the sizing rationale).
-                length = int(self.headers.get("Content-Length", 0))
+                # Read the body before the auth check (macOS RST race),
+                # but validate Content-Length first — otherwise an
+                # unauthenticated caller can stall this single-threaded
+                # handler with a malformed or oversized header.
+                try:
+                    length = int(self.headers.get("Content-Length", 0))
+                except ValueError:
+                    self._respond(400, {"error": "invalid Content-Length"})
+                    return
                 if length < 0:
                     self._respond(400, {"error": "invalid Content-Length"})
                     return

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -22,6 +22,11 @@ from app.strict_config import StrictConfigModel
 log = logging.getLogger(__name__)
 
 _DEFAULT_MAX_INBOX = 256
+# Cap on POST body size we'll accept from any caller (authed or not).
+# Bounds the pre-auth body drain that prevents the macOS RST race, so
+# a fake ``Content-Length: 1 GB`` can't stall the single-threaded
+# handler thread before token validation runs.
+_MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB
 
 
 def _wait_until_http_ready(host: str, port: int, *, timeout_s: float = 10.0) -> None:
@@ -182,8 +187,14 @@ def start_alert_listener(
                     return
                 # Read the body first. If we reply and close the
                 # connection while the client is still sending, the
-                # OS may drop our response before it arrives.
+                # OS may drop our response before it arrives. Cap the
+                # read *before* the auth check so an unauthenticated
+                # caller can't stall this single-threaded handler with
+                # a giant Content-Length.
                 length = int(self.headers.get("Content-Length", 0))
+                if length > _MAX_BODY_BYTES:
+                    self._respond(413, {"error": "payload too large"})
+                    return
                 raw = self.rfile.read(length)
                 if not self._check_auth():
                     return

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -26,6 +26,14 @@ _DEFAULT_MAX_INBOX = 256
 # Bounds the pre-auth body drain that prevents the macOS RST race, so
 # a fake ``Content-Length: 1 GB`` can't stall the single-threaded
 # handler thread before token validation runs.
+#
+# Sizing: realistic alert payloads (text + stack trace + log context)
+# top out around 50 KB, so 1 MiB is ~20× headroom while keeping reads
+# sub-millisecond on loopback and sub-second on typical networks. The
+# cap bounds bytes, NOT duration: a slowloris client could still
+# trickle 1 MiB byte-by-byte and tie up the handler for a long time.
+# Add a socket read timeout if/when this surface is exposed beyond
+# trusted callers.
 _MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MiB
 
 

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -195,11 +195,22 @@ def start_alert_listener(
                     return
                 # Read the body first. If we reply and close the
                 # connection while the client is still sending, the
-                # OS may drop our response before it arrives. Cap the
-                # read *before* the auth check so an unauthenticated
-                # caller can't stall this single-threaded handler with
-                # a giant Content-Length.
+                # OS may drop our response before it arrives. Validate
+                # ``Content-Length`` *before* the auth check so an
+                # unauthenticated caller can't stall this single-
+                # threaded handler. Reject in two separate cases so
+                # the response status matches HTTP semantics:
+                #   - Negative values → 400. ``rfile.read(-1)`` blocks
+                #     until EOF, letting an attacker hang the handler
+                #     by not closing the connection. The header itself
+                #     is malformed; 400 names that, not 413.
+                #   - Values over ``_MAX_BODY_BYTES`` → 413. Bound the
+                #     bytes a single request can pull (see the
+                #     constant for the sizing rationale).
                 length = int(self.headers.get("Content-Length", 0))
+                if length < 0:
+                    self._respond(400, {"error": "invalid Content-Length"})
+                    return
                 if length > _MAX_BODY_BYTES:
                     self._respond(413, {"error": "payload too large"})
                     return

--- a/app/cli/interactive_shell/alert_inbox.py
+++ b/app/cli/interactive_shell/alert_inbox.py
@@ -180,10 +180,13 @@ def start_alert_listener(
                     self.send_response(404)
                     self.end_headers()
                     return
-                if not self._check_auth():
-                    return
+                # Read the body first. If we reply and close the
+                # connection while the client is still sending, the
+                # OS may drop our response before it arrives.
                 length = int(self.headers.get("Content-Length", 0))
                 raw = self.rfile.read(length)
+                if not self._check_auth():
+                    return
                 try:
                     data = json.loads(raw)
                 except json.JSONDecodeError:

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -34,16 +34,21 @@ def _post_advertising_content_length(
     host: str,
     port: int,
     *,
-    advertised_length: int,
+    advertised_length: int | str,
     token: str | None = None,
 ) -> tuple[int, dict[str, object]]:
     """POST /alerts that advertises ``advertised_length`` in
     ``Content-Length`` but never sends the body.
 
-    Used to verify the listener refuses oversized requests *based on
-    the header alone* — if it tried to read the body first, this would
-    hang and the client's timeout would fire instead of returning a
-    413.
+    ``advertised_length`` accepts ints (the common case: pick a value
+    around the cap) and strings (test the parser path with values that
+    aren't valid integers at all, e.g. ``"foo"``). The header is
+    forwarded verbatim via ``str()``.
+
+    Used to verify the listener refuses out-of-range or malformed
+    requests *based on the header alone* — if it tried to read the
+    body first, the test would hang and the client's timeout would
+    fire instead of returning a clean 4xx.
     """
     conn = HTTPConnection(host, port, timeout=5)
     try:
@@ -243,6 +248,21 @@ class TestHttpListener:
             assert status == 413
         finally:
             handle.stop()
+
+    def test_non_numeric_content_length_returns_400(
+        self, listener: AlertListenerHandle, inbox: AlertInbox
+    ) -> None:
+        """Non-numeric ``Content-Length`` must produce a clean 400,
+        not an unhandled ValueError that drops the connection."""
+        status, body = _post_advertising_content_length(
+            "127.0.0.1",
+            listener._bound_port,
+            advertised_length="not-a-number",
+        )
+
+        assert status == 400
+        assert body == {"error": "invalid Content-Length"}
+        assert inbox.pop_nowait() is None
 
     def test_negative_content_length_returns_400_without_blocking(
         self, listener: AlertListenerHandle, inbox: AlertInbox

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -244,6 +244,31 @@ class TestHttpListener:
         finally:
             handle.stop()
 
+    def test_negative_content_length_returns_400_without_blocking(
+        self, listener: AlertListenerHandle, inbox: AlertInbox
+    ) -> None:
+        """A negative ``Content-Length`` must be rejected as malformed.
+
+        ``rfile.read(-1)`` reads until EOF rather than zero bytes — if
+        the cap check only rejects values above the upper bound, a
+        client that sends ``Content-Length: -1`` slips through and
+        hangs the single-threaded handler until it closes the
+        connection. The fix is a separate ``< 0`` branch that returns
+        400 (the header is malformed) before the upper-bound 413 check.
+        """
+        status, body = _post_advertising_content_length(
+            "127.0.0.1",
+            listener._bound_port,
+            advertised_length=-1,
+        )
+
+        assert status == 400
+        assert body == {"error": "invalid Content-Length"}
+        assert inbox.pop_nowait() is None
+        # Listener still responsive — handler wasn't stalled by read(-1).
+        healthz_status, _ = _get("127.0.0.1", listener._bound_port, "/healthz")
+        assert healthz_status == 200
+
     def test_auth(self) -> None:
         inbox = AlertInbox()
         handle = start_alert_listener(inbox, host="127.0.0.1", port=0, token="sekret")

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -213,3 +213,18 @@ class TestHttpListener:
     def test_bind_non_loopback_without_token_raises(self) -> None:
         with pytest.raises(OpenSREError, match="non-loopback"):
             start_alert_listener(AlertInbox(), host="0.0.0.0", port=0, token=None)
+
+    def test_unauthorized_post_with_large_body_returns_clean_401(self) -> None:
+        # Regression: handler must drain the request body before
+        # returning 401, otherwise close-with-unread-data triggers
+        # RST (RFC 1122) and can clobber the response.
+        inbox = AlertInbox()
+        handle = start_alert_listener(inbox, host="127.0.0.1", port=0, token="sekret")
+        try:
+            big_body = {"text": "x" * 64_000}
+            status, body = _post("127.0.0.1", handle._bound_port, big_body, token="wrong")
+            assert status == 401
+            assert body["error"] == "unauthorized"
+            assert inbox.qsize == 0
+        finally:
+            handle.stop()

--- a/tests/cli/interactive_shell/test_alert_inbox.py
+++ b/tests/cli/interactive_shell/test_alert_inbox.py
@@ -12,12 +12,52 @@ from http.client import HTTPConnection
 import pytest
 
 from app.cli.interactive_shell.alert_inbox import (
+    _MAX_BODY_BYTES,
     AlertInbox,
     AlertListenerHandle,
     IncomingAlert,
     start_alert_listener,
 )
 from app.cli.support.errors import OpenSREError
+
+# A Content-Length value guaranteed to trip the listener's pre-auth
+# body cap. Computed from the cap itself so the constant can't drift
+# out of sync with the production limit.
+_OVERSIZED_CONTENT_LENGTH = _MAX_BODY_BYTES + 1
+
+# Token used by the auth-related tests. Single literal so a future
+# rename happens in one place.
+_TEST_BEARER_TOKEN = "sekret"
+
+
+def _post_advertising_content_length(
+    host: str,
+    port: int,
+    *,
+    advertised_length: int,
+    token: str | None = None,
+) -> tuple[int, dict[str, object]]:
+    """POST /alerts that advertises ``advertised_length`` in
+    ``Content-Length`` but never sends the body.
+
+    Used to verify the listener refuses oversized requests *based on
+    the header alone* — if it tried to read the body first, this would
+    hang and the client's timeout would fire instead of returning a
+    413.
+    """
+    conn = HTTPConnection(host, port, timeout=5)
+    try:
+        conn.putrequest("POST", "/alerts")
+        conn.putheader("Content-Type", "application/json")
+        if token is not None:
+            conn.putheader("Authorization", f"Bearer {token}")
+        conn.putheader("Content-Length", str(advertised_length))
+        conn.endheaders()
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, json.loads(raw)
+    finally:
+        conn.close()
 
 
 class TestIncomingAlert:
@@ -163,6 +203,46 @@ class TestHttpListener:
     def test_missing_text_returns_400(self, listener: AlertListenerHandle) -> None:
         status, _ = _post("127.0.0.1", listener._bound_port, {})
         assert status == 400
+
+    def test_oversized_content_length_returns_413_without_reading_body(
+        self, listener: AlertListenerHandle, inbox: AlertInbox
+    ) -> None:
+        """Pre-auth body-drain must be capped or a fake Content-Length
+        stalls the single-threaded handler. The server should reject
+        the request based on the header alone, without waiting for the
+        body that the malicious client never sends.
+        """
+        status, body = _post_advertising_content_length(
+            "127.0.0.1",
+            listener._bound_port,
+            advertised_length=_OVERSIZED_CONTENT_LENGTH,
+        )
+
+        assert status == 413
+        assert body == {"error": "payload too large"}
+        # Inbox stays empty — nothing was queued.
+        assert inbox.pop_nowait() is None
+        # And the listener is still healthy — handler thread isn't stalled.
+        healthz_status, _ = _get("127.0.0.1", listener._bound_port, "/healthz")
+        assert healthz_status == 200
+
+    def test_oversized_content_length_returns_413_even_with_valid_token(self) -> None:
+        """The cap runs *before* auth, so even a valid token can't
+        bypass it. Otherwise an authenticated client could still DoS
+        the listener with a fake giant Content-Length.
+        """
+        inbox = AlertInbox()
+        handle = start_alert_listener(inbox, host="127.0.0.1", port=0, token=_TEST_BEARER_TOKEN)
+        try:
+            status, _ = _post_advertising_content_length(
+                "127.0.0.1",
+                handle._bound_port,
+                advertised_length=_OVERSIZED_CONTENT_LENGTH,
+                token=_TEST_BEARER_TOKEN,
+            )
+            assert status == 413
+        finally:
+            handle.stop()
 
     def test_auth(self) -> None:
         inbox = AlertInbox()


### PR DESCRIPTION
Fixes #1983 

#### Describe the changes you have made in this PR -
Fix a race condition in the alert-inbox HTTP listener's auth path (app/cli/interactive_shell/alert_inbox.py).

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions


**Explain your implementation approach:**

One of the alert-inbox auth tests kept failing on macOS with "Connection reset by peer" — not always, but enough to be annoying on `make test-cov`. I first thought the test was wrong, but the bug was in the server.

The handler was checking auth before reading the request body. When the token was missing or wrong, the server sent a 401 and closed the connection right away. The client wasn't done sending its body yet, so it still had bytes to write. On macOS, when a socket closes with unread data on it, the kernel sends a TCP reset, which surfaces to the client as `ConnectionResetError`. Linux is more forgiving in this spot, which is why CI was green and only macOS contributors saw it.

The actual fix is small: read the body first, then check auth. The auth logic is unchanged; the 401 path just doesn't send its response until the client has finished.
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
