### PR TITLE
Add Sentry debug command and coverage tests

### DIFF
--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -208,6 +208,13 @@ def _is_update_invocation(argv: list[str]) -> bool:
     return bool(command_parts) and command_parts[0] == "update"
 
 
+def _sentry_entrypoint_for_invocation(argv: list[str]) -> str:
+    command_parts = _resolve_command_parts(cli, argv)
+    if command_parts == ["debug", "sentry"]:
+        return "debug"
+    return "cli"
+
+
 def _should_capture_cli_exception(exc: click.ClickException) -> bool:
     """Return whether a Click error represents an unexpected internal failure."""
     return should_report_exception(exc)
@@ -219,7 +226,7 @@ def main(argv: list[str] | None = None) -> int:
     load_dotenv(override=False)
     cli_argv = list(sys.argv[1:] if argv is None else argv)
     try:
-        init_sentry(entrypoint="cli")
+        init_sentry(entrypoint=_sentry_entrypoint_for_invocation(cli_argv))
     except ModuleNotFoundError as exc:
         if exc.name != "sentry_sdk" or not _is_update_invocation(cli_argv):
             raise

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -210,7 +210,7 @@ def _is_update_invocation(argv: list[str]) -> bool:
 
 def _sentry_entrypoint_for_invocation(argv: list[str]) -> str:
     command_parts = _resolve_command_parts(cli, argv)
-    if command_parts == ["debug", "sentry"]:
+    if command_parts and command_parts[0] == "debug":
         return "debug"
     return "cli"
 

--- a/app/cli/commands/__init__.py
+++ b/app/cli/commands/__init__.py
@@ -6,6 +6,7 @@ import click
 
 from app.cli.commands.agent import agents
 from app.cli.commands.config import config_command
+from app.cli.commands.debug import debug_command
 from app.cli.commands.doctor import doctor_command
 from app.cli.commands.general import (
     health_command,
@@ -35,6 +36,7 @@ _COMMANDS: tuple[click.Command, ...] = (
     messaging,
     hermes_command,
     watchdog_command,
+    debug_command,
     health_command,
     doctor_command,
     update_command,

--- a/app/cli/commands/debug.py
+++ b/app/cli/commands/debug.py
@@ -1,0 +1,61 @@
+"""Debugging commands for runtime diagnostics."""
+
+from __future__ import annotations
+
+import click
+
+from app.utils.sentry_sdk import (
+    capture_exception,
+    init_sentry,
+    resolved_sentry_dsn_host,
+    sentry_transport_enabled,
+)
+
+
+@click.group(name="debug")
+def debug_command() -> None:
+    """Run targeted debug checks."""
+
+
+@debug_command.command(name="sentry")
+def debug_sentry_command() -> None:
+    """Send a synthetic Sentry event and flush the transport."""
+    dsn_host = resolved_sentry_dsn_host()
+    if not sentry_transport_enabled():
+        click.echo("Sentry is disabled or no DSN is configured.", err=True)
+        raise SystemExit(1)
+
+    try:
+        init_sentry(entrypoint="debug")
+    except Exception as exc:
+        click.echo(f"Sentry init failed: {type(exc).__name__}: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    try:
+        import sentry_sdk
+    except ModuleNotFoundError as exc:
+        click.echo("Sentry SDK is not installed.", err=True)
+        raise SystemExit(1) from exc
+
+    event_id = capture_exception(
+        RuntimeError("OpenSRE Sentry debug smoke test"),
+        context="debug.sentry",
+        tags={"debug": "true", "surface": "debug"},
+    )
+    if event_id is None:
+        click.echo("Sentry did not return an event ID.", err=True)
+        raise SystemExit(1)
+
+    try:
+        flush_result = sentry_sdk.flush(timeout=5)
+    except Exception as exc:
+        click.echo(f"Sentry flush failed: {type(exc).__name__}: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    sent = flush_result is True
+    click.echo(f"Sentry DSN host: {dsn_host or '<empty>'}")
+    click.echo(f"Sentry event ID: {event_id}")
+    click.echo(f"Sentry flush sent: {'yes' if sent else 'no'}")
+
+    if not sent:
+        raise SystemExit(1)

--- a/app/cli/commands/debug.py
+++ b/app/cli/commands/debug.py
@@ -6,7 +6,6 @@ import click
 
 from app.utils.sentry_sdk import (
     capture_exception,
-    init_sentry,
     resolved_sentry_dsn_host,
     sentry_transport_enabled,
 )
@@ -25,17 +24,7 @@ def debug_sentry_command() -> None:
         click.echo("Sentry is disabled or no DSN is configured.", err=True)
         raise SystemExit(1)
 
-    try:
-        init_sentry(entrypoint="debug")
-    except Exception as exc:
-        click.echo(f"Sentry init failed: {type(exc).__name__}: {exc}", err=True)
-        raise SystemExit(1) from exc
-
-    try:
-        import sentry_sdk
-    except ModuleNotFoundError as exc:
-        click.echo("Sentry SDK is not installed.", err=True)
-        raise SystemExit(1) from exc
+    import sentry_sdk
 
     event_id = capture_exception(
         RuntimeError("OpenSRE Sentry debug smoke test"),

--- a/app/cli/commands/debug.py
+++ b/app/cli/commands/debug.py
@@ -41,7 +41,9 @@ def debug_sentry_command() -> None:
         click.echo(f"Sentry flush failed: {type(exc).__name__}: {exc}", err=True)
         raise SystemExit(1) from exc
 
-    sent = flush_result is True
+    # sentry-sdk 2.x waits for transport flushes but returns None; older/test
+    # transports may return False to signal that pending work was not flushed.
+    sent = flush_result is not False
     click.echo(f"Sentry DSN host: {dsn_host or '<empty>'}")
     click.echo(f"Sentry event ID: {event_id}")
     click.echo(f"Sentry flush sent: {'yes' if sent else 'no'}")

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -234,6 +234,10 @@ def _cmd_watchdog(session: ReplSession, console: Console, args: list[str]) -> bo
     return run_cli_command(console, ["watchdog", *args])
 
 
+def _cmd_debug(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
+    return run_cli_command(console, ["debug", *args])
+
+
 COMMANDS: list[SlashCommand] = [
     SlashCommand(
         "/onboard",
@@ -294,6 +298,12 @@ COMMANDS: list[SlashCommand] = [
         "/watchdog",
         "monitor one process and send threshold alarms ('/watchdog --pid 123 --max-rss 1G')",
         _cmd_watchdog,
+        execution_tier=ExecutionTier.SAFE,
+    ),
+    SlashCommand(
+        "/debug",
+        "run targeted debug checks ('/debug sentry')",
+        _cmd_debug,
         execution_tier=ExecutionTier.SAFE,
     ),
 ]

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -302,7 +302,7 @@ COMMANDS: list[SlashCommand] = [
     ),
     SlashCommand(
         "/debug",
-        "run targeted debug checks ('/debug sentry')",
+        "run targeted runtime diagnostics",
         _cmd_debug,
         execution_tier=ExecutionTier.SAFE,
     ),

--- a/app/pipeline/runners.py
+++ b/app/pipeline/runners.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import queue
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -22,6 +22,42 @@ logger = logging.getLogger(__name__)
 # Serializes temporary render_report monkeypatches when multiple streaming
 # investigations run concurrently (e.g. remote server).
 _render_report_patch_lock = threading.Lock()
+_SENTRY_CAPTURED_ATTR = "_opensre_sentry_captured"
+
+
+def _exception_was_captured(exc: BaseException) -> bool:
+    return bool(getattr(exc, _SENTRY_CAPTURED_ATTR, False))
+
+
+def _mark_exception_captured(exc: BaseException) -> None:
+    with contextlib.suppress(Exception):
+        setattr(exc, _SENTRY_CAPTURED_ATTR, True)
+
+
+def _capture_exception_once(
+    exc: BaseException,
+    *,
+    context: str,
+    tags: dict[str, str] | None = None,
+) -> None:
+    if _exception_was_captured(exc):
+        return
+    from app.utils.sentry_sdk import capture_exception
+
+    capture_exception(exc, context=context, tags=tags)
+    _mark_exception_captured(exc)
+
+
+def _traced_node(node_name: str, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:
+        _capture_exception_once(
+            exc,
+            context=f"node.{node_name}",
+            tags={"surface": "node", "node": node_name},
+        )
+        raise
 
 
 def _merge_state(state: AgentState, updates: dict[str, Any]) -> None:
@@ -175,7 +211,7 @@ async def astream_investigation(
 
             # --- resolve_integrations ---
             _put(_make_node_event("on_chain_start", "resolve_integrations", {}))
-            resolved = resolve_integrations(initial)
+            resolved = _traced_node("resolve_integrations", resolve_integrations, initial)
             _merge(state_any, {"resolved_integrations": resolved})
             _put(
                 _make_node_event(
@@ -193,7 +229,7 @@ async def astream_investigation(
 
             # --- extract_alert ---
             _put(_make_node_event("on_chain_start", "extract_alert", {}))
-            _merge(state_any, extract_alert(initial))
+            _merge(state_any, _traced_node("extract_alert", extract_alert, initial))
             _put(
                 _make_node_event(
                     "on_chain_end",
@@ -213,7 +249,13 @@ async def astream_investigation(
 
             # --- investigation agent (with real tool events) ---
             _merge(
-                state_any, ConnectedInvestigationAgent().run(state_any, on_event=_on_agent_event)
+                state_any,
+                _traced_node(
+                    "investigation_agent",
+                    ConnectedInvestigationAgent().run,
+                    state_any,
+                    on_event=_on_agent_event,
+                ),
             )
 
             # --- upstream correlation ---
@@ -230,7 +272,9 @@ async def astream_investigation(
 
             _merge(
                 state_any,
-                node_correlate_upstream(
+                _traced_node(
+                    "correlate_upstream",
+                    node_correlate_upstream,
                     cast("AgentState", state_any),
                     _build_correlation_config(state_any),
                 ),
@@ -262,7 +306,10 @@ async def astream_investigation(
                 _term_mod.render_report = lambda *_a, **_kw: None  # type: ignore[assignment]
                 _publish_node.render_report = lambda *_a, **_kw: None  # type: ignore[assignment]
                 try:
-                    _merge(state_any, generate_report(cast("Any", state_any)))
+                    _merge(
+                        state_any,
+                        _traced_node("publish_findings", generate_report, cast("Any", state_any)),
+                    )
                 finally:
                     _term_mod.render_report = _orig_terminal_render  # type: ignore[assignment]
                     _publish_node.render_report = _orig_node_render  # type: ignore[assignment]
@@ -287,9 +334,7 @@ async def astream_investigation(
             )
 
         except Exception as exc:
-            from app.utils.sentry_sdk import capture_exception
-
-            capture_exception(exc)
+            _capture_exception_once(exc, context="pipeline.astream_investigation")
             with contextlib.suppress(RuntimeError):
                 loop.call_soon_threadsafe(event_queue.put_nowait, exc)
         finally:

--- a/app/tools/base.py
+++ b/app/tools/base.py
@@ -124,7 +124,11 @@ class BaseTool(ABC):
         except Exception as exc:
             from app.utils.sentry_sdk import capture_exception
 
-            capture_exception(exc, context=f"tool.{self.name}")
+            capture_exception(
+                exc,
+                context=f"tool.{self.name}",
+                tags={"surface": "tool", "tool": self.name},
+            )
             return {"error": str(exc), "exception_type": type(exc).__name__}
 
     def is_available(self, _sources: dict[str, dict]) -> bool:

--- a/app/tools/registered_tool.py
+++ b/app/tools/registered_tool.py
@@ -206,7 +206,11 @@ class RegisteredTool:
         except Exception as exc:
             from app.utils.sentry_sdk import capture_exception
 
-            capture_exception(exc, context=f"tool.{self.name}")
+            capture_exception(
+                exc,
+                context=f"tool.{self.name}",
+                tags={"surface": "tool", "tool": self.name},
+            )
             return {"error": str(exc), "exception_type": type(exc).__name__}
 
     @classmethod

--- a/app/utils/errors.py
+++ b/app/utils/errors.py
@@ -42,7 +42,10 @@ def report_exception(
         combined.update({f"tag.{k}": v for k, v in tags.items()})
     if extras:
         combined.update(extras)
-    capture_exception(exc, extra=combined or None)
+    if tags:
+        capture_exception(exc, extra=combined or None, tags=tags)
+    else:
+        capture_exception(exc, extra=combined or None)
 
 
 @contextmanager

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -14,7 +14,7 @@ import re
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager, suppress
 from functools import cache
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlsplit, urlunsplit
 
 from app.analytics.events import Event
@@ -503,7 +503,7 @@ def capture_exception(
     context: str | None = None,
     extra: Mapping[str, Any] | None = None,
     tags: Mapping[str, str] | None = None,
-) -> Any | None:
+) -> str | None:
     """Best-effort capture for exceptions swallowed by boundary adapters."""
     if _is_sentry_disabled():
         return None
@@ -511,7 +511,7 @@ def capture_exception(
         import sentry_sdk
 
         if context is None and not extra and not tags:
-            return sentry_sdk.capture_exception(exc)
+            return cast("str | None", sentry_sdk.capture_exception(exc))
         with sentry_sdk.push_scope() as scope:
             if context is not None:
                 scope.set_tag("opensre.context", context)
@@ -521,7 +521,7 @@ def capture_exception(
             if extra:
                 for key, value in extra.items():
                     scope.set_extra(key, value)
-            return sentry_sdk.capture_exception(exc)
+            return cast("str | None", sentry_sdk.capture_exception(exc))
     return None
 
 

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -269,6 +269,7 @@ def _apply_fingerprint_rules(event: dict[str, Any]) -> None:
     tool_name = tags.get("tool")
     if isinstance(tool_name, str) and tool_name:
         event["fingerprint"] = ["tool-error", tool_name, "{{ default }}"]
+        return
 
     node_name = tags.get("node")
     if isinstance(node_name, str) and node_name:

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -107,6 +107,19 @@ def _resolved_dsn() -> str:
     return os.getenv("OPENSRE_SENTRY_DSN") or os.getenv("SENTRY_DSN") or SENTRY_DSN
 
 
+def resolved_sentry_dsn_host() -> str:
+    """Return the resolved Sentry DSN host without exposing credentials."""
+    dsn = _resolved_dsn()
+    if not dsn:
+        return ""
+    return urlsplit(dsn).hostname or ""
+
+
+def sentry_transport_enabled() -> bool:
+    """Return whether Sentry events are expected to be sent."""
+    return bool(_resolved_dsn()) and not _is_sentry_disabled()
+
+
 def _scrub_string(value: object) -> object:
     if isinstance(value, str):
         return _HOME_PATH_RE.sub("~", value)
@@ -248,6 +261,20 @@ def _event_has_operator_actionable_llm_error(event: dict[str, Any]) -> bool:
     return any(pattern.search(combined) for pattern in _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS)
 
 
+def _apply_fingerprint_rules(event: dict[str, Any]) -> None:
+    tags = event.get("tags")
+    if not isinstance(tags, dict):
+        return
+
+    tool_name = tags.get("tool")
+    if isinstance(tool_name, str) and tool_name:
+        event["fingerprint"] = ["tool-error", tool_name, "{{ default }}"]
+
+    node_name = tags.get("node")
+    if isinstance(node_name, str) and node_name:
+        event["fingerprint"] = ["node-error", node_name, "{{ default }}"]
+
+
 def _before_send(event: Any, _hint: dict[str, Any]) -> Any:
     """Drop or scrub a Sentry event before transport.
 
@@ -263,6 +290,7 @@ def _before_send(event: Any, _hint: dict[str, Any]) -> Any:
         return event
     if _event_has_operator_actionable_llm_error(event):
         return None
+    _apply_fingerprint_rules(event)
     try:
         _scrub_event_in_place(event)
     except Exception:
@@ -473,23 +501,27 @@ def capture_exception(
     *,
     context: str | None = None,
     extra: Mapping[str, Any] | None = None,
-) -> None:
+    tags: Mapping[str, str] | None = None,
+) -> Any | None:
     """Best-effort capture for exceptions swallowed by boundary adapters."""
     if _is_sentry_disabled():
-        return
+        return None
     with suppress(Exception):
         import sentry_sdk
 
-        if context is None and not extra:
-            sentry_sdk.capture_exception(exc)
-            return
+        if context is None and not extra and not tags:
+            return sentry_sdk.capture_exception(exc)
         with sentry_sdk.push_scope() as scope:
             if context is not None:
                 scope.set_tag("opensre.context", context)
+            if tags:
+                for key, value in tags.items():
+                    scope.set_tag(key, value)
             if extra:
                 for key, value in extra.items():
                     scope.set_extra(key, value)
-            sentry_sdk.capture_exception(exc)
+            return sentry_sdk.capture_exception(exc)
+    return None
 
 
 @contextmanager

--- a/docs/sentry.mdx
+++ b/docs/sentry.mdx
@@ -90,6 +90,29 @@ Status: passed
 Detail: Sentry validated for org your-org; issues API responded successfully with 5 issue(s)
 ```
 
+## Verify Error Reporting
+
+Send one test event to confirm OpenSRE can report runtime errors:
+
+```bash
+opensre debug sentry
+```
+
+For a custom or self-hosted project, set the DSN first:
+
+```bash
+OPENSRE_SENTRY_DSN=https://public-key@example.ingest.sentry.io/123 opensre debug sentry
+```
+
+```text
+Sentry DSN host: example.ingest.sentry.io
+Sentry event ID: <event-id>
+Sentry flush sent: yes
+```
+
+The event is synthetic and tagged `debug=true`. If telemetry is disabled, the
+command exits non-zero without sending anything.
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -11,7 +11,7 @@ import pytest
 
 from app.analytics import provider
 from app.analytics.events import Event
-from app.cli.__main__ import main
+from app.cli.__main__ import _sentry_entrypoint_for_invocation, main
 from app.cli.interactive_shell.config import ReplConfig
 
 
@@ -361,6 +361,10 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     assert flush_calls == [5]
     assert captured[0][1]["context"] == "debug.sentry"
     assert captured[0][1]["tags"] == {"debug": "true", "surface": "debug"}
+
+
+def test_sentry_entrypoint_uses_debug_for_debug_group_invocations() -> None:
+    assert _sentry_entrypoint_for_invocation(["debug", "future-check"]) == "debug"
 
 
 def test_main_debug_sentry_exits_nonzero_when_disabled(monkeypatch, capsys) -> None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -320,7 +320,6 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     debug_module = importlib.import_module("app.cli.commands.debug")
     captured: list[tuple[tuple[object, ...], dict[str, object]]] = []
     root_init_entrypoints: list[str | None] = []
-    init_entrypoints: list[str | None] = []
     flush_calls: list[int] = []
 
     monkeypatch.setattr(
@@ -332,11 +331,6 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
     monkeypatch.setattr(debug_module, "sentry_transport_enabled", lambda: True)
     monkeypatch.setattr(debug_module, "resolved_sentry_dsn_host", lambda: "sentry.example.test")
-    monkeypatch.setattr(
-        debug_module,
-        "init_sentry",
-        lambda entrypoint=None: init_entrypoints.append(entrypoint),
-    )
 
     def capture_stub(*args: object, **kwargs: object) -> str:
         captured.append((args, kwargs))
@@ -357,7 +351,6 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     assert "Sentry event ID: event-123" in output
     assert "Sentry flush sent: yes" in output
     assert root_init_entrypoints == ["debug"]
-    assert init_entrypoints == ["debug"]
     assert flush_calls == [5]
     assert captured[0][1]["context"] == "debug.sentry"
     assert captured[0][1]["tags"] == {"debug": "true", "surface": "debug"}
@@ -390,7 +383,6 @@ def test_main_debug_sentry_exits_nonzero_when_flush_fails(monkeypatch, capsys) -
     monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
     monkeypatch.setattr(debug_module, "sentry_transport_enabled", lambda: True)
     monkeypatch.setattr(debug_module, "resolved_sentry_dsn_host", lambda: "sentry.example.test")
-    monkeypatch.setattr(debug_module, "init_sentry", lambda **_kw: None)
     monkeypatch.setattr(debug_module, "capture_exception", lambda *_args, **_kw: "event-123")
 
     def flush_stub(*, timeout: int) -> bool:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -340,7 +340,7 @@ def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
     monkeypatch.setitem(
         sys.modules,
         "sentry_sdk",
-        SimpleNamespace(flush=lambda timeout: flush_calls.append(timeout) or True),
+        SimpleNamespace(flush=lambda timeout: flush_calls.append(timeout)),
     )
 
     exit_code = main(["debug", "sentry"])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -313,6 +314,97 @@ def test_main_captures_command_metadata_for_nested_remote_ops(monkeypatch, capsy
     assert properties["command_family"] == "remote"
     assert properties["subcommand"] == "ops"
     assert properties["command_leaf"] == "status"
+
+
+def test_main_debug_sentry_sends_synthetic_event(monkeypatch, capsys) -> None:
+    debug_module = importlib.import_module("app.cli.commands.debug")
+    captured: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    root_init_entrypoints: list[str | None] = []
+    init_entrypoints: list[str | None] = []
+    flush_calls: list[int] = []
+
+    monkeypatch.setattr(
+        "app.cli.__main__.init_sentry",
+        lambda entrypoint=None: root_init_entrypoints.append(entrypoint),
+    )
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr(debug_module, "sentry_transport_enabled", lambda: True)
+    monkeypatch.setattr(debug_module, "resolved_sentry_dsn_host", lambda: "sentry.example.test")
+    monkeypatch.setattr(
+        debug_module,
+        "init_sentry",
+        lambda entrypoint=None: init_entrypoints.append(entrypoint),
+    )
+
+    def capture_stub(*args: object, **kwargs: object) -> str:
+        captured.append((args, kwargs))
+        return "event-123"
+
+    monkeypatch.setattr(debug_module, "capture_exception", capture_stub)
+    monkeypatch.setitem(
+        sys.modules,
+        "sentry_sdk",
+        SimpleNamespace(flush=lambda timeout: flush_calls.append(timeout) or True),
+    )
+
+    exit_code = main(["debug", "sentry"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Sentry DSN host: sentry.example.test" in output
+    assert "Sentry event ID: event-123" in output
+    assert "Sentry flush sent: yes" in output
+    assert root_init_entrypoints == ["debug"]
+    assert init_entrypoints == ["debug"]
+    assert flush_calls == [5]
+    assert captured[0][1]["context"] == "debug.sentry"
+    assert captured[0][1]["tags"] == {"debug": "true", "surface": "debug"}
+
+
+def test_main_debug_sentry_exits_nonzero_when_disabled(monkeypatch, capsys) -> None:
+    debug_module = importlib.import_module("app.cli.commands.debug")
+    monkeypatch.setattr("app.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr(debug_module, "sentry_transport_enabled", lambda: False)
+    monkeypatch.setattr(debug_module, "resolved_sentry_dsn_host", lambda: "")
+
+    exit_code = main(["debug", "sentry"])
+
+    assert exit_code == 1
+    assert "Sentry is disabled or no DSN is configured." in capsys.readouterr().err
+
+
+def test_main_debug_sentry_exits_nonzero_when_flush_fails(monkeypatch, capsys) -> None:
+    debug_module = importlib.import_module("app.cli.commands.debug")
+    monkeypatch.setattr("app.cli.__main__.init_sentry", lambda **_kw: None)
+    monkeypatch.setattr("app.cli.__main__.capture_first_run_if_needed", lambda: None)
+    monkeypatch.setattr("app.cli.__main__.capture_cli_invoked", lambda *_args: None)
+    monkeypatch.setattr("app.cli.__main__.shutdown_analytics", lambda **_kw: None)
+    monkeypatch.setattr(debug_module, "sentry_transport_enabled", lambda: True)
+    monkeypatch.setattr(debug_module, "resolved_sentry_dsn_host", lambda: "sentry.example.test")
+    monkeypatch.setattr(debug_module, "init_sentry", lambda **_kw: None)
+    monkeypatch.setattr(debug_module, "capture_exception", lambda *_args, **_kw: "event-123")
+
+    def flush_stub(*, timeout: int) -> bool:
+        assert timeout == 5
+        return False
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentry_sdk",
+        SimpleNamespace(flush=flush_stub),
+    )
+
+    exit_code = main(["debug", "sentry"])
+
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "Sentry event ID: event-123" in output
+    assert "Sentry flush sent: no" in output
 
 
 def test_main_emits_first_run_install_before_cli_invoked(

--- a/tests/pipeline/test_runners_sentry.py
+++ b/tests/pipeline/test_runners_sentry.py
@@ -33,3 +33,32 @@ def test_run_chat_initializes_sentry_and_captures_unhandled_errors(
 
     assert sentry_init_calls == [None]
     assert captured_errors == [expected_error]
+
+
+def test_traced_node_exception_is_captured_once_with_node_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[BaseException, dict[str, object]]] = []
+    expected_error = RuntimeError("node failed")
+
+    def failing_node() -> None:
+        raise expected_error
+
+    def capture_stub(exc: BaseException, **kwargs: object) -> None:
+        captured.append((exc, kwargs))
+
+    monkeypatch.setattr("app.utils.sentry_sdk.capture_exception", capture_stub)
+
+    with pytest.raises(RuntimeError, match="node failed") as raised:
+        runners._traced_node("extract_alert", failing_node)
+
+    runners._capture_exception_once(
+        raised.value,
+        context="pipeline.astream_investigation",
+    )
+
+    assert len(captured) == 1
+    exc, kwargs = captured[0]
+    assert exc is expected_error
+    assert kwargs["context"] == "node.extract_alert"
+    assert kwargs["tags"] == {"surface": "node", "node": "extract_alert"}

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -167,10 +167,14 @@ def test_capture_exception_attaches_context(monkeypatch) -> None:
         ValueError("boom"),
         context="interactive_shell.cli_agent.stream",
         extra={"turn": 3},
+        tags={"surface": "interactive_shell"},
     )
 
     capture_mock.assert_called_once()
-    assert tags == {"opensre.context": "interactive_shell.cli_agent.stream"}
+    assert tags == {
+        "opensre.context": "interactive_shell.cli_agent.stream",
+        "surface": "interactive_shell",
+    }
     assert extras == {"turn": 3}
 
 
@@ -276,6 +280,22 @@ def test_before_send_filters_sensitive_extra_keys() -> None:
     assert event["extra"]["github_token"] == "[Filtered]"
     assert event["extra"]["api_key"] == "[Filtered]"
     assert event["extra"]["user_email"] == "user@example.com"
+
+
+def test_before_send_fingerprints_tool_errors_by_tool_name() -> None:
+    event = {"tags": {"tool": "grafana_logs"}, "message": "tool failed"}
+
+    sentry_mod._before_send(event, {})
+
+    assert event["fingerprint"] == ["tool-error", "grafana_logs", "{{ default }}"]
+
+
+def test_before_send_fingerprints_node_errors_by_node_name() -> None:
+    event = {"tags": {"node": "extract_alert"}, "message": "node failed"}
+
+    sentry_mod._before_send(event, {})
+
+    assert event["fingerprint"] == ["node-error", "extract_alert", "{{ default }}"]
 
 
 def test_before_send_scrubs_home_paths_in_stack_frames() -> None:

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -298,6 +298,17 @@ def test_before_send_fingerprints_node_errors_by_node_name() -> None:
     assert event["fingerprint"] == ["node-error", "extract_alert", "{{ default }}"]
 
 
+def test_before_send_prefers_tool_fingerprint_when_tool_and_node_tags_exist() -> None:
+    event = {
+        "tags": {"tool": "grafana_logs", "node": "investigate"},
+        "message": "tool failed inside node",
+    }
+
+    sentry_mod._before_send(event, {})
+
+    assert event["fingerprint"] == ["tool-error", "grafana_logs", "{{ default }}"]
+
+
 def test_before_send_scrubs_home_paths_in_stack_frames() -> None:
     event = {
         "exception": {

--- a/tests/tools/test_basetool_sentry.py
+++ b/tests/tools/test_basetool_sentry.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.tools.base import BaseTool
+from app.tools.registered_tool import REGISTERED_TOOL_ATTR
+from app.tools.tool_decorator import tool
+from app.utils import sentry_sdk as sentry_mod
+
+
+class ExplodingBaseTool(BaseTool):
+    name = "exploding_base_tool"
+    description = "Tool that raises for Sentry coverage."
+    input_schema = {"type": "object", "properties": {}}
+    source = "grafana"
+
+    def run(self) -> dict[str, Any]:
+        raise RuntimeError("base boom")
+
+
+def test_base_tool_exception_is_captured_with_tool_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[BaseException, dict[str, object]]] = []
+
+    def capture_stub(exc: BaseException, **kwargs: object) -> None:
+        captured.append((exc, kwargs))
+
+    monkeypatch.setattr(sentry_mod, "capture_exception", capture_stub)
+
+    result = ExplodingBaseTool()()
+
+    assert result == {"error": "base boom", "exception_type": "RuntimeError"}
+    assert len(captured) == 1
+    exc, kwargs = captured[0]
+    assert isinstance(exc, RuntimeError)
+    assert kwargs["context"] == "tool.exploding_base_tool"
+    assert kwargs["tags"] == {"surface": "tool", "tool": "exploding_base_tool"}
+
+
+def test_decorated_function_tool_exception_is_captured_with_tool_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[BaseException, dict[str, object]]] = []
+
+    def capture_stub(exc: BaseException, **kwargs: object) -> None:
+        captured.append((exc, kwargs))
+
+    monkeypatch.setattr(sentry_mod, "capture_exception", capture_stub)
+
+    @tool(
+        name="decorated_failure",
+        description="Function tool that raises for Sentry coverage.",
+        input_schema={"type": "object", "properties": {}},
+        source="grafana",
+    )
+    def decorated_failure() -> dict[str, Any]:
+        raise ValueError("decorated boom")
+
+    registered = getattr(decorated_failure, REGISTERED_TOOL_ATTR)
+    result = registered()
+
+    assert result == {"error": "decorated boom", "exception_type": "ValueError"}
+    assert len(captured) == 1
+    exc, kwargs = captured[0]
+    assert isinstance(exc, ValueError)
+    assert kwargs["context"] == "tool.decorated_failure"
+    assert kwargs["tags"] == {"surface": "tool", "tool": "decorated_failure"}

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -58,6 +58,7 @@ class TestReportException:
         extra = mock_cap.call_args[1]["extra"]
         assert extra["tag.surface"] == "cli"
         assert extra["tag.component"] == "app.cli"
+        assert mock_cap.call_args[1]["tags"] == {"surface": "cli", "component": "app.cli"}
 
     def test_extras_are_merged(self) -> None:
         mock_log = _mock_logger()
@@ -73,6 +74,7 @@ class TestReportException:
         extra = mock_cap.call_args[1]["extra"]
         assert extra["tag.surface"] == "tool"
         assert extra["detail"] == "x"
+        assert mock_cap.call_args[1]["tags"] == {"surface": "tool"}
 
     def test_no_tags_or_extras_passes_none(self) -> None:
         mock_log = _mock_logger()


### PR DESCRIPTION
Fixes #1479

#### Describe the changes you have made in this PR -
- Add Sentry grouping for OpenSRE tool and LangGraph node exceptions.
- Capture tool failures with explicit `tool` tags from both `BaseTool` and `@tool` paths.
- Add `opensre debug sentry` as a synthetic smoke check for DSN delivery.
- Extend Sentry tests around init options, redaction, fingerprints, tool failures, node failures, and the debug command.
- Add a short Sentry docs section for the debug command.

### Demo/Screenshot for feature changes and bug fixes -
Live Sentry smoke demo:

<img width="1704" height="1470" alt="image" src="https://github.com/user-attachments/assets/4d00d54f-b3a3-4988-b695-1710d49e57c2" />

<img width="1695" height="1443" alt="image" src="https://github.com/user-attachments/assets/4d8b1f76-7a9c-4958-896d-80124ea722c1" />

<img width="1695" height="1443" alt="image" src="https://github.com/user-attachments/assets/b718e8e9-a6b6-46d4-aa85-6dae9fc99f82" />

Local verification:

```text
make lint
make format-check
make typecheck
make test-cov
```

`make test-cov` result:

```text
6809 passed, 5 skipped, 118 warnings in 94.15s
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
Draft for self-review before requesting review.

The change keeps Sentry behavior centralized in `app/utils/sentry_sdk.py`: event tagging, scrubbing, and fingerprinting are applied before events leave the process. Tool wrappers pass explicit tags when exceptions are captured, and pipeline node execution uses a traced wrapper so node-internal exceptions are captured once with the node name.

The debug command initializes Sentry with the `debug` entrypoint, sends a synthetic exception tagged `debug=true`, flushes with a short timeout, and returns a non-zero exit when telemetry is disabled, Sentry does not return an event ID, or a transport explicitly reports that pending work was not flushed.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
