### PR TITLE
fix(webapp): add /ok health route expected by remote client

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -41,6 +41,7 @@ def get_health_response() -> HealthResponse:
 
 @app.get("/", response_model=HealthResponse)
 @app.get("/health", response_model=HealthResponse)
+@app.get("/ok", response_model=HealthResponse)
 def health(response: Response) -> HealthResponse:
     health_response = get_health_response()
     response.status_code = (

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -6,6 +6,7 @@ import importlib
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
 
 from app import webapp
 
@@ -29,8 +30,6 @@ def test_health_response_returns_known_fields() -> None:
 
 
 def test_ok_route_is_registered() -> None:
-    from fastapi.testclient import TestClient
-
     client = TestClient(webapp.app)
     resp = client.get("/ok")
     assert resp.status_code in (200, 503)

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -26,3 +26,14 @@ def test_health_response_returns_known_fields() -> None:
     assert hasattr(response, "version")
     assert hasattr(response, "llm_configured")
     assert hasattr(response, "env")
+
+
+def test_ok_route_is_registered() -> None:
+    from fastapi.testclient import TestClient
+
+    client = TestClient(webapp.app)
+    resp = client.get("/ok")
+    assert resp.status_code in (200, 503)
+    data = resp.json()
+    assert "ok" in data
+    assert "version" in data


### PR DESCRIPTION
## Summary

- `app/remote/client.py` probes `GET /ok` for all health checks (`probe_health`, `_fetch_ok_payload`, `health`)
- `app/webapp.py` only registered `/` and `/health`, leaving `/ok` unmapped → 404
- This caused every remote health check to raise `ClickException: Health check failed: 404 Not Found for url .../ok`

## Fix

Added `@app.get("/ok", response_model=HealthResponse)` decorator alongside the existing `/` and `/health` routes — same handler, no new logic.

Added a test in `tests/test_webapp.py` that calls `/ok` via `TestClient` and asserts the response contains `ok` and `version` fields.

## Test plan

- [x] `uv run pytest tests/test_webapp.py -v` — all 3 tests pass
- [x] `ruff check` + `ruff format --check` — clean

Closes #2032

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcY2FXoJqTDZZdRz3sub68)_