### PR TITLE
fix(agent_llm_client): fail fast on Anthropic 500 model billing/config errors

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -98,6 +98,7 @@ class AnthropicAgentClient:
         from anthropic import (
             AuthenticationError,
             BadRequestError,
+            InternalServerError,
             NotFoundError,
             PermissionDeniedError,
         )
@@ -128,6 +129,24 @@ class AnthropicAgentClient:
                 raise RuntimeError(
                     f"{self.provider_name} request rejected (HTTP 400): {err.message}"
                 ) from err
+            except InternalServerError as err:
+                body = getattr(err, "body", {}) or {}
+                if (
+                    isinstance(body, dict)
+                    and isinstance(body.get("data"), dict)
+                    and "model" in body["data"]
+                ):
+                    raise RuntimeError(
+                        f"{self.provider_name} model '{self._model}' is not configured or billing is not enabled: "
+                        f"{body.get('message', str(err))}"
+                    ) from err
+                last_err = err
+                if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                    raise RuntimeError(
+                        f"{self.provider_name} API failed after {_RETRY_MAX_ATTEMPTS} attempts: {err}"
+                    ) from err
+                time.sleep(backoff)
+                backoff *= 2
             except TypeError as err:
                 # Anthropic SDK raises TypeError from _validate_headers when the API key is
                 # missing or malformed — retrying won't fix a credential problem.

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -29,6 +29,11 @@ def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleName
     class PermissionDeniedError(Exception):
         pass
 
+    class InternalServerError(Exception):
+        def __init__(self, message: str, body: dict | None = None) -> None:
+            super().__init__(message)
+            self.body = body or {}
+
     class Anthropic:
         def __init__(self, **_: object) -> None:
             self.messages = types.SimpleNamespace(create=lambda **_: None)
@@ -41,6 +46,7 @@ def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleName
     fake_module.BadRequestError = BadRequestError
     fake_module.NotFoundError = NotFoundError
     fake_module.PermissionDeniedError = PermissionDeniedError
+    fake_module.InternalServerError = InternalServerError
     fake_module.Anthropic = Anthropic
     fake_module.AnthropicBedrock = AnthropicBedrock
     monkeypatch.setitem(sys.modules, "anthropic", fake_module)
@@ -103,6 +109,61 @@ def test_bedrock_permission_denied_is_not_retried_and_mentions_marketplace(
     assert "AWS Marketplace" in message
     assert "aws-marketplace:ViewSubscriptions" in message
     assert "aws-marketplace:Subscribe" in message
+
+
+def test_internal_server_error_with_model_billing_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    call_count = 0
+
+    def raise_billing_error(**_: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        raise fake_anthropic.InternalServerError(
+            "Error code: 500",
+            body={"message": "模型未配置计费", "data": {"model": "claude-opus-4-7"}},
+        )
+
+    client = AnthropicAgentClient(model="claude-opus-4-7")
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=raise_billing_error)
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert call_count == 1, "billing error should not be retried"
+    message = str(exc.value)
+    assert "claude-opus-4-7" in message
+    assert "billing" in message.lower() or "not configured" in message.lower()
+
+
+def test_internal_server_error_without_model_data_is_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("app.services.agent_llm_client.time.sleep", lambda _: None)
+
+    call_count = 0
+
+    def raise_transient_error(**_: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        raise fake_anthropic.InternalServerError("Internal server error", body={})
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=raise_transient_error)
+    )
+
+    with pytest.raises(RuntimeError, match="API failed after 3 attempts"):
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert call_count == 3, "transient 500 errors should be retried"
 
 
 def _install_fake_openai(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:


### PR DESCRIPTION
## Summary

Fixes #2040, Fixes #2041

Both Sentry issues trace back to the same root cause: an `InternalServerError` (HTTP 500) from the Anthropic API with a model billing/configuration error body (e.g. `{'message': '模型未配置计费', 'data': {'model': 'claude-opus-4-7'}}`) was falling into the generic `except Exception` retry loop and being retried 3 times with exponential backoff — wasteful since billing/config errors are deterministic and will never succeed on retry.

**Changes:**
- Catch `InternalServerError` explicitly before the generic `Exception` handler in `AnthropicAgentClient.invoke`
- If the error body contains `data.model` (signature of a model configuration/billing error), raise immediately with a clear actionable message
- Transient 500s without model-specific data still retry as before

**Before:** 3 retries + ~3s of wasted backoff, then a cryptic `RuntimeError: Anthropic API failed after 3 attempts`

**After:** Fails immediately with `Anthropic model 'claude-opus-4-7' is not configured or billing is not enabled`

## Test plan

- [ ] `make test-cov` passes
- [ ] New test `test_internal_server_error_with_model_billing_fails_fast` — verifies API called exactly once (no retries), error message includes model name and "billing"/"not configured"
- [ ] New test `test_internal_server_error_without_model_data_is_retried` — verifies transient 500s are still retried 3 times