### PR TITLE
fix(integrations): eliminate silent env-loader fallbacks + scrub pydantic input_value

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -62,8 +62,54 @@ from app.integrations.supabase import build_supabase_config
 from app.llm_credentials import resolve_env_credential
 from app.services.vercel import VercelConfig
 from app.utils.coercion import safe_int
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
+
+
+def _report_classify_failure(exc: BaseException, *, integration: str, record_id: str) -> None:
+    """Route a per-instance classify failure to Sentry + warning log.
+
+    Replaces the historic ``except Exception: return None, None`` pattern in
+    ``_classify_service_instance``: the caller still gets ``(None, None)``
+    and skips the integration, but the failure is now visible to operators
+    instead of being silently swallowed (#1468).
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"classify_failed: integration={integration} record_id={record_id}",
+        severity="warning",
+        tags={
+            "surface": "integration",
+            "component": "app.integrations._catalog_impl",
+            "integration": integration,
+            "event": "classify_failed",
+        },
+        extras={"record_id": record_id},
+    )
+
+
+def _report_env_loader_failure(exc: BaseException, *, integration: str) -> None:
+    """Route a per-vendor env-loader failure to Sentry + warning log.
+
+    Replaces ``except Exception: pass`` and ``logger.debug(..., exc_info=True)``
+    paths in ``load_env_integrations``: integration is still skipped, but the
+    misconfiguration reaches Sentry rather than being lost to debug output
+    (#1468).
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"env_loader_failed: integration={integration}",
+        severity="warning",
+        tags={
+            "surface": "integration",
+            "component": "app.integrations._catalog_impl",
+            "integration": integration,
+            "event": "env_loader_failed",
+        },
+    )
 
 
 def _should_publish_instance_siblings(instances: object) -> bool:
@@ -167,7 +213,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if not grafana_config.endpoint:
             return None, None
@@ -199,7 +246,8 @@ def _classify_service_instance(
                 AWSIntegrationConfig.model_validate(raw_config).model_dump(exclude_none=True),
                 "aws",
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
 
     if key == "datadog":
@@ -212,7 +260,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if datadog_config.api_key and datadog_config.app_key:
             return datadog_config.model_dump(), "datadog"
@@ -228,7 +277,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if honeycomb_config.api_key:
             return honeycomb_config.model_dump(), "honeycomb"
@@ -245,7 +295,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if coralogix_config.api_key:
             return coralogix_config.model_dump(), "coralogix"
@@ -264,7 +315,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return github_config.model_dump(), "github"
 
@@ -279,7 +331,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if sentry_config.organization_slug and sentry_config.auth_token:
             return sentry_config.model_dump(), "sentry"
@@ -293,7 +346,8 @@ def _classify_service_instance(
                     "auth_token": credentials.get("auth_token", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return gitlab_config.model_dump(), "gitlab"
 
@@ -307,7 +361,8 @@ def _classify_service_instance(
                     "tls": credentials.get("tls", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mongodb_config.connection_string:
             return mongodb_config.model_dump(), "mongodb"
@@ -325,7 +380,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "prefer"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if postgresql_config.host and postgresql_config.database:
             return postgresql_config.model_dump(), "postgresql"
@@ -343,7 +399,8 @@ def _classify_service_instance(
                     ),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if atlas_config.api_public_key and atlas_config.api_private_key and atlas_config.project_id:
             return {
@@ -367,7 +424,8 @@ def _classify_service_instance(
                     "ssl": credentials.get("ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mariadb_config.host and mariadb_config.database:
             return {
@@ -390,7 +448,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if vercel_config.api_token:
             return vercel_config.model_dump(), "vercel"
@@ -405,7 +464,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if opsgenie_config.api_key:
             return opsgenie_config.model_dump(), "opsgenie"
@@ -420,7 +480,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if incident_io_config.api_key:
             return incident_io_config.model_dump(), "incident_io"
@@ -437,7 +498,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if jira_config.base_url and jira_config.email and jira_config.api_token:
             return jira_config.model_dump(), "jira"
@@ -453,7 +515,8 @@ def _classify_service_instance(
                     "default_channel_id": credentials.get("default_channel_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if discord_config.bot_token:
             return discord_config.model_dump(), "discord"
@@ -467,7 +530,8 @@ def _classify_service_instance(
                     "default_chat_id": credentials.get("default_chat_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if tg_config.bot_token:
             return tg_config.model_dump(), "telegram"
@@ -499,7 +563,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if openclaw_config.is_configured:
             config_dict = openclaw_config.model_dump()
@@ -519,7 +584,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "preferred"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mysql_config.host and mysql_config.database:
             return {
@@ -546,7 +612,8 @@ def _classify_service_instance(
                     "verify_ssl": credentials.get("verify_ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if rabbitmq_config.host and rabbitmq_config.username:
             return {
@@ -569,7 +636,8 @@ def _classify_service_instance(
                     "region": credentials.get("region", DEFAULT_RDS_REGION),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if rds_config.is_configured:
             return {**rds_config.model_dump(), "integration_id": record_id}, "rds"
@@ -588,7 +656,8 @@ def _classify_service_instance(
                     "max_results": credentials.get("max_results", 50),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if airflow_config.is_configured:
             return {
@@ -607,7 +676,8 @@ def _classify_service_instance(
                     "sources": credentials.get("sources", []),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if bs_config.query_endpoint and bs_config.username:
             return {
@@ -632,7 +702,8 @@ def _classify_service_instance(
                     "encrypt": credentials.get("encrypt", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if azure_sql_config.server and azure_sql_config.database:
             return azure_sql_config.model_dump(), "azure_sql"
@@ -649,7 +720,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if alertmanager_config.base_url:
             return alertmanager_config.model_dump(), "alertmanager"
@@ -671,7 +743,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if argocd_config.base_url and (
             argocd_config.bearer_token or (argocd_config.username and argocd_config.password)
@@ -694,7 +767,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return helm_config.model_dump(), "helm"
 
@@ -707,7 +781,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if victoria_logs_config.base_url:
             return victoria_logs_config.model_dump(), "victoria_logs"
@@ -816,7 +891,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if splunk_config.base_url and splunk_config.token:
             return splunk_config.model_dump(), "splunk"
@@ -830,7 +906,8 @@ def _classify_service_instance(
                     "service_key": credentials.get("service_key", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if sb_config.is_configured:
             return {
@@ -1207,9 +1284,10 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "verify_ssl": os.getenv("ARGOCD_VERIFY_SSL", "true").strip(),
                 }
             )
-        except Exception:
-            # invalid env-derived config: skip ArgoCD entry rather than fail discovery
-            pass
+        except Exception as exc:
+            # Invalid env-derived config: skip ArgoCD entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="argocd")
         else:
             integrations.append(
                 _active_env_record(
@@ -1233,8 +1311,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "default_namespace": os.getenv("HELM_NAMESPACE", "").strip(),
                 }
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="helm")
         else:
             integrations.append(
                 _active_env_record(
@@ -1282,8 +1360,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "base_url": os.getenv("INCIDENT_IO_BASE_URL", "").strip(),
                 }
             )
-        except Exception:
-            logger.debug("Failed to load incident.io config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="incident_io")
         else:
             integrations.append(
                 _active_env_record(
@@ -1401,8 +1479,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     },
                 )
             )
-        except Exception:
-            logger.debug("Failed to load OpenClaw config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="openclaw")
 
     mariadb_host = os.getenv("MARIADB_HOST", "").strip()
     mariadb_database = os.getenv("MARIADB_DATABASE", "").strip()
@@ -1424,8 +1502,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     mariadb_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load MariaDB config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="mariadb")
 
     rabbitmq_host = os.getenv("RABBITMQ_HOST", "").strip()
     rabbitmq_username = os.getenv("RABBITMQ_USERNAME", "").strip()
@@ -1450,14 +1528,14 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     rabbitmq_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load RabbitMQ config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="rabbitmq")
 
     try:
         rds_config = rds_config_from_env()
-    except Exception:
+    except Exception as exc:
         rds_config = None
-        logger.debug("Failed to load RDS config from env", exc_info=True)
+        _report_env_loader_failure(exc, integration="rds")
     if rds_config is not None and rds_config.is_configured:
         integrations.append(
             _active_env_record(
@@ -1484,8 +1562,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     bs_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Better Stack config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="betterstack")
 
     mysql_host = os.getenv("MYSQL_HOST", "").strip()
     mysql_database = os.getenv("MYSQL_DATABASE", "").strip()
@@ -1648,8 +1726,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     alertmanager_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Alertmanager config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="alertmanager")
 
     victoria_logs_url = os.getenv("VICTORIA_LOGS_URL", "").strip().rstrip("/")
     if victoria_logs_url:
@@ -1666,8 +1744,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     victoria_logs_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load VictoriaLogs config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="victoria_logs")
 
     splunk_multi = _parse_instances_env("SPLUNK_INSTANCES", "splunk")
     if splunk_multi is not None:
@@ -1705,8 +1783,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     {"project_url": sb_config.url},
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Supabase config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="supabase")
 
     try:
         signoz_config = signoz_config_from_env()

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1323,33 +1323,41 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     vercel_api_token = os.getenv("VERCEL_API_TOKEN", "").strip()
     if vercel_api_token:
-        vercel_config = VercelConfig.model_validate(
-            {
-                "api_token": vercel_api_token,
-                "team_id": os.getenv("VERCEL_TEAM_ID", "").strip(),
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "vercel",
-                vercel_config.model_dump(exclude={"integration_id"}),
+        try:
+            vercel_config = VercelConfig.model_validate(
+                {
+                    "api_token": vercel_api_token,
+                    "team_id": os.getenv("VERCEL_TEAM_ID", "").strip(),
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="vercel")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "vercel",
+                    vercel_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     opsgenie_api_key = os.getenv("OPSGENIE_API_KEY", "").strip()
     if opsgenie_api_key:
-        opsgenie_config = OpsGenieIntegrationConfig.model_validate(
-            {
-                "api_key": opsgenie_api_key,
-                "region": os.getenv("OPSGENIE_REGION", "us").strip() or "us",
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "opsgenie",
-                opsgenie_config.model_dump(exclude={"integration_id"}),
+        try:
+            opsgenie_config = OpsGenieIntegrationConfig.model_validate(
+                {
+                    "api_key": opsgenie_api_key,
+                    "region": os.getenv("OPSGENIE_REGION", "us").strip() or "us",
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="opsgenie")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "opsgenie",
+                    opsgenie_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     incident_io_api_key = resolve_env_credential("INCIDENT_IO_API_KEY")
     if incident_io_api_key:
@@ -1375,32 +1383,41 @@ def load_env_integrations() -> list[dict[str, Any]]:
     jira_api_token = os.getenv("JIRA_API_TOKEN", "").strip()
     jira_project_key = os.getenv("JIRA_PROJECT_KEY", "").strip()
     if jira_base_url and jira_email and jira_api_token:
-        jira_config = JiraIntegrationConfig.model_validate(
-            {
-                "base_url": jira_base_url,
-                "email": jira_email,
-                "api_token": jira_api_token,
-                "project_key": jira_project_key,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "jira",
-                jira_config.model_dump(exclude={"integration_id"}),
+        try:
+            jira_config = JiraIntegrationConfig.model_validate(
+                {
+                    "base_url": jira_base_url,
+                    "email": jira_email,
+                    "api_token": jira_api_token,
+                    "project_key": jira_project_key,
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="jira")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "jira",
+                    jira_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     discord_bot_token = resolve_env_credential("DISCORD_BOT_TOKEN")
     if discord_bot_token:
-        discord_config = DiscordBotConfig.model_validate(
-            {
-                "bot_token": discord_bot_token,
-                "application_id": os.getenv("DISCORD_APPLICATION_ID", "").strip(),
-                "public_key": os.getenv("DISCORD_PUBLIC_KEY", "").strip(),
-                "default_channel_id": os.getenv("DISCORD_DEFAULT_CHANNEL_ID", "").strip() or None,
-            }
-        )
-        integrations.append(_active_env_record("discord", discord_config.model_dump()))
+        try:
+            discord_config = DiscordBotConfig.model_validate(
+                {
+                    "bot_token": discord_bot_token,
+                    "application_id": os.getenv("DISCORD_APPLICATION_ID", "").strip(),
+                    "public_key": os.getenv("DISCORD_PUBLIC_KEY", "").strip(),
+                    "default_channel_id": os.getenv("DISCORD_DEFAULT_CHANNEL_ID", "").strip()
+                    or None,
+                }
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="discord")
+        else:
+            integrations.append(_active_env_record("discord", discord_config.model_dump()))
 
     airflow_config = airflow_config_from_env()
     if airflow_config is not None:
@@ -1408,13 +1425,17 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     telegram_bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
     if telegram_bot_token:
-        tg_config = TelegramBotConfig.model_validate(
-            {
-                "bot_token": telegram_bot_token,
-                "default_chat_id": os.getenv("TELEGRAM_DEFAULT_CHAT_ID", "").strip() or None,
-            }
-        )
-        integrations.append(_active_env_record("telegram", tg_config.model_dump()))
+        try:
+            tg_config = TelegramBotConfig.model_validate(
+                {
+                    "bot_token": telegram_bot_token,
+                    "default_chat_id": os.getenv("TELEGRAM_DEFAULT_CHAT_ID", "").strip() or None,
+                }
+            )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="telegram")
+        else:
+            integrations.append(_active_env_record("telegram", tg_config.model_dump()))
 
     wa_account_sid = os.getenv("TWILIO_ACCOUNT_SID", "").strip()
     wa_auth_token = os.getenv("TWILIO_AUTH_TOKEN", "").strip()
@@ -1434,22 +1455,26 @@ def load_env_integrations() -> list[dict[str, Any]]:
     atlas_priv = os.getenv("MONGODB_ATLAS_PRIVATE_KEY", "").strip()
     atlas_project = os.getenv("MONGODB_ATLAS_PROJECT_ID", "").strip()
     if atlas_pub and atlas_priv and atlas_project:
-        atlas_config = build_mongodb_atlas_config(
-            {
-                "api_public_key": atlas_pub,
-                "api_private_key": atlas_priv,
-                "project_id": atlas_project,
-                "base_url": os.getenv(
-                    "MONGODB_ATLAS_BASE_URL", "https://cloud.mongodb.com/api/atlas/v2"
-                ).strip(),
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "mongodb_atlas",
-                atlas_config.model_dump(exclude={"integration_id"}),
+        try:
+            atlas_config = build_mongodb_atlas_config(
+                {
+                    "api_public_key": atlas_pub,
+                    "api_private_key": atlas_priv,
+                    "project_id": atlas_project,
+                    "base_url": os.getenv(
+                        "MONGODB_ATLAS_BASE_URL", "https://cloud.mongodb.com/api/atlas/v2"
+                    ).strip(),
+                }
             )
-        )
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="mongodb_atlas")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "mongodb_atlas",
+                    atlas_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     openclaw_url = os.getenv("OPENCLAW_MCP_URL", "").strip()
     openclaw_command = os.getenv("OPENCLAW_MCP_COMMAND", "").strip()

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -27,6 +27,17 @@ from app.constants import (
 )
 
 _HOME_PATH_RE: re.Pattern[str] = re.compile(r"/(?:Users|home)/[^/\s]+")
+# Pydantic V2 ValidationError messages render ``input_value=<repr>`` and
+# ``input=<repr>`` for each failing field. When the failing field is e.g.
+# ``api_token`` or ``password``, the raw secret lands in the rendered text
+# and reaches Sentry through ``exception.values[].value`` — a layer the
+# existing key-based scrubbers do not walk. Strip the value portion up to
+# the next field separator (``, input_type=``, ``, ctx=``, or the trailing
+# ``]``) and leave the rest of the message intact for triage.
+_PYDANTIC_INPUT_RE: re.Pattern[str] = re.compile(
+    r"input(?:_value)?=.*?(?=,\s*(?:input_type|ctx)=|\])",
+    flags=re.DOTALL,
+)
 _SENSITIVE_KEY_SUFFIXES: tuple[str, ...] = ("_token", "_key", "_secret", "_password")
 _SENSITIVE_KEY_SUBSTRINGS: tuple[str, ...] = (
     "prompt",
@@ -203,6 +214,20 @@ def _scrub_stacktrace_frames(frames: list[dict[str, Any]]) -> None:
                     local_vars[key] = _scrub_string(value)
 
 
+def _scrub_exception_value(text: str) -> str:
+    """Strip rendered field values from an exception message string.
+
+    Pydantic V2 ``ValidationError`` is the main offender — the renderer
+    embeds ``input_value=<repr>`` for each failing field, which leaks the
+    raw value (often a secret) into ``exception.values[].value`` where the
+    existing key-based scrubbers do not reach. ``_HOME_PATH_RE`` is also
+    applied so home-directory paths in arbitrary messages get the same
+    treatment they do elsewhere.
+    """
+    scrubbed = _PYDANTIC_INPUT_RE.sub("input_value=[Filtered]", text)
+    return _HOME_PATH_RE.sub("~", scrubbed)
+
+
 def _scrub_event_in_place(event: dict[str, Any]) -> None:
     request = event.get("request")
     if isinstance(request, dict):
@@ -215,7 +240,12 @@ def _scrub_event_in_place(event: dict[str, Any]) -> None:
     exception = event.get("exception")
     if isinstance(exception, dict):
         for entry in exception.get("values", []) or []:
-            stacktrace = entry.get("stacktrace") if isinstance(entry, dict) else None
+            if not isinstance(entry, dict):
+                continue
+            value = entry.get("value")
+            if isinstance(value, str):
+                entry["value"] = _scrub_exception_value(value)
+            stacktrace = entry.get("stacktrace")
             if isinstance(stacktrace, dict):
                 frames = stacktrace.get("frames")
                 if isinstance(frames, list):

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -27,15 +27,16 @@ from app.constants import (
 )
 
 _HOME_PATH_RE: re.Pattern[str] = re.compile(r"/(?:Users|home)/[^/\s]+")
-# Pydantic V2 ValidationError messages render ``input_value=<repr>`` and
-# ``input=<repr>`` for each failing field. When the failing field is e.g.
+# Pydantic V2 ValidationError messages render ``input_value=<repr>`` (or
+# ``input=<repr>``) for each failing field. When the failing field is e.g.
 # ``api_token`` or ``password``, the raw secret lands in the rendered text
 # and reaches Sentry through ``exception.values[].value`` — a layer the
-# existing key-based scrubbers do not walk. Strip the value portion up to
-# the next field separator (``, input_type=``, ``, ctx=``, or the trailing
-# ``]``) and leave the rest of the message intact for triage.
+# existing key-based scrubbers do not walk. Strip the value up to the next
+# pydantic field separator, which is always ``, input_type=``. The placeholder
+# left behind (``input_value=[Filtered]``) has no ``, input_type=`` immediately
+# after the bracket, so re-applying the scrub is a no-op (idempotent).
 _PYDANTIC_INPUT_RE: re.Pattern[str] = re.compile(
-    r"input(?:_value)?=.*?(?=,\s*(?:input_type|ctx)=|\])",
+    r"input(?:_value)?=.*?(?=,\s*input_type=)",
     flags=re.DOTALL,
 )
 _SENSITIVE_KEY_SUFFIXES: tuple[str, ...] = ("_token", "_key", "_secret", "_password")

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -32,11 +32,13 @@ _HOME_PATH_RE: re.Pattern[str] = re.compile(r"/(?:Users|home)/[^/\s]+")
 # ``api_token`` or ``password``, the raw secret lands in the rendered text
 # and reaches Sentry through ``exception.values[].value`` — a layer the
 # existing key-based scrubbers do not walk. Strip the value up to the next
-# pydantic field separator, which is always ``, input_type=``. The placeholder
+# pydantic field separator, which is always ``, input_type=``. ``\Z`` is the
+# end-of-string fallback so a truncated message (no ``, input_type=`` after
+# the secret) still gets scrubbed instead of silently leaking. The placeholder
 # left behind (``input_value=[Filtered]``) has no ``, input_type=`` immediately
 # after the bracket, so re-applying the scrub is a no-op (idempotent).
 _PYDANTIC_INPUT_RE: re.Pattern[str] = re.compile(
-    r"input(?:_value)?=.*?(?=,\s*input_type=)",
+    r"input(?:_value)?=.*?(?=,\s*input_type=|\Z)",
     flags=re.DOTALL,
 )
 _SENSITIVE_KEY_SUFFIXES: tuple[str, ...] = ("_token", "_key", "_secret", "_password")

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -312,14 +312,17 @@ def test_one_failing_env_loader_does_not_abort_remaining_integrations(
 ) -> None:
     """The regression #2036 was filed for: a single failing ``model_validate``
     in ``load_env_integrations`` must not abort discovery for every later
-    vendor. Enable two unrelated loaders (vercel + argocd), force vercel to
-    raise, and assert argocd still appears in the returned list.
+    vendor. The survivor must run *after* the failing loader — otherwise the
+    assertion passes even when the loop aborts on vercel (caught by
+    @VibhorGautam in review).
+
+    incident_io is loaded after vercel in ``load_env_integrations``, so its
+    presence in the result proves the loop continued past the vercel failure.
     """
     for var in list(os.environ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("VERCEL_API_TOKEN", "tkn")
-    monkeypatch.setenv("ARGOCD_BASE_URL", "https://argo.example")
-    monkeypatch.setenv("ARGOCD_AUTH_TOKEN", "tkn")
+    monkeypatch.setenv("INCIDENT_IO_API_KEY", "tkn")
 
     def _boom(*_args: Any, **_kwargs: Any) -> None:
         raise RuntimeError("forced vercel failure")
@@ -331,7 +334,7 @@ def test_one_failing_env_loader_does_not_abort_remaining_integrations(
 
     services = {entry["service"] for entry in result}
     assert "vercel" not in services
-    assert "argocd" in services, (
-        "argocd was dropped — discovery aborted on the first failing loader instead of "
+    assert "incident_io" in services, (
+        "incident_io was dropped — discovery aborted on the vercel failure instead of "
         "continuing past it (this is exactly the bug #2036 is about)"
     )

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -1,0 +1,268 @@
+"""Tests for #1468: eliminate silent env-loader / classify fallbacks.
+
+Three patterns previously dropped exceptions to ``(None, None)``, ``pass``,
+or ``logger.debug(..., exc_info=True)`` with no Sentry trace:
+
+  A. ``_classify_service_instance`` per-vendor ``try/except Exception``
+     blocks (33 sites covering grafana .. supabase).
+  B. ``load_env_integrations`` argocd + helm ``except Exception: pass``.
+  C. ``load_env_integrations`` debug-only env loaders (incident_io,
+     openclaw, mariadb, rabbitmq, rds, betterstack, alertmanager,
+     victoria_logs, supabase).
+
+After the fix every site routes through ``_report_classify_failure`` or
+``_report_env_loader_failure``, which call ``report_exception`` with
+``surface=integration``, ``component=app.integrations._catalog_impl``,
+``event=classify_failed`` / ``event=env_loader_failed``, and the vendor
+tag — preserving the historic "skip the integration" caller contract.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.integrations._catalog_impl import (
+    _classify_service_instance,
+    _report_classify_failure,
+    _report_env_loader_failure,
+    load_env_integrations,
+)
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+
+
+# ---------------------------------------------------------------------------
+# Helper smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_classify_failure_forwards_tags() -> None:
+    exc = ValueError("bad config")
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_classify_failure(exc, integration="datadog", record_id="rec-1")
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "integration",
+        "component": "app.integrations._catalog_impl",
+        "integration": "datadog",
+        "event": "classify_failed",
+    }
+    assert kwargs["extras"] == {"record_id": "rec-1"}
+
+
+def test_report_env_loader_failure_forwards_tags() -> None:
+    exc = RuntimeError("env missing")
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_env_loader_failure(exc, integration="rabbitmq")
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "integration",
+        "component": "app.integrations._catalog_impl",
+        "integration": "rabbitmq",
+        "event": "env_loader_failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pattern A: _classify_service_instance routes failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+# Per-vendor: the symbol inside ``app.integrations._catalog_impl`` whose
+# constructor we force to raise, so we can prove the surrounding try/except
+# now routes the failure through ``report_exception`` instead of returning
+# ``(None, None)`` silently. Patching is more reliable than crafting bad
+# credentials, since validator strictness drifts per integration.
+_CLASSIFY_PATCH_TARGETS: list[tuple[str, str]] = [
+    ("grafana", "GrafanaIntegrationConfig"),
+    ("aws", "AWSIntegrationConfig"),
+    ("datadog", "DatadogIntegrationConfig"),
+    ("honeycomb", "HoneycombIntegrationConfig"),
+    ("coralogix", "CoralogixIntegrationConfig"),
+    ("github", "build_github_mcp_config"),
+    ("sentry", "build_sentry_config"),
+    ("gitlab", "build_gitlab_config"),
+    ("mongodb", "build_mongodb_config"),
+    ("postgresql", "build_postgresql_config"),
+    ("mongodb_atlas", "build_mongodb_atlas_config"),
+    ("mariadb", "build_mariadb_config"),
+    ("vercel", "VercelConfig"),
+    ("opsgenie", "OpsGenieIntegrationConfig"),
+    ("incident_io", "IncidentIoIntegrationConfig"),
+    ("jira", "JiraIntegrationConfig"),
+    ("discord", "DiscordBotConfig"),
+    ("telegram", "TelegramBotConfig"),
+    ("openclaw", "build_openclaw_config"),
+    ("mysql", "build_mysql_config"),
+    ("rabbitmq", "build_rabbitmq_config"),
+    ("rds", "build_rds_config"),
+    ("airflow", "build_airflow_config"),
+    ("betterstack", "build_betterstack_config"),
+    ("azure_sql", "build_azure_sql_config"),
+    ("alertmanager", "AlertmanagerIntegrationConfig"),
+    ("argocd", "ArgoCDIntegrationConfig"),
+    ("helm", "HelmIntegrationConfig"),
+    ("victoria_logs", "VictoriaLogsIntegrationConfig"),
+    ("splunk", "SplunkIntegrationConfig"),
+    ("supabase", "build_supabase_config"),
+]
+
+
+@pytest.mark.parametrize(("integration", "patch_symbol"), _CLASSIFY_PATCH_TARGETS)
+def test_classify_failure_skips_integration_and_reports(
+    integration: str,
+    patch_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every Pattern A site (``_classify_service_instance``) must still return
+    ``(None, None)`` *and* now route the exception through
+    ``report_exception`` with ``event=classify_failed`` and the vendor tag."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = _classify_service_instance(
+            integration,
+            {"endpoint": "https://x", "api_key": "k"},
+            record_id=f"rec-{integration}",
+        )
+
+    assert result == (None, None), (
+        f"caller contract broken for {integration}: must still skip integration"
+    )
+    assert mock_report.call_count == 1, (
+        f"{integration} silently swallowed exception (no report_exception call)"
+    )
+    tags = mock_report.call_args.kwargs["tags"]
+    assert tags["integration"] == integration
+    assert tags["event"] == "classify_failed"
+    assert tags["surface"] == "integration"
+    assert mock_report.call_args.kwargs["severity"] == "warning"
+    assert mock_report.call_args.kwargs["extras"]["record_id"] == f"rec-{integration}"
+
+
+# ---------------------------------------------------------------------------
+# Pattern B + C: load_env_integrations routes loader failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+# For each env-loader case: env vars to enable the loader path + the symbol in
+# ``app.integrations._catalog_impl`` to patch so its constructor raises. This
+# proves the exception is *caught* and *routed* — without depending on which
+# fields the real builder rejects (validator details drift independently).
+_ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
+    # Pattern B
+    (
+        "argocd",
+        {"ARGOCD_BASE_URL": "https://argo.example", "ARGOCD_AUTH_TOKEN": "t"},
+        "ArgoCDIntegrationConfig",
+    ),
+    (
+        "helm",
+        {"OSRE_HELM_INTEGRATION": "1"},
+        "HelmIntegrationConfig",
+    ),
+    # Pattern C
+    (
+        "incident_io",
+        {"INCIDENT_IO_API_KEY": "k"},
+        "IncidentIoIntegrationConfig",
+    ),
+    (
+        "mariadb",
+        {"MARIADB_HOST": "h", "MARIADB_DATABASE": "d"},
+        "build_mariadb_config",
+    ),
+    (
+        "rabbitmq",
+        {"RABBITMQ_HOST": "h", "RABBITMQ_USERNAME": "u"},
+        "build_rabbitmq_config",
+    ),
+    (
+        "betterstack",
+        {"BETTERSTACK_QUERY_ENDPOINT": "https://bs.example", "BETTERSTACK_USERNAME": "u"},
+        "build_betterstack_config",
+    ),
+    (
+        "alertmanager",
+        {"ALERTMANAGER_URL": "https://am.example"},
+        "AlertmanagerIntegrationConfig",
+    ),
+    (
+        "victoria_logs",
+        {"VICTORIA_LOGS_URL": "https://vl.example"},
+        "VictoriaLogsIntegrationConfig",
+    ),
+    (
+        "supabase",
+        {"SUPABASE_URL": "https://s.example", "SUPABASE_SERVICE_KEY": "k"},
+        "build_supabase_config",
+    ),
+    (
+        "openclaw",
+        {"OPENCLAW_MCP_URL": "https://oc.example"},
+        "build_openclaw_config",
+    ),
+    (
+        "rds",
+        {},
+        "rds_config_from_env",
+    ),
+]
+
+
+@pytest.mark.parametrize(("integration", "env", "patch_symbol"), _ENV_LOADER_CASES)
+def test_env_loader_failure_reports_and_skips(
+    integration: str,
+    env: dict[str, str],
+    patch_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pattern B + C: when a vendor's env-derived builder raises, the
+    integration must be skipped (preserving the historic caller contract)
+    *and* the failure must reach Sentry via ``report_exception``."""
+    # Clear ambient env so other integrations on the dev box don't enable
+    # unrelated paths and inflate the assertion.
+    for var in list(os.environ):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = load_env_integrations()
+
+    services = {entry["service"] for entry in result}
+    assert integration not in services, f"{integration} must be skipped when its env loader fails"
+
+    matching = [
+        call
+        for call in mock_report.call_args_list
+        if call.kwargs.get("tags", {}).get("integration") == integration
+    ]
+    assert matching, (
+        f"{integration} env-loader failure was swallowed silently — expected "
+        "report_exception call with event=env_loader_failed"
+    )
+    tags = matching[0].kwargs["tags"]
+    assert tags["event"] == "env_loader_failed"
+    assert tags["surface"] == "integration"
+    assert matching[0].kwargs["severity"] == "warning"

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -222,6 +222,45 @@ _ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
         {},
         "rds_config_from_env",
     ),
+    # Pattern C — added in this PR (was the #2036 follow-up scope).
+    (
+        "vercel",
+        {"VERCEL_API_TOKEN": "t"},
+        "VercelConfig",
+    ),
+    (
+        "opsgenie",
+        {"OPSGENIE_API_KEY": "k"},
+        "OpsGenieIntegrationConfig",
+    ),
+    (
+        "jira",
+        {
+            "JIRA_BASE_URL": "https://jira.example",
+            "JIRA_EMAIL": "e@example.com",
+            "JIRA_API_TOKEN": "t",
+        },
+        "JiraIntegrationConfig",
+    ),
+    (
+        "discord",
+        {"DISCORD_BOT_TOKEN": "t"},
+        "DiscordBotConfig",
+    ),
+    (
+        "telegram",
+        {"TELEGRAM_BOT_TOKEN": "t"},
+        "TelegramBotConfig",
+    ),
+    (
+        "mongodb_atlas",
+        {
+            "MONGODB_ATLAS_PUBLIC_KEY": "pub",
+            "MONGODB_ATLAS_PRIVATE_KEY": "priv",
+            "MONGODB_ATLAS_PROJECT_ID": "proj",
+        },
+        "build_mongodb_atlas_config",
+    ),
 ]
 
 
@@ -266,3 +305,33 @@ def test_env_loader_failure_reports_and_skips(
     assert tags["event"] == "env_loader_failed"
     assert tags["surface"] == "integration"
     assert matching[0].kwargs["severity"] == "warning"
+
+
+def test_one_failing_env_loader_does_not_abort_remaining_integrations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression #2036 was filed for: a single failing ``model_validate``
+    in ``load_env_integrations`` must not abort discovery for every later
+    vendor. Enable two unrelated loaders (vercel + argocd), force vercel to
+    raise, and assert argocd still appears in the returned list.
+    """
+    for var in list(os.environ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("VERCEL_API_TOKEN", "tkn")
+    monkeypatch.setenv("ARGOCD_BASE_URL", "https://argo.example")
+    monkeypatch.setenv("ARGOCD_AUTH_TOKEN", "tkn")
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("forced vercel failure")
+
+    monkeypatch.setattr("app.integrations._catalog_impl.VercelConfig", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception"):
+        result = load_env_integrations()
+
+    services = {entry["service"] for entry in result}
+    assert "vercel" not in services
+    assert "argocd" in services, (
+        "argocd was dropped — discovery aborted on the first failing loader instead of "
+        "continuing past it (this is exactly the bug #2036 is about)"
+    )

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -383,6 +383,48 @@ def test_before_send_leaves_unrelated_exception_messages_alone() -> None:
     assert event["exception"]["values"][0]["value"] == original
 
 
+def test_before_send_scrubs_list_typed_input_value_without_mid_clip() -> None:
+    # Pydantic V2 flattens list-field errors to per-element scalar entries
+    # (val.0, val.1, ...), so the rendered ``input_value=`` is always a
+    # scalar repr. Lock that behaviour: the scrubber must replace the whole
+    # value, not clip an inner bracket.
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValidationError",
+                    "value": (
+                        "2 validation errors for A\n"
+                        "val.0\n  Input should be a valid integer "
+                        "[type=int_parsing, input_value='secret_a', input_type=str]\n"
+                        "val.1\n  Input should be a valid integer "
+                        "[type=int_parsing, input_value='secret_b', input_type=str]"
+                    ),
+                }
+            ]
+        }
+    }
+
+    sentry_mod._before_send(event, {})
+
+    scrubbed = event["exception"]["values"][0]["value"]
+    assert "secret_a" not in scrubbed
+    assert "secret_b" not in scrubbed
+    assert scrubbed.count("input_value=[Filtered]") == 2
+
+
+def test_scrub_exception_value_is_idempotent() -> None:
+    # Re-scrubbing an already-scrubbed message must be a no-op. Guards
+    # against a future refactor that runs the scrub pass twice (e.g. once
+    # in before_send and once in a downstream hook).
+    once = sentry_mod._scrub_exception_value(
+        "[type=string_too_short, input_value='leaky', input_type=str]"
+    )
+    twice = sentry_mod._scrub_exception_value(once)
+    assert once == twice
+    assert "leaky" not in once
+
+
 def test_before_breadcrumb_strips_query_string_for_http_categories() -> None:
     crumb = {
         "category": "httpx",

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -425,6 +425,16 @@ def test_scrub_exception_value_is_idempotent() -> None:
     assert "leaky" not in once
 
 
+def test_scrub_exception_value_handles_truncated_message_without_input_type() -> None:
+    # Defense in depth (flagged by Greptile review): a custom-rendered or
+    # truncated message that ends mid-bracket with no `, input_type=` after
+    # the secret must still be scrubbed, not silently leaked.
+    text = "1 validation error\napi_token\n  bad [type=str, input_value='sk-leak'"
+    scrubbed = sentry_mod._scrub_exception_value(text)
+    assert "sk-leak" not in scrubbed
+    assert "input_value=[Filtered]" in scrubbed
+
+
 def test_before_breadcrumb_strips_query_string_for_http_categories() -> None:
     crumb = {
         "category": "httpx",

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -307,6 +307,82 @@ def test_before_send_scrubs_home_paths_in_stack_frames() -> None:
     assert frame["vars"]["auth_token"] == "[Filtered]"
 
 
+def test_before_send_scrubs_pydantic_input_value_from_exception_message() -> None:
+    """Pydantic V2 ValidationError renders ``input_value=<raw>`` inside the
+    exception message. When the failing field is a secret (api_token,
+    password, ...), the raw value lands in ``exception.values[].value`` and
+    bypasses the key-based scrubbers. ``_scrub_event_in_place`` strips it
+    before transport.
+    """
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValidationError",
+                    "value": (
+                        "1 validation error for VercelConfig\n"
+                        "api_token\n"
+                        "  String should match pattern '...' "
+                        "[type=string_pattern_mismatch, "
+                        "input_value='sk-real-secret-token-xyz', "
+                        "input_type=str]"
+                    ),
+                }
+            ]
+        }
+    }
+
+    sentry_mod._before_send(event, {})
+
+    scrubbed = event["exception"]["values"][0]["value"]
+    assert "sk-real-secret-token-xyz" not in scrubbed
+    assert "input_value=[Filtered]" in scrubbed
+    # Surrounding triage context must survive — only the value is stripped.
+    assert "ValidationError" in event["exception"]["values"][0]["type"]
+    assert "api_token" in scrubbed
+    assert "string_pattern_mismatch" in scrubbed
+
+
+def test_before_send_scrubs_input_value_across_multiple_errors() -> None:
+    # Multi-field ValidationError: every input_value occurrence must be stripped.
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValidationError",
+                    "value": (
+                        "2 validation errors for Demo\n"
+                        "api_key\n"
+                        "  String should have at least 10 characters "
+                        "[type=string_too_short, input_value='leaky-api-key', input_type=str]\n"
+                        "password\n"
+                        "  Input should be a valid string "
+                        "[type=string_type, input_value='p4ssword!', input_type=str]"
+                    ),
+                }
+            ]
+        }
+    }
+
+    sentry_mod._before_send(event, {})
+
+    scrubbed = event["exception"]["values"][0]["value"]
+    assert "leaky-api-key" not in scrubbed
+    assert "p4ssword!" not in scrubbed
+    assert scrubbed.count("input_value=[Filtered]") == 2
+
+
+def test_before_send_leaves_unrelated_exception_messages_alone() -> None:
+    # A non-pydantic message must pass through verbatim (modulo home-path
+    # substitution which is the existing behaviour for strings).
+    original = "ConnectionError: cannot connect to 10.0.0.1:5432"
+    event = {"exception": {"values": [{"type": "ConnectionError", "value": original}]}}
+
+    sentry_mod._before_send(event, {})
+
+    assert event["exception"]["values"][0]["value"] == original
+
+
 def test_before_breadcrumb_strips_query_string_for_http_categories() -> None:
     crumb = {
         "category": "httpx",


### PR DESCRIPTION
Fixes #1468

#### Describe the changes you have made in this PR -

`app/integrations/_catalog_impl.py` was swallowing failures in three places: 31 `except Exception: return None, None` sites in `_classify_service_instance`, two `except Exception: pass` sites and nine `logger.debug(..., exc_info=True)` debug-only sites in `load_env_integrations`, plus six unguarded `model_validate` calls that aborted the entire discovery loop on any validation error. All of those now route through two helpers (`_report_classify_failure`, `_report_env_loader_failure`) backed by `report_exception` with `severity=warning`. The historic caller contract (skip the integration) is preserved.

`app/utils/sentry_sdk.py` was missing a scrub pass over `exception.values[].value`. Pydantic V2 renders `input_value=<repr>` in its `ValidationError` message, so any failing config field with a secret value (`api_token`, `password`, …) would have leaked the raw value to Sentry once the env-loader catches above started routing through `report_exception`. Added `_scrub_exception_value` and wired it into `_scrub_event_in_place`.

### Demo/Screenshot for feature changes and bug fixes -

```
$ uv run pytest tests/integrations/test_catalog_silent_fallback_elimination.py tests/test_sentry_init.py -q
............................................................                  [ 50%]
............................................................                  [100%]
120 passed in 1.42s
```

Scrub demo — before/after for a pydantic ValidationError carrying a secret:

```
# input (as it would land in event['exception']['values'][0]['value'])
1 validation error for VercelConfig
api_token
  String should match pattern '...' [type=string_pattern_mismatch, input_value='sk-real-secret-token', input_type=str]

# after _scrub_exception_value
1 validation error for VercelConfig
api_token
  String should match pattern '...' [type=string_pattern_mismatch, input_value=[Filtered], input_type=str]
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The first commit is `0xghost42`'s closed PR #1986 cherry-picked verbatim so their authorship is preserved on the mechanical Pattern A/B/C work. I read the diff line-by-line before carrying it forward to confirm the caller contracts (`(None, None)` for classify, "skip" for env-loader) are unchanged. The two new helpers wrap `report_exception` with structured `surface`/`component`/`integration`/`event` tags so dashboards can group by vendor and by event class.

The second commit extends the same Pattern C shape to the six vendors `load_env_integrations` was still calling `model_validate` on inline. I considered factoring the boilerplate into a generic `_safe_env_record` helper but the per-vendor blocks differ enough in their env-var shapes and post-validate field checks that a generic helper would just add a layer without removing repetition. The "loop did not abort" regression test enables vercel + incident_io (chosen because incident_io is loaded *after* vercel — a survivor loaded earlier would have passed the assertion even when the loop aborts on vercel, which is the bug we're guarding against).

The scrub commit covers the exception-message string explicitly because the existing key-based scrubbers (`_scrub_extra`, stacktrace `vars`) never walk it. The regex `r"input(?:_value)?=.*?(?=,\s*input_type=|\Z)"` strips up to the next pydantic field separator. I considered the simpler `r"input(?:_value)?=[^,\]]+"` but it would over-match on values containing `,` (e.g. dict/tuple reprs). The `|\Z` end-of-string fallback is for truncated or custom-rendered messages where `, input_type=` isn't present. The placeholder `input_value=[Filtered]` is idempotent under re-application because the lookahead does not match the trailing `]` of the replacement.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions