### PR TITLE
fix(integrations): eliminate silent env-loader fallbacks in _catalog_impl (#1468)

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -59,8 +59,54 @@ from app.integrations.store import _STRUCTURAL_RECORD_FIELDS, load_integrations
 from app.integrations.supabase import build_supabase_config
 from app.services.vercel import VercelConfig
 from app.utils.coercion import safe_int
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
+
+
+def _report_classify_failure(exc: BaseException, *, integration: str, record_id: str) -> None:
+    """Route a per-instance classify failure to Sentry + warning log.
+
+    Replaces the historic ``except Exception: return None, None`` pattern in
+    ``_classify_service_instance``: the caller still gets ``(None, None)``
+    and skips the integration, but the failure is now visible to operators
+    instead of being silently swallowed (#1468).
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"classify_failed: integration={integration} record_id={record_id}",
+        severity="warning",
+        tags={
+            "surface": "integration",
+            "component": "app.integrations._catalog_impl",
+            "integration": integration,
+            "event": "classify_failed",
+        },
+        extras={"record_id": record_id},
+    )
+
+
+def _report_env_loader_failure(exc: BaseException, *, integration: str) -> None:
+    """Route a per-vendor env-loader failure to Sentry + warning log.
+
+    Replaces ``except Exception: pass`` and ``logger.debug(..., exc_info=True)``
+    paths in ``load_env_integrations``: integration is still skipped, but the
+    misconfiguration reaches Sentry rather than being lost to debug output
+    (#1468).
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"env_loader_failed: integration={integration}",
+        severity="warning",
+        tags={
+            "surface": "integration",
+            "component": "app.integrations._catalog_impl",
+            "integration": integration,
+            "event": "env_loader_failed",
+        },
+    )
 
 
 def _should_publish_instance_siblings(instances: object) -> bool:
@@ -164,7 +210,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if not grafana_config.endpoint:
             return None, None
@@ -196,7 +243,8 @@ def _classify_service_instance(
                 AWSIntegrationConfig.model_validate(raw_config).model_dump(exclude_none=True),
                 "aws",
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
 
     if key == "datadog":
@@ -209,7 +257,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if datadog_config.api_key and datadog_config.app_key:
             return datadog_config.model_dump(), "datadog"
@@ -225,7 +274,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if honeycomb_config.api_key:
             return honeycomb_config.model_dump(), "honeycomb"
@@ -242,7 +292,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if coralogix_config.api_key:
             return coralogix_config.model_dump(), "coralogix"
@@ -261,7 +312,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return github_config.model_dump(), "github"
 
@@ -276,7 +328,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if sentry_config.organization_slug and sentry_config.auth_token:
             return sentry_config.model_dump(), "sentry"
@@ -290,7 +343,8 @@ def _classify_service_instance(
                     "auth_token": credentials.get("auth_token", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return gitlab_config.model_dump(), "gitlab"
 
@@ -304,7 +358,8 @@ def _classify_service_instance(
                     "tls": credentials.get("tls", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mongodb_config.connection_string:
             return mongodb_config.model_dump(), "mongodb"
@@ -322,7 +377,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "prefer"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if postgresql_config.host and postgresql_config.database:
             return postgresql_config.model_dump(), "postgresql"
@@ -340,7 +396,8 @@ def _classify_service_instance(
                     ),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if atlas_config.api_public_key and atlas_config.api_private_key and atlas_config.project_id:
             return {
@@ -364,7 +421,8 @@ def _classify_service_instance(
                     "ssl": credentials.get("ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mariadb_config.host and mariadb_config.database:
             return {
@@ -387,7 +445,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if vercel_config.api_token:
             return vercel_config.model_dump(), "vercel"
@@ -402,7 +461,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if opsgenie_config.api_key:
             return opsgenie_config.model_dump(), "opsgenie"
@@ -417,7 +477,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if incident_io_config.api_key:
             return incident_io_config.model_dump(), "incident_io"
@@ -434,7 +495,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if jira_config.base_url and jira_config.email and jira_config.api_token:
             return jira_config.model_dump(), "jira"
@@ -450,7 +512,8 @@ def _classify_service_instance(
                     "default_channel_id": credentials.get("default_channel_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if discord_config.bot_token:
             return discord_config.model_dump(), "discord"
@@ -464,7 +527,8 @@ def _classify_service_instance(
                     "default_chat_id": credentials.get("default_chat_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if tg_config.bot_token:
             return tg_config.model_dump(), "telegram"
@@ -482,7 +546,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if openclaw_config.is_configured:
             config_dict = openclaw_config.model_dump()
@@ -502,7 +567,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "preferred"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mysql_config.host and mysql_config.database:
             return {
@@ -529,7 +595,8 @@ def _classify_service_instance(
                     "verify_ssl": credentials.get("verify_ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if rabbitmq_config.host and rabbitmq_config.username:
             return {
@@ -552,7 +619,8 @@ def _classify_service_instance(
                     "region": credentials.get("region", DEFAULT_RDS_REGION),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if rds_config.is_configured:
             return {**rds_config.model_dump(), "integration_id": record_id}, "rds"
@@ -571,7 +639,8 @@ def _classify_service_instance(
                     "max_results": credentials.get("max_results", 50),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if airflow_config.is_configured:
             return {
@@ -590,7 +659,8 @@ def _classify_service_instance(
                     "sources": credentials.get("sources", []),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if bs_config.query_endpoint and bs_config.username:
             return {
@@ -615,7 +685,8 @@ def _classify_service_instance(
                     "encrypt": credentials.get("encrypt", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if azure_sql_config.server and azure_sql_config.database:
             return azure_sql_config.model_dump(), "azure_sql"
@@ -632,7 +703,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if alertmanager_config.base_url:
             return alertmanager_config.model_dump(), "alertmanager"
@@ -654,7 +726,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if argocd_config.base_url and (
             argocd_config.bearer_token or (argocd_config.username and argocd_config.password)
@@ -677,7 +750,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return helm_config.model_dump(), "helm"
 
@@ -690,7 +764,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if victoria_logs_config.base_url:
             return victoria_logs_config.model_dump(), "victoria_logs"
@@ -799,7 +874,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if splunk_config.base_url and splunk_config.token:
             return splunk_config.model_dump(), "splunk"
@@ -813,7 +889,8 @@ def _classify_service_instance(
                     "service_key": credentials.get("service_key", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if sb_config.is_configured:
             return {
@@ -1169,9 +1246,10 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "verify_ssl": os.getenv("ARGOCD_VERIFY_SSL", "true").strip(),
                 }
             )
-        except Exception:
-            # invalid env-derived config: skip ArgoCD entry rather than fail discovery
-            pass
+        except Exception as exc:
+            # Invalid env-derived config: skip ArgoCD entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="argocd")
         else:
             integrations.append(
                 _active_env_record(
@@ -1195,8 +1273,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "default_namespace": os.getenv("HELM_NAMESPACE", "").strip(),
                 }
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="helm")
         else:
             integrations.append(
                 _active_env_record(
@@ -1244,8 +1322,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "base_url": os.getenv("INCIDENT_IO_BASE_URL", "").strip(),
                 }
             )
-        except Exception:
-            logger.debug("Failed to load incident.io config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="incident_io")
         else:
             integrations.append(
                 _active_env_record(
@@ -1349,8 +1427,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     },
                 )
             )
-        except Exception:
-            logger.debug("Failed to load OpenClaw config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="openclaw")
 
     mariadb_host = os.getenv("MARIADB_HOST", "").strip()
     mariadb_database = os.getenv("MARIADB_DATABASE", "").strip()
@@ -1372,8 +1450,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     mariadb_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load MariaDB config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="mariadb")
 
     rabbitmq_host = os.getenv("RABBITMQ_HOST", "").strip()
     rabbitmq_username = os.getenv("RABBITMQ_USERNAME", "").strip()
@@ -1398,14 +1476,14 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     rabbitmq_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load RabbitMQ config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="rabbitmq")
 
     try:
         rds_config = rds_config_from_env()
-    except Exception:
+    except Exception as exc:
         rds_config = None
-        logger.debug("Failed to load RDS config from env", exc_info=True)
+        _report_env_loader_failure(exc, integration="rds")
     if rds_config is not None and rds_config.is_configured:
         integrations.append(
             _active_env_record(
@@ -1432,8 +1510,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     bs_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Better Stack config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="betterstack")
 
     mysql_host = os.getenv("MYSQL_HOST", "").strip()
     mysql_database = os.getenv("MYSQL_DATABASE", "").strip()
@@ -1596,8 +1674,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     alertmanager_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Alertmanager config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="alertmanager")
 
     victoria_logs_url = os.getenv("VICTORIA_LOGS_URL", "").strip().rstrip("/")
     if victoria_logs_url:
@@ -1614,8 +1692,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     victoria_logs_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load VictoriaLogs config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="victoria_logs")
 
     splunk_multi = _parse_instances_env("SPLUNK_INSTANCES", "splunk")
     if splunk_multi is not None:
@@ -1653,8 +1731,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     {"project_url": sb_config.url},
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Supabase config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="supabase")
 
     return integrations
 

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -1,0 +1,268 @@
+"""Tests for #1468: eliminate silent env-loader / classify fallbacks.
+
+Three patterns previously dropped exceptions to ``(None, None)``, ``pass``,
+or ``logger.debug(..., exc_info=True)`` with no Sentry trace:
+
+  A. ``_classify_service_instance`` per-vendor ``try/except Exception``
+     blocks (33 sites covering grafana .. supabase).
+  B. ``load_env_integrations`` argocd + helm ``except Exception: pass``.
+  C. ``load_env_integrations`` debug-only env loaders (incident_io,
+     openclaw, mariadb, rabbitmq, rds, betterstack, alertmanager,
+     victoria_logs, supabase).
+
+After the fix every site routes through ``_report_classify_failure`` or
+``_report_env_loader_failure``, which call ``report_exception`` with
+``surface=integration``, ``component=app.integrations._catalog_impl``,
+``event=classify_failed`` / ``event=env_loader_failed``, and the vendor
+tag — preserving the historic "skip the integration" caller contract.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.integrations._catalog_impl import (
+    _classify_service_instance,
+    _report_classify_failure,
+    _report_env_loader_failure,
+    load_env_integrations,
+)
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+
+
+# ---------------------------------------------------------------------------
+# Helper smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_classify_failure_forwards_tags() -> None:
+    exc = ValueError("bad config")
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_classify_failure(exc, integration="datadog", record_id="rec-1")
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "integration",
+        "component": "app.integrations._catalog_impl",
+        "integration": "datadog",
+        "event": "classify_failed",
+    }
+    assert kwargs["extras"] == {"record_id": "rec-1"}
+
+
+def test_report_env_loader_failure_forwards_tags() -> None:
+    exc = RuntimeError("env missing")
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_env_loader_failure(exc, integration="rabbitmq")
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "integration",
+        "component": "app.integrations._catalog_impl",
+        "integration": "rabbitmq",
+        "event": "env_loader_failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pattern A: _classify_service_instance routes failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+# Per-vendor: the symbol inside ``app.integrations._catalog_impl`` whose
+# constructor we force to raise, so we can prove the surrounding try/except
+# now routes the failure through ``report_exception`` instead of returning
+# ``(None, None)`` silently. Patching is more reliable than crafting bad
+# credentials, since validator strictness drifts per integration.
+_CLASSIFY_PATCH_TARGETS: list[tuple[str, str]] = [
+    ("grafana", "GrafanaIntegrationConfig"),
+    ("aws", "AWSIntegrationConfig"),
+    ("datadog", "DatadogIntegrationConfig"),
+    ("honeycomb", "HoneycombIntegrationConfig"),
+    ("coralogix", "CoralogixIntegrationConfig"),
+    ("github", "build_github_mcp_config"),
+    ("sentry", "build_sentry_config"),
+    ("gitlab", "build_gitlab_config"),
+    ("mongodb", "build_mongodb_config"),
+    ("postgresql", "build_postgresql_config"),
+    ("mongodb_atlas", "build_mongodb_atlas_config"),
+    ("mariadb", "build_mariadb_config"),
+    ("vercel", "VercelConfig"),
+    ("opsgenie", "OpsGenieIntegrationConfig"),
+    ("incident_io", "IncidentIoIntegrationConfig"),
+    ("jira", "JiraIntegrationConfig"),
+    ("discord", "DiscordBotConfig"),
+    ("telegram", "TelegramBotConfig"),
+    ("openclaw", "build_openclaw_config"),
+    ("mysql", "build_mysql_config"),
+    ("rabbitmq", "build_rabbitmq_config"),
+    ("rds", "build_rds_config"),
+    ("airflow", "build_airflow_config"),
+    ("betterstack", "build_betterstack_config"),
+    ("azure_sql", "build_azure_sql_config"),
+    ("alertmanager", "AlertmanagerIntegrationConfig"),
+    ("argocd", "ArgoCDIntegrationConfig"),
+    ("helm", "HelmIntegrationConfig"),
+    ("victoria_logs", "VictoriaLogsIntegrationConfig"),
+    ("splunk", "SplunkIntegrationConfig"),
+    ("supabase", "build_supabase_config"),
+]
+
+
+@pytest.mark.parametrize(("integration", "patch_symbol"), _CLASSIFY_PATCH_TARGETS)
+def test_classify_failure_skips_integration_and_reports(
+    integration: str,
+    patch_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every Pattern A site (``_classify_service_instance``) must still return
+    ``(None, None)`` *and* now route the exception through
+    ``report_exception`` with ``event=classify_failed`` and the vendor tag."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = _classify_service_instance(
+            integration,
+            {"endpoint": "https://x", "api_key": "k"},
+            record_id=f"rec-{integration}",
+        )
+
+    assert result == (None, None), (
+        f"caller contract broken for {integration}: must still skip integration"
+    )
+    assert mock_report.call_count == 1, (
+        f"{integration} silently swallowed exception (no report_exception call)"
+    )
+    tags = mock_report.call_args.kwargs["tags"]
+    assert tags["integration"] == integration
+    assert tags["event"] == "classify_failed"
+    assert tags["surface"] == "integration"
+    assert mock_report.call_args.kwargs["severity"] == "warning"
+    assert mock_report.call_args.kwargs["extras"]["record_id"] == f"rec-{integration}"
+
+
+# ---------------------------------------------------------------------------
+# Pattern B + C: load_env_integrations routes loader failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+# For each env-loader case: env vars to enable the loader path + the symbol in
+# ``app.integrations._catalog_impl`` to patch so its constructor raises. This
+# proves the exception is *caught* and *routed* — without depending on which
+# fields the real builder rejects (validator details drift independently).
+_ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
+    # Pattern B
+    (
+        "argocd",
+        {"ARGOCD_BASE_URL": "https://argo.example", "ARGOCD_AUTH_TOKEN": "t"},
+        "ArgoCDIntegrationConfig",
+    ),
+    (
+        "helm",
+        {"OSRE_HELM_INTEGRATION": "1"},
+        "HelmIntegrationConfig",
+    ),
+    # Pattern C
+    (
+        "incident_io",
+        {"INCIDENT_IO_API_KEY": "k"},
+        "IncidentIoIntegrationConfig",
+    ),
+    (
+        "mariadb",
+        {"MARIADB_HOST": "h", "MARIADB_DATABASE": "d"},
+        "build_mariadb_config",
+    ),
+    (
+        "rabbitmq",
+        {"RABBITMQ_HOST": "h", "RABBITMQ_USERNAME": "u"},
+        "build_rabbitmq_config",
+    ),
+    (
+        "betterstack",
+        {"BETTERSTACK_QUERY_ENDPOINT": "https://bs.example", "BETTERSTACK_USERNAME": "u"},
+        "build_betterstack_config",
+    ),
+    (
+        "alertmanager",
+        {"ALERTMANAGER_URL": "https://am.example"},
+        "AlertmanagerIntegrationConfig",
+    ),
+    (
+        "victoria_logs",
+        {"VICTORIA_LOGS_URL": "https://vl.example"},
+        "VictoriaLogsIntegrationConfig",
+    ),
+    (
+        "supabase",
+        {"SUPABASE_URL": "https://s.example", "SUPABASE_SERVICE_KEY": "k"},
+        "build_supabase_config",
+    ),
+    (
+        "openclaw",
+        {"OPENCLAW_MCP_URL": "https://oc.example"},
+        "build_openclaw_config",
+    ),
+    (
+        "rds",
+        {},
+        "rds_config_from_env",
+    ),
+]
+
+
+@pytest.mark.parametrize(("integration", "env", "patch_symbol"), _ENV_LOADER_CASES)
+def test_env_loader_failure_reports_and_skips(
+    integration: str,
+    env: dict[str, str],
+    patch_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pattern B + C: when a vendor's env-derived builder raises, the
+    integration must be skipped (preserving the historic caller contract)
+    *and* the failure must reach Sentry via ``report_exception``."""
+    # Clear ambient env so other integrations on the dev box don't enable
+    # unrelated paths and inflate the assertion.
+    for var in list(os.environ):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = load_env_integrations()
+
+    services = {entry["service"] for entry in result}
+    assert integration not in services, f"{integration} must be skipped when its env loader fails"
+
+    matching = [
+        call
+        for call in mock_report.call_args_list
+        if call.kwargs.get("tags", {}).get("integration") == integration
+    ]
+    assert matching, (
+        f"{integration} env-loader failure was swallowed silently — expected "
+        "report_exception call with event=env_loader_failed"
+    )
+    tags = matching[0].kwargs["tags"]
+    assert tags["event"] == "env_loader_failed"
+    assert tags["surface"] == "integration"
+    assert matching[0].kwargs["severity"] == "warning"


### PR DESCRIPTION
Closes #1468.

## What

Forty-plus exception sites in `app/integrations/_catalog_impl.py` swallowed failures into one of three silent sinks. All routes now report to Sentry via `app.utils.errors.report_exception` (severity `warning`, since these are user-config misses, not service bugs).

The caller contract is unchanged — pattern A still returns `(None, None)` and pattern B/C still skip the integration. The only behavior delta is that the exception now surfaces.

## Patterns covered

**Pattern A — `_classify_service_instance`** (33 sites): `except Exception: return None, None`.
Now routes through `_report_classify_failure(exc, integration=<vendor>, record_id=record_id)`.

**Pattern B — `load_env_integrations` argocd + helm**: `except Exception: pass`.
Now routes through `_report_env_loader_failure(exc, integration=<vendor>)`.

**Pattern C — `load_env_integrations` debug-only env loaders**: `logger.debug(\"Failed to load <X> config from env\", exc_info=True)` (incident_io, openclaw, mariadb, rabbitmq, rds, betterstack, alertmanager, victoria_logs, supabase). Same helper as B.

## Sentry tag set

Every captured exception carries:

| tag          | value                                |
|--------------|--------------------------------------|
| `surface`    | `integration`                        |
| `component`  | `app.integrations._catalog_impl`     |
| `integration`| `<vendor>` (grafana, datadog, ...)   |
| `event`      | `classify_failed` or `env_loader_failed` |

Pattern A also threads `record_id` through `extras` for traceability back to the offending store record.

Severity is `warning` — these are user misconfigurations, not service bugs, so sampling/quota policy can treat them differently from real errors. #1454 wired `report_exception`, so this PR just consumes it.

## Tests

`tests/integrations/test_catalog_silent_fallback_elimination.py` (44 cases, ~1s):

- 2 helper smoke tests asserting the tag dict shape.
- 31 parametrized cases over `_classify_service_instance` — force-patch each vendor's config constructor (`GrafanaIntegrationConfig`, `build_supabase_config`, etc.) to raise, then assert `(None, None)` is still returned *and* `report_exception` is called once with the right vendor tag.
- 11 parametrized cases over `load_env_integrations` (Pattern B + C) — set the trigger env vars, force the builder symbol to raise, assert the integration is absent from the result *and* the failure was reported.

Patching the constructor symbol rather than crafting bad credentials proves the surrounding `try/except` actually routes the failure, without coupling the test to validator strictness (which drifts per integration).

## Local verification

- `make test-cov` clean (6602 passed, 6 skipped — same as `main`).
- `tests/integrations/` clean (1010 passed).
- `make lint`, `make format-check` clean.
- `make typecheck` clean for touched files (pre-existing missing-stubs errors in unrelated modules untouched).