### PR TITLE
revert(agent-llm): restore pre-#2135 get_agent_llm behavior

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -358,13 +358,6 @@ _AgentClientType = AnthropicAgentClient | OpenAIAgentClient
 _agent_client: _AgentClientType | None = None
 
 
-def _is_cli_provider(provider: str) -> bool:
-    """Return True when *provider* is a subprocess-backed CLI (no native tool-calling)."""
-    from app.integrations.llm_cli.registry import CLI_PROVIDER_REGISTRY
-
-    return provider in CLI_PROVIDER_REGISTRY
-
-
 def get_agent_llm() -> _AgentClientType:
     """Return a singleton tool-calling LLM client for the investigation agent."""
     global _agent_client
@@ -399,12 +392,6 @@ def get_agent_llm() -> _AgentClientType:
         _agent_client = BedrockAgentClient(
             model=settings.bedrock_reasoning_model,
             max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
-        )
-    elif _is_cli_provider(provider):
-        raise RuntimeError(
-            f"LLM_PROVIDER={provider!r} is a CLI-backed provider and cannot be used for "
-            "investigations. Investigations require native API tool-calling. "
-            "Set LLM_PROVIDER to 'anthropic', 'openai', 'bedrock', or another API provider."
         )
     else:
         # Default: Anthropic

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -339,18 +339,3 @@ def test_unrelated_type_error_is_retried_and_wrapped(
         client.invoke(messages=[{"role": "user", "content": "hi"}])
 
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
-
-
-@pytest.mark.parametrize(
-    "provider", ["codex", "opencode", "claude-code", "kimi", "cursor", "gemini-cli", "copilot"]
-)
-def test_get_agent_llm_rejects_cli_providers(
-    provider: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from app.services.agent_llm_client import get_agent_llm, reset_agent_client
-
-    monkeypatch.setenv("LLM_PROVIDER", provider)
-    reset_agent_client()
-    with pytest.raises(RuntimeError, match="CLI-backed provider"):
-        get_agent_llm()
-    reset_agent_client()

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "build", marker = "extra == 'release-dist'", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "clickhouse-connect", specifier = ">=0.15.1" },
+    { name = "clickhouse-connect", specifier = ">=0.15.1,<1.0.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.15.1" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.14.0" },
     { name = "cryptography", specifier = ">=42.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "build", marker = "extra == 'release-dist'", specifier = ">=1.2.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "clickhouse-connect", specifier = ">=0.15.1,<1.0.0" },
+    { name = "clickhouse-connect", specifier = ">=0.15.1" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.15.1" },
     { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.14.0" },
     { name = "cryptography", specifier = ">=42.0.0" },


### PR DESCRIPTION
Ref #2153

#### Describe the changes you have made in this PR -

This reverts commit 95e88cab from PR [#2135](https://github.com/Tracer-Cloud/opensre/pull/2135) (`fix(agent-llm): reject CLI-backed providers in get_agent_llm with a clear error`).

- Removes the explicit `RuntimeError` when `LLM_PROVIDER` is a CLI-backed provider (codex, etc.).
- Restores the previous `get_agent_llm()` branching so non-openai/openrouter/bedrock providers fall through to the Anthropic client path (same as before #2135).

Follow-up work to properly support or clearly gate CLI providers for investigations is tracked in #2153.

### Demo/Screenshot for feature changes and bug fixes - 

N/A — revert only; `tests/services/test_agent_llm_client.py` passes locally (`uv run pytest tests/services/test_agent_llm_client.py`).

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Git revert of a single merge commit; no manual code edits beyond the revert.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.