### PR TITLE
fix: surface friendly PermissionError when .env is not writable

### DIFF
--- a/app/cli/commands/onboard.py
+++ b/app/cli/commands/onboard.py
@@ -26,9 +26,17 @@ def _load_local_config() -> dict[str, Any]:
 def _run_onboarding_command(
     run_command: RunCommand, *, load_config: ConfigLoader = _load_local_config
 ) -> None:
+    from app.cli.support.errors import OpenSREError
+
     capture_onboard_started()
     try:
         exit_code = run_command()
+    except PermissionError as exc:
+        capture_onboard_failed()
+        raise OpenSREError(
+            str(exc),
+            suggestion="Check file permissions or set OPENSRE_PROJECT_ENV_PATH to a writable path.",
+        ) from exc
     except Exception:
         capture_onboard_failed()
         raise

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -30,6 +30,16 @@ def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
     return updated
 
 
+def _write_env(target_path: Path, content: str) -> None:
+    try:
+        target_path.write_text(content, encoding="utf-8")
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to {target_path}: permission denied. "
+            "Ensure you have write access to this file, or run the command as the file owner."
+        ) from exc
+
+
 def sync_env_values(
     values: dict[str, str],
     *,
@@ -47,7 +57,7 @@ def sync_env_values(
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    target_path.write_text("".join(lines), encoding="utf-8")
+    _write_env(target_path, "".join(lines))
     return target_path
 
 
@@ -134,5 +144,5 @@ def sync_provider_env(
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)
 
-    target_path.write_text("".join(lines), encoding="utf-8")
+    _write_env(target_path, "".join(lines))
     return target_path

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import os
 import stat
 
 import pytest
 
 from app.cli.wizard.config import PROVIDER_BY_VALUE
 from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
+
+_SKIP_AS_ROOT = not hasattr(os, "getuid") or os.getuid() == 0
 
 
 def test_sync_provider_env_updates_provider_specific_keys(tmp_path) -> None:
@@ -83,7 +86,7 @@ def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:
 
 
 @pytest.mark.skipif(
-    __import__("os").getuid() == 0, reason="root bypasses file permission checks"
+    _SKIP_AS_ROOT, reason="root bypasses file permission checks"
 )
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"
@@ -101,7 +104,7 @@ def test_sync_provider_env_permission_error(tmp_path) -> None:
 
 
 @pytest.mark.skipif(
-    __import__("os").getuid() == 0, reason="root bypasses file permission checks"
+    _SKIP_AS_ROOT, reason="root bypasses file permission checks"
 )
 def test_sync_env_values_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import stat
+
+import pytest
+
 from app.cli.wizard.config import PROVIDER_BY_VALUE
-from app.cli.wizard.env_sync import sync_provider_env
+from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
 
 
 def test_sync_provider_env_updates_provider_specific_keys(tmp_path) -> None:
@@ -76,3 +80,35 @@ def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:
     content = env_path.read_text(encoding="utf-8")
     assert "LLM_PROVIDER=gemini-cli\n" in content
     assert "GEMINI_CLI_MODEL=\n" in content
+
+
+@pytest.mark.skipif(
+    __import__("os").getuid() == 0, reason="root bypasses file permission checks"
+)
+def test_sync_provider_env_permission_error(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    env_path.chmod(stat.S_IRUSR)  # read-only
+    try:
+        with pytest.raises(PermissionError, match="permission denied"):
+            sync_provider_env(
+                provider=PROVIDER_BY_VALUE["openai"],
+                model="gpt-4o",
+                env_path=env_path,
+            )
+    finally:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+@pytest.mark.skipif(
+    __import__("os").getuid() == 0, reason="root bypasses file permission checks"
+)
+def test_sync_env_values_permission_error(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("FOO=bar\n", encoding="utf-8")
+    env_path.chmod(stat.S_IRUSR)
+    try:
+        with pytest.raises(PermissionError, match="permission denied"):
+            sync_env_values({"FOO": "baz"}, env_path=env_path)
+    finally:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -85,9 +85,7 @@ def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:
     assert "GEMINI_CLI_MODEL=\n" in content
 
 
-@pytest.mark.skipif(
-    _SKIP_AS_ROOT, reason="root bypasses file permission checks"
-)
+@pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")
@@ -103,9 +101,7 @@ def test_sync_provider_env_permission_error(tmp_path) -> None:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
-@pytest.mark.skipif(
-    _SKIP_AS_ROOT, reason="root bypasses file permission checks"
-)
+@pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_env_values_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("FOO=bar\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Wraps both `write_text` calls in `env_sync.py` via a new `_write_env` helper that catches `PermissionError` and re-raises with a clear message pointing the user to fix file ownership/permissions
- Converts `PermissionError` to `OpenSREError` in `_run_onboarding_command` so Sentry ignores it (Sentry's `ignore_errors` already filters `OpenSREError`) and the user sees a formatted error with a suggestion
- Adds two tests covering the permission-denied path for both `sync_env_values` and `sync_provider_env` (skipped when running as root)

## Root cause

When a user's `.env` file is read-only (e.g. owned by another user or `chmod 444`), the bare `Path.write_text()` call propagated an opaque OS `PermissionError` traceback with no guidance, and the Sentry SDK captured it as an unhandled exception. Sentry issue PYTHON-4M, reported as #2066.

## Test plan

- [x] `pytest tests/cli/wizard/test_env_sync.py` — all existing tests pass, new tests run on non-root CI
- [x] `ruff check app/cli/wizard/env_sync.py tests/cli/wizard/test_env_sync.py` — clean
- [x] `pytest -k "onboard or wizard or env_sync"` — 116 passed

Closes #2066

https://claude.ai/code/session_01WNpudPMsvsXWgpDrNm9oMf