### PR TITLE
feat(error-handling): surface Grafana stack soft-fail paths to Sentry

### DIFF
--- a/app/services/grafana/_telemetry.py
+++ b/app/services/grafana/_telemetry.py
@@ -43,7 +43,7 @@ def report_grafana_failure(
         "component": component,
         "method": method,
     }
-    if datasource_uid:
+    if datasource_uid is not None:
         tags["datasource_uid"] = datasource_uid
 
     report_exception(

--- a/app/services/grafana/_telemetry.py
+++ b/app/services/grafana/_telemetry.py
@@ -1,0 +1,56 @@
+"""Shared Sentry capture helper for the Grafana service stack.
+
+Used at boundaries where each Grafana mixin swallows an upstream failure
+into a degraded return value (empty list, ``{"success": False, ...}`` dict).
+The helper keeps the Sentry tag shape identical across all files so
+dashboards can pivot on (surface, integration, component, method).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.utils.errors import report_exception
+
+
+def report_grafana_failure(
+    exc: BaseException,
+    *,
+    logger: logging.Logger,
+    component: str,
+    method: str,
+    severity: str = "warning",
+    datasource_uid: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    """Capture a swallowed Grafana stack failure to Sentry + logs.
+
+    Args:
+        exc: The exception being swallowed.
+        logger: The caller module's logger.
+        component: Dotted module path, e.g. ``app.services.grafana.loki``.
+        method: Name of the method that failed, e.g. ``query_loki``.
+        severity: ``warning`` (default) for expected vendor failures,
+            ``error`` for unexpected ones.
+        datasource_uid: The Grafana datasource UID involved, when relevant.
+            Only set when present to keep tag cardinality bounded.
+        extras: Additional Sentry ``extra`` payload (e.g. query parameters).
+    """
+    tags = {
+        "surface": "service_client",
+        "integration": "grafana",
+        "component": component,
+        "method": method,
+    }
+    if datasource_uid:
+        tags["datasource_uid"] = datasource_uid
+
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"[grafana] {method} failed",
+        severity=severity,
+        tags=tags,
+        extras=extras,
+    )

--- a/app/services/grafana/base.py
+++ b/app/services/grafana/base.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 import requests
 
+from app.services.grafana._telemetry import report_grafana_failure
 from app.services.grafana.config import GrafanaAccountConfig
 
 logger = logging.getLogger(__name__)
@@ -235,8 +236,13 @@ class GrafanaClientBase:
 
             logger.info("[grafana] Discovered datasource UIDs: %s", result)
             return result
-        except Exception as e:
-            logger.warning("[grafana] Failed to discover datasource UIDs: %s", e)
+        except Exception as exc:
+            report_grafana_failure(
+                exc,
+                logger=logger,
+                component="app.services.grafana.base",
+                method="discover_datasource_uids",
+            )
             return {}
 
     def query_loki_label_values(self, label: str = "service_name") -> list[str]:
@@ -251,8 +257,15 @@ class GrafanaClientBase:
             data = self._make_request(url)
             values: list[str] = data.get("data", [])
             return values
-        except Exception:
-            logger.debug("Failed to fetch Loki label values for %s", label, exc_info=True)
+        except Exception as exc:
+            report_grafana_failure(
+                exc,
+                logger=logger,
+                component="app.services.grafana.base",
+                method="query_loki_label_values",
+                datasource_uid=self.loki_datasource_uid,
+                extras={"label": label},
+            )
             return []
 
     def query_alert_rules(self, folder: str | None = None) -> list[dict[str, Any]]:
@@ -288,8 +301,14 @@ class GrafanaClientBase:
                             }
                         )
             return rules
-        except Exception as e:
-            logger.warning("[grafana] Failed to query alert rules: %s", e)
+        except Exception as exc:
+            report_grafana_failure(
+                exc,
+                logger=logger,
+                component="app.services.grafana.base",
+                method="query_alert_rules",
+                extras={"folder": folder} if folder else None,
+            )
             return []
 
     def _get_auth_headers(self) -> dict[str, str]:

--- a/app/services/grafana/base.py
+++ b/app/services/grafana/base.py
@@ -307,7 +307,7 @@ class GrafanaClientBase:
                 logger=logger,
                 component="app.services.grafana.base",
                 method="query_alert_rules",
-                extras={"folder": folder} if folder else None,
+                extras={"folder": folder} if folder is not None else None,
             )
             return []
 

--- a/app/services/grafana/loki.py
+++ b/app/services/grafana/loki.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from app.services.grafana._telemetry import report_grafana_failure
+
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
+
+logger = logging.getLogger(__name__)
 
 
 class LokiMixin:
@@ -76,12 +81,21 @@ class LokiMixin:
                 "query": query,
                 "account_id": self.account_id,
             }
-        except Exception as e:
-            error_msg = str(e)
+        except Exception as exc:
+            error_msg = str(exc)
             response_text = ""
-            if hasattr(e, "response") and e.response is not None:
-                response_text = e.response.text[:300]
-                error_msg = f"Loki query failed: {e.response.status_code}"
+            if hasattr(exc, "response") and exc.response is not None:
+                response_text = exc.response.text[:300]
+                error_msg = f"Loki query failed: {exc.response.status_code}"
+
+            report_grafana_failure(
+                exc,
+                logger=logger,
+                component="app.services.grafana.loki",
+                method="query_loki",
+                datasource_uid=self.loki_datasource_uid,
+                extras={"query": query},
+            )
 
             return {
                 "success": False,

--- a/app/services/grafana/loki.py
+++ b/app/services/grafana/loki.py
@@ -94,7 +94,6 @@ class LokiMixin:
                 component="app.services.grafana.loki",
                 method="query_loki",
                 datasource_uid=self.loki_datasource_uid,
-                extras={"query": query},
             )
 
             return {

--- a/app/services/grafana/mimir.py
+++ b/app/services/grafana/mimir.py
@@ -81,7 +81,6 @@ class MimirMixin:
                 component="app.services.grafana.mimir",
                 method="query_mimir",
                 datasource_uid=self.mimir_datasource_uid,
-                extras={"query": query},
             )
 
             return {

--- a/app/services/grafana/mimir.py
+++ b/app/services/grafana/mimir.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
+
+from app.services.grafana._telemetry import report_grafana_failure
 
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
+
+logger = logging.getLogger(__name__)
 
 
 class MimirMixin:
@@ -63,12 +68,21 @@ class MimirMixin:
                 "query": query,
                 "account_id": self.account_id,
             }
-        except Exception as e:
-            error_msg = str(e)
+        except Exception as exc:
+            error_msg = str(exc)
             response_text = ""
-            if hasattr(e, "response") and e.response is not None:
-                response_text = e.response.text[:300]
-                error_msg = f"Mimir query failed: {e.response.status_code}"
+            if hasattr(exc, "response") and exc.response is not None:
+                response_text = exc.response.text[:300]
+                error_msg = f"Mimir query failed: {exc.response.status_code}"
+
+            report_grafana_failure(
+                exc,
+                logger=logger,
+                component="app.services.grafana.mimir",
+                method="query_mimir",
+                datasource_uid=self.mimir_datasource_uid,
+                extras={"query": query},
+            )
 
             return {
                 "success": False,

--- a/app/services/grafana/tempo.py
+++ b/app/services/grafana/tempo.py
@@ -54,9 +54,12 @@ class TempoMixin:
             traces = data.get("traces", [])
 
             enriched_traces = []
+            failed_trace_ids: list[str] = []
             for trace in traces:
                 trace_id = trace.get("traceID", "")
-                span_details = self._get_trace_details(trace_id)  # type: ignore[attr-defined]
+                span_details = self._get_trace_details(  # type: ignore[attr-defined]
+                    trace_id, failures_out=failed_trace_ids
+                )
 
                 enriched_traces.append(
                     {
@@ -66,6 +69,25 @@ class TempoMixin:
                         "span_count": trace.get("spanCount", 0),
                         "spans": span_details.get("spans", []),
                     }
+                )
+
+            if failed_trace_ids:
+                # Coalesce per-trace failures into a single Sentry event so a
+                # degraded Tempo endpoint doesn't fan out into N events per
+                # query_tempo call. Static message → Sentry groups all of
+                # them into one issue; counts live in extras.
+                synthetic = RuntimeError("tempo: trace detail lookups failed")
+                report_grafana_failure(
+                    synthetic,
+                    logger=logger,
+                    component="app.services.grafana.tempo",
+                    method="_get_trace_details_batch",
+                    datasource_uid=self.tempo_datasource_uid,
+                    extras={
+                        "failed_count": len(failed_trace_ids),
+                        "total_count": len(traces),
+                        "first_failed_trace_id": failed_trace_ids[0],
+                    },
                 )
 
             return {
@@ -101,14 +123,21 @@ class TempoMixin:
     def _get_trace_details(  # type: ignore[misc]
         self: GrafanaClientBase,
         trace_id: str,
+        *,
+        failures_out: list[str] | None = None,
     ) -> dict[str, Any]:
         """Get detailed span information for a trace.
 
         Args:
-            trace_id: The trace ID to fetch details for
+            trace_id: The trace ID to fetch details for.
+            failures_out: When provided, append ``trace_id`` to this list on
+                failure and skip the per-call Sentry capture. The caller is
+                then expected to fire a single aggregated event after the
+                batch completes. When ``None`` (standalone caller),
+                failures are reported per call as before.
 
         Returns:
-            Dictionary with spans list
+            Dictionary with spans list. ``{"spans": []}`` on failure.
         """
         url = self._build_datasource_url(
             self.tempo_datasource_uid,
@@ -141,14 +170,17 @@ class TempoMixin:
 
             return {"spans": spans}
         except Exception as exc:
-            report_grafana_failure(
-                exc,
-                logger=logger,
-                component="app.services.grafana.tempo",
-                method="_get_trace_details",
-                datasource_uid=self.tempo_datasource_uid,
-                extras={"trace_id": trace_id},
-            )
+            if failures_out is None:
+                report_grafana_failure(
+                    exc,
+                    logger=logger,
+                    component="app.services.grafana.tempo",
+                    method="_get_trace_details",
+                    datasource_uid=self.tempo_datasource_uid,
+                    extras={"trace_id": trace_id},
+                )
+            else:
+                failures_out.append(trace_id)
             return {"spans": []}
 
     def _extract_span_attributes(  # type: ignore[misc]

--- a/app/services/grafana/tempo.py
+++ b/app/services/grafana/tempo.py
@@ -110,7 +110,6 @@ class TempoMixin:
                 component="app.services.grafana.tempo",
                 method="query_tempo",
                 datasource_uid=self.tempo_datasource_uid,
-                extras={"service_name": service_name},
             )
 
             return {

--- a/app/services/grafana/tempo.py
+++ b/app/services/grafana/tempo.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 
-from app.utils.errors import report_exception
+from app.services.grafana._telemetry import report_grafana_failure
 
 if TYPE_CHECKING:
     from app.services.grafana.base import GrafanaClientBase
@@ -75,12 +75,21 @@ class TempoMixin:
                 "service_name": service_name,
                 "account_id": self.account_id,
             }
-        except Exception as e:
-            error_msg = str(e)
+        except Exception as exc:
+            error_msg = str(exc)
             response_text = ""
-            if hasattr(e, "response") and e.response is not None:
-                response_text = e.response.text[:300]
-                error_msg = f"Tempo query failed: {e.response.status_code}"
+            if hasattr(exc, "response") and exc.response is not None:
+                response_text = exc.response.text[:300]
+                error_msg = f"Tempo query failed: {exc.response.status_code}"
+
+            report_grafana_failure(
+                exc,
+                logger=logger,
+                component="app.services.grafana.tempo",
+                method="query_tempo",
+                datasource_uid=self.tempo_datasource_uid,
+                extras={"service_name": service_name},
+            )
 
             return {
                 "success": False,
@@ -112,42 +121,35 @@ class TempoMixin:
                 headers=self._get_auth_headers(),
                 timeout=10,
             )
+            response.raise_for_status()
+            trace_data = response.json()
+            spans = []
 
-            if response.status_code == 200:
-                trace_data = response.json()
-                spans = []
+            if "batches" in trace_data:
+                for batch in trace_data["batches"]:
+                    if "scopeSpans" in batch:
+                        for scope in batch["scopeSpans"]:
+                            if "spans" in scope:
+                                for span in scope["spans"]:
+                                    attributes = self._extract_span_attributes(span)  # type: ignore[attr-defined]
+                                    spans.append(
+                                        {
+                                            "name": span.get("name", "unknown"),
+                                            "attributes": attributes,
+                                        }
+                                    )
 
-                if "batches" in trace_data:
-                    for batch in trace_data["batches"]:
-                        if "scopeSpans" in batch:
-                            for scope in batch["scopeSpans"]:
-                                if "spans" in scope:
-                                    for span in scope["spans"]:
-                                        attributes = self._extract_span_attributes(span)  # type: ignore[attr-defined]
-                                        spans.append(
-                                            {
-                                                "name": span.get("name", "unknown"),
-                                                "attributes": attributes,
-                                            }
-                                        )
-
-                return {"spans": spans}
+            return {"spans": spans}
         except Exception as exc:
-            report_exception(
+            report_grafana_failure(
                 exc,
                 logger=logger,
-                message="Failed to fetch Tempo trace spans",
-                severity="warning",
-                tags={
-                    "surface": "service_client",
-                    "integration": "grafana",
-                    "component": "app.services.grafana.tempo",
-                },
+                component="app.services.grafana.tempo",
+                method="_get_trace_details",
+                datasource_uid=self.tempo_datasource_uid,
                 extras={"trace_id": trace_id},
             )
             return {"spans": []}
-
-        return {"spans": []}
 
     def _extract_span_attributes(  # type: ignore[misc]
         self: GrafanaClientBase,

--- a/app/services/grafana/tempo.py
+++ b/app/services/grafana/tempo.py
@@ -54,11 +54,11 @@ class TempoMixin:
             traces = data.get("traces", [])
 
             enriched_traces = []
-            failed_trace_ids: list[str] = []
+            trace_failures: list[tuple[str, Exception]] = []
             for trace in traces:
                 trace_id = trace.get("traceID", "")
                 span_details = self._get_trace_details(  # type: ignore[attr-defined]
-                    trace_id, failures_out=failed_trace_ids
+                    trace_id, failures_out=trace_failures
                 )
 
                 enriched_traces.append(
@@ -71,11 +71,8 @@ class TempoMixin:
                     }
                 )
 
-            if failed_trace_ids:
-                # Coalesce per-trace failures into a single Sentry event so a
-                # degraded Tempo endpoint doesn't fan out into N events per
-                # query_tempo call. Static message → Sentry groups all of
-                # them into one issue; counts live in extras.
+            if trace_failures:
+                first_tid, first_exc = trace_failures[0]
                 synthetic = RuntimeError("tempo: trace detail lookups failed")
                 report_grafana_failure(
                     synthetic,
@@ -84,9 +81,11 @@ class TempoMixin:
                     method="_get_trace_details_batch",
                     datasource_uid=self.tempo_datasource_uid,
                     extras={
-                        "failed_count": len(failed_trace_ids),
+                        "failed_count": len(trace_failures),
                         "total_count": len(traces),
-                        "first_failed_trace_id": failed_trace_ids[0],
+                        "first_failed_trace_id": first_tid,
+                        "first_failed_exception_type": type(first_exc).__name__,
+                        "first_failed_exception_message": str(first_exc)[:200],
                     },
                 )
 
@@ -123,17 +122,17 @@ class TempoMixin:
         self: GrafanaClientBase,
         trace_id: str,
         *,
-        failures_out: list[str] | None = None,
+        failures_out: list[tuple[str, Exception]] | None = None,
     ) -> dict[str, Any]:
         """Get detailed span information for a trace.
 
         Args:
             trace_id: The trace ID to fetch details for.
-            failures_out: When provided, append ``trace_id`` to this list on
-                failure and skip the per-call Sentry capture. The caller is
-                then expected to fire a single aggregated event after the
-                batch completes. When ``None`` (standalone caller),
-                failures are reported per call as before.
+            failures_out: When provided, append ``(trace_id, exc)`` to this
+                list on failure and skip the per-call Sentry capture. The
+                caller fires a single aggregated event after the batch
+                completes. When ``None`` (standalone caller), failures are
+                reported per call as before.
 
         Returns:
             Dictionary with spans list. ``{"spans": []}`` on failure.
@@ -179,7 +178,7 @@ class TempoMixin:
                     extras={"trace_id": trace_id},
                 )
             else:
-                failures_out.append(trace_id)
+                failures_out.append((trace_id, exc))
             return {"spans": []}
 
     def _extract_span_attributes(  # type: ignore[misc]

--- a/tests/services/test_grafana_loki.py
+++ b/tests/services/test_grafana_loki.py
@@ -182,7 +182,8 @@ class TestQueryLokiExceptions:
         host = _FakeLokiHost()
         host.make_request_mock.side_effect = RuntimeError("connection refused")
 
-        result = host.query_loki(_QUERY)
+        with patch("app.services.grafana.loki.report_grafana_failure") as mock_report:
+            result = host.query_loki(_QUERY)
 
         assert result == {
             "success": False,
@@ -190,6 +191,11 @@ class TestQueryLokiExceptions:
             "response": "",
             "logs": [],
         }
+        mock_report.assert_called_once()
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["component"] == "app.services.grafana.loki"
+        assert kwargs["method"] == "query_loki"
+        assert kwargs["datasource_uid"] == "loki-uid"
 
     def test_exception_with_response_includes_status_and_truncated_text(self) -> None:
         host = _FakeLokiHost()
@@ -200,13 +206,15 @@ class TestQueryLokiExceptions:
         err.response = response  # type: ignore[attr-defined]
         host.make_request_mock.side_effect = err
 
-        result = host.query_loki(_QUERY)
+        with patch("app.services.grafana.loki.report_grafana_failure") as mock_report:
+            result = host.query_loki(_QUERY)
 
         assert result["success"] is False
         assert result["error"] == "Loki query failed: 502"
         assert result["response"] == long_text[:300]
         assert len(result["response"]) == 300
         assert result["logs"] == []
+        mock_report.assert_called_once()
 
     def test_exception_with_none_response_falls_back_to_str_error(self) -> None:
         host = _FakeLokiHost()
@@ -214,11 +222,13 @@ class TestQueryLokiExceptions:
         err.response = None  # type: ignore[attr-defined]
         host.make_request_mock.side_effect = err
 
-        result = host.query_loki(_QUERY)
+        with patch("app.services.grafana.loki.report_grafana_failure") as mock_report:
+            result = host.query_loki(_QUERY)
 
         assert result["success"] is False
         assert result["error"] == "transport error"
         assert result["response"] == ""
+        mock_report.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_grafana_mimir.py
+++ b/tests/services/test_grafana_mimir.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.services.grafana.mimir import MimirMixin
 
@@ -99,12 +99,18 @@ def test_query_mimir_exception_handling():
 
     client._make_request.side_effect = Exception("Network timeout")
 
-    result = client.query_mimir("cpu_usage_total")
+    with patch("app.services.grafana.mimir.report_grafana_failure") as mock_report:
+        result = client.query_mimir("cpu_usage_total")
 
     # Requirement: Exception cases / error envelope
     assert result["success"] is False
     assert "Network timeout" in result["error"]
     assert result["metrics"] == []
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["component"] == "app.services.grafana.mimir"
+    assert kwargs["method"] == "query_mimir"
+    assert kwargs["datasource_uid"] == "mimir_uid_456"
 
 
 def test_query_mimir_http_exception_handling():
@@ -122,10 +128,12 @@ def test_query_mimir_http_exception_handling():
     # 3. Force the mock client to crash using our custom exception
     client._make_request.side_effect = mock_exception
 
-    result = client.query_mimir("cpu_usage_total")
+    with patch("app.services.grafana.mimir.report_grafana_failure") as mock_report:
+        result = client.query_mimir("cpu_usage_total")
 
-    # 4. Verify it hit lines 69-71 and correctly formatted the error
+    # 4. Verify it hit the HTTP-response formatting and captured to Sentry
     assert result["success"] is False
     assert result["error"] == "Mimir query failed: 502"
     assert result["response"] == "Bad Gateway: Mimir database is unreachable"
     assert result["metrics"] == []
+    mock_report.assert_called_once()

--- a/tests/services/test_grafana_telemetry.py
+++ b/tests/services/test_grafana_telemetry.py
@@ -58,6 +58,23 @@ class TestReportGrafanaFailureTags:
         tags = mock_report.call_args.kwargs["tags"]  # type: ignore[attr-defined]
         assert tags["datasource_uid"] == "mimir-uid-1"
 
+    def test_empty_string_datasource_uid_still_tagged(self) -> None:
+        """Empty string is a real (if degraded) configuration value and must
+        not be silently dropped — that is itself diagnostic signal."""
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.loki",
+            method="query_loki",
+            datasource_uid="",
+        )
+
+        tags = mock_report.call_args.kwargs["tags"]  # type: ignore[attr-defined]
+        assert tags["datasource_uid"] == ""
+
     def test_extras_forwarded(self) -> None:
         logger = logging.getLogger("test")
         exc = RuntimeError("boom")

--- a/tests/services/test_grafana_telemetry.py
+++ b/tests/services/test_grafana_telemetry.py
@@ -1,0 +1,137 @@
+"""Unit tests for app.services.grafana._telemetry.report_grafana_failure.
+
+Covers the standard tag shape, optional datasource_uid omission to keep tag
+cardinality bounded, severity override, and the logger + Sentry side-effects
+forwarded to app.utils.errors.report_exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+from app.services.grafana._telemetry import report_grafana_failure
+
+
+def _call(exc: Exception, **kwargs: object) -> object:
+    """Invoke report_grafana_failure with report_exception patched."""
+    with patch("app.services.grafana._telemetry.report_exception") as mock_report:
+        report_grafana_failure(exc, **kwargs)  # type: ignore[arg-type]
+    return mock_report
+
+
+class TestReportGrafanaFailureTags:
+    """Standard tag shape across all callers."""
+
+    def test_minimum_tags_when_datasource_uid_absent(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.loki",
+            method="query_loki",
+        )
+
+        mock_report.assert_called_once()  # type: ignore[attr-defined]
+        kwargs = mock_report.call_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["tags"] == {
+            "surface": "service_client",
+            "integration": "grafana",
+            "component": "app.services.grafana.loki",
+            "method": "query_loki",
+        }
+
+    def test_datasource_uid_added_only_when_present(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.mimir",
+            method="query_mimir",
+            datasource_uid="mimir-uid-1",
+        )
+
+        tags = mock_report.call_args.kwargs["tags"]  # type: ignore[attr-defined]
+        assert tags["datasource_uid"] == "mimir-uid-1"
+
+    def test_extras_forwarded(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.base",
+            method="query_loki_label_values",
+            extras={"label": "service_name"},
+        )
+
+        assert mock_report.call_args.kwargs["extras"] == {"label": "service_name"}  # type: ignore[attr-defined]
+
+
+class TestReportGrafanaFailureSeverity:
+    """Severity defaults to warning; callers can promote to error."""
+
+    def test_default_severity_is_warning(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.tempo",
+            method="query_tempo",
+        )
+
+        assert mock_report.call_args.kwargs["severity"] == "warning"  # type: ignore[attr-defined]
+
+    def test_severity_override_propagates(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.tempo",
+            method="query_tempo",
+            severity="error",
+        )
+
+        assert mock_report.call_args.kwargs["severity"] == "error"  # type: ignore[attr-defined]
+
+
+class TestReportGrafanaFailureForwarding:
+    """The helper forwards exc + logger + a method-derived message."""
+
+    def test_message_includes_method_name(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.base",
+            method="discover_datasource_uids",
+        )
+
+        message = mock_report.call_args.kwargs["message"]  # type: ignore[attr-defined]
+        assert "discover_datasource_uids" in message
+        assert "grafana" in message.lower()
+
+    def test_exception_passed_positionally(self) -> None:
+        logger = logging.getLogger("test")
+        exc = RuntimeError("boom")
+
+        mock_report = _call(
+            exc,
+            logger=logger,
+            component="app.services.grafana.loki",
+            method="query_loki",
+        )
+
+        assert mock_report.call_args.args[0] is exc  # type: ignore[attr-defined]
+        assert mock_report.call_args.kwargs["logger"] is logger  # type: ignore[attr-defined]

--- a/tests/services/test_grafana_tempo.py
+++ b/tests/services/test_grafana_tempo.py
@@ -44,12 +44,18 @@ class TestTempoMixin:
         client = FakeGrafanaClient()
         client._make_request = Mock(side_effect=Exception("Connection timeout"))
 
-        result = client.query_tempo(service_name="auth-service")
+        with patch("app.services.grafana.tempo.report_grafana_failure") as mock_report:
+            result = client.query_tempo(service_name="auth-service")
 
         assert result["success"] is False
         assert result["error"] == "Connection timeout"
         assert result["response"] == ""
         assert result["traces"] == []
+        mock_report.assert_called_once()
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["component"] == "app.services.grafana.tempo"
+        assert kwargs["method"] == "query_tempo"
+        assert kwargs["datasource_uid"] == "tempo-uid-abc"
 
     def test_query_tempo_http_exception_with_response(self):
         """Test exception handling when the exception contains a response object."""
@@ -64,11 +70,13 @@ class TestTempoMixin:
 
         client._make_request = Mock(side_effect=MockException("HTTP Error"))
 
-        result = client.query_tempo(service_name="auth-service")
+        with patch("app.services.grafana.tempo.report_grafana_failure") as mock_report:
+            result = client.query_tempo(service_name="auth-service")
 
         assert result["success"] is False
         assert result["error"] == "Tempo query failed: 403"
         assert "Permission denied" in result["response"]
+        mock_report.assert_called_once()
 
     @patch("app.services.grafana.tempo.requests.get")
     def test_query_tempo_successful_trace_parsing(self, mock_requests_get):
@@ -139,16 +147,22 @@ class TestTempoMixin:
         assert span["attributes"]["db.system"] == "postgresql"
         assert span["attributes"]["http.status_code"] == 200
 
+    @patch("app.services.grafana.tempo.report_grafana_failure")
     @patch("app.services.grafana.tempo.requests.get")
-    def test_get_trace_details_network_failure(self, mock_requests_get):
+    def test_get_trace_details_network_failure(self, mock_requests_get, mock_report):
         """Test _get_trace_details graceful degradation on network error."""
         client = FakeGrafanaClient()
         mock_requests_get.side_effect = Exception("Requests connection error")
 
         result = client._get_trace_details(trace_id="trace-123")
 
-        # Should catch the error and return empty spans gracefully
+        # Should catch the error and return empty spans gracefully + capture to Sentry
         assert result == {"spans": []}
+        mock_report.assert_called_once()
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["component"] == "app.services.grafana.tempo"
+        assert kwargs["method"] == "_get_trace_details"
+        assert kwargs["extras"] == {"trace_id": "trace-123"}
 
     def test_extract_span_attributes_edge_cases(self):
         """Test extraction of various attribute types."""
@@ -172,17 +186,32 @@ class TestTempoMixin:
         assert "empty_value" not in attributes
         assert "" not in attributes
 
+    @patch("app.services.grafana.tempo.report_grafana_failure")
     @patch("app.services.grafana.tempo.requests.get")
-    def test_get_trace_details_non_200_status(self, mock_requests_get):
-        """Test _get_trace_details when the API returns a non-200 status."""
+    def test_get_trace_details_non_200_status(self, mock_requests_get, mock_report):
+        """Test _get_trace_details when the API returns a non-200 status.
+
+        After issue #1461 the non-200 path is routed through raise_for_status,
+        so it now reports to Sentry instead of failing silently.
+        """
+        import requests as requests_module
+
         client = FakeGrafanaClient()
 
-        # Setup mock to return a 404 status code
+        # Setup mock to raise HTTPError on raise_for_status (real requests behavior on non-200)
         mock_response = Mock()
         mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = requests_module.HTTPError(
+            "404 Not Found",
+            response=mock_response,
+        )
         mock_requests_get.return_value = mock_response
 
         result = client._get_trace_details(trace_id="trace-123")
 
-        # Assert it safely falls back to empty spans
+        # Assert it safely falls back to empty spans AND captured the non-200 to Sentry
         assert result == {"spans": []}
+        mock_report.assert_called_once()
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["component"] == "app.services.grafana.tempo"
+        assert kwargs["method"] == "_get_trace_details"

--- a/tests/services/test_grafana_tempo.py
+++ b/tests/services/test_grafana_tempo.py
@@ -234,9 +234,7 @@ class TestTempoMixin:
         mock_report.assert_not_called()
 
     @patch("app.services.grafana.tempo.report_grafana_failure")
-    def test_query_tempo_aggregates_per_trace_failures_into_one_event(
-        self, mock_report
-    ):
+    def test_query_tempo_aggregates_per_trace_failures_into_one_event(self, mock_report):
         """Multiple failed _get_trace_details lookups inside one query_tempo
         call must coalesce into a single Sentry event so a degraded Tempo
         endpoint doesn't fan out into N events per query."""

--- a/tests/services/test_grafana_tempo.py
+++ b/tests/services/test_grafana_tempo.py
@@ -215,3 +215,59 @@ class TestTempoMixin:
         kwargs = mock_report.call_args.kwargs
         assert kwargs["component"] == "app.services.grafana.tempo"
         assert kwargs["method"] == "_get_trace_details"
+
+    @patch("app.services.grafana.tempo.report_grafana_failure")
+    @patch("app.services.grafana.tempo.requests.get")
+    def test_get_trace_details_with_failures_out_defers_capture(
+        self, mock_requests_get, mock_report
+    ):
+        """When failures_out is provided, the per-call Sentry capture is
+        skipped and the trace_id is appended for batch-level reporting."""
+        client = FakeGrafanaClient()
+        mock_requests_get.side_effect = Exception("Connection refused")
+
+        collected: list[str] = []
+        result = client._get_trace_details(trace_id="trace-zzz", failures_out=collected)
+
+        assert result == {"spans": []}
+        assert collected == ["trace-zzz"]
+        mock_report.assert_not_called()
+
+    @patch("app.services.grafana.tempo.report_grafana_failure")
+    def test_query_tempo_aggregates_per_trace_failures_into_one_event(
+        self, mock_report
+    ):
+        """Multiple failed _get_trace_details lookups inside one query_tempo
+        call must coalesce into a single Sentry event so a degraded Tempo
+        endpoint doesn't fan out into N events per query."""
+        client = FakeGrafanaClient()
+        client._make_request = Mock(
+            return_value={
+                "traces": [
+                    {"traceID": "trace-a", "rootServiceName": "auth", "durationMs": 1},
+                    {"traceID": "trace-b", "rootServiceName": "auth", "durationMs": 2},
+                    {"traceID": "trace-c", "rootServiceName": "auth", "durationMs": 3},
+                ]
+            }
+        )
+
+        with patch(
+            "app.services.grafana.tempo.requests.get",
+            side_effect=Exception("Tempo degraded"),
+        ):
+            result = client.query_tempo(service_name="auth-service")
+
+        # Search succeeded, but every detail lookup failed
+        assert result["success"] is True
+        assert result["total_traces"] == 3
+        for enriched in result["traces"]:
+            assert enriched["spans"] == []
+
+        # Exactly one aggregated Sentry event for all three failures
+        mock_report.assert_called_once()
+        kwargs = mock_report.call_args.kwargs
+        assert kwargs["component"] == "app.services.grafana.tempo"
+        assert kwargs["method"] == "_get_trace_details_batch"
+        assert kwargs["extras"]["failed_count"] == 3
+        assert kwargs["extras"]["total_count"] == 3
+        assert kwargs["extras"]["first_failed_trace_id"] == "trace-a"

--- a/tests/services/test_grafana_tempo.py
+++ b/tests/services/test_grafana_tempo.py
@@ -226,11 +226,13 @@ class TestTempoMixin:
         client = FakeGrafanaClient()
         mock_requests_get.side_effect = Exception("Connection refused")
 
-        collected: list[str] = []
+        collected: list[tuple[str, Exception]] = []
         result = client._get_trace_details(trace_id="trace-zzz", failures_out=collected)
 
         assert result == {"spans": []}
-        assert collected == ["trace-zzz"]
+        assert len(collected) == 1
+        assert collected[0][0] == "trace-zzz"
+        assert isinstance(collected[0][1], Exception)
         mock_report.assert_not_called()
 
     @patch("app.services.grafana.tempo.report_grafana_failure")
@@ -269,3 +271,5 @@ class TestTempoMixin:
         assert kwargs["extras"]["failed_count"] == 3
         assert kwargs["extras"]["total_count"] == 3
         assert kwargs["extras"]["first_failed_trace_id"] == "trace-a"
+        assert kwargs["extras"]["first_failed_exception_type"] == "Exception"
+        assert "Tempo degraded" in kwargs["extras"]["first_failed_exception_message"]


### PR DESCRIPTION
## Summary

Surfaces Grafana stack soft-fail paths (base/loki/mimir/tempo) to Sentry so the agent does not silently treat "vendor failed" as "no data."

Closes #1461.

## Changes

- New `app/services/grafana/_telemetry.py` with a single `report_grafana_failure()` helper. Applies the standard tag shape (`surface=service_client`, `integration=grafana`, `component`, `method`, optional `datasource_uid`) and forwards to `app.utils.errors.report_exception`.
- `base.py`: `discover_datasource_uids`, `query_loki_label_values`, `query_alert_rules` now route through the helper instead of warning/debug-only logs.
- `loki.py` and `mimir.py`: added module loggers (previously had no `logger.*` at all) and capture the swallowed `query_loki` / `query_mimir` failure.
- `tempo.py`: `query_tempo` now captures the swallowed failure; `_get_trace_details` routes non-200 responses through `raise_for_status()` so the previously silent non-200 path is reported.

## Verification

- `uv run pytest tests/services/test_grafana_loki.py tests/services/test_grafana_mimir.py tests/services/test_grafana_tempo.py tests/services/test_grafana_telemetry.py` — 31 passed
- `uv run ruff check app/services/grafana/ tests/services/test_grafana_*.py` — clean
- `uv run mypy app/services/grafana/` — clean
- Each failure-path test patches `report_grafana_failure` and asserts `assert_called_once()` with the correct component / method / datasource_uid kwargs.
