### PR TITLE
fix(cli): handle BrokenPipeError in _safe_print and guard Ctrl+C reentrancy

### DIFF
--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -76,10 +76,8 @@ def _safe_print(text: str) -> None:
         print(text)
     except UnicodeEncodeError:
         enc = sys.stdout.encoding or "utf-8"
-        try:
+        with contextlib.suppress(BrokenPipeError):
             print(text.encode(enc, errors="replace").decode(enc))
-        except BrokenPipeError:
-            pass
     except BrokenPipeError:
         # Downstream pipe/consumer closed (e.g. piping to `head`); ignore to avoid noisy traceback.
         pass

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -77,6 +77,8 @@ def _safe_print(text: str) -> None:
     except UnicodeEncodeError:
         enc = sys.stdout.encoding or "utf-8"
         print(text.encode(enc, errors="replace").decode(enc))
+    except BrokenPipeError:
+        pass
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -76,7 +76,10 @@ def _safe_print(text: str) -> None:
         print(text)
     except UnicodeEncodeError:
         enc = sys.stdout.encoding or "utf-8"
-        print(text.encode(enc, errors="replace").decode(enc))
+        try:
+            print(text.encode(enc, errors="replace").decode(enc))
+        except BrokenPipeError:
+            pass
     except BrokenPipeError:
         pass
 

--- a/app/cli/support/output.py
+++ b/app/cli/support/output.py
@@ -81,6 +81,7 @@ def _safe_print(text: str) -> None:
         except BrokenPipeError:
             pass
     except BrokenPipeError:
+        # Downstream pipe/consumer closed (e.g. piping to `head`); ignore to avoid noisy traceback.
         pass
 
 

--- a/app/cli/support/prompt_support.py
+++ b/app/cli/support/prompt_support.py
@@ -20,6 +20,9 @@ _ctrl_c_patch_installed: list[bool] = [False]
 
 # Shared timestamp of the last Ctrl+C press (None = never pressed).
 _last_ctrl_c: list[float | None] = [None]
+# Reentrancy guard: prevents a second SIGINT from re-entering the handler while
+# a print() flush in the first invocation is still running on the same buffer.
+_handling_ctrl_c: list[bool] = [False]
 
 CTRL_C_DOUBLE_PRESS_WINDOW_S: float = 2.0
 _CTRL_C_EXIT_WINDOW: float = CTRL_C_DOUBLE_PRESS_WINDOW_S
@@ -91,12 +94,18 @@ def handle_ctrl_c_press() -> None:
     First call:  prints hint.
     Second call within _CTRL_C_EXIT_WINDOW seconds:  prints Goodbye and exits.
     """
-    now = time.monotonic()
-    if _last_ctrl_c[0] is not None and now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
-        print("\nGoodbye!", flush=True)
-        sys.exit(0)
-    _last_ctrl_c[0] = now
-    print("\n(Press Ctrl+C again to exit)", flush=True)
+    if _handling_ctrl_c[0]:
+        return
+    _handling_ctrl_c[0] = True
+    try:
+        now = time.monotonic()
+        if _last_ctrl_c[0] is not None and now - _last_ctrl_c[0] <= _CTRL_C_EXIT_WINDOW:
+            print("\nGoodbye!", flush=True)
+            sys.exit(0)
+        _last_ctrl_c[0] = now
+        print("\n(Press Ctrl+C again to exit)", flush=True)
+    finally:
+        _handling_ctrl_c[0] = False
 
 
 def _with_ctrl_c_double_exit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,5 +155,7 @@ ignore_names = [
 [dependency-groups]
 dev = [
     "pre-commit>=4.0.0",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
     "types-psutil>=7.2.2.20260408",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1839,6 +1839,8 @@ postgresql = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "types-psutil" },
 ]
 
@@ -1908,6 +1910,8 @@ provides-extras = ["dev", "opensre-hub", "kafka", "clickhouse", "postgresql", "a
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "types-psutil", specifier = ">=7.2.2.20260408" },
 ]
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **BrokenPipeError (#2025):** `_safe_print` in `app/cli/support/output.py` only caught `UnicodeEncodeError`. Piping `opensre` output to any short-reading consumer (e.g. `head`) raised `BrokenPipeError` all the way up through the investigation pipeline. Added a `BrokenPipeError` handler that silently discards the write, matching standard Unix pipe behaviour.

- **Ctrl+C reentrancy (#2024):** `handle_ctrl_c_press` could be re-entered when a second SIGINT fired while `print()` was flushing the shared stdout buffer, causing `RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>`. Added a boolean module-level reentrancy guard (`_handling_ctrl_c`) so any nested invocation returns immediately.

## Test plan

- [x] `uv run python -m pytest tests/tools/` — 1677 passed
- [x] `uv run ruff check` — no issues

Closes #2025
Closes #2024
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu92YMwk8fN9PpwZCTkWSS)_