### PR TITLE
fix: harden remote config store shape

### DIFF
--- a/app/cli/wizard/store.py
+++ b/app/cli/wizard/store.py
@@ -39,6 +39,28 @@ def load_local_config(path: Path | None = None) -> dict[str, Any]:
     return _load_raw(path)
 
 
+def _remote_section(data: dict[str, Any], *, create: bool = False) -> dict[str, Any]:
+    remote = data.get("remote")
+    if isinstance(remote, dict):
+        return remote
+    if create:
+        remote = {}
+        data["remote"] = remote
+        return remote
+    return {}
+
+
+def _remote_entries(remote_section: dict[str, Any], *, create: bool = False) -> dict[str, Any]:
+    remotes = remote_section.get("remotes")
+    if isinstance(remotes, dict):
+        return remotes
+    if create:
+        remotes = {}
+        remote_section["remotes"] = remotes
+        return remotes
+    return {}
+
+
 def save_local_config(
     *,
     wizard_mode: str,
@@ -77,7 +99,7 @@ def save_local_config(
 def load_remote_url(path: Path | None = None) -> str | None:
     """Return the persisted remote agent URL, or ``None`` if not configured."""
     data = _load_raw(path)
-    url: str | None = data.get("remote", {}).get("url") or None
+    url: str | None = _remote_section(data).get("url") or None
     return url
 
 
@@ -85,7 +107,7 @@ def save_remote_url(url: str, path: Path | None = None) -> None:
     """Persist the remote agent URL to the store."""
     store_path = path or get_store_path()
     data = _load_raw(store_path)
-    data.setdefault("remote", {})["url"] = url
+    _remote_section(data, create=True)["url"] = url
     store_path.parent.mkdir(parents=True, exist_ok=True)
     store_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
@@ -93,8 +115,15 @@ def save_remote_url(url: str, path: Path | None = None) -> None:
 def load_named_remotes(path: Path | None = None) -> dict[str, str]:
     """Return all named remotes as ``{name: url}``."""
     data = _load_raw(path)
-    remotes: dict[str, Any] = data.get("remote", {}).get("remotes", {})
-    return {k: str(v.get("url", "")) for k, v in remotes.items() if v.get("url")}
+    remotes = _remote_entries(_remote_section(data))
+    named_remotes: dict[str, str] = {}
+    for name, entry in remotes.items():
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("url")
+        if url:
+            named_remotes[name] = str(url)
+    return named_remotes
 
 
 def save_named_remote(
@@ -108,8 +137,8 @@ def save_named_remote(
     """Save a named remote endpoint."""
     store_path = path or get_store_path()
     data = _load_raw(store_path)
-    remote_section = data.setdefault("remote", {})
-    remotes = remote_section.setdefault("remotes", {})
+    remote_section = _remote_section(data, create=True)
+    remotes = _remote_entries(remote_section, create=True)
     remotes[name] = {
         "url": url,
         "source": source,
@@ -126,13 +155,13 @@ def set_active_remote(name: str, path: Path | None = None) -> str:
     """Switch the active remote to *name*. Returns the URL."""
     store_path = path or get_store_path()
     data = _load_raw(store_path)
-    remotes: dict[str, Any] = data.get("remote", {}).get("remotes", {})
+    remotes = _remote_entries(_remote_section(data))
     entry = remotes.get(name)
-    if not entry or not entry.get("url"):
+    if not isinstance(entry, dict) or not entry.get("url"):
         raise KeyError(f"No remote named '{name}'")
 
     url: str = str(entry["url"])
-    remote_section = data.setdefault("remote", {})
+    remote_section = _remote_section(data, create=True)
     remote_section["url"] = url
     remote_section["active_name"] = name
     store_path.parent.mkdir(parents=True, exist_ok=True)
@@ -143,16 +172,14 @@ def set_active_remote(name: str, path: Path | None = None) -> str:
 def load_active_remote_name(path: Path | None = None) -> str | None:
     """Return the name of the currently active remote, or ``None``."""
     data = _load_raw(path)
-    name: str | None = data.get("remote", {}).get("active_name") or None
+    name: str | None = _remote_section(data).get("active_name") or None
     return name
 
 
 def load_remote_ops_config(path: Path | None = None) -> dict[str, str | None]:
     """Return persisted remote ops config values."""
     data = _load_raw(path)
-    remote_data = data.get("remote", {})
-    if not isinstance(remote_data, dict):
-        return {"provider": None, "project": None, "service": None}
+    remote_data = _remote_section(data)
     return {
         "provider": str(remote_data.get("provider") or "") or None,
         "project": str(remote_data.get("project") or "") or None,
@@ -170,7 +197,7 @@ def save_remote_ops_config(
     """Persist remote ops provider scope to the store."""
     store_path = path or get_store_path()
     data = _load_raw(store_path)
-    remote_data = data.setdefault("remote", {})
+    remote_data = _remote_section(data, create=True)
     remote_data["provider"] = provider
     if project:
         remote_data["project"] = project

--- a/tests/cli/wizard/test_store.py
+++ b/tests/cli/wizard/test_store.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 import json
 
 from app.cli.wizard.store import (
+    load_active_remote_name,
     load_local_config,
+    load_named_remotes,
     load_remote_ops_config,
+    load_remote_url,
     save_local_config,
+    save_named_remote,
     save_remote_ops_config,
+    save_remote_url,
+    set_active_remote,
 )
 
 
@@ -81,3 +87,70 @@ def test_remote_ops_config_clears_project_and_service(tmp_path) -> None:
 
     loaded = load_remote_ops_config(store_path)
     assert loaded == {"provider": "railway", "project": None, "service": None}
+
+
+def test_remote_loaders_treat_malformed_remote_section_as_empty(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+    store_path.write_text(json.dumps({"version": 1, "remote": "bad"}) + "\n", encoding="utf-8")
+
+    assert load_remote_url(store_path) is None
+    assert load_named_remotes(store_path) == {}
+    assert load_active_remote_name(store_path) is None
+
+
+def test_named_remote_loader_skips_malformed_entries(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+    store_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "remote": {
+                    "remotes": {
+                        "bad": "https://bad.example",
+                        "missing_url": {},
+                        "prod": {"url": "https://prod.example"},
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert load_named_remotes(store_path) == {"prod": "https://prod.example"}
+
+
+def test_remote_savers_replace_malformed_remote_section(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+    store_path.write_text(json.dumps({"version": 1, "remote": "bad"}) + "\n", encoding="utf-8")
+
+    save_remote_url("https://remote.example", path=store_path)
+    assert load_remote_url(store_path) == "https://remote.example"
+
+    store_path.write_text(json.dumps({"version": 1, "remote": "bad"}) + "\n", encoding="utf-8")
+    save_named_remote("prod", "https://prod.example", set_active=True, path=store_path)
+    assert load_named_remotes(store_path) == {"prod": "https://prod.example"}
+    assert load_active_remote_name(store_path) == "prod"
+
+    store_path.write_text(json.dumps({"version": 1, "remote": "bad"}) + "\n", encoding="utf-8")
+    save_remote_ops_config(provider="railway", project=None, service=None, path=store_path)
+    assert load_remote_ops_config(store_path) == {
+        "provider": "railway",
+        "project": None,
+        "service": None,
+    }
+
+
+def test_set_active_remote_handles_malformed_named_remotes(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+    store_path.write_text(
+        json.dumps({"version": 1, "remote": {"remotes": "bad"}}) + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        set_active_remote("prod", path=store_path)
+    except KeyError as exc:
+        assert str(exc) == "\"No remote named 'prod'\""
+    else:
+        raise AssertionError("Expected KeyError for missing remote")

--- a/tests/cli/wizard/test_store.py
+++ b/tests/cli/wizard/test_store.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from app.cli.wizard.store import (
     load_active_remote_name,
     load_local_config,
@@ -96,6 +98,11 @@ def test_remote_loaders_treat_malformed_remote_section_as_empty(tmp_path) -> Non
     assert load_remote_url(store_path) is None
     assert load_named_remotes(store_path) == {}
     assert load_active_remote_name(store_path) is None
+    assert load_remote_ops_config(store_path) == {
+        "provider": None,
+        "project": None,
+        "service": None,
+    }
 
 
 def test_named_remote_loader_skips_malformed_entries(tmp_path) -> None:
@@ -148,9 +155,5 @@ def test_set_active_remote_handles_malformed_named_remotes(tmp_path) -> None:
         encoding="utf-8",
     )
 
-    try:
+    with pytest.raises(KeyError, match="No remote named 'prod'"):
         set_active_remote("prod", path=store_path)
-    except KeyError as exc:
-        assert str(exc) == "\"No remote named 'prod'\""
-    else:
-        raise AssertionError("Expected KeyError for missing remote")


### PR DESCRIPTION
Fixes: N/A (bug found via code scan)

#### Describe the changes you have made in this PR -
- Treat malformed persisted `remote` sections as empty when reading remote URL, named remotes, active remote name, and remote ops config.
- Replace malformed `remote` / `remote.remotes` sections with dictionaries when saving remote settings.
- Add regression coverage for malformed remote sections, malformed named remote entries, saver recovery, and active remote selection.

### Demo/Screenshot for feature changes and bug fixes -
`uv run python -m pytest tests/cli/wizard/test_store.py tests/cli/test_remote.py tests/remote/test_runtime_alert.py -q` -> 33 passed
`uv run ruff check app/cli/wizard/store.py tests/cli/wizard/test_store.py` -> All checks passed
`uv run ruff format --check app/cli/wizard/store.py tests/cli/wizard/test_store.py` -> 2 files already formatted

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The remote store helpers assumed persisted `remote` config was always a dictionary. If a user-edited or corrupted `opensre.json` contained values like `"remote": "bad"` or `"remotes": "bad"`, read and write helpers raised `AttributeError` or `TypeError`. This PR centralizes remote-section normalization in two small helper functions: read paths treat malformed data as empty, while write paths replace malformed sections with dictionaries before persisting new values.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.