### PR TITLE
fix(agent-llm): preserve OpenAI raw message to pass Gemini thought_signature forward

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -501,9 +501,12 @@ def _build_assistant_msg(llm: Any, response: Any) -> dict[str, Any]:
         return llm.build_assistant_message(response.raw_content)
     # Use the raw API message when available so provider-specific fields (e.g. Gemini
     # thought_signature required for multi-turn function calls) are preserved.
-    if response.raw_content is not None:
-        return response.raw_content
-    return llm.build_assistant_message(response.content, response.tool_calls)
+    result: dict[str, Any] = (
+        response.raw_content
+        if response.raw_content is not None
+        else llm.build_assistant_message(response.content, response.tool_calls)
+    )
+    return result
 
 
 def _build_tool_result_messages(

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -499,8 +499,11 @@ def _build_assistant_msg(llm: Any, response: Any) -> dict[str, Any]:
 
     if isinstance(llm, AnthropicAgentClient):
         return llm.build_assistant_message(response.raw_content)
-    result: dict[str, Any] = llm.build_assistant_message(response.content, response.tool_calls)
-    return result
+    # Use the raw API message when available so provider-specific fields (e.g. Gemini
+    # thought_signature required for multi-turn function calls) are preserved.
+    if response.raw_content is not None:
+        return response.raw_content
+    return llm.build_assistant_message(response.content, response.tool_calls)
 
 
 def _build_tool_result_messages(

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -283,7 +283,9 @@ class OpenAIAgentClient:
             stop_reason=stop_reason,
             # Preserve the raw API message so provider-specific fields (e.g. Gemini
             # thought_signature in tool_calls) survive into the next conversation turn.
-            raw_content=msg.model_dump(),
+            # exclude_none=True strips null fields (refusal, audio, function_call …)
+            # that Gemini's strict endpoint would reject on the next turn.
+            raw_content=msg.model_dump(exclude_none=True),
         )
 
     @staticmethod

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -281,7 +281,9 @@ class OpenAIAgentClient:
             content=content,
             tool_calls=tool_calls,
             stop_reason=stop_reason,
-            raw_content=None,
+            # Preserve the raw API message so provider-specific fields (e.g. Gemini
+            # thought_signature in tool_calls) survive into the next conversation turn.
+            raw_content=msg.model_dump(),
         )
 
     @staticmethod

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -5,7 +5,7 @@ import types
 
 import pytest
 
-from app.services.agent_llm_client import BedrockAgentClient
+from app.services.agent_llm_client import BedrockAgentClient, OpenAIAgentClient
 
 
 def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
@@ -67,3 +67,121 @@ def test_bedrock_auth_error_message_references_aws_credentials(
     assert "Bedrock authentication failed" in message
     assert "AWS credentials" in message
     assert "ANTHROPIC_API_KEY" not in message
+
+
+def _install_fake_openai(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
+    fake_module = types.SimpleNamespace()
+
+    class AuthenticationError(Exception):
+        pass
+
+    class BadRequestError(Exception):
+        pass
+
+    class NotFoundError(Exception):
+        pass
+
+    class OpenAI:
+        def __init__(self, **_: object) -> None:
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=lambda **_: None)
+            )
+
+    fake_module.AuthenticationError = AuthenticationError
+    fake_module.BadRequestError = BadRequestError
+    fake_module.NotFoundError = NotFoundError
+    fake_module.OpenAI = OpenAI
+    monkeypatch.setitem(sys.modules, "openai", fake_module)
+    return fake_module
+
+
+def _make_fake_openai_response(
+    *,
+    content: str = "",
+    tool_calls: list[types.SimpleNamespace] | None = None,
+    finish_reason: str = "stop",
+    extra_msg_fields: dict | None = None,
+) -> types.SimpleNamespace:
+    """Build a minimal fake OpenAI chat completion response."""
+
+    def model_dump() -> dict:
+        result: dict = {"role": "assistant", "content": content or None}
+        if tool_calls:
+            result["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+        if extra_msg_fields:
+            result.update(extra_msg_fields)
+        return result
+
+    msg = types.SimpleNamespace(
+        content=content or None,
+        tool_calls=tool_calls,
+        model_dump=model_dump,
+    )
+    choice = types.SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return types.SimpleNamespace(choices=[choice])
+
+
+def test_openai_agent_client_invoke_sets_raw_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """raw_content must be the serialized API message so providers like Gemini
+    can echo back provider-specific fields (e.g. thought_signature) on the
+    next turn."""
+    fake_openai = _install_fake_openai(monkeypatch)
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    fake_response = _make_fake_openai_response(content="hello")
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=lambda **_: fake_response)
+        )
+    )
+    client._model = "gemini-2.5-flash"
+    client._max_tokens = 1024
+
+    del fake_openai  # unused; just ensures the fake module is in sys.modules
+
+    response = client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.raw_content is not None
+    assert isinstance(response.raw_content, dict)
+    assert response.raw_content.get("role") == "assistant"
+
+
+def test_openai_agent_client_invoke_raw_content_preserves_extra_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Extra fields from the provider (e.g. Gemini thought_signature inside a
+    tool call) must survive through raw_content into the next turn's message."""
+    _install_fake_openai(monkeypatch)
+
+    def fake_tc_model_dump() -> dict:
+        return {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_logs", "arguments": "{}"},
+            "thought_signature": "abc123",  # Gemini extension
+        }
+
+    fake_tc = types.SimpleNamespace(
+        id="call_1",
+        function=types.SimpleNamespace(name="get_logs", arguments="{}"),
+        model_dump=fake_tc_model_dump,
+    )
+    fake_response = _make_fake_openai_response(tool_calls=[fake_tc])
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=lambda **_: fake_response)
+        )
+    )
+    client._model = "gemini-2.5-flash"
+    client._max_tokens = 1024
+
+    response = client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.raw_content is not None
+    assert isinstance(response.raw_content.get("tool_calls"), list)
+    first_tc = response.raw_content["tool_calls"][0]
+    assert first_tc.get("thought_signature") == "abc123"

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -115,8 +115,8 @@ def _make_fake_openai_response(
         result: dict = {
             "role": "assistant",
             "content": content or None,
-            "refusal": None,        # SDK null field
-            "audio": None,          # SDK null field
+            "refusal": None,  # SDK null field
+            "audio": None,  # SDK null field
             "function_call": None,  # SDK null field
         }
         if tool_calls:

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -102,14 +102,29 @@ def _make_fake_openai_response(
     finish_reason: str = "stop",
     extra_msg_fields: dict | None = None,
 ) -> types.SimpleNamespace:
-    """Build a minimal fake OpenAI chat completion response."""
+    """Build a fake OpenAI chat completion response.
 
-    def model_dump() -> dict:
-        result: dict = {"role": "assistant", "content": content or None}
+    model_dump() mirrors the real SDK: every pydantic field is present,
+    including the null ones (refusal, audio, function_call).  This lets
+    tests verify that exclude_none=True strips those nulls before the
+    dict is stored in raw_content.
+    """
+
+    def model_dump(*, exclude_none: bool = False) -> dict:
+        # Simulate the full SDK field set, nulls included.
+        result: dict = {
+            "role": "assistant",
+            "content": content or None,
+            "refusal": None,        # SDK null field
+            "audio": None,          # SDK null field
+            "function_call": None,  # SDK null field
+        }
         if tool_calls:
             result["tool_calls"] = [tc.model_dump() for tc in tool_calls]
         if extra_msg_fields:
             result.update(extra_msg_fields)
+        if exclude_none:
+            result = {k: v for k, v in result.items() if v is not None}
         return result
 
     msg = types.SimpleNamespace(
@@ -146,6 +161,11 @@ def test_openai_agent_client_invoke_sets_raw_content(
     assert response.raw_content is not None
     assert isinstance(response.raw_content, dict)
     assert response.raw_content.get("role") == "assistant"
+    # exclude_none=True must strip SDK null fields so they don't
+    # cause 400s on Gemini's strict endpoint on the next turn.
+    assert "refusal" not in response.raw_content
+    assert "audio" not in response.raw_content
+    assert "function_call" not in response.raw_content
 
 
 def test_openai_agent_client_invoke_raw_content_preserves_extra_fields(


### PR DESCRIPTION
## Summary

- `OpenAIAgentClient.invoke()` was returning `raw_content=None`, causing `_build_assistant_msg()` to reconstruct the assistant message from extracted `ToolCall` objects — dropping any provider-specific fields in the process.
- Gemini thinking models attach a `thought_signature` to each tool call in their response; the API requires this to be echoed back verbatim in the next turn. Stripping it caused a 400 `"Function call is missing a thought_signature in functionCall parts"` on every subsequent iteration.
- Fix: serialise the API message via `msg.model_dump()` and store it in `raw_content`; `_build_assistant_msg()` now returns `raw_content` directly (matching the existing Anthropic path) so all provider-specific fields survive.

## Test plan

- [ ] New unit tests `test_openai_agent_client_invoke_sets_raw_content` and `test_openai_agent_client_invoke_raw_content_preserves_extra_fields` pass
- [ ] All pre-existing tests in `tests/services/test_agent_llm_client.py` still pass
- [ ] `uv run ruff check` on changed files passes with no warnings

Closes #2005
Closes #2006

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhPNRr81M2mzv82C7sZ9zB)_