### PR TITLE
fix:  handle 404 and model_not_found errors in investigation

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -173,6 +173,14 @@ class ConnectedInvestigationAgent:
                         "If using a local LLM, verify the model name in your .env file."
                     )
                     tracker.error("investigation_agent", message="Failed: Model not found")
+                    _emit(
+                        "agent_end",
+                        {
+                            "root_cause": error_msg,
+                            "validity_score": 0.0,
+                            "root_cause_category": "Configuration Error",
+                        },
+                    )
                     updates = {
                         "root_cause": error_msg,
                         "root_cause_category": "Configuration Error",

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -164,14 +164,15 @@ class ConnectedInvestigationAgent:
             _emit("llm_start", {"iteration": iteration})
             try:
                 response = llm.invoke(messages, system=system, tools=tool_schemas)
+
             except RuntimeError as err:
                 err_msg = str(err).lower()
-                if "not found" in err_msg or "404" in err_msg or "model_not_found" in err_msg:
+                if ("model" in err_msg and "not found" in err_msg) or "404" in err_msg:
                     error_msg = (
                         "Error: The AI model was not found (404). "
                         "If using a local LLM, verify the model name in your .env file."
                     )
-                    tracker.complete("investigation_agent", message="Failed: Model not found")
+                    tracker.error("investigation_agent", message="Failed: Model not found")
                     updates = {
                         "root_cause": error_msg,
                         "root_cause_category": "Configuration Error",

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -166,25 +166,16 @@ class ConnectedInvestigationAgent:
                 response = llm.invoke(messages, system=system, tools=tool_schemas)
             except RuntimeError as err:
                 err_msg = str(err).lower()
-                if (
-                    "not found" in err_msg
-                    or "404" in err_msg
-                    or "model_not_found" in err_msg
-                ):
+                if "not found" in err_msg or "404" in err_msg or "model_not_found" in err_msg:
                     error_msg = (
                         "Error: The AI model was not found (404). "
                         "If using a local LLM, verify the model name in your .env file."
                     )
-                    tracker.complete(
-                        "investigation_agent",
-                        message="Failed: Model not found"
-                    )
+                    tracker.complete("investigation_agent", message="Failed: Model not found")
                     updates = {
                         "root_cause": error_msg,
                         "root_cause_category": "Configuration Error",
-                        "causal_chain": [
-                            f"Model API returned error: {str(err)}"
-                        ],
+                        "causal_chain": [f"Model API returned error: {str(err)}"],
                         "validated_claims": [],
                         "non_validated_claims": [],
                         "remediation_steps": [
@@ -196,9 +187,7 @@ class ConnectedInvestigationAgent:
                         "validity_score": 0.0,
                         "investigation_recommendations": [],
                         "evidence": evidence,
-                        "evidence_entries": [
-                            e.model_dump() for e in evidence_entries
-                        ],
+                        "evidence_entries": [e.model_dump() for e in evidence_entries],
                         "agent_messages": messages,
                         "executed_hypotheses": executed_hypotheses,
                     }

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -162,7 +162,49 @@ class ConnectedInvestigationAgent:
         for iteration in range(MAX_INVESTIGATION_LOOPS):
             logger.debug("[agent] iteration=%d", iteration)
             _emit("llm_start", {"iteration": iteration})
-            response = llm.invoke(messages, system=system, tools=tool_schemas)
+            try:
+                response = llm.invoke(messages, system=system, tools=tool_schemas)
+            except RuntimeError as err:
+                err_msg = str(err).lower()
+                if (
+                    "not found" in err_msg
+                    or "404" in err_msg
+                    or "model_not_found" in err_msg
+                ):
+                    error_msg = (
+                        "Error: The AI model was not found (404). "
+                        "If using a local LLM, verify the model name in your .env file."
+                    )
+                    tracker.complete(
+                        "investigation_agent",
+                        message="Failed: Model not found"
+                    )
+                    updates = {
+                        "root_cause": error_msg,
+                        "root_cause_category": "Configuration Error",
+                        "causal_chain": [
+                            f"Model API returned error: {str(err)}"
+                        ],
+                        "validated_claims": [],
+                        "non_validated_claims": [],
+                        "remediation_steps": [
+                            "Check your .env configuration",
+                            "Verify the model name is correct",
+                            "Ensure the model is downloaded locally",
+                            "Confirm your provider supports this model",
+                        ],
+                        "validity_score": 0.0,
+                        "investigation_recommendations": [],
+                        "evidence": evidence,
+                        "evidence_entries": [
+                            e.model_dump() for e in evidence_entries
+                        ],
+                        "agent_messages": messages,
+                        "executed_hypotheses": executed_hypotheses,
+                    }
+                    updates.update(tool_context)
+                    return updates
+                raise
 
             messages.append(_build_assistant_msg(llm, response))
 

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from app.agent.investigation import _availability_view
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.agent.investigation import ConnectedInvestigationAgent, _availability_view
 
 
 def test_availability_view_marks_configured_integrations_without_mutating_state() -> None:
@@ -11,3 +15,61 @@ def test_availability_view_marks_configured_integrations_without_mutating_state(
     assert view["github"]["connection_verified"] is True
     assert "connection_verified" not in resolved["github"]
     assert view["_all"] == resolved["_all"]
+
+
+def test_run_gracefully_handles_model_not_found_runtime_error() -> None:
+    """When the LLM raises a model-not-found RuntimeError, the agent should
+    return a degraded state dict instead of crashing the pipeline."""
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = RuntimeError("OpenAI model 'qwen' not found.")
+    mock_llm.tool_schemas.return_value = []
+
+    mock_tracker = MagicMock()
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+    ):
+        agent = ConnectedInvestigationAgent()
+        state = {
+            "alert_name": "Test alert",
+            "pipeline_name": "test-pipeline",
+            "severity": "critical",
+            "resolved_integrations": {},
+        }
+        result = agent.run(state)
+
+    mock_tracker.error.assert_called_once_with(
+        "investigation_agent", message="Failed: Model not found"
+    )
+    assert result["root_cause_category"] == "Configuration Error"
+    assert result["validity_score"] == 0.0
+    assert "not found" in result["root_cause"].lower()
+    assert result["remediation_steps"]
+    assert result["causal_chain"]
+
+
+def test_run_re_raises_unmatched_runtime_error() -> None:
+    """RuntimeError messages that do not match the model-not-found heuristic
+    should be re-raised so upstream handlers can deal with them."""
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = RuntimeError("Some other API failure")
+    mock_llm.tool_schemas.return_value = []
+
+    mock_tracker = MagicMock()
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+    ):
+        agent = ConnectedInvestigationAgent()
+        state = {
+            "alert_name": "Test alert",
+            "pipeline_name": "test-pipeline",
+            "severity": "critical",
+            "resolved_integrations": {},
+        }
+        with pytest.raises(RuntimeError, match="Some other API failure"):
+            agent.run(state)
+
+    mock_tracker.error.assert_not_called()


### PR DESCRIPTION

Fixes #2083 

#### Describe the changes you have made in this PR -
- Added a `try/except block in app/agent/investigation.py` to catch RuntimeError exceptions triggered by `404/model_not_found` responses from the LLM client.

- Prevented terminal UI deadlocks by explicitly stopping the tracker spinner when the model is unreachable.

- Constructed and returned a safely formatted updates dictionary that conforms to the upstream pipeline's state expectations, allowing the application to degrade gracefully and present a clear error to the user rather than crashing silently.

- Added actionable remediation_steps for users configuring local LLMs (Ollama, vLLM, etc.).

### Demo/Screenshot for feature changes and bug fixes - 
<img width="1270" height="525" alt="image" src="https://github.com/user-attachments/assets/29dc0cac-b40c-4236-8085-3e668fd86f1b" />

> Testing Note: When reproducing this locally, my OpenAI account hit a 429 Rate Limit block before the API could process the routing request and return the 404 Model Not Found error. However, as shown in the screenshot above, the terminal cleanly exited without deadlocking.


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**What problem does your code solve?**
Invalid or unavailable models (like local Qwen models) caused `llm.invoke()` to raise a `RuntimeError`. Since the exception was uncaught in `investigation.py`, it propagated to `pipeline.py`, causing the background investigation thread to crash and the terminal UI to freeze.

**What alternative approaches did you consider?**
I considered returning a simple string error message, but the pipeline expects a structured dictionary state update. Returning a string still broke downstream processing and caused UI deadlocks.

**Why did you choose this implementation?**
I added native exception handling inside the investigation loop and returned a properly structured updates dictionary. This preserves pipeline compatibility, prevents UI freezes, and keeps the investigation flow recoverable.

**What are the key functions/components?**
The main change is a `try/except` around `llm.invoke()` inside `ConnectedInvestigationAgent.run()`. It detects common 404/model-not-found errors, stops the CLI spinner with `tracker.complete()`, and returns a safe investigation state instead of crashing the pipeline.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


