### PR TITLE
docs: add explicit CI readiness harness and align AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,11 @@
 
 ### Before Push
 
-1. Clean working tree
-2. `make test-cov` (or `make test-full`)
-3. `make lint`
-4. `make format-check` (run `make format` if it fails)
-5. `make typecheck`
+Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md).
+
+- `CI.md` is the source of truth for push/PR readiness.
+- If `AGENTS.md` and `CI.md` differ, `CI.md` takes precedence for readiness checks.
+- Do not skip required checks.
 
 ## 1. Repo Map
 
@@ -46,6 +46,7 @@
 | `README.md`           | Product overview, install, quick start, high-level capabilities, and links to deeper docs.         |
 | `docs/DEVELOPMENT.md` | Contributor workflows: CI parity commands, dev container, benchmark, deployment, telemetry detail. |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
+| `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
 | `CONTRIBUTING.md`     | Contribution workflow, branch/PR guidance, and quality expectations.                               |
 
 `app/` one level deeper:
@@ -166,6 +167,7 @@ Basic steps:
 - If adding new tests -> always place them in `tests/`, never in `app/` (no inline tests).
 - If CI-only tests are added -> mark them with the right pytest marker or place them in the appropriate e2e/synthetic/chaos folder so they do not run in the default local suite.
 - If investigation branching or loop behavior changes -> update `app/pipeline/pipeline.py` and the tests for that path.
+- If pushing or creating a PR -> follow the full pre-push checklist in [CI.md](CI.md).
 
 ## 4. Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,6 @@
 Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md).
 
 - `CI.md` is the source of truth for push/PR readiness.
-- If `AGENTS.md` and `CI.md` differ, `CI.md` takes precedence for readiness checks.
 - Do not skip required checks.
 
 ## 1. Repo Map

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,114 @@
+# CI Readiness — Mandatory Push/PR Harness
+
+This file is the **single source of truth** for local CI readiness before any push or PR.
+
+## 1) Mandatory baseline checks (every code change)
+
+Run all of these first:
+
+1. Clean working tree
+
+   ```bash
+   git status --short
+   ```
+
+   - No accidental untracked files
+   - Never commit `.env` or secrets
+
+2. Lint
+
+   ```bash
+   make lint
+   ```
+
+3. Format check
+
+   ```bash
+   make format-check
+   ```
+
+   If it fails:
+
+   ```bash
+   make format && make format-check
+   ```
+
+4. Typecheck
+
+   ```bash
+   make typecheck
+   ```
+
+## 2) Mandatory test harness (scope by touched modules)
+
+Do **module-scoped tests by default**.
+
+### A. Identify changed files
+
+```bash
+git diff --name-only HEAD~1
+```
+
+(Or diff against your base branch.)
+
+### B. Run matching tests for touched paths
+
+| Changed path | Run |
+|---|---|
+| `app/tools/` | `uv run pytest tests/tools/ -v` *(or `-k <keyword>` for focused runs)* |
+| `app/services/` | `uv run pytest tests/services/ tests/tools/ -v` *(or add `-k <service>`)* |
+| `app/integrations/` | `uv run pytest tests/integrations/ -v` |
+| `app/integrations/llm_cli/` | `uv run pytest tests/integrations/llm_cli/ -v` |
+| `app/integrations/opensre/` | `uv run pytest tests/integrations/opensre/ -v` |
+| `app/pipeline/` | `uv run pytest tests/pipeline/ -v` |
+| `app/nodes/` | `uv run pytest tests/nodes/ -v` |
+| `app/agent/` or `app/agents/` | `uv run pytest tests/agent/ tests/agents/ -v` |
+| `app/cli/` | `uv run pytest tests/cli/ -v` |
+| `app/entrypoints/` | `uv run pytest tests/entrypoints/ -v` |
+| `app/remote/` | `uv run pytest tests/remote/ -v` |
+| `app/sandbox/` | `uv run pytest tests/sandbox/ -v` |
+| `app/deployment/` | `uv run pytest tests/deployment/ tests/app/deployment/ -v` |
+| `app/delivery/` | `uv run pytest tests/delivery/ -v` |
+| `app/guardrails/` | `uv run pytest tests/test_guardrails/ -v` |
+| `app/masking/` | `uv run pytest tests/masking/ -v` |
+| `app/analytics/` | `uv run pytest tests/analytics/ -v` |
+| `app/auth/` | `uv run pytest tests/app/auth/ -v` |
+| `app/hermes/` | `uv run pytest tests/hermes/ tests/synthetic/hermes_rca/ -v` |
+| `app/watch_dog/` | `uv run pytest tests/watch_dog/ -v` |
+| `app/types/` | `uv run pytest tests/types/ -v` |
+| `app/state/` | `uv run pytest tests/test_state.py tests/types/ -v` |
+| `app/utils/` | `uv run pytest tests/utils/ -v` |
+| `app/webapp.py` | `uv run pytest tests/test_webapp.py -v` |
+| Other `app/` paths (no direct mapping above) | `make test-cov` |
+| `tests/...` only | Run the exact changed test files/directories |
+| `pyproject.toml`, `uv.lock`, `pytest.ini`, `Makefile` | `make test-cov` |
+
+## 3) Escalation rules (must run full unit CI suite)
+
+Run `make test-cov` (instead of only targeted tests) when any of these are true:
+
+- Shared/core code changed (`app/utils/`, `app/state/`, `app/types/`, `app/pipeline/`, `app/nodes/`)
+- 3+ app areas changed in one diff
+- New files with unclear blast radius
+- Cross-cutting refactor
+- You are unsure test scope is sufficient
+
+```bash
+make test-cov
+```
+
+## 4) Conditional checks
+
+If integration config, integration wiring, or related tools changed, also run:
+
+```bash
+make verify-integrations
+```
+
+## 5) Optional extra confidence
+
+You may run `make check` as a final pass, but it is heavier (`test-full`) than the required harness.
+
+## Precedence
+
+If readiness instructions conflict across docs, **this file wins** for push/PR checks.

--- a/CI.md
+++ b/CI.md
@@ -46,10 +46,10 @@ Do **module-scoped tests by default**.
 ### A. Identify changed files
 
 ```bash
-git diff --name-only HEAD~1
+git diff --name-only $(git merge-base HEAD main)
 ```
 
-(Or diff against your base branch.)
+(Use `git diff --name-only HEAD~1` only for quick single-commit checks.)
 
 ### B. Run matching tests for touched paths
 
@@ -60,8 +60,8 @@ git diff --name-only HEAD~1
 | `app/integrations/` | `uv run pytest tests/integrations/ -v` |
 | `app/integrations/llm_cli/` | `uv run pytest tests/integrations/llm_cli/ -v` |
 | `app/integrations/opensre/` | `uv run pytest tests/integrations/opensre/ -v` |
-| `app/pipeline/` | `uv run pytest tests/pipeline/ -v` |
-| `app/nodes/` | `uv run pytest tests/nodes/ -v` |
+| `app/pipeline/` | `make test-cov` |
+| `app/nodes/` | `make test-cov` |
 | `app/agent/` or `app/agents/` | `uv run pytest tests/agent/ tests/agents/ -v` |
 | `app/cli/` | `uv run pytest tests/cli/ -v` |
 | `app/entrypoints/` | `uv run pytest tests/entrypoints/ -v` |
@@ -75,9 +75,9 @@ git diff --name-only HEAD~1
 | `app/auth/` | `uv run pytest tests/app/auth/ -v` |
 | `app/hermes/` | `uv run pytest tests/hermes/ tests/synthetic/hermes_rca/ -v` |
 | `app/watch_dog/` | `uv run pytest tests/watch_dog/ -v` |
-| `app/types/` | `uv run pytest tests/types/ -v` |
-| `app/state/` | `uv run pytest tests/test_state.py tests/types/ -v` |
-| `app/utils/` | `uv run pytest tests/utils/ -v` |
+| `app/types/` | `make test-cov` |
+| `app/state/` | `make test-cov` |
+| `app/utils/` | `make test-cov` |
 | `app/webapp.py` | `uv run pytest tests/test_webapp.py -v` |
 | Other `app/` paths (no direct mapping above) | `make test-cov` |
 | `tests/...` only | Run the exact changed test files/directories |


### PR DESCRIPTION
## Summary
- add a dedicated `CI.md` as the single source of truth for push/PR readiness
- define a module-scoped test harness with clear escalation rules to `make test-cov`
- align `AGENTS.md` to reference `CI.md` instead of duplicating checklist logic

## Why
- makes pre-PR expectations explicit for humans and AI agents
- reduces instruction drift between docs
- keeps local validation efficient (targeted tests by default) while preserving safety via escalation rules

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
