### PR TITLE
fix(tools): surface tool-registry import-time failures to Sentry (#1464)

### DIFF
--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -50,6 +50,8 @@ def _record_import_health(import_failures: int) -> None:
     Sentry tag write must never break registry initialisation.
     """
     with suppress(Exception):
+        import sentry_sdk  # noqa: PLC0415 — lazy import, SDK may be absent
+
         sentry_sdk.set_tag("tools.import_failures", str(import_failures))
 
 

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -6,14 +6,37 @@ import importlib
 import inspect
 import logging
 import pkgutil
+from contextlib import suppress
 from functools import lru_cache
 from types import ModuleType
+
+import sentry_sdk
 
 from app import tools as tools_package
 from app.tools.base import BaseTool
 from app.tools.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool, ToolSurface
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
+
+
+def _classify_import_error(_module_name: str, exc: BaseException) -> tuple[str, dict[str, str]]:
+    """Classify a tool-module import failure for Sentry routing (#1464).
+
+    External ``ModuleNotFoundError`` (e.g. optional integration extras like
+    ``psycopg2``, ``boto3`` plugins not installed in this environment) is a
+    user-environment signal, captured at ``warning`` severity so it does not
+    drown real bugs. Anything else — an internal ``app.*`` import failure or
+    any other exception raised during module import — is a regression in our
+    own code and is captured at ``error`` severity.
+    """
+    if isinstance(exc, ModuleNotFoundError) and exc.name and not exc.name.startswith("app."):
+        return "warning", {
+            "event": "optional_dependency_missing",
+            "missing_module": exc.name,
+        }
+    return "error", {"event": "tool_module_import_failed"}
+
 
 _SKIP_MODULE_NAMES = {
     "__pycache__",
@@ -121,20 +144,26 @@ def _collect_registered_tools_from_module(module: ModuleType) -> list[Registered
 @lru_cache(maxsize=1)
 def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
     tools_by_name: dict[str, RegisteredTool] = {}
+    import_failures = 0
 
     for module_name in _iter_tool_module_names():
         try:
             module = _import_tool_module(module_name)
-        except ModuleNotFoundError as exc:
-            logger.warning("[tools] Skipping %s: %s", module_name, exc)
-            continue
         except Exception as exc:
-            logger.warning(
-                "[tools] Skipping %s due to import failure: %s",
-                module_name,
+            severity, extra_tags = _classify_import_error(module_name, exc)
+            report_exception(
                 exc,
-                exc_info=True,
+                logger=logger,
+                message=f"[tools] Skipping {module_name} due to import failure",
+                severity=severity,
+                tags={
+                    "surface": "tool",
+                    "component": f"app.tools.{module_name}",
+                    "module_name": module_name,
+                    **extra_tags,
+                },
             )
+            import_failures += 1
             continue
 
         for tool in _collect_registered_tools_from_module(module):
@@ -145,6 +174,13 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
                 )
                 continue
             tools_by_name[tool.name] = tool
+
+    # Surface aggregate import health as a Sentry tag so dashboards can track
+    # "% of tools that loaded successfully" over time (#1464). Best-effort —
+    # we never want a tag write to break registry initialisation.
+    if import_failures:
+        with suppress(Exception):
+            sentry_sdk.set_tag("tools.import_failures", str(import_failures))
 
     return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
 

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -20,7 +20,7 @@ from app.utils.errors import report_exception
 logger = logging.getLogger(__name__)
 
 
-def _classify_import_error(_module_name: str, exc: BaseException) -> tuple[str, dict[str, str]]:
+def _classify_import_error(exc: BaseException) -> tuple[str, dict[str, str]]:
     """Classify a tool-module import failure for Sentry routing (#1464).
 
     External ``ModuleNotFoundError`` (e.g. optional integration extras like
@@ -36,6 +36,21 @@ def _classify_import_error(_module_name: str, exc: BaseException) -> tuple[str, 
             "missing_module": exc.name,
         }
     return "error", {"event": "tool_module_import_failed"}
+
+
+def _record_import_health(import_failures: int) -> None:
+    """Publish aggregate tool-registry import health as a Sentry tag (#1464).
+
+    Always set — including ``"0"`` on a clean rebuild — so a previously written
+    failure count does not leak across cache rebuilds. ``sentry_sdk.set_tag``
+    mutates the currently active scope; when ``clear_tool_registry_cache()`` is
+    invoked from inside a request context, the tag attaches only to that
+    request, which is acceptable for dashboards but is the reason this helper
+    rewrites unconditionally rather than skipping on zero. Best-effort: a
+    Sentry tag write must never break registry initialisation.
+    """
+    with suppress(Exception):
+        sentry_sdk.set_tag("tools.import_failures", str(import_failures))
 
 
 _SKIP_MODULE_NAMES = {
@@ -150,7 +165,7 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
         try:
             module = _import_tool_module(module_name)
         except Exception as exc:
-            severity, extra_tags = _classify_import_error(module_name, exc)
+            severity, extra_tags = _classify_import_error(exc)
             report_exception(
                 exc,
                 logger=logger,
@@ -175,12 +190,7 @@ def _load_registry_snapshot() -> tuple[RegisteredTool, ...]:
                 continue
             tools_by_name[tool.name] = tool
 
-    # Surface aggregate import health as a Sentry tag so dashboards can track
-    # "% of tools that loaded successfully" over time (#1464). Best-effort —
-    # we never want a tag write to break registry initialisation.
-    if import_failures:
-        with suppress(Exception):
-            sentry_sdk.set_tag("tools.import_failures", str(import_failures))
+    _record_import_health(import_failures)
 
     return tuple(sorted(tools_by_name.values(), key=lambda tool: tool.name))
 

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -10,8 +10,6 @@ from contextlib import suppress
 from functools import lru_cache
 from types import ModuleType
 
-import sentry_sdk
-
 from app import tools as tools_package
 from app.tools.base import BaseTool
 from app.tools.registered_tool import REGISTERED_TOOL_ATTR, RegisteredTool, ToolSurface

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -393,7 +393,195 @@ def test_registry_regression_import_failures(
     assert "valid_tool" in tool_names
     assert registry_module.get_registered_tool_map()["valid_tool"].run() == {"status": "ok"}
 
+    # After #1464 the bare ``logger.warning(...)`` was replaced by
+    # ``report_exception`` which routes generic exceptions at error severity,
+    # so the surviving log record is at ERROR level.
     assert any(
-        "Skipping broken_module" in record.message and record.levelname == "WARNING"
+        "Skipping broken_module" in record.message and record.levelname == "ERROR"
         for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1464 — surface tool-registry import-time failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyImportError:
+    """Unit tests for ``_classify_import_error`` severity + tag selection."""
+
+    def test_external_module_not_found_is_warning(self) -> None:
+        exc = ModuleNotFoundError("No module named 'psycopg2'")
+        exc.name = "psycopg2"
+        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        assert severity == "warning"
+        assert tags == {
+            "event": "optional_dependency_missing",
+            "missing_module": "psycopg2",
+        }
+
+    def test_internal_module_not_found_is_error(self) -> None:
+        """Internal ``app.*`` ModuleNotFoundError is our bug — capture at error."""
+        exc = ModuleNotFoundError("No module named 'app.services.removed'")
+        exc.name = "app.services.removed"
+        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        assert severity == "error"
+        assert tags == {"event": "tool_module_import_failed"}
+
+    def test_generic_exception_is_error(self) -> None:
+        exc = RuntimeError("import side-effect blew up")
+        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        assert severity == "error"
+        assert tags == {"event": "tool_module_import_failed"}
+
+    def test_module_not_found_without_name_is_error(self) -> None:
+        """Defensive: ModuleNotFoundError with no ``.name`` cannot be classified
+        as an external optional-dep miss, so it falls through to ``error``."""
+        exc = ModuleNotFoundError("synthetic — no name attribute")
+        exc.name = None
+        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        assert severity == "error"
+        assert tags["event"] == "tool_module_import_failed"
+
+
+def _patch_registry_with_broken_module(monkeypatch: pytest.MonkeyPatch, exc: BaseException) -> None:
+    """Stub the registry to expose exactly one tool module whose import raises ``exc``."""
+
+    def mock_import(name: str) -> ModuleType:
+        raise exc
+
+    monkeypatch.setattr(
+        registry_module,
+        "_iter_tool_module_names",
+        lambda: ["broken_module"],
+    )
+    monkeypatch.setattr(registry_module, "_import_tool_module", mock_import)
+
+
+class TestImportFailuresReportToSentry:
+    """``_load_registry_snapshot`` must route every import failure through
+    ``report_exception`` (#1464), not silently warn — otherwise broken tool
+    modules vanish from the agent's toolbox at runtime with no signal."""
+
+    def test_external_dependency_missing_reports_as_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = ModuleNotFoundError("No module named 'boto3_extras'")
+        exc.name = "boto3_extras"
+        _patch_registry_with_broken_module(monkeypatch, exc)
+
+        with pytest.MonkeyPatch.context() as ctx:
+            calls: list[dict[str, Any]] = []
+            ctx.setattr(
+                registry_module,
+                "report_exception",
+                lambda exc, **kwargs: calls.append({"exc": exc, **kwargs}),
+            )
+            registry_module._load_registry_snapshot()
+
+        assert len(calls) == 1
+        assert calls[0]["severity"] == "warning"
+        tags = calls[0]["tags"]
+        assert tags["surface"] == "tool"
+        assert tags["module_name"] == "broken_module"
+        assert tags["component"] == "app.tools.broken_module"
+        assert tags["event"] == "optional_dependency_missing"
+        assert tags["missing_module"] == "boto3_extras"
+
+    def test_internal_import_failure_reports_as_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Internal ``app.*`` import failures must NOT be downgraded — they're
+        always our bug."""
+        exc = ModuleNotFoundError("No module named 'app.services.removed'")
+        exc.name = "app.services.removed"
+        _patch_registry_with_broken_module(monkeypatch, exc)
+
+        calls: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            registry_module,
+            "report_exception",
+            lambda exc, **kwargs: calls.append({"exc": exc, **kwargs}),
+        )
+        registry_module._load_registry_snapshot()
+
+        assert len(calls) == 1
+        assert calls[0]["severity"] == "error"
+        assert calls[0]["tags"]["event"] == "tool_module_import_failed"
+
+    def test_generic_exception_reports_as_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        exc = RuntimeError("import side-effect blew up")
+        _patch_registry_with_broken_module(monkeypatch, exc)
+
+        calls: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            registry_module,
+            "report_exception",
+            lambda exc, **kwargs: calls.append({"exc": exc, **kwargs}),
+        )
+        registry_module._load_registry_snapshot()
+
+        assert len(calls) == 1
+        assert calls[0]["severity"] == "error"
+        assert calls[0]["tags"]["event"] == "tool_module_import_failed"
+
+    def test_sentry_tag_set_when_failures_occur(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``tools.import_failures`` Sentry tag is set so the issue surface
+        can dashboard registry health across releases."""
+        exc = RuntimeError("boom")
+        _patch_registry_with_broken_module(monkeypatch, exc)
+
+        # Swallow the real report_exception so it doesn't actually try to ship
+        # to Sentry from a test process.
+        monkeypatch.setattr(registry_module, "report_exception", lambda *_a, **_k: None)
+
+        tags_set: list[tuple[str, str]] = []
+
+        def fake_set_tag(key: str, value: str) -> None:
+            tags_set.append((key, value))
+
+        monkeypatch.setattr(registry_module.sentry_sdk, "set_tag", fake_set_tag)
+        registry_module._load_registry_snapshot()
+
+        assert ("tools.import_failures", "1") in tags_set
+
+    def test_sentry_tag_skipped_when_no_failures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No failures → no spurious ``tools.import_failures=0`` tag that would
+        pollute Sentry's tag cardinality on healthy runs."""
+        monkeypatch.setattr(
+            registry_module,
+            "_iter_tool_module_names",
+            lambda: [],
+        )
+        tags_set: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            registry_module.sentry_sdk,
+            "set_tag",
+            lambda k, v: tags_set.append((k, v)),
+        )
+        registry_module._load_registry_snapshot()
+
+        assert all(key != "tools.import_failures" for key, _ in tags_set)
+
+
+def test_no_internal_app_imports_fail_on_default_extras() -> None:
+    """Acceptance criterion: under the default extras matrix, no tool module
+    in ``app/tools/`` should fail to import. If this test breaks, a real
+    in-tree import is broken and a tool has silently disappeared from the
+    agent's toolbox."""
+    registry_module.clear_tool_registry_cache()
+    failures: list[tuple[str, BaseException]] = []
+    for module_name in registry_module._iter_tool_module_names():
+        try:
+            registry_module._import_tool_module(module_name)
+        except ModuleNotFoundError as exc:
+            # External optional-dependency miss is acceptable; only internal
+            # ``app.*`` failures should fail this test.
+            if exc.name and not exc.name.startswith("app."):
+                continue
+            failures.append((module_name, exc))
+        except Exception as exc:  # pragma: no cover — surfaces real regressions
+            failures.append((module_name, exc))
+    assert not failures, "internal tool-module import failures detected: " + ", ".join(
+        f"{name}: {exc!r}" for name, exc in failures
     )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -413,7 +413,7 @@ class TestClassifyImportError:
     def test_external_module_not_found_is_warning(self) -> None:
         exc = ModuleNotFoundError("No module named 'psycopg2'")
         exc.name = "psycopg2"
-        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        severity, tags = registry_module._classify_import_error(exc)
         assert severity == "warning"
         assert tags == {
             "event": "optional_dependency_missing",
@@ -424,13 +424,13 @@ class TestClassifyImportError:
         """Internal ``app.*`` ModuleNotFoundError is our bug — capture at error."""
         exc = ModuleNotFoundError("No module named 'app.services.removed'")
         exc.name = "app.services.removed"
-        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        severity, tags = registry_module._classify_import_error(exc)
         assert severity == "error"
         assert tags == {"event": "tool_module_import_failed"}
 
     def test_generic_exception_is_error(self) -> None:
         exc = RuntimeError("import side-effect blew up")
-        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        severity, tags = registry_module._classify_import_error(exc)
         assert severity == "error"
         assert tags == {"event": "tool_module_import_failed"}
 
@@ -439,7 +439,7 @@ class TestClassifyImportError:
         as an external optional-dep miss, so it falls through to ``error``."""
         exc = ModuleNotFoundError("synthetic — no name attribute")
         exc.name = None
-        severity, tags = registry_module._classify_import_error("my_tool", exc)
+        severity, tags = registry_module._classify_import_error(exc)
         assert severity == "error"
         assert tags["event"] == "tool_module_import_failed"
 
@@ -470,14 +470,13 @@ class TestImportFailuresReportToSentry:
         exc.name = "boto3_extras"
         _patch_registry_with_broken_module(monkeypatch, exc)
 
-        with pytest.MonkeyPatch.context() as ctx:
-            calls: list[dict[str, Any]] = []
-            ctx.setattr(
-                registry_module,
-                "report_exception",
-                lambda exc, **kwargs: calls.append({"exc": exc, **kwargs}),
-            )
-            registry_module._load_registry_snapshot()
+        calls: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            registry_module,
+            "report_exception",
+            lambda exc, **kwargs: calls.append({"exc": exc, **kwargs}),
+        )
+        registry_module._load_registry_snapshot()
 
         assert len(calls) == 1
         assert calls[0]["severity"] == "warning"
@@ -545,9 +544,11 @@ class TestImportFailuresReportToSentry:
 
         assert ("tools.import_failures", "1") in tags_set
 
-    def test_sentry_tag_skipped_when_no_failures(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No failures → no spurious ``tools.import_failures=0`` tag that would
-        pollute Sentry's tag cardinality on healthy runs."""
+    def test_sentry_tag_always_set_on_clean_rebuild(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``tools.import_failures`` is rewritten on every rebuild — including
+        with ``"0"`` — so a stale count from a previous load cannot bleed
+        across ``clear_tool_registry_cache()`` calls and falsely flag a healthy
+        process as still degraded."""
         monkeypatch.setattr(
             registry_module,
             "_iter_tool_module_names",
@@ -561,7 +562,36 @@ class TestImportFailuresReportToSentry:
         )
         registry_module._load_registry_snapshot()
 
-        assert all(key != "tools.import_failures" for key, _ in tags_set)
+        assert ("tools.import_failures", "0") in tags_set
+
+    def test_rebuild_after_failure_overwrites_stale_tag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: a previously written ``tools.import_failures=N`` tag must
+        be overwritten with ``"0"`` when a subsequent rebuild succeeds, so the
+        stale failure count cannot continue to fire on healthy events."""
+        exc = RuntimeError("boom")
+        _patch_registry_with_broken_module(monkeypatch, exc)
+        monkeypatch.setattr(registry_module, "report_exception", lambda *_a, **_k: None)
+
+        tags_set: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            registry_module.sentry_sdk,
+            "set_tag",
+            lambda k, v: tags_set.append((k, v)),
+        )
+
+        registry_module.clear_tool_registry_cache()
+        registry_module._load_registry_snapshot()
+        registry_module.clear_tool_registry_cache()
+
+        # Now flip the registry to a healthy state and rebuild.
+        monkeypatch.setattr(registry_module, "_iter_tool_module_names", lambda: [])
+        registry_module._load_registry_snapshot()
+
+        # Final write must be "0", not the stale "1" from the first rebuild.
+        registry_writes = [(k, v) for k, v in tags_set if k == "tools.import_failures"]
+        assert registry_writes[-1] == ("tools.import_failures", "0")
 
 
 def test_no_internal_app_imports_fail_on_default_extras() -> None:


### PR DESCRIPTION
Closes #1464.

## What

`app/tools/registry.py:_load_registry_snapshot` silently warned on every tool-module import failure. A real bug in `from app.services.foo import Bar` (e.g., `Bar` was removed but a tool still imports it) made the whole tool vanish from the agent's toolbox at runtime with no Sentry event. Users got degraded answers and there was no test guard against the regression.

This PR routes both `ModuleNotFoundError` and the broader `Exception` branch through `app.utils.errors.report_exception` and classifies the failure mode so external optional-dep misses don't drown real bugs.

## Classification (`_classify_import_error`)

| Cause | Severity | `event` tag |
|------|----------|-------------|
| External `ModuleNotFoundError` (e.g., `psycopg2`, `boto3` plugins not installed) | `warning` | `optional_dependency_missing` (+ `missing_module=<name>`) |
| Internal `app.*` `ModuleNotFoundError` | `error` | `tool_module_import_failed` |
| Any other `Exception` raised during module import | `error` | `tool_module_import_failed` |

Every captured event carries:

| tag         | value                         |
|-------------|-------------------------------|
| `surface`   | `tool`                        |
| `component` | `app.tools.<module_name>`     |
| `module_name` | `<module_name>`             |
| `event`     | (per classification above)    |

Severity rule mirrors the design in the issue: external misses are user-env signals (sample noise), internal failures are our bugs (always loud).

## Aggregate health tag

After registry load, the snapshot loop sets a `tools.import_failures=<N>` Sentry tag — but only when `N > 0`, so a healthy run doesn't pollute Sentry's tag cardinality with `tools.import_failures=0` on every event. Dashboards can graph this over time to catch tool-loss regressions across releases.

The tag write is wrapped in `contextlib.suppress(Exception)` — telemetry must never break registry init.

## Tests (`tests/tools/test_registry.py`)

- **`TestClassifyImportError`** (4 cases): external vs internal `ModuleNotFoundError`, generic `Exception`, defensive no-`.name` fallback.
- **`TestImportFailuresReportToSentry`** (4 cases): each branch routes through `report_exception` with the right severity + tag set; `tools.import_failures` tag is set when failures occur and absent when none.
- **`test_no_internal_app_imports_fail_on_default_extras`** — acceptance criterion from the issue: fails the suite if any in-tree `app.tools.*` module breaks under the default extras matrix. Makes a silently disappeared tool a CI fail rather than a runtime degradation.

The existing `test_registry_regression_import_failures` was updated for the new ERROR-level log record (was WARNING before this PR, because the bare `logger.warning(...)` is gone).

## Local verification

- `make lint`, `make format-check` clean.
- `tests/tools/` + `tests/utils/` clean (1921 passed, 1 skipped).
- 24/24 in `tests/tools/test_registry.py` pass — 8 new + 16 existing.