### PR TITLE
fix(agent-llm): route CLI LLM providers for investigations

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -416,7 +416,11 @@ def _build_synthetic_assistant_tool_call_msg(
     This lets us inject pre-seeded tool results into the conversation in a format
     the LLM client already understands, without adding special-case handling.
     """
-    from app.services.agent_llm_client import AnthropicAgentClient, OpenAIAgentClient
+    from app.services.agent_llm_client import (
+        AnthropicAgentClient,
+        CLIBackedAgentClient,
+        OpenAIAgentClient,
+    )
 
     if isinstance(llm, AnthropicAgentClient):
         content = [
@@ -443,6 +447,9 @@ def _build_synthetic_assistant_tool_call_msg(
                 for tc in tool_calls
             ],
         }
+
+    if isinstance(llm, CLIBackedAgentClient):
+        return llm.build_assistant_message("", tool_calls)
 
     # Fallback: plain text summary
     names = ", ".join(tc.name for tc in tool_calls)

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -354,7 +354,127 @@ class OpenAIAgentClient:
         return msg
 
 
-_AgentClientType = AnthropicAgentClient | OpenAIAgentClient
+def _get_cli_provider_registration(provider: str) -> Any:
+    """Return the CLI registry entry for *provider*, or None if not CLI-backed."""
+    from app.integrations.llm_cli.registry import get_cli_provider_registration
+
+    return get_cli_provider_registration(provider)
+
+
+class CLIBackedAgentClient:
+    """Tool-calling wrapper for subprocess CLI providers (codex, claude-code, etc.).
+
+    CLI adapters don't expose a native tool-calling API. This client implements
+    the investigation agent's ReAct interface by embedding tool schemas in the
+    prompt as JSON and parsing the model's text response for tool call JSON.
+    Each invoke flattens the full conversation history into a single stdin prompt.
+    """
+
+    _TOOL_CALL_INSTRUCTION = (
+        "You are an SRE investigation agent. Use the available tools to investigate "
+        "the alert. On each turn respond with EITHER:\n"
+        '  (a) A JSON object: {"tool_calls": [{"id": "<unique_id>", "name": "<tool>",'
+        ' "input": {<args>}}]}\n'
+        "  (b) A plain-text final answer when investigation is complete.\n"
+        "Respond with JSON only when calling tools; respond with plain text only for the final answer."
+    )
+
+    def __init__(self, adapter: Any, *, model: str | None = None) -> None:
+        self._adapter = adapter
+        self._model = model
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        # Return the same dicts — used only to pass back into invoke() below.
+        return [
+            {"name": t.name, "description": t.description, "input_schema": t.input_schema}
+            for t in tools
+        ]
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        from app.integrations.llm_cli.runner import CLIBackedLLMClient
+        from app.integrations.llm_cli.text import flatten_messages_to_prompt
+
+        tool_block = ""
+        if tools:
+            tool_lines = json.dumps(tools, indent=2)
+            tool_block = f"\n\nAvailable tools (JSON schema):\n{tool_lines}\n"
+
+        system_block = f"System: {system}\n" if system else ""
+        instruction = self._TOOL_CALL_INSTRUCTION + tool_block
+        prompt = f"{system_block}{instruction}\n\n{flatten_messages_to_prompt(messages)}"
+
+        cli_client = CLIBackedLLMClient(self._adapter, model=self._model)
+        response = cli_client.invoke(prompt)
+        text = response.content.strip()
+
+        # Try to parse a JSON tool call response.
+        tool_calls: list[ToolCall] = []
+        parsed_json = _try_parse_tool_call_json(text)
+        if parsed_json is not None:
+            raw_calls = parsed_json.get("tool_calls") or []
+            for i, tc in enumerate(raw_calls):
+                if not isinstance(tc, dict):
+                    continue
+                tool_calls.append(
+                    ToolCall(
+                        id=str(tc.get("id") or f"call_{i}"),
+                        name=str(tc.get("name") or ""),
+                        input=tc.get("input") or {},
+                    )
+                )
+            content = ""
+        else:
+            content = text
+
+        return AgentLLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            stop_reason="tool_use" if tool_calls else "end_turn",
+            raw_content=None,  # None so _build_assistant_msg falls through to build_assistant_message
+        )
+
+    @staticmethod
+    def build_tool_result_message(tool_calls: list[ToolCall], results: list[Any]) -> dict[str, Any]:
+        parts = [
+            f"Tool result for {tc.name} (id={tc.id}): {json.dumps(result, default=str)}"
+            for tc, result in zip(tool_calls, results)
+        ]
+        return {"role": "user", "content": "\n".join(parts)}
+
+    @staticmethod
+    def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
+        """Match OpenAIAgentClient signature so investigation.py dispatch works correctly."""
+        _ = tool_calls
+        return {"role": "assistant", "content": content}
+
+
+def _try_parse_tool_call_json(text: str) -> dict[str, Any] | None:
+    """Return parsed JSON dict if *text* contains a tool_calls JSON block, else None."""
+    # Strip markdown fences.
+    cleaned = text.strip()
+    fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
+    candidate = fence.group(1).strip() if fence else cleaned
+
+    # Find the first {...} block.
+    brace = re.search(r"\{[\s\S]*\}", candidate)
+    if not brace:
+        return None
+    try:
+        payload = json.loads(brace.group(0))
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if isinstance(payload, dict) and "tool_calls" in payload:
+        return payload
+    return None
+
+
+_AgentClientType = AnthropicAgentClient | OpenAIAgentClient | CLIBackedAgentClient
 _agent_client: _AgentClientType | None = None
 
 
@@ -393,6 +513,9 @@ def get_agent_llm() -> _AgentClientType:
             model=settings.bedrock_reasoning_model,
             max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
         )
+    elif (cli_reg := _get_cli_provider_registration(provider)) is not None:
+        model_name = os.getenv(cli_reg.model_env_key, "").strip() or None
+        _agent_client = CLIBackedAgentClient(cli_reg.adapter_factory(), model=model_name)
     else:
         # Default: Anthropic
         from app.config import ANTHROPIC_LLM_CONFIG

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -467,19 +467,20 @@ class CLIBackedAgentClient:
 
 
 def _try_parse_tool_call_json(text: str) -> dict[str, Any] | None:
-    """Return parsed JSON dict if *text* contains a tool_calls JSON block, else None."""
-    # Strip markdown fences.
+    """Return parsed JSON dict if *text* starts with (or fences) a tool_calls JSON object.
+
+    Uses :meth:`json.JSONDecoder.raw_decode` so a single JSON value is parsed from
+    the start of the candidate without a greedy ``{...}`` span swallowing trailing
+    brace-containing prose and breaking :func:`json.loads`.
+    """
     cleaned = text.strip()
     fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
-    candidate = fence.group(1).strip() if fence else cleaned
-
-    # Find the first {...} block.
-    brace = re.search(r"\{[\s\S]*\}", candidate)
-    if not brace:
+    candidate = (fence.group(1).strip() if fence else cleaned).strip()
+    if not candidate:
         return None
     try:
-        payload = json.loads(brace.group(0))
-    except (json.JSONDecodeError, ValueError):
+        payload, _end = json.JSONDecoder().raw_decode(candidate)
+    except json.JSONDecodeError:
         return None
     if isinstance(payload, dict) and "tool_calls" in payload:
         return payload

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -380,8 +380,13 @@ class CLIBackedAgentClient:
     )
 
     def __init__(self, adapter: Any, *, model: str | None = None) -> None:
+        from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
         self._adapter = adapter
         self._model = model
+        # Reuse one subprocess client so the 45s probe cache in CLIBackedLLMClient
+        # applies across ReAct iterations instead of re-probing every invoke.
+        self._cli_client = CLIBackedLLMClient(adapter, model=self._model)
 
     def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
         # Return the same dicts — used only to pass back into invoke() below.
@@ -397,7 +402,6 @@ class CLIBackedAgentClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> AgentLLMResponse:
-        from app.integrations.llm_cli.runner import CLIBackedLLMClient
         from app.integrations.llm_cli.text import flatten_messages_to_prompt
 
         tool_block = ""
@@ -409,8 +413,7 @@ class CLIBackedAgentClient:
         instruction = self._TOOL_CALL_INSTRUCTION + tool_block
         prompt = f"{system_block}{instruction}\n\n{flatten_messages_to_prompt(messages)}"
 
-        cli_client = CLIBackedLLMClient(self._adapter, model=self._model)
-        response = cli_client.invoke(prompt)
+        response = self._cli_client.invoke(prompt)
         text = response.content.strip()
 
         # Try to parse a JSON tool call response.
@@ -449,8 +452,17 @@ class CLIBackedAgentClient:
 
     @staticmethod
     def build_assistant_message(content: str, tool_calls: list[ToolCall]) -> dict[str, Any]:
-        """Match OpenAIAgentClient signature so investigation.py dispatch works correctly."""
-        _ = tool_calls
+        """Match OpenAIAgentClient signature; embed tool JSON in content for CLI history."""
+        if tool_calls:
+            payload = {
+                "tool_calls": [
+                    {"id": tc.id, "name": tc.name, "input": tc.input} for tc in tool_calls
+                ]
+            }
+            tool_json = json.dumps(payload)
+            if content.strip():
+                return {"role": "assistant", "content": f"{content.strip()}\n\n{tool_json}"}
+            return {"role": "assistant", "content": tool_json}
         return {"role": "assistant", "content": content}
 
 

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.agent.investigation import ConnectedInvestigationAgent, _availability_view
+from app.agent.investigation import (
+    ConnectedInvestigationAgent,
+    _availability_view,
+    _build_synthetic_assistant_tool_call_msg,
+)
+from app.services.agent_llm_client import CLIBackedAgentClient, ToolCall
 
 
 def test_availability_view_marks_configured_integrations_without_mutating_state() -> None:
@@ -15,6 +20,36 @@ def test_availability_view_marks_configured_integrations_without_mutating_state(
     assert view["github"]["connection_verified"] is True
     assert "connection_verified" not in resolved["github"]
     assert view["_all"] == resolved["_all"]
+
+
+def test_build_synthetic_assistant_json_for_cli_backed_client() -> None:
+    """Seed assistant turn must match CLI JSON history format (Greptile)."""
+    import types as _types
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/x", logged_in=True, detail=""
+        ),
+        build=lambda **_kw: _types.SimpleNamespace(
+            argv=("/x",), stdin="", cwd="/", env=None, timeout_sec=30.0
+        ),
+        parse=lambda **_kw: "",
+        explain_failure=lambda **_kw: "",
+    )
+    llm = CLIBackedAgentClient(fake_adapter, model=None)
+    msg = _build_synthetic_assistant_tool_call_msg(
+        llm,
+        [ToolCall(id="seed_t", name="query_eks", input={"cluster": "c"})],
+    )
+    assert msg["role"] == "assistant"
+    assert '"tool_calls"' in msg["content"]
+    assert "query_eks" in msg["content"]
+    assert "seed_t" in msg["content"]
 
 
 def test_run_gracefully_handles_model_not_found_runtime_error() -> None:

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
+from typing import Any
 
 import pytest
 
@@ -405,6 +406,62 @@ def test_cli_backed_agent_client_tool_call_parsing() -> None:
     assert result.tool_calls[0].name == "my_tool"
     assert result.tool_calls[0].input == {"x": 1}
     assert result.content == ""
+
+
+def test_cli_backed_agent_client_build_assistant_message_includes_tool_json() -> None:
+    """Assistant history must retain tool_calls JSON for multi-turn CLI prompts."""
+    from app.services.agent_llm_client import CLIBackedAgentClient, ToolCall
+
+    msg = CLIBackedAgentClient.build_assistant_message(
+        "",
+        [ToolCall(id="t1", name="query_logs", input={"q": "error"})],
+    )
+    assert msg["role"] == "assistant"
+    assert "query_logs" in msg["content"]
+    assert '"tool_calls"' in msg["content"]
+    assert "t1" in msg["content"]
+
+
+def test_cli_backed_agent_client_reuses_single_cli_llm_client() -> None:
+    """CLIBackedLLMClient should be constructed once so probe cache spans invokes."""
+    import types as _types
+    import unittest.mock as mock
+
+    from app.integrations.llm_cli.runner import CLIBackedLLMClient
+    from app.services.agent_llm_client import CLIBackedAgentClient
+    from app.services.llm_client import LLMResponse
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/usr/bin/codex", logged_in=True, detail=""
+        ),
+        build=lambda **_kw: _types.SimpleNamespace(
+            argv=("/usr/bin/codex",), stdin="", cwd="/", env=None, timeout_sec=30.0
+        ),
+        parse=lambda **_kw: "",
+        explain_failure=lambda **_kw: "",
+    )
+    real_init = CLIBackedLLMClient.__init__
+    init_count = {"n": 0}
+
+    def counting_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        init_count["n"] += 1
+        return real_init(self, *args, **kwargs)
+
+    with mock.patch.object(CLIBackedLLMClient, "__init__", counting_init):
+        client = CLIBackedAgentClient(fake_adapter, model=None)
+        with mock.patch.object(
+            CLIBackedLLMClient, "invoke", return_value=LLMResponse(content="ok")
+        ):
+            client.invoke([{"role": "user", "content": "a"}])
+            client.invoke([{"role": "user", "content": "b"}])
+
+    assert init_count["n"] == 1
 
 
 def test_cli_backed_agent_client_plain_text_response() -> None:

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -339,3 +339,104 @@ def test_unrelated_type_error_is_retried_and_wrapped(
         client.invoke(messages=[{"role": "user", "content": "hi"}])
 
     assert call_count == 3, "non-auth TypeError should be retried like a generic exception"
+
+
+@pytest.mark.parametrize(
+    "provider", ["codex", "opencode", "claude-code", "kimi", "cursor", "gemini-cli", "copilot"]
+)
+def test_get_agent_llm_returns_cli_backed_client_for_cli_providers(
+    provider: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.agent_llm_client import (
+        CLIBackedAgentClient,
+        get_agent_llm,
+        reset_agent_client,
+    )
+
+    monkeypatch.setenv("LLM_PROVIDER", provider)
+    reset_agent_client()
+    client = get_agent_llm()
+    assert isinstance(client, CLIBackedAgentClient), (
+        f"Expected CLIBackedAgentClient for provider={provider!r}, got {type(client).__name__}"
+    )
+
+
+def test_cli_backed_agent_client_tool_call_parsing() -> None:
+    """CLIBackedAgentClient correctly parses a JSON tool_calls response."""
+    import types as _types
+
+    from app.services.agent_llm_client import CLIBackedAgentClient
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="npm i -g @openai/codex",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/usr/bin/codex", logged_in=True, detail=""
+        ),
+        build=lambda **kw: _types.SimpleNamespace(
+            argv=("/usr/bin/codex", "exec", "-"),
+            stdin=kw.get("prompt", ""),
+            cwd="/",
+            env=None,
+            timeout_sec=30.0,
+        ),
+        parse=lambda **kw: kw.get("stdout", ""),
+        explain_failure=lambda **kw: f"exit {kw.get('returncode')}",
+    )
+    client = CLIBackedAgentClient(fake_adapter, model=None)
+
+    # Patch CLIBackedLLMClient.invoke to return a known JSON response.
+    import unittest.mock as mock
+
+    from app.services.llm_client import LLMResponse
+
+    json_response = '{"tool_calls": [{"id": "c1", "name": "my_tool", "input": {"x": 1}}]}'
+    with mock.patch(
+        "app.integrations.llm_cli.runner.CLIBackedLLMClient.invoke",
+        return_value=LLMResponse(content=json_response),
+    ):
+        result = client.invoke([{"role": "user", "content": "investigate"}])
+
+    assert result.has_tool_calls
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "my_tool"
+    assert result.tool_calls[0].input == {"x": 1}
+    assert result.content == ""
+
+
+def test_cli_backed_agent_client_plain_text_response() -> None:
+    """CLIBackedAgentClient treats non-JSON output as a final text answer."""
+    import types as _types
+    import unittest.mock as mock
+
+    from app.services.agent_llm_client import CLIBackedAgentClient
+    from app.services.llm_client import LLMResponse
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/usr/bin/codex", logged_in=True, detail=""
+        ),
+        build=lambda **_kw: _types.SimpleNamespace(
+            argv=("/usr/bin/codex",), stdin="", cwd="/", env=None, timeout_sec=30.0
+        ),
+        parse=lambda **_kw: "",
+        explain_failure=lambda **_kw: "",
+    )
+    client = CLIBackedAgentClient(fake_adapter, model=None)
+
+    with mock.patch(
+        "app.integrations.llm_cli.runner.CLIBackedLLMClient.invoke",
+        return_value=LLMResponse(content="The root cause is a memory leak."),
+    ):
+        result = client.invoke([{"role": "user", "content": "summarise"}])
+
+    assert not result.has_tool_calls
+    assert result.content == "The root cause is a memory leak."

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -422,6 +422,17 @@ def test_cli_backed_agent_client_build_assistant_message_includes_tool_json() ->
     assert "t1" in msg["content"]
 
 
+def test_try_parse_tool_call_json_uses_raw_decode_not_greedy_brace_span() -> None:
+    """Trailing brace-containing prose after valid JSON must not drop tool_calls."""
+    from app.services import agent_llm_client as alc
+
+    text = '{"tool_calls": [{"id": "a", "name": "t1", "input": {}}]} Here\'s context: {not json}'
+    parsed = alc._try_parse_tool_call_json(text)
+    assert parsed is not None
+    assert len(parsed["tool_calls"]) == 1
+    assert parsed["tool_calls"][0]["name"] == "t1"
+
+
 def test_cli_backed_agent_client_reuses_single_cli_llm_client() -> None:
     """CLIBackedLLMClient should be constructed once so probe cache spans invokes."""
     import types as _types


### PR DESCRIPTION
## Summary

- After the LangGraph migration, `get_agent_llm()` only handled HTTP providers; `LLM_PROVIDER=codex` (and other CLI providers) fell through to Anthropic, so `opensre investigate` could hit the wrong backend and fail with billing errors.
- This PR adds `CLIBackedAgentClient`, which implements the investigation agent contract by flattening history, embedding tool schemas in the prompt, and parsing `{"tool_calls": [...]}` JSON (or treating output as a final text answer).
- `get_agent_llm()` now uses the same `llm_cli` registry as `llm_client.py` for registered CLI providers.

No linked issue (regression surfaced locally with Codex + investigate).

## Test plan

- [x] `uv run pytest tests/services/test_agent_llm_client.py -q`
- [x] `uv run ruff check` on touched files
- [x] `uv run mypy` on touched files
- [ ] Optional: `uv run opensre investigate --input tests/synthetic/eks/000-healthy/alert.json` with `LLM_PROVIDER=codex` and a working Codex session

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The investigation ReAct loop requires `tool_schemas`, `invoke(messages, system, tools)`, and message builders compatible with `app/agent/investigation.py`. CLI binaries have no native tool API, so the client sends one flattened prompt per turn with instructions plus JSON tool definitions, then parses structured `tool_calls` from the model reply when present; otherwise it treats the reply as plain-text completion. `CLIBackedLLMClient` is reused for subprocess execution and auth probing.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions