### PR TITLE
fix greeting commands

### DIFF
--- a/app/cli/interactive_shell/routing/router.py
+++ b/app/cli/interactive_shell/routing/router.py
@@ -184,11 +184,6 @@ _MIN_INVESTIGATION_LINE_LEN = 48
 
 # Bare words that map to slash commands; users often forget the leading slash.
 # Keys without an explicit value rewrite to ``/<key>`` (e.g. ``help`` → ``/help``).
-# Greetings and meta-words ("agent", "hi", "menu", …) all rewrite to ``/welcome``
-# so a wandering user always lands on the structured welcome panel rather than a
-# verbose, unstructured LLM reply. Greeting aliases are intentionally chosen to
-# avoid conflicting Tab-completion prefixes with the existing command words
-# (e.g. no ``hello`` because ``hel`` would no longer uniquely complete to ``help``).
 _BARE_COMMAND_ALIAS_MAP: dict[str, str] = {
     "help": "/help",
     "?": "/help",
@@ -212,11 +207,6 @@ _BARE_COMMAND_ALIAS_MAP: dict[str, str] = {
     "mcp": "/mcp",
     "agents": "/agents",
     "doctor": "/doctor",
-    "welcome": "/welcome",
-    "agent": "/welcome",
-    "hi": "/welcome",
-    "hey": "/welcome",
-    "menu": "/welcome",
 }
 _BARE_COMMAND_ALIASES = frozenset(_BARE_COMMAND_ALIAS_MAP.keys())
 BARE_COMMAND_ALIASES = _BARE_COMMAND_ALIASES

--- a/app/cli/interactive_shell/ui/banner.py
+++ b/app/cli/interactive_shell/ui/banner.py
@@ -10,7 +10,7 @@ render_ready_box(console, session=None)
     DIM-bordered two-column welcome panel:
       left  → ◉ OpenSRE · provider · model · mode · cwd
       right → "Tips for getting started" + "What's new"
-    Called after the splash and on /clear, /welcome, and greeting aliases.
+    Called after the splash and on /clear.
 
 render_banner(console)
     Backward-compatible shim: render_splash + render_ready_box in one call.

--- a/tests/cli/interactive_shell/routing/test_router.py
+++ b/tests/cli/interactive_shell/routing/test_router.py
@@ -31,7 +31,6 @@ class TestClassifyInput:
             "clear",
             "reset",
             "trust",
-            "welcome",
             "integrations",
             "integration",
             "int",
@@ -72,13 +71,14 @@ class TestClassifyInput:
         assert classify_input("HELP", session) == "slash"
         assert classify_input("Exit", session) == "slash"
 
-    def test_no_prior_greeting_routes_to_welcome_panel(self) -> None:
-        # Greetings and meta-words ("hi", "agent", "menu", …) are aliased to the
-        # /welcome slash command so the user always lands on the structured
-        # welcome panel instead of an unstructured LLM reply.
+    def test_no_prior_greeting_routes_to_cli_agent(self, monkeypatch) -> None:
+        # Greetings and meta-words are not slash commands. They should fall
+        # through to the normal chat surface instead of dispatching a missing
+        # /welcome command.
+        monkeypatch.setattr(_router_module, "_LLM_ROUTING_DISABLED", True)
         session = ReplSession()
         for word in ("hey", "hi", "agent", "menu", "welcome"):
-            assert classify_input(word, session) == "slash", word
+            assert classify_input(word, session) == "cli_agent", word
 
     def test_long_operational_health_question_stays_cli_agent(self) -> None:
         """Long setup questions must not start an investigation run just because len >= 48."""


### PR DESCRIPTION
Fixes #2080 

#### Describe the changes you have made in this PR -

Removed dead greeting aliases that rewrote `welcome`, `agent`, `hi`, `hey`, and `menu` to `/welcome`.

`/welcome` is not a registered slash command, so these inputs now fall through to the normal chat route instead of printing an unknown command error.

Also updated routing tests and cleaned a stale banner comment.

### Demo/Screenshot for feature changes and bug fixes -

Before:

```text
❯ hi
unknown command: /welcome  (type /help)
```
After:
<img width="1007" height="117" alt="image" src="https://github.com/user-attachments/assets/16fd4d37-be70-49a8-bee9-8c942f8a0388" />
