### PR TITLE
Fix/bedrock agent llm client

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -165,12 +165,17 @@ class BedrockAgentClient(AnthropicAgentClient):
     """Bedrock-backed client using AnthropicBedrock SDK."""
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
-        from anthropic import AnthropicBedrock
         import os
+        from typing import cast
 
-        self._client = AnthropicBedrock(
-            aws_region=os.getenv("AWS_REGION", "us-east-1"),
-            timeout=_CLIENT_TIMEOUT_SEC,
+        from anthropic import Anthropic, AnthropicBedrock
+
+        self._client = cast(
+            Anthropic,
+            AnthropicBedrock(
+                aws_region=os.getenv("AWS_REGION", "us-east-1"),
+                timeout=_CLIENT_TIMEOUT_SEC,
+            ),
         )
         self._model = model
         self._max_tokens = max_tokens

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -161,6 +161,20 @@ class AnthropicAgentClient:
         return {"role": "assistant", "content": raw_content}
 
 
+class BedrockAgentClient(AnthropicAgentClient):
+    """Bedrock-backed client using AnthropicBedrock SDK."""
+
+    def __init__(self, model: str, max_tokens: int = 4096) -> None:
+        from anthropic import AnthropicBedrock
+        import os
+
+        self._client = AnthropicBedrock(
+            aws_region=os.getenv("AWS_REGION", "us-east-1"),
+            timeout=_CLIENT_TIMEOUT_SEC,
+        )
+        self._model = model
+        self._max_tokens = max_tokens
+
 class OpenAIAgentClient:
     """OpenAI-compatible client with tool-calling for the agent loop."""
 
@@ -312,6 +326,12 @@ def get_agent_llm() -> _AgentClientType:
         from app.config import LLMSettings
 
         _agent_client = _create_openai_compat_client(settings, provider)
+    elif provider == "bedrock":
+        from app.config import BEDROCK_LLM_CONFIG
+        _agent_client = BedrockAgentClient(
+            model=settings.bedrock_reasoning_model,
+            max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+        )
     else:
         # Default: Anthropic
         from app.config import ANTHROPIC_LLM_CONFIG


### PR DESCRIPTION
Here's the filled PR description:

Fixes #2008
# Describe the changes you have made in this PR -
`agent_llm_client.py` has a provider switch that handles openai, openrouter, gemini, nvidia, minimax, requesty, and ollama — but had no bedrock case. It fell through to the else branch which instantiates `AnthropicAgentClient`, which calls `resolve_llm_api_key("ANTHROPIC_API_KEY")` and attempts to connect to the Anthropic direct API instead of Bedrock. 

This caused an auth failure for any user with `LLM_PROVIDER=bedrock` and IAM credentials.

The fix adds a `BedrockAgentClient` class that inherits from `AnthropicAgentClient` and overrides __init__ to instantiate AnthropicBedrock (IAM-based auth) instead of Anthropic (API key-based auth). A bedrock case is added to the provider switch to route to this new client. AnthropicBedrock shares the same .messages.create() interface as Anthropic so no other methods needed changing.

# Demo/Screenshot -
**Before fix:**
```
RuntimeError: Anthropic API failed after 3 attempts: "Could not resolve authentication method. 
Expected one of api_key, auth_token, or credentials to be set."
```
**After fix:** 
Investigation runs successfully via Bedrock IAM auth.

# Code Understanding and AI Usage

- [x]   Yes, I used AI assistance
- [x]   I have reviewed every single line of the AI-generated code
- [x]   I can explain the purpose and logic of each function/component I added
- [x]   I have tested edge cases and understand how the code handles them
- [x]   I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The problem was a missing bedrock case in the provider switch in `agent_llm_client.py`. The Bedrock implementation already existed in `llm_client.py` but was never wired into the agent loop client.

I considered modifying `AnthropicAgentClient` directly to handle both auth paths, but subclassing is cleaner — it keeps the two auth methods isolated and follows the existing pattern in the file where each provider has its own client class.

BedrockAgentClient inherits all tool schema handling and response parsing from AnthropicAgentClient and only overrides `__init__` to swap `Anthropic(api_key=...)` for `AnthropicBedrock(aws_region=...)`. The cast `(Anthropic, ...)` is needed to satisfy `mypy` since `AnthropicBedrock` and `Anthropic` share the same interface but `mypy` infers the parent's `_client` attribute type as `Anthropic`.

Tested with `make lint`, `make typecheck`, `make test-cov` (6565 passed) and a live opensre investigate run against a fixture using AWS Bedrock IAM credentials.

Checklist before requesting a review

- [x]  I have added proper PR title and linked to the issue
- [x]  I have performed a self-review of my code
- [x]  I can explain the purpose of every function, class, and logic block I added
- [x]  I understand why my changes work and have tested them thoroughly
- [x]  I have considered potential edge cases and how my code handles them
- [ ]  If it is a core feature, I have added thorough tests
- [x]  My code follows the project's style guidelines and conventions