### PR TITLE
fix(tests): clear OPENAI_API_KEY in codex adapter "not logged in" tests

### DIFF
--- a/tests/integrations/llm_cli/test_codex_adapter.py
+++ b/tests/integrations/llm_cli/test_codex_adapter.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.integrations.llm_cli.binary_resolver import diagnose_binary_path, npm_prefix_bin_dirs
 from app.integrations.llm_cli.codex import CodexAdapter, _fallback_codex_paths
 from app.integrations.llm_cli.text import flatten_messages_to_prompt
@@ -70,7 +72,12 @@ def test_detect_path_binary_logged_in(mock_which: MagicMock, mock_run: MagicMock
 
 @patch("app.integrations.llm_cli.codex.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
-def test_detect_not_logged_in(mock_which: MagicMock, mock_run: MagicMock) -> None:
+def test_detect_not_logged_in(
+    mock_which: MagicMock, mock_run: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Strip OPENAI_API_KEY so the dev's shell or .env can't trigger
+    # the API-key fallback and flip logged_in to True.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     mock_which.return_value = "/usr/bin/codex"
 
     def side_effect(args: list[str], **kwargs: object) -> MagicMock:
@@ -118,8 +125,13 @@ def test_detect_not_logged_in_uses_openai_api_key_fallback(
 
 @patch("app.integrations.llm_cli.codex.subprocess.run")
 @patch("app.integrations.llm_cli.binary_resolver.shutil.which")
-def test_detect_not_logged_in_exit_zero(mock_which: MagicMock, mock_run: MagicMock) -> None:
+def test_detect_not_logged_in_exit_zero(
+    mock_which: MagicMock, mock_run: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Some Codex versions may exit 0 while printing 'Not logged in' — must not match 'logged in'."""
+    # Strip OPENAI_API_KEY so the dev's shell or .env can't trigger
+    # the API-key fallback and flip logged_in to True.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     mock_which.return_value = "/usr/bin/codex"
 
     def side_effect(args: list[str], **kwargs: object) -> MagicMock:


### PR DESCRIPTION
Fixes #1991 

#### Describe the changes you have made in this PR -

Two tests in `tests/integrations/llm_cli/test_codex_adapter.py` (`test_detect_not_logged_in` and `test_detect_not_logged_in_exit_zero`) didn't isolate themselves from the developer's environment. They mock the Codex CLI to simulate "not logged in," but the adapter has an `OPENAI_API_KEY` fallback — so any developer with that env var set in their shell or `.env` file gets a `True` instead of `False` and the tests fail.

CI passes today because CI doesn't have the var set, but locally these tests are flaky depending on each developer's machine.

This PR adds `monkeypatch.delenv("OPENAI_API_KEY", raising=False)` to the two affected tests, so they explicitly clear the env var before calling `CodexAdapter.detect()`. pytest auto-restores the env at test teardown, so no leakage to other tests.

### Demo/Screenshot for feature changes and bug fixes - 

Before fix:

<img width="1133" height="136" alt="Screenshot 2026-05-14 at 12 06 26 PM" src="https://github.com/user-attachments/assets/5a70fa90-af99-425d-b840-5d27c06e4daa" />

After fix:

<img width="940" height="392" alt="image" src="https://github.com/user-attachments/assets/c65fecc4-0e93-4793-a3fe-74460d55b78a" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**The problem:** `CodexAdapter.detect()` falls back to `OPENAI_API_KEY` when `codex login status` reports "not logged in" — that's intentional product behavior so devs can authenticate via API key. But the two failing tests mock `codex login status` to say "not logged in" and assert `logged_in is False`, without clearing `OPENAI_API_KEY` from the environment. If any layer (shell export, `.env` loaded by `app/entrypoints/mcp.py:15` at import time) puts the var into `os.environ`, the fallback kicks in and the assertion flips.

**Why `monkeypatch.delenv(..., raising=False)`:**
- `delenv` removes the env var only for the duration of the test, then pytest restores the original value automatically.
- `raising=False` means: if the var wasn't set in the first place (CI), this is a no-op instead of raising `KeyError`. So CI behavior is unchanged.
- Pattern matches the sibling test `test_detect_not_logged_in_uses_openai_api_key_fallback` (line 95), which already uses `patch.dict` to set the var explicitly. Both tests now control the env explicitly instead of relying on whatever the dev happens to have.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
