### PR TITLE
Handle Bedrock permission denied as config error

### DIFF
--- a/app/cli/support/cli_error_mapping.py
+++ b/app/cli/support/cli_error_mapping.py
@@ -28,5 +28,15 @@ def reraise_cli_runtime_error(exc: BaseException) -> NoReturn:
                 str(exc),
                 suggestion="Verify your model name in ANTHROPIC_REASONING_MODEL or ANTHROPIC_TOOLCALL_MODEL environment variables.",
             ) from exc
+        if "bedrock model" in msg and "not available for your account" in msg:
+            raise OpenSREError(
+                str(exc),
+                suggestion=(
+                    "Enable access to the configured Bedrock model in the AWS region, "
+                    "verify the AWS Marketplace subscription/payment setup, and ensure "
+                    "the IAM user or role can use aws-marketplace:ViewSubscriptions "
+                    "and aws-marketplace:Subscribe."
+                ),
+            ) from exc
 
     raise exc

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -95,8 +95,12 @@ class AnthropicAgentClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> AgentLLMResponse:
-        from anthropic import AuthenticationError, BadRequestError, NotFoundError
-        from anthropic import PermissionDeniedError
+        from anthropic import (
+            AuthenticationError,
+            BadRequestError,
+            NotFoundError,
+            PermissionDeniedError,
+        )
 
         kwargs: dict[str, Any] = {
             "model": self._model,

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -96,6 +96,7 @@ class AnthropicAgentClient:
         tools: list[dict[str, Any]] | None = None,
     ) -> AgentLLMResponse:
         from anthropic import AuthenticationError, BadRequestError, NotFoundError
+        from anthropic import PermissionDeniedError
 
         kwargs: dict[str, Any] = {
             "model": self._model,
@@ -117,6 +118,8 @@ class AnthropicAgentClient:
                 raise RuntimeError(self._authentication_error_message()) from err
             except NotFoundError as err:
                 raise RuntimeError(self._model_not_found_error_message()) from err
+            except PermissionDeniedError as err:
+                raise RuntimeError(self._permission_denied_error_message()) from err
             except BadRequestError as err:
                 raise RuntimeError(
                     f"{self.provider_name} request rejected (HTTP 400): {err.message}"
@@ -174,6 +177,9 @@ class AnthropicAgentClient:
     def _model_not_found_error_message(self) -> str:
         return f"{self.provider_name} model '{self._model}' not found."
 
+    def _permission_denied_error_message(self) -> str:
+        return f"{self.provider_name} API access denied. Check your API key permissions."
+
 
 class BedrockAgentClient(AnthropicAgentClient):
     """Bedrock-backed client using AnthropicBedrock SDK."""
@@ -196,6 +202,14 @@ class BedrockAgentClient(AnthropicAgentClient):
             timeout=_CLIENT_TIMEOUT_SEC,
         )
         super().__init__(model=model, max_tokens=max_tokens, client=bedrock_client)
+
+    def _permission_denied_error_message(self) -> str:
+        return (
+            f"Bedrock model '{self._model}' is not available for your account. "
+            "Check Bedrock model access in the configured AWS region, AWS Marketplace "
+            "subscription/payment setup, and IAM permissions including "
+            "aws-marketplace:ViewSubscriptions and aws-marketplace:Subscribe."
+        )
 
 
 class OpenAIAgentClient:

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -67,6 +67,11 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # (``"<provider> billing quota exceeded. ..."``) and the Bedrock Anthropic
     # ``usage limits`` path (``"Anthropic billing quota exceeded for Bedrock model ..."``).
     re.compile(r"\bbilling quota exceeded\b", re.I),
+    # Bedrock account/model access failures are operator-actionable: the AWS
+    # account, Marketplace subscription/payment setup, region model access, or
+    # IAM policy needs to change before retrying can succeed.
+    re.compile(r"\bBedrock model\s+['\"][^'\"]+['\"]\s+is not available for your account\b", re.I),
+    re.compile(r"\bAccess denied for Bedrock model\s+['\"][^'\"]+['\"]", re.I),
 )
 
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -71,7 +71,6 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # account, Marketplace subscription/payment setup, region model access, or
     # IAM policy needs to change before retrying can succeed.
     re.compile(r"\bBedrock model\s+['\"][^'\"]+['\"]\s+is not available for your account\b", re.I),
-    re.compile(r"\bAccess denied for Bedrock model\s+['\"][^'\"]+['\"]", re.I),
 )
 
 

--- a/tests/cli/test_cli_error_mapping.py
+++ b/tests/cli/test_cli_error_mapping.py
@@ -49,3 +49,22 @@ def test_cli_not_found_still_maps_correctly() -> None:
         reraise_cli_runtime_error(exc)
 
     assert "CLI tool is not installed" in str(exc_info.value)
+
+
+def test_bedrock_model_not_available_maps_to_opensre_error() -> None:
+    exc = RuntimeError(
+        "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available for your account. "
+        "Check Bedrock model access in the configured AWS region, AWS Marketplace "
+        "subscription/payment setup, and IAM permissions including "
+        "aws-marketplace:ViewSubscriptions and aws-marketplace:Subscribe."
+    )
+
+    with pytest.raises(OpenSREError) as exc_info:
+        reraise_cli_runtime_error(exc)
+
+    err = exc_info.value
+    assert "Bedrock model" in str(err)
+    assert err.suggestion is not None
+    assert "AWS Marketplace" in err.suggestion
+    assert "aws-marketplace:ViewSubscriptions" in err.suggestion
+    assert "aws-marketplace:Subscribe" in err.suggestion

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -22,6 +22,9 @@ def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleName
     class NotFoundError(Exception):
         pass
 
+    class PermissionDeniedError(Exception):
+        pass
+
     class Anthropic:
         def __init__(self, **_: object) -> None:
             self.messages = types.SimpleNamespace(create=lambda **_: None)
@@ -33,6 +36,7 @@ def _install_fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> types.SimpleName
     fake_module.AuthenticationError = AuthenticationError
     fake_module.BadRequestError = BadRequestError
     fake_module.NotFoundError = NotFoundError
+    fake_module.PermissionDeniedError = PermissionDeniedError
     fake_module.Anthropic = Anthropic
     fake_module.AnthropicBedrock = AnthropicBedrock
     monkeypatch.setitem(sys.modules, "anthropic", fake_module)
@@ -67,6 +71,34 @@ def test_bedrock_auth_error_message_references_aws_credentials(
     assert "Bedrock authentication failed" in message
     assert "AWS credentials" in message
     assert "ANTHROPIC_API_KEY" not in message
+
+
+def test_bedrock_permission_denied_is_not_retried_and_mentions_marketplace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    client = BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+    calls = 0
+
+    def raise_permission_denied(**_: object) -> object:
+        nonlocal calls
+        calls += 1
+        raise fake_anthropic.PermissionDeniedError("marketplace denied")
+
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=raise_permission_denied)
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    message = str(exc.value)
+    assert calls == 1
+    assert "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available" in message
+    assert "AWS Marketplace" in message
+    assert "aws-marketplace:ViewSubscriptions" in message
+    assert "aws-marketplace:Subscribe" in message
 
 
 def _install_fake_openai(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -661,6 +661,10 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "RuntimeError",
             "Anthropic request rejected (HTTP 400): Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'You have reached your specified API usage limits. You will regain access on 2026-06-01 at 00:00 UTC.'}, 'request_id': 'req_011CaxxMA8NCSdDvaM2LaRm6'}",
         ),
+        (
+            "RuntimeError",
+            "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available for your account. Check Bedrock model access in the configured AWS region, AWS Marketplace subscription/payment setup, and IAM permissions including aws-marketplace:ViewSubscriptions and aws-marketplace:Subscribe.",
+        ),
     ],
 )
 def test_before_send_drops_operator_actionable_llm_errors(


### PR DESCRIPTION
Fixes #2067

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Handle Bedrock `PermissionDeniedError` in the investigation agent LLM client.
- Stop retrying deterministic Bedrock 403 model access failures.
- Show a clearer error explaining Bedrock model access, AWS Marketplace subscription/payment setup, region, and IAM permissions.
- Map this failure to a user-facing `OpenSREError`.
- Filter this operator-actionable Bedrock setup error from Sentry.
- Added tests for Bedrock permission denial, CLI error mapping, and Sentry filtering.

### Demo/Screenshot for feature changes and bug fixes -

```bash
uv run pytest tests/services/test_agent_llm_client.py tests/cli/test_cli_error_mapping.py tests/test_sentry_init.py
```




**Note**: LLM provider error handling is currently duplicated across a few service clients. This PR keeps the fix narrow, but a future cleanup could add a shared provider-error abstraction for retryability, user-facing suggestions, and Sentry filtering.