### PR TITLE
feat(correlation): add upstream correlation validation path

### DIFF
--- a/app/cli/commands/tests.py
+++ b/app/cli/commands/tests.py
@@ -19,6 +19,13 @@ from app.analytics.cli import (
 )
 from app.cli.support.context import is_json_output, is_yes
 from app.cli.support.errors import OpenSREError
+from app.correlation.runtime import build_runtime_correlation
+from app.correlation.upstream import (
+    LogSignal,
+    MetricSeries,
+    TopologyHint,
+    UpstreamEvidenceBundle,
+)
 
 _TEST_CATEGORIES: tuple[str, ...] = (
     "all",
@@ -421,6 +428,90 @@ def list_tests(category: str, search: str) -> None:
 
     for item in items:
         _echo_catalog_item(item)
+
+
+@tests.command(name="upstream-correlation-smoke")
+@click.option("--json", "output_json", is_flag=True, help="Print machine-readable JSON output.")
+def upstream_correlation_smoke(output_json: bool) -> None:
+    """Run deterministic upstream-correlation smoke validation."""
+    evidence = UpstreamEvidenceBundle(
+        rds_metrics=(
+            MetricSeries(
+                source="datadog",
+                name="aws.rds.cpuutilization{dbinstanceidentifier:orders-rds-prod}",
+                timestamps=(
+                    "2026-04-15T14:00:00Z",
+                    "2026-04-15T14:01:00Z",
+                    "2026-04-15T14:02:00Z",
+                ),
+                values=(35.0, 92.0, 95.0),
+            ),
+        ),
+        upstream_metrics=(
+            MetricSeries(
+                source="datadog",
+                name="system.cpu.user{service:orders-web}",
+                timestamps=(
+                    "2026-04-15T14:00:00Z",
+                    "2026-04-15T14:01:00Z",
+                    "2026-04-15T14:02:00Z",
+                ),
+                values=(30.0, 90.0, 94.0),
+            ),
+        ),
+        web_request_logs=(
+            LogSignal(
+                source="datadog",
+                name="alb",
+                timestamps=("2026-04-15T14:01:00Z",),
+                messages=("GET /checkout 200",),
+            ),
+        ),
+        app_logs=(
+            LogSignal(
+                source="datadog",
+                name="orders-app",
+                timestamps=("2026-04-15T14:01:00Z",),
+                messages=("checkout fanout started",),
+            ),
+        ),
+        topology_hints=(
+            TopologyHint(
+                source="system.cpu.user{service:orders-web}",
+                target="orders-rds-prod",
+                relation="upstream_of",
+            ),
+        ),
+        operator_hints=("checkout traffic spike detected",),
+    )
+
+    result = build_runtime_correlation(
+        evidence,
+        target_resource="orders-rds-prod",
+    )
+
+    signals = result.get("correlated_signals") or []
+    drivers = result.get("most_likely_causal_drivers") or []
+
+    if not signals or not drivers:
+        raise OpenSREError("Upstream correlation smoke validation failed.")
+
+    if output_json or is_json_output():
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    click.echo("")
+    click.echo("Upstream Correlation Smoke Validation")
+    click.echo("")
+    click.echo("Correlated signals:")
+    for signal in signals:
+        click.echo(f"- {signal['name']} (source={signal['source']}, score={signal['score']})")
+
+    click.echo("")
+    click.echo("Most likely causal driver(s):")
+    for driver in drivers:
+        click.echo(f"- {driver['name']} (confidence={driver['confidence']})")
+        click.echo(f"  rationale={driver['rationale']}")
 
 
 @tests.command(name="run")

--- a/app/correlation/datadog_provider.py
+++ b/app/correlation/datadog_provider.py
@@ -28,6 +28,9 @@ def _scoped_rds_metric(
 ) -> str:
     metric = metric_name.strip()
 
+    if not target_resource or target_resource == "unknown-rds":
+        return metric
+
     if "{" in metric and "}" in metric:
         prefix, _, rest = metric.partition("{")
         tags, _, suffix = rest.partition("}")
@@ -39,9 +42,6 @@ def _scoped_rds_metric(
             f"{tags},{scope_tag}:{target_resource}" if tags else f"{scope_tag}:{target_resource}"
         )
         return f"{prefix}{{{scoped_tags}}}{suffix}"
-
-    if not target_resource or target_resource == "unknown-rds":
-        return metric
 
     return f"{metric}{{{scope_tag}:{target_resource}}}"
 

--- a/app/correlation/datadog_provider.py
+++ b/app/correlation/datadog_provider.py
@@ -29,7 +29,16 @@ def _scoped_rds_metric(
     metric = metric_name.strip()
 
     if "{" in metric and "}" in metric:
-        return metric
+        prefix, _, rest = metric.partition("{")
+        tags, _, suffix = rest.partition("}")
+
+        if f"{scope_tag}:" in tags:
+            return metric
+
+        scoped_tags = (
+            f"{tags},{scope_tag}:{target_resource}" if tags else f"{scope_tag}:{target_resource}"
+        )
+        return f"{prefix}{{{scoped_tags}}}{suffix}"
 
     if not target_resource or target_resource == "unknown-rds":
         return metric

--- a/app/correlation/datadog_provider.py
+++ b/app/correlation/datadog_provider.py
@@ -13,10 +13,28 @@ from app.correlation.upstream import (
 class DatadogCorrelationQueries:
     rds_cpu_metric: str = "aws.rds.cpuutilization"
     rds_connections_metric: str = "aws.rds.database_connections"
+    rds_scope_tag: str = "dbinstanceidentifier"
     upstream_cpu_metric_template: str = "system.cpu.user{service:%s}"
     alb_log_query_template: str = "service:%s source:alb"
     app_log_query_template: str = "service:%s"
     upstream_service_names: tuple[str, ...] = ()
+
+
+def _scoped_rds_metric(
+    metric_name: str,
+    *,
+    target_resource: str,
+    scope_tag: str,
+) -> str:
+    metric = metric_name.strip()
+
+    if "{" in metric and "}" in metric:
+        return metric
+
+    if not target_resource or target_resource == "unknown-rds":
+        return metric
+
+    return f"{metric}{{{scope_tag}:{target_resource}}}"
 
 
 class DatadogUpstreamEvidenceProvider:
@@ -41,14 +59,26 @@ class DatadogUpstreamEvidenceProvider:
     ) -> UpstreamEvidenceBundle:
         _ = alert_id
 
+        rds_cpu_metric = _scoped_rds_metric(
+            self._queries.rds_cpu_metric,
+            target_resource=self._target_resource,
+            scope_tag=self._queries.rds_scope_tag,
+        )
+
+        rds_connections_metric = _scoped_rds_metric(
+            self._queries.rds_connections_metric,
+            target_resource=self._target_resource,
+            scope_tag=self._queries.rds_scope_tag,
+        )
+
         rds_metrics = (
             self._adapter.query_metric_series(
-                metric_name=self._queries.rds_cpu_metric,
+                metric_name=rds_cpu_metric,
                 start=window_start,
                 end=window_end,
             ),
             self._adapter.query_metric_series(
-                metric_name=self._queries.rds_connections_metric,
+                metric_name=rds_connections_metric,
                 start=window_start,
                 end=window_end,
             ),

--- a/docs/rds.mdx
+++ b/docs/rds.mdx
@@ -79,3 +79,69 @@ Both tools become available to the planner whenever `rds.db_instance_identifier`
 | **AccessDenied on `rds:DescribeDBInstances`** | Add the IAM policy above to the role or user used by the AWS integration. |
 | **DBInstanceNotFound** | Confirm `RDS_DB_INSTANCE_IDENTIFIER` matches an instance in `AWS_REGION`. |
 | **Tool reports the wrong region** | Either `AWS_REGION` is set to a different region, or the source dict has a stale `region` field. Check the resolution order above. |
+
+## Upstream correlation validation
+
+OpenSRE also includes a deterministic upstream-correlation smoke validation path for no-trace-ID RDS CPU spike investigations.
+
+This allows validating correlation output locally without requiring live Datadog credentials or full LLM investigation setup.
+
+### Local smoke validation
+
+Run:
+
+```bash
+opensre tests upstream-correlation-smoke
+```
+
+Expected output includes separate sections for:
+
+- correlated signals
+- most likely causal driver(s)
+
+Example:
+
+```
+Upstream Correlation Smoke Validation
+
+Correlated signals:
+- upstream-correlation (source=runtime, score=0.9)
+
+Most likely causal driver(s):
+- system.cpu.user{service:orders-web} (confidence=0.9)
+```
+
+For machine-readable output:
+
+```bash
+opensre tests upstream-correlation-smoke --json
+```
+
+### Live investigation validation
+
+For live validation, configure Datadog and trigger an investigation against an RDS CPU spike alert.
+
+The upstream correlation runtime automatically scopes RDS metrics to the alerting DB instance using the `dbinstanceidentifier` tag to avoid cross-instance aggregation in multi-RDS environments.
+
+Recommended alert fields:
+
+```json
+{
+  "service": "orders",
+  "resource": "orders-rds-prod",
+  "upstream_services": ["orders-web"]
+}
+```
+
+Then run a live investigation:
+
+```bash
+opensre investigate
+```
+
+When runtime evidence is available, the final report includes:
+
+- correlated signals
+- most likely causal driver(s)
+
+This validation flow is intended as a lightweight smoke/integration path and does not require synthetic benchmark execution.

--- a/docs/rds.mdx
+++ b/docs/rds.mdx
@@ -109,6 +109,7 @@ Correlated signals:
 
 Most likely causal driver(s):
 - system.cpu.user{service:orders-web} (confidence=0.9)
+  rationale=time_window=1.0, topology=1.0, periodicity=1.0, operator_hint=0.0
 ```
 
 For machine-readable output:

--- a/tests/synthetic/rds_postgres/test_observation_correlation.py
+++ b/tests/synthetic/rds_postgres/test_observation_correlation.py
@@ -9,7 +9,6 @@ from app.correlation.upstream import (
     TopologyHint,
     UpstreamEvidenceBundle,
 )
-
 from tests.synthetic.rds_postgres.observations import (
     build_observation,
     compute_trajectory_metrics,

--- a/tests/synthetic/rds_postgres/test_observation_correlation.py
+++ b/tests/synthetic/rds_postgres/test_observation_correlation.py
@@ -132,6 +132,11 @@ def test_runtime_correlation_smoke_payload_shape() -> None:
     assert "correlated_signals" in result
     assert "most_likely_causal_drivers" in result
 
+    signals = result["correlated_signals"]
+
+    assert signals
+    assert {"name", "source", "score"} <= set(signals[0])
+
     drivers = result["most_likely_causal_drivers"]
 
     assert drivers

--- a/tests/synthetic/rds_postgres/test_observation_correlation.py
+++ b/tests/synthetic/rds_postgres/test_observation_correlation.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from app.correlation.runtime import build_runtime_correlation
+from app.correlation.upstream import (
+    LogSignal,
+    MetricSeries,
+    TopologyHint,
+    UpstreamEvidenceBundle,
+)
+
 from tests.synthetic.rds_postgres.observations import (
     build_observation,
     compute_trajectory_metrics,
@@ -63,3 +71,70 @@ def test_build_observation_includes_correlation_payload_in_canonical_report() ->
         "correlated_signals",
         "most_likely_causal_drivers",
     ]
+
+
+def test_runtime_correlation_smoke_payload_shape() -> None:
+    evidence = UpstreamEvidenceBundle(
+        rds_metrics=(
+            MetricSeries(
+                source="datadog",
+                name="aws.rds.cpuutilization",
+                timestamps=(
+                    "2026-04-15T14:00:00Z",
+                    "2026-04-15T14:01:00Z",
+                    "2026-04-15T14:02:00Z",
+                ),
+                values=(35.0, 92.0, 95.0),
+            ),
+        ),
+        upstream_metrics=(
+            MetricSeries(
+                source="datadog",
+                name="system.cpu.user{service:orders-web}",
+                timestamps=(
+                    "2026-04-15T14:00:00Z",
+                    "2026-04-15T14:01:00Z",
+                    "2026-04-15T14:02:00Z",
+                ),
+                values=(30.0, 90.0, 94.0),
+            ),
+        ),
+        web_request_logs=(
+            LogSignal(
+                source="datadog",
+                name="alb",
+                timestamps=("2026-04-15T14:01:00Z",),
+                messages=("GET /checkout 200",),
+            ),
+        ),
+        app_logs=(
+            LogSignal(
+                source="datadog",
+                name="orders-app",
+                timestamps=("2026-04-15T14:01:00Z",),
+                messages=("checkout fanout started",),
+            ),
+        ),
+        topology_hints=(
+            TopologyHint(
+                source="system.cpu.user{service:orders-web}",
+                target="orders-rds-prod",
+                relation="upstream_of",
+            ),
+        ),
+        operator_hints=("scheduled checkout sync introduced recently",),
+    )
+
+    result = build_runtime_correlation(
+        evidence,
+        target_resource="orders-rds-prod",
+    )
+
+    assert "correlated_signals" in result
+    assert "most_likely_causal_drivers" in result
+
+    drivers = result["most_likely_causal_drivers"]
+
+    assert drivers
+    assert drivers[0]["confidence"] > 0.0
+    assert "rationale" in drivers[0]

--- a/tests/test_datadog_provider.py
+++ b/tests/test_datadog_provider.py
@@ -178,3 +178,41 @@ def test_datadog_upstream_provider_adds_instance_scope_to_tagged_rds_metrics() -
         "aws.rds.cpuutilization{env:prod,dbinstanceidentifier:orders-rds-prod}",
         "aws.rds.database_connections{env:prod,dbinstanceidentifier:orders-rds-prod}",
     ]
+
+
+def test_datadog_upstream_provider_does_not_scope_unknown_target_for_tagged_metrics() -> None:
+    metric_queries: list[str] = []
+
+    adapter = DatadogCorrelationAdapter(
+        metric_query_fn=lambda metric, _params: (
+            metric_queries.append(metric)
+            or {
+                "timestamps": ("2026-04-15T14:00:00Z",),
+                "values": (40.0,),
+            }
+        ),
+        log_query_fn=lambda _query, _params: {
+            "timestamps": (),
+            "messages": (),
+        },
+    )
+
+    provider = DatadogUpstreamEvidenceProvider(
+        adapter=adapter,
+        queries=DatadogCorrelationQueries(
+            rds_cpu_metric="aws.rds.cpuutilization{env:prod}",
+            rds_connections_metric="aws.rds.database_connections{env:prod}",
+        ),
+    )
+
+    provider.collect_upstream_evidence(
+        alert_id="alert-1",
+        service_name="orders",
+        window_start="2026-04-15T14:00:00Z",
+        window_end="2026-04-15T14:15:00Z",
+    )
+
+    assert metric_queries[:2] == [
+        "aws.rds.cpuutilization{env:prod}",
+        "aws.rds.database_connections{env:prod}",
+    ]

--- a/tests/test_datadog_provider.py
+++ b/tests/test_datadog_provider.py
@@ -139,3 +139,42 @@ def test_datadog_upstream_provider_preserves_prescoped_rds_metrics() -> None:
         "aws.rds.cpuutilization{dbinstanceidentifier:custom-rds}",
         "aws.rds.database_connections{dbinstanceidentifier:custom-rds}",
     ]
+
+
+def test_datadog_upstream_provider_adds_instance_scope_to_tagged_rds_metrics() -> None:
+    metric_queries: list[str] = []
+
+    adapter = DatadogCorrelationAdapter(
+        metric_query_fn=lambda metric, _params: (
+            metric_queries.append(metric)
+            or {
+                "timestamps": ("2026-04-15T14:00:00Z",),
+                "values": (40.0,),
+            }
+        ),
+        log_query_fn=lambda _query, _params: {
+            "timestamps": (),
+            "messages": (),
+        },
+    )
+
+    provider = DatadogUpstreamEvidenceProvider(
+        adapter=adapter,
+        queries=DatadogCorrelationQueries(
+            rds_cpu_metric="aws.rds.cpuutilization{env:prod}",
+            rds_connections_metric="aws.rds.database_connections{env:prod}",
+        ),
+        target_resource="orders-rds-prod",
+    )
+
+    provider.collect_upstream_evidence(
+        alert_id="alert-1",
+        service_name="orders",
+        window_start="2026-04-15T14:00:00Z",
+        window_end="2026-04-15T14:15:00Z",
+    )
+
+    assert metric_queries[:2] == [
+        "aws.rds.cpuutilization{env:prod,dbinstanceidentifier:orders-rds-prod}",
+        "aws.rds.database_connections{env:prod,dbinstanceidentifier:orders-rds-prod}",
+    ]

--- a/tests/test_datadog_provider.py
+++ b/tests/test_datadog_provider.py
@@ -47,8 +47,8 @@ def test_datadog_upstream_provider_collects_metrics_logs_and_topology() -> None:
     )
 
     assert metric_queries == [
-        "aws.rds.cpuutilization",
-        "aws.rds.database_connections",
+        "aws.rds.cpuutilization{dbinstanceidentifier:orders-rds-prod}",
+        "aws.rds.database_connections{dbinstanceidentifier:orders-rds-prod}",
         "system.cpu.user{service:orders}",
     ]
     assert log_queries == [
@@ -97,4 +97,45 @@ def test_datadog_upstream_provider_can_query_multiple_candidate_services() -> No
     assert [hint.target for hint in bundle.topology_hints] == [
         "orders-rds-prod",
         "orders-rds-prod",
+    ]
+
+
+def test_datadog_upstream_provider_preserves_prescoped_rds_metrics() -> None:
+    metric_queries: list[str] = []
+
+    adapter = DatadogCorrelationAdapter(
+        metric_query_fn=lambda metric, _params: (
+            metric_queries.append(metric)
+            or {
+                "timestamps": ("2026-04-15T14:00:00Z",),
+                "values": (40.0,),
+            }
+        ),
+        log_query_fn=lambda _query, _params: {
+            "timestamps": (),
+            "messages": (),
+        },
+    )
+
+    provider = DatadogUpstreamEvidenceProvider(
+        adapter=adapter,
+        queries=DatadogCorrelationQueries(
+            rds_cpu_metric="aws.rds.cpuutilization{dbinstanceidentifier:custom-rds}",
+            rds_connections_metric=(
+                "aws.rds.database_connections{dbinstanceidentifier:custom-rds}"
+            ),
+        ),
+        target_resource="orders-rds-prod",
+    )
+
+    provider.collect_upstream_evidence(
+        alert_id="alert-1",
+        service_name="orders",
+        window_start="2026-04-15T14:00:00Z",
+        window_end="2026-04-15T14:15:00Z",
+    )
+
+    assert metric_queries[:2] == [
+        "aws.rds.cpuutilization{dbinstanceidentifier:custom-rds}",
+        "aws.rds.database_connections{dbinstanceidentifier:custom-rds}",
     ]


### PR DESCRIPTION
## Summary

Adds a repeatable upstream-correlation validation path following #2027.

This PR introduces a deterministic smoke/integration validation flow for symptom-first upstream correlation investigations, plus fixes the remaining Datadog RDS metric scoping gap from the previous correlation runtime work.

## Included

### Deterministic smoke validation command

Added:

```bash
opensre tests upstream-correlation-smoke
```

This provides a lightweight validation path that:

* builds a deterministic upstream-correlation payload
* prints separated:

  * correlated signals
  * most likely causal driver(s)
* supports machine-readable JSON output via:

  ```bash
  opensre tests upstream-correlation-smoke --json
  ```

The smoke flow intentionally avoids requiring:

* live Datadog credentials
* synthetic benchmark execution
* full LLM investigation runtime

while still exercising the runtime correlation/reporting path.

### Datadog RDS metric scoping fix

Fixed the remaining multi-RDS correctness issue noted in the previous PR review.

RDS metric queries are now automatically scoped to the alerting DB instance using:

```text
dbinstanceidentifier:<target_resource>
```

This prevents correlation scoring from accidentally using aggregated cross-instance RDS metrics in multi-RDS environments.

### Observation/report validation

Extended correlation observation coverage to validate:

* canonical correlation payload propagation
* correlated_signals rendering
* most_likely_causal_drivers rendering
* deterministic payload ordering

### Documentation

Added upstream correlation validation docs to `docs/rds.mdx` including:

* local smoke validation flow
* JSON output mode
* live `opensre investigate` validation guidance
* recommended alert payload fields
* Datadog scoping explanation

## Validation

```bash
ruff format .
ruff check .
```

```bash
pytest tests/test_datadog_provider.py \
       tests/test_datadog_adapter.py \
       tests/synthetic/rds_postgres/test_observation_correlation.py -q
```

Result:

* 10/10 targeted tests passing

Smoke validation:

```bash
opensre tests upstream-correlation-smoke
opensre tests upstream-correlation-smoke --json
```

Validated output includes:

* correlated_signals
* most_likely_causal_drivers
* confidence/rationale fields
* deterministic JSON payload structure

## Why

The previous upstream-correlation runtime work already validated scoring and runtime wiring, but there was still no simple operator-facing way to validate the correlation path outside unit tests/synthetic suites.

This PR adds a minimal reversible validation layer intended for:

* local smoke testing
* CI/debug validation
* investigation output verification
* live integration sanity checks

https://github.com/user-attachments/assets/d172dcc4-3a87-4f1c-9afb-6031b6be9341

