### PR TITLE
fix: add utf-8 encoding to subprocess calls and improve psycopg2 error

### DIFF
--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -164,6 +164,8 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
             [binary_path, "auth", "status"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_PROBE_TIMEOUT_SEC,
             check=False,
             env=build_cli_subprocess_env(_anthropic_env_overrides()),
@@ -255,6 +257,8 @@ class ClaudeCodeAdapter:
                 [binary_path, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -74,6 +74,8 @@ def _codex_workspace_and_skip_git() -> tuple[str, bool]:
             ["git", "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5.0,
             check=False,
         )
@@ -117,6 +119,8 @@ class CodexAdapter:
                 [binary_path, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )
@@ -152,6 +156,8 @@ class CodexAdapter:
                 [binary_path, "login", "status"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )

--- a/app/integrations/llm_cli/copilot.py
+++ b/app/integrations/llm_cli/copilot.py
@@ -161,6 +161,8 @@ def _classify_gh_auth_status() -> tuple[bool | None, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_GH_AUTH_TIMEOUT_SEC,
             check=False,
         )
@@ -229,6 +231,8 @@ class CopilotAdapter:
                 [binary_path, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )

--- a/app/integrations/llm_cli/cursor.py
+++ b/app/integrations/llm_cli/cursor.py
@@ -95,6 +95,8 @@ class CursorAdapter:
                 [binary, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )
@@ -134,6 +136,8 @@ class CursorAdapter:
                 [binary, "status"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )

--- a/app/integrations/llm_cli/gemini_cli.py
+++ b/app/integrations/llm_cli/gemini_cli.py
@@ -153,6 +153,8 @@ class GeminiCLIAdapter:
                 [binary_path, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )
@@ -182,6 +184,8 @@ class GeminiCLIAdapter:
                 [binary_path, "-p", "respond with: ok", "--output-format", "json"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
                 env=probe_env,

--- a/app/integrations/llm_cli/opencode.py
+++ b/app/integrations/llm_cli/opencode.py
@@ -92,6 +92,8 @@ def _probe_opencode_auth_via_cli(binary_path: str) -> tuple[bool | None, str]:
             [binary_path, "auth", "list"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_AUTH_LIST_TIMEOUT_SEC,
             check=False,
             env=env,
@@ -142,6 +144,8 @@ class OpenCodeAdapter:
                 [binary_path, "--version"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_PROBE_TIMEOUT_SEC,
                 check=False,
             )

--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -123,7 +123,12 @@ def resolve_postgresql_config(
 
 def _get_connection(config: PostgreSQLConfig) -> Any:
     """Create a psycopg2 connection from config. Caller must close."""
-    import psycopg2  # type: ignore[import-untyped]
+    try:
+        import psycopg2  # type: ignore[import-untyped]
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "psycopg2 is not installed. Install it with: pip install psycopg2-binary"
+        ) from exc
 
     return psycopg2.connect(
         host=config.host,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `encoding="utf-8"` and `errors="replace"` to all LLM CLI adapter subprocess calls that used `text=True` without an explicit encoding — fixes `UnicodeDecodeError` on Windows machines with non-UTF-8 system encodings (cp1252, gbk). Affected adapters: `gemini_cli`, `codex`, `claude_code`, `copilot`, `cursor`, `opencode`.
- Wrap the lazy `import psycopg2` in `_get_connection` with a `try/except ModuleNotFoundError` so users see an actionable `pip install psycopg2-binary` hint instead of a raw `ModuleNotFoundError`.

## Root causes

- **#2085 / #2049**: `subprocess.run(..., text=True)` without `encoding=` uses the OS locale encoding on Windows (cp1252, gbk), which raises `UnicodeDecodeError` when CLI output contains bytes outside that encoding. `runner.py` already used the correct pattern; the adapter probe/detect methods did not.
- **#2065 / #2064**: `import psycopg2` inside `_get_connection` raised `ModuleNotFoundError` with no guidance when the optional driver is absent.

## Test plan

- [x] `uv run ruff check` passes on all changed files
- [x] `uv run ruff format --check` passes on all changed files
- [x] `uv run pytest tests/integrations/ tests/tools/` — 2724 passed
- [x] Full unit suite (excluding pre-existing async-plugin failure in `test_sampler.py`) passes

Closes #2085
Closes #2049
Closes #2065
Closes #2064

https://claude.ai/code/session_01GWQN9WUNJdU7vA5gdfMxed
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWQN9WUNJdU7vA5gdfMxed)_