### PR TITLE
feat(error-handling): add Sentry capture to integration verification adapters

### DIFF
--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -702,10 +702,10 @@ def _verify_slack_without_test(source: str, config: dict[str, Any]) -> dict[str,
     return _verify_slack(source, config, send_slack_test=False)
 
 
-def _verify_supabase(service: str, config: dict[str, Any]) -> dict[str, str]:
+def _verify_supabase(source: str, config: dict[str, Any]) -> dict[str, str]:
     return _verify_with_validation_result(
-        service,
         "supabase",
+        source,
         config,
         build_config=build_supabase_config,
         validate_config=validate_supabase_config,

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -92,7 +92,7 @@ def _report_probe_failure(
 ) -> None:
     is_vendor = isinstance(exc, _VENDOR_TRANSPORT_ERRORS) or expected
     is_optional_dep = isinstance(exc, (ImportError, ModuleNotFoundError))
-    is_bad_config = isinstance(exc, PydanticValidationError)
+    is_bad_config = isinstance(exc, (PydanticValidationError, ValueError))
     benign = is_vendor or is_optional_dep or is_bad_config
     report_exception(
         exc,
@@ -272,6 +272,10 @@ def _verify_grafana(source: str, config: dict[str, Any]) -> dict[str, str]:
 def _verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         sts_client, region, mode = _build_sts_client(config)
+    except Exception as exc:
+        _report_probe_failure(exc, integration="aws")
+        return result("aws", source, "missing", f"AWS config error: {exc}")
+    try:
         identity = sts_client.get_caller_identity()
     except Exception as exc:
         _report_probe_failure(exc, integration="aws")

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -89,10 +89,11 @@ def _report_probe_failure(
     *,
     integration: str,
     expected: bool = False,
+    config_error: bool = False,
 ) -> None:
     is_vendor = isinstance(exc, _VENDOR_TRANSPORT_ERRORS) or expected
     is_optional_dep = isinstance(exc, (ImportError, ModuleNotFoundError))
-    is_bad_config = isinstance(exc, (PydanticValidationError, ValueError))
+    is_bad_config = isinstance(exc, PydanticValidationError) or config_error
     benign = is_vendor or is_optional_dep or is_bad_config
     report_exception(
         exc,
@@ -272,9 +273,12 @@ def _verify_grafana(source: str, config: dict[str, Any]) -> dict[str, str]:
 def _verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         sts_client, region, mode = _build_sts_client(config)
+    except (PydanticValidationError, ValueError) as exc:
+        _report_probe_failure(exc, integration="aws", config_error=True)
+        return result("aws", source, "missing", f"AWS config error: {exc}")
     except Exception as exc:
         _report_probe_failure(exc, integration="aws")
-        return result("aws", source, "missing", f"AWS config error: {exc}")
+        return result("aws", source, "failed", f"AWS STS check failed: {exc}")
     try:
         identity = sts_client.get_caller_identity()
     except Exception as exc:

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -211,7 +211,11 @@ def _build_sts_client(config: dict[str, Any]) -> tuple[Any, str, str]:
 
 
 def _verify_grafana(source: str, config: dict[str, Any]) -> dict[str, str]:
-    grafana_config = GrafanaIntegrationConfig.model_validate(config)
+    try:
+        grafana_config = GrafanaIntegrationConfig.model_validate(config)
+    except Exception as exc:
+        _report_probe_failure(exc, integration="grafana")
+        return result("grafana", source, "missing", str(exc))
     endpoint = grafana_config.endpoint
     api_key = grafana_config.api_key
     if not endpoint or not api_key:
@@ -309,7 +313,11 @@ def _verify_slack(
 
 
 def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
-    tracer_config = TracerIntegrationConfig.model_validate(config)
+    try:
+        tracer_config = TracerIntegrationConfig.model_validate(config)
+    except Exception as exc:
+        _report_probe_failure(exc, integration="tracer")
+        return result("tracer", source, "missing", str(exc))
     if not tracer_config.jwt_token:
         return result("tracer", source, "missing", "Missing JWT token.")
 

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -368,11 +368,11 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         import discord  # type: ignore[import-not-found]
     except Exception as exc:
-        _report_probe_failure(exc, integration="discord")
         with suppress(Exception):
             import sentry_sdk
 
             sentry_sdk.set_tag("integrations.discord.import_failed", "true")
+        _report_probe_failure(exc, integration="discord")
         return result("discord", source, "failed", "discord.py is not installed.")
 
     bot_token = str(config.get("bot_token", "")).strip()

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -394,7 +394,13 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     except Exception as err:
         detail = str(err)
         if "run() cannot be called from a running event loop" in detail:
-            return result("discord", source, "passed", "Discord bot token accepted.")
+            _report_probe_failure(err, integration="discord", expected=True)
+            return result(
+                "discord",
+                source,
+                "failed",
+                "Cannot verify Discord token inside a running event loop.",
+            )
         _report_probe_failure(err, integration="discord")
         return result("discord", source, "failed", f"Discord API check failed: {err}")
     return result("discord", source, "passed", "Discord bot token accepted.")

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -12,6 +12,7 @@ import httpx
 import requests
 from botocore.exceptions import BotoCoreError
 from botocore.exceptions import ClientError as BotoClientError
+from pydantic import ValidationError as PydanticValidationError
 
 from app.auth.jwt_auth import extract_org_id_from_jwt
 from app.config import get_tracer_base_url
@@ -87,15 +88,17 @@ def _report_probe_failure(
     exc: BaseException,
     *,
     integration: str,
+    expected: bool = False,
 ) -> None:
-    is_vendor = isinstance(exc, _VENDOR_TRANSPORT_ERRORS)
+    is_vendor = isinstance(exc, _VENDOR_TRANSPORT_ERRORS) or expected
     is_optional_dep = isinstance(exc, (ImportError, ModuleNotFoundError))
-    expected = is_vendor or is_optional_dep
+    is_bad_config = isinstance(exc, PydanticValidationError)
+    benign = is_vendor or is_optional_dep or is_bad_config
     report_exception(
         exc,
         logger=logger,
         message=f"[{integration}] verification probe failed",
-        severity="info" if expected else "error",
+        severity="info" if benign else "error",
         tags={
             "surface": "integration_probe",
             "integration": integration,
@@ -103,6 +106,8 @@ def _report_probe_failure(
             if is_vendor
             else "missing_dependency"
             if is_optional_dep
+            else "invalid_config"
+            if is_bad_config
             else "verify_failed",
         },
     )
@@ -376,7 +381,7 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         client.run(bot_token)
     except discord.LoginFailure as err:
-        _report_probe_failure(err, integration="discord")
+        _report_probe_failure(err, integration="discord", expected=True)
         return result("discord", source, "failed", f"Discord login failed: {err}")
     except Exception as err:
         detail = str(err)

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -112,6 +112,10 @@ def _verify_with_validation_result[ConfigT](
 ) -> dict[str, str]:
     try:
         normalized_config = build_config(config)
+    except Exception as exc:
+        _report_probe_failure(exc, integration=service)
+        return result(service, source, "missing", str(exc))
+    try:
         validation_result = validate_config(normalized_config)
     except Exception as exc:
         _report_probe_failure(exc, integration=service)
@@ -340,7 +344,8 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
 def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         import discord  # type: ignore[import-not-found]
-    except Exception:
+    except Exception as exc:
+        _report_probe_failure(exc, integration="discord")
         with suppress(Exception):
             import sentry_sdk
 

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from contextlib import suppress
@@ -368,6 +369,14 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
     )
 
 
+def _has_running_event_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
 def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         import discord  # type: ignore[import-not-found]
@@ -383,6 +392,16 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     if not bot_token:
         return result("discord", source, "missing", "Missing bot_token.")
 
+    if _has_running_event_loop():
+        err = RuntimeError("Cannot verify Discord token: event loop already running")
+        _report_probe_failure(err, integration="discord", expected=True)
+        return result(
+            "discord",
+            source,
+            "failed",
+            "Cannot verify Discord token inside a running event loop.",
+        )
+
     intents = discord.Intents.none()
     intents.guilds = True
     client = discord.Client(intents=intents)
@@ -392,15 +411,6 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
         _report_probe_failure(err, integration="discord", expected=True)
         return result("discord", source, "failed", f"Discord login failed: {err}")
     except Exception as err:
-        detail = str(err)
-        if "run() cannot be called from a running event loop" in detail:
-            _report_probe_failure(err, integration="discord", expected=True)
-            return result(
-                "discord",
-                source,
-                "failed",
-                "Cannot verify Discord token inside a running event loop.",
-            )
         _report_probe_failure(err, integration="discord")
         return result("discord", source, "failed", f"Discord API check failed: {err}")
     return result("discord", source, "passed", "Discord bot token accepted.")

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -89,15 +89,21 @@ def _report_probe_failure(
     integration: str,
 ) -> None:
     is_vendor = isinstance(exc, _VENDOR_TRANSPORT_ERRORS)
+    is_optional_dep = isinstance(exc, (ImportError, ModuleNotFoundError))
+    expected = is_vendor or is_optional_dep
     report_exception(
         exc,
         logger=logger,
         message=f"[{integration}] verification probe failed",
-        severity="info" if is_vendor else "error",
+        severity="info" if expected else "error",
         tags={
             "surface": "integration_probe",
             "integration": integration,
-            "event": "vendor_failure" if is_vendor else "verify_failed",
+            "event": "vendor_failure"
+            if is_vendor
+            else "missing_dependency"
+            if is_optional_dep
+            else "verify_failed",
         },
     )
 

--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
+from contextlib import suppress
 from typing import Any
 
 import boto3
 import httpx
 import requests
+from botocore.exceptions import BotoCoreError
+from botocore.exceptions import ClientError as BotoClientError
 
 from app.auth.jwt_auth import extract_org_id_from_jwt
 from app.config import get_tracer_base_url
@@ -48,8 +52,19 @@ from app.services.splunk import SplunkClient, SplunkConfig
 from app.services.tracer_client.client import TracerClient
 from app.services.vercel.client import VercelClient, VercelConfig
 from app.services.victoria_logs import VictoriaLogsClient, VictoriaLogsConfig
+from app.utils.errors import report_exception
+
+logger = logging.getLogger(__name__)
 
 VerifierFn = Callable[[str, dict[str, Any]], dict[str, str]]
+
+_VENDOR_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.HTTPStatusError,
+    httpx.TransportError,
+    requests.exceptions.RequestException,
+    BotoClientError,
+    BotoCoreError,
+)
 
 _SUPPORTED_GRAFANA_TYPES = ("loki", "tempo", "prometheus")
 
@@ -68,6 +83,25 @@ def result(
     }
 
 
+def _report_probe_failure(
+    exc: BaseException,
+    *,
+    integration: str,
+) -> None:
+    is_vendor = isinstance(exc, _VENDOR_TRANSPORT_ERRORS)
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"[{integration}] verification probe failed",
+        severity="info" if is_vendor else "error",
+        tags={
+            "surface": "integration_probe",
+            "integration": integration,
+            "event": "vendor_failure" if is_vendor else "verify_failed",
+        },
+    )
+
+
 def _verify_with_validation_result[ConfigT](
     service: str,
     source: str,
@@ -76,8 +110,12 @@ def _verify_with_validation_result[ConfigT](
     build_config: Callable[[dict[str, Any]], ConfigT],
     validate_config: Callable[[ConfigT], Any],
 ) -> dict[str, str]:
-    normalized_config = build_config(config)
-    validation_result = validate_config(normalized_config)
+    try:
+        normalized_config = build_config(config)
+        validation_result = validate_config(normalized_config)
+    except Exception as exc:
+        _report_probe_failure(exc, integration=service)
+        return result(service, source, "failed", str(exc))
     return result(
         service,
         source,
@@ -114,10 +152,12 @@ def build_probe_verifier[ConfigT](
         try:
             normalized_config = build_config(config)
         except Exception as err:
+            _report_probe_failure(err, integration=service)
             return result(service, source, "missing", str(err))
         try:
             probe_result = client_factory(normalized_config).probe_access()
         except Exception as err:
+            _report_probe_failure(err, integration=service)
             return result(service, source, "failed", str(err))
         return result(service, source, probe_result.status, probe_result.detail)
 
@@ -182,6 +222,7 @@ def _verify_grafana(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        _report_probe_failure(exc, integration="grafana")
         return result("grafana", source, "failed", f"Datasource discovery failed: {exc}")
 
     datasources = payload if isinstance(payload, list) else []
@@ -214,6 +255,7 @@ def _verify_aws(source: str, config: dict[str, Any]) -> dict[str, str]:
         sts_client, region, mode = _build_sts_client(config)
         identity = sts_client.get_caller_identity()
     except Exception as exc:
+        _report_probe_failure(exc, integration="aws")
         return result("aws", source, "failed", f"AWS STS check failed: {exc}")
 
     account = str(identity.get("Account", "")).strip()
@@ -238,6 +280,7 @@ def _verify_slack(
     try:
         slack_config = SlackWebhookConfig.model_validate(config)
     except Exception as err:
+        _report_probe_failure(err, integration="slack")
         return result("slack", source, "missing", str(err))
 
     webhook_url = slack_config.webhook_url
@@ -256,6 +299,7 @@ def _verify_slack(
         response = httpx.post(webhook_url, json=payload, timeout=10.0)
         response.raise_for_status()
     except Exception as exc:
+        _report_probe_failure(exc, integration="slack")
         return result("slack", source, "failed", f"Webhook delivery failed: {exc}")
     return result("slack", source, "passed", "Webhook delivered test message successfully.")
 
@@ -269,6 +313,7 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         org_id = extract_org_id_from_jwt(tracer_config.jwt_token)
     except Exception as err:
+        _report_probe_failure(err, integration="tracer")
         return result("tracer", source, "failed", f"JWT decode failed: {err}")
     if not org_id:
         return result("tracer", source, "failed", "JWT did not contain an org identifier.")
@@ -281,6 +326,7 @@ def _verify_tracer(source: str, config: dict[str, Any]) -> dict[str, str]:
         )
         integrations = tracer_client.get_all_integrations()
     except Exception as err:
+        _report_probe_failure(err, integration="tracer")
         return result("tracer", source, "failed", f"Tracer API check failed: {err}")
 
     return result(
@@ -295,6 +341,10 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         import discord  # type: ignore[import-not-found]
     except Exception:
+        with suppress(Exception):
+            import sentry_sdk
+
+            sentry_sdk.set_tag("integrations.discord.import_failed", "true")
         return result("discord", source, "failed", "discord.py is not installed.")
 
     bot_token = str(config.get("bot_token", "")).strip()
@@ -307,11 +357,13 @@ def _verify_discord(source: str, config: dict[str, Any]) -> dict[str, str]:
     try:
         client.run(bot_token)
     except discord.LoginFailure as err:
+        _report_probe_failure(err, integration="discord")
         return result("discord", source, "failed", f"Discord login failed: {err}")
     except Exception as err:
         detail = str(err)
         if "run() cannot be called from a running event loop" in detail:
             return result("discord", source, "passed", "Discord bot token accepted.")
+        _report_probe_failure(err, integration="discord")
         return result("discord", source, "failed", f"Discord API check failed: {err}")
     return result("discord", source, "passed", "Discord bot token accepted.")
 
@@ -326,6 +378,7 @@ def _verify_telegram(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        _report_probe_failure(exc, integration="telegram")
         return result("telegram", source, "failed", f"Telegram API check failed: {exc}")
 
     if not payload.get("ok"):
@@ -363,6 +416,7 @@ def _verify_whatsapp(source: str, config: dict[str, Any]) -> dict[str, str]:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        _report_probe_failure(exc, integration="whatsapp")
         return result("whatsapp", source, "failed", f"Twilio API check failed: {exc}")
 
     friendly_name = str(payload.get("friendly_name", "")).strip()

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -199,6 +199,16 @@ def test_pydantic_validation_error_gets_info_severity(mock_report: MagicMock) ->
 
 
 @patch("app.integrations._verification_adapters.report_exception")
+def test_value_error_gets_info_severity(mock_report: MagicMock) -> None:
+    exc = ValueError("Missing AWS role_arn or credentials.")
+    _report_probe_failure(exc, integration="aws")
+
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "invalid_config"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
 def test_expected_override_gets_info_severity(mock_report: MagicMock) -> None:
     exc = RuntimeError("discord login failure")
     _report_probe_failure(exc, integration="discord", expected=True)

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -199,13 +199,29 @@ def test_pydantic_validation_error_gets_info_severity(mock_report: MagicMock) ->
 
 
 @patch("app.integrations._verification_adapters.report_exception")
-def test_value_error_gets_info_severity(mock_report: MagicMock) -> None:
+def test_config_error_override_gets_info_severity(mock_report: MagicMock) -> None:
     exc = ValueError("Missing AWS role_arn or credentials.")
-    _report_probe_failure(exc, integration="aws")
+    _report_probe_failure(exc, integration="aws", config_error=True)
 
     mock_report.assert_called_once()
     assert mock_report.call_args.kwargs["severity"] == "info"
     assert mock_report.call_args.kwargs["tags"]["event"] == "invalid_config"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+@patch("app.integrations._verification_adapters._build_sts_client")
+def test_verify_aws_missing_credentials_returns_missing(
+    mock_build: MagicMock, mock_report: MagicMock
+) -> None:
+    from app.integrations._verification_adapters import _verify_aws
+
+    mock_build.side_effect = ValueError("Missing AWS role_arn or credentials.")
+    res = _verify_aws("env", {"region": "us-east-1"})
+    assert res["status"] == "missing"
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "invalid_config"
+    assert mock_report.call_args.kwargs["tags"]["integration"] == "aws"
 
 
 @patch("app.integrations._verification_adapters.report_exception")

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -283,6 +283,23 @@ def test_verify_slack_captures_on_config_validation_error(
     assert mock_report.call_args.kwargs["tags"]["event"] == "invalid_config"
 
 
+@patch("app.integrations._verification_adapters.report_exception")
+@patch("app.integrations._verification_adapters.validate_supabase_config")
+@patch("app.integrations._verification_adapters.build_supabase_config")
+def test_verify_supabase_tags_integration_correctly(
+    mock_build: MagicMock, mock_validate: MagicMock, mock_report: MagicMock
+) -> None:
+    from app.integrations._verification_adapters import _verify_supabase
+
+    mock_build.side_effect = ValueError("bad supabase url")
+    res = _verify_supabase("env", {"url": "bad"})
+    assert res["status"] == "missing"
+    assert res["service"] == "supabase"
+    assert res["source"] == "env"
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["tags"]["integration"] == "supabase"
+
+
 # ---------------------------------------------------------------------------
 # Discord ImportError special path
 # ---------------------------------------------------------------------------

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -313,3 +313,33 @@ def test_discord_import_failure_sets_sentry_tag(mock_report: MagicMock) -> None:
     finally:
         if saved is not None:
             sys.modules["discord"] = saved
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_verify_discord_event_loop_reports_as_expected(mock_report: MagicMock) -> None:
+    mock_discord = MagicMock()
+    mock_discord.LoginFailure = type("LoginFailure", (Exception,), {})
+    mock_discord.Intents.none.return_value = MagicMock(guilds=False)
+    mock_client = MagicMock()
+    mock_client.run.side_effect = RuntimeError("run() cannot be called from a running event loop")
+    mock_discord.Client.return_value = mock_client
+
+    saved = sys.modules.pop("discord", None)
+    real_import = builtins.__import__
+
+    def _mock_discord(name: str, *args: object, **kwargs: object) -> object:
+        if name == "discord":
+            return mock_discord
+        return real_import(name, *args, **kwargs)
+
+    try:
+        with patch("builtins.__import__", side_effect=_mock_discord):
+            res = _verify_discord("env", {"bot_token": "fake-token"})
+        assert res["status"] == "failed"
+        mock_report.assert_called_once()
+        assert mock_report.call_args.kwargs["severity"] == "info"
+        assert mock_report.call_args.kwargs["tags"]["event"] == "vendor_failure"
+        assert mock_report.call_args.kwargs["tags"]["integration"] == "discord"
+    finally:
+        if saved is not None:
+            sys.modules["discord"] = saved

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -18,6 +18,8 @@ exception and assert the Sentry path fires.
 from __future__ import annotations
 
 import ast
+import builtins
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -28,6 +30,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from app.integrations._verification_adapters import (
     _report_probe_failure,
+    _verify_discord,
     _verify_grafana,
     _verify_slack,
     _verify_telegram,
@@ -80,16 +83,6 @@ def _contains_call(handler: ast.ExceptHandler, func_name: str) -> bool:
     return False
 
 
-def _is_success_passthrough(handler: ast.ExceptHandler) -> bool:
-    """True when the handler is a known success-path passthrough.
-
-    The Discord event-loop handler returns "passed" without capture because
-    the exception means the token was accepted. This is intentional.
-    """
-    src = ast.dump(handler)
-    return "run() cannot be called from a running event loop" in src
-
-
 @pytest.mark.parametrize(
     ("func_name", "integration"),
     _PROBE_SITES,
@@ -103,11 +96,7 @@ def test_except_blocks_call_report_probe_failure(func_name: str, integration: st
 
     for fn in functions:
         handlers = _except_handlers(fn)
-        uncovered = [
-            h
-            for h in handlers
-            if not _contains_call(h, "_report_probe_failure") and not _is_success_passthrough(h)
-        ]
+        uncovered = [h for h in handlers if not _contains_call(h, "_report_probe_failure")]
         assert not uncovered, (
             f"{_MODULE}::{func_name} has {len(uncovered)} except handler(s) "
             f"without _report_probe_failure"
@@ -299,6 +288,28 @@ def test_verify_slack_captures_on_config_validation_error(
 # ---------------------------------------------------------------------------
 
 
-def test_discord_import_failure_sets_sentry_tag() -> None:
-    source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
-    assert 'sentry_sdk.set_tag("integrations.discord.import_failed", "true")' in source
+@patch("app.integrations._verification_adapters.report_exception")
+def test_discord_import_failure_sets_sentry_tag(mock_report: MagicMock) -> None:
+    import sentry_sdk
+
+    saved = sys.modules.pop("discord", None)
+    real_import = builtins.__import__
+
+    def _fail_discord(name: str, *args: object, **kwargs: object) -> object:
+        if name == "discord":
+            raise ImportError("No module named 'discord'")
+        return real_import(name, *args, **kwargs)
+
+    try:
+        with (
+            patch("builtins.__import__", side_effect=_fail_discord),
+            patch.object(sentry_sdk, "set_tag") as mock_tag,
+        ):
+            res = _verify_discord("env", {"bot_token": "fake"})
+        assert res["status"] == "failed"
+        mock_tag.assert_called_once_with("integrations.discord.import_failed", "true")
+        mock_report.assert_called_once()
+        assert mock_report.call_args.kwargs["tags"]["integration"] == "discord"
+    finally:
+        if saved is not None:
+            sys.modules["discord"] = saved

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -332,15 +332,12 @@ def test_discord_import_failure_sets_sentry_tag(mock_report: MagicMock) -> None:
             sys.modules["discord"] = saved
 
 
+@patch("app.integrations._verification_adapters._has_running_event_loop", return_value=True)
 @patch("app.integrations._verification_adapters.report_exception")
-def test_verify_discord_event_loop_reports_as_expected(mock_report: MagicMock) -> None:
+def test_verify_discord_event_loop_reports_as_expected(
+    mock_report: MagicMock, _mock_loop: MagicMock
+) -> None:
     mock_discord = MagicMock()
-    mock_discord.LoginFailure = type("LoginFailure", (Exception,), {})
-    mock_discord.Intents.none.return_value = MagicMock(guilds=False)
-    mock_client = MagicMock()
-    mock_client.run.side_effect = RuntimeError("run() cannot be called from a running event loop")
-    mock_discord.Client.return_value = mock_client
-
     saved = sys.modules.pop("discord", None)
     real_import = builtins.__import__
 
@@ -353,6 +350,7 @@ def test_verify_discord_event_loop_reports_as_expected(mock_report: MagicMock) -
         with patch("builtins.__import__", side_effect=_mock_discord):
             res = _verify_discord("env", {"bot_token": "fake-token"})
         assert res["status"] == "failed"
+        mock_discord.Client.assert_not_called()
         mock_report.assert_called_once()
         assert mock_report.call_args.kwargs["severity"] == "info"
         assert mock_report.call_args.kwargs["tags"]["event"] == "vendor_failure"

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -79,6 +79,16 @@ def _contains_call(handler: ast.ExceptHandler, func_name: str) -> bool:
     return False
 
 
+def _is_success_passthrough(handler: ast.ExceptHandler) -> bool:
+    """True when the handler is a known success-path passthrough.
+
+    The Discord event-loop handler returns "passed" without capture because
+    the exception means the token was accepted. This is intentional.
+    """
+    src = ast.dump(handler)
+    return "run() cannot be called from a running event loop" in src
+
+
 @pytest.mark.parametrize(
     ("func_name", "integration"),
     _PROBE_SITES,
@@ -90,13 +100,17 @@ def test_except_blocks_call_report_probe_failure(func_name: str, integration: st
     functions = _find_functions(tree, func_name)
     assert functions, f"{func_name} not found in {_MODULE}"
 
-    found = False
     for fn in functions:
-        for handler in _except_handlers(fn):
-            if _contains_call(handler, "_report_probe_failure"):
-                found = True
-                break
-    assert found, f"{_MODULE}::{func_name} has no except handler calling _report_probe_failure"
+        handlers = _except_handlers(fn)
+        uncovered = [
+            h
+            for h in handlers
+            if not _contains_call(h, "_report_probe_failure") and not _is_success_passthrough(h)
+        ]
+        assert not uncovered, (
+            f"{_MODULE}::{func_name} has {len(uncovered)} except handler(s) "
+            f"without _report_probe_failure"
+        )
 
 
 def test_module_imports_report_exception() -> None:
@@ -108,8 +122,8 @@ def test_report_probe_failure_call_count() -> None:
     source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
     count = source.count("_report_probe_failure(")
     definition_count = source.count("def _report_probe_failure(")
-    assert count - definition_count >= 13, (
-        f"expected at least 13 call sites, found {count - definition_count}"
+    assert count - definition_count >= 14, (
+        f"expected at least 14 call sites, found {count - definition_count}"
     )
 
 

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -122,8 +122,8 @@ def test_report_probe_failure_call_count() -> None:
     source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
     count = source.count("_report_probe_failure(")
     definition_count = source.count("def _report_probe_failure(")
-    assert count - definition_count >= 14, (
-        f"expected at least 14 call sites, found {count - definition_count}"
+    assert count - definition_count >= 16, (
+        f"expected at least 16 call sites, found {count - definition_count}"
     )
 
 

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -1,0 +1,224 @@
+"""Sentry capture coverage for verification adapter probe failures.
+
+Issue #1469: every ``except`` block in ``_verification_adapters.py`` that
+swallows a probe error must call ``_report_probe_failure`` so failures reach
+Sentry with structured tags (surface, integration, event).
+
+Part 1 -- AST-level: parametrized checks that each listed except handler
+contains a ``_report_probe_failure`` call with the expected ``integration=``
+keyword argument.
+
+Part 2 -- runtime: mock ``report_exception`` and exercise ``_report_probe_failure``
+directly to verify vendor-vs-bug severity split and tag structure.
+
+Part 3 -- integration: exercise selected verifiers end-to-end through a forced
+exception and assert the Sentry path fires.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import requests
+
+from app.integrations._verification_adapters import (
+    _report_probe_failure,
+    _verify_grafana,
+    _verify_slack,
+    _verify_telegram,
+    _verify_whatsapp,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE = "app/integrations/_verification_adapters.py"
+
+
+# ---------------------------------------------------------------------------
+# Part 1 -- AST: every except block calls _report_probe_failure
+# ---------------------------------------------------------------------------
+
+_PROBE_SITES: tuple[tuple[str, str], ...] = (
+    ("_verify_with_validation_result", "service"),
+    ("_verifier", "service"),
+    ("_verify_grafana", "grafana"),
+    ("_verify_aws", "aws"),
+    ("_verify_slack", "slack"),
+    ("_verify_tracer", "tracer"),
+    ("_verify_discord", "discord"),
+    ("_verify_telegram", "telegram"),
+    ("_verify_whatsapp", "whatsapp"),
+)
+
+
+def _find_functions(tree: ast.AST, name: str) -> list[ast.FunctionDef]:
+    return [
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+
+
+def _except_handlers(fn: ast.FunctionDef) -> list[ast.ExceptHandler]:
+    handlers: list[ast.ExceptHandler] = []
+    for node in ast.walk(fn):
+        if isinstance(node, ast.ExceptHandler):
+            handlers.append(node)
+    return handlers
+
+
+def _contains_call(handler: ast.ExceptHandler, func_name: str) -> bool:
+    for node in ast.walk(handler):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == func_name
+        ):
+            return True
+    return False
+
+
+@pytest.mark.parametrize(
+    ("func_name", "integration"),
+    _PROBE_SITES,
+    ids=[f"{fn}({integ})" for fn, integ in _PROBE_SITES],
+)
+def test_except_blocks_call_report_probe_failure(func_name: str, integration: str) -> None:
+    source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    functions = _find_functions(tree, func_name)
+    assert functions, f"{func_name} not found in {_MODULE}"
+
+    found = False
+    for fn in functions:
+        for handler in _except_handlers(fn):
+            if _contains_call(handler, "_report_probe_failure"):
+                found = True
+                break
+    assert found, f"{_MODULE}::{func_name} has no except handler calling _report_probe_failure"
+
+
+def test_module_imports_report_exception() -> None:
+    source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
+    assert "from app.utils.errors import report_exception" in source
+
+
+def test_report_probe_failure_call_count() -> None:
+    source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
+    count = source.count("_report_probe_failure(")
+    definition_count = source.count("def _report_probe_failure(")
+    assert count - definition_count >= 13, (
+        f"expected at least 13 call sites, found {count - definition_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part 2 -- runtime: _report_probe_failure severity and tag routing
+# ---------------------------------------------------------------------------
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_vendor_transport_error_gets_info_severity(
+    mock_report: MagicMock,
+) -> None:
+    exc = httpx.ConnectError("connection refused")
+    _report_probe_failure(exc, integration="grafana")
+
+    mock_report.assert_called_once()
+    call_kwargs = mock_report.call_args
+    assert call_kwargs.kwargs["severity"] == "info"
+    assert call_kwargs.kwargs["tags"]["event"] == "vendor_failure"
+    assert call_kwargs.kwargs["tags"]["surface"] == "integration_probe"
+    assert call_kwargs.kwargs["tags"]["integration"] == "grafana"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_requests_timeout_gets_info_severity(mock_report: MagicMock) -> None:
+    exc = requests.exceptions.Timeout("read timed out")
+    _report_probe_failure(exc, integration="telegram")
+
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "vendor_failure"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_unknown_error_gets_error_severity(mock_report: MagicMock) -> None:
+    exc = RuntimeError("unexpected")
+    _report_probe_failure(exc, integration="slack")
+
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "error"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "verify_failed"
+    assert mock_report.call_args.kwargs["tags"]["surface"] == "integration_probe"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_message_includes_integration_name(mock_report: MagicMock) -> None:
+    _report_probe_failure(ValueError("bad"), integration="aws")
+    msg = mock_report.call_args.kwargs["message"]
+    assert "[aws]" in msg
+    assert "verification probe failed" in msg
+
+
+# ---------------------------------------------------------------------------
+# Part 3 -- integration: verifier functions fire Sentry on probe failure
+# ---------------------------------------------------------------------------
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+@patch("app.integrations._verification_adapters.requests.get")
+def test_verify_grafana_captures_on_connection_error(
+    mock_get: MagicMock, mock_report: MagicMock
+) -> None:
+    mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+    res = _verify_grafana("env", {"endpoint": "http://graf:3000", "api_key": "tok"})
+    assert res["status"] == "failed"
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["tags"]["integration"] == "grafana"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+@patch("app.integrations._verification_adapters.requests.get")
+def test_verify_telegram_captures_on_timeout(mock_get: MagicMock, mock_report: MagicMock) -> None:
+    mock_get.side_effect = requests.exceptions.Timeout("timeout")
+    res = _verify_telegram("env", {"bot_token": "123:ABC"})
+    assert res["status"] == "failed"
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["integration"] == "telegram"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+@patch("app.integrations._verification_adapters.requests.get")
+def test_verify_whatsapp_captures_on_http_error(
+    mock_get: MagicMock, mock_report: MagicMock
+) -> None:
+    mock_get.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+    res = _verify_whatsapp("env", {"account_sid": "AC123", "auth_token": "secret"})
+    assert res["status"] == "failed"
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["tags"]["integration"] == "whatsapp"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "vendor_failure"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_verify_slack_captures_on_config_validation_error(
+    mock_report: MagicMock,
+) -> None:
+    res = _verify_slack("env", {"webhook_url": 12345}, send_slack_test=False)
+    assert res["status"] == "missing"
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["tags"]["integration"] == "slack"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "verify_failed"
+
+
+# ---------------------------------------------------------------------------
+# Discord ImportError special path
+# ---------------------------------------------------------------------------
+
+
+def test_discord_import_failure_sets_sentry_tag() -> None:
+    source = (_REPO_ROOT / _MODULE).read_text(encoding="utf-8")
+    assert 'sentry_sdk.set_tag("integrations.discord.import_failed", "true")' in source

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -169,6 +169,17 @@ def test_unknown_error_gets_error_severity(mock_report: MagicMock) -> None:
 
 
 @patch("app.integrations._verification_adapters.report_exception")
+def test_import_error_gets_info_severity(mock_report: MagicMock) -> None:
+    exc = ImportError("No module named 'discord'")
+    _report_probe_failure(exc, integration="discord")
+
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "missing_dependency"
+    assert mock_report.call_args.kwargs["tags"]["surface"] == "integration_probe"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
 def test_message_includes_integration_name(mock_report: MagicMock) -> None:
     _report_probe_failure(ValueError("bad"), integration="aws")
     msg = mock_report.call_args.kwargs["message"]

--- a/tests/integrations/test_verify_probe_sentry.py
+++ b/tests/integrations/test_verify_probe_sentry.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 import requests
+from pydantic import ValidationError as PydanticValidationError
 
 from app.integrations._verification_adapters import (
     _report_probe_failure,
@@ -180,6 +181,34 @@ def test_import_error_gets_info_severity(mock_report: MagicMock) -> None:
 
 
 @patch("app.integrations._verification_adapters.report_exception")
+def test_pydantic_validation_error_gets_info_severity(mock_report: MagicMock) -> None:
+    from pydantic import BaseModel
+
+    class _Dummy(BaseModel):
+        x: int
+
+    try:
+        _Dummy.model_validate({"x": "not_an_int"})
+    except PydanticValidationError as exc:
+        _report_probe_failure(exc, integration="grafana")
+
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "invalid_config"
+    assert mock_report.call_args.kwargs["tags"]["surface"] == "integration_probe"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
+def test_expected_override_gets_info_severity(mock_report: MagicMock) -> None:
+    exc = RuntimeError("discord login failure")
+    _report_probe_failure(exc, integration="discord", expected=True)
+
+    mock_report.assert_called_once()
+    assert mock_report.call_args.kwargs["severity"] == "info"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "vendor_failure"
+
+
+@patch("app.integrations._verification_adapters.report_exception")
 def test_message_includes_integration_name(mock_report: MagicMock) -> None:
     _report_probe_failure(ValueError("bad"), integration="aws")
     msg = mock_report.call_args.kwargs["message"]
@@ -236,7 +265,7 @@ def test_verify_slack_captures_on_config_validation_error(
     assert res["status"] == "missing"
     mock_report.assert_called_once()
     assert mock_report.call_args.kwargs["tags"]["integration"] == "slack"
-    assert mock_report.call_args.kwargs["tags"]["event"] == "verify_failed"
+    assert mock_report.call_args.kwargs["tags"]["event"] == "invalid_config"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1469

#### Describe the changes you have made in this PR -

Wires structured Sentry capture into every except block in `_verification_adapters.py`. Previously, verification probe failures were silently collapsed into string results with no logging or Sentry visibility.

Added a `_report_probe_failure()` helper that routes through `report_exception()` (same pattern as `capture_service_error` from #1922) with structured tags:

- **Vendor transport errors** (httpx, requests, botocore base classes) get `severity=info` and `event=vendor_failure` since these are expected network conditions during probing
- **Unknown exceptions** get `severity=error` and `event=verify_failed` to flag actual bugs in verification logic
- All events carry `surface=integration_probe` and the integration name for Sentry filtering

14 except sites instrumented across: `_verify_with_validation_result`, `build_probe_verifier`, grafana, aws, slack (2 sites), tracer (2 sites), discord (LoginFailure + general), telegram, whatsapp.

Discord ImportError also sets `sentry_sdk.set_tag("integrations.discord.import_failed", "true")` per issue spec.

### Demo/Screenshot for feature changes and bug fixes - 

https://github.com/user-attachments/assets/f90251b5-0455-4caa-94ea-1fa5df631b0d

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The core problem is that verification probes swallow exceptions into plain string results, making failures invisible in Sentry. I considered two approaches: (a) inline `report_exception` calls at each site, or (b) a thin helper that encapsulates the vendor-vs-bug severity decision. Went with (b) because the severity split logic would be duplicated 14 times otherwise.

`_report_probe_failure` checks `isinstance(exc, _VENDOR_TRANSPORT_ERRORS)` to decide severity. The vendor tuple uses base classes (`httpx.TransportError`, `requests.exceptions.RequestException`, botocore bases) rather than listing every subclass, so new transport errors like SSLError or ProxyError are automatically covered.

The test suite has three layers: AST-level checks that every verifier function has `_report_probe_failure` in its except handlers, runtime unit tests on the helper itself verifying severity routing and tag structure, and integration tests that exercise real verifiers with mocked transport to confirm end-to-end capture.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions