### PR TITLE
fix: use max_completion_tokens for OpenAI o1/o3/o4 reasoning models

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -233,10 +234,9 @@ class OpenAIAgentClient:
         if system:
             msgs = [{"role": "system", "content": system}] + msgs
 
-        # OpenAI o1/o3/o4 reasoning models use max_completion_tokens; all others use max_tokens.
-        tokens_key = (
-            "max_completion_tokens" if self._model.startswith(("o1", "o3", "o4")) else "max_tokens"
-        )
+        # OpenAI o-series reasoning models (o1, o3, o4, and future variants) use
+        # max_completion_tokens; all other models use max_tokens.
+        tokens_key = "max_completion_tokens" if re.match(r"^o\d", self._model) else "max_tokens"
         kwargs: dict[str, Any] = {
             "model": self._model,
             tokens_key: self._max_tokens,

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -233,9 +233,13 @@ class OpenAIAgentClient:
         if system:
             msgs = [{"role": "system", "content": system}] + msgs
 
+        # OpenAI o1/o3/o4 reasoning models use max_completion_tokens; all others use max_tokens.
+        tokens_key = (
+            "max_completion_tokens" if self._model.startswith(("o1", "o3", "o4")) else "max_tokens"
+        )
         kwargs: dict[str, Any] = {
             "model": self._model,
-            "max_tokens": self._max_tokens,
+            tokens_key: self._max_tokens,
             "messages": msgs,
         }
         if tools:

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -210,8 +210,10 @@ def test_openai_agent_client_invoke_raw_content_preserves_extra_fields(
 @pytest.mark.parametrize(
     "model,expected_key",
     [
+        ("o1", "max_completion_tokens"),
         ("o1-mini", "max_completion_tokens"),
         ("o1-preview", "max_completion_tokens"),
+        ("o3", "max_completion_tokens"),
         ("o3-mini", "max_completion_tokens"),
         ("o4-mini", "max_completion_tokens"),
         ("o5-mini", "max_completion_tokens"),  # future model covered by regex

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -205,3 +205,42 @@ def test_openai_agent_client_invoke_raw_content_preserves_extra_fields(
     assert isinstance(response.raw_content.get("tool_calls"), list)
     first_tc = response.raw_content["tool_calls"][0]
     assert first_tc.get("thought_signature") == "abc123"
+
+
+@pytest.mark.parametrize(
+    "model,expected_key",
+    [
+        ("o1-mini", "max_completion_tokens"),
+        ("o1-preview", "max_completion_tokens"),
+        ("o3-mini", "max_completion_tokens"),
+        ("o4-mini", "max_completion_tokens"),
+        ("gpt-4o", "max_tokens"),
+        ("gemini-2.5-flash", "max_tokens"),
+    ],
+)
+def test_openai_agent_client_uses_correct_tokens_param(
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+    expected_key: str,
+) -> None:
+    """Reasoning models (o1/o3/o4) require max_completion_tokens; others use max_tokens."""
+    _install_fake_openai(monkeypatch)
+
+    captured: dict[str, object] = {}
+
+    def fake_create(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return _make_fake_openai_response(content="ok")
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    )
+    client._model = model
+    client._max_tokens = 512
+
+    client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert expected_key in captured, f"expected '{expected_key}' in kwargs for model {model!r}"
+    other_key = "max_tokens" if expected_key == "max_completion_tokens" else "max_completion_tokens"
+    assert other_key not in captured, f"unexpected '{other_key}' in kwargs for model {model!r}"

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -214,6 +214,7 @@ def test_openai_agent_client_invoke_raw_content_preserves_extra_fields(
         ("o1-preview", "max_completion_tokens"),
         ("o3-mini", "max_completion_tokens"),
         ("o4-mini", "max_completion_tokens"),
+        ("o5-mini", "max_completion_tokens"),  # future model covered by regex
         ("gpt-4o", "max_tokens"),
         ("gemini-2.5-flash", "max_tokens"),
     ],
@@ -223,7 +224,7 @@ def test_openai_agent_client_uses_correct_tokens_param(
     model: str,
     expected_key: str,
 ) -> None:
-    """Reasoning models (o1/o3/o4) require max_completion_tokens; others use max_tokens."""
+    """O-series reasoning models require max_completion_tokens; others use max_tokens."""
     _install_fake_openai(monkeypatch)
 
     captured: dict[str, object] = {}


### PR DESCRIPTION
## Summary

- OpenAI reasoning models (`o1`, `o3`, `o4`) reject `max_tokens` with HTTP 400 and require `max_completion_tokens` instead
- `OpenAIAgentClient.invoke()` now detects the model prefix at call time and uses the correct parameter key
- Added 6 parametrized tests covering all affected model families and non-affected models

## Test plan

- [ ] `uv run pytest tests/services/test_agent_llm_client.py -v` — all 10 tests pass
- [ ] `make lint` passes
- [ ] `make format-check` passes
- [ ] `make typecheck` passes

Closes #2053

https://claude.ai/code/session_01LhPNRr81M2mzv82C7sZ9zB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhPNRr81M2mzv82C7sZ9zB)_