### PR TITLE
fix: validate Slack webhook host boundary

### DIFF
--- a/app/integrations/config_models.py
+++ b/app/integrations/config_models.py
@@ -176,7 +176,8 @@ class SlackWebhookConfig(StrictConfigModel):
         parsed = urlparse(self.webhook_url)
         if parsed.scheme != "https" or not parsed.netloc:
             raise ValueError("Slack webhook must be a valid HTTPS URL.")
-        if "slack.com" not in parsed.netloc:
+        hostname = (parsed.hostname or "").lower()
+        if hostname != "slack.com" and not hostname.endswith(".slack.com"):
             raise ValueError("Slack webhook host must be a Slack domain.")
         return self
 

--- a/tests/integrations/test_config_validation.py
+++ b/tests/integrations/test_config_validation.py
@@ -200,6 +200,19 @@ def test_slack_config_rejects_non_slack_host() -> None:
         SlackWebhookConfig.model_validate({"webhook_url": "https://example.com/webhook"})
 
 
+@pytest.mark.parametrize(
+    "webhook_url",
+    [
+        "https://hooks.slack.com.evil.test/services/T000/B000/test",
+        "https://evilslack.com/services/T000/B000/test",
+        "https://hooks.slack.com@evil.test/services/T000/B000/test",
+    ],
+)
+def test_slack_config_rejects_spoofed_slack_hosts(webhook_url: str) -> None:
+    with pytest.raises(ValidationError, match="Slack webhook host must be a Slack domain"):
+        SlackWebhookConfig.model_validate({"webhook_url": webhook_url})
+
+
 def test_tracer_config_strips_bearer_prefix() -> None:
     config = TracerIntegrationConfig.model_validate(
         {


### PR DESCRIPTION
Fixes: N/A (bug found via code scan)

#### Describe the changes you have made in this PR -
- Validate Slack webhook URLs using the parsed hostname instead of substring-matching the full netloc.
- Reject spoofed hosts like `evilslack.com`, `hooks.slack.com.evil.test`, and userinfo tricks like `hooks.slack.com@evil.test`.
- Add regression coverage for spoofed Slack webhook hosts.

### Demo/Screenshot for feature changes and bug fixes -
`uv run python -m pytest tests/integrations/test_config_validation.py -q` -> 24 passed
`SLACK_WEBHOOK_URL='https://hooks.slack.com/services/T000/B000/test' make verify-integrations SERVICE=slack` -> slack passed

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The existing Slack webhook validator accepted any URL whose netloc contained `slack.com`, which allowed spoofed domains such as `evilslack.com` and `hooks.slack.com.evil.test`. This PR switches validation to `urlparse(...).hostname` and requires either the exact `slack.com` domain or a proper `.slack.com` subdomain boundary. The tests exercise the spoofed domains directly so the validator cannot regress to substring matching.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.