### PR TITLE
fix(integrations): catch ValidationError from invalid Slack webhook URL in resolve_effective_integrations

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1812,14 +1812,20 @@ def resolve_effective_integrations(
             try:
                 slack_config = SlackWebhookConfig.model_validate({"webhook_url": webhook_url})
                 effective["slack"] = _effective_entry("local store", slack_config.model_dump())
-            except Exception as exc:
-                logger.warning("Slack webhook URL from store is invalid: %s", exc)
+            except Exception:
+                # Do NOT include the exception value — Pydantic v2 ValidationError
+                # embeds the input_value (here a SlackWebhookConfig containing the
+                # webhook_url) in its string representation, and Slack webhook URLs
+                # carry a secret token in the path. Log only a static message.
+                logger.warning("Slack webhook URL from store is invalid; skipping Slack")
     elif slack_webhook_url := os.getenv("SLACK_WEBHOOK_URL", "").strip():
         try:
             slack_config = SlackWebhookConfig.model_validate({"webhook_url": slack_webhook_url})
             effective["slack"] = _effective_entry("local env", slack_config.model_dump())
-        except Exception as exc:
-            logger.warning("SLACK_WEBHOOK_URL is invalid: %s", exc)
+        except Exception:
+            # See note above: avoid logging the ValidationError which embeds the
+            # raw webhook_url (and its secret token).
+            logger.warning("SLACK_WEBHOOK_URL is invalid; skipping Slack")
 
     google_docs_integration = classified_integrations.get("google_docs")
     if isinstance(google_docs_integration, dict):

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1809,11 +1809,17 @@ def resolve_effective_integrations(
         slack_credentials = _raw_credentials(slack_store_integration)
         webhook_url = str(slack_credentials.get("webhook_url", "")).strip()
         if webhook_url:
-            slack_config = SlackWebhookConfig.model_validate({"webhook_url": webhook_url})
-            effective["slack"] = _effective_entry("local store", slack_config.model_dump())
+            try:
+                slack_config = SlackWebhookConfig.model_validate({"webhook_url": webhook_url})
+                effective["slack"] = _effective_entry("local store", slack_config.model_dump())
+            except Exception as exc:
+                logger.warning("Slack webhook URL from store is invalid: %s", exc)
     elif slack_webhook_url := os.getenv("SLACK_WEBHOOK_URL", "").strip():
-        slack_config = SlackWebhookConfig.model_validate({"webhook_url": slack_webhook_url})
-        effective["slack"] = _effective_entry("local env", slack_config.model_dump())
+        try:
+            slack_config = SlackWebhookConfig.model_validate({"webhook_url": slack_webhook_url})
+            effective["slack"] = _effective_entry("local env", slack_config.model_dump())
+        except Exception as exc:
+            logger.warning("SLACK_WEBHOOK_URL is invalid: %s", exc)
 
     google_docs_integration = classified_integrations.get("google_docs")
     if isinstance(google_docs_integration, dict):

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -613,3 +613,47 @@ def test_resolve_effective_integrations_includes_vercel_from_env(
     assert vercel is not None
     assert vercel["config"]["api_token"] == "tok_env"
     assert vercel["source"] == "local env"
+
+
+def test_resolve_effective_integrations_skips_invalid_slack_env_url(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-Slack SLACK_WEBHOOK_URL must not crash resolve_effective_integrations (Sentry #1987)."""
+    monkeypatch.setattr("app.integrations.catalog.load_integrations", lambda: [])
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://example.com/not-slack")
+
+    with caplog.at_level(logging.WARNING):
+        effective = resolve_effective_integrations()
+
+    assert "slack" not in effective
+    assert any("SLACK_WEBHOOK_URL" in r.message for r in caplog.records)
+
+
+def test_resolve_effective_integrations_skips_invalid_slack_store_url(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An invalid webhook_url in the store must not crash resolve_effective_integrations."""
+    monkeypatch.setattr(
+        "app.integrations.catalog.load_integrations",
+        lambda: [
+            {
+                "id": "slack-local",
+                "service": "slack",
+                "status": "active",
+                "instances": [
+                    {
+                        "name": "default",
+                        "tags": {},
+                        "credentials": {"webhook_url": "https://example.com/not-slack"},
+                    }
+                ],
+            }
+        ],
+    )
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        effective = resolve_effective_integrations()
+
+    assert "slack" not in effective
+    assert any("Slack webhook" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- `resolve_effective_integrations` in `app/integrations/_catalog_impl.py` called `SlackWebhookConfig.model_validate()` without catching `ValidationError` at two call sites (lines 1812 and 1815).
- If `SLACK_WEBHOOK_URL` (or a stored `webhook_url`) doesn't pass the Slack-domain check, the error propagated uncaught and crashed the entire `verify_integrations` flow (Sentry issue PYTHON-3P).
- Wrapped both call sites in `try/except Exception`, logging a warning and skipping Slack rather than aborting — consistent with every other `model_validate()` call in `_classify_service_instance` in the same file.
- Added two regression tests covering the env-var and store paths.

## Test plan

- [x] `make test-cov` — 6559 passed, 0 failures
- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues found in 554 source files
- [x] New tests `test_resolve_effective_integrations_skips_invalid_slack_env_url` and `test_resolve_effective_integrations_skips_invalid_slack_store_url` pass

Closes #1987

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2GcxYjbL43o73q1J3mxWy)_