### PR TITLE
fix(integrations): eliminate silent env-loader fallbacks in _catalog_impl (#1468)

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -62,8 +62,54 @@ from app.integrations.supabase import build_supabase_config
 from app.llm_credentials import resolve_env_credential
 from app.services.vercel import VercelConfig
 from app.utils.coercion import safe_int
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
+
+
+def _report_classify_failure(exc: BaseException, *, integration: str, record_id: str) -> None:
+    """Route a per-instance classify failure to Sentry + warning log.
+
+    Replaces the historic ``except Exception: return None, None`` pattern in
+    ``_classify_service_instance``: the caller still gets ``(None, None)``
+    and skips the integration, but the failure is now visible to operators
+    instead of being silently swallowed (#1468).
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"classify_failed: integration={integration} record_id={record_id}",
+        severity="warning",
+        tags={
+            "surface": "integration",
+            "component": "app.integrations._catalog_impl",
+            "integration": integration,
+            "event": "classify_failed",
+        },
+        extras={"record_id": record_id},
+    )
+
+
+def _report_env_loader_failure(exc: BaseException, *, integration: str) -> None:
+    """Route a per-vendor env-loader failure to Sentry + warning log.
+
+    Replaces ``except Exception: pass`` and ``logger.debug(..., exc_info=True)``
+    paths in ``load_env_integrations``: integration is still skipped, but the
+    misconfiguration reaches Sentry rather than being lost to debug output
+    (#1468).
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"env_loader_failed: integration={integration}",
+        severity="warning",
+        tags={
+            "surface": "integration",
+            "component": "app.integrations._catalog_impl",
+            "integration": integration,
+            "event": "env_loader_failed",
+        },
+    )
 
 
 def _should_publish_instance_siblings(instances: object) -> bool:
@@ -167,7 +213,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if not grafana_config.endpoint:
             return None, None
@@ -199,7 +246,8 @@ def _classify_service_instance(
                 AWSIntegrationConfig.model_validate(raw_config).model_dump(exclude_none=True),
                 "aws",
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
 
     if key == "datadog":
@@ -212,7 +260,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if datadog_config.api_key and datadog_config.app_key:
             return datadog_config.model_dump(), "datadog"
@@ -228,7 +277,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if honeycomb_config.api_key:
             return honeycomb_config.model_dump(), "honeycomb"
@@ -245,7 +295,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if coralogix_config.api_key:
             return coralogix_config.model_dump(), "coralogix"
@@ -264,7 +315,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return github_config.model_dump(), "github"
 
@@ -279,7 +331,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if sentry_config.organization_slug and sentry_config.auth_token:
             return sentry_config.model_dump(), "sentry"
@@ -293,7 +346,8 @@ def _classify_service_instance(
                     "auth_token": credentials.get("auth_token", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return gitlab_config.model_dump(), "gitlab"
 
@@ -307,7 +361,8 @@ def _classify_service_instance(
                     "tls": credentials.get("tls", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mongodb_config.connection_string:
             return mongodb_config.model_dump(), "mongodb"
@@ -325,7 +380,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "prefer"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if postgresql_config.host and postgresql_config.database:
             return postgresql_config.model_dump(), "postgresql"
@@ -343,7 +399,8 @@ def _classify_service_instance(
                     ),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if atlas_config.api_public_key and atlas_config.api_private_key and atlas_config.project_id:
             return {
@@ -367,7 +424,8 @@ def _classify_service_instance(
                     "ssl": credentials.get("ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mariadb_config.host and mariadb_config.database:
             return {
@@ -390,7 +448,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if vercel_config.api_token:
             return vercel_config.model_dump(), "vercel"
@@ -405,7 +464,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if opsgenie_config.api_key:
             return opsgenie_config.model_dump(), "opsgenie"
@@ -420,7 +480,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if incident_io_config.api_key:
             return incident_io_config.model_dump(), "incident_io"
@@ -437,7 +498,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if jira_config.base_url and jira_config.email and jira_config.api_token:
             return jira_config.model_dump(), "jira"
@@ -453,7 +515,8 @@ def _classify_service_instance(
                     "default_channel_id": credentials.get("default_channel_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if discord_config.bot_token:
             return discord_config.model_dump(), "discord"
@@ -467,7 +530,8 @@ def _classify_service_instance(
                     "default_chat_id": credentials.get("default_chat_id"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if tg_config.bot_token:
             return tg_config.model_dump(), "telegram"
@@ -499,7 +563,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if openclaw_config.is_configured:
             config_dict = openclaw_config.model_dump()
@@ -519,7 +584,8 @@ def _classify_service_instance(
                     "ssl_mode": credentials.get("ssl_mode", "preferred"),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if mysql_config.host and mysql_config.database:
             return {
@@ -546,7 +612,8 @@ def _classify_service_instance(
                     "verify_ssl": credentials.get("verify_ssl", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if rabbitmq_config.host and rabbitmq_config.username:
             return {
@@ -569,7 +636,8 @@ def _classify_service_instance(
                     "region": credentials.get("region", DEFAULT_RDS_REGION),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if rds_config.is_configured:
             return {**rds_config.model_dump(), "integration_id": record_id}, "rds"
@@ -588,7 +656,8 @@ def _classify_service_instance(
                     "max_results": credentials.get("max_results", 50),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if airflow_config.is_configured:
             return {
@@ -607,7 +676,8 @@ def _classify_service_instance(
                     "sources": credentials.get("sources", []),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if bs_config.query_endpoint and bs_config.username:
             return {
@@ -632,7 +702,8 @@ def _classify_service_instance(
                     "encrypt": credentials.get("encrypt", True),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if azure_sql_config.server and azure_sql_config.database:
             return azure_sql_config.model_dump(), "azure_sql"
@@ -649,7 +720,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if alertmanager_config.base_url:
             return alertmanager_config.model_dump(), "alertmanager"
@@ -671,7 +743,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if argocd_config.base_url and (
             argocd_config.bearer_token or (argocd_config.username and argocd_config.password)
@@ -694,7 +767,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         return helm_config.model_dump(), "helm"
 
@@ -707,7 +781,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if victoria_logs_config.base_url:
             return victoria_logs_config.model_dump(), "victoria_logs"
@@ -816,7 +891,8 @@ def _classify_service_instance(
                     "integration_id": record_id,
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if splunk_config.base_url and splunk_config.token:
             return splunk_config.model_dump(), "splunk"
@@ -830,7 +906,8 @@ def _classify_service_instance(
                     "service_key": credentials.get("service_key", ""),
                 }
             )
-        except Exception:
+        except Exception as exc:
+            _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
         if sb_config.is_configured:
             return {
@@ -1207,9 +1284,10 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "verify_ssl": os.getenv("ARGOCD_VERIFY_SSL", "true").strip(),
                 }
             )
-        except Exception:
-            # invalid env-derived config: skip ArgoCD entry rather than fail discovery
-            pass
+        except Exception as exc:
+            # Invalid env-derived config: skip ArgoCD entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="argocd")
         else:
             integrations.append(
                 _active_env_record(
@@ -1233,8 +1311,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "default_namespace": os.getenv("HELM_NAMESPACE", "").strip(),
                 }
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="helm")
         else:
             integrations.append(
                 _active_env_record(
@@ -1282,8 +1360,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     "base_url": os.getenv("INCIDENT_IO_BASE_URL", "").strip(),
                 }
             )
-        except Exception:
-            logger.debug("Failed to load incident.io config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="incident_io")
         else:
             integrations.append(
                 _active_env_record(
@@ -1401,8 +1479,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     },
                 )
             )
-        except Exception:
-            logger.debug("Failed to load OpenClaw config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="openclaw")
 
     mariadb_host = os.getenv("MARIADB_HOST", "").strip()
     mariadb_database = os.getenv("MARIADB_DATABASE", "").strip()
@@ -1424,8 +1502,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     mariadb_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load MariaDB config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="mariadb")
 
     rabbitmq_host = os.getenv("RABBITMQ_HOST", "").strip()
     rabbitmq_username = os.getenv("RABBITMQ_USERNAME", "").strip()
@@ -1450,14 +1528,14 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     rabbitmq_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load RabbitMQ config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="rabbitmq")
 
     try:
         rds_config = rds_config_from_env()
-    except Exception:
+    except Exception as exc:
         rds_config = None
-        logger.debug("Failed to load RDS config from env", exc_info=True)
+        _report_env_loader_failure(exc, integration="rds")
     if rds_config is not None and rds_config.is_configured:
         integrations.append(
             _active_env_record(
@@ -1484,8 +1562,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     bs_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Better Stack config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="betterstack")
 
     mysql_host = os.getenv("MYSQL_HOST", "").strip()
     mysql_database = os.getenv("MYSQL_DATABASE", "").strip()
@@ -1648,8 +1726,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     alertmanager_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Alertmanager config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="alertmanager")
 
     victoria_logs_url = os.getenv("VICTORIA_LOGS_URL", "").strip().rstrip("/")
     if victoria_logs_url:
@@ -1666,8 +1744,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     victoria_logs_config.model_dump(exclude={"integration_id"}),
                 )
             )
-        except Exception:
-            logger.debug("Failed to load VictoriaLogs config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="victoria_logs")
 
     splunk_multi = _parse_instances_env("SPLUNK_INSTANCES", "splunk")
     if splunk_multi is not None:
@@ -1705,8 +1783,8 @@ def load_env_integrations() -> list[dict[str, Any]]:
                     {"project_url": sb_config.url},
                 )
             )
-        except Exception:
-            logger.debug("Failed to load Supabase config from env", exc_info=True)
+        except Exception as exc:
+            _report_env_loader_failure(exc, integration="supabase")
 
     try:
         signoz_config = signoz_config_from_env()

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -37,6 +37,31 @@ _SENSITIVE_KEY_SUBSTRINGS: tuple[str, ...] = (
     "auth",
     "credential",
 )
+# Pydantic ValidationError and Python's default exception ``__str__`` render offending
+# values verbatim into the exception message — e.g. ``input_value={'api_key': 'sk-...'}``
+# or ``KeyError: "password='abc'"``. The structured scrubbers walk request/extra/locals
+# but not ``exception.values[].value``, so without this pass raw secrets reach Sentry.
+# Matches a sensitive-looking key followed by ``=`` or ``:`` (dict literal, kwargs repr,
+# or printf-style message) and replaces the value with ``[Filtered]`` while keeping the
+# key for grouping/debuggability.
+_SECRET_IN_MESSAGE_RE: re.Pattern[str] = re.compile(
+    r"""
+    (                                       # group 1: key + separator (kept)
+        ['"]?
+        \w*
+        (?:token|key|secret|password|auth|credential|bearer|dsn|cookie)
+        \w*
+        ['"]?
+        \s*[:=]\s*
+    )
+    (?:                                     # value (replaced)
+        '[^']*'
+        | "[^"]*"
+        | [^\s,'")}\]]+
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 _SENSITIVE_HEADERS: frozenset[str] = frozenset(
     {"authorization", "cookie", "set-cookie", "x-api-key"}
 )
@@ -203,6 +228,10 @@ def _scrub_stacktrace_frames(frames: list[dict[str, Any]]) -> None:
                     local_vars[key] = _scrub_string(value)
 
 
+def _scrub_exception_message(value: str) -> str:
+    return _SECRET_IN_MESSAGE_RE.sub(r"\1[Filtered]", value)
+
+
 def _scrub_event_in_place(event: dict[str, Any]) -> None:
     request = event.get("request")
     if isinstance(request, dict):
@@ -215,7 +244,12 @@ def _scrub_event_in_place(event: dict[str, Any]) -> None:
     exception = event.get("exception")
     if isinstance(exception, dict):
         for entry in exception.get("values", []) or []:
-            stacktrace = entry.get("stacktrace") if isinstance(entry, dict) else None
+            if not isinstance(entry, dict):
+                continue
+            message = entry.get("value")
+            if isinstance(message, str):
+                entry["value"] = _scrub_exception_message(message)
+            stacktrace = entry.get("stacktrace")
             if isinstance(stacktrace, dict):
                 frames = stacktrace.get("frames")
                 if isinstance(frames, list):

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -1,0 +1,268 @@
+"""Tests for #1468: eliminate silent env-loader / classify fallbacks.
+
+Three patterns previously dropped exceptions to ``(None, None)``, ``pass``,
+or ``logger.debug(..., exc_info=True)`` with no Sentry trace:
+
+  A. ``_classify_service_instance`` per-vendor ``try/except Exception``
+     blocks (33 sites covering grafana .. supabase).
+  B. ``load_env_integrations`` argocd + helm ``except Exception: pass``.
+  C. ``load_env_integrations`` debug-only env loaders (incident_io,
+     openclaw, mariadb, rabbitmq, rds, betterstack, alertmanager,
+     victoria_logs, supabase).
+
+After the fix every site routes through ``_report_classify_failure`` or
+``_report_env_loader_failure``, which call ``report_exception`` with
+``surface=integration``, ``component=app.integrations._catalog_impl``,
+``event=classify_failed`` / ``event=env_loader_failed``, and the vendor
+tag — preserving the historic "skip the integration" caller contract.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.integrations._catalog_impl import (
+    _classify_service_instance,
+    _report_classify_failure,
+    _report_env_loader_failure,
+    load_env_integrations,
+)
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+
+
+# ---------------------------------------------------------------------------
+# Helper smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_classify_failure_forwards_tags() -> None:
+    exc = ValueError("bad config")
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_classify_failure(exc, integration="datadog", record_id="rec-1")
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "integration",
+        "component": "app.integrations._catalog_impl",
+        "integration": "datadog",
+        "event": "classify_failed",
+    }
+    assert kwargs["extras"] == {"record_id": "rec-1"}
+
+
+def test_report_env_loader_failure_forwards_tags() -> None:
+    exc = RuntimeError("env missing")
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_env_loader_failure(exc, integration="rabbitmq")
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "integration",
+        "component": "app.integrations._catalog_impl",
+        "integration": "rabbitmq",
+        "event": "env_loader_failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pattern A: _classify_service_instance routes failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+# Per-vendor: the symbol inside ``app.integrations._catalog_impl`` whose
+# constructor we force to raise, so we can prove the surrounding try/except
+# now routes the failure through ``report_exception`` instead of returning
+# ``(None, None)`` silently. Patching is more reliable than crafting bad
+# credentials, since validator strictness drifts per integration.
+_CLASSIFY_PATCH_TARGETS: list[tuple[str, str]] = [
+    ("grafana", "GrafanaIntegrationConfig"),
+    ("aws", "AWSIntegrationConfig"),
+    ("datadog", "DatadogIntegrationConfig"),
+    ("honeycomb", "HoneycombIntegrationConfig"),
+    ("coralogix", "CoralogixIntegrationConfig"),
+    ("github", "build_github_mcp_config"),
+    ("sentry", "build_sentry_config"),
+    ("gitlab", "build_gitlab_config"),
+    ("mongodb", "build_mongodb_config"),
+    ("postgresql", "build_postgresql_config"),
+    ("mongodb_atlas", "build_mongodb_atlas_config"),
+    ("mariadb", "build_mariadb_config"),
+    ("vercel", "VercelConfig"),
+    ("opsgenie", "OpsGenieIntegrationConfig"),
+    ("incident_io", "IncidentIoIntegrationConfig"),
+    ("jira", "JiraIntegrationConfig"),
+    ("discord", "DiscordBotConfig"),
+    ("telegram", "TelegramBotConfig"),
+    ("openclaw", "build_openclaw_config"),
+    ("mysql", "build_mysql_config"),
+    ("rabbitmq", "build_rabbitmq_config"),
+    ("rds", "build_rds_config"),
+    ("airflow", "build_airflow_config"),
+    ("betterstack", "build_betterstack_config"),
+    ("azure_sql", "build_azure_sql_config"),
+    ("alertmanager", "AlertmanagerIntegrationConfig"),
+    ("argocd", "ArgoCDIntegrationConfig"),
+    ("helm", "HelmIntegrationConfig"),
+    ("victoria_logs", "VictoriaLogsIntegrationConfig"),
+    ("splunk", "SplunkIntegrationConfig"),
+    ("supabase", "build_supabase_config"),
+]
+
+
+@pytest.mark.parametrize(("integration", "patch_symbol"), _CLASSIFY_PATCH_TARGETS)
+def test_classify_failure_skips_integration_and_reports(
+    integration: str,
+    patch_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every Pattern A site (``_classify_service_instance``) must still return
+    ``(None, None)`` *and* now route the exception through
+    ``report_exception`` with ``event=classify_failed`` and the vendor tag."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = _classify_service_instance(
+            integration,
+            {"endpoint": "https://x", "api_key": "k"},
+            record_id=f"rec-{integration}",
+        )
+
+    assert result == (None, None), (
+        f"caller contract broken for {integration}: must still skip integration"
+    )
+    assert mock_report.call_count == 1, (
+        f"{integration} silently swallowed exception (no report_exception call)"
+    )
+    tags = mock_report.call_args.kwargs["tags"]
+    assert tags["integration"] == integration
+    assert tags["event"] == "classify_failed"
+    assert tags["surface"] == "integration"
+    assert mock_report.call_args.kwargs["severity"] == "warning"
+    assert mock_report.call_args.kwargs["extras"]["record_id"] == f"rec-{integration}"
+
+
+# ---------------------------------------------------------------------------
+# Pattern B + C: load_env_integrations routes loader failures to Sentry
+# ---------------------------------------------------------------------------
+
+
+# For each env-loader case: env vars to enable the loader path + the symbol in
+# ``app.integrations._catalog_impl`` to patch so its constructor raises. This
+# proves the exception is *caught* and *routed* — without depending on which
+# fields the real builder rejects (validator details drift independently).
+_ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
+    # Pattern B
+    (
+        "argocd",
+        {"ARGOCD_BASE_URL": "https://argo.example", "ARGOCD_AUTH_TOKEN": "t"},
+        "ArgoCDIntegrationConfig",
+    ),
+    (
+        "helm",
+        {"OSRE_HELM_INTEGRATION": "1"},
+        "HelmIntegrationConfig",
+    ),
+    # Pattern C
+    (
+        "incident_io",
+        {"INCIDENT_IO_API_KEY": "k"},
+        "IncidentIoIntegrationConfig",
+    ),
+    (
+        "mariadb",
+        {"MARIADB_HOST": "h", "MARIADB_DATABASE": "d"},
+        "build_mariadb_config",
+    ),
+    (
+        "rabbitmq",
+        {"RABBITMQ_HOST": "h", "RABBITMQ_USERNAME": "u"},
+        "build_rabbitmq_config",
+    ),
+    (
+        "betterstack",
+        {"BETTERSTACK_QUERY_ENDPOINT": "https://bs.example", "BETTERSTACK_USERNAME": "u"},
+        "build_betterstack_config",
+    ),
+    (
+        "alertmanager",
+        {"ALERTMANAGER_URL": "https://am.example"},
+        "AlertmanagerIntegrationConfig",
+    ),
+    (
+        "victoria_logs",
+        {"VICTORIA_LOGS_URL": "https://vl.example"},
+        "VictoriaLogsIntegrationConfig",
+    ),
+    (
+        "supabase",
+        {"SUPABASE_URL": "https://s.example", "SUPABASE_SERVICE_KEY": "k"},
+        "build_supabase_config",
+    ),
+    (
+        "openclaw",
+        {"OPENCLAW_MCP_URL": "https://oc.example"},
+        "build_openclaw_config",
+    ),
+    (
+        "rds",
+        {},
+        "rds_config_from_env",
+    ),
+]
+
+
+@pytest.mark.parametrize(("integration", "env", "patch_symbol"), _ENV_LOADER_CASES)
+def test_env_loader_failure_reports_and_skips(
+    integration: str,
+    env: dict[str, str],
+    patch_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pattern B + C: when a vendor's env-derived builder raises, the
+    integration must be skipped (preserving the historic caller contract)
+    *and* the failure must reach Sentry via ``report_exception``."""
+    # Clear ambient env so other integrations on the dev box don't enable
+    # unrelated paths and inflate the assertion.
+    for var in list(os.environ):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = load_env_integrations()
+
+    services = {entry["service"] for entry in result}
+    assert integration not in services, f"{integration} must be skipped when its env loader fails"
+
+    matching = [
+        call
+        for call in mock_report.call_args_list
+        if call.kwargs.get("tags", {}).get("integration") == integration
+    ]
+    assert matching, (
+        f"{integration} env-loader failure was swallowed silently — expected "
+        "report_exception call with event=env_loader_failed"
+    )
+    tags = matching[0].kwargs["tags"]
+    assert tags["event"] == "env_loader_failed"
+    assert tags["surface"] == "integration"
+    assert matching[0].kwargs["severity"] == "warning"

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -307,6 +307,74 @@ def test_before_send_scrubs_home_paths_in_stack_frames() -> None:
     assert frame["vars"]["auth_token"] == "[Filtered]"
 
 
+def test_before_send_scrubs_secrets_in_exception_message() -> None:
+    """Pydantic ``ValidationError`` renders the offending value into the message
+    body (``input_value={'api_key': 'sk-leaked'}``). Without scrubbing the
+    ``exception.values[].value`` string, the raw key escapes the SDK."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValidationError",
+                    "value": (
+                        "1 validation error for VercelConfig\n"
+                        "api_key\n"
+                        "  Input should be a valid string, got int "
+                        "[type=string_type, input_value={'api_key': 'sk-leaked-1234', "
+                        "'project_id': 'prj_x'}, input_type=dict]"
+                    ),
+                }
+            ]
+        }
+    }
+
+    sentry_mod._before_send(event, {})
+
+    value = event["exception"]["values"][0]["value"]
+    assert "sk-leaked-1234" not in value
+    assert "[Filtered]" in value
+    # Non-secret fields are preserved so grouping/debuggability survive.
+    assert "prj_x" in value
+    assert "VercelConfig" in value
+
+
+@pytest.mark.parametrize(
+    "message,leaked",
+    [
+        ("api_key='sk-abc'", "sk-abc"),
+        ("token: 'gho_xxx'", "gho_xxx"),
+        ('password="hunter2"', "hunter2"),
+        ("{'auth_token': 'lk-1'}", "lk-1"),
+    ],
+)
+def test_before_send_scrubs_inline_secret_forms(message: str, leaked: str) -> None:
+    event = {"exception": {"values": [{"type": "RuntimeError", "value": message}]}}
+
+    sentry_mod._before_send(event, {})
+
+    assert leaked not in event["exception"]["values"][0]["value"]
+
+
+def test_before_send_leaves_unrelated_messages_intact() -> None:
+    """Regression — operator-actionable LLM routing relies on substrings like
+    ``MINIMAX_API_KEY to be set`` matching after scrubbing; the message scrub
+    must not over-redact when no ``key=value`` pattern is present."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "RuntimeError",
+                    "value": "Connection refused to upstream service",
+                }
+            ]
+        }
+    }
+
+    sentry_mod._before_send(event, {})
+
+    assert event["exception"]["values"][0]["value"] == "Connection refused to upstream service"
+
+
 def test_before_breadcrumb_strips_query_string_for_http_categories() -> None:
     crumb = {
         "category": "httpx",


### PR DESCRIPTION
Re-open of #1986 with the PII-scrub gap that @cerencamkiran and @WatchTree-19 flagged closed out, and a rebase on `main` to clear stale conflicts.

## Scope

Same as #1986:

- 31 `except Exception: return None, None` sites in `_classify_service_instance` → `_report_classify_failure(exc, integration=..., record_id=...)`.
- 11 `except Exception: pass` / `logger.debug` sites in `load_env_integrations` → `_report_env_loader_failure(exc, integration=...)`.
- Caller contracts unchanged — integrations still skipped on error, just no longer invisibly.

Follow-up issue [#2036](https://github.com/Tracer-Cloud/opensre/issues/2036) still tracks the 6 unguarded `model_validate()` paths in `load_env_integrations` (vercel/opsgenie/jira/discord/telegram/mongodb_atlas) — held out of scope to keep this PR a near-merge change.

## New in this re-open: exception-message PII scrub

The Pydantic-validator gap raised on #1986:

> Now that these env-loader failures are routed through "report_exception", some Pydantic "ValidationError" messages could end up sending raw "api_key" or "password" values to Sentry.

That's a real leak vector — `_scrub_event_in_place` walked `request` / `extra` / stacktrace `vars` but not `exception.values[].value`, so a failed `model_validate({"api_key": "sk-..."})` would ship `input_value={'api_key': 'sk-...'}` to Sentry verbatim.

This PR adds `_SECRET_IN_MESSAGE_RE` and runs every `exception.values[].value` string through it before the SDK transports the event:

- Matches sensitive-looking keys (`*token`, `*key`, `*secret`, `*password`, `auth`, `credential`, `bearer`, `dsn`, `cookie`) followed by `=` or `:`.
- Replaces the value with `[Filtered]` while preserving the key for Sentry grouping and debuggability.
- Operator-actionable LLM routing patterns (e.g. `requires MINIMAX_API_KEY to be set`) are unaffected — they don't carry a `key=value` separator.

Regression coverage in `tests/test_sentry_init.py`:

- Full Pydantic `ValidationError` payload (`VercelConfig` rejecting an `api_key=`).
- Parametrised dict-literal / kwargs / single + double-quoted forms.
- Negative case: unrelated `Connection refused` message is left intact (guards against over-redaction).

## Verification

- `make test-cov` → 7002 passed, 6 skipped
- `make lint` → clean
- `make format-check` → clean

## What's NOT changed

- Routing logic in `_before_send` order is preserved — `_event_has_operator_actionable_llm_error` runs **before** scrubbing, so LLM auth-failure drops are unaffected by the new message rewrite.
- No new dependencies, no public-API change.

Will trigger Greptile review after open.