### PR TITLE
style(llm-cli): format cursor adapter

### DIFF
--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -143,9 +143,7 @@ class CursorAdapter:
             if _has_cursor_api_key():
                 logged_in = True
                 reason = (
-                    "timed out"
-                    if isinstance(exc, subprocess.TimeoutExpired)
-                    else f"failed ({exc})"
+                    "timed out" if isinstance(exc, subprocess.TimeoutExpired) else f"failed ({exc})"
                 )
                 detail = (
                     f"Cursor Agent auth probe {reason}; "


### PR DESCRIPTION
Fixes failing `ruff format --check app/ tests/` on `main` for `app/integrations/llm_cli/cursor.py`.

No behavior change.