### PR TITLE
fix: harden guardrails rules config shape

### DIFF
--- a/app/guardrails/rules.py
+++ b/app/guardrails/rules.py
@@ -61,8 +61,13 @@ def load_rules(path: Path | None = None) -> list[GuardrailRule]:
         logger.warning("Guardrails config missing 'rules' key at %s", rules_path)
         return []
 
+    raw_rules = raw["rules"]
+    if not isinstance(raw_rules, list):
+        logger.warning("Guardrails config 'rules' must be a list at %s", rules_path)
+        return []
+
     rules: list[GuardrailRule] = []
-    for entry in raw["rules"]:
+    for entry in raw_rules:
         if not isinstance(entry, dict):
             continue
         parsed = _parse_rule(entry)

--- a/tests/test_guardrails/test_rules.py
+++ b/tests/test_guardrails/test_rules.py
@@ -27,7 +27,7 @@ class TestLoadRules:
         path = _write_config(tmp_path, {"version": 1})
         assert load_rules(path) == []
 
-    @pytest.mark.parametrize("rules_value", [1, "secret", {"name": "bad"}])
+    @pytest.mark.parametrize("rules_value", [1, "secret", {"name": "bad"}, None])
     def test_returns_empty_when_rules_section_is_not_a_list(
         self,
         tmp_path: Path,

--- a/tests/test_guardrails/test_rules.py
+++ b/tests/test_guardrails/test_rules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from app.guardrails.rules import GuardrailAction, load_rules
@@ -24,6 +25,15 @@ class TestLoadRules:
 
     def test_returns_empty_when_rules_key_missing(self, tmp_path: Path) -> None:
         path = _write_config(tmp_path, {"version": 1})
+        assert load_rules(path) == []
+
+    @pytest.mark.parametrize("rules_value", [1, "secret", {"name": "bad"}])
+    def test_returns_empty_when_rules_section_is_not_a_list(
+        self,
+        tmp_path: Path,
+        rules_value: object,
+    ) -> None:
+        path = _write_config(tmp_path, {"rules": rules_value})
         assert load_rules(path) == []
 
     def test_parses_pattern_rule(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

- Treat malformed guardrails configs whose `rules` value is not a YAML list as invalid instead of iterating them.
- Add regression coverage for scalar, string, and mapping `rules` values returning no loaded rules.

### Demo/Screenshot for feature changes and bug fixes - 

```console
$ uv run ruff check app/guardrails/rules.py tests/test_guardrails/test_rules.py
All checks passed!

$ uv run ruff format --check app/guardrails/rules.py tests/test_guardrails/test_rules.py
2 files already formatted

$ uv run python -m pytest tests/test_guardrails -q
111 passed in 4.75s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`load_rules()` already treats missing or malformed guardrails config as no valid rules. This change extends that behavior to malformed `rules` values by validating that `rules` is a YAML list before iterating it. That keeps malformed scalar or mapping values from raising `TypeError` and preserves the existing behavior of returning an empty rule set for invalid config.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions