### PR TITLE
fix: run LLM judge when --evaluate flag is passed

### DIFF
--- a/app/delivery/__init__.py
+++ b/app/delivery/__init__.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from app.state import InvestigationState
-import logging
+
 logger = logging.getLogger(__name__)
 
 

--- a/app/delivery/__init__.py
+++ b/app/delivery/__init__.py
@@ -17,4 +17,21 @@ def deliver(state: InvestigationState) -> dict[str, Any]:
     """
     from app.delivery.publish_findings.node import generate_report
 
+    state_dict = dict(state)
+
+    if state_dict.get("opensre_evaluate") and state_dict.get("opensre_eval_rubric"):
+        from app.integrations.opensre.llm_eval_judge import run_opensre_llm_judge
+
+        try:
+            judge_result = run_opensre_llm_judge(
+                state=state_dict,
+                rubric=state_dict["opensre_eval_rubric"],
+            )
+            state["opensre_llm_eval"] = judge_result
+        except Exception:
+            state["opensre_llm_eval"] = {
+                "skipped": True,
+                "reason": "Judge run failed - check logs for details.",
+            }
+
     return generate_report(state)

--- a/app/delivery/__init__.py
+++ b/app/delivery/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from app.state import InvestigationState
+import logging
+logger = logging.getLogger(__name__)
 
 
 def deliver(state: InvestigationState) -> dict[str, Any]:
@@ -28,10 +30,11 @@ def deliver(state: InvestigationState) -> dict[str, Any]:
                 rubric=state_dict["opensre_eval_rubric"],
             )
             state["opensre_llm_eval"] = judge_result
-        except Exception:
+        except Exception as exc:
+            logger.exception("LLM judge failed: %s", exc)
             state["opensre_llm_eval"] = {
                 "skipped": True,
-                "reason": "Judge run failed - check logs for details.",
+                "reason": f"Judge run failed: {exc}",
             }
 
     return generate_report(state)

--- a/tests/delivery/test_evaluate.py
+++ b/tests/delivery/test_evaluate.py
@@ -57,7 +57,7 @@ def test_deliver_skips_judge_when_evaluate_is_false(
     _patch_generate_report(monkeypatch)
     monkeypatch.setattr(
         "app.integrations.opensre.llm_eval_judge.run_opensre_llm_judge",
-        lambda *a, **kw: pytest.fail("judge should not be called"),
+        lambda *_, **__: pytest.fail("judge should not be called"),
     )
 
     state = _make_state(evaluate=False, rubric="test rubric")

--- a/tests/delivery/test_evaluate.py
+++ b/tests/delivery/test_evaluate.py
@@ -1,0 +1,86 @@
+"""Tests for app/delivery/__init__.py — LLM judge invocation path."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.delivery import deliver
+from app.state import make_initial_state
+
+
+def _make_state(*, evaluate: bool = False, rubric: str = "") -> dict[str, Any]:
+    raw: dict[str, Any] = {"commonAnnotations": {"summary": "x"}}
+    if rubric:
+        raw["commonAnnotations"]["scoring_points"] = rubric
+
+    state = make_initial_state(raw_alert=raw, opensre_evaluate=evaluate)
+    return dict(state)
+
+
+def _patch_generate_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.delivery.publish_findings.node.generate_report",
+        lambda _s: {"slack_message": "", "report": ""},
+    )
+
+
+def test_deliver_runs_judge_when_evaluate_and_rubric_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_generate_report(monkeypatch)
+
+    fake: dict[str, Any] = {
+        "overall_pass": True,
+        "score_0_100": 85,
+        "rubric_items": [],
+        "summary": "ok",
+    }
+
+    def mock_judge(*, state: dict[str, Any], rubric: str) -> dict[str, Any]:
+        return fake
+
+    monkeypatch.setattr(
+        "app.integrations.opensre.llm_eval_judge.run_opensre_llm_judge",
+        mock_judge,
+    )
+
+    state = _make_state(evaluate=True, rubric="test rubric")
+    deliver(state)
+    assert state["opensre_llm_eval"] == fake
+
+
+def test_deliver_skips_judge_when_evaluate_is_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_generate_report(monkeypatch)
+    monkeypatch.setattr(
+        "app.integrations.opensre.llm_eval_judge.run_opensre_llm_judge",
+        lambda *a, **kw: pytest.fail("judge should not be called"),
+    )
+
+    state = _make_state(evaluate=False, rubric="test rubric")
+    deliver(state)
+    assert not state.get("opensre_llm_eval")
+
+
+def test_deliver_sets_skip_on_judge_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_generate_report(monkeypatch)
+
+    def failing_judge(*, state: dict[str, Any], rubric: str) -> Any:
+        raise RuntimeError("API timeout")
+
+    monkeypatch.setattr(
+        "app.integrations.opensre.llm_eval_judge.run_opensre_llm_judge",
+        failing_judge,
+    )
+
+    state = _make_state(evaluate=True, rubric="test rubric")
+    deliver(state)
+    ev = state.get("opensre_llm_eval")
+    assert ev is not None
+    assert ev.get("skipped") is True
+    assert "API timeout" in ev.get("reason", "")

--- a/tests/delivery/test_evaluate.py
+++ b/tests/delivery/test_evaluate.py
@@ -61,6 +61,7 @@ def test_deliver_skips_judge_when_evaluate_is_false(
     )
 
     state = _make_state(evaluate=False, rubric="test rubric")
+    state["opensre_eval_rubric"] = "test rubric"
     deliver(state)
     assert not state.get("opensre_llm_eval")
 


### PR DESCRIPTION

Fixes #2070

#### Describe the changes you have made in this PR -
Fixed the `--evaluate` flag so it actually runs the LLM judge. The judge function existed in the codebase but was never called. Added the call in `app/delivery/__init__.py` to run `run_opensre_llm_judge()` after investigation completes when `--evaluate` is passed.

### Demo/Screenshot for feature changes and bug fixes -
BEFORE (bug - judge not running):
```
"opensre_llm_eval": {
  "skipped": true,
  "reason": "Evaluate was enabled but no judge output was recorded."
}
```
AFTER (fixed - judge runs and evaluates):
```
"opensre_llm_eval": {
  "overall_pass": false,
  "score_0_100": 0,
  "rubric_items": 
    {"id": "shippingservice-1", "satisfied": false, "explanation": "The agent concluded that the root cause category is configuration, which does not match the predicted root cause component in the rubric, which is shippingservice-1."},
    {"id": "container_read_io_load", "satisfied": false, "explanation": "The agent did not identify any evidence related to container read I/O load, which is the predicted root cause reason in the rubric."}
  ,
  "summary": "The investigation did not match the rubric, as the agent concluded a different root cause category and reason."
}
```
---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance
**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The fix adds a call to `run_opensre_llm_judge()` in `app/delivery/__init__.py`. When `opensre_evaluate=True` and `opensre_eval_rubric` exists (extracted from the alert's scoring_points), the judge runs after the investigation completes and stores the evaluation result in `state["opensre_llm_eval"]`. If the judge fails, it falls back to a skip message with an error reason.

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue (#2070)
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] Tests pass: pytest tests/test_state.py -v
- [x] My code follows the project's style guidelines and conventions

you can run  to verify it too:

`opensre investigate -i "json-path" --evaluate`
