### PR TITLE
feat(agents): add status heuristic — active / idle / stuck (#1491)

### DIFF
--- a/app/agents/status.py
+++ b/app/agents/status.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from app.agents.probe import ProcessSnapshot
+
+_CPU_THRESHOLD_PERCENT = 5.0
+
+
+class Status(Enum):
+    ACTIVE = "active"
+    IDLE = "idle"
+    STUCK = "stuck"
+
+
+def compute_status(
+    record: ProcessSnapshot,
+    now: datetime,
+    *,
+    last_output_at: datetime | None,
+    idle_after_s: int = 120,
+    stuck_after_s: int = 480,
+) -> Status:
+    """
+    Classify an agent process as active, idle, or stuck based on CPU activity and output recency.
+
+    When last_output_at is None (no output tracking available), falls back to record.started_at
+    as the last-known-activity reference. This may produce false positives for
+    stuck on processes that are actively producing output but lack an output tracker.
+    """
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware (e.g. datetime.now(UTC)), got naive datetime")
+
+    if last_output_at is None:
+        last_output_at = record.started_at
+    elif last_output_at.tzinfo is None:
+        raise ValueError(
+            "last_output_at must be timezone-aware (e.g. datetime.now(UTC)), got naive datetime"
+        )
+
+    delta = now - last_output_at
+    high_cpu = record.cpu_percent >= _CPU_THRESHOLD_PERCENT
+
+    if not high_cpu and delta.total_seconds() >= idle_after_s:
+        return Status.IDLE
+    if high_cpu and delta.total_seconds() >= stuck_after_s:
+        return Status.STUCK
+
+    return Status.ACTIVE

--- a/app/cli/interactive_shell/ui/agents_view.py
+++ b/app/cli/interactive_shell/ui/agents_view.py
@@ -28,6 +28,7 @@ from rich.table import Table
 from app.agents.config import load_agents_config
 from app.agents.registry import AgentRecord
 from app.agents.sampler import get_snapshot
+from app.agents.status import Status, compute_status
 from app.cli.interactive_shell.ui.theme import BOLD_BRAND
 
 # Placeholder for columns without a live data source (currently only tokens/min).
@@ -47,6 +48,12 @@ _COLUMNS: tuple[tuple[str, JustifyMethod], ...] = (
     ("status", "left"),
 )
 
+_STATUS_COLORS: dict[Status, str] = {
+    Status.ACTIVE: "green",
+    Status.IDLE: "yellow",
+    Status.STUCK: "red",
+}
+
 
 def _format_uptime(delta: timedelta) -> str:
     """Format a timedelta as a compact human-readable duration string."""
@@ -62,6 +69,13 @@ def _format_uptime(delta: timedelta) -> str:
     days = hours // 24
     remaining_hours = hours % 24
     return f"{days}d{remaining_hours}h"
+
+
+def _format_status(status: Status, msg: str = "") -> str:
+    """Return a Rich-markup-colorized status cell for the /agents table."""
+    color = _STATUS_COLORS.get(status, "default")
+    label = f"{status.value} ({msg})" if msg else status.value
+    return f"[{color}]{label}[/{color}]"
 
 
 def render_agents_table(records: Iterable[AgentRecord]) -> Table:
@@ -106,9 +120,23 @@ def render_agents_table(records: Iterable[AgentRecord]) -> Table:
         )
         snapshot = get_snapshot(record.pid)
         if snapshot is not None:
+            # last_output_at requires a background collector that tracks when each agent last wrote
+            # to stdout — not yet implemented. Until that lands, the fallback to snapshot.started_at
+            # means the heuristic overestimates silence duration for agents that are actively producing output.
+            status = compute_status(
+                snapshot,
+                now,
+                last_output_at=None,
+                idle_after_s=120,
+                stuck_after_s=480,
+            )
+            status_msg = ""
+            if status is Status.STUCK:
+                status_msg = f"{_format_uptime(now - snapshot.started_at)} no progress"
+
             uptime_cell = _format_uptime(now - snapshot.started_at)
             cpu_cell = f"{snapshot.cpu_percent:.1f}"
-            status_cell = snapshot.status
+            status_cell = _format_status(status, status_msg)
         else:
             uptime_cell = _UNFILLED
             cpu_cell = _UNFILLED

--- a/tests/agents/test_status.py
+++ b/tests/agents/test_status.py
@@ -1,0 +1,226 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.agents.probe import ProcessSnapshot
+from app.agents.status import Status, compute_status
+
+
+@pytest.mark.parametrize(
+    "record, now, last_output, idle_after, stuck_after, expectation",
+    [
+        # High CPU + recent activity → active
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=23.5,
+                rss_mb=128.0,
+                num_fds=42,
+                num_connections=3,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 3, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 2, 0, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.ACTIVE,
+        ),
+        # Low CPU + recent activity → active
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=4.8,
+                rss_mb=83.0,
+                num_fds=12,
+                num_connections=1,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 3, 15, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 2, 15, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.ACTIVE,
+        ),
+        # Low CPU + silence >= idle_after_s → idle
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=4.8,
+                rss_mb=83.0,
+                num_fds=12,
+                num_connections=1,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 7, 25, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 5, 25, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.IDLE,
+        ),
+        # High CPU + silence >= stuck_after_s → stuck
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=20.0,
+                rss_mb=120,
+                num_fds=32,
+                num_connections=2,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 25, 25, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 5, 25, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.STUCK,
+        ),
+        # Edge: zero uptime
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=4.5,
+                rss_mb=120,
+                num_fds=32,
+                num_connections=2,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),  # now
+            None,  # last_output
+            120,
+            480,
+            Status.ACTIVE,
+        ),
+        # Edge: exactly at threshold (exactly 120s)
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=4.5,
+                rss_mb=120,
+                num_fds=32,
+                num_connections=2,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 7, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 5, 0, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.IDLE,
+        ),
+        # Edge: exactly at threshold (exactly 480s)
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=20.0,
+                rss_mb=120,
+                num_fds=32,
+                num_connections=2,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 9, 0, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 1, 0, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.STUCK,
+        ),
+        # Edge: last_output_at is not provided (None)
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=20.0,
+                rss_mb=120,
+                num_fds=32,
+                num_connections=2,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 9, 0, tzinfo=UTC),  # now
+            None,  # last_output
+            120,
+            480,
+            Status.STUCK,
+        ),
+        # Edge: high CPU + silence between idle and stuck thresholds
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=30.0,
+                rss_mb=250,
+                num_fds=80,
+                num_connections=5,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 14, 12, 7, 30, tzinfo=UTC),  # now
+            datetime(2026, 5, 14, 12, 1, 0, tzinfo=UTC),  # last_output
+            120,
+            480,
+            Status.ACTIVE,
+        ),
+    ],
+)
+def test_compute_status(record, now, last_output, idle_after, stuck_after, expectation) -> None:
+    """Table-driven cases covering all three status classifications and boundary conditions."""
+    assert (
+        compute_status(
+            record,
+            now,
+            last_output_at=last_output,
+            idle_after_s=idle_after,
+            stuck_after_s=stuck_after,
+        )
+        == expectation
+    )
+
+
+@pytest.mark.parametrize(
+    "record, now, last_output, idle_after, stuck_after",
+    [
+        # now without timezone info
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=23.5,
+                rss_mb=128.0,
+                num_fds=42,
+                num_connections=3,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 17, 12, 3, 0),  # now
+            datetime(2026, 5, 17, 12, 2, 0, tzinfo=UTC),  # last_output
+            120,
+            480,
+        ),
+        # last_output_at without timezone info
+        (
+            ProcessSnapshot(
+                pid=8421,
+                cpu_percent=4.8,
+                rss_mb=83.0,
+                num_fds=12,
+                num_connections=1,
+                status="running",
+                started_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC),
+            ),
+            datetime(2026, 5, 17, 12, 3, 15, tzinfo=UTC),  # now
+            datetime(2026, 5, 17, 12, 2, 15),  # last_output
+            120,
+            480,
+        ),
+    ],
+)
+def test_compute_status_raises_on_naive_datetime(record, now, last_output, idle_after, stuck_after):
+    with pytest.raises(ValueError, match="naive datetime"):
+        compute_status(
+            record,
+            now,
+            last_output_at=last_output,
+            idle_after_s=idle_after,
+            stuck_after_s=stuck_after,
+        )

--- a/tests/cli/interactive_shell/ui/test_agents_view.py
+++ b/tests/cli/interactive_shell/ui/test_agents_view.py
@@ -159,7 +159,7 @@ def test_table_shows_live_probe_data_when_snapshot_exists(monkeypatch: pytest.Mo
     table, _ = _render([AgentRecord(name="cursor", pid=8444, command="cursor")])
 
     rendered_cells = [list(col.cells)[0] for col in table.columns]
-    assert rendered_cells[2:] == ["2h0m", "23.5", "-", "-", "running"]
+    assert rendered_cells[2:] == ["2h0m", "23.5", "-", "-", "[red]stuck (2h0m no progress)[/red]"]
 
 
 def test_multiple_records_are_each_rendered_in_order() -> None:


### PR DESCRIPTION
Fixes #1491 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR
Add a pure `compute_status()` heuristic that classifies agents as active/idle/stuck based on CPU and output recency, and render it as a colorized status cell in the `/agents` dashboard.

### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->
<!-- Do not add code diff here -->

Before:
https://github.com/user-attachments/assets/e9e6b44c-a556-4c38-99d6-565f18848fdb

After:
https://github.com/user-attachments/assets/920582ce-cc31-4a29-b8fc-21f7c55a4a18

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->
**What problem does your code solve?**
Without a status column, every agent in the `/agents` table looks identical. The user can't tell at a glance which agent is actively working, which is idle, or which is stuck in a loop burning CPU. This PR adds a `compute_status()` heuristic that classifies each agent as `active`, `idle`, or `stuck` based on CPU activity and output recency, then renders it as a colorized cell in the dashboard.

**What alternative approaches did you consider?**
1. Returning `None` when `last_output_at` is unavailable (introducing a 4th "unknown" state) — rejected because the issue spec defines exactly three states and a permanently empty status column ships no user value until an output tracker is built.
2. Raising an exception when `last_output_at` is None — rejected because it pushes classification responsibility to the caller, defeating the purpose of a self-contained pure function.

**Why did you choose this specific implementation?**
The function falls back to `record.started_at` when `last_output_at` is None. This means the heuristic is usable today (no output tracker exists yet) at the cost of potential false positives for `stuck` on agents that are actively producing output. This trade-off is documented in the docstring. The pure function boundary makes it trivial to swap in a real `last_output_at` value once a background output collector lands.

**What are the key functions/components and what do they do?**
- `app/agents/status.py` — `Status` enum (`active`/`idle`/`stuck`) and `compute_status()` pure function. No I/O, no dependencies beyond the `ProcessSnapshot` dataclass. CPU threshold hardcoded at 5%.
- `app/cli/interactive_shell/ui/agents_view.py` — `_format_status()` maps Status → Rich color markup (`green`/`yellow`/`red`). Wired into `render_agents_table()` replacing the raw psutil status string.
- `tests/agents/test_status.py` — Table-driven parametrized tests covering all three states, threshold boundaries, the None fallback path, and the "gray zone" (high CPU between idle and stuck thresholds).
---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
