### PR TITLE
fix(agent): handle tool-unsupported model errors gracefully in investigation loop

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -173,37 +173,52 @@ class ConnectedInvestigationAgent:
                         "Error: The AI model was not found (404). "
                         "If using a local LLM, verify the model name in your .env file."
                     )
+                    remediation_steps = [
+                        "Check your .env configuration",
+                        "Verify the model name is correct",
+                        "Ensure the model is downloaded locally",
+                        "Confirm your provider supports this model",
+                    ]
                     tracker.error("investigation_agent", message="Failed: Model not found")
-                    _emit(
-                        "agent_end",
-                        {
-                            "root_cause": error_msg,
-                            "validity_score": 0.0,
-                            "root_cause_category": "Configuration Error",
-                        },
+                elif "does not support tool" in err_msg or "only supports single tool" in err_msg:
+                    error_msg = (
+                        "Error: The configured model does not support tool calling. "
+                        "The investigation agent requires a model with native tool-calling support."
                     )
-                    updates = {
+                    remediation_steps = [
+                        "Switch to a model that supports tool calling (e.g. claude-opus-4-7, gpt-4o)",
+                        "For Ollama: use llama3.1, qwen2.5, or another tool-call-capable model",
+                        "Check your LLM_MODEL or LLM_PROVIDER setting in .env",
+                    ]
+                    tracker.error(
+                        "investigation_agent", message="Failed: Model does not support tools"
+                    )
+                else:
+                    raise
+                _emit(
+                    "agent_end",
+                    {
                         "root_cause": error_msg,
-                        "root_cause_category": "Configuration Error",
-                        "causal_chain": [f"Model API returned error: {str(err)}"],
-                        "validated_claims": [],
-                        "non_validated_claims": [],
-                        "remediation_steps": [
-                            "Check your .env configuration",
-                            "Verify the model name is correct",
-                            "Ensure the model is downloaded locally",
-                            "Confirm your provider supports this model",
-                        ],
                         "validity_score": 0.0,
-                        "investigation_recommendations": [],
-                        "evidence": evidence,
-                        "evidence_entries": [e.model_dump() for e in evidence_entries],
-                        "agent_messages": messages,
-                        "executed_hypotheses": executed_hypotheses,
-                    }
-                    updates.update(tool_context)
-                    return updates
-                raise
+                        "root_cause_category": "Configuration Error",
+                    },
+                )
+                updates = {
+                    "root_cause": error_msg,
+                    "root_cause_category": "Configuration Error",
+                    "causal_chain": [f"Model API returned error: {str(err)}"],
+                    "validated_claims": [],
+                    "non_validated_claims": [],
+                    "remediation_steps": remediation_steps,
+                    "validity_score": 0.0,
+                    "investigation_recommendations": [],
+                    "evidence": evidence,
+                    "evidence_entries": [e.model_dump() for e in evidence_entries],
+                    "agent_messages": messages,
+                    "executed_hypotheses": executed_hypotheses,
+                }
+                updates.update(tool_context)
+                return updates
 
             messages.append(_build_assistant_msg(llm, response))
 

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -73,3 +73,77 @@ def test_run_re_raises_unmatched_runtime_error() -> None:
             agent.run(state)
 
     mock_tracker.error.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        "OpenAI request rejected: Error code: 400 - {'error': {'message': 'registry.ollama.ai/library/llama3:latest does not support tools'}}",
+        "OpenAI request rejected: Error code: 400 - {'error': {'message': 'llama3:latest does not support tool calls'}}",
+    ],
+)
+def test_run_gracefully_handles_tool_unsupported_model(error_msg: str) -> None:
+    """When the LLM raises a 'does not support tools' error the agent returns
+    a degraded state with a clear configuration-error message."""
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = RuntimeError(error_msg)
+    mock_llm.tool_schemas.return_value = []
+
+    mock_tracker = MagicMock()
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+    ):
+        agent = ConnectedInvestigationAgent()
+        state = {
+            "alert_name": "Test alert",
+            "pipeline_name": "test-pipeline",
+            "severity": "critical",
+            "resolved_integrations": {},
+        }
+        result = agent.run(state)
+
+    mock_tracker.error.assert_called_once_with(
+        "investigation_agent", message="Failed: Model does not support tools"
+    )
+    assert result["root_cause_category"] == "Configuration Error"
+    assert result["validity_score"] == 0.0
+    assert "tool calling" in result["root_cause"].lower()
+    assert result["remediation_steps"]
+    assert result["causal_chain"]
+
+
+def test_run_gracefully_handles_single_tool_call_only_model() -> None:
+    """When the provider reports that a model only supports single tool-calls
+    the agent returns a degraded state with a clear configuration-error message."""
+    mock_llm = MagicMock()
+    mock_llm.invoke.side_effect = RuntimeError(
+        "OpenAI API failed: Error code: 500 - {'error': {'message': "
+        "'This model only supports single tool-calls at once! (in tool_use:95)'}}"
+    )
+    mock_llm.tool_schemas.return_value = []
+
+    mock_tracker = MagicMock()
+
+    with (
+        patch("app.agent.investigation.get_agent_llm", return_value=mock_llm),
+        patch("app.agent.investigation.get_tracker", return_value=mock_tracker),
+    ):
+        agent = ConnectedInvestigationAgent()
+        state = {
+            "alert_name": "Test alert",
+            "pipeline_name": "test-pipeline",
+            "severity": "critical",
+            "resolved_integrations": {},
+        }
+        result = agent.run(state)
+
+    mock_tracker.error.assert_called_once_with(
+        "investigation_agent", message="Failed: Model does not support tools"
+    )
+    assert result["root_cause_category"] == "Configuration Error"
+    assert result["validity_score"] == 0.0
+    assert "tool calling" in result["root_cause"].lower()
+    assert result["remediation_steps"]
+    assert result["causal_chain"]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes Sentry issues #2087 and #2089: when the LLM returns `400 "does not support tools"` or `500 "only supports single tool-calls at once"`, the investigation agent now returns a graceful `Configuration Error` state instead of re-raising and crashing the pipeline
- Refactors the `except RuntimeError` handler in `investigation.py` to share the graceful-return path between model-not-found and tool-unsupported cases, eliminating code duplication
- Adds 3 new parametrised tests covering both Sentry error patterns

**Root cause:** `investigation.py`'s error handler only matched "model not found / 404" errors. Tool-calling unsupported errors (HTTP 400/500 from Ollama/LM-Studio) escaped the handler, reached `pipeline.py`'s `capture_exception`, and hit Sentry as unexpected bugs — even though they are operator-actionable config issues.

## Test plan

- [x] `uv run pytest tests/agent/test_investigation.py -v` — 6 passed (3 new tests)
- [x] `uv run make test-cov` — 6802 passed, 7 skipped
- [x] `uv run make lint` — no issues
- [x] `uv run make format-check` — clean
- [x] `uv run make typecheck` — no issues

Closes #2087
Closes #2089

https://claude.ai/code/session_01UL8AK4wnj1YN76WDqPLRnp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UL8AK4wnj1YN76WDqPLRnp)_