### PR TITLE
feat(integrations): add ServiceNow incident context

### DIFF
--- a/app/cli/support/constants.py
+++ b/app/cli/support/constants.py
@@ -56,10 +56,12 @@ SETUP_SERVICES: tuple[str, ...] = (
     "rabbitmq",
     "rds",
     "sentry",
+    "servicenow",
     "slack",
     "tracer",
     "vercel",
 )
+
 
 
 def __getattr__(name: str) -> tuple[str, ...]:

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -187,6 +187,12 @@ def validate_incident_io_integration(**kwargs):
     return _validate(**kwargs)
 
 
+def validate_servicenow_integration(**kwargs):
+    from app.cli.wizard.integration_health import validate_servicenow_integration as _validate
+
+    return _validate(**kwargs)
+
+
 def validate_discord_bot(**kwargs):
     from app.cli.wizard.integration_health import validate_discord_bot as _validate
 
@@ -1520,6 +1526,59 @@ def _configure_incident_io() -> tuple[str, str]:
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
+def _configure_servicenow() -> tuple[str, str]:
+    _, credentials = _integration_defaults("servicenow")
+    while True:
+        instance_url = _prompt_value(
+            "ServiceNow instance URL",
+            default=_string_value(credentials.get("instance_url")),
+        )
+        api_token = _prompt_value(
+            "ServiceNow OAuth/API token (optional)",
+            default=_string_value(credentials.get("api_token")),
+            secret=True,
+            allow_empty=True,
+        )
+        username = ""
+        password = ""
+        if not api_token:
+            username = _prompt_value(
+                "ServiceNow username",
+                default=_string_value(credentials.get("username")),
+            )
+            password = _prompt_value(
+                "ServiceNow password",
+                default=_string_value(credentials.get("password")),
+                secret=True,
+            )
+        with _console.status("Validating ServiceNow integration...", spinner="dots"):
+            result = validate_servicenow_integration(
+                instance_url=instance_url,
+                username=username,
+                password=password,
+                api_token=api_token,
+            )
+        _render_integration_result("ServiceNow", result)
+        if result.ok:
+            credentials_payload = {
+                "instance_url": instance_url,
+                "username": username,
+                "password": password,
+                "api_token": api_token,
+            }
+            upsert_integration("servicenow", {"credentials": credentials_payload})
+            env_path = sync_env_values(
+                {
+                    "SERVICENOW_INSTANCE_URL": instance_url,
+                    "SERVICENOW_USERNAME": username,
+                    "SERVICENOW_PASSWORD": password,
+                    "SERVICENOW_API_TOKEN": api_token,
+                }
+            )
+            return "ServiceNow", str(env_path)
+        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+
+
 def _configure_discord() -> tuple[str, str]:
     _, credentials = _integration_defaults("discord")
     _console.print(
@@ -1805,6 +1864,11 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
             hint="Read incident context and updates from incident.io",
         ),
         Choice(
+            value="servicenow",
+            label="ServiceNow",
+            hint="Read incidents, services, and change records from ServiceNow",
+        ),
+        Choice(
             value="notion",
             label="Notion",
             hint="Post investigation reports to a Notion database",
@@ -1853,6 +1917,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "alertmanager": _configure_alertmanager,
         "opsgenie": _configure_opsgenie,
         "incident_io": _configure_incident_io,
+        "servicenow": _configure_servicenow,
         "notion": _configure_notion,
         "openclaw": _configure_openclaw,
         "opensearch": _configure_opensearch,
@@ -1876,6 +1941,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "alertmanager": "alertmanager",
         "opsgenie": "opsgenie",
         "incident_io": "incident.io",
+        "servicenow": "servicenow",
         "notion": "notion",
         "openclaw": "openclaw",
         "opensearch": "opensearch",

--- a/app/cli/wizard/integration_health.py
+++ b/app/cli/wizard/integration_health.py
@@ -16,6 +16,7 @@ from app.cli.wizard.integration_validators.client_validators import (
     validate_opensearch_integration,
     validate_opsgenie_integration,
     validate_sentry_integration,
+    validate_servicenow_integration,
     validate_splunk_integration,
     validate_vercel_integration,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "validate_opensearch_integration",
     "validate_opsgenie_integration",
     "validate_sentry_integration",
+    "validate_servicenow_integration",
     "validate_slack_webhook",
     "validate_splunk_integration",
     "validate_vercel_integration",

--- a/app/cli/wizard/integration_validators/client_validators.py
+++ b/app/cli/wizard/integration_validators/client_validators.py
@@ -23,6 +23,7 @@ from app.services.grafana import get_grafana_client_from_credentials
 from app.services.honeycomb import HoneycombClient
 from app.services.incident_io import IncidentIoClient
 from app.services.opsgenie import OpsGenieClient, OpsGenieConfig
+from app.services.servicenow import ServiceNowClient, ServiceNowConfig
 from app.services.splunk import SplunkClient, SplunkConfig
 from app.services.vercel import VercelClient, VercelConfig
 
@@ -451,6 +452,47 @@ def validate_incident_io_integration(
             ok=False,
             detail=f"incident.io validation failed: {str(err).replace(api_key, '[REDACTED]')}",
         )
+
+
+def validate_servicenow_integration(
+    *,
+    instance_url: str,
+    username: str = "",
+    password: str = "",
+    api_token: str = "",
+) -> IntegrationHealthResult:
+    """Validate ServiceNow connectivity by listing one incident."""
+    if not instance_url:
+        return IntegrationHealthResult(ok=False, detail="ServiceNow instance URL is required.")
+    if not api_token and not (username and password):
+        return IntegrationHealthResult(
+            ok=False,
+            detail="ServiceNow API token or username/password is required.",
+        )
+    try:
+        config = ServiceNowConfig(
+            instance_url=instance_url,
+            username=username,
+            password=password,
+            api_token=api_token,
+        )
+        with ServiceNowClient(config) as client:
+            result = client.list_incidents(limit=1)
+        if result.get("success"):
+            return IntegrationHealthResult(
+                ok=True,
+                detail="ServiceNow validated; credentials accepted.",
+            )
+        return IntegrationHealthResult(
+            ok=False,
+            detail=f"ServiceNow validation failed: {result.get('error', 'unknown error')}",
+        )
+    except Exception as err:
+        redacted = str(err)
+        for secret in (password, api_token):
+            if secret:
+                redacted = redacted.replace(secret, "[REDACTED]")
+        return IntegrationHealthResult(ok=False, detail=f"ServiceNow validation failed: {redacted}")
 
 
 def validate_splunk_integration(

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -28,6 +28,7 @@ from app.integrations.config_models import (
     IncidentIoIntegrationConfig,
     JiraIntegrationConfig,
     OpsGenieIntegrationConfig,
+    ServiceNowIntegrationConfig,
     SlackWebhookConfig,
     SplunkIntegrationConfig,
     TelegramBotConfig,
@@ -422,6 +423,21 @@ def _classify_service_instance(
         if incident_io_config.api_key:
             return incident_io_config.model_dump(), "incident_io"
         return None, None
+
+    if key == "servicenow":
+        try:
+            servicenow_config = ServiceNowIntegrationConfig.model_validate(
+                {
+                    "instance_url": credentials.get("instance_url", ""),
+                    "username": credentials.get("username", ""),
+                    "password": credentials.get("password", ""),
+                    "api_token": credentials.get("api_token", ""),
+                    "integration_id": record_id,
+                }
+            )
+        except Exception:
+            return None, None
+        return servicenow_config.model_dump(), "servicenow"
 
     if key == "jira":
         try:
@@ -1251,6 +1267,32 @@ def load_env_integrations() -> list[dict[str, Any]]:
                 _active_env_record(
                     "incident_io",
                     incident_io_config.model_dump(exclude={"integration_id"}),
+                )
+            )
+
+    servicenow_instance_url = os.getenv("SERVICENOW_INSTANCE_URL", "").strip()
+    servicenow_api_token = os.getenv("SERVICENOW_API_TOKEN", "").strip()
+    servicenow_username = os.getenv("SERVICENOW_USERNAME", "").strip()
+    servicenow_password = os.getenv("SERVICENOW_PASSWORD", "").strip()
+    if servicenow_instance_url and (
+        servicenow_api_token or (servicenow_username and servicenow_password)
+    ):
+        try:
+            servicenow_config = ServiceNowIntegrationConfig.model_validate(
+                {
+                    "instance_url": servicenow_instance_url,
+                    "username": servicenow_username,
+                    "password": servicenow_password,
+                    "api_token": servicenow_api_token,
+                }
+            )
+        except Exception:
+            logger.debug("Failed to load ServiceNow config from env", exc_info=True)
+        else:
+            integrations.append(
+                _active_env_record(
+                    "servicenow",
+                    servicenow_config.model_dump(exclude={"integration_id"}),
                 )
             )
 

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -21,6 +21,7 @@ from app.integrations.config_models import (
     HelmIntegrationConfig,
     HoneycombIntegrationConfig,
     IncidentIoIntegrationConfig,
+    ServiceNowIntegrationConfig,
     SlackWebhookConfig,
     TracerIntegrationConfig,
 )
@@ -43,6 +44,7 @@ from app.services.helm import HelmClient
 from app.services.honeycomb import HoneycombClient
 from app.services.incident_io import IncidentIoClient
 from app.services.opsgenie import OpsGenieClient, OpsGenieConfig
+from app.services.servicenow import ServiceNowClient
 from app.services.splunk import SplunkClient, SplunkConfig
 from app.services.tracer_client.client import TracerClient
 from app.services.vercel.client import VercelClient, VercelConfig
@@ -545,6 +547,12 @@ _verify_incident_io = build_probe_verifier(
     build_config=IncidentIoIntegrationConfig.model_validate,
     client_factory=IncidentIoClient,
 )
+
+_verify_servicenow = build_probe_verifier(
+    "servicenow",
+    build_config=ServiceNowIntegrationConfig.model_validate,
+    client_factory=ServiceNowClient,
+)
 _verify_alertmanager = build_probe_verifier(
     "alertmanager",
     build_config=AlertmanagerConfig.model_validate,
@@ -605,6 +613,7 @@ __all__ = [
     "_verify_honeycomb",
     "_verify_helm",
     "_verify_incident_io",
+    "_verify_servicenow",
     "_verify_kafka",
     "_verify_mariadb",
     "_verify_mongodb",

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -349,6 +349,31 @@ def _setup_incident_io() -> None:
     )
 
 
+def _setup_servicenow() -> None:
+    instance_url = _p("ServiceNow instance URL")
+    api_token = _p("ServiceNow OAuth/API token (optional)", secret=True)
+    username = ""
+    password = ""
+    if not api_token:
+        username = _p("ServiceNow username")
+        password = _p("ServiceNow password", secret=True)
+    if not instance_url:
+        _die("instance_url is required.")
+    if not api_token and not (username and password):
+        _die("api_token or username/password is required.")
+    upsert_integration(
+        "servicenow",
+        {
+            "credentials": {
+                "instance_url": instance_url,
+                "username": username,
+                "password": password,
+                "api_token": api_token,
+            }
+        },
+    )
+
+
 def _setup_github() -> None:
     from app.integrations.github_mcp import (
         GitHubMcpRepoView,
@@ -739,6 +764,7 @@ _HANDLERS: dict[str, Any] = {
     "grafana": _setup_grafana,
     "honeycomb": _setup_honeycomb,
     "incident_io": _setup_incident_io,
+    "servicenow": _setup_servicenow,
     "mariadb": _setup_mariadb,
     "mongodb_atlas": _setup_mongodb_atlas,
     "slack": _setup_slack,

--- a/app/integrations/config_models.py
+++ b/app/integrations/config_models.py
@@ -233,6 +233,46 @@ class IncidentIoIntegrationConfig(StrictConfigModel):
         }
 
 
+class ServiceNowIntegrationConfig(StrictConfigModel):
+    """Normalized ServiceNow credentials used by investigation and verification flows."""
+
+    instance_url: str
+    username: str = ""
+    password: str = ""
+    api_token: str = ""
+    integration_id: str = ""
+
+    @field_validator("instance_url", mode="before")
+    @classmethod
+    def _normalize_instance_url(cls, value: object) -> str:
+        normalized = normalize_url()(value)
+        return validate_https_or_loopback_http_url(normalized, service_name="ServiceNow")
+
+    _normalize_username = field_validator("username", mode="before")(normalize_str())
+    _normalize_password = field_validator("password", mode="before")(normalize_str())
+    _normalize_api_token = field_validator("api_token", mode="before")(normalize_str())
+
+    @model_validator(mode="after")
+    def _require_auth(self) -> ServiceNowIntegrationConfig:
+        if self.api_token or (self.username and self.password):
+            return self
+        raise ValueError("ServiceNow requires api_token or username/password credentials.")
+
+    @property
+    def base_url(self) -> str:
+        return self.instance_url.rstrip("/")
+
+    @property
+    def headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+        return headers
+
+
 class AlertmanagerIntegrationConfig(StrictConfigModel):
     """Normalized Alertmanager credentials used by resolution and verification flows."""
 

--- a/app/integrations/effective_models.py
+++ b/app/integrations/effective_models.py
@@ -72,6 +72,7 @@ class EffectiveIntegrations(StrictConfigModel):
     jira: EffectiveIntegrationEntry | None = None
     opsgenie: EffectiveIntegrationEntry | None = None
     incident_io: EffectiveIntegrationEntry | None = None
+    servicenow: EffectiveIntegrationEntry | None = None
     notion: EffectiveIntegrationEntry | None = None
     prefect: EffectiveIntegrationEntry | None = None
     posthog: EffectiveIntegrationEntry | None = None

--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -36,6 +36,7 @@ from app.integrations._verification_adapters import (
     _verify_postgresql,
     _verify_rabbitmq,
     _verify_sentry,
+    _verify_servicenow,
     _verify_slack_without_test,
     _verify_snowflake,
     _verify_splunk,
@@ -196,6 +197,14 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
         direct_effective=True,
         setup_order=22,
         verify_order=22,
+    ),
+    IntegrationSpec(
+        service="servicenow",
+        aliases=("service now", "snow"),
+        verifier=_verify_servicenow,
+        direct_effective=True,
+        setup_order=23,
+        verify_order=23,
     ),
     IntegrationSpec(
         service="jira",

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -42,6 +42,7 @@ _verify_opsgenie = _adapters._verify_opsgenie
 _verify_postgresql = _adapters._verify_postgresql
 _verify_rabbitmq = _adapters._verify_rabbitmq
 _verify_sentry = _adapters._verify_sentry
+_verify_servicenow = _adapters._verify_servicenow
 _verify_slack = _adapters._verify_slack
 _verify_snowflake = _adapters._verify_snowflake
 _verify_splunk = _adapters._verify_splunk
@@ -185,6 +186,7 @@ __all__ = [
     "_verify_postgresql",
     "_verify_rabbitmq",
     "_verify_sentry",
+    "_verify_servicenow",
     "_verify_slack",
     "_verify_snowflake",
     "_verify_splunk",

--- a/app/services/servicenow/__init__.py
+++ b/app/services/servicenow/__init__.py
@@ -1,0 +1,7 @@
+from app.services.servicenow.client import (
+    ServiceNowClient,
+    ServiceNowConfig,
+    make_servicenow_client,
+)
+
+__all__ = ["ServiceNowClient", "ServiceNowConfig", "make_servicenow_client"]

--- a/app/services/servicenow/client.py
+++ b/app/services/servicenow/client.py
@@ -33,7 +33,7 @@ _CHANGE_FIELDS = (
     "sys_id,number,short_description,type,state,risk,impact,assignment_group,"
     "cmdb_ci,business_service,start_date,end_date,sys_updated_on"
 )
-_SERVICE_FIELDS = "sys_id,name,owned_by,operational_status,busines_criticality"
+_SERVICE_FIELDS = "sys_id,name,owned_by,operational_status,business_criticality"
 
 
 def _limit(value: int | None, default: int = 10) -> int:
@@ -158,7 +158,7 @@ class ServiceNowClient:
         changes = self.list_recent_changes(query=change_query, limit=limit)
         services = self.list_services(query=service_query, limit=limit)
         return {
-            "success": changes.get("success", False) and services.get("success", False),
+            "success": True,
             "incident": incident.get("incident", {}),
             "changes": changes.get("changes", []),
             "services": services.get("services", []),

--- a/app/services/servicenow/client.py
+++ b/app/services/servicenow/client.py
@@ -1,0 +1,288 @@
+"""Small ServiceNow Table API client for investigation context."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+from app.integrations.config_models import ServiceNowIntegrationConfig
+from app.integrations.probes import ProbeResult
+
+logger = logging.getLogger(__name__)
+
+ServiceNowConfig = ServiceNowIntegrationConfig
+
+_DEFAULT_TIMEOUT = 30
+_MAX_LIMIT = 100
+_SECRET_RE = re.compile(
+    r"(?i)(bearer\s+[A-Za-z0-9._~+/=-]{6,}"
+    r"|authorization\s*[:=]\s*\S+"
+    r"|servicenow[_-]?(api[_-]?)?token\s*[:=]\s*\S+"
+    r"|password\s*[:=]\s*\S+)"
+)
+
+_INCIDENT_FIELDS = (
+    "sys_id,number,short_description,description,state,priority,urgency,"
+    "assignment_group,cmdb_ci,business_service,opened_at,sys_updated_on"
+)
+_CHANGE_FIELDS = (
+    "sys_id,number,short_description,type,state,risk,impact,assignment_group,"
+    "cmdb_ci,business_service,start_date,end_date,sys_updated_on"
+)
+_SERVICE_FIELDS = "sys_id,name,owned_by,operational_status,busines_criticality"
+
+
+def _limit(value: int | None, default: int = 10) -> int:
+    return default if value is None else max(1, min(int(value), _MAX_LIMIT))
+
+
+def _record(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: (
+            str(value.get("display_value") or value.get("value") or "").strip()
+            if isinstance(value, dict)
+            else value
+        )
+        for key, value in data.items()
+    }
+
+
+class ServiceNowClient:
+    """Synchronous client for the ServiceNow Table API."""
+
+    def __init__(self, config: ServiceNowConfig) -> None:
+        self.config = config
+        use_basic_auth = bool(config.username and config.password)
+        auth = (config.username, config.password) if use_basic_auth else None
+        headers = dict(config.headers)
+        if use_basic_auth:
+            headers.pop("Authorization", None)
+        self._client = httpx.Client(
+            base_url=config.base_url,
+            headers=headers,
+            auth=auth,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.config.api_token or (self.config.username and self.config.password))
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> ServiceNowClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def probe_access(self) -> ProbeResult:
+        if not self.is_configured:
+            return ProbeResult.missing("Missing ServiceNow credentials.")
+        try:
+            self._rows("incident", fields="sys_id,number", limit=1)
+        except Exception as exc:
+            return ProbeResult.failed(
+                f"Connection failed: {self._redact(exc)}",
+                base_url=self.config.base_url,
+            )
+        return ProbeResult.passed(
+            "Connected to ServiceNow; credentials accepted.",
+            base_url=self.config.base_url,
+        )
+
+    def list_incidents(
+        self, *, query: str = "active=true", limit: int | None = 10
+    ) -> dict[str, Any]:
+        return self._list(
+            "List incidents",
+            "incident",
+            "incidents",
+            query=query or "active=true",
+            fields=_INCIDENT_FIELDS,
+            limit=limit,
+        )
+
+    def get_incident(self, incident_id: str) -> dict[str, Any]:
+        """Fetch an incident by sys_id or number."""
+
+        def load() -> dict[str, Any]:
+            if incident_id.upper().startswith("INC"):
+                rows = self._rows("incident", query=f"number={incident_id}", limit=1)
+                return _record(rows[0]) if rows else {}
+            return _record(self._row("incident", incident_id))
+
+        return self._capture("Get incident", lambda: {"success": True, "incident": load()})
+
+    def list_recent_changes(
+        self,
+        *,
+        query: str = "active=true^ORDERBYDESCsys_updated_on",
+        limit: int | None = 10,
+    ) -> dict[str, Any]:
+        return self._list(
+            "List changes",
+            "change_request",
+            "changes",
+            query=query or "active=true^ORDERBYDESCsys_updated_on",
+            fields=_CHANGE_FIELDS,
+            limit=limit,
+        )
+
+    def list_services(self, *, query: str = "", limit: int | None = 10) -> dict[str, Any]:
+        return self._list(
+            "List services",
+            "cmdb_ci_service",
+            "services",
+            query=query,
+            fields=_SERVICE_FIELDS,
+            limit=limit,
+        )
+
+    def get_context(
+        self,
+        incident_id: str,
+        *,
+        change_query: str = "active=true^ORDERBYDESCsys_updated_on",
+        service_query: str = "",
+        limit: int | None = 10,
+    ) -> dict[str, Any]:
+        incident = self.get_incident(incident_id)
+        if not incident.get("success"):
+            return incident
+        changes = self.list_recent_changes(query=change_query, limit=limit)
+        services = self.list_services(query=service_query, limit=limit)
+        return {
+            "success": changes.get("success", False) and services.get("success", False),
+            "incident": incident.get("incident", {}),
+            "changes": changes.get("changes", []),
+            "services": services.get("services", []),
+            "errors": [
+                str(result.get("error"))
+                for result in (changes, services)
+                if not result.get("success") and result.get("error")
+            ],
+        }
+
+    def append_work_note(self, incident_id: str, note: str) -> dict[str, Any]:
+        if not note.strip():
+            return {"success": False, "error": "note is required for append_work_note."}
+
+        def patch() -> dict[str, Any]:
+            target = incident_id
+            if incident_id.upper().startswith("INC"):
+                target = str(self.get_incident(incident_id).get("incident", {}).get("sys_id") or "")
+            if not target:
+                return {"success": False, "error": "incident was not found."}
+            response = self._client.patch(
+                f"/api/now/table/incident/{target}",
+                json={"work_notes": note},
+                params={"sysparm_display_value": "true", "sysparm_exclude_reference_link": "true"},
+            )
+            response.raise_for_status()
+            return {"success": True, "incident": _record(response.json().get("result", {}))}
+
+        return self._capture("Append work note", patch)
+
+    def _list(
+        self,
+        action: str,
+        table: str,
+        key: str,
+        *,
+        query: str,
+        fields: str,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        def load() -> dict[str, Any]:
+            records = [
+                _record(row) for row in self._rows(table, query=query, fields=fields, limit=limit)
+            ]
+            return {"success": True, key: records, "total": len(records)}
+
+        return self._capture(
+            action,
+            load,
+        )
+
+    def _rows(
+        self,
+        table: str,
+        *,
+        query: str = "",
+        fields: str = "",
+        limit: int | None = 10,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {
+            "sysparm_limit": _limit(limit),
+            "sysparm_display_value": "true",
+            "sysparm_exclude_reference_link": "true",
+        }
+        if query:
+            params["sysparm_query"] = query
+        if fields:
+            params["sysparm_fields"] = fields
+        response = self._client.get(f"/api/now/table/{table}", params=params)
+        response.raise_for_status()
+        result = response.json().get("result", [])
+        return result if isinstance(result, list) else []
+
+    def _row(self, table: str, sys_id: str) -> dict[str, Any]:
+        response = self._client.get(
+            f"/api/now/table/{table}/{sys_id}",
+            params={"sysparm_display_value": "true", "sysparm_exclude_reference_link": "true"},
+        )
+        response.raise_for_status()
+        result = response.json().get("result", {})
+        return result if isinstance(result, dict) else {}
+
+    def _capture(self, action: str, fn: Callable[[], dict[str, Any]]) -> dict[str, Any]:
+        try:
+            return fn()
+        except httpx.HTTPStatusError as exc:
+            detail = self._redact(exc.response.text[:300])
+            logger.warning(
+                "[servicenow] %s HTTP failure status=%s error=%r",
+                action,
+                exc.response.status_code,
+                detail,
+            )
+            return {"success": False, "error": f"HTTP {exc.response.status_code}: {detail}"}
+        except Exception as exc:
+            detail = self._redact(exc)
+            logger.warning("[servicenow] %s error: %s", action, detail)
+            return {"success": False, "error": detail}
+
+    def _redact(self, value: object) -> str:
+        text = str(value)
+        for secret in (self.config.api_token, self.config.password):
+            if secret:
+                text = text.replace(secret, "[REDACTED]")
+        return _SECRET_RE.sub("[REDACTED]", text)
+
+
+def make_servicenow_client(
+    instance_url: str | None,
+    *,
+    username: str | None = "",
+    password: str | None = "",
+    api_token: str | None = "",
+) -> ServiceNowClient | None:
+    """Create a ServiceNow client if usable credentials are provided."""
+    try:
+        return ServiceNowClient(
+            ServiceNowConfig(
+                instance_url=instance_url or "",
+                username=username or "",
+                password=password or "",
+                api_token=api_token or "",
+            )
+        )
+    except Exception as exc:
+        logger.warning("[servicenow] Failed to build client config: %s", exc)
+        return None

--- a/app/tools/ServiceNowRecordsTool/__init__.py
+++ b/app/tools/ServiceNowRecordsTool/__init__.py
@@ -1,0 +1,173 @@
+"""ServiceNow incident, change, service, and work-note tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.servicenow import make_servicenow_client
+from app.tools.base import BaseTool
+
+
+class ServiceNowRecordsTool(BaseTool):
+    """Read ServiceNow operational context and optionally append incident work notes."""
+
+    name = "servicenow_records"
+    source = "servicenow"
+    description = (
+        "Read ServiceNow incidents, related business services, and recent changes for RCA "
+        "context. Can append OpenSRE findings to incident work notes when explicitly requested."
+    )
+    use_cases = [
+        "Reading ServiceNow incident context linked from an alert",
+        "Finding active incidents and recent change records during RCA",
+        "Looking up ServiceNow business services from CMDB service records",
+        "Posting investigation findings as ServiceNow incident work notes when requested",
+    ]
+    requires = ["instance_url", "api_token or username/password"]
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "list_incidents",
+                    "get_incident",
+                    "changes",
+                    "services",
+                    "context",
+                    "append_work_note",
+                ],
+                "default": "context",
+                "description": "ServiceNow action to perform.",
+            },
+            "incident_id": {
+                "type": "string",
+                "description": "ServiceNow incident sys_id or number, e.g. INC0010001.",
+            },
+            "incident_query": {
+                "type": "string",
+                "default": "active=true",
+                "description": "ServiceNow encoded query for incident list.",
+            },
+            "change_query": {
+                "type": "string",
+                "default": "active=true^ORDERBYDESCsys_updated_on",
+                "description": "ServiceNow encoded query for change_request records.",
+            },
+            "service_query": {
+                "type": "string",
+                "description": "ServiceNow encoded query for cmdb_ci_service records.",
+            },
+            "limit": {
+                "type": "integer",
+                "default": 10,
+                "description": "Maximum records to return.",
+            },
+            "note": {
+                "type": "string",
+                "description": "Work note body for append_work_note.",
+            },
+        },
+        "required": [],
+    }
+    outputs = {
+        "incidents": "List of ServiceNow incident summaries",
+        "incident": "ServiceNow incident detail for a single incident",
+        "changes": "Recent ServiceNow change_request records",
+        "services": "ServiceNow cmdb_ci_service records",
+        "success": "Whether the action succeeded",
+    }
+
+    def is_available(self, sources: dict) -> bool:
+        return bool(sources.get("servicenow", {}).get("connection_verified"))
+
+    def extract_params(self, sources: dict) -> dict[str, Any]:
+        servicenow = sources.get("servicenow", {})
+        incident_id = str(servicenow.get("incident_id", "")).strip()
+        return {
+            "instance_url": servicenow.get("instance_url", ""),
+            "username": servicenow.get("username", ""),
+            "password": servicenow.get("password", ""),
+            "api_token": servicenow.get("api_token", ""),
+            "action": "context" if incident_id else "list_incidents",
+            "incident_id": incident_id,
+            "incident_query": servicenow.get("incident_query", "active=true"),
+            "change_query": servicenow.get("change_query", "active=true^ORDERBYDESCsys_updated_on"),
+            "service_query": servicenow.get("service_query", ""),
+            "limit": servicenow.get("limit", 10),
+        }
+
+    def run(
+        self,
+        instance_url: str,
+        *,
+        username: str = "",
+        password: str = "",
+        api_token: str = "",
+        action: str = "context",
+        incident_id: str = "",
+        incident_query: str = "active=true",
+        change_query: str = "active=true^ORDERBYDESCsys_updated_on",
+        service_query: str = "",
+        limit: int | None = 10,
+        note: str = "",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        client = make_servicenow_client(
+            instance_url,
+            username=username,
+            password=password,
+            api_token=api_token,
+        )
+        if client is None:
+            return {
+                "source": "servicenow",
+                "available": False,
+                "success": False,
+                "error": "ServiceNow integration is not configured.",
+            }
+
+        normalized_action = (action or "context").strip().lower()
+        with client:
+            if normalized_action == "list_incidents":
+                result = client.list_incidents(query=incident_query, limit=limit)
+            elif normalized_action == "get_incident":
+                result = (
+                    client.get_incident(incident_id)
+                    if incident_id
+                    else {"success": False, "error": "incident_id is required for get_incident."}
+                )
+            elif normalized_action == "changes":
+                result = client.list_recent_changes(query=change_query, limit=limit)
+            elif normalized_action == "services":
+                result = client.list_services(query=service_query, limit=limit)
+            elif normalized_action == "append_work_note":
+                if not incident_id:
+                    result = {
+                        "success": False,
+                        "error": "incident_id is required for append_work_note.",
+                    }
+                else:
+                    result = client.append_work_note(incident_id, note)
+            else:
+                if not incident_id:
+                    result = {"success": False, "error": "incident_id is required for context."}
+                else:
+                    result = client.get_context(
+                        incident_id,
+                        change_query=change_query,
+                        service_query=service_query,
+                        limit=limit,
+                    )
+
+        result.update(
+            {
+                "source": "servicenow",
+                "available": bool(result.get("success")),
+                "action": normalized_action,
+            }
+        )
+        return result
+
+
+servicenow_records = ServiceNowRecordsTool()

--- a/app/types/evidence.py
+++ b/app/types/evidence.py
@@ -29,6 +29,7 @@ EvidenceSource = Literal[
     "vercel",
     "opsgenie",
     "incident_io",
+    "servicenow",
     "jira",
     "elasticsearch",
     "prefect",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,6 +104,7 @@
               "honeycomb",
               "incident_io",
               "opsgenie",
+              "servicenow",
               "sentry",
               "splunk"
             ]

--- a/docs/servicenow.mdx
+++ b/docs/servicenow.mdx
@@ -1,0 +1,68 @@
+---
+title: ServiceNow
+description: Connect OpenSRE to ServiceNow incidents, change records, and service metadata.
+---
+
+ServiceNow gives investigations ticket, change, and CMDB service context from the same workflow that queries telemetry.
+
+## Capabilities
+
+- Verify connectivity to a ServiceNow instance.
+- Read active or query-scoped incident records.
+- Fetch a linked incident by number or `sys_id`.
+- Read recent `change_request` records.
+- Read `cmdb_ci_service` business service records.
+- Append investigation findings to incident work notes when explicitly requested.
+
+## Setup
+
+Create credentials with read access to the `incident`, `change_request`, and `cmdb_ci_service` tables. Add write permission to `incident.work_notes` only if you want OpenSRE to post findings back.
+
+```bash
+opensre integrations setup servicenow
+```
+
+You can also configure ServiceNow from environment variables:
+
+```bash
+export SERVICENOW_INSTANCE_URL="https://dev12345.service-now.com"
+export SERVICENOW_USERNAME="admin"
+export SERVICENOW_PASSWORD="..."
+```
+
+For bearer token authentication, use:
+
+```bash
+export SERVICENOW_INSTANCE_URL="https://dev12345.service-now.com"
+export SERVICENOW_API_TOKEN="..."
+```
+
+## Verify
+
+```bash
+opensre integrations verify servicenow
+```
+
+Verification performs a minimal Table API read from `incident`.
+
+## Investigation Usage
+
+When an alert includes `servicenow_incident_id`, `servicenow_incident_number`, `servicenow_url`, or `servicenow_incident_url`, OpenSRE makes the `servicenow_records` action available with `action="context"`. That reads:
+
+- incident detail from `incident`
+- recent changes from `change_request`
+- business services from `cmdb_ci_service`
+
+You can scope ServiceNow reads with alert annotations:
+
+```json
+{
+  "servicenow_incident_number": "INC0010001",
+  "servicenow_change_query": "business_service=checkout^ORDERBYDESCsys_updated_on",
+  "servicenow_service_query": "nameLIKEcheckout"
+}
+```
+
+## Write-Back
+
+The `append_work_note` action writes to `incident.work_notes`. Use a least-privilege credential and reserve write-back for workflows where posting findings is expected.

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -18,6 +18,7 @@ from app.cli.wizard.integration_health import (
     validate_honeycomb_integration,
     validate_incident_io_integration,
     validate_sentry_integration,
+    validate_servicenow_integration,
     validate_slack_webhook,
     validate_vercel_integration,
 )
@@ -48,6 +49,7 @@ def test_legacy_integration_health_import_surface_still_exports_validators() -> 
         "validate_opensearch_integration",
         "validate_opsgenie_integration",
         "validate_sentry_integration",
+        "validate_servicenow_integration",
         "validate_slack_webhook",
         "validate_splunk_integration",
         "validate_vercel_integration",
@@ -165,6 +167,34 @@ def test_validate_incident_io_integration_succeeds(monkeypatch) -> None:
 
     assert result.ok is True
     assert "api key accepted" in result.detail.lower()
+
+
+def test_validate_servicenow_integration_succeeds(monkeypatch) -> None:
+    class _FakeServiceNowClient:
+        def __init__(self, _config) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def list_incidents(self, **_kwargs):
+            return {"success": True}
+
+    monkeypatch.setattr(
+        "app.cli.wizard.integration_validators.client_validators.ServiceNowClient",
+        _FakeServiceNowClient,
+    )
+
+    result = validate_servicenow_integration(
+        instance_url="https://dev12345.service-now.com",
+        api_token="token",
+    )
+
+    assert result.ok is True
+    assert "credentials accepted" in result.detail.lower()
 
 
 def test_validate_coralogix_integration_fails(monkeypatch) -> None:

--- a/tests/e2e/servicenow/test_servicenow_e2e.py
+++ b/tests/e2e/servicenow/test_servicenow_e2e.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services.servicenow import make_servicenow_client
+
+
+@pytest.mark.e2e
+def test_servicenow_real_api_list_incidents() -> None:
+    instance_url = os.getenv("SERVICENOW_INSTANCE_URL", "").strip()
+    api_token = os.getenv("SERVICENOW_API_TOKEN", "").strip()
+    username = os.getenv("SERVICENOW_USERNAME", "").strip()
+    password = os.getenv("SERVICENOW_PASSWORD", "").strip()
+    if not instance_url or not (api_token or (username and password)):
+        pytest.skip("Set SERVICENOW_INSTANCE_URL and ServiceNow credentials to run this e2e test.")
+
+    client = make_servicenow_client(
+        instance_url,
+        username=username,
+        password=password,
+        api_token=api_token,
+    )
+    assert client is not None
+    with client:
+        result = client.list_incidents(limit=1)
+
+    assert result["success"] is True
+    assert "incidents" in result

--- a/tests/integrations/test_servicenow.py
+++ b/tests/integrations/test_servicenow.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.integrations.catalog import classify_integrations
+from app.nodes.plan_actions.detect_sources import detect_sources
+
+
+def test_classify_servicenow_record() -> None:
+    resolved = classify_integrations(
+        [
+            {
+                "id": "sn-1",
+                "service": "servicenow",
+                "status": "active",
+                "credentials": {
+                    "instance_url": "https://dev12345.service-now.com",
+                    "api_token": "token",
+                },
+            }
+        ]
+    )
+
+    assert resolved["servicenow"]["instance_url"] == "https://dev12345.service-now.com"
+    assert resolved["servicenow"]["api_token"] == "token"
+    assert resolved["servicenow"]["integration_id"] == "sn-1"
+
+
+def test_detect_sources_servicenow_from_annotations() -> None:
+    sources = detect_sources(
+        {
+            "annotations": {
+                "servicenow_incident_number": "INC0010001",
+                "servicenow_change_query": "business_service=checkout",
+            }
+        },
+        {},
+        resolved_integrations={
+            "servicenow": {
+                "instance_url": "https://dev12345.service-now.com",
+                "username": "admin",
+                "password": "secret",
+                "api_token": "",
+                "integration_id": "sn-1",
+            }
+        },
+    )
+
+    assert sources["servicenow"]["incident_id"] == "INC0010001"
+    assert sources["servicenow"]["change_query"] == "business_service=checkout"
+    assert sources["servicenow"]["connection_verified"] is True
+
+
+def test_detect_sources_servicenow_extracts_sys_id_from_url() -> None:
+    sources = detect_sources(
+        {
+            "annotations": {
+                "servicenow_incident_url": (
+                    "https://dev12345.service-now.com/nav_to.do?uri=incident.do?sys_id=abc123"
+                )
+            }
+        },
+        {},
+        resolved_integrations={
+            "servicenow": {
+                "instance_url": "https://dev12345.service-now.com",
+                "api_token": "token",
+            }
+        },
+    )
+
+    assert sources["servicenow"]["incident_id"] == "abc123"

--- a/tests/services/test_servicenow_client.py
+++ b/tests/services/test_servicenow_client.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.integrations.config_models import ServiceNowIntegrationConfig
+from app.services.servicenow import ServiceNowClient, make_servicenow_client
+
+
+def _response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    response.status_code = 200
+    return response
+
+
+@pytest.fixture
+def client() -> ServiceNowClient:
+    return ServiceNowClient(
+        ServiceNowIntegrationConfig(
+            instance_url="https://dev12345.service-now.com",
+            username="admin",
+            password="secret",
+        )
+    )
+
+
+def test_config_rejects_non_https_remote_instance_url() -> None:
+    with pytest.raises(ValueError, match="must use https"):
+        ServiceNowIntegrationConfig(
+            instance_url="http://169.254.169.254/latest",
+            username="admin",
+            password="secret",
+        )
+
+
+def test_config_requires_token_or_basic_auth() -> None:
+    with pytest.raises(ValueError, match="requires api_token"):
+        ServiceNowIntegrationConfig(instance_url="https://dev12345.service-now.com")
+
+
+def test_make_client_allows_bearer_token() -> None:
+    created = make_servicenow_client(
+        "https://dev12345.service-now.com",
+        api_token="token",
+    )
+
+    assert created is not None
+    assert created.config.headers["Authorization"] == "Bearer token"
+
+
+def test_client_prefers_basic_auth_when_basic_and_token_are_present(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_client(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("app.services.servicenow.client.httpx.Client", fake_client)
+
+    ServiceNowClient(
+        ServiceNowIntegrationConfig(
+            instance_url="https://dev12345.service-now.com",
+            username="admin",
+            password="secret",
+            api_token="stale-token",
+        )
+    )
+
+    assert captured["auth"] == ("admin", "secret")
+    assert "Authorization" not in captured["headers"]
+
+
+def test_list_incidents_uses_table_api_query(client: ServiceNowClient, monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_rows(table: str, **kwargs):
+        calls.append((table, kwargs))
+        return [
+            {
+                "sys_id": "abc",
+                "number": "INC001",
+                "short_description": "Checkout down",
+                "assignment_group": {"display_value": "SRE", "value": "grp"},
+            }
+        ]
+
+    monkeypatch.setattr(client, "_rows", fake_rows)
+
+    result = client.list_incidents(query="active=true", limit=1)
+
+    assert result["success"] is True
+    assert result["incidents"][0]["assignment_group"] == "SRE"
+    assert calls[0][0] == "incident"
+    assert calls[0][1]["query"] == "active=true"
+    assert calls[0][1]["limit"] == 1
+
+
+def test_context_reads_incident_changes_and_services(
+    client: ServiceNowClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        client,
+        "get_incident",
+        lambda incident_id: {"success": True, "incident": {"number": incident_id}},
+    )
+    monkeypatch.setattr(
+        client,
+        "list_recent_changes",
+        lambda **_kwargs: {"success": True, "changes": [{"number": "CHG001"}]},
+    )
+    monkeypatch.setattr(
+        client,
+        "list_services",
+        lambda **_kwargs: {"success": True, "services": [{"name": "checkout"}]},
+    )
+
+    result = client.get_context("INC001")
+
+    assert result["success"] is True
+    assert result["incident"]["number"] == "INC001"
+    assert result["changes"][0]["number"] == "CHG001"
+    assert result["services"][0]["name"] == "checkout"
+
+
+def test_append_work_note_resolves_incident_number_to_sys_id(
+    client: ServiceNowClient,
+    monkeypatch,
+) -> None:
+    patch = MagicMock(return_value=_response({"result": {"sys_id": "abc", "number": "INC001"}}))
+    monkeypatch.setattr(client, "get_incident", lambda _id: {"incident": {"sys_id": "abc"}})
+    monkeypatch.setattr(client._client, "patch", patch)
+
+    result = client.append_work_note("INC001", "OpenSRE finding")
+
+    assert result["success"] is True
+    patch.assert_called_once()
+    assert patch.call_args.kwargs["json"] == {"work_notes": "OpenSRE finding"}

--- a/tests/tools/test_servicenow_records_tool.py
+++ b/tests/tools/test_servicenow_records_tool.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.tools.ServiceNowRecordsTool import ServiceNowRecordsTool
+
+
+def test_servicenow_tool_extracts_credentials_from_sources() -> None:
+    tool = ServiceNowRecordsTool()
+
+    params = tool.extract_params(
+        {
+            "servicenow": {
+                "instance_url": "https://dev12345.service-now.com",
+                "api_token": "token",
+                "incident_id": "INC001",
+            }
+        }
+    )
+
+    assert params["instance_url"] == "https://dev12345.service-now.com"
+    assert params["api_token"] == "token"
+    assert params["action"] == "context"
+    assert params["incident_id"] == "INC001"
+
+
+def test_servicenow_tool_runs_context(monkeypatch) -> None:
+    tool = ServiceNowRecordsTool()
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.get_context.return_value = {
+        "success": True,
+        "incident": {"number": "INC001"},
+        "changes": [],
+        "services": [],
+    }
+
+    monkeypatch.setattr(
+        "app.tools.ServiceNowRecordsTool.make_servicenow_client",
+        lambda *_args, **_kwargs: client,
+    )
+
+    result = tool.run(
+        instance_url="https://dev12345.service-now.com",
+        api_token="token",
+        action="context",
+        incident_id="INC001",
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "servicenow"
+    client.get_context.assert_called_once_with(
+        "INC001",
+        change_query="active=true^ORDERBYDESCsys_updated_on",
+        service_query="",
+        limit=10,
+    )
+
+
+def test_servicenow_tool_runs_append_work_note(monkeypatch) -> None:
+    tool = ServiceNowRecordsTool()
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.return_value = None
+    client.append_work_note.return_value = {"success": True}
+
+    monkeypatch.setattr(
+        "app.tools.ServiceNowRecordsTool.make_servicenow_client",
+        lambda *_args, **_kwargs: client,
+    )
+
+    result = tool.run(
+        instance_url="https://dev12345.service-now.com",
+        api_token="token",
+        action="append_work_note",
+        incident_id="INC001",
+        note="Finding",
+    )
+
+    assert result["success"] is True
+    client.append_work_note.assert_called_once_with("INC001", "Finding")


### PR DESCRIPTION
Fixes #314

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This PR adds ServiceNow integration so OpenSRE can use incident tickets, change records, and service metadata during investigations.

Changes included:

- Added ServiceNow integration config normalization, environment loading, setup flow, and verification registry wiring.
- Added a ServiceNow Table API client for:
  - incident lookup by number or `sys_id`
  - incident listing
  - recent `change_request` lookup
  - `cmdb_ci_service` lookup
  - optional incident work-note write-back
- Added the `servicenow_records` investigation tool.
- Added source detection for ServiceNow alert annotations and URLs, including:
  - `servicenow_incident_id`
  - `servicenow_incident_number`
  - `servicenow_url`
  - `servicenow_incident_url`
  - query overrides for incidents, changes, and services
- Added ServiceNow documentation and navigation entry.
- Added unit, integration, wizard validation, registry, and env-gated e2e coverage.

The implementation supports either:

- `SERVICENOW_API_TOKEN`, or
- `SERVICENOW_USERNAME` + `SERVICENOW_PASSWORD`

When both auth styles are present, username/password basic auth is preferred so a stale bearer token does not override working basic credentials.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

<img width="2596" height="758" alt="terminal-output" src="https://github.com/user-attachments/assets/5ba3732c-fa76-42da-82e9-de1b4ad09d40" />

Screen recording attached in the PR shows:

- ServiceNow environment configured with secrets hidden.
- `uv run opensre integrations verify servicenow` passing against a real ServiceNow developer instance.
- `uv run pytest tests/e2e/servicenow/test_servicenow_e2e.py` passing.
- Real incident records returned from ServiceNow, including `INC0000060` and `INC0008001`.

```bash
SERVICE      SOURCE       STATUS      DETAIL
servicenow   local env    passed      Connected to ServiceNow; credentials accepted.
```

```bash
tests/e2e/servicenow/test_servicenow_e2e.py::test_servicenow_real_api_list_incidents PASSED
1 passed
```

Additional real-data smoke check through the OpenSRE ServiceNow client returned:

```bash
{'success': True, 'incidents': [{'number': 'INC0008001', ...}], 'total': 1}
```
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

OpenSRE did not have a ServiceNow source, so investigations could not use enterprise incident ticket, change, or service context. I followed the existing incident-management integration patterns and kept the implementation scoped to the existing integration surfaces:

- `ServiceNowIntegrationConfig` validates instance URL and auth settings.
- `ServiceNowClient` wraps the ServiceNow Table API with a small synchronous client and shared error handling.
- `ServiceNowRecordsTool` exposes read actions and explicit work-note write-back to the investigation planner.
- `detect_sources()` makes the tool available when a configured ServiceNow integration exists and alert annotations contain ServiceNow incident context.
- The registry and verifier wiring let `opensre integrations verify servicenow` validate credentials with a minimal incident-table read.

I considered making separate tools for incidents, changes, services, and write-back, but chose one ServiceNow records tool because these records are usually consumed together as incident context and this keeps planner surface area smaller. Write-back is still a distinct explicit action (`append_work_note`) rather than automatic behavior.

Key edge cases covered:

- missing credentials
- invalid non-HTTPS remote instance URLs
- basic auth and bearer-token auth
- stale bearer token present alongside valid basic auth
- incident lookup by either `INC...` number or `sys_id`
- ServiceNow incident URL extraction
- env-gated e2e test skips when credentials are absent
## Testing

Focused local tests:

```bash
uv run pytest \
  tests/services/test_servicenow_client.py \
  tests/tools/test_servicenow_records_tool.py \
  tests/integrations/test_servicenow.py \
  tests/cli/wizard/test_integration_health.py \
  tests/integrations/test_registry.py
```

Result:

```bash
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0 -- /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre/.venv/bin/python3.14
cachedir: .pytest_cache
rootdir: /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre
configfile: pytest.ini
plugins: langsmith-0.8.0, cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 49 items                                                                                                                                

tests/services/test_servicenow_client.py::test_config_rejects_non_https_remote_instance_url PASSED                                          [  2%]
tests/services/test_servicenow_client.py::test_config_requires_token_or_basic_auth PASSED                                                   [  4%]
tests/services/test_servicenow_client.py::test_make_client_allows_bearer_token PASSED                                                       [  6%]
tests/services/test_servicenow_client.py::test_client_prefers_basic_auth_when_basic_and_token_are_present PASSED                            [  8%]
tests/services/test_servicenow_client.py::test_list_incidents_uses_table_api_query PASSED                                                   [ 10%]
tests/services/test_servicenow_client.py::test_context_reads_incident_changes_and_services PASSED                                           [ 12%]
tests/services/test_servicenow_client.py::test_append_work_note_resolves_incident_number_to_sys_id PASSED                                   [ 14%]
tests/tools/test_servicenow_records_tool.py::test_servicenow_tool_extracts_credentials_from_sources PASSED                                  [ 16%]
tests/tools/test_servicenow_records_tool.py::test_servicenow_tool_runs_context PASSED                                                       [ 18%]
tests/tools/test_servicenow_records_tool.py::test_servicenow_tool_runs_append_work_note PASSED                                              [ 20%]
tests/integrations/test_servicenow.py::test_classify_servicenow_record PASSED                                                               [ 22%]
tests/integrations/test_servicenow.py::test_detect_sources_servicenow_from_annotations PASSED                                               [ 24%]
tests/integrations/test_servicenow.py::test_detect_sources_servicenow_extracts_sys_id_from_url PASSED                                       [ 26%]
tests/cli/wizard/test_integration_health.py::test_legacy_integration_health_import_surface_still_exports_validators PASSED                  [ 28%]
tests/cli/wizard/test_integration_health.py::test_validate_grafana_integration_succeeds_when_datasources_are_discovered PASSED              [ 30%]
tests/cli/wizard/test_integration_health.py::test_validate_grafana_integration_fails_when_no_datasources_are_found PASSED                   [ 32%]
tests/cli/wizard/test_integration_health.py::test_validate_datadog_integration_succeeds PASSED                                              [ 34%]
tests/cli/wizard/test_integration_health.py::test_validate_datadog_integration_fails PASSED                                                 [ 36%]
tests/cli/wizard/test_integration_health.py::test_validate_honeycomb_integration_succeeds PASSED                                            [ 38%]
tests/cli/wizard/test_integration_health.py::test_validate_incident_io_integration_succeeds PASSED                                          [ 40%]
tests/cli/wizard/test_integration_health.py::test_validate_servicenow_integration_succeeds PASSED                                           [ 42%]
tests/cli/wizard/test_integration_health.py::test_validate_coralogix_integration_fails PASSED                                               [ 44%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_succeeds_for_allowed_probe_statuses[200] PASSED                    [ 46%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_succeeds_for_allowed_probe_statuses[400] PASSED                    [ 48%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_succeeds_for_allowed_probe_statuses[403] PASSED                    [ 51%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_succeeds_for_allowed_probe_statuses[405] PASSED                    [ 53%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_fails_for_not_found PASSED                                         [ 55%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_fails_for_httpx_request_error PASSED                               [ 57%]
tests/cli/wizard/test_integration_health.py::test_validate_slack_webhook_fails_for_invalid_host PASSED                                      [ 59%]
tests/cli/wizard/test_integration_health.py::test_validate_aws_integration_succeeds_with_static_credentials PASSED                          [ 61%]
tests/cli/wizard/test_integration_health.py::test_validate_aws_integration_succeeds_with_role_assumption PASSED                             [ 63%]
tests/cli/wizard/test_integration_health.py::test_validate_aws_integration_fails_when_boto3_client_raises PASSED                            [ 65%]
tests/cli/wizard/test_integration_health.py::test_validate_github_mcp_integration_uses_shared_validator PASSED                              [ 67%]
tests/cli/wizard/test_integration_health.py::test_validate_sentry_integration_uses_shared_validator PASSED                                  [ 69%]
tests/cli/wizard/test_integration_health.py::test_validate_vercel_integration_succeeds PASSED                                               [ 71%]
tests/cli/wizard/test_integration_health.py::test_validate_vercel_integration_succeeds_with_team_id PASSED                                  [ 73%]
tests/cli/wizard/test_integration_health.py::test_validate_vercel_integration_fails_on_api_error PASSED                                     [ 75%]
tests/cli/wizard/test_integration_health.py::test_validate_vercel_integration_fails_with_empty_token PASSED                                 [ 77%]
tests/cli/wizard/test_integration_health.py::test_validate_vercel_integration_surfaces_exception PASSED                                     [ 79%]
tests/cli/wizard/test_integration_health.py::test_validate_discord_bot_succeeds PASSED                                                      [ 81%]
tests/cli/wizard/test_integration_health.py::test_validate_discord_bot_invalid_token PASSED                                                 [ 83%]
tests/cli/wizard/test_integration_health.py::test_validate_discord_bot_unexpected_status PASSED                                             [ 85%]
tests/cli/wizard/test_integration_health.py::test_validate_discord_bot_network_error PASSED                                                 [ 87%]
tests/cli/wizard/test_integration_health.py::test_validate_betterstack_integration_succeeds PASSED                                          [ 89%]
tests/cli/wizard/test_integration_health.py::test_validate_betterstack_integration_forwards_failure_detail PASSED                           [ 91%]
tests/cli/wizard/test_integration_health.py::test_validate_betterstack_integration_accepts_empty_tables PASSED                              [ 93%]
tests/integrations/test_registry.py::test_registry_declares_each_service_once PASSED                                                        [ 95%]
tests/integrations/test_registry.py::test_registry_supported_lists_are_derived_from_specs PASSED                                            [ 97%]
tests/integrations/test_registry.py::test_registry_preserves_aliases_and_special_case_buckets PASSED                                        [100%]

================================================================ warnings summary =================================================================
.venv/lib/python3.14/site-packages/langgraph/cache/base/__init__.py:8
  /Users/turanbuyukkamaci/Developer/ai-ml-research/opensre/.venv/lib/python3.14/site-packages/langgraph/cache/base/__init__.py:8: LangChainPendingDeprecationWarning: The default value of `allowed_objects` will change in a future version. Pass an explicit value (e.g., allowed_objects='messages' or allowed_objects='core') to suppress this warning.
    from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== slowest 20 durations ===============================================================
0.03s call     tests/services/test_servicenow_client.py::test_make_client_allows_bearer_token
0.01s setup    tests/services/test_servicenow_client.py::test_list_incidents_uses_table_api_query
0.01s setup    tests/services/test_servicenow_client.py::test_append_work_note_resolves_incident_number_to_sys_id
0.01s setup    tests/services/test_servicenow_client.py::test_context_reads_incident_changes_and_services

(16 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================================== 49 passed, 1 warning in 1.83s ==========================================================
```

Live ServiceNow e2e:

```bash
$ uv run opensre integrations verify servicenow                                                                                                 ─╯
uv run pytest tests/e2e/servicenow/test_servicenow_e2e.py

  SERVICE    SOURCE       STATUS      DETAIL
  servicenowlocal env    passed      Connected to ServiceNow; credentials accepted.

=============================================================== test session starts ===============================================================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0 -- .venv/bin/python3.14
cachedir: .pytest_cache
configfile: pytest.ini
plugins: langsmith-0.8.0, cov-7.1.0, xdist-3.8.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                  

tests/e2e/servicenow/test_servicenow_e2e.py::test_servicenow_real_api_list_incidents PASSED                                                 [100%]

============================================================== slowest 20 durations ===============================================================
0.77s call     tests/e2e/servicenow/test_servicenow_e2e.py::test_servicenow_real_api_list_incidents

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
================================================================ 1 passed in 1.50s ================================================================

```

Result:

```text
ServiceNow verification passed
1 passed
```
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
