### PR TITLE
Add CloudOpsBench LLM benchmark framework

### DIFF
--- a/app/cli/commands/__init__.py
+++ b/app/cli/commands/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from app.cli.commands.agent import agents
+from app.cli.commands.bench import bench_command
 from app.cli.commands.config import config_command
 from app.cli.commands.doctor import doctor_command
 from app.cli.commands.general import (
@@ -28,6 +29,7 @@ _COMMANDS: tuple[click.Command, ...] = (
     onboard,
     config_command,
     remote,
+    bench_command,
     tests,
     integrations,
     guardrails,

--- a/app/cli/commands/bench.py
+++ b/app/cli/commands/bench.py
@@ -1,0 +1,163 @@
+"""Benchmark CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from app.cli.support.errors import OpenSREError
+
+
+@click.group(name="bench")
+def bench_command() -> None:
+    """Run and report OpenSRE benchmark suites."""
+
+
+@bench_command.command(name="list")
+def list_benchmarks() -> None:
+    """Show available benchmark adapters."""
+    from tests.benchmarks._framework.registry import available_adapters
+
+    for name in sorted(available_adapters()):
+        click.echo(name)
+
+
+@bench_command.command(name="validate")
+@click.argument("config", type=click.Path(exists=True, dir_okay=False))
+def validate_config(config: str) -> None:
+    """Validate a benchmark YAML config without executing cases."""
+    from tests.benchmarks._framework.config import load_benchmark_config
+    from tests.benchmarks._framework.registry import create_adapter
+
+    try:
+        loaded = load_benchmark_config(config)
+        create_adapter(loaded.benchmark)
+    except Exception as exc:
+        raise OpenSREError(str(exc)) from exc
+    click.echo(f"OK: {config}")
+
+
+@bench_command.command(name="run")
+@click.option("--config", "config_path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--benchmark", default="", help="Benchmark adapter name for ad-hoc runs.")
+@click.option("--llm", "llms", multiple=True, help="LLM alias or provider:model. Repeatable.")
+@click.option("--workers", default=0, type=int, help="Override worker count.")
+@click.option("--limit", default=0, type=int, help="Limit cases for ad-hoc runs.")
+@click.option("--output-dir", default="", help="Override result output directory.")
+@click.option("--json", "output_json", is_flag=True, help="Print machine-readable summary.")
+def run_benchmark(
+    config_path: str | None,
+    benchmark: str,
+    llms: tuple[str, ...],
+    workers: int,
+    limit: int,
+    output_dir: str,
+    output_json: bool,
+) -> None:
+    """Run a benchmark from YAML or ad-hoc options."""
+    from tests.benchmarks._framework.config import BenchmarkConfig, load_benchmark_config
+    from tests.benchmarks._framework.registry import create_adapter
+    from tests.benchmarks._framework.runner import run_benchmark as run_framework_benchmark
+
+    try:
+        if config_path:
+            loaded = load_benchmark_config(config_path)
+            filters = dict(loaded.filters)
+            if limit:
+                filters["limit"] = limit
+            config = BenchmarkConfig(
+                benchmark=loaded.benchmark,
+                modes=loaded.modes,
+                llms=llms or loaded.llms,
+                runs_per_case=loaded.runs_per_case,
+                workers=workers or loaded.workers,
+                cost_budget_usd=loaded.cost_budget_usd,
+                filters=filters,
+                output_dir=output_dir or loaded.output_dir,
+                report_formats=loaded.report_formats,
+                strict_parity=loaded.strict_parity,
+            )
+        else:
+            if not benchmark:
+                raise OpenSREError(
+                    "Missing --config or --benchmark.",
+                    suggestion="Run 'opensre bench run --config tests/benchmarks/configs/claude-vs-paper.yml'.",
+                )
+            filters: dict[str, Any] = {}
+            if limit:
+                filters["limit"] = limit
+            config = BenchmarkConfig(
+                benchmark=benchmark,
+                llms=llms,
+                workers=workers or 8,
+                filters=filters,
+                output_dir=output_dir or ".bench-results/latest",
+                report_formats=("json", "markdown"),
+            )
+        result = run_framework_benchmark(create_adapter(config.benchmark), config)
+    except OpenSREError:
+        raise
+    except Exception as exc:
+        raise OpenSREError(str(exc)) from exc
+
+    if output_json:
+        click.echo(json.dumps(result.payload, indent=2))
+    else:
+        click.echo(f"Wrote benchmark reports to {result.output_dir}")
+
+
+@bench_command.command(name="report")
+@click.argument("run_dir", type=click.Path(exists=True, file_okay=False))
+@click.option("--format", "formats", multiple=True, default=("markdown",))
+def report_benchmark(run_dir: str, formats: tuple[str, ...]) -> None:
+    """Regenerate benchmark reports from a run directory summary."""
+    from tests.benchmarks._framework.reporting import write_reports
+
+    summary_path = Path(run_dir) / "summary.json"
+    if not summary_path.is_file():
+        raise OpenSREError(f"No summary.json found in {run_dir}")
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    write_reports(payload, Path(run_dir), tuple(formats))
+    click.echo(f"Wrote {', '.join(formats)} report(s) to {run_dir}")
+
+
+@bench_command.command(name="compare")
+@click.argument("left", type=click.Path(exists=True, file_okay=False))
+@click.argument("right", type=click.Path(exists=True, file_okay=False))
+def compare_benchmarks(left: str, right: str) -> None:
+    """Compare two benchmark summary directories."""
+    left_payload = _read_summary(left)
+    right_payload = _read_summary(right)
+    click.echo(json.dumps(_compare_payloads(left_payload, right_payload), indent=2))
+
+
+def _read_summary(run_dir: str) -> dict[str, Any]:
+    path = Path(run_dir) / "summary.json"
+    if not path.is_file():
+        raise OpenSREError(f"No summary.json found in {run_dir}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise OpenSREError(f"{path}: expected JSON object")
+    return payload
+
+
+def _compare_payloads(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "left": {
+            "benchmark": left.get("benchmark"),
+            "runs": len(left.get("results", [])),
+            "cost_usd": left.get("cost_usd", 0.0),
+        },
+        "right": {
+            "benchmark": right.get("benchmark"),
+            "runs": len(right.get("results", [])),
+            "cost_usd": right.get("cost_usd", 0.0),
+        },
+        "delta": {
+            "runs": len(right.get("results", [])) - len(left.get("results", [])),
+            "cost_usd": float(right.get("cost_usd", 0.0)) - float(left.get("cost_usd", 0.0)),
+        },
+    }

--- a/tests/benchmarks/_framework/__init__.py
+++ b/tests/benchmarks/_framework/__init__.py
@@ -1,0 +1,14 @@
+"""Reusable benchmark framework for OpenSRE evaluation suites."""
+
+from tests.benchmarks._framework.adapters import BenchmarkAdapter, BenchmarkCase
+from tests.benchmarks._framework.config import BenchmarkConfig, load_benchmark_config
+from tests.benchmarks._framework.runner import BenchmarkRunResult, run_benchmark
+
+__all__ = [
+    "BenchmarkAdapter",
+    "BenchmarkCase",
+    "BenchmarkConfig",
+    "BenchmarkRunResult",
+    "load_benchmark_config",
+    "run_benchmark",
+]

--- a/tests/benchmarks/_framework/adapters.py
+++ b/tests/benchmarks/_framework/adapters.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """Framework-neutral case metadata used by benchmark adapters."""
+
+    case_id: str
+    payload: Any
+    tags: dict[str, Any] = field(default_factory=dict)
+
+
+class BenchmarkAdapter(ABC):
+    """Contract implemented by benchmark-specific adapters."""
+
+    name: str
+    version: str
+
+    @abstractmethod
+    def load_cases(self, filters: dict[str, Any]) -> Iterable[BenchmarkCase]:
+        """Load cases matching framework-level filters."""
+
+    @abstractmethod
+    def run_case(self, case: BenchmarkCase, output_dir: str) -> dict[str, Any]:
+        """Execute one OpenSRE run and return a serializable run payload."""
+
+    @abstractmethod
+    def score_case(self, case: BenchmarkCase, run_result: dict[str, Any]) -> dict[str, Any]:
+        """Score one run result using the adapter's benchmark metrics."""
+
+    @abstractmethod
+    def metric_schema(self) -> dict[str, Any]:
+        """Return metric metadata for reports and comparison tooling."""

--- a/tests/benchmarks/_framework/config.py
+++ b/tests/benchmarks/_framework/config.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_WORKERS = min(8, os.cpu_count() or 1)
+DEFAULT_MODES = ("opensre+llm",)
+DEFAULT_REPORT_FORMATS = ("json", "markdown")
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    benchmark: str
+    modes: tuple[str, ...] = DEFAULT_MODES
+    llms: tuple[str, ...] = ()
+    runs_per_case: int = 1
+    workers: int = DEFAULT_WORKERS
+    cost_budget_usd: float | None = None
+    filters: dict[str, Any] = field(default_factory=dict)
+    output_dir: str = ".bench-results/latest"
+    report_formats: tuple[str, ...] = DEFAULT_REPORT_FORMATS
+    strict_parity: bool = False
+
+
+def _as_tuple(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field_name} must be a list of strings")
+    return tuple(item.strip() for item in value if item.strip())
+
+
+def _positive_int(raw: Any, *, field_name: str) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer") from exc
+    if value < 1:
+        raise ValueError(f"{field_name} must be >= 1")
+    return value
+
+
+def benchmark_config_from_dict(payload: dict[str, Any]) -> BenchmarkConfig:
+    benchmark = str(payload.get("benchmark") or "").strip()
+    if not benchmark:
+        raise ValueError("benchmark is required")
+
+    filters = payload.get("filters") or {}
+    if not isinstance(filters, dict):
+        raise ValueError("filters must be an object")
+
+    modes = _as_tuple(payload.get("modes", list(DEFAULT_MODES)), field_name="modes")
+    if not modes:
+        modes = DEFAULT_MODES
+    unsupported_modes = sorted(set(modes) - {"opensre+llm", "llm_alone"})
+    if unsupported_modes:
+        raise ValueError(f"unsupported modes: {', '.join(unsupported_modes)}")
+
+    formats = _as_tuple(
+        payload.get("report_formats", list(DEFAULT_REPORT_FORMATS)),
+        field_name="report_formats",
+    )
+    if not formats:
+        formats = DEFAULT_REPORT_FORMATS
+    unsupported_formats = sorted(set(formats) - {"json", "markdown", "html"})
+    if unsupported_formats:
+        raise ValueError(f"unsupported report formats: {', '.join(unsupported_formats)}")
+
+    cost_budget_raw = payload.get("cost_budget_usd")
+    cost_budget = float(cost_budget_raw) if cost_budget_raw is not None else None
+    if cost_budget is not None and cost_budget <= 0:
+        raise ValueError("cost_budget_usd must be > 0")
+
+    return BenchmarkConfig(
+        benchmark=benchmark,
+        modes=modes,
+        llms=_as_tuple(payload.get("llms", []), field_name="llms"),
+        runs_per_case=_positive_int(payload.get("runs_per_case", 1), field_name="runs_per_case"),
+        workers=_positive_int(payload.get("workers", DEFAULT_WORKERS), field_name="workers"),
+        cost_budget_usd=cost_budget,
+        filters=dict(filters),
+        output_dir=str(payload.get("output_dir") or ".bench-results/latest"),
+        report_formats=formats,
+        strict_parity=bool(payload.get("strict_parity", False)),
+    )
+
+
+def load_benchmark_config(path: str | Path) -> BenchmarkConfig:
+    config_path = Path(path)
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{config_path}: expected a YAML object")
+    return benchmark_config_from_dict(raw)

--- a/tests/benchmarks/_framework/cost.py
+++ b/tests/benchmarks/_framework/cost.py
@@ -8,6 +8,7 @@ DEFAULT_MODEL_PRICES_USD_PER_MTOK: dict[str, float] = {
     "gpt-5": 3.0,
     "gpt-4o": 2.5,
 }
+TOOL_TIER_PRICE_MULTIPLIER = 0.2
 
 
 def _classify_pricing_tier(model_id: str, reasoning_model: str, tool_model: str) -> str:
@@ -55,17 +56,17 @@ def estimate_case_cost_usd(
 ) -> tuple[float, dict[str, float]]:
     if not tokens_by_model:
         return 0.0, {}
-    if all(isinstance(value, dict) for value in tokens_by_model.values()):
-        price = DEFAULT_MODEL_PRICES_USD_PER_MTOK.get(llm.lower(), 3.0)
-        breakdown = {
-            model_id: (token_count(value) / 1_000_000.0) * price
-            for model_id, value in tokens_by_model.items()
-        }
-        return sum(breakdown.values()), breakdown
     price = DEFAULT_MODEL_PRICES_USD_PER_MTOK.get(llm.lower(), 3.0)
+    if all(isinstance(value, dict) for value in tokens_by_model.values()):
+        breakdown = {}
+        for model_id, value in tokens_by_model.items():
+            tier = _classify_pricing_tier(model_id, reasoning_model=llm, tool_model=llm)
+            rate = price if tier == "reasoning" else price * TOOL_TIER_PRICE_MULTIPLIER
+            breakdown[model_id] = (token_count(value) / 1_000_000.0) * rate
+        return sum(breakdown.values()), breakdown
     breakdown: dict[str, float] = {}
     for model_id, token_bucket in tokens_by_model.items():
         tier = _classify_pricing_tier(model_id, reasoning_model=llm, tool_model=llm)
-        rate = price if tier == "reasoning" else price
+        rate = price if tier == "reasoning" else price * TOOL_TIER_PRICE_MULTIPLIER
         breakdown[model_id] = (token_count(token_bucket) / 1_000_000.0) * rate
     return sum(breakdown.values()), breakdown

--- a/tests/benchmarks/_framework/cost.py
+++ b/tests/benchmarks/_framework/cost.py
@@ -2,14 +2,25 @@ from __future__ import annotations
 
 from typing import Any
 
-from tests.benchmarks.toolcall_model_benchmark.pricing import estimate_run_cost_usd
-
 DEFAULT_MODEL_PRICES_USD_PER_MTOK: dict[str, float] = {
     "claude-4-sonnet": 3.0,
     "deepseek-v3.2": 1.0,
     "gpt-5": 3.0,
     "gpt-4o": 2.5,
 }
+
+
+def _classify_pricing_tier(model_id: str, reasoning_model: str, tool_model: str) -> str:
+    normalized = model_id.lower()
+    if model_id == reasoning_model or normalized == reasoning_model.lower():
+        return "reasoning"
+    if model_id == tool_model or normalized == tool_model.lower():
+        return "tool"
+    if "haiku" in normalized:
+        return "tool"
+    if "sonnet" in normalized or "opus" in normalized:
+        return "reasoning"
+    return "reasoning"
 
 
 def token_count(value: Any) -> int:
@@ -52,10 +63,9 @@ def estimate_case_cost_usd(
         }
         return sum(breakdown.values()), breakdown
     price = DEFAULT_MODEL_PRICES_USD_PER_MTOK.get(llm.lower(), 3.0)
-    return estimate_run_cost_usd(
-        tokens_by_model,
-        reasoning_model=llm,
-        tool_model=llm,
-        reasoning_usd_per_mtok=price,
-        tool_usd_per_mtok=price,
-    )
+    breakdown: dict[str, float] = {}
+    for model_id, token_bucket in tokens_by_model.items():
+        tier = _classify_pricing_tier(model_id, reasoning_model=llm, tool_model=llm)
+        rate = price if tier == "reasoning" else price
+        breakdown[model_id] = (token_count(token_bucket) / 1_000_000.0) * rate
+    return sum(breakdown.values()), breakdown

--- a/tests/benchmarks/_framework/cost.py
+++ b/tests/benchmarks/_framework/cost.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tests.benchmarks.toolcall_model_benchmark.pricing import estimate_run_cost_usd
+
+DEFAULT_MODEL_PRICES_USD_PER_MTOK: dict[str, float] = {
+    "claude-4-sonnet": 3.0,
+    "deepseek-v3.2": 1.0,
+    "gpt-5": 3.0,
+    "gpt-4o": 2.5,
+}
+
+
+def token_count(value: Any) -> int:
+    total = getattr(value, "total", None)
+    if callable(total):
+        return int(total())
+    if isinstance(total, int):
+        return total
+    if isinstance(value, dict):
+        return int(value.get("input_tokens", 0) or 0) + int(value.get("output_tokens", 0) or 0)
+    return int(getattr(value, "input_tokens", 0) or 0) + int(
+        getattr(value, "output_tokens", 0) or 0
+    )
+
+
+def tokens_by_model_from_state(state: dict[str, Any]) -> dict[str, Any]:
+    candidates = [
+        state.get("tokens_by_model"),
+        state.get("token_usage_by_model"),
+        state.get("usage_by_model"),
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            return candidate
+    return {}
+
+
+def estimate_case_cost_usd(
+    tokens_by_model: dict[str, Any],
+    *,
+    llm: str,
+) -> tuple[float, dict[str, float]]:
+    if not tokens_by_model:
+        return 0.0, {}
+    if all(isinstance(value, dict) for value in tokens_by_model.values()):
+        price = DEFAULT_MODEL_PRICES_USD_PER_MTOK.get(llm.lower(), 3.0)
+        breakdown = {
+            model_id: (token_count(value) / 1_000_000.0) * price
+            for model_id, value in tokens_by_model.items()
+        }
+        return sum(breakdown.values()), breakdown
+    price = DEFAULT_MODEL_PRICES_USD_PER_MTOK.get(llm.lower(), 3.0)
+    return estimate_run_cost_usd(
+        tokens_by_model,
+        reasoning_model=llm,
+        tool_model=llm,
+        reasoning_usd_per_mtok=price,
+        tool_usd_per_mtok=price,
+    )

--- a/tests/benchmarks/_framework/llm_dispatch.py
+++ b/tests/benchmarks/_framework/llm_dispatch.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+MODEL_ALIASES: dict[str, tuple[str, str]] = {
+    "claude-4-sonnet": ("anthropic", "claude-sonnet-4-20250514"),
+    "deepseek-v3.2": ("openrouter", "deepseek/deepseek-v3.2"),
+    "gpt-5": ("openai", "gpt-5"),
+    "gpt-4o": ("openai", "gpt-4o"),
+}
+
+
+def resolve_llm_alias(llm: str) -> tuple[str, str]:
+    if ":" in llm:
+        provider, model = llm.split(":", 1)
+        return provider.strip(), model.strip()
+    return MODEL_ALIASES.get(llm.lower(), ("", llm))
+
+
+@contextmanager
+def llm_environment(llm: str) -> Iterator[None]:
+    """Temporarily pin OpenSRE's provider/model environment for one run."""
+
+    provider, model = resolve_llm_alias(llm)
+    updates: dict[str, str] = {"OPENSRE_BENCH_LLM": llm}
+    if provider:
+        updates["LLM_PROVIDER"] = provider
+        prefix = provider.upper()
+        updates[f"{prefix}_REASONING_MODEL"] = model
+        updates[f"{prefix}_CLASSIFICATION_MODEL"] = model
+        updates[f"{prefix}_TOOLCALL_MODEL"] = model
+
+    previous = {key: os.environ.get(key) for key in updates}
+    os.environ.update(updates)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value

--- a/tests/benchmarks/_framework/llm_dispatch.py
+++ b/tests/benchmarks/_framework/llm_dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -10,6 +11,8 @@ MODEL_ALIASES: dict[str, tuple[str, str]] = {
     "gpt-5": ("openai", "gpt-5"),
     "gpt-4o": ("openai", "gpt-4o"),
 }
+
+_ENV_LOCK = threading.RLock()
 
 
 def resolve_llm_alias(llm: str) -> tuple[str, str]:
@@ -23,22 +26,23 @@ def resolve_llm_alias(llm: str) -> tuple[str, str]:
 def llm_environment(llm: str) -> Iterator[None]:
     """Temporarily pin OpenSRE's provider/model environment for one run."""
 
-    provider, model = resolve_llm_alias(llm)
-    updates: dict[str, str] = {"OPENSRE_BENCH_LLM": llm}
-    if provider:
-        updates["LLM_PROVIDER"] = provider
-        prefix = provider.upper()
-        updates[f"{prefix}_REASONING_MODEL"] = model
-        updates[f"{prefix}_CLASSIFICATION_MODEL"] = model
-        updates[f"{prefix}_TOOLCALL_MODEL"] = model
+    with _ENV_LOCK:
+        provider, model = resolve_llm_alias(llm)
+        updates: dict[str, str] = {"OPENSRE_BENCH_LLM": llm}
+        if provider:
+            updates["LLM_PROVIDER"] = provider
+            prefix = provider.upper()
+            updates[f"{prefix}_REASONING_MODEL"] = model
+            updates[f"{prefix}_CLASSIFICATION_MODEL"] = model
+            updates[f"{prefix}_TOOLCALL_MODEL"] = model
 
-    previous = {key: os.environ.get(key) for key in updates}
-    os.environ.update(updates)
-    try:
-        yield
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
+        previous = {key: os.environ.get(key) for key in updates}
+        os.environ.update(updates)
+        try:
+            yield
+        finally:
+            for key, value in previous.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value

--- a/tests/benchmarks/_framework/registry.py
+++ b/tests/benchmarks/_framework/registry.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from tests.benchmarks._framework.adapters import BenchmarkAdapter
+from tests.benchmarks.cloudopsbench.adapter import CloudOpsBenchAdapter
+from tests.benchmarks.openrca_scenarios.adapter import OpenRCAScenariosAdapter
+
+
+def available_adapters() -> dict[str, type[BenchmarkAdapter]]:
+    return {
+        "cloudopsbench": CloudOpsBenchAdapter,
+        "openrca_scenarios": OpenRCAScenariosAdapter,
+    }
+
+
+def create_adapter(name: str) -> BenchmarkAdapter:
+    adapters = available_adapters()
+    try:
+        return adapters[name]()
+    except KeyError as exc:
+        names = ", ".join(sorted(adapters))
+        raise ValueError(f"Unknown benchmark adapter '{name}'. Available: {names}") from exc

--- a/tests/benchmarks/_framework/reporting.py
+++ b/tests/benchmarks/_framework/reporting.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+PAPER_BASELINES: dict[str, dict[str, float]] = {
+    "deepseek-v3.2": {"a1": 0.73},
+    "gpt-5": {"a1": 0.67},
+    "gpt-4o": {"a1": 0.49},
+    "claude-4-sonnet": {"a1": 0.50},
+}
+
+
+def summarize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    results = payload.get("results", [])
+    by_llm: dict[str, list[dict[str, Any]]] = {}
+    for result in results:
+        if isinstance(result, dict):
+            by_llm.setdefault(str(result.get("llm") or ""), []).append(result)
+
+    comparisons: dict[str, dict[str, float]] = {}
+    for llm, rows in by_llm.items():
+        metrics = [
+            (row.get("score") or {}).get("metrics", {})
+            for row in rows
+            if isinstance(row.get("score"), dict)
+        ]
+        a1_values = [float(metric["a1"]) for metric in metrics if "a1" in metric]
+        if not a1_values:
+            continue
+        opensre_a1 = sum(a1_values) / len(a1_values)
+        paper_a1 = PAPER_BASELINES.get(llm.lower(), {}).get("a1")
+        comparisons[llm] = {
+            "opensre_a1": opensre_a1,
+            "paper_a1": paper_a1 if paper_a1 is not None else 0.0,
+            "a1_lift": opensre_a1 - paper_a1 if paper_a1 is not None else 0.0,
+        }
+    return {"paper_baseline_comparison": comparisons}
+
+
+def write_reports(payload: dict[str, Any], output_dir: Path, formats: tuple[str, ...]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    enriched = dict(payload)
+    enriched["comparison"] = summarize_payload(payload)
+    if "json" in formats:
+        (output_dir / "summary.json").write_text(
+            json.dumps(enriched, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    if "markdown" in formats:
+        (output_dir / "summary.md").write_text(render_markdown(enriched), encoding="utf-8")
+    if "html" in formats:
+        (output_dir / "summary.html").write_text(render_html(enriched), encoding="utf-8")
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# OpenSRE Benchmark Report",
+        "",
+        f"- Benchmark: `{payload.get('benchmark', '')}`",
+        f"- Cases: {payload.get('case_count', 0)}",
+        f"- Runs: {len(payload.get('results', []))}",
+        f"- Estimated cost: ${float(payload.get('cost_usd', 0.0)):.4f}",
+        "",
+        "## LLM vs Paper Baseline",
+        "",
+        "| LLM | OpenSRE A@1 | Paper A@1 | Lift |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    comparison = payload.get("comparison", {}).get("paper_baseline_comparison", {})
+    if comparison:
+        for llm, row in sorted(comparison.items()):
+            lines.append(
+                f"| {llm} | {row['opensre_a1']:.3f} | "
+                f"{row['paper_a1']:.3f} | {row['a1_lift']:.3f} |"
+            )
+    else:
+        lines.append("| - | - | - | - |")
+    lines.extend(["", "## Notes", "", "- Expected deltas: validity > accuracy > speed."])
+    return "\n".join(lines) + "\n"
+
+
+def render_html(payload: dict[str, Any]) -> str:
+    markdown = html.escape(render_markdown(payload))
+    return (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        "<title>OpenSRE Benchmark Report</title></head><body><pre>"
+        f"{markdown}</pre></body></html>\n"
+    )

--- a/tests/benchmarks/_framework/runner.py
+++ b/tests/benchmarks/_framework/runner.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tests.benchmarks._framework.adapters import BenchmarkAdapter, BenchmarkCase
+from tests.benchmarks._framework.config import BenchmarkConfig
+from tests.benchmarks._framework.cost import estimate_case_cost_usd, tokens_by_model_from_state
+from tests.benchmarks._framework.llm_dispatch import llm_environment
+from tests.benchmarks._framework.reporting import write_reports
+
+
+@dataclass(frozen=True)
+class BenchmarkRunResult:
+    payload: dict[str, Any]
+    output_dir: Path
+
+
+def _case_seen_shape(case: BenchmarkCase) -> bool:
+    raw = case.tags.get("seen_shape")
+    return bool(raw) if raw is not None else False
+
+
+def _run_one(
+    adapter: BenchmarkAdapter,
+    case: BenchmarkCase,
+    *,
+    llm: str,
+    run_index: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    case_output = output_dir / "cases" / llm / f"run-{run_index}"
+    with llm_environment(llm):
+        run_payload = adapter.run_case(case, str(case_output))
+    score = adapter.score_case(case, run_payload)
+    final_state = run_payload.get("run", {}).get("final_state", {})
+    tokens_by_model = tokens_by_model_from_state(
+        final_state if isinstance(final_state, dict) else {}
+    )
+    cost_usd, cost_breakdown = estimate_case_cost_usd(tokens_by_model, llm=llm)
+    return {
+        "benchmark": adapter.name,
+        "adapter_version": adapter.version,
+        "mode": "opensre+llm",
+        "llm": llm,
+        "run_index": run_index,
+        "case_id": case.case_id,
+        "seen_shape": _case_seen_shape(case),
+        "duration_seconds": time.perf_counter() - started,
+        "cost_usd": cost_usd,
+        "cost_breakdown_usd": cost_breakdown,
+        "decision_trace": run_payload.get("run", {}).get("steps", []),
+        "run": run_payload.get("run", {}),
+        "score": score,
+    }
+
+
+def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> BenchmarkRunResult:
+    output_dir = Path(config.output_dir)
+    llms = config.llms or ("default",)
+    cases = list(adapter.load_cases(config.filters))
+    if not cases:
+        raise RuntimeError("No benchmark cases matched the requested filters.")
+
+    results: list[dict[str, Any]] = []
+    total_cost = 0.0
+
+    def record(result: dict[str, Any]) -> None:
+        nonlocal total_cost
+        total_cost += float(result.get("cost_usd") or 0.0)
+        if config.cost_budget_usd is not None and total_cost > config.cost_budget_usd:
+            raise RuntimeError(
+                f"Cost budget exceeded: ${total_cost:.4f} > ${config.cost_budget_usd:.4f}"
+            )
+        results.append(result)
+
+    workers = max(1, int(config.workers))
+    for llm in llms:
+        jobs = [
+            (case, run_index) for case in cases for run_index in range(1, config.runs_per_case + 1)
+        ]
+        if workers == 1:
+            for case, run_index in jobs:
+                record(_run_one(adapter, case, llm=llm, run_index=run_index, output_dir=output_dir))
+            continue
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [
+                executor.submit(
+                    _run_one,
+                    adapter,
+                    case,
+                    llm=llm,
+                    run_index=run_index,
+                    output_dir=output_dir,
+                )
+                for case, run_index in jobs
+            ]
+            for future in as_completed(futures):
+                record(future.result())
+
+    results.sort(key=lambda row: (row["llm"], row["case_id"], row["run_index"]))
+    payload = {
+        "benchmark": adapter.name,
+        "adapter_version": adapter.version,
+        "case_count": len(cases),
+        "llms": list(llms),
+        "runs_per_case": config.runs_per_case,
+        "workers": workers,
+        "filters": config.filters,
+        "metric_schema": adapter.metric_schema(),
+        "cost_usd": total_cost,
+        "results": results,
+    }
+    write_reports(payload, output_dir, config.report_formats)
+    return BenchmarkRunResult(payload=payload, output_dir=output_dir)

--- a/tests/benchmarks/_framework/runner.py
+++ b/tests/benchmarks/_framework/runner.py
@@ -28,12 +28,13 @@ def _run_one(
     adapter: BenchmarkAdapter,
     case: BenchmarkCase,
     *,
+    mode: str,
     llm: str,
     run_index: int,
     output_dir: Path,
 ) -> dict[str, Any]:
     started = time.perf_counter()
-    case_output = output_dir / "cases" / llm / f"run-{run_index}"
+    case_output = output_dir / "cases" / mode / llm / case.case_id / f"run-{run_index}"
     run_payload = adapter.run_case(case, str(case_output))
     score = adapter.score_case(case, run_payload)
     final_state = run_payload.get("run", {}).get("final_state", {})
@@ -44,7 +45,7 @@ def _run_one(
     return {
         "benchmark": adapter.name,
         "adapter_version": adapter.version,
-        "mode": "opensre+llm",
+        "mode": mode,
         "llm": llm,
         "run_index": run_index,
         "case_id": case.case_id,
@@ -79,36 +80,57 @@ def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> Benchma
 
     requested_workers = max(1, int(config.workers))
     workers = 1 if config.cost_budget_usd is not None else requested_workers
-    for llm in llms:
-        jobs = [
-            (case, run_index) for case in cases for run_index in range(1, config.runs_per_case + 1)
-        ]
-        with llm_environment(llm):
-            if workers == 1:
-                for case, run_index in jobs:
-                    record(
-                        _run_one(adapter, case, llm=llm, run_index=run_index, output_dir=output_dir)
-                    )
-                continue
-            with ThreadPoolExecutor(max_workers=workers) as executor:
-                futures = [
-                    executor.submit(
-                        _run_one,
-                        adapter,
-                        case,
-                        llm=llm,
-                        run_index=run_index,
-                        output_dir=output_dir,
-                    )
-                    for case, run_index in jobs
-                ]
-                for future in as_completed(futures):
-                    record(future.result())
+    modes = config.modes or ("opensre+llm",)
+    for mode in modes:
+        for llm in llms:
+            jobs = [
+                (case, run_index)
+                for case in cases
+                for run_index in range(1, config.runs_per_case + 1)
+            ]
+            with llm_environment(llm):
+                if workers == 1:
+                    for case, run_index in jobs:
+                        record(
+                            _run_one(
+                                adapter,
+                                case,
+                                mode=mode,
+                                llm=llm,
+                                run_index=run_index,
+                                output_dir=output_dir,
+                            )
+                        )
+                    continue
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    futures = [
+                        executor.submit(
+                            _run_one,
+                            adapter,
+                            case,
+                            mode=mode,
+                            llm=llm,
+                            run_index=run_index,
+                            output_dir=output_dir,
+                        )
+                        for case, run_index in jobs
+                    ]
+                    for future in as_completed(futures):
+                        record(future.result())
 
-    results.sort(key=lambda row: (row["llm"], row["case_id"], row["run_index"]))
+    mode_order = {mode: index for index, mode in enumerate(modes)}
+    results.sort(
+        key=lambda row: (
+            mode_order.get(str(row["mode"]), len(mode_order)),
+            row["llm"],
+            row["case_id"],
+            row["run_index"],
+        )
+    )
     if config.strict_parity:
         _validate_strict_parity(
             results,
+            modes=modes,
             llms=llms,
             cases=cases,
             runs_per_case=config.runs_per_case,
@@ -117,6 +139,7 @@ def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> Benchma
         "benchmark": adapter.name,
         "adapter_version": adapter.version,
         "case_count": len(cases),
+        "modes": list(modes),
         "llms": list(llms),
         "runs_per_case": config.runs_per_case,
         "workers": workers,
@@ -134,18 +157,25 @@ def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> Benchma
 def _validate_strict_parity(
     results: list[dict[str, Any]],
     *,
+    modes: tuple[str, ...],
     llms: tuple[str, ...],
     cases: list[BenchmarkCase],
     runs_per_case: int,
 ) -> None:
     expected = {
-        (llm, case.case_id, run_index)
+        (mode, llm, case.case_id, run_index)
+        for mode in modes
         for llm in llms
         for case in cases
         for run_index in range(1, runs_per_case + 1)
     }
     observed = {
-        (str(row.get("llm")), str(row.get("case_id")), int(row.get("run_index", 0)))
+        (
+            str(row.get("mode")),
+            str(row.get("llm")),
+            str(row.get("case_id")),
+            int(row.get("run_index", 0)),
+        )
         for row in results
     }
     if observed != expected or len(results) != len(expected):

--- a/tests/benchmarks/_framework/runner.py
+++ b/tests/benchmarks/_framework/runner.py
@@ -34,8 +34,7 @@ def _run_one(
 ) -> dict[str, Any]:
     started = time.perf_counter()
     case_output = output_dir / "cases" / llm / f"run-{run_index}"
-    with llm_environment(llm):
-        run_payload = adapter.run_case(case, str(case_output))
+    run_payload = adapter.run_case(case, str(case_output))
     score = adapter.score_case(case, run_payload)
     final_state = run_payload.get("run", {}).get("final_state", {})
     tokens_by_model = tokens_by_model_from_state(
@@ -78,31 +77,42 @@ def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> Benchma
             )
         results.append(result)
 
-    workers = max(1, int(config.workers))
+    requested_workers = max(1, int(config.workers))
+    workers = 1 if config.cost_budget_usd is not None else requested_workers
     for llm in llms:
         jobs = [
             (case, run_index) for case in cases for run_index in range(1, config.runs_per_case + 1)
         ]
-        if workers == 1:
-            for case, run_index in jobs:
-                record(_run_one(adapter, case, llm=llm, run_index=run_index, output_dir=output_dir))
-            continue
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = [
-                executor.submit(
-                    _run_one,
-                    adapter,
-                    case,
-                    llm=llm,
-                    run_index=run_index,
-                    output_dir=output_dir,
-                )
-                for case, run_index in jobs
-            ]
-            for future in as_completed(futures):
-                record(future.result())
+        with llm_environment(llm):
+            if workers == 1:
+                for case, run_index in jobs:
+                    record(
+                        _run_one(adapter, case, llm=llm, run_index=run_index, output_dir=output_dir)
+                    )
+                continue
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                futures = [
+                    executor.submit(
+                        _run_one,
+                        adapter,
+                        case,
+                        llm=llm,
+                        run_index=run_index,
+                        output_dir=output_dir,
+                    )
+                    for case, run_index in jobs
+                ]
+                for future in as_completed(futures):
+                    record(future.result())
 
     results.sort(key=lambda row: (row["llm"], row["case_id"], row["run_index"]))
+    if config.strict_parity:
+        _validate_strict_parity(
+            results,
+            llms=llms,
+            cases=cases,
+            runs_per_case=config.runs_per_case,
+        )
     payload = {
         "benchmark": adapter.name,
         "adapter_version": adapter.version,
@@ -110,6 +120,8 @@ def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> Benchma
         "llms": list(llms),
         "runs_per_case": config.runs_per_case,
         "workers": workers,
+        "requested_workers": requested_workers,
+        "strict_parity": config.strict_parity,
         "filters": config.filters,
         "metric_schema": adapter.metric_schema(),
         "cost_usd": total_cost,
@@ -117,3 +129,30 @@ def run_benchmark(adapter: BenchmarkAdapter, config: BenchmarkConfig) -> Benchma
     }
     write_reports(payload, output_dir, config.report_formats)
     return BenchmarkRunResult(payload=payload, output_dir=output_dir)
+
+
+def _validate_strict_parity(
+    results: list[dict[str, Any]],
+    *,
+    llms: tuple[str, ...],
+    cases: list[BenchmarkCase],
+    runs_per_case: int,
+) -> None:
+    expected = {
+        (llm, case.case_id, run_index)
+        for llm in llms
+        for case in cases
+        for run_index in range(1, runs_per_case + 1)
+    }
+    observed = {
+        (str(row.get("llm")), str(row.get("case_id")), int(row.get("run_index", 0)))
+        for row in results
+    }
+    if observed != expected or len(results) != len(expected):
+        missing = sorted(expected - observed)
+        extra = sorted(observed - expected)
+        raise RuntimeError(
+            "Strict parity failed: "
+            f"missing={missing[:5]} extra={extra[:5]} "
+            f"expected={len(expected)} observed={len(observed)}"
+        )

--- a/tests/benchmarks/_framework/test_config.py
+++ b/tests/benchmarks/_framework/test_config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmarks._framework.config import benchmark_config_from_dict
+
+
+def test_benchmark_config_defaults_parallel_workers() -> None:
+    config = benchmark_config_from_dict({"benchmark": "cloudopsbench"})
+
+    assert config.benchmark == "cloudopsbench"
+    assert config.modes == ("opensre+llm",)
+    assert config.workers >= 1
+    assert "json" in config.report_formats
+
+
+def test_benchmark_config_rejects_unknown_modes() -> None:
+    with pytest.raises(ValueError, match="unsupported modes"):
+        benchmark_config_from_dict({"benchmark": "cloudopsbench", "modes": ["unknown"]})

--- a/tests/benchmarks/_framework/test_cost.py
+++ b/tests/benchmarks/_framework/test_cost.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmarks._framework.cost import estimate_case_cost_usd
+
+
+def test_estimate_case_cost_uses_tool_tier_discount() -> None:
+    total, breakdown = estimate_case_cost_usd(
+        {
+            "claude-sonnet-4": {"input_tokens": 1_000_000, "output_tokens": 0},
+            "claude-3-haiku": {"input_tokens": 1_000_000, "output_tokens": 0},
+        },
+        llm="claude-4-sonnet",
+    )
+
+    assert breakdown["claude-sonnet-4"] == 3.0
+    assert breakdown["claude-3-haiku"] == pytest.approx(0.6)
+    assert total == pytest.approx(3.6)

--- a/tests/benchmarks/_framework/test_reporting.py
+++ b/tests/benchmarks/_framework/test_reporting.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+
+from tests.benchmarks._framework.reporting import summarize_payload, write_reports
+
+
+def test_summarize_payload_compares_against_paper_baseline() -> None:
+    summary = summarize_payload(
+        {
+            "results": [
+                {"llm": "gpt-4o", "score": {"metrics": {"a1": 1.0}}},
+                {"llm": "gpt-4o", "score": {"metrics": {"a1": 0.0}}},
+            ]
+        }
+    )
+
+    comparison = summary["paper_baseline_comparison"]["gpt-4o"]
+    assert comparison["opensre_a1"] == 0.5
+    assert comparison["paper_a1"] == 0.49
+    assert round(comparison["a1_lift"], 2) == 0.01
+
+
+def test_write_reports_writes_json_and_markdown(tmp_path) -> None:
+    write_reports(
+        {
+            "benchmark": "cloudopsbench",
+            "case_count": 1,
+            "cost_usd": 0.0,
+            "results": [{"llm": "gpt-5", "score": {"metrics": {"a1": 1.0}}}],
+        },
+        tmp_path,
+        ("json", "markdown"),
+    )
+
+    assert json.loads((tmp_path / "summary.json").read_text())["benchmark"] == "cloudopsbench"
+    assert "OpenSRE Benchmark Report" in (tmp_path / "summary.md").read_text()

--- a/tests/benchmarks/_framework/test_runner.py
+++ b/tests/benchmarks/_framework/test_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from typing import Any
 
@@ -33,6 +34,19 @@ class FakeAdapter(BenchmarkAdapter):
         return {"primary": "a1", "metrics": ["a1"]}
 
 
+class TwoCaseAdapter(FakeAdapter):
+    def __init__(self) -> None:
+        self.seen_llms: list[str | None] = []
+
+    def load_cases(self, _filters: dict[str, Any]) -> Iterable[BenchmarkCase]:
+        yield BenchmarkCase("case-1", {"id": 1}, {"seen_shape": True})
+        yield BenchmarkCase("case-2", {"id": 2}, {"seen_shape": False})
+
+    def run_case(self, case: BenchmarkCase, output_dir: str) -> dict[str, Any]:
+        self.seen_llms.append(os.environ.get("OPENSRE_BENCH_LLM"))
+        return super().run_case(case, output_dir)
+
+
 def test_run_benchmark_writes_reports_and_cost(tmp_path) -> None:
     result = run_benchmark(
         FakeAdapter(),
@@ -48,3 +62,38 @@ def test_run_benchmark_writes_reports_and_cost(tmp_path) -> None:
     assert result.payload["results"][0]["seen_shape"] is True
     assert result.payload["cost_usd"] > 0
     assert (tmp_path / "summary.json").is_file()
+
+
+def test_run_benchmark_pins_llm_env_once_for_parallel_batch(tmp_path) -> None:
+    adapter = TwoCaseAdapter()
+
+    result = run_benchmark(
+        adapter,
+        BenchmarkConfig(
+            benchmark="fake",
+            llms=("gpt-5",),
+            output_dir=str(tmp_path),
+            workers=2,
+            strict_parity=True,
+        ),
+    )
+
+    assert adapter.seen_llms == ["gpt-5", "gpt-5"]
+    assert result.payload["workers"] == 2
+    assert result.payload["strict_parity"] is True
+
+
+def test_run_benchmark_uses_one_worker_when_budget_is_set(tmp_path) -> None:
+    result = run_benchmark(
+        TwoCaseAdapter(),
+        BenchmarkConfig(
+            benchmark="fake",
+            llms=("gpt-5",),
+            output_dir=str(tmp_path),
+            workers=8,
+            cost_budget_usd=1.0,
+        ),
+    )
+
+    assert result.payload["workers"] == 1
+    assert result.payload["requested_workers"] == 8

--- a/tests/benchmarks/_framework/test_runner.py
+++ b/tests/benchmarks/_framework/test_runner.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from tests.benchmarks._framework.adapters import BenchmarkAdapter, BenchmarkCase
+from tests.benchmarks._framework.config import BenchmarkConfig
+from tests.benchmarks._framework.runner import run_benchmark
+
+
+class FakeAdapter(BenchmarkAdapter):
+    name = "fake"
+    version = "1"
+
+    def load_cases(self, _filters: dict[str, Any]) -> Iterable[BenchmarkCase]:
+        yield BenchmarkCase("case-1", {"id": 1}, {"seen_shape": True})
+
+    def run_case(self, case: BenchmarkCase, _output_dir: str) -> dict[str, Any]:
+        return {
+            "run": {
+                "case_id": case.case_id,
+                "steps": [{"action_name": "GetResources"}],
+                "final_state": {
+                    "tokens_by_model": {"gpt-5": {"input_tokens": 1000, "output_tokens": 1000}}
+                },
+            }
+        }
+
+    def score_case(self, case: BenchmarkCase, _run_result: dict[str, Any]) -> dict[str, Any]:
+        return {"case_id": case.case_id, "metrics": {"a1": 1.0}, "error": ""}
+
+    def metric_schema(self) -> dict[str, Any]:
+        return {"primary": "a1", "metrics": ["a1"]}
+
+
+def test_run_benchmark_writes_reports_and_cost(tmp_path) -> None:
+    result = run_benchmark(
+        FakeAdapter(),
+        BenchmarkConfig(
+            benchmark="fake",
+            llms=("gpt-5",),
+            output_dir=str(tmp_path),
+            workers=1,
+        ),
+    )
+
+    assert result.payload["case_count"] == 1
+    assert result.payload["results"][0]["seen_shape"] is True
+    assert result.payload["cost_usd"] > 0
+    assert (tmp_path / "summary.json").is_file()

--- a/tests/benchmarks/_framework/test_runner.py
+++ b/tests/benchmarks/_framework/test_runner.py
@@ -97,3 +97,23 @@ def test_run_benchmark_uses_one_worker_when_budget_is_set(tmp_path) -> None:
 
     assert result.payload["workers"] == 1
     assert result.payload["requested_workers"] == 8
+
+
+def test_run_benchmark_emits_requested_modes(tmp_path) -> None:
+    result = run_benchmark(
+        FakeAdapter(),
+        BenchmarkConfig(
+            benchmark="fake",
+            modes=("opensre+llm", "llm_alone"),
+            llms=("gpt-5",),
+            output_dir=str(tmp_path),
+            workers=1,
+            strict_parity=True,
+        ),
+    )
+
+    assert result.payload["modes"] == ["opensre+llm", "llm_alone"]
+    assert [row["mode"] for row in result.payload["results"]] == [
+        "opensre+llm",
+        "llm_alone",
+    ]

--- a/tests/benchmarks/cloudopsbench/README.md
+++ b/tests/benchmarks/cloudopsbench/README.md
@@ -24,6 +24,20 @@ Run the benchmark:
 make test-cloudopsbench
 ```
 
+Run the reusable benchmark harness:
+
+```bash
+uv run opensre bench validate tests/benchmarks/configs/claude-vs-paper.yml
+uv run opensre bench run --config tests/benchmarks/configs/claude-vs-paper.yml
+```
+
+The harness writes JSON, Markdown, and optional HTML reports under the config's
+`output_dir`, including per-case decision traces, estimated token cost when
+token usage is present in the run state, CloudOpsBench paper-metric scores, and
+the checked-in paper A@1 comparison for GPT-4o, GPT-5, Claude-4-Sonnet, and
+DeepSeek-V3.2. Use `workers: 1` in YAML for serial execution; configs default to
+parallel execution.
+
 Run only a subset of cases:
 
 ```bash

--- a/tests/benchmarks/cloudopsbench/adapter.py
+++ b/tests/benchmarks/cloudopsbench/adapter.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from app.pipeline.runners import run_investigation
+from tests.benchmarks._framework.adapters import BenchmarkAdapter, BenchmarkCase
+from tests.benchmarks.cloudopsbench.case_loader import (
+    BENCHMARK_DIR,
+    CloudOpsCase,
+    build_alert,
+    file_sha256,
+    load_cases,
+)
+from tests.benchmarks.cloudopsbench.replay_backend import CloudOpsBenchReplayBackend
+from tests.benchmarks.cloudopsbench.run_suite import _build_resolved_integrations, _json_safe
+from tests.benchmarks.cloudopsbench.scoring import score_case
+
+
+class CloudOpsBenchAdapter(BenchmarkAdapter):
+    name = "cloudopsbench"
+    version = "1"
+
+    def load_cases(self, filters: dict[str, Any]) -> Iterable[BenchmarkCase]:
+        systems = filters.get("systems")
+        fault_categories = filters.get("fault_categories") or filters.get("difficulty")
+        case_name = filters.get("case") or filters.get("case_name")
+        limit = filters.get("limit")
+
+        system_values = systems if isinstance(systems, list) and systems else [None]
+        fault_values = (
+            fault_categories
+            if isinstance(fault_categories, list) and fault_categories
+            else [filters.get("fault_category")]
+        )
+        yielded = 0
+        for system in system_values:
+            for fault_category in fault_values:
+                for case in load_cases(
+                    Path(filters.get("benchmark_dir") or BENCHMARK_DIR),
+                    system=system,
+                    fault_category=fault_category,
+                    case_name=case_name,
+                    limit=None,
+                ):
+                    yield BenchmarkCase(
+                        case_id=case.case_id,
+                        payload=case,
+                        tags={"seen_shape": _seen_shape(case)},
+                    )
+                    yielded += 1
+                    if limit and yielded >= int(limit):
+                        return
+
+    def run_case(self, case: BenchmarkCase, output_dir: str) -> dict[str, Any]:
+        cloudops_case = _cloudops_case(case)
+        backend = CloudOpsBenchReplayBackend(cloudops_case)
+        final_state = run_investigation(
+            build_alert(cloudops_case),
+            resolved_integrations=_build_resolved_integrations(cloudops_case, backend),
+        )
+        final_state_dict = _json_safe(dict(final_state))
+        case_data = {
+            "case_id": cloudops_case.case_id,
+            "system": cloudops_case.system,
+            "fault_category": cloudops_case.fault_category,
+            "case_name": cloudops_case.case_name,
+            "metadata_sha256": file_sha256(cloudops_case.metadata_path),
+            "tool_cache_sha256": file_sha256(cloudops_case.tool_cache_path),
+            "ground_truth": {
+                "fault_taxonomy": cloudops_case.result.fault_taxonomy,
+                "fault_object": cloudops_case.result.fault_object,
+                "root_cause": cloudops_case.result.root_cause,
+            },
+            "final_answer": final_state_dict.get("final_answer") or final_state_dict.get("report"),
+            "root_cause": final_state_dict.get("root_cause"),
+            "report": final_state_dict.get("report"),
+            "expert_steps": {
+                "path1": list(cloudops_case.process.get("path1") or []),
+                "path2": list(cloudops_case.process.get("path2") or []),
+            },
+            "steps": _steps_from_backend(backend),
+            "final_state": final_state_dict,
+        }
+        payload = {
+            "case": {
+                "case_id": cloudops_case.case_id,
+                "system": cloudops_case.system,
+                "fault_category": cloudops_case.fault_category,
+                "case_name": cloudops_case.case_name,
+                "metadata_path": str(cloudops_case.metadata_path),
+                "tool_cache_path": str(cloudops_case.tool_cache_path),
+            },
+            "run": case_data,
+        }
+        output_path = Path(output_dir) / f"{cloudops_case.case_name}.json"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return payload
+
+    def score_case(self, case: BenchmarkCase, run_result: dict[str, Any]) -> dict[str, Any]:
+        payload = score_case(_cloudops_case(case), run_result["run"]).to_dict()
+        metrics = payload.get("metrics", {})
+        invalid_reasons = payload.get("invalid_reasons", [])
+        steps = run_result.get("run", {}).get("steps", [])
+        tool_steps = [step for step in steps if isinstance(step, dict) and step.get("action_name")]
+        payload["validity_metrics"] = {
+            "hallucination_rate": 1.0 if invalid_reasons else 0.0,
+            "evidence_support": float(metrics.get("tcr", 0.0)),
+            "kubectl_actionability": 1.0 if tool_steps else 0.0,
+        }
+        return payload
+
+    def metric_schema(self) -> dict[str, Any]:
+        return {
+            "primary": "a1",
+            "metrics": [
+                "a1",
+                "a3",
+                "partial_a1",
+                "partial_a3",
+                "tcr",
+                "exact",
+                "in_order",
+                "any_order",
+                "rel",
+                "cov",
+                "steps",
+                "mtti",
+                "iac",
+                "rar",
+                "ztdr",
+            ],
+            "validity": ["hallucination_rate", "evidence_support", "kubectl_actionability"],
+        }
+
+
+def _cloudops_case(case: BenchmarkCase) -> CloudOpsCase:
+    if not isinstance(case.payload, CloudOpsCase):
+        raise TypeError(f"{case.case_id}: expected CloudOpsCase payload")
+    return case.payload
+
+
+def _seen_shape(case: CloudOpsCase) -> bool:
+    raw = case.metadata.get("seen_shape")
+    if isinstance(raw, bool):
+        return raw
+    return case.fault_category in {"runtime", "startup", "service"}
+
+
+def _steps_from_backend(backend: CloudOpsBenchReplayBackend) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    for idx, entry in enumerate(backend.action_log, start=1):
+        steps.append(
+            {
+                "step_id": idx,
+                "action_type": "tool",
+                "action_name": entry.get("action_name"),
+                "action_input": entry.get("action_input", {}),
+                "error": entry.get("error"),
+                "tool_latency": 0.0,
+            }
+        )
+    return steps

--- a/tests/benchmarks/configs/claude-vs-paper.yml
+++ b/tests/benchmarks/configs/claude-vs-paper.yml
@@ -1,0 +1,23 @@
+benchmark: cloudopsbench
+
+modes:
+  - opensre+llm
+
+llms:
+  - claude-4-sonnet
+  - deepseek-v3.2
+  - gpt-5
+  - gpt-4o
+
+runs_per_case: 3
+workers: 8
+cost_budget_usd: 500
+
+filters:
+  systems: [boutique]
+  fault_categories: [service]
+  limit: 5
+
+output_dir: .bench-results/claude-vs-paper
+report_formats: [json, markdown, html]
+strict_parity: true

--- a/tests/benchmarks/openrca_scenarios/adapter.py
+++ b/tests/benchmarks/openrca_scenarios/adapter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from app.pipeline.runners import run_investigation
+from tests.benchmarks._framework.adapters import BenchmarkAdapter, BenchmarkCase
+
+SUITE_DIR = Path(__file__).resolve().parent
+
+
+class OpenRCAScenariosAdapter(BenchmarkAdapter):
+    name = "openrca_scenarios"
+    version = "1"
+
+    def load_cases(self, filters: dict[str, Any]) -> Iterable[BenchmarkCase]:
+        limit = int(filters.get("limit") or 0)
+        for idx, path in enumerate(sorted(SUITE_DIR.rglob("alert.json")), start=1):
+            if limit and idx > limit:
+                return
+            yield BenchmarkCase(
+                case_id=str(path.relative_to(SUITE_DIR).parent),
+                payload=path,
+                tags={"seen_shape": False},
+            )
+
+    def run_case(self, case: BenchmarkCase, output_dir: str) -> dict[str, Any]:
+        path = Path(case.payload)
+        alert = json.loads(path.read_text(encoding="utf-8"))
+        final_state = dict(run_investigation(alert))
+        payload = {
+            "case": {"case_id": case.case_id, "alert_path": str(path)},
+            "run": {
+                "case_id": case.case_id,
+                "final_answer": final_state.get("final_answer") or final_state.get("report"),
+                "root_cause": final_state.get("root_cause"),
+                "report": final_state.get("report"),
+                "steps": [],
+                "final_state": final_state,
+            },
+        }
+        output_path = Path(output_dir) / f"{case.case_id.replace('/', '__')}.json"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return payload
+
+    def score_case(self, case: BenchmarkCase, run_result: dict[str, Any]) -> dict[str, Any]:
+        has_answer = bool(run_result.get("run", {}).get("final_answer"))
+        return {
+            "case_id": case.case_id,
+            "metrics": {"answer_present": 1.0 if has_answer else 0.0},
+            "error": "" if has_answer else "missing_final_answer",
+        }
+
+    def metric_schema(self) -> dict[str, Any]:
+        return {"primary": "answer_present", "metrics": ["answer_present"]}


### PR DESCRIPTION
## Summary

Fixes #2074

- Adds a reusable benchmark framework under `tests/benchmarks/_framework` with YAML config loading, adapter registry, parallel execution, model environment pinning, cost capture, and JSON/Markdown/HTML report generation.
- Adds `cloudopsbench` and `openrca_scenarios` adapters so CloudOpsBench is the first full adapter and OpenRCA validates the interface is reusable.
- Adds top-level `opensre bench` commands for `list`, `validate`, `run`, `report`, and `compare`, plus a checked-in `tests/benchmarks/configs/claude-vs-paper.yml` config.
- Documents the new CloudOpsBench benchmark workflow and includes paper A@1 baseline comparison output in reports.

## Tests run

- `uv run pytest tests/benchmarks/_framework/test_config.py tests/benchmarks/_framework/test_reporting.py tests/benchmarks/_framework/test_runner.py`
- `uv run opensre bench validate tests/benchmarks/configs/claude-vs-paper.yml && uv run opensre bench list`
- `uv run ruff check app/cli/commands/bench.py app/cli/commands/__init__.py tests/benchmarks/_framework tests/benchmarks/cloudopsbench/adapter.py tests/benchmarks/openrca_scenarios/adapter.py`
- `uv run ruff format --check app/cli/commands/bench.py app/cli/commands/__init__.py tests/benchmarks/_framework tests/benchmarks/cloudopsbench/adapter.py tests/benchmarks/openrca_scenarios/adapter.py`
- `git diff --cached --check`

## Notes

I did not run the full CloudOpsBench pilot because this environment does not include the downloaded CloudOpsBench corpus or live LLM credentials. The new CLI validates the checked-in config and the framework unit tests cover config/reporting/runner behavior without API calls.
