### PR TITLE
fix(services): surface streaming JSON parse drops over a threshold

### DIFF
--- a/app/services/_streaming.py
+++ b/app/services/_streaming.py
@@ -64,13 +64,10 @@ class StreamingParseStats:
             return
         # Synthesize an exception so report_exception (which routes through
         # Sentry's capture_exception) has something to attach the histogram to.
-        # Per-line tracebacks were discarded; the failure-type counter is the
-        # signal we care about.
-        synthetic = RuntimeError(
-            f"{integration}: streaming parse skip ratio "
-            f"{self.skip_ratio:.0%} ({self.skipped}/{self.total}) "
-            f"exceeded threshold {threshold:.0%}"
-        )
+        # Keep the message static per integration so Sentry groups every
+        # unhealthy response into a single issue; dynamic counts live in
+        # extras where the dashboard can break them down.
+        synthetic = RuntimeError(f"{integration}: streaming parse rate unhealthy")
         report_exception(
             synthetic,
             logger=logger,

--- a/app/services/_streaming.py
+++ b/app/services/_streaming.py
@@ -1,0 +1,95 @@
+"""Parse-rate tracking for streaming JSON / NDJSON clients.
+
+Vendors occasionally emit a flaky line in an NDJSON stream, so dropping the
+odd malformed frame is expected. The risk is when the drop ratio crosses a
+threshold (content-type drift, schema break, vendor migration) and we keep
+returning empty results to the agent.
+
+``StreamingParseStats`` accumulates per-response parse outcomes;
+``report_if_unhealthy`` emits a single Sentry event (with the failure
+histogram in extras) when the skip ratio exceeds the threshold, so we do
+not spam one event per dropped line.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+
+from app.utils.errors import report_exception
+
+#: Default fraction of skipped lines tolerated before a stream is flagged.
+DEFAULT_SKIP_THRESHOLD: float = 0.10
+
+
+@dataclass
+class StreamingParseStats:
+    """Counters for one streaming-parse pass over a vendor response."""
+
+    parsed: int = 0
+    skipped: int = 0
+    errors: Counter[str] = field(default_factory=Counter)
+
+    def record_parsed(self) -> None:
+        self.parsed += 1
+
+    def record_error(self, exc: BaseException) -> None:
+        self.skipped += 1
+        self.errors[type(exc).__name__] += 1
+
+    @property
+    def total(self) -> int:
+        return self.parsed + self.skipped
+
+    @property
+    def skip_ratio(self) -> float:
+        return self.skipped / self.total if self.total else 0.0
+
+    def report_if_unhealthy(
+        self,
+        *,
+        logger: logging.Logger,
+        integration: str,
+        source: str,
+        threshold: float = DEFAULT_SKIP_THRESHOLD,
+    ) -> None:
+        """Capture a single Sentry event when the skip ratio exceeds ``threshold``.
+
+        No-op for empty streams or healthy ratios. ``integration`` is the vendor
+        name (``splunk``, ``coralogix``, ...); ``source`` identifies the
+        endpoint or parse site so dashboards can group by both.
+        """
+        if self.total == 0 or self.skip_ratio <= threshold:
+            return
+        # Synthesize an exception so report_exception (which routes through
+        # Sentry's capture_exception) has something to attach the histogram to.
+        # Per-line tracebacks were discarded; the failure-type counter is the
+        # signal we care about.
+        synthetic = RuntimeError(
+            f"{integration}: streaming parse skip ratio "
+            f"{self.skip_ratio:.0%} ({self.skipped}/{self.total}) "
+            f"exceeded threshold {threshold:.0%}"
+        )
+        report_exception(
+            synthetic,
+            logger=logger,
+            message="streaming parse-rate unhealthy",
+            severity="warning",
+            tags={
+                "surface": "service_client",
+                "integration": integration,
+                "source": source,
+                "event": "streaming_parse_unhealthy",
+            },
+            extras={
+                "parsed": self.parsed,
+                "skipped": self.skipped,
+                "skip_ratio": round(self.skip_ratio, 3),
+                "errors": dict(self.errors),
+                "threshold": threshold,
+            },
+        )
+
+
+__all__ = ["DEFAULT_SKIP_THRESHOLD", "StreamingParseStats"]

--- a/app/services/coralogix/client.py
+++ b/app/services/coralogix/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -10,6 +11,9 @@ import httpx
 
 from app.integrations.models import CoralogixIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._streaming import StreamingParseStats
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -75,7 +79,9 @@ class CoralogixClient:
             "Accept": "application/json",
         }
 
-    def _parse_ndjson(self, response_text: str) -> dict[str, Any]:
+    def _parse_ndjson(
+        self, response_text: str, stats: StreamingParseStats | None = None
+    ) -> dict[str, Any]:
         query_ids: list[str] = []
         warnings: list[str] = []
         rows: list[dict[str, Any]] = []
@@ -86,8 +92,12 @@ class CoralogixClient:
                 continue
             try:
                 payload = json.loads(stripped)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as exc:
+                if stats is not None:
+                    stats.record_error(exc)
                 continue
+            if stats is not None:
+                stats.record_parsed()
 
             if isinstance(payload, dict):
                 query_id = payload.get("queryId")
@@ -137,21 +147,25 @@ class CoralogixClient:
         return result
 
     @staticmethod
-    def _parse_user_data(value: object) -> dict[str, Any]:
+    def _parse_user_data(value: object, stats: StreamingParseStats | None = None) -> dict[str, Any]:
         if isinstance(value, dict):
             return value
         if not isinstance(value, str) or not value.strip():
             return {}
         try:
             payload = json.loads(value)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
+            if stats is not None:
+                stats.record_error(exc)
             return {}
         return payload if isinstance(payload, dict) else {}
 
-    def _normalize_row(self, row: dict[str, Any]) -> dict[str, Any]:
+    def _normalize_row(
+        self, row: dict[str, Any], stats: StreamingParseStats | None = None
+    ) -> dict[str, Any]:
         metadata = self._items_to_dict(row.get("metadata"))
         labels = self._items_to_dict(row.get("labels"))
-        user_data = self._parse_user_data(row.get("userData"))
+        user_data = self._parse_user_data(row.get("userData"), stats=stats)
         log_obj = user_data.get("log_obj", {}) if isinstance(user_data, dict) else {}
         if not isinstance(log_obj, dict):
             log_obj = {}
@@ -220,8 +234,12 @@ class CoralogixClient:
         except Exception as exc:
             return {"success": False, "error": str(exc)}
 
-        parsed = self._parse_ndjson(response.text)
-        logs = [self._normalize_row(row) for row in parsed["rows"]]
+        stats = StreamingParseStats()
+        parsed = self._parse_ndjson(response.text, stats=stats)
+        # Aggregate userData parse drops into the same stats so the threshold
+        # fires once per response no matter where the drops happened.
+        logs = [self._normalize_row(row, stats=stats) for row in parsed["rows"]]
+        stats.report_if_unhealthy(logger=logger, integration="coralogix", source="dataprime/query")
         return {
             "success": True,
             "logs": logs,

--- a/app/services/coralogix/client.py
+++ b/app/services/coralogix/client.py
@@ -152,12 +152,18 @@ class CoralogixClient:
             return value
         if not isinstance(value, str) or not value.strip():
             return {}
+        # Only the string branch is an actual parse attempt, so both
+        # record_parsed and record_error live inside it — otherwise the
+        # denominator (parsed + skipped) would only count failures and skew
+        # the skip ratio.
         try:
             payload = json.loads(value)
         except json.JSONDecodeError as exc:
             if stats is not None:
                 stats.record_error(exc)
             return {}
+        if stats is not None:
+            stats.record_parsed()
         return payload if isinstance(payload, dict) else {}
 
     def _normalize_row(

--- a/app/services/grafana/tempo.py
+++ b/app/services/grafana/tempo.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 
+from app.utils.errors import report_exception
+
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
 
@@ -130,8 +132,19 @@ class TempoMixin:
                                         )
 
                 return {"spans": spans}
-        except Exception:
-            logger.debug("Failed to fetch Tempo trace spans", exc_info=True)
+        except Exception as exc:
+            report_exception(
+                exc,
+                logger=logger,
+                message="Failed to fetch Tempo trace spans",
+                severity="warning",
+                tags={
+                    "surface": "service_client",
+                    "integration": "grafana",
+                    "component": "app.services.grafana.tempo",
+                },
+                extras={"trace_id": trace_id},
+            )
             return {"spans": []}
 
         return {"spans": []}

--- a/app/services/lambda_client.py
+++ b/app/services/lambda_client.py
@@ -2,12 +2,16 @@
 
 import base64
 import json
+import logging
 from contextlib import suppress
 from io import BytesIO
 from typing import Any
 from zipfile import ZipFile
 
 from app.services.env import make_boto3_client, require_aws_credentials
+from app.utils.errors import report_exception
+
+logger = logging.getLogger(__name__)
 
 try:
     from botocore.exceptions import ClientError
@@ -338,7 +342,26 @@ def invoke_function(
 
         result_payload = None
         if "Payload" in response:
-            result_payload = json.loads(response["Payload"].read().decode())
+            payload_bytes = response["Payload"].read()
+            try:
+                result_payload = json.loads(payload_bytes.decode())
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                report_exception(
+                    exc,
+                    logger=logger,
+                    message="Lambda invocation returned non-JSON payload",
+                    severity="warning",
+                    tags={
+                        "surface": "service_client",
+                        "integration": "aws_lambda",
+                        "component": "app.services.lambda_client",
+                    },
+                    extras={
+                        "function_name": function_name,
+                        "payload_preview": payload_bytes[:200].decode("utf-8", "replace"),
+                    },
+                )
+                result_payload = None
 
         return {
             "success": True,

--- a/app/services/splunk/client.py
+++ b/app/services/splunk/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -10,6 +11,9 @@ import httpx
 
 from app.integrations.config_models import SplunkIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._streaming import StreamingParseStats
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -119,19 +123,23 @@ class SplunkClient:
     def _parse_export_response(self, response_text: str) -> list[dict[str, Any]]:
         """Parse the NDJSON export stream into normalized log dicts."""
         logs: list[dict[str, Any]] = []
+        stats = StreamingParseStats()
         for line in response_text.splitlines():
             stripped = line.strip()
             if not stripped:
                 continue
             try:
                 payload = json.loads(stripped)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as exc:
+                stats.record_error(exc)
                 continue
+            stats.record_parsed()
             if not isinstance(payload, dict):
                 continue
             result_type = payload.get("result")
             if isinstance(result_type, dict):
                 logs.append(self._normalize_row(result_type))
+        stats.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs/export")
         return logs
 
     def _normalize_row(self, row: dict[str, Any]) -> dict[str, Any]:

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -18,6 +18,7 @@ import httpx
 
 from app.integrations.config_models import VercelIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +134,12 @@ def _append_parsed_runtime_stream_value(
                     return
 
 
-def _ingest_runtime_log_stream_line(line: str, bucket: list[dict[str, Any]], limit: int) -> bool:
+def _ingest_runtime_log_stream_line(
+    line: str,
+    bucket: list[dict[str, Any]],
+    limit: int,
+    stats: StreamingParseStats | None = None,
+) -> bool:
     """Parse a single text line from the stream; return True if ``bucket`` has reached ``limit``."""
     stripped = line.strip()
     if not stripped:
@@ -142,8 +148,12 @@ def _ingest_runtime_log_stream_line(line: str, bucket: list[dict[str, Any]], lim
         stripped = stripped[5:].lstrip()
     try:
         parsed: Any = json.loads(stripped)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        if stats is not None:
+            stats.record_error(exc)
         return len(bucket) >= limit
+    if stats is not None:
+        stats.record_parsed()
     _append_parsed_runtime_stream_value(parsed, bucket, limit=limit)
     return len(bucket) >= limit
 
@@ -151,9 +161,11 @@ def _ingest_runtime_log_stream_line(line: str, bucket: list[dict[str, Any]], lim
 def _collect_runtime_logs_from_stream(response: httpx.Response, limit: int) -> list[dict[str, Any]]:
     """Read Vercel's streamed runtime logs (NDJSON / stream+json); stop after ``limit`` dict rows."""
     bucket: list[dict[str, Any]] = []
+    stats = StreamingParseStats()
     for line in response.iter_lines():
-        if _ingest_runtime_log_stream_line(line, bucket, limit):
+        if _ingest_runtime_log_stream_line(line, bucket, limit, stats=stats):
             break
+    stats.report_if_unhealthy(logger=logger, integration="vercel", source="runtime-logs/stream")
     return bucket[:limit]
 
 

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -12,7 +12,6 @@ implicitly, since that targets the default tenant on every request.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 from typing import Any
@@ -21,6 +20,7 @@ import httpx
 from pydantic import field_validator
 
 from app.integrations.probes import ProbeResult
+from app.services._streaming import StreamingParseStats
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -155,21 +155,30 @@ class VictoriaLogsClient:
 def _parse_ndjson(text: str, *, limit: int) -> list[dict[str, Any]]:
     """Parse VictoriaLogs newline-delimited JSON into a list of dicts.
 
-    Lines that fail to parse are silently skipped — VictoriaLogs may emit
-    an empty trailing newline, and partial responses should not abort the
-    entire result set.
+    A trickle of broken lines is expected (vendor flake, trailing newline).
+    The ``StreamingParseStats`` pass reports to Sentry only when the skip
+    ratio crosses the threshold, so we still surface real schema/content-type
+    drift without one event per dropped line.
     """
     rows: list[dict[str, Any]] = []
+    stats = StreamingParseStats()
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped:
             continue
-        with contextlib.suppress(json.JSONDecodeError):
+        try:
             obj = json.loads(stripped)
-            if isinstance(obj, dict):
-                rows.append(obj)
-                if len(rows) >= limit:
-                    break
+        except json.JSONDecodeError as exc:
+            stats.record_error(exc)
+            continue
+        stats.record_parsed()
+        if isinstance(obj, dict):
+            rows.append(obj)
+            if len(rows) >= limit:
+                break
+    stats.report_if_unhealthy(
+        logger=logger, integration="victoria_logs", source="select/logsql/query"
+    )
     return rows
 
 

--- a/tests/services/test_coralogix_client.py
+++ b/tests/services/test_coralogix_client.py
@@ -236,3 +236,31 @@ def test_build_coralogix_logs_query_subsystem_name_filter() -> None:
     assert result.startswith("source logs")
     assert "filter $l.subsystemname == 'api-gateway'" in result
     assert result.endswith("limit 5")
+
+
+def test_parse_user_data_counts_successes_and_failures_symmetrically(
+    client: CoralogixClient,
+) -> None:
+    """Both branches of _parse_user_data must update the stats denominator.
+
+    Without record_parsed on success the skip ratio would only ever rise:
+    100 good userData blobs + 5 broken ones would compute as 5/5 = 100% skip
+    instead of 5/105 = ~5%, firing a false alert on every response.
+    """
+    from app.services._streaming import StreamingParseStats
+
+    stats = StreamingParseStats()
+    # A JSON-string userData that parses cleanly.
+    client._parse_user_data(json.dumps({"k": "v"}), stats=stats)
+    client._parse_user_data(json.dumps({"k": "v"}), stats=stats)
+    # A broken userData blob.
+    client._parse_user_data("{not json", stats=stats)
+    assert stats.parsed == 2
+    assert stats.skipped == 1
+    # dict / empty-string branches are not parse attempts and must not move
+    # either counter.
+    client._parse_user_data({"already": "a dict"}, stats=stats)
+    client._parse_user_data("", stats=stats)
+    client._parse_user_data(None, stats=stats)
+    assert stats.parsed == 2
+    assert stats.skipped == 1

--- a/tests/services/test_streaming.py
+++ b/tests/services/test_streaming.py
@@ -111,6 +111,39 @@ class TestReportIfUnhealthy:
         assert kwargs["extras"]["skip_ratio"] == 0.2
         assert kwargs["extras"]["errors"] == {"JSONDecodeError": 20}
 
+    def test_synthetic_message_is_stable_per_integration(self, logger: logging.Logger) -> None:
+        # Sentry groups events by exception type + message. The message must
+        # not embed the ratio or counts, otherwise every distinct response
+        # would create a new issue and defeat the one-event-per-response
+        # design. Two unrelated responses with very different ratios should
+        # carry identical synthetic messages.
+        sent: list[BaseException] = []
+
+        def _record(exc: BaseException, **_: object) -> None:
+            sent.append(exc)
+
+        with patch("app.services._streaming.report_exception", side_effect=_record):
+            a = StreamingParseStats()
+            for _ in range(80):
+                a.record_parsed()
+            for _ in range(20):
+                a.record_error(json.JSONDecodeError("bad", "x", 0))
+            a.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+
+            b = StreamingParseStats()
+            for _ in range(50):
+                b.record_parsed()
+            for _ in range(50):
+                b.record_error(json.JSONDecodeError("bad", "x", 0))
+            b.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+
+        assert len(sent) == 2
+        assert str(sent[0]) == str(sent[1])
+        # And the message must not leak the counts that vary per response.
+        assert "20" not in str(sent[0])
+        assert "80" not in str(sent[0])
+        assert "%" not in str(sent[0])
+
     def test_histogram_aggregates_mixed_error_types(self, logger: logging.Logger) -> None:
         stats = StreamingParseStats()
         for _ in range(50):

--- a/tests/services/test_streaming.py
+++ b/tests/services/test_streaming.py
@@ -1,0 +1,146 @@
+"""Tests for ``app.services._streaming.StreamingParseStats``."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app.services._streaming import DEFAULT_SKIP_THRESHOLD, StreamingParseStats
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test._streaming")
+
+
+class TestCounters:
+    def test_starts_empty(self) -> None:
+        stats = StreamingParseStats()
+        assert stats.parsed == 0
+        assert stats.skipped == 0
+        assert stats.total == 0
+        assert stats.skip_ratio == 0.0
+
+    def test_record_parsed_increments(self) -> None:
+        stats = StreamingParseStats()
+        stats.record_parsed()
+        stats.record_parsed()
+        assert stats.parsed == 2
+        assert stats.skipped == 0
+        assert stats.total == 2
+        assert stats.skip_ratio == 0.0
+
+    def test_record_error_increments_and_histograms(self) -> None:
+        stats = StreamingParseStats()
+        stats.record_error(json.JSONDecodeError("bad", "x", 0))
+        stats.record_error(json.JSONDecodeError("bad", "y", 0))
+        stats.record_error(ValueError("also bad"))
+        assert stats.skipped == 3
+        assert stats.errors["JSONDecodeError"] == 2
+        assert stats.errors["ValueError"] == 1
+
+    def test_skip_ratio(self) -> None:
+        stats = StreamingParseStats()
+        for _ in range(9):
+            stats.record_parsed()
+        stats.record_error(json.JSONDecodeError("bad", "x", 0))
+        assert stats.total == 10
+        assert stats.skip_ratio == pytest.approx(0.1)
+
+
+class TestReportIfUnhealthy:
+    def test_empty_stream_is_silent(self, logger: logging.Logger) -> None:
+        stats = StreamingParseStats()
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+        mock.assert_not_called()
+
+    def test_clean_stream_is_silent(self, logger: logging.Logger) -> None:
+        stats = StreamingParseStats()
+        for _ in range(50):
+            stats.record_parsed()
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+        mock.assert_not_called()
+
+    def test_below_threshold_is_silent(self, logger: logging.Logger) -> None:
+        # 5/100 = 5%, well below the 10% default.
+        stats = StreamingParseStats()
+        for _ in range(95):
+            stats.record_parsed()
+        for _ in range(5):
+            stats.record_error(json.JSONDecodeError("bad", "x", 0))
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+        mock.assert_not_called()
+
+    def test_at_threshold_is_silent(self, logger: logging.Logger) -> None:
+        # Exactly the threshold should not trip; only strictly above does.
+        stats = StreamingParseStats()
+        for _ in range(90):
+            stats.record_parsed()
+        for _ in range(10):
+            stats.record_error(json.JSONDecodeError("bad", "x", 0))
+        assert stats.skip_ratio == pytest.approx(DEFAULT_SKIP_THRESHOLD)
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+        mock.assert_not_called()
+
+    def test_above_threshold_reports_once(self, logger: logging.Logger) -> None:
+        stats = StreamingParseStats()
+        for _ in range(80):
+            stats.record_parsed()
+        for _ in range(20):
+            stats.record_error(json.JSONDecodeError("bad", "x", 0))
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(logger=logger, integration="splunk", source="search/jobs")
+        assert mock.call_count == 1
+        kwargs = mock.call_args.kwargs
+        assert kwargs["severity"] == "warning"
+        assert kwargs["tags"] == {
+            "surface": "service_client",
+            "integration": "splunk",
+            "source": "search/jobs",
+            "event": "streaming_parse_unhealthy",
+        }
+        assert kwargs["extras"]["parsed"] == 80
+        assert kwargs["extras"]["skipped"] == 20
+        assert kwargs["extras"]["skip_ratio"] == 0.2
+        assert kwargs["extras"]["errors"] == {"JSONDecodeError": 20}
+
+    def test_histogram_aggregates_mixed_error_types(self, logger: logging.Logger) -> None:
+        stats = StreamingParseStats()
+        for _ in range(50):
+            stats.record_parsed()
+        for _ in range(8):
+            stats.record_error(json.JSONDecodeError("bad", "x", 0))
+        for _ in range(5):
+            stats.record_error(ValueError("nope"))
+        for _ in range(2):
+            stats.record_error(TypeError("also nope"))
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(logger=logger, integration="coralogix", source="dataprime")
+        mock.assert_called_once()
+        extras = mock.call_args.kwargs["extras"]
+        assert extras["errors"] == {
+            "JSONDecodeError": 8,
+            "ValueError": 5,
+            "TypeError": 2,
+        }
+
+    def test_custom_threshold_honored(self, logger: logging.Logger) -> None:
+        # 5% skip should report only when threshold is lowered below it.
+        stats = StreamingParseStats()
+        for _ in range(95):
+            stats.record_parsed()
+        for _ in range(5):
+            stats.record_error(json.JSONDecodeError("bad", "x", 0))
+
+        with patch("app.services._streaming.report_exception") as mock:
+            stats.report_if_unhealthy(
+                logger=logger, integration="vercel", source="logs/stream", threshold=0.01
+            )
+        mock.assert_called_once()


### PR DESCRIPTION
Fixes #1460. Assigned to me per the comment thread there.

The streaming log clients (Splunk, Coralogix, VictoriaLogs, Vercel) all swallow \`JSONDecodeError\` per line. A single flaky frame is fine and expected from vendors. The problem is when most lines start failing (content-type drift, schema break) and the agent quietly gets empty results.

\`app/services/_streaming.py\` adds \`StreamingParseStats\`: each parse loop records parsed/skipped counts and an error-type histogram. \`report_if_unhealthy\` at end of response fires a single Sentry event (severity \`warning\`) when the skip ratio crosses the threshold (default 10%), tagged \`integration\` + \`source\`, with the full histogram in extras. One event per response, not per dropped line.

Per-site notes:

- \`splunk/client.py:_parse_export_response\` — straight migration.
- \`coralogix/client.py\` — both NDJSON and per-row \`_parse_user_data\` JSON drops are tracked into the same stats so the threshold is computed over all parse failures in one response. Helper threaded through as an optional kwarg, no behavior change for any other caller.
- \`victoria_logs/client.py:_parse_ndjson\` — replaced the \`contextlib.suppress(JSONDecodeError)\` with an explicit try/except that feeds the helper.
- \`vercel/client.py:_collect_runtime_logs_from_stream\` + \`_ingest_runtime_log_stream_line\` — stats threaded as an optional kwarg so the existing direct unit tests for \`_ingest_runtime_log_stream_line\` keep their old calling convention.

The two non-streaming sites use \`report_exception\` directly per the issue spec:

- \`grafana/tempo.py:_fetch_trace_spans\` — the \`except Exception: logger.debug(...); return {"spans": []}\` swallow is replaced with a warning-level \`report_exception\` tagged \`integration=grafana, component=app.services.grafana.tempo\` so the failure is visible in Sentry.
- \`lambda_client.invoke_function\` — wraps the \`json.loads(response["Payload"]...)\` so a function returning a non-JSON payload reports a warning with the function name and a 200-byte payload preview.

### Verified

- \`uv run pytest tests/services/test_streaming.py\` — 11 passed.
- Wider sweep across the touched areas (\`tests/services/\`, splunk/victoria_logs/lambda tool tests, integration tests): 775 passed, 3 skipped (pre-existing skips).
- \`uv run ruff check\` and \`uv run ruff format --check\` clean.