### PR TITLE
feat(hermes): add RCA synthetic/e2e suite + session evidence tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert opensre-hub-fetch opensre-hub-export opensre-hub-investigate verify-integrations check-docker grafana-local-up grafana-local-down grafana-local-seed clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock download-cloudopsbench-hf validate-cloudopsbench test-openclaw test-openclaw-synthetic
+.PHONY: install onboard benchmark benchmark-update-readme test test-full demo alert-template investigate-alert opensre-hub-fetch opensre-hub-export opensre-hub-investigate verify-integrations check-docker grafana-local-up grafana-local-down grafana-local-seed clean lint format deploy deploy-lambda deploy-prefect deploy-flink destroy destroy-lambda destroy-prefect destroy-flink prefect-local-test simulate-k8s-alert test-k8s-local test-k8s test-k8s-datadog chaos-mesh-up chaos-mesh-down chaos-engineering-apply chaos-engineering-delete chaos-lab-up chaos-lab-down chaos-experiment-list chaos-experiment-up chaos-experiment-down deploy-dd-monitors cleanup-dd-monitors deploy-eks destroy-eks test-k8s-eks datadog-demo crashloop-demo regen-trigger-config test-rca test-rca-grafana test-synthetic test-rds-synthetic test-cli-smoke deploy-vercel destroy-vercel test-vercel deploy-ec2 destroy-ec2 test-ec2 deploy-ec2-hello destroy-ec2-hello deploy-remote destroy-remote deploy-bedrock destroy-bedrock test-bedrock download-cloudopsbench-hf validate-cloudopsbench test-openclaw test-openclaw-synthetic test-hermes test-hermes-synthetic
 
 
 ifneq ($(wildcard .venv/bin/python),)
@@ -387,6 +387,14 @@ test-openclaw:
 test-openclaw-synthetic:
 	$(PYTHON) -m tests.synthetic.openclaw.run_suite
 
+# Run Hermes incident-identification suites: Hermes RCA synthetic tests + Hermes e2e.
+test-hermes:
+	$(PYTHON) -m pytest tests/synthetic/hermes_rca tests/e2e/hermes -v
+
+# Deterministic/no-key Hermes RCA synthetic checks only.
+test-hermes-synthetic:
+	$(PYTHON) -m pytest tests/synthetic/hermes_rca -v
+
 # Run the RabbitMQ integration + tool tests, then invoke the verify command
 # against the live broker.  Requires the rabbitmq-local-up stack to be running.
 test-rabbitmq-real:
@@ -546,6 +554,8 @@ help:
 	@echo "  make test-rca FILE=pipeline_error_in_logs - Run a single RCA alert test"
 	@echo "  make test-rds-synthetic - Run the synthetic RDS PostgreSQL RCA suite"
 	@echo "  make test-openclaw   - Run OpenClaw integration + e2e tests (skips when openclaw CLI absent)"
+	@echo "  make test-hermes     - Run Hermes synthetic + e2e suites"
+	@echo "  make test-hermes-synthetic - Run Hermes RCA synthetic suite only (no-key deterministic path)"
 	@echo "  make download-cloudopsbench-hf - Download Cloud-OpsBench from Hugging Face"
 	@echo "  make test-cloudopsbench - Run the Cloud-OpsBench synthetic RCA suite"
 	@echo "  make clean           - Clean up cache files"

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -206,7 +206,12 @@ class ConnectedInvestigationAgent:
                 MAX_INVESTIGATION_LOOPS,
             )
 
-        result = parse_diagnosis(messages, evidence, state.get("alert_name", ""))
+        result = parse_diagnosis(
+            messages,
+            evidence,
+            state.get("alert_name", ""),
+            alert_source=_get_alert_source(state),
+        )
         result.evidence = evidence
         result.evidence_entries = [e.model_dump() for e in evidence_entries]
         result.agent_messages = messages

--- a/app/agent/prompt.py
+++ b/app/agent/prompt.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.types.root_cause_categories import render_prompt_taxonomy
+
 _INVESTIGATION_SYSTEM = """You are Tracer, an AI SRE performing a live production incident investigation.
 
 Your task: investigate the alert below and produce a clear, evidence-backed root cause analysis.
@@ -28,12 +30,15 @@ Your task: investigate the alert below and produce a clear, evidence-backed root
 
 When you are done investigating (no more tool calls), write a diagnosis that includes:
 - **Root cause**: What failed and why (2-3 sentences, specific)
-- **Root cause category**: One of database / infrastructure / code_bug / configuration / network / performance / healthy / unknown
+- **Root cause category**: Use exactly one category name from the taxonomy below
 - **Evidence**: Which tool results support your conclusion
 - **Validated claims**: Specific facts confirmed by evidence (e.g. "Error rate spiked to 47% at 14:32 UTC per Grafana logs")
 - **Non-validated claims**: Hypotheses you could not confirm
 - **Remediation steps**: Ordered, concrete actions to fix the issue
 - **Validity score**: 0.0–1.0 reflecting your confidence based on evidence quality
+
+## Root cause category taxonomy (single source of truth)
+{root_cause_taxonomy}
 """
 
 _ALERT_CONTEXT_TEMPLATE = """## Alert
@@ -94,7 +99,7 @@ _SECONDARY_SOURCES = {"knowledge", "openclaw", "google_docs"}
 
 
 def build_system_prompt(_state: dict[str, Any]) -> str:
-    return _INVESTIGATION_SYSTEM
+    return _INVESTIGATION_SYSTEM.format(root_cause_taxonomy=render_prompt_taxonomy().strip())
 
 
 def format_alert_context(state: dict[str, Any]) -> str:

--- a/app/agent/prompt.py
+++ b/app/agent/prompt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.types.root_cause_categories import render_prompt_taxonomy
+from app.types.root_cause_categories import HERMES_ROOT_CAUSE_CATEGORIES, render_prompt_taxonomy
 
 _INVESTIGATION_SYSTEM = """You are Tracer, an AI SRE performing a live production incident investigation.
 
@@ -30,15 +30,12 @@ Your task: investigate the alert below and produce a clear, evidence-backed root
 
 When you are done investigating (no more tool calls), write a diagnosis that includes:
 - **Root cause**: What failed and why (2-3 sentences, specific)
-- **Root cause category**: Use exactly one category name from the taxonomy below
+- **Root cause category**: {root_cause_category_instruction}
 - **Evidence**: Which tool results support your conclusion
 - **Validated claims**: Specific facts confirmed by evidence (e.g. "Error rate spiked to 47% at 14:32 UTC per Grafana logs")
 - **Non-validated claims**: Hypotheses you could not confirm
 - **Remediation steps**: Ordered, concrete actions to fix the issue
 - **Validity score**: 0.0–1.0 reflecting your confidence based on evidence quality
-
-## Root cause category taxonomy (single source of truth)
-{root_cause_taxonomy}
 """
 
 _ALERT_CONTEXT_TEMPLATE = """## Alert
@@ -97,9 +94,29 @@ _ALERT_SOURCE_TO_TOOL_SOURCES: dict[str, list[str]] = {
 # Generic fallback sources — always secondary, never primary.
 _SECONDARY_SOURCES = {"knowledge", "openclaw", "google_docs"}
 
+_DEFAULT_ROOT_CAUSE_CATEGORY_INSTRUCTION = (
+    "One of database / infrastructure / code_bug / configuration / network / performance / "
+    "healthy / unknown"
+)
 
-def build_system_prompt(_state: dict[str, Any]) -> str:
-    return _INVESTIGATION_SYSTEM.format(root_cause_taxonomy=render_prompt_taxonomy().strip())
+
+def build_system_prompt(state: dict[str, Any]) -> str:
+    alert_source = _get_alert_source(state)
+    root_cause_category_instruction = _DEFAULT_ROOT_CAUSE_CATEGORY_INSTRUCTION
+
+    if alert_source == "hermes":
+        taxonomy = render_prompt_taxonomy(
+            HERMES_ROOT_CAUSE_CATEGORIES | {"healthy", "unknown"}
+        ).strip()
+        root_cause_category_instruction = (
+            "Use exactly one category name from the Hermes taxonomy below\n\n"
+            "## Hermes root cause category taxonomy (single source of truth)\n"
+            f"{taxonomy}"
+        )
+
+    return _INVESTIGATION_SYSTEM.format(
+        root_cause_category_instruction=root_cause_category_instruction
+    )
 
 
 def format_alert_context(state: dict[str, Any]) -> str:

--- a/app/agent/result.py
+++ b/app/agent/result.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.types.root_cause_categories import render_prompt_taxonomy
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,8 +17,7 @@ class _DiagnosisSchema(BaseModel):
     root_cause: str = Field(description="Concise root cause statement (2-3 sentences max)")
     root_cause_category: str = Field(
         description=(
-            "One of: database, infrastructure, code_bug, configuration, "
-            "network, performance, healthy, unknown"
+            f"Use exactly one category from this taxonomy:\n{render_prompt_taxonomy().strip()}"
         )
     )
     causal_chain: list[str] = Field(

--- a/app/agent/result.py
+++ b/app/agent/result.py
@@ -8,31 +8,13 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from app.types.root_cause_categories import render_prompt_taxonomy
+from app.types.root_cause_categories import (
+    HERMES_ROOT_CAUSE_CATEGORIES,
+    VALID_ROOT_CAUSE_CATEGORIES,
+    render_prompt_taxonomy,
+)
 
 logger = logging.getLogger(__name__)
-
-
-class _DiagnosisSchema(BaseModel):
-    root_cause: str = Field(description="Concise root cause statement (2-3 sentences max)")
-    root_cause_category: str = Field(
-        description=(
-            f"Use exactly one category from this taxonomy:\n{render_prompt_taxonomy().strip()}"
-        )
-    )
-    causal_chain: list[str] = Field(
-        default_factory=list, description="Ordered steps leading to the failure"
-    )
-    validated_claims: list[str] = Field(
-        default_factory=list, description="Claims supported by tool evidence"
-    )
-    non_validated_claims: list[str] = Field(
-        default_factory=list, description="Claims not yet confirmed by evidence"
-    )
-    remediation_steps: list[str] = Field(
-        default_factory=list, description="Concrete remediation actions in order"
-    )
-    validity_score: float = Field(default=0.0, description="0.0–1.0 confidence in the diagnosis")
 
 
 @dataclass
@@ -76,6 +58,7 @@ def parse_diagnosis(
     messages: list[dict[str, Any]],
     evidence: dict[str, Any],
     alert_name: str = "",
+    alert_source: str = "",
 ) -> InvestigationResult:
     """Parse the agent's final response into a structured InvestigationResult.
 
@@ -87,7 +70,7 @@ def parse_diagnosis(
         return InvestigationResult.unknown(alert_name)
 
     try:
-        return _parse_via_structured_output(last_text, evidence)
+        return _parse_via_structured_output(last_text, evidence, alert_source=alert_source)
     except Exception as err:
         logger.warning("Structured diagnosis parse failed, falling back: %s", err)
         return _parse_via_legacy(last_text, evidence, alert_name)
@@ -120,7 +103,46 @@ def _extract_last_assistant_text(messages: list[dict[str, Any]]) -> str:
     return ""
 
 
-def _parse_via_structured_output(last_text: str, evidence: dict[str, Any]) -> InvestigationResult:
+def _taxonomy_categories_for_alert_source(alert_source: str) -> set[str]:
+    source = alert_source.strip().lower()
+    if source == "hermes":
+        return set(HERMES_ROOT_CAUSE_CATEGORIES | {"healthy", "unknown"})
+    return set(VALID_ROOT_CAUSE_CATEGORIES - HERMES_ROOT_CAUSE_CATEGORIES)
+
+
+def _build_diagnosis_schema(include_categories: set[str]) -> type[BaseModel]:
+    category_taxonomy = render_prompt_taxonomy(include_categories).strip()
+
+    class DiagnosisSchema(BaseModel):
+        root_cause: str = Field(description="Concise root cause statement (2-3 sentences max)")
+        root_cause_category: str = Field(
+            description=(f"Use exactly one category from this taxonomy:\n{category_taxonomy}")
+        )
+        causal_chain: list[str] = Field(
+            default_factory=list, description="Ordered steps leading to the failure"
+        )
+        validated_claims: list[str] = Field(
+            default_factory=list, description="Claims supported by tool evidence"
+        )
+        non_validated_claims: list[str] = Field(
+            default_factory=list, description="Claims not yet confirmed by evidence"
+        )
+        remediation_steps: list[str] = Field(
+            default_factory=list, description="Concrete remediation actions in order"
+        )
+        validity_score: float = Field(
+            default=0.0, description="0.0–1.0 confidence in the diagnosis"
+        )
+
+    return DiagnosisSchema
+
+
+def _parse_via_structured_output(
+    last_text: str,
+    evidence: dict[str, Any],
+    *,
+    alert_source: str = "",
+) -> InvestigationResult:
     from app.services import get_llm_for_reasoning
 
     prompt = f"""Extract the structured diagnosis from this investigation conclusion.
@@ -131,13 +153,14 @@ Investigation conclusion:
 Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
 """
     llm = get_llm_for_reasoning()
-    import typing
-
-    schema = typing.cast(
-        _DiagnosisSchema,
-        llm.with_structured_output(_DiagnosisSchema)
+    schema_model = _build_diagnosis_schema(_taxonomy_categories_for_alert_source(alert_source))
+    raw_schema = (
+        llm.with_structured_output(schema_model)
         .with_config(run_name="LLM – Parse diagnosis")
-        .invoke(prompt),
+        .invoke(prompt)
+    )
+    schema = (
+        raw_schema if isinstance(raw_schema, BaseModel) else schema_model.model_validate(raw_schema)
     )
 
     def _to_claim_dicts(claims: list[str], status: str) -> list[dict]:

--- a/app/agent/result.py
+++ b/app/agent/result.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel, Field
 
@@ -152,6 +152,16 @@ Investigation conclusion:
 
 Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
 """
+
+    class _DiagnosisPayload(TypedDict):
+        root_cause: str
+        root_cause_category: str
+        causal_chain: list[str]
+        validated_claims: list[str]
+        non_validated_claims: list[str]
+        remediation_steps: list[str]
+        validity_score: float
+
     llm = get_llm_for_reasoning()
     schema_model = _build_diagnosis_schema(_taxonomy_categories_for_alert_source(alert_source))
     raw_schema = (
@@ -159,21 +169,22 @@ Evidence keys collected: {", ".join(evidence.keys()) if evidence else "none"}
         .with_config(run_name="LLM – Parse diagnosis")
         .invoke(prompt)
     )
-    schema = (
+    schema_instance = (
         raw_schema if isinstance(raw_schema, BaseModel) else schema_model.model_validate(raw_schema)
     )
+    schema = cast(_DiagnosisPayload, schema_instance.model_dump())
 
     def _to_claim_dicts(claims: list[str], status: str) -> list[dict]:
         return [{"claim": c, "validation_status": status} for c in claims if c]
 
     return InvestigationResult(
-        root_cause=schema.root_cause,
-        root_cause_category=schema.root_cause_category,
-        causal_chain=schema.causal_chain,
-        validated_claims=_to_claim_dicts(schema.validated_claims, "validated"),
-        non_validated_claims=_to_claim_dicts(schema.non_validated_claims, "not_validated"),
-        remediation_steps=schema.remediation_steps,
-        validity_score=schema.validity_score,
+        root_cause=schema["root_cause"],
+        root_cause_category=schema["root_cause_category"],
+        causal_chain=schema["causal_chain"],
+        validated_claims=_to_claim_dicts(schema["validated_claims"], "validated"),
+        non_validated_claims=_to_claim_dicts(schema["non_validated_claims"], "not_validated"),
+        remediation_steps=schema["remediation_steps"],
+        validity_score=schema["validity_score"],
     )
 
 

--- a/app/delivery/__init__.py
+++ b/app/delivery/__init__.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from app.state import InvestigationState
+
+logger = logging.getLogger(__name__)
 
 
 def deliver(state: InvestigationState) -> dict[str, Any]:
@@ -16,5 +19,30 @@ def deliver(state: InvestigationState) -> dict[str, Any]:
     Returns state updates with slack_message and report fields.
     """
     from app.delivery.publish_findings.node import generate_report
+
+    state_dict = dict(state)
+
+    if state_dict.get("opensre_evaluate"):
+        rubric_value = state_dict.get("opensre_eval_rubric")
+        if isinstance(rubric_value, str) and rubric_value.strip():
+            from app.integrations.opensre.llm_eval_judge import run_opensre_llm_judge
+
+            try:
+                judge_result = run_opensre_llm_judge(
+                    state=state_dict,
+                    rubric=rubric_value,
+                )
+                state["opensre_llm_eval"] = judge_result
+            except Exception as exc:
+                logger.exception("LLM judge failed: %s", exc)
+                state["opensre_llm_eval"] = {
+                    "skipped": True,
+                    "reason": f"Judge run failed: {exc}",
+                }
+        else:
+            state["opensre_llm_eval"] = {
+                "skipped": True,
+                "reason": "opensre_eval_rubric missing or invalid; expected non-empty string",
+            }
 
     return generate_report(state)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1249,9 +1249,17 @@ def parse_root_cause(response: str) -> RootCauseResult:
             after = parts[1]
             for line in after.split("\n"):
                 candidate = line.strip().lower()
-                if candidate and candidate in VALID_ROOT_CAUSE_CATEGORIES:
+                if not candidate:
+                    continue
+                if candidate in VALID_ROOT_CAUSE_CATEGORIES:
                     root_cause_category = candidate
                     break
+                token_match = re.search(r"[a-z0-9_]+", candidate)
+                if token_match:
+                    token = token_match.group(0)
+                    if token in VALID_ROOT_CAUSE_CATEGORIES:
+                        root_cause_category = token
+                        break
 
     if "ROOT_CAUSE:" in response:
         parts = response.split("ROOT_CAUSE:", 1)

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1254,7 +1254,7 @@ def parse_root_cause(response: str) -> RootCauseResult:
                 if candidate in VALID_ROOT_CAUSE_CATEGORIES:
                     root_cause_category = candidate
                     break
-                token_match = re.search(r"[a-z0-9_]+", candidate)
+                token_match = re.search(r"[a-z_][a-z0-9_]*", candidate)
                 if token_match:
                     token = token_match.group(0)
                     if token in VALID_ROOT_CAUSE_CATEGORIES:

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1254,12 +1254,12 @@ def parse_root_cause(response: str) -> RootCauseResult:
                 if candidate in VALID_ROOT_CAUSE_CATEGORIES:
                     root_cause_category = candidate
                     break
-                token_match = re.search(r"[a-z_][a-z0-9_]*", candidate)
-                if token_match:
-                    token = token_match.group(0)
+                for token in re.findall(r"[a-z_][a-z0-9_]*", candidate):
                     if token in VALID_ROOT_CAUSE_CATEGORIES:
                         root_cause_category = token
                         break
+                if root_cause_category != "unknown":
+                    break
 
     if "ROOT_CAUSE:" in response:
         parts = response.split("ROOT_CAUSE:", 1)

--- a/app/tools/HermesSessionEvidenceTool/__init__.py
+++ b/app/tools/HermesSessionEvidenceTool/__init__.py
@@ -1,0 +1,189 @@
+"""Structured Hermes session evidence tools for incident investigation."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from app.tools.tool_decorator import tool
+from app.tools.utils.availability import hermes_available_or_backend
+
+
+def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
+    hermes = sources.get("hermes", {})
+    return {
+        "session_id": str(hermes.get("session_id") or ""),
+        "hermes_backend": hermes.get("_backend"),
+    }
+
+
+def _backend_or_error(hermes_backend: Any, tool_name: str) -> Any:
+    if hermes_backend is None:
+        return {
+            "source": "hermes",
+            "available": False,
+            "error": (
+                f"{tool_name} requires a Hermes backend. Configure Hermes integration "
+                "or inject a fixture backend for synthetic/e2e runs."
+            ),
+        }
+    return hermes_backend
+
+
+@tool(
+    name="get_hermes_session_log",
+    source="hermes",
+    description="Get structured Hermes session event log entries.",
+    use_cases=["Inspect message/tool/error/retry event sequence for a Hermes session"],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=hermes_available_or_backend,
+    extract_params=_extract_params,
+)
+def get_hermes_session_log(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_session_log")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_session_log(session_id=session_id))
+
+
+@tool(
+    name="get_hermes_message_history",
+    source="hermes",
+    description="Get full Hermes conversation message history for ordering/invariant checks.",
+    use_cases=["Detect malformed tool_call/tool sequencing after compression"],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=hermes_available_or_backend,
+    extract_params=_extract_params,
+)
+def get_hermes_message_history(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_message_history")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_message_history(session_id=session_id))
+
+
+@tool(
+    name="get_hermes_kv_cache_state",
+    source="hermes",
+    description="Get Hermes KV cache counters and miss-diff diagnostics.",
+    use_cases=["Diagnose cache-thrash caused by formatting drift"],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=hermes_available_or_backend,
+    extract_params=_extract_params,
+)
+def get_hermes_kv_cache_state(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_kv_cache_state")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_kv_cache_state(session_id=session_id))
+
+
+@tool(
+    name="get_hermes_runtime_state",
+    source="hermes",
+    description="Get Hermes runtime state including queue depth/progress timestamps.",
+    use_cases=["Diagnose hangs via deterministic frozen_now_ts vs last_progress_ts"],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=hermes_available_or_backend,
+    extract_params=_extract_params,
+)
+def get_hermes_runtime_state(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_runtime_state")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_runtime_state(session_id=session_id))
+
+
+@tool(
+    name="get_hermes_cron_state",
+    source="hermes",
+    description="Get Hermes cron execution and delivery timing state.",
+    use_cases=["Differentiate agent completion from downstream delivery hangs"],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=hermes_available_or_backend,
+    extract_params=_extract_params,
+)
+def get_hermes_cron_state(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_cron_state")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_cron_state(session_id=session_id))
+
+
+@tool(
+    name="get_hermes_session_topology",
+    source="hermes",
+    description="Get Hermes visible/continuation session topology for ghost-session detection.",
+    use_cases=["Follow continuation_of chains to detect invisible forked sessions"],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=hermes_available_or_backend,
+    extract_params=_extract_params,
+)
+def get_hermes_session_topology(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_session_topology")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_session_topology(session_id=session_id))
+
+
+__all__ = [
+    "get_hermes_session_log",
+    "get_hermes_message_history",
+    "get_hermes_kv_cache_state",
+    "get_hermes_runtime_state",
+    "get_hermes_cron_state",
+    "get_hermes_session_topology",
+]

--- a/app/tools/HermesSessionEvidenceTool/__init__.py
+++ b/app/tools/HermesSessionEvidenceTool/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any, cast
 
 from app.tools.tool_decorator import tool
-from app.tools.utils.availability import hermes_available_or_backend
 
 
 def _extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -29,6 +28,11 @@ def _backend_or_error(hermes_backend: Any, tool_name: str) -> Any:
     return hermes_backend
 
 
+def _fixture_backend_only(sources: dict[str, Any]) -> bool:
+    hermes = sources.get("hermes")
+    return isinstance(hermes, dict) and hermes.get("_backend") is not None
+
+
 @tool(
     name="get_hermes_session_log",
     source="hermes",
@@ -40,7 +44,7 @@ def _backend_or_error(hermes_backend: Any, tool_name: str) -> Any:
         "properties": {"session_id": {"type": "string"}},
         "required": [],
     },
-    is_available=hermes_available_or_backend,
+    is_available=_fixture_backend_only,
     extract_params=_extract_params,
 )
 def get_hermes_session_log(
@@ -65,7 +69,7 @@ def get_hermes_session_log(
         "properties": {"session_id": {"type": "string"}},
         "required": [],
     },
-    is_available=hermes_available_or_backend,
+    is_available=_fixture_backend_only,
     extract_params=_extract_params,
 )
 def get_hermes_message_history(
@@ -90,7 +94,7 @@ def get_hermes_message_history(
         "properties": {"session_id": {"type": "string"}},
         "required": [],
     },
-    is_available=hermes_available_or_backend,
+    is_available=_fixture_backend_only,
     extract_params=_extract_params,
 )
 def get_hermes_kv_cache_state(
@@ -115,7 +119,7 @@ def get_hermes_kv_cache_state(
         "properties": {"session_id": {"type": "string"}},
         "required": [],
     },
-    is_available=hermes_available_or_backend,
+    is_available=_fixture_backend_only,
     extract_params=_extract_params,
 )
 def get_hermes_runtime_state(
@@ -140,7 +144,7 @@ def get_hermes_runtime_state(
         "properties": {"session_id": {"type": "string"}},
         "required": [],
     },
-    is_available=hermes_available_or_backend,
+    is_available=_fixture_backend_only,
     extract_params=_extract_params,
 )
 def get_hermes_cron_state(
@@ -165,7 +169,7 @@ def get_hermes_cron_state(
         "properties": {"session_id": {"type": "string"}},
         "required": [],
     },
-    is_available=hermes_available_or_backend,
+    is_available=_fixture_backend_only,
     extract_params=_extract_params,
 )
 def get_hermes_session_topology(

--- a/app/tools/utils/availability.py
+++ b/app/tools/utils/availability.py
@@ -54,3 +54,9 @@ def cloudwatch_is_available(sources: dict[str, dict]) -> bool:
     the LLM.
     """
     return bool(sources.get("cloudwatch"))
+
+
+def hermes_available_or_backend(sources: dict[str, dict]) -> bool:
+    """Available when Hermes integration is connected or a fixture backend is injected."""
+    hermes = sources.get("hermes", {})
+    return bool(hermes.get("connection_verified") or hermes.get("_backend"))

--- a/app/types/root_cause_categories.py
+++ b/app/types/root_cause_categories.py
@@ -504,6 +504,32 @@ _TAXONOMY: tuple[RootCauseCategory, ...] = (
         GROUP_INFRASTRUCTURE,
         "AWS/cloud account-level quota or limit reached.",
     ),
+    # ── Agent / orchestration runtime (Hermes + similar control-planes) ──
+    RootCauseCategory(
+        "agent_state_corruption",
+        GROUP_CODE_AND_CONFIG,
+        "Agent conversation/tool-call ordering invariants are violated by state corruption.",
+    ),
+    RootCauseCategory(
+        "agent_hang",
+        GROUP_WORKLOAD,
+        "Agent runtime is blocked or makes no progress beyond hang threshold.",
+    ),
+    RootCauseCategory(
+        "delivery_hang",
+        GROUP_WORKLOAD,
+        "Agent work completed but downstream delivery/dispatch remains stuck.",
+    ),
+    RootCauseCategory(
+        "ghost_session",
+        GROUP_CODE_AND_CONFIG,
+        "Visible session diverged from actual continuation chain; output lands in hidden session.",
+    ),
+    RootCauseCategory(
+        "performance_degradation",
+        GROUP_WORKLOAD,
+        "System remains up but materially slower due to cache-thrash/inefficiency regressions.",
+    ),
     # ── Generic fallbacks (kept for backward compatibility) ────────────
     # These exist so legacy answer keys, eval pipelines, and prior LLM
     # outputs continue to validate. New diagnoses should always prefer a

--- a/app/types/root_cause_categories.py
+++ b/app/types/root_cause_categories.py
@@ -589,6 +589,18 @@ _TAXONOMY: tuple[RootCauseCategory, ...] = (
 
 VALID_ROOT_CAUSE_CATEGORIES: frozenset[str] = frozenset(entry.name for entry in _TAXONOMY)
 
+# Hermes/runtime-specific categories. Keep these scoped in prompts so
+# non-Hermes investigations don't get steered toward agent-runtime labels.
+HERMES_ROOT_CAUSE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "agent_state_corruption",
+        "agent_hang",
+        "delivery_hang",
+        "ghost_session",
+        "performance_degradation",
+    }
+)
+
 
 # Names that should never be the diagnosis target for a real incident, but
 # remain valid string outputs (e.g. ``healthy`` short-circuit, ``unknown``
@@ -612,7 +624,9 @@ def categories_by_group() -> dict[str, list[RootCauseCategory]]:
     return grouped
 
 
-def render_prompt_taxonomy() -> str:
+def render_prompt_taxonomy(
+    include_categories: set[str] | frozenset[str] | None = None,
+) -> str:
     """Render the taxonomy as a multi-line string for inclusion in prompts.
 
     The output is a grouped, line-per-category list: each category is shown
@@ -622,18 +636,24 @@ def render_prompt_taxonomy() -> str:
     module is automatically reflected in the prompt without surgery
     elsewhere.
     """
+    include = set(include_categories) if include_categories is not None else None
+
     lines: list[str] = []
     for group, entries in categories_by_group().items():
-        if not entries:
+        filtered_entries = (
+            [entry for entry in entries if entry.name in include] if include is not None else entries
+        )
+        if not filtered_entries:
             continue
         lines.append(f"[{group}]")
-        for entry in entries:
+        for entry in filtered_entries:
             lines.append(f"- {entry.name} — {entry.description}")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
 
 __all__ = [
+    "HERMES_ROOT_CAUSE_CATEGORIES",
     "GENERIC_FALLBACK_CATEGORIES",
     "GROUP_CLOUD_STORAGE",
     "GROUP_CODE_AND_CONFIG",

--- a/app/types/root_cause_categories.py
+++ b/app/types/root_cause_categories.py
@@ -641,7 +641,9 @@ def render_prompt_taxonomy(
     lines: list[str] = []
     for group, entries in categories_by_group().items():
         filtered_entries = (
-            [entry for entry in entries if entry.name in include] if include is not None else entries
+            [entry for entry in entries if entry.name in include]
+            if include is not None
+            else entries
         )
         if not filtered_entries:
             continue

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -46,7 +46,7 @@ PR reviewers expect a **visible demo** (terminal log or screenshot) in the PR un
 Automated equivalent (runs in `make test-cov`):  
 `uv run pytest tests/cli/interactive_shell/test_watchdog_repl_e2e_demo.py -v --tb=short`
 
-Longer transcript (optional): [tests/cli/interactive_shell/repl_watchdog_demo.md](../tests/cli/interactive_shell/repl_watchdog_demo.md).
+Longer transcript (optional): [tests/cli/interactive_shell/repl_watchdog_demo.md](https://github.com/Tracer-Cloud/opensre/blob/main/tests/cli/interactive_shell/repl_watchdog_demo.md).
 
 ## VS Code dev container
 

--- a/docs/hermes.mdx
+++ b/docs/hermes.mdx
@@ -16,10 +16,16 @@ Telegram delivery uses the same credential model as the rest of OpenSRE. For **`
 ## Local demo: synthetic tests, then watch
 
 **1 — Offline “investigation” of the classifier (pytest, no Telegram)**  
-The Hermes synthetic suite feeds real-shaped `errors.log` slices through `IncidentClassifier` and asserts against `answer.yml`. This is the same regression loop documented in the repo’s [`tests/synthetic/hermes/README.md`](https://github.com/Tracer-Cloud/opensre/blob/main/tests/synthetic/hermes/README.md):
+The Hermes log-classifier synthetic suite feeds real-shaped `errors.log` slices through `IncidentClassifier` and asserts against `answer.yml`. This is the same regression loop documented in the repo’s [`tests/synthetic/hermes/README.md`](https://github.com/Tracer-Cloud/opensre/blob/main/tests/synthetic/hermes/README.md):
 
 ```bash
 uv run pytest tests/synthetic/hermes -q
+```
+
+For incident-identification RCA fixtures (session topology, runtime hangs, cron delivery, KV cache drift), run the parallel suite:
+
+```bash
+uv run pytest tests/synthetic/hermes_rca -q
 ```
 
 To run every synthetic-marked test under `tests/synthetic/` (includes Hermes and other packages):

--- a/docs/styles/config/vocabularies/Mintlify/accept.txt
+++ b/docs/styles/config/vocabularies/Mintlify/accept.txt
@@ -128,3 +128,15 @@ URIs
 URI
 hostnames
 hostname
+# Hermes / incident operations terms
+cron
+cooldown
+correlator
+Correlator
+dedup
+deduplicate
+hoc
+routable
+systemd
+tailer
+traceback

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,4 @@ markers =
     cloudopsbench: Cloud-OpsBench synthetic RCA benchmark tests
     e2e: requires live infrastructure or external credentials (skip in offline CI)
     axis2: adversarial offline tests; uses SelectiveGrafanaBackend and asserts ruling-out reasoning
+    hermes: Hermes-focused synthetic/e2e scenario coverage

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from app.agent.prompt import build_system_prompt
+
+
+def test_build_system_prompt_non_hermes_uses_generic_category_instruction() -> None:
+    prompt = build_system_prompt({"alert_source": "grafana"})
+
+    assert "One of database / infrastructure / code_bug / configuration / network / performance" in prompt
+    assert "Hermes root cause category taxonomy" not in prompt
+    assert "agent_hang" not in prompt
+
+
+def test_build_system_prompt_hermes_includes_hermes_taxonomy_only() -> None:
+    prompt = build_system_prompt({"alert_source": "hermes"})
+
+    assert "Hermes root cause category taxonomy" in prompt
+    assert "agent_hang" in prompt
+    assert "delivery_hang" in prompt
+    assert "ghost_session" in prompt
+    assert "connection_exhaustion" not in prompt

--- a/tests/agent/test_prompt.py
+++ b/tests/agent/test_prompt.py
@@ -6,7 +6,10 @@ from app.agent.prompt import build_system_prompt
 def test_build_system_prompt_non_hermes_uses_generic_category_instruction() -> None:
     prompt = build_system_prompt({"alert_source": "grafana"})
 
-    assert "One of database / infrastructure / code_bug / configuration / network / performance" in prompt
+    assert (
+        "One of database / infrastructure / code_bug / configuration / network / performance"
+        in prompt
+    )
     assert "Hermes root cause category taxonomy" not in prompt
     assert "agent_hang" not in prompt
 

--- a/tests/agent/test_result.py
+++ b/tests/agent/test_result.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from app.agent.result import _extract_last_assistant_text
+from app.agent.result import (
+    _build_diagnosis_schema,
+    _extract_last_assistant_text,
+    _taxonomy_categories_for_alert_source,
+)
 
 
 class _TextBlock:
@@ -31,3 +35,21 @@ def test_extract_last_assistant_text_handles_anthropic_content_blocks() -> None:
     assert _extract_last_assistant_text(messages) == (
         "## Diagnosis\n Root cause: missing telemetry"
     )
+
+
+def test_non_hermes_taxonomy_excludes_hermes_categories() -> None:
+    categories = _taxonomy_categories_for_alert_source("postgresql")
+    assert "agent_hang" not in categories
+    assert "ghost_session" not in categories
+
+
+def test_hermes_taxonomy_is_scoped_to_hermes_categories() -> None:
+    categories = _taxonomy_categories_for_alert_source("hermes")
+    assert "agent_hang" in categories
+    assert "ghost_session" in categories
+    assert "connection_exhaustion" not in categories
+
+    schema = _build_diagnosis_schema(categories)
+    description = str(schema.model_fields["root_cause_category"].description)
+    assert "agent_hang" in description
+    assert "connection_exhaustion" not in description

--- a/tests/e2e/hermes/README.md
+++ b/tests/e2e/hermes/README.md
@@ -1,0 +1,12 @@
+# Hermes e2e suites
+
+Hermes e2e tests execute the OpenSRE investigation pipeline against fixture-backed
+Hermes evidence with `context_sources="hermes"`.
+
+Run only Hermes e2e:
+
+```bash
+uv run pytest tests/e2e/hermes -m e2e -v
+```
+
+These tests are LLM-credential gated via `has_credentials_for_active_llm_provider()`.

--- a/tests/e2e/hermes/__init__.py
+++ b/tests/e2e/hermes/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes e2e scenario suites."""

--- a/tests/e2e/hermes/long_running/__init__.py
+++ b/tests/e2e/hermes/long_running/__init__.py
@@ -1,0 +1,1 @@
+"""Long-running Hermes reliability e2e scenarios."""

--- a/tests/e2e/hermes/long_running/conftest.py
+++ b/tests/e2e/hermes/long_running/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+from app.config import has_credentials_for_active_llm_provider
+
+LLM_CREDENTIAL_SKIP_REASON = (
+    "SKIPPED: Hermes long-running e2e requires both active LLM credentials and "
+    "OPENSRE_RUN_HERMES_E2E=1"
+)
+
+
+def llm_ready() -> bool:
+    return has_credentials_for_active_llm_provider() and os.getenv("OPENSRE_RUN_HERMES_E2E") == "1"

--- a/tests/e2e/hermes/long_running/fixtures/README.md
+++ b/tests/e2e/hermes/long_running/fixtures/README.md
@@ -1,0 +1,5 @@
+# Hermes long-running fixtures
+
+This folder can store captured Hermes session artifacts for long-running
+e2e scenarios. Current tests load deterministic fixture bundles from
+`tests/synthetic/hermes_rca/*` via the shared backend.

--- a/tests/e2e/hermes/long_running/test_cli_hang_no_interrupt.py
+++ b/tests/e2e/hermes/long_running/test_cli_hang_no_interrupt.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.hermes.long_running.conftest import LLM_CREDENTIAL_SKIP_REASON, llm_ready
+from tests.e2e.hermes.orchestrator import run_hermes_scenario
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not llm_ready(), reason=LLM_CREDENTIAL_SKIP_REASON)
+def test_cli_hang_no_interrupt() -> None:
+    state = run_hermes_scenario("011-cli-hang-no-interrupt-drain")
+    assert str(state.get("root_cause_category", "")).lower() == "agent_hang"
+    assert float(state.get("validity_score") or 0.0) > 0.7

--- a/tests/e2e/hermes/long_running/test_compression_invalid_ordering.py
+++ b/tests/e2e/hermes/long_running/test_compression_invalid_ordering.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.hermes.long_running.conftest import LLM_CREDENTIAL_SKIP_REASON, llm_ready
+from tests.e2e.hermes.orchestrator import run_hermes_scenario
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not llm_ready(), reason=LLM_CREDENTIAL_SKIP_REASON)
+def test_compression_invalid_ordering() -> None:
+    state = run_hermes_scenario("010-compression-invalid-tool-ordering")
+    assert str(state.get("root_cause_category", "")).lower() == "agent_state_corruption"
+    assert float(state.get("validity_score") or 0.0) > 0.7

--- a/tests/e2e/hermes/long_running/test_cron_hang_post_output.py
+++ b/tests/e2e/hermes/long_running/test_cron_hang_post_output.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.hermes.long_running.conftest import LLM_CREDENTIAL_SKIP_REASON, llm_ready
+from tests.e2e.hermes.orchestrator import run_hermes_scenario
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not llm_ready(), reason=LLM_CREDENTIAL_SKIP_REASON)
+def test_cron_hang_post_output() -> None:
+    state = run_hermes_scenario("012-cron-hang-post-output")
+    assert str(state.get("root_cause_category", "")).lower() == "delivery_hang"
+    assert float(state.get("validity_score") or 0.0) > 0.7

--- a/tests/e2e/hermes/long_running/test_kv_cache_invalidation.py
+++ b/tests/e2e/hermes/long_running/test_kv_cache_invalidation.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.hermes.long_running.conftest import LLM_CREDENTIAL_SKIP_REASON, llm_ready
+from tests.e2e.hermes.orchestrator import run_hermes_scenario
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not llm_ready(), reason=LLM_CREDENTIAL_SKIP_REASON)
+def test_kv_cache_invalidation() -> None:
+    state = run_hermes_scenario("013-kv-cache-invalidation-format-drift")
+    assert str(state.get("root_cause_category", "")).lower() == "performance_degradation"
+    assert float(state.get("validity_score") or 0.0) > 0.7

--- a/tests/e2e/hermes/long_running/test_tui_compression_ghost_session.py
+++ b/tests/e2e/hermes/long_running/test_tui_compression_ghost_session.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.hermes.long_running.conftest import LLM_CREDENTIAL_SKIP_REASON, llm_ready
+from tests.e2e.hermes.orchestrator import run_hermes_scenario
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.skipif(not llm_ready(), reason=LLM_CREDENTIAL_SKIP_REASON)
+def test_tui_compression_ghost_session() -> None:
+    state = run_hermes_scenario("014-tui-compression-ghost-session")
+    assert str(state.get("root_cause_category", "")).lower() == "ghost_session"
+    assert float(state.get("validity_score") or 0.0) > 0.7

--- a/tests/e2e/hermes/orchestrator.py
+++ b/tests/e2e/hermes/orchestrator.py
@@ -30,11 +30,7 @@ def _build_annotations(scenario_id: str, scenario_alert: dict[str, Any]) -> dict
 def run_hermes_scenario(scenario_id: str) -> dict[str, Any]:
     fixture = load_scenario(SUITE_DIR / scenario_id)
 
-    session_id = ""
-    if fixture.evidence.hermes_session_log is not None:
-        session_id = str(fixture.evidence.hermes_session_log.get("session_id", ""))
-    elif fixture.evidence.hermes_message_history is not None:
-        session_id = str(fixture.evidence.hermes_message_history.get("session_id", ""))
+    session_id = fixture.session_id()
 
     raw_alert = create_alert(
         pipeline_name="hermes-long-running-e2e",

--- a/tests/e2e/hermes/orchestrator.py
+++ b/tests/e2e/hermes/orchestrator.py
@@ -1,0 +1,69 @@
+"""Shared orchestration helpers for Hermes e2e investigation scenarios."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from app.pipeline.runners import run_investigation
+from app.utils.tracing import traceable
+from tests.synthetic.hermes_rca.scenario_loader import SUITE_DIR, load_scenario
+from tests.synthetic.mock_hermes_backend.backend import FixtureHermesBackend
+from tests.utils.alert_factory.factory import create_alert
+
+
+def _build_annotations(scenario_id: str, scenario_alert: dict[str, Any]) -> dict[str, Any]:
+    labels = scenario_alert.get("commonLabels") or {}
+    annotations = scenario_alert.get("commonAnnotations") or {}
+    return {
+        "context_sources": "hermes",
+        "scenario_id": scenario_id,
+        "failure_mode": annotations.get("failure_mode", "unknown"),
+        "hermes_session_id": annotations.get("hermes_session_id", ""),
+        "hermes_provider": annotations.get("hermes_provider", ""),
+        "hermes_model": annotations.get("hermes_model", ""),
+        "severity": labels.get("severity", "critical"),
+    }
+
+
+def run_hermes_scenario(scenario_id: str) -> dict[str, Any]:
+    fixture = load_scenario(SUITE_DIR / scenario_id)
+
+    session_id = ""
+    if fixture.evidence.hermes_session_log is not None:
+        session_id = str(fixture.evidence.hermes_session_log.get("session_id", ""))
+    elif fixture.evidence.hermes_message_history is not None:
+        session_id = str(fixture.evidence.hermes_message_history.get("session_id", ""))
+
+    raw_alert = create_alert(
+        pipeline_name="hermes-long-running-e2e",
+        run_name=f"{scenario_id}-{uuid.uuid4().hex[:8]}",
+        status="failed",
+        timestamp=datetime.now(UTC).isoformat(),
+        severity=str((fixture.alert.get("commonLabels") or {}).get("severity", "critical")),
+        alert_name=str(fixture.alert.get("title") or scenario_id),
+        annotations=_build_annotations(scenario_id, fixture.alert),
+    )
+
+    resolved_integrations = {
+        "hermes": {
+            "connection_verified": True,
+            "session_id": session_id,
+            "_backend": FixtureHermesBackend(fixture),
+        }
+    }
+
+    @traceable(
+        run_type="chain",
+        name=f"hermes_e2e_{scenario_id}",
+        metadata={
+            "scenario_id": scenario_id,
+            "context_sources": "hermes",
+            "session_id": session_id,
+        },
+    )
+    def _invoke() -> dict[str, Any]:
+        return dict(run_investigation(raw_alert, resolved_integrations=resolved_integrations))
+
+    return _invoke()

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -218,7 +218,6 @@ def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
 
     client = llm_client.BedrockLLMClient(model="mistral.mistral-large-2402-v1:0")
     assert client._use_anthropic is False
-
     resp = client.invoke([{"role": "user", "content": "hi"}])
     assert resp.content == "ok"
     assert len(runtime.converse_calls) == 1
@@ -228,6 +227,20 @@ def test_bedrock_client_routes_mistral_to_converse(monkeypatch) -> None:
         {"role": "user", "content": [{"text": "hi"}]},
     ]
     assert "system" not in call
+
+
+def test_parse_root_cause_extracts_category_when_not_first_token() -> None:
+    parsed = llm_client.parse_root_cause(
+        "ROOT_CAUSE_CATEGORY:\nroot_cause_category: agent_hang\nROOT_CAUSE: test"
+    )
+    assert parsed.root_cause_category == "agent_hang"
+
+
+def test_parse_root_cause_extracts_category_from_arrow_format() -> None:
+    parsed = llm_client.parse_root_cause(
+        "ROOT_CAUSE_CATEGORY:\ncategory -> delivery_hang\nROOT_CAUSE: test"
+    )
+    assert parsed.root_cause_category == "delivery_hang"
 
 
 def test_invoke_converse_includes_optional_system_temperature(monkeypatch) -> None:

--- a/tests/synthetic/hermes_rca/000-healthy/alert.json
+++ b/tests/synthetic/hermes_rca/000-healthy/alert.json
@@ -1,0 +1,16 @@
+{
+  "title": "[synthetic-hermes] Scheduled health check",
+  "state": "normal",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesHealthCheck",
+    "severity": "info",
+    "pipeline_name": "hermes-synthetic"
+  },
+  "commonAnnotations": {
+    "summary": "Hermes session is healthy.",
+    "context_sources": "hermes",
+    "failure_mode": "healthy",
+    "hermes_session_id": "sess-healthy-1"
+  }
+}

--- a/tests/synthetic/hermes_rca/000-healthy/answer.yml
+++ b/tests/synthetic/hermes_rca/000-healthy/answer.yml
@@ -1,0 +1,10 @@
+root_cause_category: healthy
+required_keywords:
+- healthy
+- no failure
+forbidden_categories:
+- unknown
+required_evidence_sources:
+- hermes_session_log
+- hermes_runtime_state
+model_response: Hermes session healthy; no failure detected.

--- a/tests/synthetic/hermes_rca/000-healthy/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/000-healthy/hermes_runtime_state.json
@@ -1,0 +1,9 @@
+{
+  "pid": 4102,
+  "started_at": "2026-05-01T09:00:00Z",
+  "frozen_now_ts": "2026-05-01T10:10:00Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-01T10:09:58Z",
+  "is_blocked": false,
+  "blocking_call": null
+}

--- a/tests/synthetic/hermes_rca/000-healthy/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/000-healthy/hermes_session_log.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "sess-healthy-1",
+  "events": [
+    {
+      "ts": "2026-05-01T10:00:00Z",
+      "kind": "message",
+      "payload": {
+        "role": "assistant",
+        "content": "ok"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/000-healthy/scenario.yml
+++ b/tests/synthetic/hermes_rca/000-healthy/scenario.yml
@@ -1,0 +1,8 @@
+schema_version: '1.0'
+scenario_id: 000-healthy
+failure_mode: healthy
+severity: info
+scenario_difficulty: 0
+available_evidence:
+- hermes_session_log
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/alert.json
+++ b/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/alert.json
@@ -1,0 +1,16 @@
+{
+  "title": "Hermes session crashed after compression step",
+  "state": "alerting",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesCompressionCrash",
+    "severity": "critical",
+    "pipeline_name": "hermes-synthetic"
+  },
+  "commonAnnotations": {
+    "summary": "Provider rejected malformed message sequence",
+    "context_sources": "hermes",
+    "failure_mode": "agent_state_corruption",
+    "hermes_session_id": "sess-010"
+  }
+}

--- a/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/answer.yml
+++ b/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/answer.yml
@@ -1,0 +1,17 @@
+root_cause_category: agent_state_corruption
+required_keywords:
+- context compression
+- malformed
+- tool_call
+forbidden_categories:
+- unknown
+- healthy
+- provider_transport_error
+required_evidence_sources:
+- hermes_message_history
+optimal_trajectory:
+- get_hermes_message_history
+- get_hermes_session_log
+max_investigation_loops: 3
+model_response: Context compression corrupted tool_call/tool ordering and caused provider
+  400.

--- a/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/hermes_message_history.json
+++ b/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/hermes_message_history.json
@@ -1,0 +1,25 @@
+{
+  "session_id": "sess-010",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are Hermes",
+      "tool_call_id": null,
+      "ts": "2026-05-02T09:59:00Z"
+    },
+    {
+      "role": "tool",
+      "content": "{\"result\":\"done\"}",
+      "tool_call_id": "call-9",
+      "ts": "2026-05-02T10:00:01Z"
+    },
+    {
+      "role": "tool_call",
+      "content": {
+        "name": "query_logs"
+      },
+      "tool_call_id": "call-9",
+      "ts": "2026-05-02T10:00:02Z"
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/hermes_message_history.json
+++ b/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/hermes_message_history.json
@@ -21,5 +21,51 @@
       "tool_call_id": "call-9",
       "ts": "2026-05-02T10:00:02Z"
     }
-  ]
+  ],
+  "snapshots": {
+    "pre_compression": [
+      {
+        "role": "system",
+        "content": "You are Hermes",
+        "tool_call_id": null,
+        "ts": "2026-05-02T09:59:00Z"
+      },
+      {
+        "role": "tool_call",
+        "content": {
+          "name": "query_logs"
+        },
+        "tool_call_id": "call-9",
+        "ts": "2026-05-02T10:00:01Z"
+      },
+      {
+        "role": "tool",
+        "content": "{\"result\":\"done\"}",
+        "tool_call_id": "call-9",
+        "ts": "2026-05-02T10:00:02Z"
+      }
+    ],
+    "post_compression": [
+      {
+        "role": "system",
+        "content": "You are Hermes",
+        "tool_call_id": null,
+        "ts": "2026-05-02T09:59:00Z"
+      },
+      {
+        "role": "tool",
+        "content": "{\"result\":\"done\"}",
+        "tool_call_id": "call-9",
+        "ts": "2026-05-02T10:00:01Z"
+      },
+      {
+        "role": "tool_call",
+        "content": {
+          "name": "query_logs"
+        },
+        "tool_call_id": "call-9",
+        "ts": "2026-05-02T10:00:02Z"
+      }
+    ]
+  }
 }

--- a/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/hermes_session_log.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "sess-010",
+  "events": [
+    {
+      "ts": "2026-05-02T10:00:00Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "HTTPError",
+        "error_message": "400 malformed messages after compression"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/scenario.yml
+++ b/tests/synthetic/hermes_rca/010-compression-invalid-tool-ordering/scenario.yml
@@ -1,0 +1,8 @@
+schema_version: '1.0'
+scenario_id: 010-compression-invalid-tool-ordering
+failure_mode: agent_state_corruption
+severity: critical
+scenario_difficulty: 3
+available_evidence:
+- hermes_session_log
+- hermes_message_history

--- a/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/alert.json
+++ b/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/alert.json
@@ -1,0 +1,16 @@
+{
+  "title": "Hermes CLI hung with blocked tool call",
+  "state": "alerting",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesCLIHang",
+    "severity": "critical",
+    "pipeline_name": "hermes-synthetic"
+  },
+  "commonAnnotations": {
+    "summary": "No progress while interrupt queue grows",
+    "context_sources": "hermes",
+    "failure_mode": "agent_hang",
+    "hermes_session_id": "sess-011"
+  }
+}

--- a/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/answer.yml
+++ b/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/answer.yml
@@ -1,0 +1,16 @@
+root_cause_category: agent_hang
+required_keywords:
+- interrupt
+- blocked
+- v0.12.0
+forbidden_categories:
+- unknown
+- provider_transport_error
+- healthy
+required_evidence_sources:
+- hermes_runtime_state
+optimal_trajectory:
+- get_hermes_runtime_state
+- get_hermes_session_log
+max_investigation_loops: 2
+model_response: Interrupt queue drain regression in v0.12.0 caused blocked CLI hang.

--- a/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/hermes_runtime_state.json
@@ -1,0 +1,13 @@
+{
+  "pid": 4111,
+  "started_at": "2026-05-02T11:00:00Z",
+  "frozen_now_ts": "2026-05-02T12:20:00Z",
+  "interrupt_queue_depth": 9,
+  "last_progress_ts": "2026-05-02T12:00:10Z",
+  "is_blocked": true,
+  "blocking_call": {
+    "tool_name": "execute_cmd",
+    "started_at": "2026-05-02T12:00:00Z",
+    "duration_s": 1200
+  }
+}

--- a/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/hermes_session_log.json
@@ -1,0 +1,20 @@
+{
+  "session_id": "sess-011",
+  "events": [
+    {
+      "ts": "2026-05-02T12:00:00Z",
+      "kind": "tool_call",
+      "payload": {
+        "tool": "execute_cmd"
+      }
+    },
+    {
+      "ts": "2026-05-02T12:20:00Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "HangDetected",
+        "error_message": "No progress for 1200s"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/scenario.yml
+++ b/tests/synthetic/hermes_rca/011-cli-hang-no-interrupt-drain/scenario.yml
@@ -1,0 +1,8 @@
+schema_version: '1.0'
+scenario_id: 011-cli-hang-no-interrupt-drain
+failure_mode: agent_hang
+severity: critical
+scenario_difficulty: 3
+available_evidence:
+- hermes_session_log
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/012-cron-hang-post-output/alert.json
+++ b/tests/synthetic/hermes_rca/012-cron-hang-post-output/alert.json
@@ -1,0 +1,16 @@
+{
+  "title": "Hermes cron output produced but not delivered",
+  "state": "alerting",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesCronDeliveryHang",
+    "severity": "high",
+    "pipeline_name": "hermes-synthetic"
+  },
+  "commonAnnotations": {
+    "summary": "Agent completed but delivery did not start",
+    "context_sources": "hermes",
+    "failure_mode": "delivery_hang",
+    "hermes_session_id": "sess-012"
+  }
+}

--- a/tests/synthetic/hermes_rca/012-cron-hang-post-output/answer.yml
+++ b/tests/synthetic/hermes_rca/012-cron-hang-post-output/answer.yml
@@ -1,0 +1,16 @@
+root_cause_category: delivery_hang
+required_keywords:
+- delivery
+- never started
+- agent completed
+forbidden_categories:
+- unknown
+- agent_hang
+- healthy
+required_evidence_sources:
+- hermes_cron_state
+optimal_trajectory:
+- get_hermes_cron_state
+- get_hermes_session_log
+max_investigation_loops: 2
+model_response: Cron run completed agent output, but delivery adapter never started.

--- a/tests/synthetic/hermes_rca/012-cron-hang-post-output/hermes_cron_state.json
+++ b/tests/synthetic/hermes_rca/012-cron-hang-post-output/hermes_cron_state.json
@@ -1,0 +1,10 @@
+{
+  "schedule_cron": "0 */2 * * *",
+  "last_run": {
+    "started_at": "2026-05-03T02:00:00Z",
+    "agent_completed_at": "2026-05-03T02:00:05Z",
+    "delivery_started_at": null,
+    "delivery_completed_at": null,
+    "delivery_status": "never_started"
+  }
+}

--- a/tests/synthetic/hermes_rca/012-cron-hang-post-output/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/012-cron-hang-post-output/hermes_session_log.json
@@ -1,0 +1,20 @@
+{
+  "session_id": "sess-012",
+  "events": [
+    {
+      "ts": "2026-05-03T02:00:00Z",
+      "kind": "message",
+      "payload": {
+        "content": "daily summary generated"
+      }
+    },
+    {
+      "ts": "2026-05-03T02:00:10Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "DeliveryNotStarted",
+        "error_message": "cron delivery adapter did not run"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/012-cron-hang-post-output/scenario.yml
+++ b/tests/synthetic/hermes_rca/012-cron-hang-post-output/scenario.yml
@@ -1,0 +1,8 @@
+schema_version: '1.0'
+scenario_id: 012-cron-hang-post-output
+failure_mode: delivery_hang
+severity: high
+scenario_difficulty: 3
+available_evidence:
+- hermes_session_log
+- hermes_cron_state

--- a/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/alert.json
+++ b/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/alert.json
@@ -1,0 +1,16 @@
+{
+  "title": "Hermes performance degraded with cache misses",
+  "state": "alerting",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesKVCacheThrash",
+    "severity": "warning",
+    "pipeline_name": "hermes-synthetic"
+  },
+  "commonAnnotations": {
+    "summary": "Repeated cache invalidation despite semantic-equivalent messages",
+    "context_sources": "hermes",
+    "failure_mode": "performance_degradation",
+    "hermes_session_id": "sess-013"
+  }
+}

--- a/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/answer.yml
+++ b/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/answer.yml
@@ -1,0 +1,15 @@
+root_cause_category: performance_degradation
+required_keywords:
+- cache miss
+- format drift
+- canonicalization
+forbidden_categories:
+- unknown
+- healthy
+required_evidence_sources:
+- hermes_kv_cache_state
+optimal_trajectory:
+- get_hermes_kv_cache_state
+- get_hermes_session_log
+max_investigation_loops: 2
+model_response: KV cache thrash is caused by message formatting drift and needs canonicalization.

--- a/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/hermes_kv_cache_state.json
+++ b/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/hermes_kv_cache_state.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-013",
+  "cache_hits": 14,
+  "cache_misses": 36,
+  "last_cached_prefix_bytes": 8192,
+  "last_invalidated_reason": "role format drift",
+  "messages_with_cache_miss": [
+    {
+      "message_index": 40,
+      "expected_prefix_bytes": 8090,
+      "actual_prefix_bytes": 8080,
+      "diff_kind": "whitespace"
+    },
+    {
+      "message_index": 41,
+      "expected_prefix_bytes": 8090,
+      "actual_prefix_bytes": 8048,
+      "diff_kind": "role_format"
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/hermes_session_log.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-013",
+  "events": [
+    {
+      "ts": "2026-05-03T14:10:00Z",
+      "kind": "retry",
+      "payload": {
+        "attempt": 3,
+        "delay_ms": 400
+      }
+    },
+    {
+      "ts": "2026-05-03T14:11:00Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "LatencySpike",
+        "error_message": "Token latency increased due to cache miss storm"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/scenario.yml
+++ b/tests/synthetic/hermes_rca/013-kv-cache-invalidation-format-drift/scenario.yml
@@ -1,0 +1,8 @@
+schema_version: '1.0'
+scenario_id: 013-kv-cache-invalidation-format-drift
+failure_mode: performance_degradation
+severity: warning
+scenario_difficulty: 2
+available_evidence:
+- hermes_session_log
+- hermes_kv_cache_state

--- a/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/alert.json
+++ b/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/alert.json
@@ -1,0 +1,16 @@
+{
+  "title": "Hermes TUI stopped progressing on visible session",
+  "state": "alerting",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesGhostSession",
+    "severity": "critical",
+    "pipeline_name": "hermes-synthetic"
+  },
+  "commonAnnotations": {
+    "summary": "Compression continuation likely forked hidden session",
+    "context_sources": "hermes",
+    "failure_mode": "ghost_session",
+    "hermes_session_id": "sess-visible-014"
+  }
+}

--- a/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/answer.yml
+++ b/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/answer.yml
@@ -1,0 +1,16 @@
+root_cause_category: ghost_session
+required_keywords:
+- continuation
+- ghost
+- session-id reconciliation
+forbidden_categories:
+- unknown
+- healthy
+required_evidence_sources:
+- hermes_session_topology
+optimal_trajectory:
+- get_hermes_session_topology
+- get_hermes_session_log
+max_investigation_loops: 3
+model_response: Compression continuation forked a ghost session and messages diverged
+  from visible session due to session-id reconciliation gap.

--- a/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/hermes_session_log.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-visible-014",
+  "events": [
+    {
+      "ts": "2026-05-04T08:00:00Z",
+      "kind": "message",
+      "payload": {
+        "role": "assistant",
+        "content": "waiting..."
+      }
+    },
+    {
+      "ts": "2026-05-04T08:02:00Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "NoVisibleProgress",
+        "error_message": "messages routed to continuation session"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/hermes_session_topology.json
+++ b/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/hermes_session_topology.json
@@ -1,0 +1,19 @@
+{
+  "visible_session_id": "sess-visible-014",
+  "all_sessions": [
+    {
+      "session_id": "sess-visible-014",
+      "parent_session_id": null,
+      "continuation_of": null,
+      "last_message_ts": "2026-05-04T08:00:00Z",
+      "message_count": 31
+    },
+    {
+      "session_id": "sess-ghost-014",
+      "parent_session_id": "sess-visible-014",
+      "continuation_of": "sess-visible-014",
+      "last_message_ts": "2026-05-04T08:05:00Z",
+      "message_count": 48
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/scenario.yml
+++ b/tests/synthetic/hermes_rca/014-tui-compression-ghost-session/scenario.yml
@@ -1,0 +1,8 @@
+schema_version: '1.0'
+scenario_id: 014-tui-compression-ghost-session
+failure_mode: ghost_session
+severity: critical
+scenario_difficulty: 4
+available_evidence:
+- hermes_session_log
+- hermes_session_topology

--- a/tests/synthetic/hermes_rca/README.md
+++ b/tests/synthetic/hermes_rca/README.md
@@ -1,0 +1,13 @@
+# Hermes RCA synthetic suite
+
+This suite is the incident-identification track for Hermes failures.
+
+- Path: `tests/synthetic/hermes_rca/`
+- Deterministic checks (no LLM):
+  - `uv run python -m tests.synthetic.hermes_rca.run_suite --offline-only`
+  - `uv run pytest tests/synthetic/hermes_rca -v`
+- LLM-backed RCA checks (optional):
+  - `uv run python -m tests.synthetic.hermes_rca.run_suite`
+
+This suite intentionally coexists with the existing `tests/synthetic/hermes/`
+log-classifier suite from PR #1860.

--- a/tests/synthetic/hermes_rca/__init__.py
+++ b/tests/synthetic/hermes_rca/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic Hermes RCA scenarios (incident-identification track)."""

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -7,6 +7,8 @@ from typing import Any, NotRequired
 
 from typing_extensions import TypedDict
 
+from app.types.root_cause_categories import VALID_ROOT_CAUSE_CATEGORIES
+
 VALID_HERMES_FAILURE_MODES = frozenset(
     {
         "healthy",
@@ -327,6 +329,12 @@ def validate_hermes_session_topology(data: dict[str, Any]) -> HermesSessionTopol
 def validate_hermes_answer_key(data: dict[str, Any]) -> HermesScenarioAnswerKeySchema:
     ctx = "answer.yml"
     _require_str(data, "root_cause_category", ctx)
+    root_cause_category = str(data["root_cause_category"]).strip()
+    if root_cause_category not in VALID_ROOT_CAUSE_CATEGORIES:
+        raise ValueError(
+            f"{ctx}: unknown root_cause_category {root_cause_category!r}; "
+            f"expected one of {sorted(VALID_ROOT_CAUSE_CATEGORIES)}"
+        )
     _require_non_empty_str_list(data, "required_keywords", ctx, required=True)
     _require_str(data, "model_response", ctx)
 

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -350,6 +350,17 @@ def validate_hermes_answer_key(data: dict[str, Any]) -> HermesScenarioAnswerKeyS
         if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
             raise ValueError(f"{ctx}: '{field}' must be a list of strings")
 
+    forbidden_categories = {
+        item.strip()
+        for item in (data.get("forbidden_categories") or [])
+        if isinstance(item, str) and item.strip()
+    }
+    if root_cause_category in forbidden_categories:
+        raise ValueError(
+            f"{ctx}: root_cause_category {root_cause_category!r} cannot also appear in "
+            "'forbidden_categories'"
+        )
+
     trajectory = data.get("optimal_trajectory")
     if isinstance(trajectory, list):
         unknown_actions = [

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -1,0 +1,407 @@
+"""Schema definitions for Hermes incident-identification synthetic fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, NotRequired
+
+from typing_extensions import TypedDict
+
+VALID_HERMES_FAILURE_MODES = frozenset(
+    {
+        "healthy",
+        # Part 1/5
+        "provider_empty_response",
+        "provider_http_400",
+        "provider_overload_529",
+        "provider_imds_override",
+        "provider_headers_dropped",
+        "sse_line_overflow",
+        # Part 2/5
+        "agent_state_corruption",
+        "agent_hang",
+        "delivery_hang",
+        "performance_degradation",
+        "ghost_session",
+    }
+)
+
+VALID_HERMES_EVIDENCE_SOURCES = frozenset(
+    {
+        "hermes_session_log",
+        "hermes_provider_traffic",
+        "hermes_config",
+        "hermes_runtime_state",
+        "hermes_message_history",
+        "hermes_kv_cache_state",
+        "hermes_cron_state",
+        "hermes_session_topology",
+    }
+)
+
+VALID_HERMES_TRAJECTORY_ACTIONS = frozenset(
+    {
+        "get_hermes_session_log",
+        "get_hermes_message_history",
+        "get_hermes_kv_cache_state",
+        "get_hermes_runtime_state",
+        "get_hermes_cron_state",
+        "get_hermes_session_topology",
+        "get_hermes_logs",
+    }
+)
+
+
+class HermesAlertLabels(TypedDict, total=False):
+    alertname: str
+    severity: str
+    pipeline_name: str
+    service: str
+
+
+class HermesAlertAnnotations(TypedDict, total=False):
+    summary: str
+    description: str
+    context_sources: str
+    hermes_session_id: str
+    hermes_provider: str
+    hermes_model: str
+    failure_mode: str
+
+
+class HermesAlertFixture(TypedDict):
+    title: str
+    state: str
+    alert_source: str
+    commonLabels: HermesAlertLabels
+    commonAnnotations: HermesAlertAnnotations
+
+
+class HermesSessionEvent(TypedDict, total=False):
+    ts: str
+    kind: str
+    payload: dict[str, Any]
+
+
+class HermesSessionLogFixture(TypedDict):
+    session_id: str
+    events: list[HermesSessionEvent]
+
+
+class HermesMessageEntry(TypedDict):
+    role: str
+    content: str | dict[str, Any]
+    tool_call_id: str | None
+    ts: str
+
+
+class HermesMessageHistoryFixture(TypedDict):
+    session_id: str
+    messages: list[HermesMessageEntry]
+
+
+class HermesCacheMissEntry(TypedDict):
+    message_index: int
+    expected_prefix_bytes: int
+    actual_prefix_bytes: int
+    diff_kind: str
+
+
+class HermesKVCacheStateFixture(TypedDict):
+    session_id: str
+    cache_hits: int
+    cache_misses: int
+    last_cached_prefix_bytes: int
+    last_invalidated_reason: str
+    messages_with_cache_miss: list[HermesCacheMissEntry]
+
+
+class HermesBlockingCall(TypedDict):
+    tool_name: str
+    started_at: str
+    duration_s: int
+
+
+class HermesRuntimeStateFixture(TypedDict):
+    pid: int
+    started_at: str
+    frozen_now_ts: str
+    interrupt_queue_depth: int
+    last_progress_ts: str
+    is_blocked: bool
+    blocking_call: HermesBlockingCall | None
+
+
+class HermesCronLastRun(TypedDict):
+    started_at: str
+    agent_completed_at: str | None
+    delivery_started_at: str | None
+    delivery_completed_at: str | None
+    delivery_status: str
+
+
+class HermesCronStateFixture(TypedDict):
+    schedule_cron: str
+    last_run: HermesCronLastRun
+
+
+class HermesSessionNode(TypedDict):
+    session_id: str
+    parent_session_id: str | None
+    continuation_of: str | None
+    last_message_ts: str
+    message_count: int
+
+
+class HermesSessionTopologyFixture(TypedDict):
+    visible_session_id: str
+    all_sessions: list[HermesSessionNode]
+
+
+class HermesScenarioAnswerKeySchema(TypedDict):
+    root_cause_category: str
+    required_keywords: list[str]
+    model_response: str
+    forbidden_categories: NotRequired[list[str]]
+    forbidden_keywords: NotRequired[list[str]]
+    required_evidence_sources: NotRequired[list[str]]
+    optimal_trajectory: NotRequired[list[str]]
+    max_investigation_loops: NotRequired[int]
+
+
+class HermesScenarioMetadataSchema(TypedDict):
+    schema_version: str
+    scenario_id: str
+    failure_mode: str
+    severity: str
+    available_evidence: list[str]
+    scenario_difficulty: NotRequired[int]
+
+
+@dataclass(frozen=True)
+class HermesScenarioEvidence:
+    hermes_session_log: HermesSessionLogFixture | None
+    hermes_provider_traffic: dict[str, Any] | None
+    hermes_config: dict[str, Any] | None
+    hermes_runtime_state: HermesRuntimeStateFixture | None
+    hermes_message_history: HermesMessageHistoryFixture | None
+    hermes_kv_cache_state: HermesKVCacheStateFixture | None
+    hermes_cron_state: HermesCronStateFixture | None
+    hermes_session_topology: HermesSessionTopologyFixture | None
+
+    def as_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in self.__dict__.items():
+            if value is not None:
+                result[key] = value
+        return result
+
+
+def validate_hermes_alert(data: dict[str, Any]) -> HermesAlertFixture:
+    _require_str(data, "title", "alert.json")
+    _require_str(data, "state", "alert.json")
+    _require_str(data, "alert_source", "alert.json")
+    if not isinstance(data.get("commonLabels"), dict):
+        raise ValueError("alert.json: 'commonLabels' must be an object")
+    if not isinstance(data.get("commonAnnotations"), dict):
+        raise ValueError("alert.json: 'commonAnnotations' must be an object")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_session_log(data: dict[str, Any]) -> HermesSessionLogFixture:
+    ctx = "hermes_session_log.json"
+    _require_str(data, "session_id", ctx)
+    events = data.get("events")
+    if not isinstance(events, list):
+        raise ValueError(f"{ctx}: 'events' must be a list")
+    for index, event in enumerate(events):
+        ectx = f"{ctx}:events[{index}]"
+        _require_str(event, "ts", ectx)
+        _require_str(event, "kind", ectx)
+        if not isinstance(event.get("payload"), dict):
+            raise ValueError(f"{ectx}: 'payload' must be an object")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_message_history(data: dict[str, Any]) -> HermesMessageHistoryFixture:
+    ctx = "hermes_message_history.json"
+    _require_str(data, "session_id", ctx)
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        raise ValueError(f"{ctx}: 'messages' must be a list")
+
+    for index, message in enumerate(messages):
+        mctx = f"{ctx}:messages[{index}]"
+        role = str(message.get("role", "")).strip()
+        if role not in {"system", "user", "assistant", "tool_call", "tool"}:
+            raise ValueError(f"{mctx}: invalid role {role!r}")
+        if not isinstance(message.get("content"), (str, dict)):
+            raise ValueError(f"{mctx}: 'content' must be string or object")
+        _require_str(message, "ts", mctx)
+        tool_call_id = message.get("tool_call_id")
+        if tool_call_id is not None and not isinstance(tool_call_id, str):
+            raise ValueError(f"{mctx}: 'tool_call_id' must be a string or null")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_kv_cache_state(data: dict[str, Any]) -> HermesKVCacheStateFixture:
+    ctx = "hermes_kv_cache_state.json"
+    _require_str(data, "session_id", ctx)
+    for field in ("cache_hits", "cache_misses", "last_cached_prefix_bytes"):
+        if not isinstance(data.get(field), int):
+            raise ValueError(f"{ctx}: '{field}' must be an integer")
+    _require_str(data, "last_invalidated_reason", ctx)
+
+    misses = data.get("messages_with_cache_miss")
+    if not isinstance(misses, list):
+        raise ValueError(f"{ctx}: 'messages_with_cache_miss' must be a list")
+    for index, miss in enumerate(misses):
+        mctx = f"{ctx}:messages_with_cache_miss[{index}]"
+        for field in ("message_index", "expected_prefix_bytes", "actual_prefix_bytes"):
+            if not isinstance(miss.get(field), int):
+                raise ValueError(f"{mctx}: '{field}' must be an integer")
+        diff_kind = miss.get("diff_kind")
+        if diff_kind not in {"whitespace", "role_format", "content"}:
+            raise ValueError(f"{mctx}: invalid diff_kind {diff_kind!r}")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_runtime_state(data: dict[str, Any]) -> HermesRuntimeStateFixture:
+    ctx = "hermes_runtime_state.json"
+    if not isinstance(data.get("pid"), int):
+        raise ValueError(f"{ctx}: 'pid' must be an integer")
+    for field in ("started_at", "frozen_now_ts", "last_progress_ts"):
+        _require_str(data, field, ctx)
+    if not isinstance(data.get("interrupt_queue_depth"), int):
+        raise ValueError(f"{ctx}: 'interrupt_queue_depth' must be an integer")
+    if not isinstance(data.get("is_blocked"), bool):
+        raise ValueError(f"{ctx}: 'is_blocked' must be a boolean")
+
+    blocking_call = data.get("blocking_call")
+    if blocking_call is not None:
+        if not isinstance(blocking_call, dict):
+            raise ValueError(f"{ctx}: 'blocking_call' must be an object or null")
+        _require_str(blocking_call, "tool_name", f"{ctx}:blocking_call")
+        _require_str(blocking_call, "started_at", f"{ctx}:blocking_call")
+        if not isinstance(blocking_call.get("duration_s"), int):
+            raise ValueError(f"{ctx}:blocking_call: 'duration_s' must be an integer")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_cron_state(data: dict[str, Any]) -> HermesCronStateFixture:
+    ctx = "hermes_cron_state.json"
+    _require_str(data, "schedule_cron", ctx)
+    last_run = data.get("last_run")
+    if not isinstance(last_run, dict):
+        raise ValueError(f"{ctx}: 'last_run' must be an object")
+    _require_str(last_run, "started_at", f"{ctx}:last_run")
+    delivery_status = last_run.get("delivery_status")
+    if delivery_status not in {"ok", "hung", "failed", "never_started"}:
+        raise ValueError(f"{ctx}:last_run: invalid delivery_status {delivery_status!r}")
+    for field in ("agent_completed_at", "delivery_started_at", "delivery_completed_at"):
+        value = last_run.get(field)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"{ctx}:last_run: '{field}' must be a string or null")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_session_topology(data: dict[str, Any]) -> HermesSessionTopologyFixture:
+    ctx = "hermes_session_topology.json"
+    _require_str(data, "visible_session_id", ctx)
+    sessions = data.get("all_sessions")
+    if not isinstance(sessions, list):
+        raise ValueError(f"{ctx}: 'all_sessions' must be a list")
+    for index, session in enumerate(sessions):
+        sctx = f"{ctx}:all_sessions[{index}]"
+        _require_str(session, "session_id", sctx)
+        for field in ("parent_session_id", "continuation_of"):
+            value = session.get(field)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{sctx}: '{field}' must be a string or null")
+        _require_str(session, "last_message_ts", sctx)
+        if not isinstance(session.get("message_count"), int):
+            raise ValueError(f"{sctx}: 'message_count' must be an integer")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_answer_key(data: dict[str, Any]) -> HermesScenarioAnswerKeySchema:
+    ctx = "answer.yml"
+    _require_str(data, "root_cause_category", ctx)
+    _require_non_empty_str_list(data, "required_keywords", ctx, required=True)
+    _require_str(data, "model_response", ctx)
+
+    for field in (
+        "forbidden_categories",
+        "forbidden_keywords",
+        "required_evidence_sources",
+        "optimal_trajectory",
+    ):
+        value = data.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError(f"{ctx}: '{field}' must be a list of strings")
+
+    trajectory = data.get("optimal_trajectory")
+    if isinstance(trajectory, list):
+        unknown_actions = [
+            item for item in trajectory if item not in VALID_HERMES_TRAJECTORY_ACTIONS
+        ]
+        if unknown_actions:
+            raise ValueError(
+                f"{ctx}: unknown trajectory action(s) {unknown_actions}; expected subset of "
+                f"{sorted(VALID_HERMES_TRAJECTORY_ACTIONS)}"
+            )
+
+    max_loops = data.get("max_investigation_loops")
+    if max_loops is not None and (not isinstance(max_loops, int) or max_loops < 1):
+        raise ValueError(f"{ctx}: 'max_investigation_loops' must be a positive integer")
+    return data  # type: ignore[return-value]
+
+
+def validate_hermes_scenario_metadata(data: dict[str, Any]) -> HermesScenarioMetadataSchema:
+    ctx = "scenario.yml"
+    for field in ("schema_version", "scenario_id", "failure_mode", "severity"):
+        _require_str(data, field, ctx)
+
+    failure_mode = data["failure_mode"]
+    if failure_mode not in VALID_HERMES_FAILURE_MODES:
+        raise ValueError(
+            f"{ctx}: unknown failure_mode {failure_mode!r}; expected one of {sorted(VALID_HERMES_FAILURE_MODES)}"
+        )
+
+    sources = data.get("available_evidence")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError(f"{ctx}: 'available_evidence' must be a non-empty list")
+
+    unknown_sources = [source for source in sources if source not in VALID_HERMES_EVIDENCE_SOURCES]
+    if unknown_sources:
+        raise ValueError(
+            f"{ctx}: unknown evidence source(s) {unknown_sources}; expected subset of "
+            f"{sorted(VALID_HERMES_EVIDENCE_SOURCES)}"
+        )
+    return data  # type: ignore[return-value]
+
+
+def _require_str(obj: dict[str, Any], key: str, ctx: str) -> None:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{ctx}: missing or empty required string field '{key}'")
+
+
+def _require_non_empty_str_list(
+    obj: dict[str, Any],
+    key: str,
+    ctx: str,
+    *,
+    required: bool = False,
+) -> None:
+    value = obj.get(key)
+    if value is None:
+        if required:
+            raise ValueError(f"{ctx}: '{key}' must be a non-empty list")
+        return
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{ctx}: '{key}' must be a non-empty list")
+    if not all(isinstance(item, str) and item.strip() for item in value):
+        raise ValueError(f"{ctx}: all '{key}' entries must be non-empty strings")

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -97,9 +97,15 @@ class HermesMessageEntry(TypedDict):
     ts: str
 
 
+class HermesMessageHistorySnapshots(TypedDict):
+    pre_compression: list[HermesMessageEntry]
+    post_compression: list[HermesMessageEntry]
+
+
 class HermesMessageHistoryFixture(TypedDict):
     session_id: str
     messages: list[HermesMessageEntry]
+    snapshots: NotRequired[HermesMessageHistorySnapshots]
 
 
 class HermesCacheMissEntry(TypedDict):
@@ -231,9 +237,28 @@ def validate_hermes_message_history(data: dict[str, Any]) -> HermesMessageHistor
     messages = data.get("messages")
     if not isinstance(messages, list):
         raise ValueError(f"{ctx}: 'messages' must be a list")
+    _validate_hermes_messages(messages, f"{ctx}:messages")
 
+    snapshots = data.get("snapshots")
+    if snapshots is not None:
+        if not isinstance(snapshots, dict):
+            raise ValueError(f"{ctx}: 'snapshots' must be an object")
+        pre_compression = snapshots.get("pre_compression")
+        post_compression = snapshots.get("post_compression")
+        if not isinstance(pre_compression, list) or not isinstance(post_compression, list):
+            raise ValueError(
+                f"{ctx}: 'snapshots.pre_compression' and 'snapshots.post_compression' must be lists"
+            )
+        _validate_hermes_messages(pre_compression, f"{ctx}:snapshots.pre_compression")
+        _validate_hermes_messages(post_compression, f"{ctx}:snapshots.post_compression")
+    return data  # type: ignore[return-value]
+
+
+def _validate_hermes_messages(messages: list[Any], ctx: str) -> None:
     for index, message in enumerate(messages):
-        mctx = f"{ctx}:messages[{index}]"
+        if not isinstance(message, dict):
+            raise ValueError(f"{ctx}[{index}]: message must be an object")
+        mctx = f"{ctx}[{index}]"
         role = str(message.get("role", "")).strip()
         if role not in {"system", "user", "assistant", "tool_call", "tool"}:
             raise ValueError(f"{mctx}: invalid role {role!r}")
@@ -243,7 +268,6 @@ def validate_hermes_message_history(data: dict[str, Any]) -> HermesMessageHistor
         tool_call_id = message.get("tool_call_id")
         if tool_call_id is not None and not isinstance(tool_call_id, str):
             raise ValueError(f"{mctx}: 'tool_call_id' must be a string or null")
-    return data  # type: ignore[return-value]
 
 
 def validate_hermes_kv_cache_state(data: dict[str, Any]) -> HermesKVCacheStateFixture:

--- a/tests/synthetic/hermes_rca/run_suite.py
+++ b/tests/synthetic/hermes_rca/run_suite.py
@@ -24,6 +24,7 @@ class ScenarioScore:
     expected_category: str
     actual_category: str
     missing_keywords: list[str]
+    forbidden_keywords_present: list[str]
     failure_reason: str = ""
 
 
@@ -50,6 +51,9 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
     missing_keywords = [
         kw for kw in fixture.answer_key.required_keywords if _normalized(kw) not in output
     ]
+    forbidden_keywords_present = [
+        kw for kw in fixture.answer_key.forbidden_keywords if _normalized(kw) in output
+    ]
 
     forbidden = {item.strip().lower() for item in fixture.answer_key.forbidden_categories}
     category_forbidden = actual_category in forbidden
@@ -61,6 +65,7 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
             expected_category=expected_category,
             actual_category=actual_category,
             missing_keywords=missing_keywords,
+            forbidden_keywords_present=forbidden_keywords_present,
             failure_reason=f"forbidden category emitted: {actual_category}",
         )
 
@@ -71,7 +76,19 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
             expected_category=expected_category,
             actual_category=actual_category,
             missing_keywords=missing_keywords,
+            forbidden_keywords_present=forbidden_keywords_present,
             failure_reason=f"wrong category: expected {expected_category}, got {actual_category}",
+        )
+
+    if forbidden_keywords_present:
+        return ScenarioScore(
+            scenario_id=fixture.scenario_id,
+            passed=False,
+            expected_category=expected_category,
+            actual_category=actual_category,
+            missing_keywords=missing_keywords,
+            forbidden_keywords_present=forbidden_keywords_present,
+            failure_reason=f"forbidden keywords present: {forbidden_keywords_present}",
         )
 
     if missing_keywords:
@@ -81,6 +98,7 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
             expected_category=expected_category,
             actual_category=actual_category,
             missing_keywords=missing_keywords,
+            forbidden_keywords_present=forbidden_keywords_present,
             failure_reason=f"missing required keywords: {missing_keywords}",
         )
 
@@ -90,6 +108,7 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
         expected_category=expected_category,
         actual_category=actual_category,
         missing_keywords=[],
+        forbidden_keywords_present=[],
     )
 
 
@@ -178,6 +197,7 @@ def main(argv: list[str] | None = None) -> int:
                     "expected_category": score.expected_category,
                     "actual_category": score.actual_category,
                     "missing_keywords": score.missing_keywords,
+                    "forbidden_keywords_present": score.forbidden_keywords_present,
                     "failure_reason": score.failure_reason,
                     "validity_score": final_state.get("validity_score"),
                 }

--- a/tests/synthetic/hermes_rca/run_suite.py
+++ b/tests/synthetic/hermes_rca/run_suite.py
@@ -54,16 +54,6 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
     forbidden = {item.strip().lower() for item in fixture.answer_key.forbidden_categories}
     category_forbidden = actual_category in forbidden
 
-    if actual_category != expected_category:
-        return ScenarioScore(
-            scenario_id=fixture.scenario_id,
-            passed=False,
-            expected_category=expected_category,
-            actual_category=actual_category,
-            missing_keywords=missing_keywords,
-            failure_reason=f"wrong category: expected {expected_category}, got {actual_category}",
-        )
-
     if category_forbidden:
         return ScenarioScore(
             scenario_id=fixture.scenario_id,
@@ -72,6 +62,16 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
             actual_category=actual_category,
             missing_keywords=missing_keywords,
             failure_reason=f"forbidden category emitted: {actual_category}",
+        )
+
+    if actual_category != expected_category:
+        return ScenarioScore(
+            scenario_id=fixture.scenario_id,
+            passed=False,
+            expected_category=expected_category,
+            actual_category=actual_category,
+            missing_keywords=missing_keywords,
+            failure_reason=f"wrong category: expected {expected_category}, got {actual_category}",
         )
 
     if missing_keywords:
@@ -95,11 +95,7 @@ def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) ->
 
 def _build_resolved_integrations(fixture: HermesScenarioFixture) -> dict[str, Any]:
     backend = FixtureHermesBackend(fixture)
-    session_id = ""
-    if fixture.evidence.hermes_session_log is not None:
-        session_id = str(fixture.evidence.hermes_session_log.get("session_id", ""))
-    elif fixture.evidence.hermes_message_history is not None:
-        session_id = str(fixture.evidence.hermes_message_history.get("session_id", ""))
+    session_id = fixture.session_id()
 
     return {
         "hermes": {

--- a/tests/synthetic/hermes_rca/run_suite.py
+++ b/tests/synthetic/hermes_rca/run_suite.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from app.config import has_credentials_for_active_llm_provider
+from app.pipeline.runners import run_investigation
+from tests.synthetic.hermes_rca.scenario_loader import (
+    SUITE_DIR,
+    HermesScenarioFixture,
+    load_all_scenarios,
+    load_scenario,
+)
+from tests.synthetic.mock_hermes_backend.backend import FixtureHermesBackend
+
+
+@dataclass(frozen=True)
+class ScenarioScore:
+    scenario_id: str
+    passed: bool
+    expected_category: str
+    actual_category: str
+    missing_keywords: list[str]
+    failure_reason: str = ""
+
+
+def _normalized(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def _scored_output_text(final_state: dict[str, Any]) -> str:
+    return " ".join(
+        [
+            str(final_state.get("root_cause") or ""),
+            str(final_state.get("report") or ""),
+            str(final_state.get("problem_md") or ""),
+            " ".join(claim.get("claim", "") for claim in final_state.get("validated_claims", [])),
+        ]
+    )
+
+
+def score_result(fixture: HermesScenarioFixture, final_state: dict[str, Any]) -> ScenarioScore:
+    expected_category = fixture.answer_key.root_cause_category
+    actual_category = str(final_state.get("root_cause_category") or "unknown").strip().lower()
+    output = _normalized(_scored_output_text(final_state))
+
+    missing_keywords = [
+        kw for kw in fixture.answer_key.required_keywords if _normalized(kw) not in output
+    ]
+
+    forbidden = {item.strip().lower() for item in fixture.answer_key.forbidden_categories}
+    category_forbidden = actual_category in forbidden
+
+    if actual_category != expected_category:
+        return ScenarioScore(
+            scenario_id=fixture.scenario_id,
+            passed=False,
+            expected_category=expected_category,
+            actual_category=actual_category,
+            missing_keywords=missing_keywords,
+            failure_reason=f"wrong category: expected {expected_category}, got {actual_category}",
+        )
+
+    if category_forbidden:
+        return ScenarioScore(
+            scenario_id=fixture.scenario_id,
+            passed=False,
+            expected_category=expected_category,
+            actual_category=actual_category,
+            missing_keywords=missing_keywords,
+            failure_reason=f"forbidden category emitted: {actual_category}",
+        )
+
+    if missing_keywords:
+        return ScenarioScore(
+            scenario_id=fixture.scenario_id,
+            passed=False,
+            expected_category=expected_category,
+            actual_category=actual_category,
+            missing_keywords=missing_keywords,
+            failure_reason=f"missing required keywords: {missing_keywords}",
+        )
+
+    return ScenarioScore(
+        scenario_id=fixture.scenario_id,
+        passed=True,
+        expected_category=expected_category,
+        actual_category=actual_category,
+        missing_keywords=[],
+    )
+
+
+def _build_resolved_integrations(fixture: HermesScenarioFixture) -> dict[str, Any]:
+    backend = FixtureHermesBackend(fixture)
+    session_id = ""
+    if fixture.evidence.hermes_session_log is not None:
+        session_id = str(fixture.evidence.hermes_session_log.get("session_id", ""))
+    elif fixture.evidence.hermes_message_history is not None:
+        session_id = str(fixture.evidence.hermes_message_history.get("session_id", ""))
+
+    return {
+        "hermes": {
+            "connection_verified": True,
+            "session_id": session_id,
+            "_backend": backend,
+        }
+    }
+
+
+def run_scenario(fixture: HermesScenarioFixture) -> tuple[dict[str, Any], ScenarioScore]:
+    final_state = run_investigation(
+        fixture.alert,
+        resolved_integrations=_build_resolved_integrations(fixture),
+    )
+    final_state_dict = dict(final_state)
+    return final_state_dict, score_result(fixture, final_state_dict)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run synthetic Hermes RCA suite.")
+    parser.add_argument("--scenario", default="", help="Run one scenario directory name.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output")
+    parser.add_argument(
+        "--offline-only",
+        action="store_true",
+        help=(
+            "Only validate scenario fixtures and answer keys (no LLM call). "
+            "Useful for deterministic local/CI checks without provider keys."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _offline_result(fixture: HermesScenarioFixture) -> dict[str, Any]:
+    required_sources = set(fixture.answer_key.required_evidence_sources)
+    available = set(fixture.metadata.available_evidence)
+    missing_sources = sorted(required_sources - available)
+    passed = not missing_sources
+    return {
+        "scenario_id": fixture.scenario_id,
+        "status": "pass" if passed else "fail",
+        "mode": "offline",
+        "error": "" if passed else f"missing required evidence sources: {missing_sources}",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.scenario:
+        scenarios = [load_scenario(SUITE_DIR / args.scenario)]
+    else:
+        scenarios = load_all_scenarios(SUITE_DIR)
+
+    if not scenarios:
+        print("No Hermes RCA scenarios found.", file=sys.stderr)
+        return 1
+
+    results: list[dict[str, Any]] = []
+
+    if args.offline_only:
+        for fixture in scenarios:
+            results.append(_offline_result(fixture))
+    else:
+        if not has_credentials_for_active_llm_provider():
+            print(
+                "Skipping LLM-backed Hermes RCA run: no credentials for active provider. "
+                "Use --offline-only for deterministic checks.",
+                file=sys.stderr,
+            )
+            return 0
+
+        for fixture in scenarios:
+            final_state, score = run_scenario(fixture)
+            results.append(
+                {
+                    "scenario_id": fixture.scenario_id,
+                    "status": "pass" if score.passed else "fail",
+                    "mode": "llm",
+                    "expected_category": score.expected_category,
+                    "actual_category": score.actual_category,
+                    "missing_keywords": score.missing_keywords,
+                    "failure_reason": score.failure_reason,
+                    "validity_score": final_state.get("validity_score"),
+                }
+            )
+
+    failed = sum(1 for item in results if item["status"] != "pass")
+    passed = len(results) - failed
+
+    if args.json:
+        print(json.dumps({"results": results, "passed": passed, "failed": failed}, indent=2))
+    else:
+        for item in results:
+            print(f"[{item['status'].upper()}] {item['scenario_id']} ({item['mode']})")
+            if item.get("failure_reason"):
+                print(f"  reason: {item['failure_reason']}")
+            if item.get("error"):
+                print(f"  error: {item['error']}")
+        print(f"\nResults: {passed}/{len(results)} passed")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/synthetic/hermes_rca/scenario_loader.py
+++ b/tests/synthetic/hermes_rca/scenario_loader.py
@@ -56,6 +56,13 @@ class HermesScenarioFixture:
     metadata: HermesScenarioMetadata
     answer_key: HermesScenarioAnswerKey
 
+    def session_id(self) -> str:
+        if self.evidence.hermes_session_log is not None:
+            return str(self.evidence.hermes_session_log.get("session_id", ""))
+        if self.evidence.hermes_message_history is not None:
+            return str(self.evidence.hermes_message_history.get("session_id", ""))
+        return ""
+
 
 def _read_json(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))

--- a/tests/synthetic/hermes_rca/scenario_loader.py
+++ b/tests/synthetic/hermes_rca/scenario_loader.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tests.synthetic.hermes_rca.hermes_schemas import (
+    HermesScenarioAnswerKeySchema,
+    HermesScenarioEvidence,
+    HermesScenarioMetadataSchema,
+    validate_hermes_alert,
+    validate_hermes_answer_key,
+    validate_hermes_cron_state,
+    validate_hermes_kv_cache_state,
+    validate_hermes_message_history,
+    validate_hermes_runtime_state,
+    validate_hermes_scenario_metadata,
+    validate_hermes_session_log,
+    validate_hermes_session_topology,
+)
+
+SUITE_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class HermesScenarioMetadata:
+    schema_version: str
+    scenario_id: str
+    failure_mode: str
+    severity: str
+    available_evidence: list[str]
+    scenario_difficulty: int = 1
+
+
+@dataclass(frozen=True)
+class HermesScenarioAnswerKey:
+    root_cause_category: str
+    required_keywords: list[str]
+    model_response: str
+    forbidden_categories: list[str] = field(default_factory=list)
+    forbidden_keywords: list[str] = field(default_factory=list)
+    required_evidence_sources: list[str] = field(default_factory=list)
+    optimal_trajectory: list[str] = field(default_factory=list)
+    max_investigation_loops: int = 1
+
+
+@dataclass(frozen=True)
+class HermesScenarioFixture:
+    scenario_id: str
+    scenario_dir: Path
+    alert: dict[str, Any]
+    evidence: HermesScenarioEvidence
+    metadata: HermesScenarioMetadata
+    answer_key: HermesScenarioAnswerKey
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected YAML object in {path}")
+    return payload
+
+
+def _parse_metadata(path: Path) -> HermesScenarioMetadata:
+    raw = _read_yaml(path)
+    validated: HermesScenarioMetadataSchema = validate_hermes_scenario_metadata(raw)
+    return HermesScenarioMetadata(
+        schema_version=validated["schema_version"],
+        scenario_id=validated["scenario_id"],
+        failure_mode=validated["failure_mode"],
+        severity=validated["severity"],
+        available_evidence=list(validated["available_evidence"]),
+        scenario_difficulty=int(validated.get("scenario_difficulty") or 1),
+    )
+
+
+def _parse_answer_key(path: Path) -> HermesScenarioAnswerKey:
+    raw = _read_yaml(path)
+    validated: HermesScenarioAnswerKeySchema = validate_hermes_answer_key(raw)
+    return HermesScenarioAnswerKey(
+        root_cause_category=str(validated["root_cause_category"]).strip(),
+        required_keywords=[item.strip() for item in validated["required_keywords"]],
+        model_response=str(validated["model_response"]).strip(),
+        forbidden_categories=list(validated.get("forbidden_categories") or []),
+        forbidden_keywords=list(validated.get("forbidden_keywords") or []),
+        required_evidence_sources=list(validated.get("required_evidence_sources") or []),
+        optimal_trajectory=list(validated.get("optimal_trajectory") or []),
+        max_investigation_loops=int(validated.get("max_investigation_loops") or 1),
+    )
+
+
+def _load_evidence(scenario_dir: Path, available_evidence: list[str]) -> HermesScenarioEvidence:
+    session_log = None
+    provider_traffic = None
+    hermes_config = None
+    runtime_state = None
+    message_history = None
+    kv_cache_state = None
+    cron_state = None
+    session_topology = None
+
+    if "hermes_session_log" in available_evidence:
+        session_log = validate_hermes_session_log(
+            _read_json(scenario_dir / "hermes_session_log.json")
+        )
+
+    if "hermes_provider_traffic" in available_evidence:
+        provider_traffic = _read_json(scenario_dir / "hermes_provider_traffic.json")
+
+    if "hermes_config" in available_evidence:
+        hermes_config = _read_json(scenario_dir / "hermes_config.json")
+
+    if "hermes_runtime_state" in available_evidence:
+        runtime_state = validate_hermes_runtime_state(
+            _read_json(scenario_dir / "hermes_runtime_state.json")
+        )
+
+    if "hermes_message_history" in available_evidence:
+        message_history = validate_hermes_message_history(
+            _read_json(scenario_dir / "hermes_message_history.json")
+        )
+
+    if "hermes_kv_cache_state" in available_evidence:
+        kv_cache_state = validate_hermes_kv_cache_state(
+            _read_json(scenario_dir / "hermes_kv_cache_state.json")
+        )
+
+    if "hermes_cron_state" in available_evidence:
+        cron_state = validate_hermes_cron_state(_read_json(scenario_dir / "hermes_cron_state.json"))
+
+    if "hermes_session_topology" in available_evidence:
+        session_topology = validate_hermes_session_topology(
+            _read_json(scenario_dir / "hermes_session_topology.json")
+        )
+
+    return HermesScenarioEvidence(
+        hermes_session_log=session_log,
+        hermes_provider_traffic=provider_traffic,
+        hermes_config=hermes_config,
+        hermes_runtime_state=runtime_state,
+        hermes_message_history=message_history,
+        hermes_kv_cache_state=kv_cache_state,
+        hermes_cron_state=cron_state,
+        hermes_session_topology=session_topology,
+    )
+
+
+def load_scenario(scenario_dir: Path) -> HermesScenarioFixture:
+    metadata = _parse_metadata(scenario_dir / "scenario.yml")
+    answer_key = _parse_answer_key(scenario_dir / "answer.yml")
+    alert = validate_hermes_alert(_read_json(scenario_dir / "alert.json"))
+    evidence = _load_evidence(scenario_dir, metadata.available_evidence)
+
+    return HermesScenarioFixture(
+        scenario_id=metadata.scenario_id,
+        scenario_dir=scenario_dir,
+        alert=alert,
+        evidence=evidence,
+        metadata=metadata,
+        answer_key=answer_key,
+    )
+
+
+def load_all_scenarios(root_dir: Path | None = None) -> list[HermesScenarioFixture]:
+    base_dir = root_dir or SUITE_DIR
+    scenario_dirs = sorted(
+        path for path in base_dir.iterdir() if path.is_dir() and path.name[:3].isdigit()
+    )
+    return [load_scenario(path) for path in scenario_dirs]

--- a/tests/synthetic/hermes_rca/test_suite.py
+++ b/tests/synthetic/hermes_rca/test_suite.py
@@ -86,6 +86,18 @@ def test_answer_key_category_must_be_valid_taxonomy_value() -> None:
         )
 
 
+def test_answer_key_rejects_conflicting_forbidden_category() -> None:
+    with pytest.raises(ValueError, match="cannot also appear"):
+        validate_hermes_answer_key(
+            {
+                "root_cause_category": "agent_hang",
+                "required_keywords": ["x"],
+                "model_response": "y",
+                "forbidden_categories": ["agent_hang"],
+            }
+        )
+
+
 def test_forbidden_category_check_precedes_wrong_category_reason() -> None:
     fixture = next(
         scenario
@@ -111,3 +123,30 @@ def test_forbidden_category_check_precedes_wrong_category_reason() -> None:
     )
     assert score.passed is False
     assert score.failure_reason == "forbidden category emitted: agent_hang"
+
+
+def test_forbidden_keywords_fail_score() -> None:
+    fixture = next(
+        scenario
+        for scenario in load_all_scenarios(SUITE_DIR)
+        if scenario.scenario_id == "000-healthy"
+    )
+    fixture = replace(
+        fixture,
+        answer_key=replace(
+            fixture.answer_key,
+            forbidden_keywords=["panic"],
+        ),
+    )
+    score = score_result(
+        fixture,
+        {
+            "root_cause_category": "healthy",
+            "root_cause": "service panic observed",
+            "report": "",
+            "problem_md": "",
+            "validated_claims": [],
+        },
+    )
+    assert score.passed is False
+    assert score.forbidden_keywords_present == ["panic"]

--- a/tests/synthetic/hermes_rca/test_suite.py
+++ b/tests/synthetic/hermes_rca/test_suite.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.synthetic.hermes_rca.hermes_schemas import (
+    VALID_HERMES_EVIDENCE_SOURCES,
+    VALID_HERMES_FAILURE_MODES,
+)
+from tests.synthetic.hermes_rca.scenario_loader import SUITE_DIR, load_all_scenarios
+from tests.synthetic.mock_hermes_backend.backend import FixtureHermesBackend
+
+pytestmark = [pytest.mark.synthetic, pytest.mark.hermes]
+
+
+def test_load_all_scenarios_discovers_cases() -> None:
+    fixtures = load_all_scenarios(SUITE_DIR)
+    scenario_ids = [fixture.scenario_id for fixture in fixtures]
+    assert "000-healthy" in scenario_ids
+    assert "010-compression-invalid-tool-ordering" in scenario_ids
+    assert "014-tui-compression-ghost-session" in scenario_ids
+
+
+def test_scenario_metadata_uses_valid_vocab() -> None:
+    fixtures = load_all_scenarios(SUITE_DIR)
+    assert fixtures, "no Hermes RCA scenarios discovered"
+
+    for fixture in fixtures:
+        assert fixture.metadata.failure_mode in VALID_HERMES_FAILURE_MODES
+        assert fixture.metadata.available_evidence
+        unknown = set(fixture.metadata.available_evidence) - VALID_HERMES_EVIDENCE_SOURCES
+        assert not unknown, f"{fixture.scenario_id}: unknown evidence sources {unknown}"
+
+
+def test_scenario_evidence_matches_declared_available_evidence() -> None:
+    fixtures = load_all_scenarios(SUITE_DIR)
+
+    for fixture in fixtures:
+        evidence_keys = set(fixture.evidence.as_dict().keys())
+        declared = set(fixture.metadata.available_evidence)
+        assert evidence_keys == declared, (
+            f"{fixture.scenario_id}: evidence keys {evidence_keys} do not match "
+            f"available_evidence {declared}"
+        )
+
+
+def test_fixture_backend_hang_detection_uses_frozen_now_ts() -> None:
+    fixture = next(
+        scenario
+        for scenario in load_all_scenarios(SUITE_DIR)
+        if scenario.scenario_id == "011-cli-hang-no-interrupt-drain"
+    )
+    backend = FixtureHermesBackend(fixture, hang_threshold_s=120)
+    runtime = backend.get_runtime_state()
+
+    assert runtime["available"] is True
+    assert runtime["is_blocked"] is True
+    assert runtime["frozen_now_ts"]
+    assert runtime["last_progress_ts"]
+
+
+def test_fixture_backend_delivery_hang_shape() -> None:
+    fixture = next(
+        scenario
+        for scenario in load_all_scenarios(SUITE_DIR)
+        if scenario.scenario_id == "012-cron-hang-post-output"
+    )
+    backend = FixtureHermesBackend(fixture)
+    cron_state = backend.get_cron_state()
+
+    assert cron_state["available"] is True
+    assert cron_state["last_run"]["delivery_status"] == "never_started"

--- a/tests/synthetic/hermes_rca/test_suite.py
+++ b/tests/synthetic/hermes_rca/test_suite.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from tests.synthetic.hermes_rca.hermes_schemas import (
     VALID_HERMES_EVIDENCE_SOURCES,
     VALID_HERMES_FAILURE_MODES,
+    validate_hermes_answer_key,
 )
+from tests.synthetic.hermes_rca.run_suite import score_result
 from tests.synthetic.hermes_rca.scenario_loader import SUITE_DIR, load_all_scenarios
 from tests.synthetic.mock_hermes_backend.backend import FixtureHermesBackend
 
@@ -69,3 +73,41 @@ def test_fixture_backend_delivery_hang_shape() -> None:
 
     assert cron_state["available"] is True
     assert cron_state["last_run"]["delivery_status"] == "never_started"
+
+
+def test_answer_key_category_must_be_valid_taxonomy_value() -> None:
+    with pytest.raises(ValueError, match="unknown root_cause_category"):
+        validate_hermes_answer_key(
+            {
+                "root_cause_category": "not_a_real_category",
+                "required_keywords": ["x"],
+                "model_response": "y",
+            }
+        )
+
+
+def test_forbidden_category_check_precedes_wrong_category_reason() -> None:
+    fixture = next(
+        scenario
+        for scenario in load_all_scenarios(SUITE_DIR)
+        if scenario.scenario_id == "012-cron-hang-post-output"
+    )
+    fixture = replace(
+        fixture,
+        answer_key=replace(
+            fixture.answer_key,
+            forbidden_categories=["agent_hang"],
+        ),
+    )
+    score = score_result(
+        fixture,
+        {
+            "root_cause_category": "agent_hang",
+            "root_cause": "",
+            "report": "",
+            "problem_md": "",
+            "validated_claims": [],
+        },
+    )
+    assert score.passed is False
+    assert score.failure_reason == "forbidden category emitted: agent_hang"

--- a/tests/synthetic/hermes_rca/test_suite.py
+++ b/tests/synthetic/hermes_rca/test_suite.py
@@ -75,6 +75,29 @@ def test_fixture_backend_delivery_hang_shape() -> None:
     assert cron_state["last_run"]["delivery_status"] == "never_started"
 
 
+def test_compression_ordering_fixture_includes_pre_and_post_snapshots() -> None:
+    fixture = next(
+        scenario
+        for scenario in load_all_scenarios(SUITE_DIR)
+        if scenario.scenario_id == "010-compression-invalid-tool-ordering"
+    )
+    backend = FixtureHermesBackend(fixture)
+    history = backend.get_message_history()
+
+    snapshots = history.get("snapshots")
+    assert isinstance(snapshots, dict)
+
+    pre_messages = snapshots.get("pre_compression")
+    post_messages = snapshots.get("post_compression")
+    assert isinstance(pre_messages, list)
+    assert isinstance(post_messages, list)
+
+    assert pre_messages[1]["role"] == "tool_call"
+    assert pre_messages[2]["role"] == "tool"
+    assert post_messages[1]["role"] == "tool"
+    assert post_messages[2]["role"] == "tool_call"
+
+
 def test_answer_key_category_must_be_valid_taxonomy_value() -> None:
     with pytest.raises(ValueError, match="unknown root_cause_category"):
         validate_hermes_answer_key(

--- a/tests/synthetic/mock_hermes_backend/__init__.py
+++ b/tests/synthetic/mock_hermes_backend/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture-backed Hermes backend used by synthetic/e2e RCA suites."""

--- a/tests/synthetic/mock_hermes_backend/backend.py
+++ b/tests/synthetic/mock_hermes_backend/backend.py
@@ -11,17 +11,23 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class HermesBackend(Protocol):
-    def get_session_log(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+    def get_session_log(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
 
-    def get_message_history(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+    def get_message_history(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
 
-    def get_kv_cache_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+    def get_kv_cache_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
 
-    def get_runtime_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+    def get_runtime_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
 
-    def get_cron_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+    def get_cron_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
 
-    def get_session_topology(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+    def get_session_topology(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
 
 
 class FixtureHermesBackend:

--- a/tests/synthetic/mock_hermes_backend/backend.py
+++ b/tests/synthetic/mock_hermes_backend/backend.py
@@ -1,0 +1,145 @@
+"""FixtureHermesBackend for synthetic Hermes incident-identification scenarios."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tests.synthetic.hermes_rca.scenario_loader import HermesScenarioFixture
+
+
+@runtime_checkable
+class HermesBackend(Protocol):
+    def get_session_log(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_message_history(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_kv_cache_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_runtime_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_cron_state(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+
+    def get_session_topology(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]: ...
+
+
+class FixtureHermesBackend:
+    """Backend that serves evidence from ``HermesScenarioFixture`` in tool envelopes."""
+
+    def __init__(self, fixture: HermesScenarioFixture, *, hang_threshold_s: int = 120) -> None:
+        self._fixture = fixture
+        self._hang_threshold_s = hang_threshold_s
+
+    def get_session_log(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_session_log
+        if evidence is None:
+            return self._missing("session_log")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id or evidence.get("session_id", ""),
+            "events": list(evidence.get("events", [])),
+            "error": None,
+        }
+
+    def get_message_history(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_message_history
+        if evidence is None:
+            return self._missing("message_history")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id or evidence.get("session_id", ""),
+            "messages": list(evidence.get("messages", [])),
+            "error": None,
+        }
+
+    def get_kv_cache_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_kv_cache_state
+        if evidence is None:
+            return self._missing("kv_cache_state")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id or evidence.get("session_id", ""),
+            "cache_hits": int(evidence.get("cache_hits", 0)),
+            "cache_misses": int(evidence.get("cache_misses", 0)),
+            "last_cached_prefix_bytes": int(evidence.get("last_cached_prefix_bytes", 0)),
+            "last_invalidated_reason": str(evidence.get("last_invalidated_reason", "")),
+            "messages_with_cache_miss": list(evidence.get("messages_with_cache_miss", [])),
+            "error": None,
+        }
+
+    def get_runtime_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_runtime_state
+        if evidence is None:
+            return self._missing("runtime_state")
+
+        frozen_now_ts = str(evidence.get("frozen_now_ts", ""))
+        last_progress_ts = str(evidence.get("last_progress_ts", ""))
+
+        computed_blocked = bool(evidence.get("is_blocked", False))
+        if frozen_now_ts and last_progress_ts:
+            try:
+                frozen_dt = datetime.fromisoformat(frozen_now_ts.replace("Z", "+00:00")).astimezone(
+                    UTC
+                )
+                progress_dt = datetime.fromisoformat(
+                    last_progress_ts.replace("Z", "+00:00")
+                ).astimezone(UTC)
+                computed_blocked = (
+                    frozen_dt - progress_dt
+                ).total_seconds() > self._hang_threshold_s
+            except ValueError:
+                computed_blocked = bool(evidence.get("is_blocked", False))
+
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "pid": int(evidence.get("pid", 0)),
+            "started_at": str(evidence.get("started_at", "")),
+            "frozen_now_ts": frozen_now_ts,
+            "interrupt_queue_depth": int(evidence.get("interrupt_queue_depth", 0)),
+            "last_progress_ts": last_progress_ts,
+            "is_blocked": computed_blocked,
+            "blocking_call": evidence.get("blocking_call"),
+            "error": None,
+        }
+
+    def get_cron_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_cron_state
+        if evidence is None:
+            return self._missing("cron_state")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "schedule_cron": str(evidence.get("schedule_cron", "")),
+            "last_run": dict(evidence.get("last_run", {})),
+            "error": None,
+        }
+
+    def get_session_topology(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_session_topology
+        if evidence is None:
+            return self._missing("session_topology")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id or str(evidence.get("visible_session_id", "")),
+            "visible_session_id": str(evidence.get("visible_session_id", "")),
+            "all_sessions": list(evidence.get("all_sessions", [])),
+            "error": None,
+        }
+
+    def _missing(self, evidence_key: str) -> dict[str, Any]:
+        return {
+            "source": "hermes",
+            "available": False,
+            "error": (
+                f"{self._fixture.scenario_id}: {evidence_key} requested "
+                "but not present in available_evidence"
+            ),
+        }

--- a/tests/synthetic/mock_hermes_backend/backend.py
+++ b/tests/synthetic/mock_hermes_backend/backend.py
@@ -53,13 +53,20 @@ class FixtureHermesBackend:
         evidence = self._fixture.evidence.hermes_message_history
         if evidence is None:
             return self._missing("message_history")
-        return {
+        result: dict[str, Any] = {
             "source": "hermes",
             "available": True,
             "session_id": session_id or evidence.get("session_id", ""),
             "messages": list(evidence.get("messages", [])),
             "error": None,
         }
+        snapshots = evidence.get("snapshots")
+        if isinstance(snapshots, dict):
+            result["snapshots"] = {
+                "pre_compression": list(snapshots.get("pre_compression", [])),
+                "post_compression": list(snapshots.get("post_compression", [])),
+            }
+        return result
 
     def get_kv_cache_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
         evidence = self._fixture.evidence.hermes_kv_cache_state

--- a/tests/tools/test_hermes_session_evidence_tool.py
+++ b/tests/tools/test_hermes_session_evidence_tool.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.tools.HermesSessionEvidenceTool import (
+    get_hermes_cron_state,
+    get_hermes_kv_cache_state,
+    get_hermes_message_history,
+    get_hermes_runtime_state,
+    get_hermes_session_log,
+    get_hermes_session_topology,
+)
+
+
+class _FakeHermesBackend:
+    def get_session_log(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        return {"source": "hermes", "available": True, "session_id": session_id, "events": []}
+
+    def get_message_history(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        return {"source": "hermes", "available": True, "session_id": session_id, "messages": []}
+
+    def get_kv_cache_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "cache_hits": 1,
+            "cache_misses": 0,
+            "messages_with_cache_miss": [],
+        }
+
+    def get_runtime_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "is_blocked": False,
+        }
+
+    def get_cron_state(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "last_run": {"delivery_status": "ok"},
+        }
+
+    def get_session_topology(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "visible_session_id": session_id,
+            "all_sessions": [],
+        }
+
+
+def test_tools_delegate_to_backend() -> None:
+    backend = _FakeHermesBackend()
+
+    assert get_hermes_session_log("s1", hermes_backend=backend)["available"] is True
+    assert get_hermes_message_history("s1", hermes_backend=backend)["available"] is True
+    assert get_hermes_kv_cache_state("s1", hermes_backend=backend)["cache_hits"] == 1
+    assert get_hermes_runtime_state("s1", hermes_backend=backend)["is_blocked"] is False
+    assert (
+        get_hermes_cron_state("s1", hermes_backend=backend)["last_run"]["delivery_status"] == "ok"
+    )
+    assert get_hermes_session_topology("s1", hermes_backend=backend)["visible_session_id"] == "s1"
+
+
+def test_tools_require_backend_when_not_configured() -> None:
+    result = get_hermes_session_log(session_id="")
+    assert result["available"] is False
+    assert "requires a Hermes backend" in str(result["error"])


### PR DESCRIPTION
Fixes #1510

#### Describe the changes you have made in this PR -
This PR implements the Hermes RCA synthetic + long-running test track requested in issue #1510, aligned with the existing Hermes direction from merged sample PR #1860.

What’s included:
- Added a new parallel synthetic suite at `tests/synthetic/hermes_rca/` (keeps existing `tests/synthetic/hermes/` untouched).
- Added deterministic fixture backend `tests/synthetic/mock_hermes_backend/backend.py` used by both synthetic and e2e harnesses.
- Added Hermes investigation evidence tools in `app/tools/HermesSessionEvidenceTool/`:
  - `get_hermes_session_log`
  - `get_hermes_message_history`
  - `get_hermes_kv_cache_state`
  - `get_hermes_runtime_state`
  - `get_hermes_cron_state`
  - `get_hermes_session_topology`
- Added long-running e2e harness and tests under `tests/e2e/hermes/long_running/`.
- Added `pytest` marker wiring + Make targets:
  - `make test-hermes-synthetic`
  - `make test-hermes`
- Updated docs (`docs/hermes.mdx`) to reference the new parallel suite.

Follow-up fixes in this PR after first live run:
- Expanded root-cause taxonomy to include Hermes-specific categories used by the scenarios:
  - `agent_state_corruption`, `agent_hang`, `delivery_hang`, `ghost_session`, `performance_degradation`
- Prompt now uses taxonomy from `app/types/root_cause_categories.py` instead of hard-coded legacy category list.
- Structured diagnosis schema guidance updated to use taxonomy source-of-truth.
- Legacy category parser made slightly more robust for noisy formatting.
- Fixture backend now returns structured `available=False` envelopes for missing evidence instead of throwing, to reduce brittle LLM-path failures.

### Demo/Screenshot for feature changes and bug fixes -
Terminal evidence:

- Live e2e run started with:
  - `LLM_PROVIDER=codex CODEX_MODEL=gpt-5.4-mini OPENSRE_REASONING_EFFORT=low OPENSRE_RUN_HERMES_E2E=1 uv run pytest tests/e2e/hermes/long_running -m e2e -v`

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- Problem solved: provide a dedicated Hermes RCA benchmark track with realistic failure modes and enforce evidence-backed categorization behavior.
- Alternatives considered: (1) mutate existing `tests/synthetic/hermes` in place, (2) add a new parallel suite. Chosen (2) to avoid regressions and allow incremental rollout.
- Why this approach: shared fixture backend + new evidence tools keeps synthetic/e2e consistent while making scenarios explicit and maintainable.
- Key components:
  - `tests/synthetic/hermes_rca/*`: scenarios, alert fixtures, answer keys, suite runner.
  - `tests/synthetic/mock_hermes_backend/backend.py`: deterministic evidence transport.
  - `app/tools/HermesSessionEvidenceTool/*`: investigation-facing evidence collection.
  - `tests/e2e/hermes/orchestrator.py`: invokes OpenSRE investigation path with Hermes fixture context.
  - taxonomy/prompt updates: ensure emitted categories and parser expectations are consistent.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
