### PR TITLE
fix(agents): deduplicate Codex wrapper sessions

### DIFF
--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -208,7 +208,11 @@ def _parse_ps_line(line: str) -> ProcessRow | None:
         return None
 
     if len(parts) == 2:
-        return ProcessRow(pid=pid, command=parts[1])
+        try:
+            ppid = int(parts[1])
+        except ValueError:
+            ppid = None
+        return ProcessRow(pid=pid, ppid=ppid, command="")
 
     try:
         ppid = int(parts[1])

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -6,17 +6,19 @@ import logging
 import os
 import shlex
 import subprocess
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from app.agents.probe import process_has_open_codex_rollout
 from app.agents.registry import AgentRecord, AgentRegistry
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_CURSOR_PROJECTS_DIR = Path.home() / ".cursor" / "projects"
-_PS_COMMAND = ("ps", "-axo", "pid=,args=")
+_PS_COMMAND = ("ps", "-axo", "pid=,ppid=,args=")
 _MAX_DISPLAY_COMMAND_LENGTH = 120
+_NODE_EXECUTABLES: frozenset[str] = frozenset({"node", "nodejs"})
 _NOISE_PROCESS_TOKENS: tuple[str, ...] = (
     "chrome_crashpad_handler",
     "shipit",
@@ -60,14 +62,16 @@ class ProcessRow:
 
     pid: int
     command: str
+    ppid: int | None = None
 
 
 def discover_agent_processes(*, include_all: bool = False) -> list[DiscoveredAgent]:
     """Return likely local AI-agent sessions visible to the current user."""
 
-    candidates: list[DiscoveredAgent] = []
+    candidates_by_pid: dict[int, tuple[str, ProcessRow]] = {}
     current_pid = os.getpid()
-    for row in _current_process_rows():
+    rows = _current_process_rows()
+    for row in rows:
         if row.pid <= 0 or row.pid == current_pid:
             continue
         cmdline = _split_command(row.command)
@@ -76,10 +80,18 @@ def discover_agent_processes(*, include_all: bool = False) -> list[DiscoveredAge
         agent_name = _classify_agent(process_name, cmdline, include_all=include_all)
         if agent_name is None:
             continue
-        candidates.append(
-            DiscoveredAgent(name=f"{agent_name}-{row.pid}", pid=row.pid, command=row.command)
-        )
+        candidates_by_pid[row.pid] = (agent_name, row)
 
+    for pid in _codex_duplicate_pids_to_drop(
+        rows,
+        {pid for pid, (name, _) in candidates_by_pid.items() if name == "codex"},
+    ):
+        candidates_by_pid.pop(pid, None)
+
+    candidates = [
+        DiscoveredAgent(name=f"{agent_name}-{row.pid}", pid=row.pid, command=row.command)
+        for agent_name, row in candidates_by_pid.values()
+    ]
     return sorted(candidates, key=lambda item: (item.name, item.pid))
 
 
@@ -111,6 +123,12 @@ def discover_agents(
 
     for record in _discover_cursor_terminal_agents(cursor_projects_dir):
         records_by_pid.setdefault(record.pid, record)
+
+    for pid in _codex_duplicate_pids_to_drop(
+        rows,
+        {pid for pid, record in records_by_pid.items() if record.name == "codex"},
+    ):
+        records_by_pid.pop(pid, None)
 
     return sorted(records_by_pid.values(), key=lambda record: (record.name, record.pid))
 
@@ -180,14 +198,22 @@ def _parse_ps_line(line: str) -> ProcessRow | None:
     stripped = line.strip()
     if not stripped:
         return None
-    parts = stripped.split(maxsplit=1)
-    if len(parts) != 2:
+    parts = stripped.split(maxsplit=2)
+    if len(parts) < 2:
         return None
     try:
         pid = int(parts[0])
     except ValueError:
         return None
-    return ProcessRow(pid=pid, command=parts[1])
+
+    if len(parts) == 2:
+        return ProcessRow(pid=pid, command=parts[1])
+
+    try:
+        ppid = int(parts[1])
+    except ValueError:
+        ppid = None
+    return ProcessRow(pid=pid, ppid=ppid, command=parts[2])
 
 
 def _split_command(command: str) -> list[str]:
@@ -195,6 +221,64 @@ def _split_command(command: str) -> list[str]:
         return shlex.split(command)
     except ValueError:
         return command.split()
+
+
+def _codex_duplicate_pids_to_drop(rows: Iterable[ProcessRow], codex_pids: set[int]) -> set[int]:
+    if len(codex_pids) < 2:
+        return set()
+
+    rows_by_pid = {row.pid: row for row in rows if row.pid in codex_pids}
+    rollout_owner_cache: dict[int, bool] = {}
+    pids_to_drop: set[int] = set()
+
+    def owns_rollout(pid: int) -> bool:
+        if pid not in rollout_owner_cache:
+            rollout_owner_cache[pid] = process_has_open_codex_rollout(pid)
+        return rollout_owner_cache[pid]
+
+    for child in rows_by_pid.values():
+        if child.ppid is None:
+            continue
+        parent = rows_by_pid.get(child.ppid)
+        if parent is None or not _is_codex_wrapper_native_pair(parent, child):
+            continue
+
+        keep_pid = _preferred_codex_pair_pid(parent, child, owns_rollout)
+        drop_pid = parent.pid if keep_pid == child.pid else child.pid
+        pids_to_drop.add(drop_pid)
+
+    return pids_to_drop
+
+
+def _is_codex_wrapper_native_pair(parent: ProcessRow, child: ProcessRow) -> bool:
+    return _is_node_codex_wrapper(parent.command) and _is_native_codex_process(child.command)
+
+
+def _is_node_codex_wrapper(command: str) -> bool:
+    cmdline = _split_command(command)
+    if not cmdline:
+        return False
+    executable = _normalized_token(cmdline[0])
+    return executable in _NODE_EXECUTABLES and _has_command_token(command.lower(), "codex")
+
+
+def _is_native_codex_process(command: str) -> bool:
+    cmdline = _split_command(command)
+    if not cmdline:
+        return False
+    return _normalized_token(cmdline[0]) == "codex"
+
+
+def _preferred_codex_pair_pid(
+    parent: ProcessRow,
+    child: ProcessRow,
+    owns_rollout: Callable[[int], bool],
+) -> int:
+    parent_owns_rollout = owns_rollout(parent.pid)
+    child_owns_rollout = owns_rollout(child.pid)
+    if parent_owns_rollout and not child_owns_rollout:
+        return parent.pid
+    return child.pid
 
 
 def _discover_cursor_terminal_agents(cursor_projects_dir: Path) -> list[AgentRecord]:

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CURSOR_PROJECTS_DIR = Path.home() / ".cursor" / "projects"
 _PS_COMMAND = ("ps", "-axo", "pid=,ppid=,args=")
 _MAX_DISPLAY_COMMAND_LENGTH = 120
+_CODEX_LAUNCHER_TOKENS: frozenset[str] = frozenset({"codex", "codex.js", "codex.mjs", "codex.cjs"})
 _NODE_EXECUTABLES: frozenset[str] = frozenset({"node", "nodejs"})
 _NOISE_PROCESS_TOKENS: tuple[str, ...] = (
     "chrome_crashpad_handler",
@@ -256,17 +257,34 @@ def _is_codex_wrapper_native_pair(parent: ProcessRow, child: ProcessRow) -> bool
 
 def _is_node_codex_wrapper(command: str) -> bool:
     cmdline = _split_command(command)
-    if not cmdline:
-        return False
-    executable = _normalized_token(cmdline[0])
-    return executable in _NODE_EXECUTABLES and _has_command_token(command.lower(), "codex")
+    return _is_node_codex_cmdline(cmdline)
 
 
 def _is_native_codex_process(command: str) -> bool:
     cmdline = _split_command(command)
+    return bool(cmdline) and _is_codex_launcher_token(cmdline[0])
+
+
+def _is_codex_command(command: str) -> bool:
+    return _is_codex_cmdline(_split_command(command))
+
+
+def _is_codex_cmdline(cmdline: list[str]) -> bool:
     if not cmdline:
         return False
-    return _normalized_token(cmdline[0]) == "codex"
+    if _is_codex_launcher_token(cmdline[0]):
+        return True
+    return _is_node_codex_cmdline(cmdline)
+
+
+def _is_node_codex_cmdline(cmdline: list[str]) -> bool:
+    if not cmdline or _normalized_token(cmdline[0]) not in _NODE_EXECUTABLES:
+        return False
+    return any(_is_codex_launcher_token(part) for part in cmdline[1:])
+
+
+def _is_codex_launcher_token(value: str) -> bool:
+    return _normalized_token(value) in _CODEX_LAUNCHER_TOKENS
 
 
 def _preferred_codex_pair_pid(
@@ -333,7 +351,7 @@ def _agent_name_for_command(command: str) -> str | None:
         return "cursor-agent"
     if _has_command_token(lower, "claude") and _has_command_token(lower, "code"):
         return "claude-code"
-    if _has_command_token(lower, "codex"):
+    if _is_codex_command(command):
         return "codex"
     if _has_command_token(lower, "aider"):
         return "aider"
@@ -377,6 +395,10 @@ def _classify_agent_loose(process_name: str, cmdline: list[str]) -> str | None:
     tokens.add(_normalized_token(process_name))
 
     for signature, label in _LOOSE_AGENT_SIGNATURES:
+        if label == "codex":
+            if _is_codex_cmdline(cmdline):
+                return label
+            continue
         if signature in tokens or signature in haystack:
             return label
     return None

--- a/app/agents/probe.py
+++ b/app/agents/probe.py
@@ -1,9 +1,8 @@
-"""Per-PID resource snapshot for the monitor-local-agents fleet view.
+"""Per-PID process helpers for the monitor-local-agents fleet view.
 
-Pure collector: one function, one PID, one snapshot. No background
-loop, no caching, no UI wiring. The wiring layer (#1490) batches calls
-in a REPL background task; the registry layer (#1487) decides which
-PIDs to ask about.
+Pure collectors: no background loop, no caching, no UI wiring. The
+wiring layer (#1490) batches calls in a REPL background task; the
+registry layer (#1487) decides which PIDs to ask about.
 
 The acceptance criterion for the parent issue (#1489) requires that
 ``psutil`` stay confined to this module so the dependency surface
@@ -16,6 +15,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 
 import psutil
 
@@ -82,6 +82,30 @@ def process(pid: int) -> psutil.Process:
 def process_iter(attrs: Iterable[str]) -> Iterator[psutil.Process]:
     """Yield process handles with preloaded attrs from the local probe module."""
     return psutil.process_iter(list(attrs))
+
+
+def process_has_open_codex_rollout(pid: int) -> bool:
+    """Return whether ``pid`` has an open Codex ``rollout-*.jsonl`` file."""
+    try:
+        proc = psutil.Process(pid)
+        open_files = proc.open_files()
+    # The stdlib exceptions cover invalid/raced PIDs and platform-specific
+    # ``open_files()`` failures that psutil may surface directly.
+    except PROCESS_ERROR + (
+        ProcessLookupError,
+        OSError,
+        ValueError,
+        OverflowError,
+    ):
+        return False
+
+    for open_file in open_files:
+        path = getattr(open_file, "path", None)
+        if isinstance(path, str):
+            name = Path(path).name
+            if name.startswith("rollout-") and name.endswith(".jsonl"):
+                return True
+    return False
 
 
 def probe(pid: int, *, cpu_interval: float = 0.1) -> ProcessSnapshot | None:

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -11,6 +11,10 @@ from app.agents.discovery import ProcessRow, discover_agents, registered_and_dis
 from app.agents.registry import AgentRecord, AgentRegistry
 
 
+def _patch_codex_rollout_owners(monkeypatch: pytest.MonkeyPatch, owners: set[int]) -> None:
+    monkeypatch.setattr(discovery, "process_has_open_codex_rollout", lambda pid: pid in owners)
+
+
 def test_discover_agent_processes_matches_known_agent_commands(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -207,6 +211,145 @@ def test_ignores_plain_claude_commands_with_code_prefix_arguments() -> None:
     )
 
     assert records == []
+
+
+def test_discovers_single_codex_row_for_node_wrapper_and_native_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_codex_rollout_owners(monkeypatch, {702})
+
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=701, ppid=1, command="node /Users/me/.local/bin/codex"),
+            ProcessRow(
+                pid=702,
+                ppid=701,
+                command="/Users/me/.local/share/codex/vendor/aarch64-apple-darwin/codex/codex",
+            ),
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert [(record.name, record.pid) for record in records] == [("codex", 702)]
+
+
+def test_codex_dedupe_runs_after_cursor_terminal_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    terminal = tmp_path / "project" / "terminals" / "71.txt"
+    terminal.parent.mkdir(parents=True)
+    terminal.write_text(
+        "---\npid: 711\ncwd: /repo\nactive_command: codex\n---\n",
+        encoding="utf-8",
+    )
+    _patch_codex_rollout_owners(monkeypatch, {712})
+
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=711, ppid=1, command="node /Users/me/.local/bin/codex"),
+            ProcessRow(
+                pid=712,
+                ppid=711,
+                command="/Users/me/.local/share/codex/vendor/aarch64-apple-darwin/codex/codex",
+            ),
+        ],
+        cursor_projects_dir=tmp_path,
+    )
+
+    assert [(record.name, record.pid) for record in records] == [("codex", 712)]
+
+
+def test_discover_agent_processes_deduplicates_codex_wrapper_child_in_all_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = [
+        ProcessRow(pid=10, command="opensre"),
+        ProcessRow(pid=801, ppid=1, command="node /Users/me/.local/bin/codex"),
+        ProcessRow(
+            pid=802,
+            ppid=801,
+            command="/Users/me/.local/share/codex/vendor/aarch64-apple-darwin/codex/codex",
+        ),
+    ]
+    _patch_codex_rollout_owners(monkeypatch, {802})
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(discovery, "_current_process_rows", lambda: rows)
+
+    candidates = discovery.discover_agent_processes(include_all=True)
+
+    assert [(item.name, item.pid) for item in candidates] == [("codex-802", 802)]
+
+
+def test_codex_wrapper_native_dedupe_prefers_pid_with_open_rollout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_codex_rollout_owners(monkeypatch, {901})
+
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=901, ppid=1, command="node /Users/me/.local/bin/codex"),
+            ProcessRow(
+                pid=902,
+                ppid=901,
+                command="/Users/me/.local/share/codex/vendor/aarch64-apple-darwin/codex/codex",
+            ),
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert [(record.name, record.pid) for record in records] == [("codex", 901)]
+
+
+def test_discovers_concurrent_codex_sessions_after_deduping_each_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_codex_rollout_owners(monkeypatch, {1002, 1102})
+
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=1001, ppid=1, command="node /Users/me/.local/bin/codex"),
+            ProcessRow(
+                pid=1002,
+                ppid=1001,
+                command="/Users/me/session-a/vendor/aarch64-apple-darwin/codex/codex",
+            ),
+            ProcessRow(pid=1101, ppid=1, command="node /Users/me/.local/bin/codex"),
+            ProcessRow(
+                pid=1102,
+                ppid=1101,
+                command="/Users/me/session-b/vendor/aarch64-apple-darwin/codex/codex",
+            ),
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert [(record.name, record.pid) for record in records] == [
+        ("codex", 1002),
+        ("codex", 1102),
+    ]
+
+
+def test_keeps_independent_codex_processes_that_are_not_wrapper_child_pairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_codex_rollout_owners(monkeypatch, set())
+
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=1201, ppid=1, command="node /Users/me/.local/bin/codex"),
+            ProcessRow(
+                pid=1202,
+                ppid=1,
+                command="/Users/me/.local/share/codex/vendor/aarch64-apple-darwin/codex/codex",
+            ),
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert [(record.name, record.pid) for record in records] == [
+        ("codex", 1201),
+        ("codex", 1202),
+    ]
 
 
 def test_registered_records_win_over_discovered_pid(

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -213,6 +213,46 @@ def test_ignores_plain_claude_commands_with_code_prefix_arguments() -> None:
     assert records == []
 
 
+def test_ignores_non_codex_process_from_codex_named_directory() -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(
+                pid=4242,
+                ppid=4200,
+                command=(
+                    "/workspace/project-with-codex-in-name/.venv/bin/python "
+                    "/workspace/project-with-codex-in-name/.venv/bin/opensre"
+                ),
+            )
+        ],
+        cursor_projects_dir=Path("/does/not/exist"),
+    )
+
+    assert records == []
+
+
+def test_scan_all_ignores_non_codex_process_from_codex_named_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(
+                pid=4242,
+                ppid=4200,
+                command=(
+                    "/workspace/project-with-codex-in-name/.venv/bin/python "
+                    "/workspace/project-with-codex-in-name/.venv/bin/opensre"
+                ),
+            )
+        ],
+    )
+
+    assert discovery.discover_agent_processes(include_all=True) == []
+
+
 def test_discovers_single_codex_row_for_node_wrapper_and_native_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -127,6 +127,18 @@ def test_display_command_truncates_long_commands() -> None:
     assert display.endswith("...")
 
 
+def test_parse_ps_line_with_missing_args_keeps_ppid_and_empty_command() -> None:
+    row = discovery._parse_ps_line("123 45")
+
+    assert row == ProcessRow(pid=123, ppid=45, command="")
+
+
+def test_parse_ps_line_with_missing_args_tolerates_invalid_ppid() -> None:
+    row = discovery._parse_ps_line("123 not-a-ppid")
+
+    assert row == ProcessRow(pid=123, ppid=None, command="")
+
+
 def test_discovers_cursor_claude_code_process() -> None:
     records = discover_agents(
         process_rows=[

--- a/tests/agents/test_probe.py
+++ b/tests/agents/test_probe.py
@@ -9,12 +9,13 @@ import sys
 import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import psutil
 import pytest
 
-from app.agents.probe import ProcessSnapshot, probe
+from app.agents.probe import ProcessSnapshot, probe, process_has_open_codex_rollout
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 _PROBE_MODULE = _REPO_ROOT / "app" / "agents" / "probe.py"
@@ -81,6 +82,27 @@ def test_probe_returns_none_for_access_denied_process() -> None:
         side_effect=psutil.AccessDenied(pid=os.getpid()),
     ):
         assert probe(os.getpid(), cpu_interval=0.0) is None
+
+
+def test_process_has_open_codex_rollout_matches_rollout_jsonl() -> None:
+    with patch.object(
+        psutil.Process,
+        "open_files",
+        return_value=[
+            SimpleNamespace(path="/tmp/unrelated.log"),
+            SimpleNamespace(path="/Users/me/.codex/rollout-2026-05-17.jsonl"),
+        ],
+    ):
+        assert process_has_open_codex_rollout(os.getpid()) is True
+
+
+def test_process_has_open_codex_rollout_returns_false_when_inaccessible() -> None:
+    with patch.object(
+        psutil.Process,
+        "open_files",
+        side_effect=psutil.AccessDenied(pid=os.getpid()),
+    ):
+        assert process_has_open_codex_rollout(os.getpid()) is False
 
 
 def test_psutil_is_not_imported_outside_probe_module() -> None:


### PR DESCRIPTION
Fixes #2145

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

This fixes duplicate Codex rows in `/agents` when a single Codex session is represented by both a Node wrapper process and the native Codex child process.

Changes:
- include PPID in local agent process discovery so wrapper/native parent-child relationships can be identified
- deduplicate Codex wrapper/native pairs while preserving independent concurrent Codex sessions
- prefer the PID that owns an open `rollout-*.jsonl`, falling back to the native child process
- apply deduplication after Cursor terminal metadata is merged so Cursor-sourced wrapper records cannot reintroduce duplicates
- keep psutil usage confined to `app.agents.probe`

### Demo/Screenshot for feature changes and bug fixes - 

Terminal validation:

```text
uv run pytest tests/agent/ tests/agents/ -v
303 passed in 26.54s

uv run pytest tests/agents/test_discovery.py tests/agents/test_probe.py -v
24 passed in 0.33s

make lint
All checks passed!

make format-check
1382 files already formatted

make typecheck
Success: no issues found in 581 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug was caused by PID-based discovery treating the Codex Node wrapper and native child as separate `codex` agents. The fix keeps the discovery model process-based, but adds enough process-tree context to collapse only the known wrapper/native Codex pair.

The main logic is `_codex_duplicate_pids_to_drop`, which receives the discovered process rows and the PIDs already classified as Codex. It only deduplicates a direct parent-child pair where the parent is a Node Codex wrapper and the child executable is native `codex`. It prefers the process with an open `rollout-*.jsonl` file through `process_has_open_codex_rollout`; if neither process has that signal, it keeps the native child because that is the real Codex process in the observed setup.

I considered broader provider-agnostic deduplication, but kept this scoped to Codex because other agents may legitimately spawn helper processes and do not currently have an equivalent rollout ownership signal. Tests cover the wrapper/native case, Cursor terminal metadata merging, rollout ownership preference, concurrent Codex sessions, and independent Codex processes that must remain separate.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.