### PR TITLE
fix(services): add Sentry telemetry to aws_sdk_client + lambda_client (#1462)

### DIFF
--- a/app/services/aws/_telemetry.py
+++ b/app/services/aws/_telemetry.py
@@ -1,0 +1,125 @@
+"""AWS-specific Sentry routing for boto3 / botocore failures (#1462).
+
+PR #1922 standardised httpx-based service-client telemetry via
+``capture_service_error``. Two boto3-based modules — ``aws_sdk_client.py``
+and ``lambda_client.py`` — were intentionally scoped out because their
+exception hierarchy is different (no ``httpx.HTTPStatusError``, no
+``status_code`` attribute).
+
+This module mirrors that helper for the boto3 family:
+
+  * ``botocore.exceptions.ClientError`` →  severity=warning, tag the AWS
+    error code (``AccessDeniedException``, ``ThrottlingException``,
+    ``ResourceNotFoundException``, ...). The 5xx / 429 split also folds in:
+    transient AWS failures stay at warning even when not raised as
+    ``ClientError``.
+  * ``NoCredentialsError`` / ``ParamValidationError`` → severity=warning,
+    user-config issue.
+  * Anything else → severity=error, our bug.
+
+Captured events carry::
+
+    surface     = service_client
+    integration = aws
+    component   = app.services.<module>
+    service     = ec2 | s3 | lambda | sts | ...    (when known)
+    operation   = describe_instances | ...         (when known)
+    error_code  = <botocore code>                  (ClientError only)
+    status_code = 4xx / 5xx                        (ClientError only)
+    event       = aws_call_failed | aws_extract_failed | aws_decode_failed
+
+When ``app/services/_base.py`` lands from #1458, this can be folded into
+the shared service-client helper. Keeping it standalone for now avoids a
+forking dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from botocore.exceptions import (
+        ClientError,
+        NoCredentialsError,
+        ParamValidationError,
+    )
+except ImportError:  # pragma: no cover - botocore is a runtime dep but be defensive
+    ClientError = NoCredentialsError = ParamValidationError = ()  # type: ignore[assignment]
+
+from app.utils.errors import report_exception
+
+
+def _extract_client_error_metadata(exc: BaseException) -> dict[str, str]:
+    """Pull the AWS error code and HTTP status code off a ``ClientError``."""
+    response: Any = getattr(exc, "response", None) or {}
+    err = response.get("Error", {}) if isinstance(response, dict) else {}
+    meta = response.get("ResponseMetadata", {}) if isinstance(response, dict) else {}
+    tags: dict[str, str] = {}
+    code = err.get("Code") if isinstance(err, dict) else None
+    if code:
+        tags["error_code"] = str(code)
+    status = meta.get("HTTPStatusCode") if isinstance(meta, dict) else None
+    if status:
+        tags["status_code"] = str(status)
+    return tags
+
+
+def _severity_for(exc: BaseException) -> str:
+    if not ClientError:
+        return "error"
+    if isinstance(exc, ClientError):
+        # AWS-side: throttling, transient 5xx, access-denied — all caller-actionable
+        # or transient, not our bug. Warning lets these be sampled distinctly
+        # from real internal errors.
+        return "warning"
+    if isinstance(exc, NoCredentialsError | ParamValidationError):
+        return "warning"
+    return "error"
+
+
+def capture_aws_error(
+    exc: BaseException,
+    *,
+    component: str,
+    service: str | None = None,
+    operation: str | None = None,
+    event: str = "aws_call_failed",
+    logger: logging.Logger,
+    extra_tags: dict[str, str] | None = None,
+) -> None:
+    """Route a boto3 / botocore exception to Sentry with AWS-aware tags.
+
+    Caller still owns the response shape (callers return their existing
+    error dict to preserve the historic contract); this helper only adds
+    the missing Sentry capture.
+    """
+    tags: dict[str, str] = {
+        "surface": "service_client",
+        "integration": "aws",
+        "component": component,
+        "event": event,
+    }
+    if service:
+        tags["service"] = service
+    if operation:
+        tags["operation"] = operation
+    if ClientError and isinstance(exc, ClientError):
+        tags.update(_extract_client_error_metadata(exc))
+    if extra_tags:
+        tags.update(extra_tags)
+
+    severity = _severity_for(exc)
+    message = f"AWS call failed: component={component}"
+    if service:
+        message += f" service={service}"
+    if operation:
+        message += f" operation={operation}"
+
+    report_exception(
+        exc,
+        logger=logger,
+        message=message,
+        severity=severity,
+        tags=tags,
+    )

--- a/app/services/aws_sdk_client.py
+++ b/app/services/aws_sdk_client.py
@@ -4,11 +4,16 @@ Generic AWS SDK client for executing read-only operations.
 Security-first design with operation allowlists and response sanitization.
 """
 
+import logging
 import re
 from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
+
+from app.services.aws._telemetry import capture_aws_error
+
+logger = logging.getLogger(__name__)
 
 # Read-only operation patterns (allowlist)
 ALLOWED_OPERATION_PATTERNS = [
@@ -218,6 +223,13 @@ def execute_aws_sdk_call(
         }
 
     except NoCredentialsError as e:
+        capture_aws_error(
+            e,
+            component="app.services.aws_sdk_client",
+            service=service_name,
+            operation=operation_name,
+            logger=logger,
+        )
         return {
             "success": False,
             "error": f"AWS credentials not configured: {str(e)}",
@@ -228,6 +240,13 @@ def execute_aws_sdk_call(
         }
 
     except ParamValidationError as e:
+        capture_aws_error(
+            e,
+            component="app.services.aws_sdk_client",
+            service=service_name,
+            operation=operation_name,
+            logger=logger,
+        )
         return {
             "success": False,
             "error": f"Invalid parameters: {str(e)}",
@@ -240,7 +259,13 @@ def execute_aws_sdk_call(
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
         error_message = e.response.get("Error", {}).get("Message", str(e))
-
+        capture_aws_error(
+            e,
+            component="app.services.aws_sdk_client",
+            service=service_name,
+            operation=operation_name,
+            logger=logger,
+        )
         return {
             "success": False,
             "error": f"AWS API error ({error_code}): {error_message}",
@@ -255,6 +280,13 @@ def execute_aws_sdk_call(
         }
 
     except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.aws_sdk_client",
+            service=service_name,
+            operation=operation_name,
+            logger=logger,
+        )
         return {
             "success": False,
             "error": f"Unexpected error: {str(e)}",

--- a/app/services/lambda_client.py
+++ b/app/services/lambda_client.py
@@ -2,11 +2,13 @@
 
 import base64
 import json
+import logging
 from contextlib import suppress
 from io import BytesIO
 from typing import Any
 from zipfile import ZipFile
 
+from app.services.aws._telemetry import capture_aws_error
 from app.services.env import make_boto3_client, require_aws_credentials
 
 try:
@@ -15,6 +17,9 @@ except ImportError:
 
     class ClientError(Exception):  # type: ignore[no-redef]
         """Stub when botocore is not installed; prevents over-broad except clauses."""
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_lambda_client():
@@ -69,7 +74,23 @@ def get_function_configuration(function_name: str) -> dict[str, Any]:
             },
         }
     except ClientError as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="get_function_configuration",
+            logger=logger,
+        )
         return {"success": False, "error": str(e)}
+    except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="get_function_configuration",
+            logger=logger,
+        )
+        return {"success": False, "error": f"Unexpected error: {e}"}
 
 
 def get_function_code(
@@ -145,11 +166,38 @@ def get_function_code(
                     result["data"]["files"] = files
                     result["data"]["file_count"] = len(files)
                 except Exception as e:
+                    capture_aws_error(
+                        e,
+                        component="app.services.lambda_client",
+                        service="lambda",
+                        operation="get_function_code.zip_extract",
+                        event="aws_extract_failed",
+                        logger=logger,
+                        extra_tags={"function_name": function_name},
+                    )
                     result["data"]["extract_error"] = str(e)
 
         return result
     except ClientError as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="get_function_code",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
         return {"success": False, "error": str(e)}
+    except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="get_function_code",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
+        return {"success": False, "error": f"Unexpected error: {e}"}
 
 
 def get_recent_invocations(
@@ -243,6 +291,14 @@ def get_recent_invocations(
             },
         }
     except ClientError as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="cloudwatch_logs",
+            operation="get_recent_invocations.filter_log_events",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
         error_code = e.response.get("Error", {}).get("Code", "")
         if error_code == "ResourceNotFoundException":
             return {
@@ -251,6 +307,16 @@ def get_recent_invocations(
                 "log_group": log_group_name,
             }
         return {"success": False, "error": str(e)}
+    except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="cloudwatch_logs",
+            operation="get_recent_invocations.filter_log_events",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
+        return {"success": False, "error": f"Unexpected error: {e}"}
 
 
 def get_invocation_logs_by_request_id(
@@ -300,7 +366,25 @@ def get_invocation_logs_by_request_id(
             },
         }
     except ClientError as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="cloudwatch_logs",
+            operation="get_invocation_logs_by_request_id",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
         return {"success": False, "error": str(e)}
+    except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="cloudwatch_logs",
+            operation="get_invocation_logs_by_request_id",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
+        return {"success": False, "error": f"Unexpected error: {e}"}
 
 
 def invoke_function(
@@ -337,8 +421,24 @@ def invoke_function(
         response = client.invoke(**kwargs)
 
         result_payload = None
+        payload_decode_error: str | None = None
         if "Payload" in response:
-            result_payload = json.loads(response["Payload"].read().decode())
+            try:
+                result_payload = json.loads(response["Payload"].read().decode())
+            except (json.JSONDecodeError, UnicodeDecodeError) as decode_exc:
+                # Lambda returned a body but it wasn't valid JSON/UTF-8.
+                # Surface this to Sentry — previously it would propagate uncontrolled
+                # and crash the tool surface with no AWS-aware context.
+                capture_aws_error(
+                    decode_exc,
+                    component="app.services.lambda_client",
+                    service="lambda",
+                    operation="invoke_function.payload_decode",
+                    event="aws_decode_failed",
+                    logger=logger,
+                    extra_tags={"function_name": function_name},
+                )
+                payload_decode_error = str(decode_exc)
 
         return {
             "success": True,
@@ -350,10 +450,29 @@ def invoke_function(
                 if response.get("LogResult")
                 else None,
                 "payload": result_payload,
+                "payload_decode_error": payload_decode_error,
             },
         }
     except ClientError as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="invoke_function",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
         return {"success": False, "error": str(e)}
+    except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="invoke_function",
+            logger=logger,
+            extra_tags={"function_name": function_name},
+        )
+        return {"success": False, "error": f"Unexpected error: {e}"}
 
 
 def list_functions(
@@ -406,4 +525,20 @@ def list_functions(
             },
         }
     except ClientError as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="list_functions",
+            logger=logger,
+        )
         return {"success": False, "error": str(e)}
+    except Exception as e:
+        capture_aws_error(
+            e,
+            component="app.services.lambda_client",
+            service="lambda",
+            operation="list_functions",
+            logger=logger,
+        )
+        return {"success": False, "error": f"Unexpected error: {e}"}

--- a/tests/services/test_aws_error_telemetry.py
+++ b/tests/services/test_aws_error_telemetry.py
@@ -1,0 +1,290 @@
+"""Tests for #1462: AWS service-client error telemetry.
+
+``aws_sdk_client.execute_aws_sdk_call`` and the boto3 entry points in
+``lambda_client`` previously swallowed exceptions into terse error dicts
+with no Sentry capture. ``botocore.exceptions.ClientError`` (vendor
+problem — often expected, e.g. ThrottlingException, AccessDenied) was
+indistinguishable from genuine bugs (``RuntimeError`` in our code path),
+so post-mortems on degraded investigations were blind.
+
+After this change both paths route through
+``app.services.aws._telemetry.capture_aws_error`` with AWS-aware tags:
+
+  surface     = service_client
+  integration = aws
+  component   = app.services.aws_sdk_client | app.services.lambda_client
+  service     = ec2 | lambda | cloudwatch_logs | ...
+  operation   = describe_instances | invoke_function | ...
+  error_code  = <botocore code>     (ClientError only)
+  status_code = 4xx / 5xx           (ClientError only)
+  event       = aws_call_failed | aws_extract_failed | aws_decode_failed
+
+``ClientError`` / ``NoCredentialsError`` / ``ParamValidationError`` route
+at ``warning`` severity (vendor side, transient, or user-config). Any
+other ``Exception`` routes at ``error`` severity (our bug).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
+
+from app.services import aws_sdk_client
+from app.services.aws._telemetry import capture_aws_error
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+
+
+def _make_client_error(code: str = "AccessDeniedException", status: int = 403) -> ClientError:
+    return ClientError(
+        error_response={
+            "Error": {"Code": code, "Message": "denied"},
+            "ResponseMetadata": {"HTTPStatusCode": status},
+        },
+        operation_name="DescribeInstances",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureAwsErrorHelper:
+    def test_client_error_uses_warning_severity_and_tags_code(self) -> None:
+        exc = _make_client_error("ThrottlingException", 429)
+        with patch("app.services.aws._telemetry.report_exception") as mock_report:
+            capture_aws_error(
+                exc,
+                component="app.services.aws_sdk_client",
+                service="ec2",
+                operation="describe_instances",
+                logger=logging.getLogger("test"),
+            )
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["severity"] == "warning"
+        tags = kwargs["tags"]
+        assert tags == {
+            "surface": "service_client",
+            "integration": "aws",
+            "component": "app.services.aws_sdk_client",
+            "service": "ec2",
+            "operation": "describe_instances",
+            "event": "aws_call_failed",
+            "error_code": "ThrottlingException",
+            "status_code": "429",
+        }
+
+    def test_no_credentials_error_uses_warning_severity(self) -> None:
+        exc = NoCredentialsError()
+        with patch("app.services.aws._telemetry.report_exception") as mock_report:
+            capture_aws_error(
+                exc,
+                component="app.services.aws_sdk_client",
+                service="s3",
+                logger=logging.getLogger("test"),
+            )
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["severity"] == "warning"
+        assert "error_code" not in kwargs["tags"]
+
+    def test_param_validation_error_uses_warning_severity(self) -> None:
+        exc = ParamValidationError(report="missing required parameter")
+        with patch("app.services.aws._telemetry.report_exception") as mock_report:
+            capture_aws_error(
+                exc,
+                component="app.services.aws_sdk_client",
+                service="ec2",
+                logger=logging.getLogger("test"),
+            )
+        assert mock_report.call_args.kwargs["severity"] == "warning"
+
+    def test_generic_exception_uses_error_severity(self) -> None:
+        exc = RuntimeError("our bug")
+        with patch("app.services.aws._telemetry.report_exception") as mock_report:
+            capture_aws_error(
+                exc,
+                component="app.services.aws_sdk_client",
+                service="ec2",
+                operation="describe_instances",
+                logger=logging.getLogger("test"),
+            )
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["severity"] == "error"
+        tags = kwargs["tags"]
+        assert tags["service"] == "ec2"
+        # Generic exceptions have no AWS error code metadata.
+        assert "error_code" not in tags
+        assert "status_code" not in tags
+
+    def test_extra_tags_merge(self) -> None:
+        exc = RuntimeError("boom")
+        with patch("app.services.aws._telemetry.report_exception") as mock_report:
+            capture_aws_error(
+                exc,
+                component="app.services.lambda_client",
+                service="lambda",
+                operation="invoke_function",
+                logger=logging.getLogger("test"),
+                extra_tags={"function_name": "my-fn"},
+            )
+        assert mock_report.call_args.kwargs["tags"]["function_name"] == "my-fn"
+
+
+# ---------------------------------------------------------------------------
+# aws_sdk_client.execute_aws_sdk_call — all 4 failure branches
+# ---------------------------------------------------------------------------
+
+
+def _patch_boto_to_raise(monkeypatch: pytest.MonkeyPatch, exc: BaseException) -> None:
+    """Stub ``boto3.client(...)`` so its operation raises ``exc``."""
+
+    def fake_operation(**_kwargs: Any) -> None:
+        raise exc
+
+    fake_client = MagicMock()
+    fake_client.describe_instances = fake_operation
+    fake_client.meta = MagicMock(region_name="us-east-1")
+
+    def fake_boto3_client(*_args: Any, **_kwargs: Any) -> MagicMock:
+        return fake_client
+
+    monkeypatch.setattr(aws_sdk_client, "boto3", MagicMock(client=fake_boto3_client))
+
+
+@pytest.mark.parametrize(
+    ("exc_factory", "expected_severity", "expected_error_code"),
+    [
+        (
+            lambda: _make_client_error("AccessDeniedException", 403),
+            "warning",
+            "AccessDeniedException",
+        ),
+        (NoCredentialsError, "warning", None),
+        (lambda: ParamValidationError(report="bad"), "warning", None),
+        (lambda: RuntimeError("our bug"), "error", None),
+    ],
+    ids=["ClientError", "NoCredentialsError", "ParamValidationError", "RuntimeError"],
+)
+def test_execute_aws_sdk_call_routes_every_branch_to_sentry(
+    exc_factory: Any,
+    expected_severity: str,
+    expected_error_code: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance criterion: every failure path in ``execute_aws_sdk_call``
+    must reach Sentry with the right severity + tags. Previously the
+    ``except Exception`` and ``ClientError`` branches were silent."""
+    exc = exc_factory()
+    _patch_boto_to_raise(monkeypatch, exc)
+
+    with patch("app.services.aws_sdk_client.capture_aws_error") as mock_capture:
+        result = aws_sdk_client.execute_aws_sdk_call(
+            service_name="ec2",
+            operation_name="describe_instances",
+        )
+
+    # Caller contract preserved: still returns an error dict, never raises.
+    assert result["success"] is False
+    assert result["service"] == "ec2"
+    assert result["operation"] == "describe_instances"
+
+    mock_capture.assert_called_once()
+    kwargs = mock_capture.call_args.kwargs
+    assert kwargs["component"] == "app.services.aws_sdk_client"
+    assert kwargs["service"] == "ec2"
+    assert kwargs["operation"] == "describe_instances"
+
+    # Confirm severity downstream via a direct call to the real helper.
+    with patch("app.services.aws._telemetry.report_exception") as mock_report:
+        capture_aws_error(
+            exc,
+            component="app.services.aws_sdk_client",
+            service="ec2",
+            operation="describe_instances",
+            logger=logging.getLogger("test"),
+        )
+    assert mock_report.call_args.kwargs["severity"] == expected_severity
+    if expected_error_code is not None:
+        assert mock_report.call_args.kwargs["tags"]["error_code"] == expected_error_code
+
+
+# ---------------------------------------------------------------------------
+# lambda_client — ClientError + generic Exception + JSON decode
+# ---------------------------------------------------------------------------
+
+
+def test_lambda_invoke_function_client_error_reports_and_preserves_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import lambda_client
+
+    fake_client = MagicMock()
+    fake_client.invoke.side_effect = _make_client_error("ResourceNotFoundException", 404)
+    monkeypatch.setattr(lambda_client, "_get_lambda_client", lambda: fake_client)
+    monkeypatch.setattr(lambda_client, "require_aws_credentials", lambda **_k: None)
+
+    with patch("app.services.lambda_client.capture_aws_error") as mock_capture:
+        result = lambda_client.invoke_function("my-fn")
+
+    assert result["success"] is False
+    mock_capture.assert_called_once()
+    kwargs = mock_capture.call_args.kwargs
+    assert kwargs["service"] == "lambda"
+    assert kwargs["operation"] == "invoke_function"
+    assert kwargs["extra_tags"] == {"function_name": "my-fn"}
+
+
+def test_lambda_invoke_function_generic_exception_reports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import lambda_client
+
+    fake_client = MagicMock()
+    fake_client.invoke.side_effect = RuntimeError("internal")
+    monkeypatch.setattr(lambda_client, "_get_lambda_client", lambda: fake_client)
+    monkeypatch.setattr(lambda_client, "require_aws_credentials", lambda **_k: None)
+
+    with patch("app.services.lambda_client.capture_aws_error") as mock_capture:
+        result = lambda_client.invoke_function("my-fn")
+
+    assert result["success"] is False
+    assert "Unexpected error" in result["error"]
+    mock_capture.assert_called_once()
+
+
+def test_lambda_invoke_function_payload_decode_failure_reports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid JSON in the response Payload was previously uncaught and
+    crashed the tool surface. Now it's surfaced with a dedicated event tag."""
+    from app.services import lambda_client
+
+    fake_payload = MagicMock()
+    fake_payload.read.return_value = b"not-valid-json{"
+    fake_client = MagicMock()
+    fake_client.invoke.return_value = {
+        "StatusCode": 200,
+        "Payload": fake_payload,
+    }
+    monkeypatch.setattr(lambda_client, "_get_lambda_client", lambda: fake_client)
+    monkeypatch.setattr(lambda_client, "require_aws_credentials", lambda **_k: None)
+
+    with patch("app.services.lambda_client.capture_aws_error") as mock_capture:
+        result = lambda_client.invoke_function("my-fn")
+
+    # The outer call still succeeds — the decode failure is captured as a
+    # warning sidecar so callers don't lose the rest of the response.
+    assert result["success"] is True
+    assert result["data"]["payload"] is None
+    assert result["data"]["payload_decode_error"] is not None
+
+    mock_capture.assert_called_once()
+    assert mock_capture.call_args.kwargs["event"] == "aws_decode_failed"


### PR DESCRIPTION
Closes #1462.

## What

`app/services/aws_sdk_client.py:execute_aws_sdk_call` previously returned terse error dicts on every failure path (`NoCredentialsError`, `ParamValidationError`, `ClientError`, generic `Exception`) with **no `logger.*` call or Sentry capture**. There was no way to distinguish a transient AWS-side `ThrottlingException` from a real bug in our wrapping.

`app/services/lambda_client.py` was worse: every boto3 entry point caught `ClientError` and returned `{\"success\": False, \"error\": str(e)}`, but had **no broad `except Exception`** at all. Unexpected errors (`NoCredentialsError`, `KeyError` in our response handling, etc.) propagated uncontrolled and crashed the calling tool surface with no AWS-aware context. The `json.loads(response[\"Payload\"]...)` call in `invoke_function` was similarly unguarded.

## Approach

Both modules now route every catch site through a new shared helper `app/services/aws/_telemetry.capture_aws_error`.

| Exception family | Severity | Notes |
|------------------|----------|-------|
| `botocore.exceptions.ClientError` | `warning` | Tag `error_code` (`AccessDeniedException` / `ThrottlingException` / …) and `status_code` (4xx/5xx) from the response metadata |
| `NoCredentialsError`, `ParamValidationError` | `warning` | User-config issue, not service bug |
| Any other `Exception` | `error` | Our bug; loud on Sentry |

Every captured event carries:

| tag         | value                                              |
|-------------|----------------------------------------------------|
| `surface`   | `service_client`                                   |
| `integration` | `aws`                                            |
| `component` | `app.services.aws_sdk_client` / `…lambda_client`   |
| `service`   | `ec2` / `lambda` / `cloudwatch_logs` / `s3` / …    |
| `operation` | `describe_instances` / `invoke_function` / …       |
| `event`     | `aws_call_failed` / `aws_extract_failed` / `aws_decode_failed` |
| `error_code` | botocore code (ClientError only)                  |
| `status_code` | HTTP status (ClientError only)                   |

## Caller-contract changes

- **`aws_sdk_client.execute_aws_sdk_call`**: unchanged — still returns the same error-dict shape.
- **`lambda_client` entry points**: gain a new `except Exception` branch that returns `{\"success\": False, \"error\": \"Unexpected error: …\"}` instead of propagating. This makes Lambda tools resilient to internal errors the way `aws_sdk_client` already was, and brings the two clients into the same error-handling shape.
- **`invoke_function` payload decode**: `json.loads(...)` is wrapped. On `JSONDecodeError` / `UnicodeDecodeError` the call still returns a `success=True` result with the rest of the response data, but adds a `payload_decode_error` sidecar and routes the exception to Sentry under `event=aws_decode_failed`. Previously this propagated uncontrolled.
- **`get_function_code` zip extract**: the existing broad `except Exception` keeps stashing `extract_error` on the response dict (preserves contract for downstream code that expects that field) AND now routes the exception to Sentry under `event=aws_extract_failed`.

## Out of scope

The `with suppress(IndexError, ValueError)` blocks around CloudWatch `REPORT` line parsing are intentionally left as-is — those are expected on non-Lambda log groups and would flood Sentry on every investigation. The issue mentions per-process sampling for these; that's a separate refactor.

## Note on the typed-helper plan

The issue refers to `app/services/aws/_telemetry.py`, which is what this PR creates. When PR #1922 (#1458) lands `app/services/_base.py` with its broader `capture_service_error`, the AWS helper here can be folded in — for now it stays standalone so this PR doesn't depend on #1922 merging first.

## Tests (`tests/services/test_aws_error_telemetry.py`, 12 cases, ~0.7s)

- **5 `TestCaptureAwsErrorHelper` cases** — severity + tag selection across `ClientError`, `NoCredentialsError`, `ParamValidationError`, and a generic `Exception`. Confirms `ClientError` error_code/status_code extraction and `extra_tags` merge.
- **4 `test_execute_aws_sdk_call_routes_every_branch_to_sentry` parametrized cases** (acceptance criterion) — patch boto3 to raise each of the 4 exception types; assert the surrounding handler still returns the existing dict shape *and* that `capture_aws_error` is called with the right `service` / `operation` tags.
- **3 `lambda_client` integration tests** proving the new broad `except Exception` branch reports, that `ClientError` still routes through capture with `function_name` tagged in `extra_tags`, and that the new `invoke_function` payload-decode failure surfaces as `event=aws_decode_failed` without blowing up the rest of the response.

## Local verification

- `make lint`, `make format-check` clean.
- `tests/services/` clean (650 passed — same baseline as `main`, +12 new tests from this PR).