### PR TITLE
fix: handle BrokenPipeError in _safe_print when stdout is closed

### DIFF
--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -77,6 +77,8 @@ def _safe_print(text: str) -> None:
     except UnicodeEncodeError:
         enc = sys.stdout.encoding or "utf-8"
         print(text.encode(enc, errors="replace").decode(enc))
+    except BrokenPipeError:
+        sys.stdout.close()
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
When output is piped to a reader that closes early (e.g. head), print() raises BrokenPipeError. Catch it and close stdout cleanly to prevent a crash and avoid a second error on interpreter exit.
Closes #2025
Fixes #2025
#### Describe the changes you have made in this PR -
Added a `BrokenPipeError` handler in `_safe_print()` in `app/cli/support/output.py` that catches the error and closes `sys.stdout`, preventing the crash and a secondary traceback from Python's interpreter shutdown.
### Demo/Screenshot for feature changes and bug fixes -
$ uv run opensre investigate "some long investigation" | head -n 5
Before: BrokenPipeError crash + traceback
After: clean exit, no error
---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)
**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions
**Explain your implementation approach:**
The problem: when investigation output is piped to a command like `head`, the downstream reader closes its stdin early, causing `print()` to raise `BrokenPipeError`. Only `UnicodeEncodeError` was handled in `_safe_print`, so the error propagated up the call stack uncaught.
I considered two approaches: (1) using `signal.SIGPIPE` to ignore the signal, and (2) catching `BrokenPipeError` directly. SIGPIPE is Unix-only and not available on Windows, so I chose the direct exception handler. After catching the error, `sys.stdout.close()` is called to prevent Python's interpreter shutdown from printing a second "close of fd <N> failed" error.
The fix is minimal — two lines — and lives entirely in `_safe_print()`, which is the single choke point for all CLI text output. No other call sites needed changes.
---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
