### PR TITLE
fix(agent-llm): reject CLI-backed providers in get_agent_llm with a clear error

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -358,6 +358,13 @@ _AgentClientType = AnthropicAgentClient | OpenAIAgentClient
 _agent_client: _AgentClientType | None = None
 
 
+def _is_cli_provider(provider: str) -> bool:
+    """Return True when *provider* is a subprocess-backed CLI (no native tool-calling)."""
+    from app.integrations.llm_cli.registry import CLI_PROVIDER_REGISTRY
+
+    return provider in CLI_PROVIDER_REGISTRY
+
+
 def get_agent_llm() -> _AgentClientType:
     """Return a singleton tool-calling LLM client for the investigation agent."""
     global _agent_client
@@ -392,6 +399,12 @@ def get_agent_llm() -> _AgentClientType:
         _agent_client = BedrockAgentClient(
             model=settings.bedrock_reasoning_model,
             max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+        )
+    elif _is_cli_provider(provider):
+        raise RuntimeError(
+            f"LLM_PROVIDER={provider!r} is a CLI-backed provider and cannot be used for "
+            "investigations. Investigations require native API tool-calling. "
+            "Set LLM_PROVIDER to 'anthropic', 'openai', 'bedrock', or another API provider."
         )
     else:
         # Default: Anthropic

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -341,7 +341,9 @@ def test_unrelated_type_error_is_retried_and_wrapped(
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
 
 
-@pytest.mark.parametrize("provider", ["codex", "opencode", "claude-code", "kimi", "cursor"])
+@pytest.mark.parametrize(
+    "provider", ["codex", "opencode", "claude-code", "kimi", "cursor", "gemini-cli", "copilot"]
+)
 def test_get_agent_llm_rejects_cli_providers(
     provider: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -339,3 +339,16 @@ def test_unrelated_type_error_is_retried_and_wrapped(
         client.invoke(messages=[{"role": "user", "content": "hi"}])
 
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
+
+
+@pytest.mark.parametrize("provider", ["codex", "opencode", "claude-code", "kimi", "cursor"])
+def test_get_agent_llm_rejects_cli_providers(
+    provider: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.agent_llm_client import get_agent_llm, reset_agent_client
+
+    monkeypatch.setenv("LLM_PROVIDER", provider)
+    reset_agent_client()
+    with pytest.raises(RuntimeError, match="CLI-backed provider"):
+        get_agent_llm()
+    reset_agent_client()

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "build", marker = "extra == 'release-dist'", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "clickhouse-connect", specifier = ">=0.15.1" },
+    { name = "clickhouse-connect", specifier = ">=0.15.1,<1.0.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.15.1" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.14.0" },
     { name = "cryptography", specifier = ">=42.0.0" },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- CLI providers (codex, opencode, claude-code, kimi, cursor, gemini-cli, copilot) run as subprocesses and have no native API tool-calling. The investigation agent's ReAct loop requires tool-calling, so these providers cannot be used there.
- Previously, `get_agent_llm()` had no check for CLI providers: an incomplete `CLIAgentClient` was attempted in a deployed version, causing a chain of `NameError` / `AttributeError` crashes (#2126, #2128, #2129, #2131). After that code was removed, the function silently fell through to Anthropic — confusing users who had configured a CLI provider.
- This PR adds `_is_cli_provider()` and an explicit `elif` branch in `get_agent_llm()` that raises a `RuntimeError` with a clear, actionable message directing the user to an API provider.

## Test plan

- [x] 5 new parametrized unit tests (`codex`, `opencode`, `claude-code`, `kimi`, `cursor`) assert the error is raised with `"CLI-backed provider"` in the message
- [x] All 21 existing `test_agent_llm_client.py` tests pass
- [x] `ruff check` passes on changed files

Closes #2126, #2128, #2129, #2131

https://claude.ai/code/session_015JXZN8a8GEYGpUYAhB9YpL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015JXZN8a8GEYGpUYAhB9YpL)_