### PR TITLE
fix(agent-llm): harden CLI tool-call JSON parsing for preamble output

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -420,18 +420,24 @@ class CLIBackedAgentClient:
         tool_calls: list[ToolCall] = []
         parsed_json = _try_parse_tool_call_json(text)
         if parsed_json is not None:
-            raw_calls = parsed_json.get("tool_calls") or []
-            for i, tc in enumerate(raw_calls):
-                if not isinstance(tc, dict):
-                    continue
-                tool_calls.append(
-                    ToolCall(
-                        id=str(tc.get("id") or f"call_{i}"),
-                        name=str(tc.get("name") or ""),
-                        input=tc.get("input") or {},
+            raw_calls = parsed_json.get("tool_calls")
+            if isinstance(raw_calls, list):
+                for i, tc in enumerate(raw_calls):
+                    if not isinstance(tc, dict):
+                        continue
+                    name = tc.get("name")
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    raw_input = tc.get("input")
+                    input_payload = raw_input if isinstance(raw_input, dict) else {}
+                    tool_calls.append(
+                        ToolCall(
+                            id=str(tc.get("id") or f"call_{i}"),
+                            name=name.strip(),
+                            input=input_payload,
+                        )
                     )
-                )
-            content = ""
+            content = "" if tool_calls else text
         else:
             content = text
 
@@ -467,23 +473,42 @@ class CLIBackedAgentClient:
 
 
 def _try_parse_tool_call_json(text: str) -> dict[str, Any] | None:
-    """Return parsed JSON dict if *text* starts with (or fences) a tool_calls JSON object.
+    """Return parsed JSON dict if *text* contains a tool_calls JSON object.
 
-    Uses :meth:`json.JSONDecoder.raw_decode` so a single JSON value is parsed from
-    the start of the candidate without a greedy ``{...}`` span swallowing trailing
-    brace-containing prose and breaking :func:`json.loads`.
+    Uses :meth:`json.JSONDecoder.raw_decode` so a single JSON value is parsed
+    without a greedy ``{...}`` span swallowing trailing brace-containing prose and
+    breaking :func:`json.loads`.
     """
     cleaned = text.strip()
     fence = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
     candidate = (fence.group(1).strip() if fence else cleaned).strip()
     if not candidate:
         return None
-    try:
-        payload, _end = json.JSONDecoder().raw_decode(candidate)
-    except json.JSONDecodeError:
+
+    decoder = json.JSONDecoder()
+
+    def _decode_at(idx: int) -> dict[str, Any] | None:
+        try:
+            payload, _end = decoder.raw_decode(candidate, idx)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, dict) and "tool_calls" in payload:
+            return payload
         return None
-    if isinstance(payload, dict) and "tool_calls" in payload:
-        return payload
+
+    # Fast path: candidate is pure JSON (the preferred model behavior).
+    parsed = _decode_at(0)
+    if parsed is not None:
+        return parsed
+
+    # Recovery path: some CLI models prepend unfenced prose before the JSON
+    # object. Scan object starts and accept the first dict that contains
+    # "tool_calls".
+    for match in re.finditer(r"\{", candidate):
+        parsed = _decode_at(match.start())
+        if parsed is not None:
+            return parsed
+
     return None
 
 

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -503,8 +503,10 @@ def _try_parse_tool_call_json(text: str) -> dict[str, Any] | None:
 
     # Recovery path: some CLI models prepend unfenced prose before the JSON
     # object. Scan object starts and accept the first dict that contains
-    # "tool_calls".
+    # "tool_calls". Skip index 0 because the fast path already attempted it.
     for match in re.finditer(r"\{", candidate):
+        if match.start() == 0:
+            continue
         parsed = _decode_at(match.start())
         if parsed is not None:
             return parsed

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -433,6 +433,17 @@ def test_try_parse_tool_call_json_uses_raw_decode_not_greedy_brace_span() -> Non
     assert parsed["tool_calls"][0]["name"] == "t1"
 
 
+def test_try_parse_tool_call_json_recovers_when_unfenced_preamble_precedes_json() -> None:
+    """Unfenced prose before JSON should still allow tool_calls extraction."""
+    from app.services import agent_llm_client as alc
+
+    text = 'Reasoning preamble {draft}\n{"tool_calls": [{"id": "a", "name": "t1", "input": {}}]}'
+    parsed = alc._try_parse_tool_call_json(text)
+    assert parsed is not None
+    assert len(parsed["tool_calls"]) == 1
+    assert parsed["tool_calls"][0]["name"] == "t1"
+
+
 def test_cli_backed_agent_client_reuses_single_cli_llm_client() -> None:
     """CLIBackedLLMClient should be constructed once so probe cache spans invokes."""
     import types as _types
@@ -508,3 +519,39 @@ def test_cli_backed_agent_client_plain_text_response() -> None:
 
     assert not result.has_tool_calls
     assert result.content == "The root cause is a memory leak."
+
+
+def test_cli_backed_agent_client_invalid_tool_json_falls_back_to_text_response() -> None:
+    """Malformed tool_calls payload should not erase the model's textual response."""
+    import types as _types
+    import unittest.mock as mock
+
+    from app.services.agent_llm_client import CLIBackedAgentClient
+    from app.services.llm_client import LLMResponse
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/usr/bin/codex", logged_in=True, detail=""
+        ),
+        build=lambda **_kw: _types.SimpleNamespace(
+            argv=("/usr/bin/codex",), stdin="", cwd="/", env=None, timeout_sec=30.0
+        ),
+        parse=lambda **_kw: "",
+        explain_failure=lambda **_kw: "",
+    )
+    client = CLIBackedAgentClient(fake_adapter, model=None)
+    raw = '{"tool_calls":"not-a-list"}'
+
+    with mock.patch(
+        "app.integrations.llm_cli.runner.CLIBackedLLMClient.invoke",
+        return_value=LLMResponse(content=raw),
+    ):
+        result = client.invoke([{"role": "user", "content": "summarise"}])
+
+    assert not result.has_tool_calls
+    assert result.content == raw

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -555,3 +555,39 @@ def test_cli_backed_agent_client_invalid_tool_json_falls_back_to_text_response()
 
     assert not result.has_tool_calls
     assert result.content == raw
+
+
+def test_cli_backed_agent_client_filtered_tool_calls_fall_back_to_text_response() -> None:
+    """If all parsed tool calls are filtered out, preserve text content."""
+    import types as _types
+    import unittest.mock as mock
+
+    from app.services.agent_llm_client import CLIBackedAgentClient
+    from app.services.llm_client import LLMResponse
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/usr/bin/codex", logged_in=True, detail=""
+        ),
+        build=lambda **_kw: _types.SimpleNamespace(
+            argv=("/usr/bin/codex",), stdin="", cwd="/", env=None, timeout_sec=30.0
+        ),
+        parse=lambda **_kw: "",
+        explain_failure=lambda **_kw: "",
+    )
+    client = CLIBackedAgentClient(fake_adapter, model=None)
+    raw = '{"tool_calls":[{"id":"c1","name":"   ","input":{"x":1}}]}'
+
+    with mock.patch(
+        "app.integrations.llm_cli.runner.CLIBackedLLMClient.invoke",
+        return_value=LLMResponse(content=raw),
+    ):
+        result = client.invoke([{"role": "user", "content": "summarise"}])
+
+    assert not result.has_tool_calls
+    assert result.content == raw


### PR DESCRIPTION
## Summary
Follow-up hardening for the merged CLI provider routing work in #2156.

This PR strengthens CLI tool-call parsing so we don't silently miss valid tool calls when a CLI model adds unfenced prose before the JSON payload.

## Root cause
`_try_parse_tool_call_json()` only attempted `JSONDecoder.raw_decode()` from index `0` (or fenced content). If the response started with prose and the tool-call object appeared later, parsing failed and the turn was treated as a plain-text final answer.

## What changed
- Updated `_try_parse_tool_call_json()` to:
  - keep the fast path for pure JSON / fenced JSON
  - add a recovery path that scans object starts (`{`) and attempts `raw_decode(..., idx=...)`
  - return the first decoded dict containing `tool_calls`
- Hardened `CLIBackedAgentClient.invoke()`:
  - only accepts `tool_calls` when it is a list of dict calls with a non-empty `name`
  - normalizes non-dict `input` payloads to `{}`
  - falls back to the original text response when parsed JSON contains no usable tool calls (prevents blank final answers)

## Tests
Added/updated service tests:
- unfenced preamble + braces before JSON is recoverable
- malformed `tool_calls` payload (`{"tool_calls":"not-a-list"}`) falls back to plain text instead of erasing content

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run pytest tests/services/ tests/tools/ -v`
