### PR TITLE
fix: validate Vercel URL host boundary

### DIFF
--- a/app/remote/vercel_poller.py
+++ b/app/remote/vercel_poller.py
@@ -260,7 +260,8 @@ def parse_vercel_url(vercel_url: str) -> ParsedVercelUrl:
     parsed = urlparse(cleaned)
     if not cleaned:
         raise VercelResolutionError("Vercel URL is required.")
-    if "vercel.com" not in parsed.netloc.lower():
+    hostname = (parsed.hostname or "").lower()
+    if hostname != "vercel.com" and not hostname.endswith(".vercel.com"):
         raise VercelResolutionError(f"Unsupported Vercel URL host: {parsed.netloc or '<empty>'}")
 
     parts = [part for part in parsed.path.split("/") if part]

--- a/tests/remote/test_vercel_poller.py
+++ b/tests/remote/test_vercel_poller.py
@@ -161,6 +161,15 @@ def test_parse_vercel_url_extracts_project_and_selected_log_id() -> None:
     assert parsed.selected_log_id == "54w4s-1775494460431-b04b1df81301"
 
 
+def test_parse_vercel_url_accepts_vercel_subdomain() -> None:
+    parsed = parse_vercel_url(
+        "https://api.vercel.com/vincenthus-projects/tracer-marketing-website-v3/logs"
+    )
+
+    assert parsed.team_slug == "vincenthus-projects"
+    assert parsed.project_slug == "tracer-marketing-website-v3"
+
+
 @pytest.mark.parametrize(
     "vercel_url",
     [

--- a/tests/remote/test_vercel_poller.py
+++ b/tests/remote/test_vercel_poller.py
@@ -161,6 +161,19 @@ def test_parse_vercel_url_extracts_project_and_selected_log_id() -> None:
     assert parsed.selected_log_id == "54w4s-1775494460431-b04b1df81301"
 
 
+@pytest.mark.parametrize(
+    "vercel_url",
+    [
+        "https://vercel.com.evil.test/vincenthus-projects/tracer-marketing-website-v3/logs",
+        "https://evilvercel.com/vincenthus-projects/tracer-marketing-website-v3/logs",
+        "https://vercel.com@evil.test/vincenthus-projects/tracer-marketing-website-v3/logs",
+    ],
+)
+def test_parse_vercel_url_rejects_spoofed_vercel_hosts(vercel_url: str) -> None:
+    with pytest.raises(VercelResolutionError, match="Unsupported Vercel URL host"):
+        parse_vercel_url(vercel_url)
+
+
 def test_enrich_remote_alert_from_vercel_resolves_selected_log_id(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Fixes: N/A (bug found via code scan)

#### Describe the changes you have made in this PR -
- Validate Vercel URLs using the parsed hostname instead of substring-matching the full netloc.
- Reject spoofed hosts like `evilvercel.com`, `vercel.com.evil.test`, and userinfo tricks like `vercel.com@evil.test`.
- Add regression coverage for spoofed Vercel URL hosts.

### Demo/Screenshot for feature changes and bug fixes -
`uv run python -m pytest tests/remote/test_vercel_poller.py -q` -> 20 passed
`uv run ruff check app/remote/vercel_poller.py tests/remote/test_vercel_poller.py` -> All checks passed
`uv run ruff format --check app/remote/vercel_poller.py tests/remote/test_vercel_poller.py` -> 2 files already formatted

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The existing Vercel URL parser accepted any URL whose netloc contained `vercel.com`, which allowed spoofed domains such as `evilvercel.com` and `vercel.com.evil.test`. This PR switches validation to `urlparse(...).hostname` and requires either the exact `vercel.com` domain or a proper `.vercel.com` subdomain boundary. The tests cover spoofed domains and userinfo-style URLs so the parser cannot regress to substring matching.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.