### PR TITLE
fix(streaming): run upstream correlation in streaming investigations

### DIFF
--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -220,6 +220,14 @@ async def astream_investigation(
             from app.correlation.node import node_correlate_upstream
             from app.pipeline.pipeline import _build_correlation_config
 
+            _put(
+                _make_node_event(
+                    "on_chain_start",
+                    "correlate_upstream",
+                    {},
+                )
+            )
+
             _merge(
                 state_any,
                 node_correlate_upstream(

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -228,6 +228,18 @@ async def astream_investigation(
                 ),
             )
 
+            _put(
+                _make_node_event(
+                    "on_chain_end",
+                    "correlate_upstream",
+                    {
+                        "output": {
+                            "correlation": state_any.get("correlation", {}),
+                        }
+                    },
+                )
+            )
+
             # --- deliver / publish (skip terminal render — StreamRenderer owns it) ---
             _put(_make_node_event("on_chain_start", "publish_findings", {}))
 

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -216,6 +216,18 @@ async def astream_investigation(
                 state_any, ConnectedInvestigationAgent().run(state_any, on_event=_on_agent_event)
             )
 
+            # --- upstream correlation ---
+            from app.correlation.node import node_correlate_upstream
+            from app.pipeline.pipeline import _build_correlation_config
+
+            _merge(
+                state_any,
+                node_correlate_upstream(
+                    cast("AgentState", state_any),
+                    _build_correlation_config(state_any),
+                ),
+            )
+
             # --- deliver / publish (skip terminal render — StreamRenderer owns it) ---
             _put(_make_node_event("on_chain_start", "publish_findings", {}))
 

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -219,7 +219,7 @@ def test_execute_investigation_tracks_remote_http_source(
     ]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_investigate_stream_persists_state_on_disconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -275,7 +275,7 @@ async def test_investigate_stream_persists_state_on_disconnect(
     assert call0["raw_alert"].get("alert_name") == "PayloadAlert"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_investigate_stream_captures_streaming_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -327,7 +327,7 @@ async def test_investigate_stream_captures_streaming_exception(
     assert astream_calls[0]["raw_alert"].get("alert_name") == "PayloadAlert"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_lifespan_starts_and_cancels_vercel_poller(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -354,7 +354,7 @@ async def test_lifespan_starts_and_cancels_vercel_poller(
     assert cancelled.is_set()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_lifespan_raises_helpful_error_on_permission_denied(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -635,3 +635,77 @@ def test_check_memory_health_returns_missing_on_oserror(
     assert result.name == "Memory"
     assert result.status == "missing"
     assert "Unable to read meminfo:" in result.detail
+
+
+@pytest.mark.anyio
+async def test_investigate_stream_includes_correlation_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_astream_investigation(*args: object, **kwargs: object):
+        _ = (args, kwargs)
+
+        yield StreamEvent(
+            "events",
+            data={
+                "data": {
+                    "output": {
+                        "root_cause": "RDS CPU spike",
+                        "report": "Correlation attached",
+                        "correlation": {
+                            "correlated_signals": [
+                                {
+                                    "name": "upstream-correlation",
+                                    "source": "runtime",
+                                    "score": 0.9,
+                                }
+                            ],
+                            "most_likely_causal_drivers": [
+                                {
+                                    "name": "system.cpu.user{service:orders-web}",
+                                    "confidence": 0.9,
+                                    "rationale": "time_window=1.0",
+                                }
+                            ],
+                        },
+                    }
+                }
+            },
+            kind="on_chain_end",
+        )
+
+    persisted: dict[str, Any] = {}
+
+    monkeypatch.setattr("app.config.LLMSettings.from_env", object)
+
+    monkeypatch.setattr(
+        "app.cli.investigation.resolve_investigation_context",
+        lambda **_kwargs: ("test-alert", "orders-pipeline", "critical"),
+    )
+
+    monkeypatch.setattr(
+        "app.pipeline.runners.astream_investigation",
+        fake_astream_investigation,
+    )
+
+    monkeypatch.setattr(
+        "app.remote.server._persist_streamed_result",
+        lambda **kwargs: persisted.update(kwargs),
+    )
+
+    response = await investigate_stream(
+        InvestigateRequest(raw_alert={"alert_name": "PayloadAlert"})
+    )
+
+    chunks = [chunk async for chunk in response.body_iterator]
+
+    assert chunks
+
+    correlation = persisted["state"]["correlation"]
+
+    assert correlation["correlated_signals"]
+    assert correlation["most_likely_causal_drivers"]
+
+    assert (
+        correlation["most_likely_causal_drivers"][0]["name"]
+        == "system.cpu.user{service:orders-web}"
+    )

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -638,42 +638,22 @@ def test_check_memory_health_returns_missing_on_oserror(
 
 
 @pytest.mark.anyio
-async def test_investigate_stream_includes_correlation_payload(
+async def test_investigate_stream_emits_correlation_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fake_astream_investigation(*args: object, **kwargs: object):
-        _ = (args, kwargs)
-
-        yield StreamEvent(
-            "events",
-            data={
-                "data": {
-                    "output": {
-                        "root_cause": "RDS CPU spike",
-                        "report": "Correlation attached",
-                        "correlation": {
-                            "correlated_signals": [
-                                {
-                                    "name": "upstream-correlation",
-                                    "source": "runtime",
-                                    "score": 0.9,
-                                }
-                            ],
-                            "most_likely_causal_drivers": [
-                                {
-                                    "name": "system.cpu.user{service:orders-web}",
-                                    "confidence": 0.9,
-                                    "rationale": "time_window=1.0",
-                                }
-                            ],
-                        },
-                    }
-                }
-            },
-            kind="on_chain_end",
-        )
-
     persisted: dict[str, Any] = {}
+
+    def fake_investigation_run(
+        _self: object,
+        _state: object,
+        *,
+        on_event: object | None = None,
+    ) -> dict[str, str]:
+        _ = on_event
+        return {
+            "root_cause": "RDS CPU spike",
+            "report": "Correlation attached",
+        }
 
     monkeypatch.setattr("app.config.LLMSettings.from_env", object)
 
@@ -683,8 +663,61 @@ async def test_investigate_stream_includes_correlation_payload(
     )
 
     monkeypatch.setattr(
-        "app.pipeline.runners.astream_investigation",
-        fake_astream_investigation,
+        "app.agent.context.resolve_integrations",
+        lambda _state: {},
+    )
+
+    monkeypatch.setattr(
+        "app.agent.extract.extract_alert",
+        lambda _state: {
+            "raw_alert": {
+                "alert_name": "PayloadAlert",
+                "service": "orders",
+                "resource": "orders-rds-prod",
+            },
+            "alert_name": "PayloadAlert",
+            "pipeline_name": "orders",
+            "severity": "critical",
+            "incident_window": {
+                "since": "2026-04-15T14:00:00Z",
+                "until": "2026-04-15T14:15:00Z",
+            },
+        },
+    )
+
+    monkeypatch.setattr(
+        "app.agent.investigation.ConnectedInvestigationAgent.run",
+        fake_investigation_run,
+    )
+
+    monkeypatch.setattr(
+        "app.correlation.node.node_correlate_upstream",
+        lambda _state, _config=None: {
+            "correlation": {
+                "correlated_signals": [
+                    {
+                        "name": "upstream-correlation",
+                        "source": "runtime",
+                        "score": 0.9,
+                    }
+                ],
+                "most_likely_causal_drivers": [
+                    {
+                        "name": "system.cpu.user{service:orders-web}",
+                        "confidence": 0.9,
+                        "rationale": "time_window=1.0",
+                    }
+                ],
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        "app.delivery.publish_findings.node.generate_report",
+        lambda _state: {
+            "root_cause": "RDS CPU spike",
+            "report": "Correlation attached",
+        },
     )
 
     monkeypatch.setattr(
@@ -699,12 +732,12 @@ async def test_investigate_stream_includes_correlation_payload(
     chunks = [chunk async for chunk in response.body_iterator]
 
     assert chunks
+    assert any("correlate_upstream" in chunk for chunk in chunks)
 
     correlation = persisted["state"]["correlation"]
 
     assert correlation["correlated_signals"]
     assert correlation["most_likely_causal_drivers"]
-
     assert (
         correlation["most_likely_causal_drivers"][0]["name"]
         == "system.cpu.user{service:orders-web}"


### PR DESCRIPTION
## Summary

Fixes #2077

Fix streaming/non-streaming investigation drift where upstream correlation
was skipped in `astream_investigation`.

Previously the blocking pipeline (`run_connected_investigation`) executed
`node_correlate_upstream`, while the streaming path manually reimplemented
the investigation flow and omitted the correlation step entirely. As a result,
`/investigate/stream` responses could miss correlation payloads that were
present in blocking investigations.

## Changes

* run `node_correlate_upstream` during streaming investigations
* align streaming investigation behavior with the blocking pipeline
* preserve correlation payloads in streamed investigation state/results
* add regression coverage for streamed correlation persistence

## Validation

```bash
ruff check app/pipeline/runners.py tests/remote/test_server.py

python -m pytest tests/remote/test_server.py -q
```

Verified that streamed investigations now include:

* `correlated_signals`
* `most_likely_causal_drivers`

the same way as blocking investigations.

<img width="1538" height="755" alt="Ekran görüntüsü 2026-05-16 160604" src="https://github.com/user-attachments/assets/cca3c80a-0418-4bc5-9b8a-7b7505c5176e" />
<img width="1542" height="630" alt="Ekran görüntüsü 2026-05-16 160623" src="https://github.com/user-attachments/assets/9a75cb13-7d5d-4bf4-b141-ba0635ddb228" />
