### PR TITLE
fix(llm-cli): lengthen Cursor Agent status probe timeout

### DIFF
--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -142,8 +142,13 @@ class CursorAdapter:
             logged_in: bool | None = None
             if _has_cursor_api_key():
                 logged_in = True
+                reason = (
+                    "timed out"
+                    if isinstance(exc, subprocess.TimeoutExpired)
+                    else f"failed ({exc})"
+                )
                 detail = (
-                    "Cursor Agent auth probe timed out; "
+                    f"Cursor Agent auth probe {reason}; "
                     "headless auth via CURSOR_API_KEY is configured."
                 )
             return CLIProbe(

--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -17,7 +17,9 @@ from app.integrations.llm_cli.binary_resolver import resolve_cli_binary
 from app.integrations.llm_cli.env_overrides import CURSOR_CLI_ENV_KEYS, nonempty_env_values
 
 _CURSOR_VERSION_RE = re.compile(r"(\d{4}\.\d{2}\.\d{2}-[a-zA-Z0-9]+|\d+\.\d+\.\d+)")
-_PROBE_TIMEOUT_SEC = 3.0
+# `agent status` often hits the network and prints a short spinner; ~4s locally is common,
+# so 3s probes spuriously timed out during wizard/doctor detection.
+_PROBE_TIMEOUT_SEC = 15.0
 
 
 def _parse_version(text: str) -> str | None:
@@ -136,12 +138,20 @@ class CursorAdapter:
                 check=False,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
+            detail = f"Could not verify auth status with `{binary} status`: {exc}"
+            logged_in: bool | None = None
+            if _has_cursor_api_key():
+                logged_in = True
+                detail = (
+                    "Cursor Agent auth probe timed out; "
+                    "headless auth via CURSOR_API_KEY is configured."
+                )
             return CLIProbe(
                 installed=True,
                 version=version,
-                logged_in=None,
+                logged_in=logged_in,
                 bin_path=binary,
-                detail=f"Could not verify auth status with `{binary} status`: {exc}",
+                detail=detail,
             )
 
         logged_in, detail = _classify_cursor_auth(

--- a/tests/integrations/llm_cli/test_cursor_adapter.py
+++ b/tests/integrations/llm_cli/test_cursor_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from subprocess import TimeoutExpired
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -166,6 +167,58 @@ def test_detect_not_logged_in(mock_which: MagicMock, mock_run: MagicMock) -> Non
 
     assert probe.installed is True
     assert probe.logged_in is False
+
+
+@patch("app.integrations.llm_cli.cursor.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_status_timeout_without_api_key(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    mock_which.return_value = "agent"
+
+    def side_effect(args, **kwargs):
+        if "--version" in args:
+            return _version_proc()
+        if "status" in args:
+            raise TimeoutExpired(cmd=args, timeout=kwargs.get("timeout", 0))
+        return _fallback_proc()
+
+    mock_run.side_effect = side_effect
+
+    with patch.dict(
+        os.environ,
+        {"CURSOR_BIN": "agent", "CURSOR_API_KEY": "", "USERPROFILE": r"C:\Users\test"},
+        clear=True,
+    ):
+        probe = CursorAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is None
+    assert "status" in probe.detail
+
+
+@patch("app.integrations.llm_cli.cursor.subprocess.run")
+@patch("app.integrations.llm_cli.binary_resolver.shutil.which")
+def test_detect_status_timeout_with_api_key(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    mock_which.return_value = "agent"
+
+    def side_effect(args, **kwargs):
+        if "--version" in args:
+            return _version_proc()
+        if "status" in args:
+            raise TimeoutExpired(cmd=args, timeout=kwargs.get("timeout", 0))
+        return _fallback_proc()
+
+    mock_run.side_effect = side_effect
+
+    with patch.dict(
+        os.environ,
+        {"CURSOR_BIN": "agent", "CURSOR_API_KEY": "ck", "USERPROFILE": r"C:\Users\test"},
+        clear=True,
+    ):
+        probe = CursorAdapter().detect()
+
+    assert probe.installed is True
+    assert probe.logged_in is True
+    assert "CURSOR_API_KEY" in probe.detail
 
 
 @patch.dict(os.environ, {"CURSOR_API_KEY": ""}, clear=False)


### PR DESCRIPTION
Fixes #2000 

No linked GitHub issue (onboarding probe: `agent status` can exceed 3s while the spinner and network check run).

#### Describe the changes you have made in this PR -

- Raised the Cursor Agent CLI probe timeout from 3s to 15s for `agent --version` and `agent status` so normal `status` latency does not fail wizard / doctor detection.
- When `agent status` times out, treat `CURSOR_API_KEY` as sufficient headless auth (same spirit as unclear status + API key).
- Added unit tests for timeout paths with and without `CURSOR_API_KEY`.

### Demo/Screenshot for feature changes and bug fixes -

**Before:** Wizard showed `Could not verify auth status … timed out after 3.0 seconds` even when `agent status` succeeds (~3.9s observed locally).

**After:** Probe allows enough time for `agent status` to finish; timeout + `CURSOR_API_KEY` continues as authenticated.

```text
$ time ~/.local/bin/agent status
 ✓ Logged in as ...
real ~3.89s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The Cursor adapter’s `detect()` path runs `agent status` to infer login state. That subprocess routinely takes several seconds because the CLI renders progress and verifies auth remotely. Matching other CLI adapters in this repo (Claude/OpenCode ~8s, Gemini ~20s for auth-ish probes), 15 seconds caps worst-case wait without wedging onboarding forever. The API-key fallback on timeout mirrors the adapter’s existing behavior when stdout is ambiguous but `CURSOR_API_KEY` is set, and parallels Kimi’s env fallback when probes fail.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist with the PR.
