### PR TITLE
fix(hermes): prevent PatternRule/RepeatRule false positives on logger…

### DIFF
--- a/app/hermes/rules.py
+++ b/app/hermes/rules.py
@@ -44,8 +44,11 @@ from app.hermes.incident import HermesIncident, IncidentSeverity, LogLevel, LogR
 class PatternRule:
     """Rule that emits one incident per matching log record.
 
-    Patterns are matched case-insensitively against the record's
-    message. Any pattern matching causes the rule to fire.
+    Patterns are matched case-insensitively against ``record.message``
+    only. ``record.raw`` (which includes the timestamp/level/logger
+    prefix) is intentionally excluded so a keyword appearing in a
+    logger name — e.g. ``oom_monitor`` — cannot fire an OOM rule on
+    an otherwise benign message.
     """
 
     name: str
@@ -60,7 +63,7 @@ class PatternRule:
         if record.level.severity_rank < self.min_level.severity_rank:
             return None
         for pattern in self.patterns:
-            if pattern.search(record.message) or pattern.search(record.raw):
+            if pattern.search(record.message):
                 title = self.title_template.format(
                     logger=record.logger or "unknown",
                     level=record.level.value,
@@ -85,6 +88,10 @@ class RepeatRule:
     Used for ``crash_loop`` and any other failure mode that's only
     actionable when it repeats. Each rule keeps its own bounded deque
     keyed by logger; older matches age out automatically.
+
+    As with :class:`PatternRule`, patterns match against
+    ``record.message`` only — never the raw line — so logger names
+    can't accidentally satisfy a rule.
     """
 
     name: str
@@ -101,7 +108,7 @@ class RepeatRule:
             return None
         if record.level.severity_rank < self.min_level.severity_rank:
             return None
-        if not any(p.search(record.message) or p.search(record.raw) for p in self.patterns):
+        if not any(p.search(record.message) for p in self.patterns):
             return None
         key = record.logger or "_unknown"
         bucket = self._hits.setdefault(key, deque())

--- a/tests/hermes/test_rules.py
+++ b/tests/hermes/test_rules.py
@@ -94,8 +94,11 @@ def test_pattern_rule_does_not_match_logger_name_in_raw_line() -> None:
         logger_name="oom_killer_watcher",
     )
     # Confirm the raw line actually triggers the pattern — ensures the
-    # test is a genuine regression guard, not vacuously green.
-    assert rule.patterns[2].search(record.raw) is not None  # \boom[- _]killer
+    # test is a genuine regression guard, not vacuously green. Looked
+    # up by pattern source so reordering the tuple can't silently make
+    # this assertion test the wrong pattern.
+    oom_killer_pat = next(p for p in rule.patterns if r"oom[- _]killer" in p.pattern)
+    assert oom_killer_pat.search(record.raw) is not None
     assert rule.evaluate(record) is None
 
 
@@ -151,8 +154,11 @@ def test_repeat_rule_does_not_match_logger_name_in_raw_line() -> None:
             message="heartbeat ok",
             raw="WARNING service restart: heartbeat ok",
         )
-        # Confirm the raw line actually triggers the pattern.
-        assert crash.patterns[0].search(record.raw) is not None
+        # Confirm the raw line actually triggers the pattern. Looked up
+        # by pattern source so reordering the tuple can't silently make
+        # this assertion test the wrong pattern.
+        restart_pat = next(p for p in crash.patterns if "start" in p.pattern)
+        assert restart_pat.search(record.raw) is not None
         assert crash.evaluate(record) is None
 
 

--- a/tests/hermes/test_rules.py
+++ b/tests/hermes/test_rules.py
@@ -77,6 +77,28 @@ def test_pattern_rules_ignore_continuation_lines() -> None:
     assert rule.evaluate(record) is None
 
 
+def test_pattern_rule_does_not_match_logger_name_in_raw_line() -> None:
+    """Regression: rule keywords appearing only in the logger prefix must
+    not fire — patterns scan ``record.message`` exclusively.
+
+    ``oom_killer_watcher`` contains ``oom_killer`` which *does* match the
+    ``\\boom[- _]killer`` pattern when ``record.raw`` is searched, so this
+    test would fail if the old ``or pattern.search(record.raw)`` guard
+    were re-introduced.
+    """
+    rules = {r.name: r for r in default_pattern_rules()}
+    rule = rules["oom_killed"]
+    record = _rec(
+        "heartbeat ok",
+        level=LogLevel.ERROR,
+        logger_name="oom_killer_watcher",
+    )
+    # Confirm the raw line actually triggers the pattern — ensures the
+    # test is a genuine regression guard, not vacuously green.
+    assert rule.patterns[2].search(record.raw) is not None  # \boom[- _]killer
+    assert rule.evaluate(record) is None
+
+
 def test_repeat_rule_only_fires_at_threshold() -> None:
     crash = next(r for r in default_pattern_rules() if r.name == "crash_loop")
     assert isinstance(crash, RepeatRule)
@@ -108,6 +130,30 @@ def test_repeat_rule_window_ages_out_old_hits() -> None:
     crash.evaluate(_rec("agent restarting", level=LogLevel.WARNING, seconds=10))
     # 200s later — first two have aged out, this is hit #1
     assert crash.evaluate(_rec("agent restarting", level=LogLevel.WARNING, seconds=200)) is None
+
+
+def test_repeat_rule_does_not_match_logger_name_in_raw_line() -> None:
+    """Regression: a keyword appearing only in ``record.raw`` (not the
+    message) must not count toward the RepeatRule threshold.
+
+    ``service restart`` as a logger name produces a raw line that matches
+    ``(?:service)\\s+(?:re)?start`` — the crash-loop pattern. This test
+    confirms that 5 such records with a benign message never fire an
+    incident, and would fail if raw-matching were re-introduced.
+    """
+    crash = next(r for r in default_pattern_rules() if r.name == "crash_loop")
+    assert isinstance(crash, RepeatRule)
+    for i in range(5):
+        record = LogRecord(
+            timestamp=datetime(2026, 5, 12, 12, 0, 0) + timedelta(seconds=i * 5),
+            level=LogLevel.WARNING,
+            logger="service restart",
+            message="heartbeat ok",
+            raw="WARNING service restart: heartbeat ok",
+        )
+        # Confirm the raw line actually triggers the pattern.
+        assert crash.patterns[0].search(record.raw) is not None
+        assert crash.evaluate(record) is None
 
 
 def test_classifier_picks_up_default_pattern_rules() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "build", marker = "extra == 'release-dist'", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "clickhouse-connect", specifier = ">=0.15.1" },
+    { name = "clickhouse-connect", specifier = ">=0.15.1,<1.0.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.15.1" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.14.0" },
     { name = "cryptography", specifier = ">=42.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "build", marker = "extra == 'release-dist'", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "clickhouse-connect", specifier = ">=0.15.1,<1.0.0" },
+    { name = "clickhouse-connect", specifier = ">=0.15.1" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.15.1" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.14.0" },
     { name = "cryptography", specifier = ">=42.0.0" },


### PR DESCRIPTION
… names

Fixes #1874 

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -
 - Updated PatternRule and RepeatRule in app/hermes/rules.py to exclusively scan record.message instead of falling back to record.raw.
 - Added regression tests that verify rule keywords in the logger prefix do not trigger false-positive incidents. Tests explicitly assert that the raw line matches the regex, but the evaluate() method correctly ignores it.
 - 
### Demo/Screenshot for feature changes and bug fixes - 
<!-- Include at least one proof of the change: UI screenshot, terminal screenshot/log snippet, short video/GIF, or equivalent demo output. -->

https://github.com/user-attachments/assets/532d8539-f930-4892-95bc-e3ef3af816eb

<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
<!-- 
Describe in your own words:
- What problem does your code solve?
- What alternative approaches did you consider?
- Why did you choose this specific implementation?
- What are the key functions/components and what do they do?

This helps reviewers understand your thought process and ensures you understand the code.
-->

Dropped the or pattern.search(record.raw) fallback in both PatternRule and RepeatRule so patterns only scan record.message, preventing keywords in logger-name prefixes from firing false-positive incidents. Updated docstrings to document the scope and added two regression tests that construct records where record.raw matches a pattern but the message is benign confirmed they fail on the old code and pass on the fix.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
