### PR TITLE
fix(sentry): filter Bedrock cross-region inference profile and model-not-found errors

### DIFF
--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -51,7 +51,8 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\brequires\s+[A-Z0-9_]+_API_KEY\s+to\s+be\s+set\b", re.I),
     re.compile(r"\brate limit exceeded\b.*\b(?:quota|billing)\b", re.I),
     re.compile(r"\bcredit balance is too low\b", re.I),
-    re.compile(r"\bmodel\s+['\"][^'\"]+['\"]\s+was not found\b", re.I),
+    # llm_client.py uses "was not found"; agent_llm_client.py uses "not found" — cover both.
+    re.compile(r"\bmodel\s+['\"][^'\"]+['\"]\s+(?:was )?not found\b", re.I),
     re.compile(r"\bcheck your configured model name or endpoint\b", re.I),
     # Relay/proxy forwarding an invalid model group to Anthropic.
     re.compile(r"\bprovided model identifier is invalid\b", re.I),
@@ -71,6 +72,9 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # account, Marketplace subscription/payment setup, region model access, or
     # IAM policy needs to change before retrying can succeed.
     re.compile(r"\bBedrock model\s+['\"][^'\"]+['\"]\s+is not available for your account\b", re.I),
+    # Bedrock cross-region inference profile misconfiguration (HTTP 400 "on-demand throughput
+    # isn't supported") — user must add the 'us.' prefix to their model ID.
+    re.compile(r"\brequires a cross-region inference profile\b", re.I),
 )
 
 

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -665,6 +665,20 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "RuntimeError",
             "Bedrock model 'us.anthropic.claude-sonnet-4-6' is not available for your account. Check Bedrock model access in the configured AWS region, AWS Marketplace subscription/payment setup, and IAM permissions including aws-marketplace:ViewSubscriptions and aws-marketplace:Subscribe.",
         ),
+        # Bedrock cross-region inference profile misconfiguration (issue #2167).
+        (
+            "RuntimeError",
+            "Bedrock model 'anthropic.claude-haiku-4-5-20251001-v1:0' requires a cross-region inference profile. Try prefixing with 'us.' (e.g. 'us.anthropic.claude-haiku-4-5-20251001-v1:0') and update BEDROCK_REASONING_MODEL or BEDROCK_TOOLCALL_MODEL.",
+        ),
+        # agent_llm_client uses "not found" (no "was") unlike llm_client — both must be caught.
+        (
+            "RuntimeError",
+            "Bedrock model 'anthropic.claude-3-sonnet-20240229-v1:0' not found.",
+        ),
+        (
+            "RuntimeError",
+            "OpenAI model 'llama3.2' not found.",
+        ),
     ],
 )
 def test_before_send_drops_operator_actionable_llm_errors(


### PR DESCRIPTION
## Summary

- Adds a new `_OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS` entry for `"requires a cross-region inference profile"` — raised when a Bedrock model ID is missing the `us.` prefix (Sentry issue #2167)
- Extends the existing `"was not found"` model pattern to `"(?:was )?not found"` — `agent_llm_client.py` omits `"was"` while `llm_client.py` includes it; the old pattern silently missed agent-client errors (Sentry issues #2164, #2048)
- Adds three new parametrized test cases to `test_before_send_drops_operator_actionable_llm_errors`

These are operator-configuration errors (wrong Bedrock model ID prefix, mistyped model name) that the code already surfaces clearly to the user. They should not create high-priority Sentry issues.

## Test plan

- [ ] `uv run python -m pytest tests/test_sentry_init.py -x -q` — all 63 tests pass
- [ ] `uv run ruff check app/ tests/` — no lint errors

Closes #2167
Closes #2164
Closes #2048

---
_Generated by [Claude Code](https://claude.ai/code/session_016WPqK1XFKJVWDkuqHZfjYU)_