### PR TITLE
fix(integrations): log runtime tool failures without Sentry capture

### DIFF
--- a/app/integrations/_validation_helpers.py
+++ b/app/integrations/_validation_helpers.py
@@ -1,9 +1,14 @@
-"""Sentry capture for integration-validator broad-exception sites.
+"""Reporting helpers for integration broad-exception sites.
 
 Every ``except Exception`` block in ``app/integrations/<vendor>.py`` validators
 should call :func:`report_validation_failure` *before* returning the degraded
 ``ValidationResult``. This keeps vendor-level failure trends visible in Sentry
 without changing operator-visible output.
+
+Runtime diagnostic helpers should call :func:`report_integration_runtime_failure`.
+Those failures usually describe downstream service availability, credentials, or
+permissions, so they are logged for local debugging but are not captured to
+OpenSRE's Sentry as product errors.
 """
 
 from __future__ import annotations
@@ -12,6 +17,21 @@ import logging
 from typing import Any
 
 from app.utils.errors import report_exception
+
+
+def _log_integration_failure(
+    exc: BaseException,
+    *,
+    logger: logging.Logger,
+    message: str,
+    severity: str,
+    extras: dict[str, Any] | None = None,
+) -> None:
+    log_fn = getattr(logger, severity, logger.warning)
+    if extras:
+        log_fn("%s extras=%s", message, extras, exc_info=exc)
+        return
+    log_fn("%s", message, exc_info=exc)
 
 
 def report_validation_failure(
@@ -50,5 +70,30 @@ def report_validation_failure(
             "event": "validation_failed",
             "method": method,
         },
+        extras=extras,
+    )
+
+
+def report_integration_runtime_failure(
+    exc: BaseException,
+    *,
+    logger: logging.Logger,
+    integration: str,
+    method: str,
+    severity: str = "warning",
+    extras: dict[str, Any] | None = None,
+) -> None:
+    """Log a runtime integration failure without Sentry capture.
+
+    Runtime integration functions are diagnostic probes against customer-owned
+    or third-party systems. Their broad-except paths normally return degraded
+    tool output, so downstream outages should be visible in logs and tool
+    results without becoming OpenSRE product-error issues in Sentry.
+    """
+    _log_integration_failure(
+        exc,
+        logger=logger,
+        message=f"[{integration}] {method} runtime failed",
+        severity=severity,
         extras=extras,
     )

--- a/app/integrations/airflow.py
+++ b/app/integrations/airflow.py
@@ -11,7 +11,10 @@ from urllib.parse import quote
 import httpx
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -295,7 +298,7 @@ def get_recent_airflow_failures(
                 dag_run_id=dag_run_id,
             )
         except Exception as err:
-            report_validation_failure(
+            report_integration_runtime_failure(
                 err,
                 logger=logger,
                 integration="airflow",

--- a/app/integrations/azure_sql.py
+++ b/app/integrations/azure_sql.py
@@ -19,7 +19,10 @@ from typing import Any
 
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 from app.utils.truncation import truncate
 
@@ -338,7 +341,7 @@ def get_server_status(config: AzureSQLConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="azure_sql",
@@ -421,7 +424,7 @@ def get_current_queries(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="azure_sql",
@@ -508,7 +511,7 @@ def get_resource_stats(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="azure_sql",
@@ -586,7 +589,7 @@ def get_slow_queries(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="azure_sql",
@@ -647,7 +650,7 @@ def get_wait_stats(config: AzureSQLConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="azure_sql",

--- a/app/integrations/betterstack.py
+++ b/app/integrations/betterstack.py
@@ -27,7 +27,10 @@ from typing import Any
 import httpx
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -399,7 +402,7 @@ def query_logs(
         with _sql_client(config) as client:
             response, err = _post_sql(client, config.query_endpoint, sql)
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="betterstack",

--- a/app/integrations/bitbucket.py
+++ b/app/integrations/bitbucket.py
@@ -15,7 +15,10 @@ from typing import Any
 import httpx
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -167,7 +170,7 @@ def list_commits(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="bitbucket",
@@ -209,7 +212,7 @@ def get_file_contents(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="bitbucket",
@@ -265,7 +268,7 @@ def search_code(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="bitbucket",

--- a/app/integrations/clickhouse.py
+++ b/app/integrations/clickhouse.py
@@ -14,7 +14,10 @@ from typing import Any
 
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -216,7 +219,7 @@ def get_query_activity(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="clickhouse",
@@ -264,7 +267,7 @@ def get_system_health(config: ClickHouseConfig) -> dict[str, Any]:
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="clickhouse",
@@ -328,7 +331,7 @@ def get_table_stats(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="clickhouse",

--- a/app/integrations/daily_update.py
+++ b/app/integrations/daily_update.py
@@ -17,7 +17,7 @@ from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import report_integration_runtime_failure
 from app.services.llm_client import get_llm_for_reasoning
 from app.version import get_version
 
@@ -524,7 +524,7 @@ def summarize_highlights(
         if _bool_env("DAILY_UPDATE_REQUIRE_LLM", default=False):
             # Let an outer boundary capture this — avoids a double Sentry event.
             raise
-        report_validation_failure(
+        report_integration_runtime_failure(
             exc,
             logger=logger,
             integration="daily_update",

--- a/app/integrations/kafka.py
+++ b/app/integrations/kafka.py
@@ -14,7 +14,10 @@ from typing import Any
 
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -228,7 +231,7 @@ def get_topic_health(
             "topics": topics,
         }
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="kafka",
@@ -298,7 +301,7 @@ def get_consumer_group_lag(
         finally:
             consumer.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="kafka",

--- a/app/integrations/llm_cli/kimi.py
+++ b/app/integrations/llm_cli/kimi.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import report_integration_runtime_failure
 from app.integrations.llm_cli.base import CLIInvocation, CLIProbe
 from app.integrations.llm_cli.binary_resolver import (
     candidate_binary_names as _candidate_binary_names,
@@ -93,7 +93,7 @@ def _check_kimi_auth_fallback() -> tuple[bool | None, str]:
                     return True, "Authenticated via config.toml."
         return False, "No API key configured. Run: kimi login"
     except Exception as e:
-        report_validation_failure(
+        report_integration_runtime_failure(
             e,
             logger=logger,
             integration="kimi",

--- a/app/integrations/mariadb.py
+++ b/app/integrations/mariadb.py
@@ -15,7 +15,10 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from app.integrations._relational import RelationalConfigBase, env_bool, env_str
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.utils.coercion import safe_int
 from app.utils.truncation import truncate
 
@@ -211,7 +214,7 @@ def get_process_list(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mariadb",
@@ -267,7 +270,7 @@ def get_global_status(config: MariaDBConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mariadb",
@@ -304,7 +307,7 @@ def get_innodb_status(config: MariaDBConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mariadb",
@@ -376,7 +379,7 @@ def get_slow_queries(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mariadb",
@@ -450,7 +453,7 @@ def get_replication_status(config: MariaDBConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mariadb",

--- a/app/integrations/mongodb.py
+++ b/app/integrations/mongodb.py
@@ -14,7 +14,10 @@ from typing import Any
 
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -193,7 +196,7 @@ def get_server_status(config: MongoDBConfig) -> dict[str, Any]:
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb",
@@ -248,7 +251,7 @@ def get_current_ops(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb",
@@ -304,7 +307,7 @@ def get_rs_status(config: MongoDBConfig) -> dict[str, Any]:
                 "members": [],
                 "note": "Server is not part of a replica set.",
             }
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb",
@@ -386,7 +389,7 @@ def get_profiler_data(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb",
@@ -438,7 +441,7 @@ def get_collection_stats(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb",

--- a/app/integrations/mongodb_atlas.py
+++ b/app/integrations/mongodb_atlas.py
@@ -18,7 +18,10 @@ from typing import Any
 import httpx
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -209,7 +212,7 @@ def get_clusters(config: MongoDBAtlasConfig) -> dict[str, Any]:
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb_atlas",
@@ -263,7 +266,7 @@ def get_alerts(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb_atlas",
@@ -405,7 +408,7 @@ def get_cluster_metrics(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb_atlas",
@@ -494,7 +497,7 @@ def get_performance_advisor(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb_atlas",
@@ -552,7 +555,7 @@ def get_cluster_events(
         finally:
             client.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mongodb_atlas",

--- a/app/integrations/mysql.py
+++ b/app/integrations/mysql.py
@@ -20,7 +20,10 @@ from app.integrations._relational import (
     env_str,
     resolve_stored_or_env_config,
 )
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.utils.truncation import truncate
 
 logger = logging.getLogger(__name__)
@@ -301,7 +304,7 @@ def get_server_status(config: MySQLConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mysql",
@@ -363,7 +366,7 @@ def get_current_processes(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mysql",
@@ -443,7 +446,7 @@ def get_replication_status(config: MySQLConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mysql",
@@ -546,7 +549,7 @@ def get_slow_queries(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mysql",
@@ -627,7 +630,7 @@ def get_table_stats(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="mysql",

--- a/app/integrations/postgresql.py
+++ b/app/integrations/postgresql.py
@@ -20,7 +20,10 @@ from app.integrations._relational import (
     env_str,
     resolve_stored_or_env_config,
 )
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +286,7 @@ def get_server_status(config: PostgreSQLConfig) -> dict[str, Any]:
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="postgresql",
@@ -361,7 +364,7 @@ def get_current_queries(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="postgresql",
@@ -476,7 +479,7 @@ def get_replication_status(config: PostgreSQLConfig) -> dict[str, Any]:
                 "replicas": [],
                 "note": "Server appears to be a replica, not a primary.",
             }
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="postgresql",
@@ -575,7 +578,7 @@ def get_slow_queries(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="postgresql",
@@ -682,7 +685,7 @@ def get_table_stats(
         finally:
             conn.close()
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="postgresql",

--- a/app/integrations/rabbitmq.py
+++ b/app/integrations/rabbitmq.py
@@ -26,7 +26,10 @@ from typing import Any
 import httpx
 from pydantic import Field, field_validator
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 from app.strict_config import StrictConfigModel
 from app.utils.coercion import safe_int
 
@@ -282,7 +285,7 @@ def get_queue_backlog(
                 "queues": truncated,
             }
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="rabbitmq",
@@ -333,7 +336,7 @@ def get_consumer_health(
                 "consumers": consumers,
             }
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="rabbitmq",
@@ -411,7 +414,7 @@ def get_broker_overview(config: RabbitMQConfig) -> dict[str, Any]:
                 "alarms": alarm_payload,
             }
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="rabbitmq",
@@ -463,7 +466,7 @@ def get_node_health(config: RabbitMQConfig) -> dict[str, Any]:
                 "nodes": nodes,
             }
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="rabbitmq",
@@ -522,7 +525,7 @@ def get_connection_stats(
                 "connections": truncated,
             }
     except Exception as err:
-        report_validation_failure(
+        report_integration_runtime_failure(
             err,
             logger=logger,
             integration="rabbitmq",

--- a/tests/integrations/test_validation_helpers.py
+++ b/tests/integrations/test_validation_helpers.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock, patch
 
-from app.integrations._validation_helpers import report_validation_failure
+from app.integrations._validation_helpers import (
+    report_integration_runtime_failure,
+    report_validation_failure,
+)
 
 
 def _mock_logger() -> MagicMock:
@@ -96,3 +99,41 @@ class TestReportValidationFailure:
             )
         mock_cap.assert_called_once()
         assert mock_cap.call_args[0][0] is exc
+
+
+class TestReportIntegrationRuntimeFailure:
+    def test_logs_warning_without_sentry_capture(self) -> None:
+        mock_log = _mock_logger()
+        exc = RuntimeError("connection refused")
+        with patch("app.utils.errors.capture_exception") as mock_cap:
+            report_integration_runtime_failure(
+                exc,
+                logger=mock_log,
+                integration="postgresql",
+                method="get_table_stats",
+            )
+        mock_log.warning.assert_called_once()
+        mock_cap.assert_not_called()
+
+    def test_runtime_message_includes_integration_and_method(self) -> None:
+        mock_log = _mock_logger()
+        report_integration_runtime_failure(
+            RuntimeError("x"),
+            logger=mock_log,
+            integration="kafka",
+            method="get_topic_health",
+        )
+        message = mock_log.warning.call_args[0][1]
+        assert message == "[kafka] get_topic_health runtime failed"
+
+    def test_runtime_severity_override_routes_to_logger(self) -> None:
+        mock_log = _mock_logger()
+        report_integration_runtime_failure(
+            RuntimeError("x"),
+            logger=mock_log,
+            integration="mongodb",
+            method="get_server_status",
+            severity="error",
+        )
+        mock_log.error.assert_called_once()
+        mock_log.warning.assert_not_called()

--- a/tests/integrations/test_validator_sentry_capture.py
+++ b/tests/integrations/test_validator_sentry_capture.py
@@ -1,15 +1,19 @@
-"""AST checks: every migrated broad-except in app/integrations calls report_validation_failure.
+"""AST checks: migrated integration broad-except blocks use the right reporter.
 
 Issue #1470 acceptance criterion: every listed validator must invoke
 ``report_validation_failure`` on its broad ``except Exception`` block, with
 tags carrying ``integration`` and ``method`` so Sentry events are filterable
 by vendor.
 
+Runtime diagnostic/query functions must invoke
+``report_integration_runtime_failure`` instead. Those failures usually reflect
+downstream service state and should be logged without Sentry capture.
+
 This test parses each integration module and asserts, for every listed
 ``(function, line)`` pair, that:
 
-1. The function's broad ``except Exception`` handler contains a call to
-   ``report_validation_failure``.
+1. The function's broad ``except Exception`` handler contains a call to the
+   expected reporter.
 2. The ``integration=`` and ``method=`` keyword arguments are string literals
    matching the expected tag values.
 
@@ -362,12 +366,18 @@ def _kwarg_str(call: ast.Call, key: str) -> str | None:
     return None
 
 
+def _expected_reporter(case: MigrationCase) -> str:
+    if case.function.startswith("validate_"):
+        return "report_validation_failure"
+    return "report_integration_runtime_failure"
+
+
 @pytest.mark.parametrize(
     "case",
     CASES,
     ids=lambda c: f"{Path(c.module_path).stem}::{c.function}",
 )
-def test_broad_except_calls_report_validation_failure(case: MigrationCase) -> None:
+def test_broad_except_calls_expected_integration_reporter(case: MigrationCase) -> None:
     source = (_REPO_ROOT / case.module_path).read_text(encoding="utf-8")
     tree = ast.parse(source)
     fn = _find_function(tree, case.function)
@@ -376,16 +386,17 @@ def test_broad_except_calls_report_validation_failure(case: MigrationCase) -> No
     handlers = _broad_except_handlers(fn)
     assert handlers, f"no `except Exception` handlers in {case.module_path}::{case.function}"
 
+    expected_reporter = _expected_reporter(case)
     matching_calls: list[ast.Call] = []
     for h in handlers:
-        for call in _calls_to(h, "report_validation_failure"):
+        for call in _calls_to(h, expected_reporter):
             integration = _kwarg_str(call, "integration")
             method = _kwarg_str(call, "method")
             if integration == case.integration and method == case.method:
                 matching_calls.append(call)
 
     assert matching_calls, (
-        f"{case.module_path}::{case.function} has no `report_validation_failure` call "
+        f"{case.module_path}::{case.function} has no `{expected_reporter}` call "
         f"with integration={case.integration!r} and method={case.method!r}"
     )
     # Each tagged (integration, method) pair should appear exactly once per function
@@ -398,13 +409,15 @@ def test_broad_except_calls_report_validation_failure(case: MigrationCase) -> No
 
 
 def test_every_migrated_module_imports_the_helper() -> None:
-    """Sanity guard: every file we touched should import report_validation_failure."""
-    seen_modules = {case.module_path for case in CASES}
-    for module_path in seen_modules:
+    """Sanity guard: every file we touched imports its expected reporter(s)."""
+    by_module: dict[str, set[str]] = {}
+    for case in CASES:
+        by_module.setdefault(case.module_path, set()).add(_expected_reporter(case))
+
+    for module_path, expected_helpers in by_module.items():
         source = (_REPO_ROOT / module_path).read_text(encoding="utf-8")
-        assert (
-            "from app.integrations._validation_helpers import report_validation_failure" in source
-        ), f"{module_path} migration is incomplete: missing import of report_validation_failure"
+        for helper in expected_helpers:
+            assert helper in source, f"{module_path} migration is incomplete: missing {helper}"
 
 
 def test_broad_except_handlers_skips_nested_handlers() -> None:

--- a/tests/integrations/test_validator_sentry_capture.py
+++ b/tests/integrations/test_validator_sentry_capture.py
@@ -43,20 +43,39 @@ class MigrationCase:
     function: str  # outer function name (may include "."-separated nested suffix)
     integration: str  # expected tag.integration
     method: str  # expected tag.method
+    reporter: str
 
 
 CASES: tuple[MigrationCase, ...] = (
     # trello
     MigrationCase(
-        "app/integrations/trello.py", "validate_trello_config", "trello", "validate_trello_config"
+        "app/integrations/trello.py",
+        "validate_trello_config",
+        "trello",
+        "validate_trello_config",
+        "report_validation_failure",
     ),
     # kafka
     MigrationCase(
-        "app/integrations/kafka.py", "validate_kafka_config", "kafka", "validate_kafka_config"
+        "app/integrations/kafka.py",
+        "validate_kafka_config",
+        "kafka",
+        "validate_kafka_config",
+        "report_validation_failure",
     ),
-    MigrationCase("app/integrations/kafka.py", "get_topic_health", "kafka", "get_topic_health"),
     MigrationCase(
-        "app/integrations/kafka.py", "get_consumer_group_lag", "kafka", "get_consumer_group_lag"
+        "app/integrations/kafka.py",
+        "get_topic_health",
+        "kafka",
+        "get_topic_health",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/kafka.py",
+        "get_consumer_group_lag",
+        "kafka",
+        "get_consumer_group_lag",
+        "report_integration_runtime_failure",
     ),
     # clickhouse
     MigrationCase(
@@ -64,15 +83,28 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_clickhouse_config",
         "clickhouse",
         "validate_clickhouse_config",
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/clickhouse.py", "get_query_activity", "clickhouse", "get_query_activity"
+        "app/integrations/clickhouse.py",
+        "get_query_activity",
+        "clickhouse",
+        "get_query_activity",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/clickhouse.py", "get_system_health", "clickhouse", "get_system_health"
+        "app/integrations/clickhouse.py",
+        "get_system_health",
+        "clickhouse",
+        "get_system_health",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/clickhouse.py", "get_table_stats", "clickhouse", "get_table_stats"
+        "app/integrations/clickhouse.py",
+        "get_table_stats",
+        "clickhouse",
+        "get_table_stats",
+        "report_integration_runtime_failure",
     ),
     # github_mcp
     MigrationCase(
@@ -80,6 +112,7 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_github_mcp_config",
         "github_mcp",
         "validate_github_mcp_config",
+        "report_validation_failure",
     ),
     # airflow (validate + loop site)
     MigrationCase(
@@ -87,12 +120,14 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_airflow_config",
         "airflow",
         "validate_airflow_config",
+        "report_validation_failure",
     ),
     MigrationCase(
         "app/integrations/airflow.py",
         "get_recent_airflow_failures",
         "airflow",
         "get_recent_airflow_failures.task_instances",
+        "report_integration_runtime_failure",
     ),
     # posthog
     MigrationCase(
@@ -100,6 +135,7 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_posthog_config",
         "posthog",
         "validate_posthog_config",
+        "report_validation_failure",
     ),
     # azure_sql
     MigrationCase(
@@ -107,26 +143,50 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_azure_sql_config",
         "azure_sql",
         "validate_azure_sql_config",
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/azure_sql.py", "get_server_status", "azure_sql", "get_server_status"
+        "app/integrations/azure_sql.py",
+        "get_server_status",
+        "azure_sql",
+        "get_server_status",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/azure_sql.py", "get_current_queries", "azure_sql", "get_current_queries"
+        "app/integrations/azure_sql.py",
+        "get_current_queries",
+        "azure_sql",
+        "get_current_queries",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/azure_sql.py", "get_resource_stats", "azure_sql", "get_resource_stats"
+        "app/integrations/azure_sql.py",
+        "get_resource_stats",
+        "azure_sql",
+        "get_resource_stats",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/azure_sql.py", "get_slow_queries", "azure_sql", "get_slow_queries"
+        "app/integrations/azure_sql.py",
+        "get_slow_queries",
+        "azure_sql",
+        "get_slow_queries",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/azure_sql.py", "get_wait_stats", "azure_sql", "get_wait_stats"),
+    MigrationCase(
+        "app/integrations/azure_sql.py",
+        "get_wait_stats",
+        "azure_sql",
+        "get_wait_stats",
+        "report_integration_runtime_failure",
+    ),
     # openclaw
     MigrationCase(
         "app/integrations/openclaw.py",
         "validate_openclaw_config",
         "openclaw",
         "validate_openclaw_config",
+        "report_validation_failure",
     ),
     # betterstack
     MigrationCase(
@@ -134,11 +194,22 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_betterstack_config",
         "betterstack",
         "validate_betterstack_config",
+        "report_validation_failure",
     ),
-    MigrationCase("app/integrations/betterstack.py", "query_logs", "betterstack", "query_logs"),
+    MigrationCase(
+        "app/integrations/betterstack.py",
+        "query_logs",
+        "betterstack",
+        "query_logs",
+        "report_integration_runtime_failure",
+    ),
     # gitlab
     MigrationCase(
-        "app/integrations/gitlab.py", "validate_gitlab_config", "gitlab", "validate_gitlab_config"
+        "app/integrations/gitlab.py",
+        "validate_gitlab_config",
+        "gitlab",
+        "validate_gitlab_config",
+        "report_validation_failure",
     ),
     # bitbucket
     MigrationCase(
@@ -146,29 +217,71 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_bitbucket_config",
         "bitbucket",
         "validate_bitbucket_config",
+        "report_validation_failure",
     ),
-    MigrationCase("app/integrations/bitbucket.py", "list_commits", "bitbucket", "list_commits"),
     MigrationCase(
-        "app/integrations/bitbucket.py", "get_file_contents", "bitbucket", "get_file_contents"
+        "app/integrations/bitbucket.py",
+        "list_commits",
+        "bitbucket",
+        "list_commits",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/bitbucket.py", "search_code", "bitbucket", "search_code"),
+    MigrationCase(
+        "app/integrations/bitbucket.py",
+        "get_file_contents",
+        "bitbucket",
+        "get_file_contents",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/bitbucket.py",
+        "search_code",
+        "bitbucket",
+        "search_code",
+        "report_integration_runtime_failure",
+    ),
     # mongodb
     MigrationCase(
         "app/integrations/mongodb.py",
         "validate_mongodb_config",
         "mongodb",
         "validate_mongodb_config",
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/mongodb.py", "get_server_status", "mongodb", "get_server_status"
+        "app/integrations/mongodb.py",
+        "get_server_status",
+        "mongodb",
+        "get_server_status",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/mongodb.py", "get_current_ops", "mongodb", "get_current_ops"),
-    MigrationCase("app/integrations/mongodb.py", "get_rs_status", "mongodb", "get_rs_status"),
     MigrationCase(
-        "app/integrations/mongodb.py", "get_profiler_data", "mongodb", "get_profiler_data"
+        "app/integrations/mongodb.py",
+        "get_current_ops",
+        "mongodb",
+        "get_current_ops",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/mongodb.py", "get_collection_stats", "mongodb", "get_collection_stats"
+        "app/integrations/mongodb.py",
+        "get_rs_status",
+        "mongodb",
+        "get_rs_status",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mongodb.py",
+        "get_profiler_data",
+        "mongodb",
+        "get_profiler_data",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mongodb.py",
+        "get_collection_stats",
+        "mongodb",
+        "get_collection_stats",
+        "report_integration_runtime_failure",
     ),
     # postgresql
     MigrationCase(
@@ -176,55 +289,128 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_postgresql_config",
         "postgresql",
         "validate_postgresql_config",
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/postgresql.py", "get_server_status", "postgresql", "get_server_status"
+        "app/integrations/postgresql.py",
+        "get_server_status",
+        "postgresql",
+        "get_server_status",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/postgresql.py", "get_current_queries", "postgresql", "get_current_queries"
+        "app/integrations/postgresql.py",
+        "get_current_queries",
+        "postgresql",
+        "get_current_queries",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
         "app/integrations/postgresql.py",
         "get_replication_status",
         "postgresql",
         "get_replication_status",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/postgresql.py", "get_slow_queries", "postgresql", "get_slow_queries"
+        "app/integrations/postgresql.py",
+        "get_slow_queries",
+        "postgresql",
+        "get_slow_queries",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/postgresql.py", "get_table_stats", "postgresql", "get_table_stats"
+        "app/integrations/postgresql.py",
+        "get_table_stats",
+        "postgresql",
+        "get_table_stats",
+        "report_integration_runtime_failure",
     ),
     # mysql
     MigrationCase(
-        "app/integrations/mysql.py", "validate_mysql_config", "mysql", "validate_mysql_config"
+        "app/integrations/mysql.py",
+        "validate_mysql_config",
+        "mysql",
+        "validate_mysql_config",
+        "report_validation_failure",
     ),
-    MigrationCase("app/integrations/mysql.py", "get_server_status", "mysql", "get_server_status"),
     MigrationCase(
-        "app/integrations/mysql.py", "get_current_processes", "mysql", "get_current_processes"
+        "app/integrations/mysql.py",
+        "get_server_status",
+        "mysql",
+        "get_server_status",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/mysql.py", "get_replication_status", "mysql", "get_replication_status"
+        "app/integrations/mysql.py",
+        "get_current_processes",
+        "mysql",
+        "get_current_processes",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/mysql.py", "get_slow_queries", "mysql", "get_slow_queries"),
-    MigrationCase("app/integrations/mysql.py", "get_table_stats", "mysql", "get_table_stats"),
+    MigrationCase(
+        "app/integrations/mysql.py",
+        "get_replication_status",
+        "mysql",
+        "get_replication_status",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mysql.py",
+        "get_slow_queries",
+        "mysql",
+        "get_slow_queries",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mysql.py",
+        "get_table_stats",
+        "mysql",
+        "get_table_stats",
+        "report_integration_runtime_failure",
+    ),
     # mariadb
     MigrationCase(
         "app/integrations/mariadb.py",
         "validate_mariadb_config",
         "mariadb",
         "validate_mariadb_config",
-    ),
-    MigrationCase("app/integrations/mariadb.py", "get_process_list", "mariadb", "get_process_list"),
-    MigrationCase(
-        "app/integrations/mariadb.py", "get_global_status", "mariadb", "get_global_status"
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/mariadb.py", "get_innodb_status", "mariadb", "get_innodb_status"
+        "app/integrations/mariadb.py",
+        "get_process_list",
+        "mariadb",
+        "get_process_list",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/mariadb.py", "get_slow_queries", "mariadb", "get_slow_queries"),
     MigrationCase(
-        "app/integrations/mariadb.py", "get_replication_status", "mariadb", "get_replication_status"
+        "app/integrations/mariadb.py",
+        "get_global_status",
+        "mariadb",
+        "get_global_status",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mariadb.py",
+        "get_innodb_status",
+        "mariadb",
+        "get_innodb_status",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mariadb.py",
+        "get_slow_queries",
+        "mariadb",
+        "get_slow_queries",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/mariadb.py",
+        "get_replication_status",
+        "mariadb",
+        "get_replication_status",
+        "report_integration_runtime_failure",
     ),
     # rabbitmq
     MigrationCase(
@@ -232,19 +418,42 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_rabbitmq_config",
         "rabbitmq",
         "validate_rabbitmq_config",
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/rabbitmq.py", "get_queue_backlog", "rabbitmq", "get_queue_backlog"
+        "app/integrations/rabbitmq.py",
+        "get_queue_backlog",
+        "rabbitmq",
+        "get_queue_backlog",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/rabbitmq.py", "get_consumer_health", "rabbitmq", "get_consumer_health"
+        "app/integrations/rabbitmq.py",
+        "get_consumer_health",
+        "rabbitmq",
+        "get_consumer_health",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
-        "app/integrations/rabbitmq.py", "get_broker_overview", "rabbitmq", "get_broker_overview"
+        "app/integrations/rabbitmq.py",
+        "get_broker_overview",
+        "rabbitmq",
+        "get_broker_overview",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/rabbitmq.py", "get_node_health", "rabbitmq", "get_node_health"),
     MigrationCase(
-        "app/integrations/rabbitmq.py", "get_connection_stats", "rabbitmq", "get_connection_stats"
+        "app/integrations/rabbitmq.py",
+        "get_node_health",
+        "rabbitmq",
+        "get_node_health",
+        "report_integration_runtime_failure",
+    ),
+    MigrationCase(
+        "app/integrations/rabbitmq.py",
+        "get_connection_stats",
+        "rabbitmq",
+        "get_connection_stats",
+        "report_integration_runtime_failure",
     ),
     # mongodb_atlas
     MigrationCase(
@@ -252,32 +461,50 @@ CASES: tuple[MigrationCase, ...] = (
         "validate_mongodb_atlas_config",
         "mongodb_atlas",
         "validate_mongodb_atlas_config",
+        "report_validation_failure",
     ),
     MigrationCase(
-        "app/integrations/mongodb_atlas.py", "get_clusters", "mongodb_atlas", "get_clusters"
+        "app/integrations/mongodb_atlas.py",
+        "get_clusters",
+        "mongodb_atlas",
+        "get_clusters",
+        "report_integration_runtime_failure",
     ),
-    MigrationCase("app/integrations/mongodb_atlas.py", "get_alerts", "mongodb_atlas", "get_alerts"),
+    MigrationCase(
+        "app/integrations/mongodb_atlas.py",
+        "get_alerts",
+        "mongodb_atlas",
+        "get_alerts",
+        "report_integration_runtime_failure",
+    ),
     MigrationCase(
         "app/integrations/mongodb_atlas.py",
         "get_cluster_metrics",
         "mongodb_atlas",
         "get_cluster_metrics",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
         "app/integrations/mongodb_atlas.py",
         "get_performance_advisor",
         "mongodb_atlas",
         "get_performance_advisor",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
         "app/integrations/mongodb_atlas.py",
         "get_cluster_events",
         "mongodb_atlas",
         "get_cluster_events",
+        "report_integration_runtime_failure",
     ),
     # sentry (its own validator captures into OpenSRE's Sentry)
     MigrationCase(
-        "app/integrations/sentry.py", "validate_sentry_config", "sentry", "validate_sentry_config"
+        "app/integrations/sentry.py",
+        "validate_sentry_config",
+        "sentry",
+        "validate_sentry_config",
+        "report_validation_failure",
     ),
     # adjacent
     MigrationCase(
@@ -285,12 +512,14 @@ CASES: tuple[MigrationCase, ...] = (
         "summarize_highlights",
         "daily_update",
         "summarize_highlights",
+        "report_integration_runtime_failure",
     ),
     MigrationCase(
         "app/integrations/llm_cli/kimi.py",
         "_check_kimi_auth_fallback",
         "kimi",
         "_check_kimi_auth_fallback",
+        "report_integration_runtime_failure",
     ),
 )
 
@@ -366,10 +595,16 @@ def _kwarg_str(call: ast.Call, key: str) -> str | None:
     return None
 
 
-def _expected_reporter(case: MigrationCase) -> str:
-    if case.function.startswith("validate_"):
-        return "report_validation_failure"
-    return "report_integration_runtime_failure"
+def _imported_validation_helpers(tree: ast.AST) -> set[str]:
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "app.integrations._validation_helpers"
+        ):
+            continue
+        imported.update(alias.asname or alias.name for alias in node.names)
+    return imported
 
 
 @pytest.mark.parametrize(
@@ -386,17 +621,16 @@ def test_broad_except_calls_expected_integration_reporter(case: MigrationCase) -
     handlers = _broad_except_handlers(fn)
     assert handlers, f"no `except Exception` handlers in {case.module_path}::{case.function}"
 
-    expected_reporter = _expected_reporter(case)
     matching_calls: list[ast.Call] = []
     for h in handlers:
-        for call in _calls_to(h, expected_reporter):
+        for call in _calls_to(h, case.reporter):
             integration = _kwarg_str(call, "integration")
             method = _kwarg_str(call, "method")
             if integration == case.integration and method == case.method:
                 matching_calls.append(call)
 
     assert matching_calls, (
-        f"{case.module_path}::{case.function} has no `{expected_reporter}` call "
+        f"{case.module_path}::{case.function} has no `{case.reporter}` call "
         f"with integration={case.integration!r} and method={case.method!r}"
     )
     # Each tagged (integration, method) pair should appear exactly once per function
@@ -412,12 +646,17 @@ def test_every_migrated_module_imports_the_helper() -> None:
     """Sanity guard: every file we touched imports its expected reporter(s)."""
     by_module: dict[str, set[str]] = {}
     for case in CASES:
-        by_module.setdefault(case.module_path, set()).add(_expected_reporter(case))
+        by_module.setdefault(case.module_path, set()).add(case.reporter)
 
     for module_path, expected_helpers in by_module.items():
         source = (_REPO_ROOT / module_path).read_text(encoding="utf-8")
-        for helper in expected_helpers:
-            assert helper in source, f"{module_path} migration is incomplete: missing {helper}"
+        tree = ast.parse(source)
+        imported_helpers = _imported_validation_helpers(tree)
+        missing = expected_helpers - imported_helpers
+        assert not missing, (
+            f"{module_path} migration is incomplete: missing imports from "
+            f"app.integrations._validation_helpers: {sorted(missing)!r}"
+        )
 
 
 def test_broad_except_handlers_skips_nested_handlers() -> None:


### PR DESCRIPTION
Fixes #2071
Fixes #2072
Fixes #2073

#### Describe the changes you have made in this PR

Runtime integration tool failures are now logged without being reported to Sentry.

Previously, PostgreSQL diagnostic failures like “server unreachable” were returned as tool results but also captured as Sentry issues. These are downstream/operator-actionable failures, not OpenSRE product bugs.

Changes:
- Added `report_integration_runtime_failure(...)` for runtime integration/tool failures.
- Kept `report_validation_failure(...)` for validation/config failures that should still go to Sentry.
- Migrated runtime integration diagnostic methods to the new helper.
- Updated the AST guard test to enforce the correct helper by function type.

This is related in theme to #2111, but this PR fixes the integration runtime reporting path. #2111 tracks LLM provider error classification.

### Demo/Screenshot for feature changes and bug fixes

Verified locally:

```powershell
uv run ruff check app/integrations tests/integrations/test_validation_helpers.py tests/integrations/test_validator_sentry_capture.py

uv run pytest tests/integrations/test_validation_helpers.py tests/integrations/test_validator_sentry_capture.py tests/tools/test_postgresql_replication_status_tool.py tests/tools/test_postgresql_slow_queries_tool.py tests/tools/test_postgresql_table_stats_tool.py tests/integrations/test_postgresql.py
```