### PR TITLE
fix(webapp): add /ok health endpoint

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -41,6 +41,7 @@ def get_health_response() -> HealthResponse:
 
 @app.get("/", response_model=HealthResponse)
 @app.get("/health", response_model=HealthResponse)
+@app.get("/ok", response_model=HealthResponse)
 def health(response: Response) -> HealthResponse:
     health_response = get_health_response()
     response.status_code = (


### PR DESCRIPTION
## Summary

- `RemoteAgentClient` probes `GET /ok` for health checks but `webapp.py` only exposed `/` and `/health`, causing HTTP 404 errors for users running the FastAPI backend and using `opensre remote health`
- Add `/ok` as an additional route alias on the existing health handler

## Test plan

- [ ] `GET /ok` returns 200 with `HealthResponse` JSON
- [ ] `GET /health` and `GET /` still work as before
- [ ] `opensre remote health` no longer fails with 404 against a local webapp

Closes #2032

https://claude.ai/code/session_01K1EgmerGdJBbAo29Usxdet

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1EgmerGdJBbAo29Usxdet)_