### PR TITLE
fix(bedrock): surface cross-region inference profile guidance in agent LLM client

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -131,9 +131,7 @@ class AnthropicAgentClient:
             except PermissionDeniedError as err:
                 raise RuntimeError(self._permission_denied_error_message()) from err
             except BadRequestError as err:
-                raise RuntimeError(
-                    f"{self.provider_name} request rejected (HTTP 400): {err.message}"
-                ) from err
+                raise RuntimeError(self._bad_request_error_message(err)) from err
             except RateLimitError as err:
                 raise RuntimeError(f"{self.provider_name} rate limit exceeded: {err}") from err
             except InternalServerError as err:
@@ -222,6 +220,9 @@ class AnthropicAgentClient:
     def _permission_denied_error_message(self) -> str:
         return f"{self.provider_name} API access denied. Check your API key permissions."
 
+    def _bad_request_error_message(self, err: Any) -> str:
+        return f"{self.provider_name} request rejected (HTTP 400): {err.message}"
+
 
 class BedrockAgentClient(AnthropicAgentClient):
     """Bedrock-backed client using AnthropicBedrock SDK."""
@@ -252,6 +253,16 @@ class BedrockAgentClient(AnthropicAgentClient):
             "subscription/payment setup, and IAM permissions including "
             "aws-marketplace:ViewSubscriptions and aws-marketplace:Subscribe."
         )
+
+    def _bad_request_error_message(self, err: Any) -> str:
+        err_str = str(err)
+        if "on-demand throughput" in err_str or "inference profile" in err_str.lower():
+            return (
+                f"Bedrock model '{self._model}' requires a cross-region inference profile. "
+                f"Try prefixing with 'us.' (e.g. 'us.{self._model}') and update "
+                "BEDROCK_REASONING_MODEL or BEDROCK_TOOLCALL_MODEL."
+            )
+        return f"{self.provider_name} request rejected (HTTP 400): {err.message}"
 
 
 _OPENAI_O_SERIES_RE = re.compile(r"(?:^|[^A-Za-z0-9])o\d", re.IGNORECASE)

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -788,3 +788,51 @@ def test_cli_backed_agent_client_filtered_tool_calls_fall_back_to_text_response(
 
     assert not result.has_tool_calls
     assert result.content == raw
+
+
+def test_bedrock_bad_request_cross_region_inference_gives_helpful_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    client = BedrockAgentClient(model="anthropic.claude-sonnet-4-20250514-v1:0")
+    bedrock_error_body = (
+        "Error code: 400 - {'message': \"Invocation of model ID "
+        "anthropic.claude-sonnet-4-20250514-v1:0 with on-demand throughput isn't supported. "
+        'Retry your request with the ID or ARN of an inference profile that contains this model."}'
+    )
+
+    def raise_bad_request(**_: object) -> object:
+        raise fake_anthropic.BadRequestError(bedrock_error_body)
+
+    client._client = types.SimpleNamespace(messages=types.SimpleNamespace(create=raise_bad_request))
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    message = str(exc.value)
+    assert "requires a cross-region inference profile" in message
+    assert "Try prefixing with 'us.'" in message
+    assert "BEDROCK_REASONING_MODEL" in message
+
+
+def test_bedrock_bad_request_generic_error_uses_default_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_anthropic = _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    client = BedrockAgentClient(model="us.anthropic.claude-sonnet-4-6")
+
+    def raise_bad_request(**_: object) -> object:
+        raise fake_anthropic.BadRequestError("content policy violation")
+
+    client._client = types.SimpleNamespace(messages=types.SimpleNamespace(create=raise_bad_request))
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    message = str(exc.value)
+    assert "Bedrock request rejected (HTTP 400)" in message
+    assert "cross-region" not in message


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `BedrockAgentClient` inherited `AnthropicAgentClient`'s generic `BadRequestError` handler, producing an opaque `"Bedrock request rejected (HTTP 400)"` error when Bedrock rejected a model ID that required a cross-region inference profile.
- `llm_client.py` already detects `"on-demand throughput"` / `"inference profile"` in the error body and raises a helpful `"requires a cross-region inference profile. Try prefixing with 'us.'"` message — but `agent_llm_client.py` (used by the investigation agent) did not.
- Added `_bad_request_error_message(err)` hook to `AnthropicAgentClient` following the same pattern as the existing `_permission_denied_error_message` / `_model_not_found_error_message` hooks, and overrode it in `BedrockAgentClient` to surface the actionable guidance.

## Test plan

- [ ] `test_bedrock_bad_request_cross_region_inference_gives_helpful_message` — verifies the "on-demand throughput" error produces the cross-region inference guidance.
- [ ] `test_bedrock_bad_request_generic_error_uses_default_message` — verifies other 400 errors still fall through to the default message.
- [ ] All 32 existing `tests/services/test_agent_llm_client.py` tests continue to pass.

Closes #2165
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012EWowY828yD2ogzGK5cTz9)_