### PR TITLE
Fix: use max_completion_tokens for gpt-5 in investigation agent

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
+
+from app.services.llm_client import _uses_max_completion_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -246,9 +247,9 @@ class OpenAIAgentClient:
         if system:
             msgs = [{"role": "system", "content": system}] + msgs
 
-        # OpenAI o-series reasoning models (o1, o3, o4, and future variants) use
-        # max_completion_tokens; all other models use max_tokens.
-        tokens_key = "max_completion_tokens" if re.match(r"^o\d", self._model) else "max_tokens"
+        tokens_key = (
+            "max_completion_tokens" if _uses_max_completion_tokens(self._model) else "max_tokens"
+        )
         kwargs: dict[str, Any] = {
             "model": self._model,
             tokens_key: self._max_tokens,

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -221,6 +221,9 @@ def test_openai_agent_client_invoke_raw_content_preserves_extra_fields(
         ("o3-mini", "max_completion_tokens"),
         ("o4-mini", "max_completion_tokens"),
         ("o5-mini", "max_completion_tokens"),  # future model covered by regex
+        ("gpt-5", "max_completion_tokens"),
+        ("gpt-5.2", "max_completion_tokens"),
+        ("gpt-5.4-mini", "max_completion_tokens"),
         ("gpt-4o", "max_tokens"),
         ("gemini-2.5-flash", "max_tokens"),
     ],
@@ -230,7 +233,7 @@ def test_openai_agent_client_uses_correct_tokens_param(
     model: str,
     expected_key: str,
 ) -> None:
-    """O-series reasoning models require max_completion_tokens; others use max_tokens."""
+    """Reasoning models (o-series, gpt-5) require max_completion_tokens; others use max_tokens."""
     _install_fake_openai(monkeypatch)
 
     captured: dict[str, object] = {}


### PR DESCRIPTION
Investigations failed when OPENAI_REASONING_MODEL was a gpt-5 model because OpenAIAgentClient sent max_tokens. Reuse the same model check as OpenAILLMClient and add regression tests for gpt-5 model IDs.

Fixes #2118 

#### Describe the changes you have made in this PR -
- Investigation agent OpenAI client now uses `max_completion_tokens` for gpt-5 (and o1/o3/o4) models, matching `OpenAILLMClient`.
- Fixes 400 errors: "Unsupported parameter: 'max_tokens'... Use 'max_completion_tokens' instead."
- Added unit tests for gpt-5 model IDs.

### Demo/Screenshot for feature changes and bug fixes - 

Ran this and it works:

using gpt-5.2 
uv run opensre investigate -i tests/fixtures/openclaw_test_alert.json


<img width="2036" height="1332" alt="image" src="https://github.com/user-attachments/assets/1eba4c53-185f-4331-aef1-a49fa6ef8e85" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?

OpenAI investigations fail with a 400 when the reasoning model is a gpt-5... model. The API rejects max_tokens and requires max_completion_tokens instead. The regular OpenAILLMClient already picks the right parameter, but OpenAIAgentClient (used by the investigation ReAct loop) did not—it only treated o-series models matching ^o\d as special, so gpt-5 models still got max_tokens.

- What alternative approaches did you consider?
I considered duplicating the prefix list in agent_llm_client.py (e.g. startswith(("o1", "o3", "o4", "gpt-5"))) works, but two places to update when OpenAI adds new model. So following DRY i reused the helper function. 

- Why did you choose this specific implementation?
Investigations and other LLM calls should behave the same for the same model ID. Importing _uses_max_completion_tokens keeps agent and non-agent OpenAI clients aligned and fixes the reported bug with a small, low-risk change
- What are the key functions/components and what do they do?


| Piece | Role |
|--------|------|
| `_uses_max_completion_tokens(model)` in `llm_client.py` | Returns whether the model needs `max_completion_tokens` (prefixes: `o1`, `o3`, `o4`, `gpt-5`). |
| `OpenAIAgentClient.invoke()` in `agent_llm_client.py` | Builds the chat completion kwargs; now sets `max_completion_tokens` or `max_tokens` via the helper. |
| `test_openai_agent_client_uses_correct_tokens_param` | Parametrized test that mocks the API and asserts the correct kwarg for each model (including `gpt-5*`). |


This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
