### PR TITLE
test(hermes): add provider/transport RCA synthetic scenarios

### DIFF
--- a/app/tools/HermesSessionEvidenceTool/__init__.py
+++ b/app/tools/HermesSessionEvidenceTool/__init__.py
@@ -59,6 +59,60 @@ def get_hermes_session_log(
 
 
 @tool(
+    name="get_hermes_provider_traffic",
+    source="hermes",
+    description="Get captured Hermes provider HTTP/SSE request and response traffic.",
+    use_cases=[
+        "Diagnose provider 4xx/5xx responses, malformed bodies, dropped headers, and SSE drift"
+    ],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=_fixture_backend_only,
+    extract_params=_extract_params,
+)
+def get_hermes_provider_traffic(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_provider_traffic")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_provider_traffic(session_id=session_id))
+
+
+@tool(
+    name="get_hermes_config",
+    source="hermes",
+    description="Get resolved Hermes provider, model, region, and transport configuration.",
+    use_cases=[
+        "Diagnose provider selection, Bedrock IMDS overrides, transport limits, and adapter config mismatches"
+    ],
+    surfaces=("investigation",),
+    input_schema={
+        "type": "object",
+        "properties": {"session_id": {"type": "string"}},
+        "required": [],
+    },
+    is_available=_fixture_backend_only,
+    extract_params=_extract_params,
+)
+def get_hermes_config(
+    session_id: str = "",
+    hermes_backend: Any = None,
+    **_kwargs: Any,
+) -> dict[str, Any]:
+    backend = _backend_or_error(hermes_backend, "get_hermes_config")
+    if isinstance(backend, dict):
+        return backend
+    return cast(dict[str, Any], backend.get_config(session_id=session_id))
+
+
+@tool(
     name="get_hermes_message_history",
     source="hermes",
     description="Get full Hermes conversation message history for ordering/invariant checks.",
@@ -185,6 +239,8 @@ def get_hermes_session_topology(
 
 __all__ = [
     "get_hermes_session_log",
+    "get_hermes_provider_traffic",
+    "get_hermes_config",
     "get_hermes_message_history",
     "get_hermes_kv_cache_state",
     "get_hermes_runtime_state",

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/alert.json
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/alert.json
@@ -1,0 +1,19 @@
+{
+  "title": "Hermes Codex session failed after malformed provider response",
+  "state": "firing",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesProviderFailure",
+    "severity": "critical",
+    "service": "hermes"
+  },
+  "commonAnnotations": {
+    "summary": "Codex Responses API returned malformed output",
+    "description": "Hermes session crashed after provider returned empty/malformed response body.",
+    "context_sources": "hermes",
+    "hermes_session_id": "sess-codex-001",
+    "hermes_provider": "codex",
+    "hermes_model": "gpt-5.4-mini",
+    "failure_mode": "provider_empty_response"
+  }
+}

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
@@ -21,4 +21,4 @@ optimal_trajectory:
 
 max_investigation_loops: 3
 
-model_response: Codex Responses API returned an empty/malformed response body and Hermes terminated the session.
+model_response: Codex Responses API returned an empty/malformed response body; Hermes retried the request and then terminated the session.

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
@@ -21,4 +21,4 @@ optimal_trajectory:
 
 max_investigation_loops: 3
 
-model_response: Codex Responses API returned an empty/malformed response body; Hermes retried the request and then terminated the session.
+model_response: Codex Responses API returned an empty/malformed response body; Hermes issued a retry and then terminated the session.

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
@@ -5,7 +5,6 @@ required_keywords:
   - empty
   - malformed
   - retry
-  - backoff
 
 forbidden_categories:
   - unknown

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/answer.yml
@@ -1,0 +1,25 @@
+root_cause_category: upstream_service_outage
+
+required_keywords:
+  - codex
+  - empty
+  - malformed
+  - retry
+  - backoff
+
+forbidden_categories:
+  - unknown
+  - healthy
+  - agent_hang
+
+required_evidence_sources:
+  - hermes_provider_traffic
+
+optimal_trajectory:
+  - get_hermes_provider_traffic
+  - get_hermes_session_log
+  - get_hermes_config
+
+max_investigation_loops: 3
+
+model_response: Codex Responses API returned an empty/malformed response body and Hermes terminated the session.

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_config.json
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_config.json
@@ -1,0 +1,16 @@
+{
+  "provider": "codex",
+  "model": "gpt-5.4-mini",
+  "region": "us-east-1",
+  "providers": [
+    {
+      "name": "codex",
+      "base_url": "https://api.openai.com",
+      "auth_kind": "api_key"
+    }
+  ],
+  "transport": {
+    "sse_max_line_bytes": 131072,
+    "request_timeout_s": 120
+  }
+}

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_provider_traffic.json
@@ -21,6 +21,28 @@
         "body_sample": "",
         "duration_ms": 842
       }
+    },
+    {
+      "ts": "2026-05-17T10:15:06Z",
+      "provider": "codex",
+      "model": "gpt-5.4-mini",
+      "endpoint": "/v1/responses",
+      "request": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"input\":\"generate kubernetes deployment\"}"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"output\": null}",
+        "duration_ms": 910
+      }
     }
   ]
 }

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_provider_traffic.json
@@ -1,0 +1,26 @@
+{
+  "calls": [
+    {
+      "ts": "2026-05-17T10:15:04Z",
+      "provider": "codex",
+      "model": "gpt-5.4-mini",
+      "endpoint": "/v1/responses",
+      "request": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"input\":\"generate kubernetes deployment\"}"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "",
+        "duration_ms": 842
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_runtime_state.json
@@ -1,0 +1,9 @@
+{
+  "pid": 4812,
+  "started_at": "2026-05-17T10:10:00Z",
+  "frozen_now_ts": "2026-05-17T10:15:08Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-17T10:15:07Z",
+  "is_blocked": false,
+  "blocking_call": null
+}

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/hermes_session_log.json
@@ -1,0 +1,29 @@
+{
+  "session_id": "sess-codex-001",
+  "events": [
+    {
+      "ts": "2026-05-17T10:15:02Z",
+      "kind": "message",
+      "payload": {
+        "role": "user",
+        "content": "generate kubernetes deployment"
+      }
+    },
+    {
+      "ts": "2026-05-17T10:15:05Z",
+      "kind": "retry",
+      "payload": {
+        "attempt": 1,
+        "delay_ms": 1500
+      }
+    },
+    {
+      "ts": "2026-05-17T10:15:07Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "MalformedProviderResponse",
+        "error_message": "Codex Responses API returned empty body"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/001-codex-empty-response/scenario.yml
+++ b/tests/synthetic/hermes_rca/001-codex-empty-response/scenario.yml
@@ -1,0 +1,10 @@
+schema_version: '1.0'
+scenario_id: 001-codex-empty-response
+failure_mode: provider_empty_response
+severity: critical
+scenario_difficulty: 2
+available_evidence:
+- hermes_session_log
+- hermes_provider_traffic
+- hermes_config
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/alert.json
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/alert.json
@@ -1,0 +1,19 @@
+{
+  "title": "Hermes OpenRouter requests failing with HTTP 400",
+  "state": "firing",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesProviderFailure",
+    "severity": "critical",
+    "service": "hermes"
+  },
+  "commonAnnotations": {
+    "summary": "OpenRouter returned HTTP 400 for every model request",
+    "description": "Hermes session failed because all OpenRouter requests returned HTTP 400.",
+    "context_sources": "hermes",
+    "hermes_session_id": "sess-openrouter-002",
+    "hermes_provider": "openrouter",
+    "hermes_model": "claude-3.7-sonnet",
+    "failure_mode": "provider_http_400"
+  }
+}

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/answer.yml
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/answer.yml
@@ -1,0 +1,25 @@
+root_cause_category: upstream_service_outage
+
+required_keywords:
+  - openrouter
+  - "400"
+  - request
+  - payload
+  - provider
+
+forbidden_categories:
+  - unknown
+  - healthy
+  - agent_hang
+
+required_evidence_sources:
+  - hermes_provider_traffic
+
+optimal_trajectory:
+  - get_hermes_provider_traffic
+  - get_hermes_config
+  - get_hermes_session_log
+
+max_investigation_loops: 3
+
+model_response: OpenRouter returned HTTP 400 because the provider request payload was malformed or unsupported.

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/answer.yml
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/answer.yml
@@ -1,4 +1,4 @@
-root_cause_category: upstream_service_outage
+root_cause_category: configuration_error
 
 required_keywords:
   - openrouter

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_config.json
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_config.json
@@ -1,0 +1,16 @@
+{
+  "provider": "openrouter",
+  "model": "claude-3.7-sonnet",
+  "region": "global",
+  "providers": [
+    {
+      "name": "openrouter",
+      "base_url": "https://openrouter.ai",
+      "auth_kind": "api_key"
+    }
+  ],
+  "transport": {
+    "sse_max_line_bytes": 131072,
+    "request_timeout_s": 120
+  }
+}

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_provider_traffic.json
@@ -1,0 +1,26 @@
+{
+  "calls": [
+    {
+      "ts": "2026-05-17T11:00:04Z",
+      "provider": "openrouter",
+      "model": "claude-3.7-sonnet",
+      "endpoint": "/api/v1/chat/completions",
+      "request": {
+        "method": "POST",
+        "url": "https://openrouter.ai/api/v1/chat/completions",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"messages\":[]}"
+      },
+      "response": {
+        "status": 400,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"error\":\"invalid request payload\"}",
+        "duration_ms": 522
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_runtime_state.json
@@ -1,0 +1,9 @@
+{
+  "pid": 5120,
+  "started_at": "2026-05-17T10:58:00Z",
+  "frozen_now_ts": "2026-05-17T11:00:06Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-17T11:00:05Z",
+  "is_blocked": false,
+  "blocking_call": null
+}

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/hermes_session_log.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-openrouter-002",
+  "events": [
+    {
+      "ts": "2026-05-17T11:00:02Z",
+      "kind": "message",
+      "payload": {
+        "role": "user",
+        "content": "summarize terraform plan"
+      }
+    },
+    {
+      "ts": "2026-05-17T11:00:05Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "ProviderHTTPError",
+        "error_message": "OpenRouter returned HTTP 400 Bad Request"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/002-openrouter-400-all-models/scenario.yml
+++ b/tests/synthetic/hermes_rca/002-openrouter-400-all-models/scenario.yml
@@ -1,0 +1,10 @@
+schema_version: '1.0'
+scenario_id: 002-openrouter-400-all-models
+failure_mode: provider_http_400
+severity: critical
+scenario_difficulty: 2
+available_evidence:
+- hermes_session_log
+- hermes_provider_traffic
+- hermes_config
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/alert.json
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/alert.json
@@ -1,0 +1,19 @@
+{
+  "title": "Hermes MiniMax provider overload",
+  "state": "firing",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesProviderOverload",
+    "severity": "critical",
+    "service": "hermes"
+  },
+  "commonAnnotations": {
+    "summary": "MiniMax returned repeated 529 overload responses",
+    "description": "Hermes provider calls failed because the MiniMax cluster was overloaded.",
+    "context_sources": "hermes",
+    "hermes_session_id": "sess-minimax-003",
+    "hermes_provider": "minimax",
+    "hermes_model": "abab6.5-chat",
+    "failure_mode": "provider_overload_529"
+  }
+}

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/answer.yml
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/answer.yml
@@ -5,7 +5,7 @@ required_keywords:
   - "529"
   - overload
   - provider
-  - failover
+  - fail over
 
 forbidden_categories:
   - unknown

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/answer.yml
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/answer.yml
@@ -1,0 +1,25 @@
+root_cause_category: upstream_service_outage
+
+required_keywords:
+  - minimax
+  - "529"
+  - overload
+  - provider
+  - failover
+
+forbidden_categories:
+  - unknown
+  - healthy
+  - agent_hang
+
+required_evidence_sources:
+  - hermes_provider_traffic
+
+optimal_trajectory:
+  - get_hermes_provider_traffic
+  - get_hermes_config
+  - get_hermes_session_log
+
+max_investigation_loops: 3
+
+model_response: MiniMax provider returned repeated 529 overload responses and Hermes should fail over to another configured provider.

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_config.json
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_config.json
@@ -1,0 +1,16 @@
+{
+  "provider": "minimax",
+  "model": "abab6.5-chat",
+  "region": "ap-southeast-1",
+  "providers": [
+    {
+      "name": "minimax",
+      "base_url": "https://api.minimax.chat",
+      "auth_kind": "api_key"
+    }
+  ],
+  "transport": {
+    "sse_max_line_bytes": 131072,
+    "request_timeout_s": 120
+  }
+}

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_provider_traffic.json
@@ -1,0 +1,48 @@
+{
+  "calls": [
+    {
+      "ts": "2026-05-17T12:00:04Z",
+      "provider": "minimax",
+      "model": "abab6.5-chat",
+      "endpoint": "/v1/chat/completions",
+      "request": {
+        "method": "POST",
+        "url": "https://api.minimax.chat/v1/chat/completions",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"messages\":[{\"role\":\"user\",\"content\":\"analyze redis latency spike\"}]}"
+      },
+      "response": {
+        "status": 529,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"error\":\"cluster overloaded\"}",
+        "duration_ms": 1840
+      }
+    },
+    {
+      "ts": "2026-05-17T12:00:09Z",
+      "provider": "minimax",
+      "model": "abab6.5-chat",
+      "endpoint": "/v1/chat/completions",
+      "request": {
+        "method": "POST",
+        "url": "https://api.minimax.chat/v1/chat/completions",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"messages\":[{\"role\":\"user\",\"content\":\"analyze redis latency spike\"}]}"
+      },
+      "response": {
+        "status": 529,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"error\":\"cluster overloaded\"}",
+        "duration_ms": 2011
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_runtime_state.json
@@ -1,0 +1,9 @@
+{
+  "pid": 6201,
+  "started_at": "2026-05-17T11:58:00Z",
+  "frozen_now_ts": "2026-05-17T12:00:10Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-17T12:00:09Z",
+  "is_blocked": false,
+  "blocking_call": null
+}

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/hermes_session_log.json
@@ -1,0 +1,29 @@
+{
+  "session_id": "sess-minimax-003",
+  "events": [
+    {
+      "ts": "2026-05-17T12:00:02Z",
+      "kind": "message",
+      "payload": {
+        "role": "user",
+        "content": "analyze redis latency spike"
+      }
+    },
+    {
+      "ts": "2026-05-17T12:00:05Z",
+      "kind": "retry",
+      "payload": {
+        "attempt": 2,
+        "delay_ms": 3000
+      }
+    },
+    {
+      "ts": "2026-05-17T12:00:09Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "ProviderOverload",
+        "error_message": "MiniMax returned HTTP 529 overload"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/003-minimax-529-overload/scenario.yml
+++ b/tests/synthetic/hermes_rca/003-minimax-529-overload/scenario.yml
@@ -1,0 +1,10 @@
+schema_version: '1.0'
+scenario_id: 003-minimax-529-overload
+failure_mode: provider_overload_529
+severity: critical
+scenario_difficulty: 2
+available_evidence:
+- hermes_session_log
+- hermes_provider_traffic
+- hermes_config
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/alert.json
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/alert.json
@@ -1,0 +1,19 @@
+{
+  "title": "Hermes provider unexpectedly switched to Bedrock",
+  "state": "firing",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesProviderOverride",
+    "severity": "critical",
+    "service": "hermes"
+  },
+  "commonAnnotations": {
+    "summary": "Hermes ignored configured provider and switched to Bedrock",
+    "description": "Hermes auto-detected AWS Bedrock credentials through IMDS and overrode the configured provider.",
+    "context_sources": "hermes",
+    "hermes_session_id": "sess-bedrock-004",
+    "hermes_provider": "bedrock",
+    "hermes_model": "anthropic.claude-3-sonnet",
+    "failure_mode": "provider_imds_override"
+  }
+}

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/answer.yml
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/answer.yml
@@ -23,4 +23,4 @@ optimal_trajectory:
 
 max_investigation_loops: 4
 
-model_response: Hermes auto-detected AWS Bedrock credentials from IMDS and silently overrode the configured custom provider.
+model_response: Hermes triggered an IMDS override and switched to the Bedrock provider using AWS instance credentials.

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/answer.yml
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/answer.yml
@@ -1,0 +1,26 @@
+root_cause_category: configuration_error
+
+required_keywords:
+  - bedrock
+  - imds
+  - override
+  - aws
+  - provider
+
+forbidden_categories:
+  - unknown
+  - healthy
+  - agent_hang
+
+required_evidence_sources:
+  - hermes_runtime_state
+  - hermes_config
+
+optimal_trajectory:
+  - get_hermes_runtime_state
+  - get_hermes_config
+  - get_hermes_provider_traffic
+
+max_investigation_loops: 4
+
+model_response: Hermes auto-detected AWS Bedrock credentials from IMDS and silently overrode the configured custom provider.

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_config.json
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_config.json
@@ -1,0 +1,16 @@
+{
+  "provider": "custom",
+  "model": "custom-gpt",
+  "region": "us-east-1",
+  "providers": [
+    {
+      "name": "custom",
+      "base_url": "https://custom-llm.internal",
+      "auth_kind": "api_key"
+    }
+  ],
+  "transport": {
+    "sse_max_line_bytes": 131072,
+    "request_timeout_s": 120
+  }
+}

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_provider_traffic.json
@@ -1,0 +1,26 @@
+{
+  "calls": [
+    {
+      "ts": "2026-05-17T13:00:04Z",
+      "provider": "bedrock",
+      "model": "anthropic.claude-3-sonnet",
+      "endpoint": "/model/anthropic.claude-3-sonnet/invoke",
+      "request": {
+        "method": "POST",
+        "url": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "headers": {
+          "x-amz-source": "imds"
+        },
+        "body_sample": "{\"input\":\"deploy helm chart\"}"
+      },
+      "response": {
+        "status": 403,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"message\":\"access denied\"}",
+        "duration_ms": 1100
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_runtime_state.json
@@ -1,0 +1,14 @@
+{
+  "pid": 7302,
+  "started_at": "2026-05-17T12:58:00Z",
+  "frozen_now_ts": "2026-05-17T13:00:06Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-17T13:00:05Z",
+  "is_blocked": false,
+  "blocking_call": null,
+  "imds_fingerprint": {
+    "instance_profile": "eks-node-role",
+    "region": "us-east-1"
+  },
+  "resolved_aws_role_arn": "arn:aws:iam::123456789012:role/eks-node-role"
+}

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/hermes_session_log.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-bedrock-004",
+  "events": [
+    {
+      "ts": "2026-05-17T13:00:01Z",
+      "kind": "message",
+      "payload": {
+        "role": "user",
+        "content": "deploy helm chart"
+      }
+    },
+    {
+      "ts": "2026-05-17T13:00:05Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "ProviderOverride",
+        "error_message": "Resolved provider switched from custom to Bedrock via IMDS detection"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/004-bedrock-imds-override/scenario.yml
+++ b/tests/synthetic/hermes_rca/004-bedrock-imds-override/scenario.yml
@@ -1,0 +1,10 @@
+schema_version: '1.0'
+scenario_id: 004-bedrock-imds-override
+failure_mode: provider_imds_override
+severity: critical
+scenario_difficulty: 3
+available_evidence:
+- hermes_session_log
+- hermes_provider_traffic
+- hermes_config
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/alert.json
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/alert.json
@@ -1,0 +1,19 @@
+{
+  "title": "Hermes Codex requests missing required headers",
+  "state": "firing",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesProviderHeadersDropped",
+    "severity": "critical",
+    "service": "hermes"
+  },
+  "commonAnnotations": {
+    "summary": "Codex request headers were silently dropped",
+    "description": "Hermes requests to Codex failed because required headers were missing.",
+    "context_sources": "hermes",
+    "hermes_session_id": "sess-codex-005",
+    "hermes_provider": "codex",
+    "hermes_model": "gpt-5.4-mini",
+    "failure_mode": "provider_headers_dropped"
+  }
+}

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/answer.yml
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/answer.yml
@@ -22,4 +22,4 @@ optimal_trajectory:
 
 max_investigation_loops: 3
 
-model_response: Hermes dropped required Codex request headers and the provider rejected the request.
+model_response: Hermes dropped required Codex authorization headers from the request and the provider rejected it.

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/answer.yml
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/answer.yml
@@ -1,0 +1,25 @@
+root_cause_category: configuration_error
+
+required_keywords:
+  - codex
+  - headers
+  - dropped
+  - authorization
+  - request
+
+forbidden_categories:
+  - unknown
+  - healthy
+  - agent_hang
+
+required_evidence_sources:
+  - hermes_provider_traffic
+
+optimal_trajectory:
+  - get_hermes_provider_traffic
+  - get_hermes_config
+  - get_hermes_session_log
+
+max_investigation_loops: 3
+
+model_response: Hermes dropped required Codex request headers and the provider rejected the request.

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_config.json
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_config.json
@@ -1,0 +1,16 @@
+{
+  "provider": "codex",
+  "model": "gpt-5.4-mini",
+  "region": "us-east-1",
+  "providers": [
+    {
+      "name": "codex",
+      "base_url": "https://api.openai.com",
+      "auth_kind": "api_key"
+    }
+  ],
+  "transport": {
+    "sse_max_line_bytes": 131072,
+    "request_timeout_s": 120
+  }
+}

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_provider_traffic.json
@@ -1,0 +1,26 @@
+{
+  "calls": [
+    {
+      "ts": "2026-05-17T14:00:04Z",
+      "provider": "codex",
+      "model": "gpt-5.4-mini",
+      "endpoint": "/v1/responses",
+      "request": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"input\":\"summarize kubernetes events\"}"
+      },
+      "response": {
+        "status": 401,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body_sample": "{\"error\":\"missing authorization header\"}",
+        "duration_ms": 490
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_runtime_state.json
@@ -1,0 +1,9 @@
+{
+  "pid": 8104,
+  "started_at": "2026-05-17T13:58:00Z",
+  "frozen_now_ts": "2026-05-17T14:00:06Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-17T14:00:05Z",
+  "is_blocked": false,
+  "blocking_call": null
+}

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/hermes_session_log.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-codex-005",
+  "events": [
+    {
+      "ts": "2026-05-17T14:00:01Z",
+      "kind": "message",
+      "payload": {
+        "role": "user",
+        "content": "summarize kubernetes events"
+      }
+    },
+    {
+      "ts": "2026-05-17T14:00:05Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "MissingHeaders",
+        "error_message": "Authorization header missing from Codex request"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/005-codex-headers-dropped/scenario.yml
+++ b/tests/synthetic/hermes_rca/005-codex-headers-dropped/scenario.yml
@@ -1,0 +1,10 @@
+schema_version: '1.0'
+scenario_id: 005-codex-headers-dropped
+failure_mode: provider_headers_dropped
+severity: critical
+scenario_difficulty: 2
+available_evidence:
+- hermes_session_log
+- hermes_provider_traffic
+- hermes_config
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/alert.json
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/alert.json
@@ -1,0 +1,19 @@
+{
+  "title": "Hermes SSE parser overflow",
+  "state": "firing",
+  "alert_source": "hermes",
+  "commonLabels": {
+    "alertname": "HermesSSEOverflow",
+    "severity": "critical",
+    "service": "hermes"
+  },
+  "commonAnnotations": {
+    "summary": "SSE response exceeded parser line limit",
+    "description": "Hermes streaming parser crashed because a response.completed event exceeded the configured line size.",
+    "context_sources": "hermes",
+    "hermes_session_id": "sess-sse-006",
+    "hermes_provider": "codex",
+    "hermes_model": "gpt-5.4-mini",
+    "failure_mode": "sse_line_overflow"
+  }
+}

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/answer.yml
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/answer.yml
@@ -1,0 +1,25 @@
+root_cause_category: configuration_error
+
+required_keywords:
+  - sse
+  - overflow
+  - stream
+  - line
+  - parser
+
+forbidden_categories:
+  - unknown
+  - healthy
+  - agent_hang
+
+required_evidence_sources:
+  - hermes_provider_traffic
+
+optimal_trajectory:
+  - get_hermes_provider_traffic
+  - get_hermes_config
+  - get_hermes_session_log
+
+max_investigation_loops: 4
+
+model_response: Hermes SSE parser failed because a streamed response line exceeded the configured maximum line size.

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/answer.yml
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/answer.yml
@@ -22,4 +22,4 @@ optimal_trajectory:
 
 max_investigation_loops: 4
 
-model_response: Hermes SSE parser failed because a streamed response line exceeded the configured maximum line size.
+model_response: Hermes SSE parser hit a line overflow because a streamed response line exceeded the configured maximum line size.

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_config.json
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_config.json
@@ -1,0 +1,16 @@
+{
+  "provider": "codex",
+  "model": "gpt-5.4-mini",
+  "region": "us-east-1",
+  "providers": [
+    {
+      "name": "codex",
+      "base_url": "https://api.openai.com",
+      "auth_kind": "api_key"
+    }
+  ],
+  "transport": {
+    "sse_max_line_bytes": 131072,
+    "request_timeout_s": 120
+  }
+}

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_provider_traffic.json
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_provider_traffic.json
@@ -1,0 +1,26 @@
+{
+  "calls": [
+    {
+      "ts": "2026-05-17T15:00:05Z",
+      "provider": "codex",
+      "model": "gpt-5.4-mini",
+      "endpoint": "/v1/responses",
+      "request": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/responses",
+        "headers": {
+          "accept": "text/event-stream"
+        },
+        "body_sample": "{\"stream\":true}"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "body_sample": "event: response.completed\\ndata: [truncated oversized SSE line]",
+        "duration_ms": 4210
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_runtime_state.json
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_runtime_state.json
@@ -1,0 +1,9 @@
+{
+  "pid": 9210,
+  "started_at": "2026-05-17T14:58:00Z",
+  "frozen_now_ts": "2026-05-17T15:00:09Z",
+  "interrupt_queue_depth": 0,
+  "last_progress_ts": "2026-05-17T15:00:08Z",
+  "is_blocked": false,
+  "blocking_call": null
+}

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_session_log.json
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/hermes_session_log.json
@@ -1,0 +1,21 @@
+{
+  "session_id": "sess-sse-006",
+  "events": [
+    {
+      "ts": "2026-05-17T15:00:01Z",
+      "kind": "message",
+      "payload": {
+        "role": "user",
+        "content": "stream deployment logs"
+      }
+    },
+    {
+      "ts": "2026-05-17T15:00:08Z",
+      "kind": "error",
+      "payload": {
+        "error_class": "SSELineOverflow",
+        "error_message": "response.completed event exceeded SSE line limit"
+      }
+    }
+  ]
+}

--- a/tests/synthetic/hermes_rca/006-sse-line-overflow/scenario.yml
+++ b/tests/synthetic/hermes_rca/006-sse-line-overflow/scenario.yml
@@ -1,0 +1,10 @@
+schema_version: '1.0'
+scenario_id: 006-sse-line-overflow
+failure_mode: sse_line_overflow
+severity: critical
+scenario_difficulty: 3
+available_evidence:
+- hermes_session_log
+- hermes_provider_traffic
+- hermes_config
+- hermes_runtime_state

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -233,6 +233,72 @@ def validate_hermes_session_log(data: dict[str, Any]) -> HermesSessionLogFixture
     return data  # type: ignore[return-value]
 
 
+def validate_hermes_provider_traffic(data: dict[str, Any]) -> dict[str, Any]:
+    ctx = "hermes_provider_traffic.json"
+    calls = data.get("calls")
+    if not isinstance(calls, list):
+        raise ValueError(f"{ctx}: 'calls' must be a list")
+
+    for index, call in enumerate(calls):
+        if not isinstance(call, dict):
+            raise ValueError(f"{ctx}:calls[{index}] must be an object")
+
+        cctx = f"{ctx}:calls[{index}]"
+        for field in ("ts", "provider", "model", "endpoint"):
+            _require_str(call, field, cctx)
+
+        request = call.get("request")
+        if not isinstance(request, dict):
+            raise ValueError(f"{cctx}: 'request' must be an object")
+        for field in ("method", "url"):
+            _require_str(request, field, f"{cctx}:request")
+
+        if not isinstance(request.get("body_sample"), str):
+            raise ValueError(f"{cctx}:request: 'body_sample' must be a string")
+        if not isinstance(request.get("headers"), dict):
+            raise ValueError(f"{cctx}:request: 'headers' must be an object")
+
+        response = call.get("response")
+        if not isinstance(response, dict):
+            raise ValueError(f"{cctx}: 'response' must be an object")
+        if not isinstance(response.get("status"), int):
+            raise ValueError(f"{cctx}:response: 'status' must be an integer")
+        if not isinstance(response.get("headers"), dict):
+            raise ValueError(f"{cctx}:response: 'headers' must be an object")
+        if not isinstance(response.get("body_sample"), str):
+            raise ValueError(f"{cctx}:response: 'body_sample' must be a string")
+        if not isinstance(response.get("duration_ms"), int):
+            raise ValueError(f"{cctx}:response: 'duration_ms' must be an integer")
+
+    return data
+
+
+def validate_hermes_config(data: dict[str, Any]) -> dict[str, Any]:
+    ctx = "hermes_config.json"
+    for field in ("provider", "model", "region"):
+        _require_str(data, field, ctx)
+
+    providers = data.get("providers")
+    if not isinstance(providers, list):
+        raise ValueError(f"{ctx}: 'providers' must be a list")
+    for index, provider in enumerate(providers):
+        if not isinstance(provider, dict):
+            raise ValueError(f"{ctx}:providers[{index}] must be an object")
+        pctx = f"{ctx}:providers[{index}]"
+        for field in ("name", "base_url", "auth_kind"):
+            _require_str(provider, field, pctx)
+
+    transport = data.get("transport")
+    if not isinstance(transport, dict):
+        raise ValueError(f"{ctx}: 'transport' must be an object")
+    if not isinstance(transport.get("sse_max_line_bytes"), int):
+        raise ValueError(f"{ctx}:transport: 'sse_max_line_bytes' must be an integer")
+    if not isinstance(transport.get("request_timeout_s"), int):
+        raise ValueError(f"{ctx}:transport: 'request_timeout_s' must be an integer")
+
+    return data
+
+
 def validate_hermes_message_history(data: dict[str, Any]) -> HermesMessageHistoryFixture:
     ctx = "hermes_message_history.json"
     _require_str(data, "session_id", ctx)

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -44,6 +44,8 @@ VALID_HERMES_EVIDENCE_SOURCES = frozenset(
 VALID_HERMES_TRAJECTORY_ACTIONS = frozenset(
     {
         "get_hermes_session_log",
+        "get_hermes_provider_traffic",
+        "get_hermes_config",
         "get_hermes_message_history",
         "get_hermes_kv_cache_state",
         "get_hermes_runtime_state",

--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -140,6 +140,8 @@ class HermesRuntimeStateFixture(TypedDict):
     last_progress_ts: str
     is_blocked: bool
     blocking_call: HermesBlockingCall | None
+    imds_fingerprint: NotRequired[dict[str, Any] | None]
+    resolved_aws_role_arn: NotRequired[str | None]
 
 
 class HermesCronLastRun(TypedDict):
@@ -379,6 +381,15 @@ def validate_hermes_runtime_state(data: dict[str, Any]) -> HermesRuntimeStateFix
         _require_str(blocking_call, "started_at", f"{ctx}:blocking_call")
         if not isinstance(blocking_call.get("duration_s"), int):
             raise ValueError(f"{ctx}:blocking_call: 'duration_s' must be an integer")
+
+    imds_fingerprint = data.get("imds_fingerprint")
+    if imds_fingerprint is not None and not isinstance(imds_fingerprint, dict):
+        raise ValueError(f"{ctx}: 'imds_fingerprint' must be an object or null")
+
+    resolved_aws_role_arn = data.get("resolved_aws_role_arn")
+    if resolved_aws_role_arn is not None and not isinstance(resolved_aws_role_arn, str):
+        raise ValueError(f"{ctx}: 'resolved_aws_role_arn' must be a string or null")
+
     return data  # type: ignore[return-value]
 
 

--- a/tests/synthetic/hermes_rca/scenario_loader.py
+++ b/tests/synthetic/hermes_rca/scenario_loader.py
@@ -13,9 +13,11 @@ from tests.synthetic.hermes_rca.hermes_schemas import (
     HermesScenarioMetadataSchema,
     validate_hermes_alert,
     validate_hermes_answer_key,
+    validate_hermes_config,
     validate_hermes_cron_state,
     validate_hermes_kv_cache_state,
     validate_hermes_message_history,
+    validate_hermes_provider_traffic,
     validate_hermes_runtime_state,
     validate_hermes_scenario_metadata,
     validate_hermes_session_log,
@@ -122,10 +124,12 @@ def _load_evidence(scenario_dir: Path, available_evidence: list[str]) -> HermesS
         )
 
     if "hermes_provider_traffic" in available_evidence:
-        provider_traffic = _read_json(scenario_dir / "hermes_provider_traffic.json")
+        provider_traffic = validate_hermes_provider_traffic(
+            _read_json(scenario_dir / "hermes_provider_traffic.json")
+        )
 
     if "hermes_config" in available_evidence:
-        hermes_config = _read_json(scenario_dir / "hermes_config.json")
+        hermes_config = validate_hermes_config(_read_json(scenario_dir / "hermes_config.json"))
 
     if "hermes_runtime_state" in available_evidence:
         runtime_state = validate_hermes_runtime_state(

--- a/tests/synthetic/mock_hermes_backend/backend.py
+++ b/tests/synthetic/mock_hermes_backend/backend.py
@@ -14,6 +14,12 @@ class HermesBackend(Protocol):
     def get_session_log(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
         pass
 
+    def get_provider_traffic(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
+
+    def get_config(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
+        pass
+
     def get_message_history(self, session_id: str = "", **kwargs: Any) -> dict[str, Any]:
         pass
 
@@ -46,6 +52,34 @@ class FixtureHermesBackend:
             "available": True,
             "session_id": session_id or evidence.get("session_id", ""),
             "events": list(evidence.get("events", [])),
+            "error": None,
+        }
+
+    def get_provider_traffic(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_provider_traffic
+        if evidence is None:
+            return self._missing("provider_traffic")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id or str(evidence.get("session_id", "")),
+            "calls": list(evidence.get("calls", [])),
+            "error": None,
+        }
+
+    def get_config(self, session_id: str = "", **_: Any) -> dict[str, Any]:
+        evidence = self._fixture.evidence.hermes_config
+        if evidence is None:
+            return self._missing("config")
+        return {
+            "source": "hermes",
+            "available": True,
+            "session_id": session_id,
+            "provider": str(evidence.get("provider", "")),
+            "model": str(evidence.get("model", "")),
+            "region": str(evidence.get("region", "")),
+            "providers": list(evidence.get("providers", [])),
+            "transport": dict(evidence.get("transport", {})),
             "error": None,
         }
 

--- a/tests/synthetic/mock_hermes_backend/backend.py
+++ b/tests/synthetic/mock_hermes_backend/backend.py
@@ -152,6 +152,8 @@ class FixtureHermesBackend:
             "last_progress_ts": last_progress_ts,
             "is_blocked": computed_blocked,
             "blocking_call": evidence.get("blocking_call"),
+            "imds_fingerprint": evidence.get("imds_fingerprint"),
+            "resolved_aws_role_arn": evidence.get("resolved_aws_role_arn"),
             "error": None,
         }
 


### PR DESCRIPTION
Fixes #1509

Implements the Part 1/5 Hermes provider/transport RCA track on top of the merged Hermes RCA harness from #2075.

This PR adds six synthetic provider/transport failure scenarios under `tests/synthetic/hermes_rca/` covering the highest-frequency Hermes adapter failure classes referenced in the upstream tracker:

* `001-codex-empty-response`
* `002-openrouter-400-all-models`
* `003-minimax-529-overload`
* `004-bedrock-imds-override`
* `005-codex-headers-dropped`
* `006-sse-line-overflow`

The scenarios extend the existing Hermes RCA harness with provider-traffic-aware evidence collection so investigations can reason over captured HTTP/SSE request-response pairs and resolved provider configuration state.

Added evidence/tooling support:

* `get_hermes_provider_traffic`
* `get_hermes_config`

This wiring is implemented across:

* `tests/synthetic/mock_hermes_backend/backend.py`
* `app/tools/HermesSessionEvidenceTool/`
* `tests/synthetic/hermes_rca/hermes_schemas.py`

The new fixtures exercise:

* malformed/empty provider bodies
* request-shape HTTP 400 failures
* provider overload handling
* IMDS-based provider override paths
* dropped auth/header propagation
* SSE parser overflow conditions

Validation performed:

* `python -m pytest tests/synthetic/hermes_rca -q`
* `python -m pytest tests/synthetic/hermes_rca/test_suite.py -q`
* `python -m ruff format tests/synthetic/hermes_rca tests/synthetic/mock_hermes_backend/backend.py app/tools/HermesSessionEvidenceTool/__init__.py`
* `python -m ruff check tests/synthetic/hermes_rca tests/synthetic/mock_hermes_backend/backend.py app/tools/HermesSessionEvidenceTool/__init__.py`


https://github.com/user-attachments/assets/77240273-8c60-4b7f-ae82-510b3d0ea992

<img width="1524" height="602" alt="Ekran görüntüsü 2026-05-17 190049" src="https://github.com/user-attachments/assets/6faf3698-942f-49ce-b760-c42d8c8997f4" />



