### PR TITLE
fix(agent-llm): improve Bedrock auth/region handling

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -165,12 +165,17 @@ class BedrockAgentClient(AnthropicAgentClient):
     """Bedrock-backed client using AnthropicBedrock SDK."""
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
-        from anthropic import AnthropicBedrock
         import os
+        from typing import cast
 
-        self._client = AnthropicBedrock(
-            aws_region=os.getenv("AWS_REGION", "us-east-1"),
-            timeout=_CLIENT_TIMEOUT_SEC,
+        from anthropic import Anthropic, AnthropicBedrock
+
+        self._client = cast(
+            Anthropic,
+            AnthropicBedrock(
+                aws_region=os.getenv("AWS_REGION", "us-east-1"),
+                timeout=_CLIENT_TIMEOUT_SEC,
+            ),
         )
         self._model = model
         self._max_tokens = max_tokens

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -72,9 +72,9 @@ class AnthropicAgentClient:
     auth_error_hint = "Check ANTHROPIC_API_KEY."
 
     def __init__(self, model: str, max_tokens: int = 4096, *, client: Any | None = None) -> None:
-        from anthropic import Anthropic
-
         if client is None:
+            from anthropic import Anthropic
+
             from app.llm_credentials import resolve_llm_api_key
 
             api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
@@ -184,9 +184,7 @@ class BedrockAgentClient(AnthropicAgentClient):
     )
 
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
-        from typing import cast
-
-        from anthropic import Anthropic, AnthropicBedrock
+        from anthropic import AnthropicBedrock
 
         region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
         if not region:
@@ -194,14 +192,11 @@ class BedrockAgentClient(AnthropicAgentClient):
                 "Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set."
             )
 
-        client = cast(
-            Anthropic,
-            AnthropicBedrock(
-                aws_region=region,
-                timeout=_CLIENT_TIMEOUT_SEC,
-            ),
+        bedrock_client = AnthropicBedrock(
+            aws_region=region,
+            timeout=_CLIENT_TIMEOUT_SEC,
         )
-        super().__init__(model=model, max_tokens=max_tokens, client=client)
+        super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
 
 
 class OpenAIAgentClient:
@@ -357,6 +352,7 @@ def get_agent_llm() -> _AgentClientType:
         _agent_client = _create_openai_compat_client(settings, provider)
     elif provider == "bedrock":
         from app.config import BEDROCK_LLM_CONFIG
+
         _agent_client = BedrockAgentClient(
             model=settings.bedrock_reasoning_model,
             max_tokens=BEDROCK_LLM_CONFIG.max_tokens,

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -67,13 +68,19 @@ def _openai_tool_schema(tool: Any) -> dict[str, Any]:
 class AnthropicAgentClient:
     """Anthropic client with native tool-calling for the agent loop."""
 
-    def __init__(self, model: str, max_tokens: int = 4096) -> None:
+    provider_name = "Anthropic"
+    auth_error_hint = "Check ANTHROPIC_API_KEY."
+
+    def __init__(self, model: str, max_tokens: int = 4096, *, client: Any | None = None) -> None:
         from anthropic import Anthropic
 
-        from app.llm_credentials import resolve_llm_api_key
+        if client is None:
+            from app.llm_credentials import resolve_llm_api_key
 
-        api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
-        self._client = Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
+            api_key = resolve_llm_api_key("ANTHROPIC_API_KEY")
+            self._client = Anthropic(api_key=api_key, timeout=_CLIENT_TIMEOUT_SEC)
+        else:
+            self._client = client
         self._model = model
         self._max_tokens = max_tokens
 
@@ -106,23 +113,23 @@ class AnthropicAgentClient:
                 response = self._client.messages.create(**kwargs)
                 break
             except AuthenticationError as err:
-                raise RuntimeError(
-                    "Anthropic authentication failed. Check ANTHROPIC_API_KEY."
-                ) from err
+                raise RuntimeError(self._authentication_error_message()) from err
             except NotFoundError as err:
-                raise RuntimeError(f"Anthropic model '{self._model}' not found.") from err
+                raise RuntimeError(self._model_not_found_error_message()) from err
             except BadRequestError as err:
-                raise RuntimeError(f"Anthropic request rejected (HTTP 400): {err.message}") from err
+                raise RuntimeError(
+                    f"{self.provider_name} request rejected (HTTP 400): {err.message}"
+                ) from err
             except Exception as err:
                 last_err = err
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
                     raise RuntimeError(
-                        f"Anthropic API failed after {_RETRY_MAX_ATTEMPTS} attempts: {err}"
+                        f"{self.provider_name} API failed after {_RETRY_MAX_ATTEMPTS} attempts: {err}"
                     ) from err
                 time.sleep(backoff)
                 backoff *= 2
         else:
-            raise RuntimeError("Anthropic invocation failed") from last_err
+            raise RuntimeError(f"{self.provider_name} invocation failed") from last_err
 
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
@@ -160,25 +167,42 @@ class AnthropicAgentClient:
         """Build the assistant message preserving full Anthropic content blocks."""
         return {"role": "assistant", "content": raw_content}
 
+    def _authentication_error_message(self) -> str:
+        return f"{self.provider_name} authentication failed. {self.auth_error_hint}"
+
+    def _model_not_found_error_message(self) -> str:
+        return f"{self.provider_name} model '{self._model}' not found."
+
 
 class BedrockAgentClient(AnthropicAgentClient):
     """Bedrock-backed client using AnthropicBedrock SDK."""
 
+    provider_name = "Bedrock"
+    auth_error_hint = (
+        "Check AWS credentials (for example AWS_PROFILE, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, "
+        "or instance role) and AWS_REGION/AWS_DEFAULT_REGION."
+    )
+
     def __init__(self, model: str, max_tokens: int = 4096) -> None:
-        import os
         from typing import cast
 
         from anthropic import Anthropic, AnthropicBedrock
 
-        self._client = cast(
+        region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
+        if not region:
+            raise RuntimeError(
+                "Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set."
+            )
+
+        client = cast(
             Anthropic,
             AnthropicBedrock(
-                aws_region=os.getenv("AWS_REGION", "us-east-1"),
+                aws_region=region,
                 timeout=_CLIENT_TIMEOUT_SEC,
             ),
         )
-        self._model = model
-        self._max_tokens = max_tokens
+        super().__init__(model=model, max_tokens=max_tokens, client=client)
+
 
 class OpenAIAgentClient:
     """OpenAI-compatible client with tool-calling for the agent loop."""

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -161,6 +161,20 @@ class AnthropicAgentClient:
         return {"role": "assistant", "content": raw_content}
 
 
+class BedrockAgentClient(AnthropicAgentClient):
+    """Bedrock-backed client using AnthropicBedrock SDK."""
+
+    def __init__(self, model: str, max_tokens: int = 4096) -> None:
+        from anthropic import AnthropicBedrock
+        import os
+
+        self._client = AnthropicBedrock(
+            aws_region=os.getenv("AWS_REGION", "us-east-1"),
+            timeout=_CLIENT_TIMEOUT_SEC,
+        )
+        self._model = model
+        self._max_tokens = max_tokens
+
 class OpenAIAgentClient:
     """OpenAI-compatible client with tool-calling for the agent loop."""
 
@@ -312,6 +326,12 @@ def get_agent_llm() -> _AgentClientType:
         from app.config import LLMSettings
 
         _agent_client = _create_openai_compat_client(settings, provider)
+    elif provider == "bedrock":
+        from app.config import BEDROCK_LLM_CONFIG
+        _agent_client = BedrockAgentClient(
+            model=settings.bedrock_reasoning_model,
+            max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+        )
     else:
         # Default: Anthropic
         from app.config import ANTHROPIC_LLM_CONFIG

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -188,9 +188,7 @@ class BedrockAgentClient(AnthropicAgentClient):
 
         region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
         if not region:
-            raise RuntimeError(
-                "Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set."
-            )
+            raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
 
         bedrock_client = AnthropicBedrock(
             aws_region=region,

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from app.services.agent_llm_client import BedrockAgentClient
+
+
+def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
+    fake_module = types.SimpleNamespace()
+
+    class AuthenticationError(Exception):
+        pass
+
+    class BadRequestError(Exception):
+        def __init__(self, message: str) -> None:
+            super().__init__(message)
+            self.message = message
+
+    class NotFoundError(Exception):
+        pass
+
+    class Anthropic:
+        def __init__(self, **_: object) -> None:
+            self.messages = types.SimpleNamespace(create=lambda **_: None)
+
+    class AnthropicBedrock:
+        def __init__(self, **_: object) -> None:
+            self.messages = types.SimpleNamespace(create=lambda **_: None)
+
+    fake_module.AuthenticationError = AuthenticationError
+    fake_module.BadRequestError = BadRequestError
+    fake_module.NotFoundError = NotFoundError
+    fake_module.Anthropic = Anthropic
+    fake_module.AnthropicBedrock = AnthropicBedrock
+    monkeypatch.setitem(sys.modules, "anthropic", fake_module)
+    return fake_module
+
+
+def test_bedrock_client_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+        BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+
+def test_bedrock_auth_error_message_references_aws_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    client = BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    def raise_auth_error(**_: object) -> object:
+        raise fake_anthropic.AuthenticationError("expired")
+
+    client._client = types.SimpleNamespace(messages=types.SimpleNamespace(create=raise_auth_error))
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    message = str(exc.value)
+    assert "Bedrock authentication failed" in message
+    assert "AWS credentials" in message
+    assert "ANTHROPIC_API_KEY" not in message


### PR DESCRIPTION
Fixes https://github.com/Tracer-Cloud/opensre/issues/2008

## Summary
- fix Bedrock provider error messaging so auth/model errors reference Bedrock/AWS (not Anthropic API key)
- require explicit AWS region via `AWS_REGION` or `AWS_DEFAULT_REGION` for Bedrock client init
- refactor Bedrock client init to call superclass constructor through injected client
- move `os` import to module scope and fix class spacing/style
- add targeted tests for Bedrock region requirement and auth error messaging

## Validation
- `uv run ruff check app/services/agent_llm_client.py tests/services/test_agent_llm_client.py`
- `uv run pytest tests/services/test_agent_llm_client.py -q`

## Notes
Original PR #2011 is from a fork branch I cannot push to from this account, so this PR carries the review fixes on an upstream branch.
