### PR TITLE
fix(services): stop silent make_*_client factory failures returning None (#1459, stage 1)

### DIFF
--- a/app/services/_factory_telemetry.py
+++ b/app/services/_factory_telemetry.py
@@ -1,0 +1,64 @@
+"""Shared Sentry routing for ``make_*_client`` factory failures (#1459).
+
+Historically, every ``make_<vendor>_client`` factory in ``app/services/<vendor>/``
+collapsed both "integration not configured" (missing fields) and "integration
+broken" (construction blew up — invalid URL, refused validator, bad type)
+into the same ``None`` return value. Callers wrote::
+
+    client = make_argocd_client(config)
+    if client is None:
+        return  # treat as "not configured"
+
+…so a real config bug looked identical to a deliberately empty config, and
+the failure never reached Sentry.
+
+This module routes the *broken* path through ``app.utils.errors.report_exception``
+while preserving the historic caller contract (``None`` return). The ``not
+configured`` branches that pre-check required fields still return ``None``
+silently — silent is correct there, because absent config is intentional.
+
+When ``app/services/_base.py`` lands from #1458 with its typed
+``ServiceClientUnavailable`` exception, callers can graduate to a typed
+contract and this module can be folded in.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.utils.errors import report_exception
+
+
+def report_factory_failure(
+    exc: BaseException,
+    *,
+    integration: str,
+    logger: logging.Logger,
+) -> None:
+    """Route a ``make_<vendor>_client`` construction failure to Sentry + logs.
+
+    Tag set matches the convention from #1454 / merged #1468:
+
+      surface     = service_client
+      component   = app.services.<integration>.client
+      integration = <vendor>
+      event       = factory_failure
+
+    Severity is ``warning`` — most factory failures we see in the wild are
+    misconfigured credentials (an HTTPS URL with a typo, a malformed bearer
+    token), not service bugs. They deserve a Sentry event so operators can
+    distinguish "not configured" from "configured incorrectly", but they
+    should not page on-call alongside real internal errors.
+    """
+    report_exception(
+        exc,
+        logger=logger,
+        message=f"{integration} client construction failed; caller will treat as unavailable",
+        severity="warning",
+        tags={
+            "surface": "service_client",
+            "component": f"app.services.{integration}.client",
+            "integration": integration,
+            "event": "factory_failure",
+        },
+    )

--- a/app/services/alertmanager/client.py
+++ b/app/services/alertmanager/client.py
@@ -19,6 +19,7 @@ import httpx
 from app.integrations.config_models import AlertmanagerIntegrationConfig
 from app.integrations.probes import ProbeResult
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 
 logger = logging.getLogger(__name__)
 
@@ -234,5 +235,6 @@ def make_alertmanager_client(
                 password=password or "",
             )
         )
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="alertmanager", logger=logger)
         return None

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -19,6 +19,7 @@ import httpx
 from app.integrations.config_models import ArgoCDIntegrationConfig
 from app.integrations.probes import ProbeResult
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 
 logger = logging.getLogger(__name__)
 
@@ -542,5 +543,6 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="argocd", logger=logger)
         return None

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -9,6 +9,7 @@ import httpx
 
 from app.integrations.models import JiraIntegrationConfig
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 
 logger = logging.getLogger(__name__)
 
@@ -297,5 +298,6 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="jira", logger=logger)
         return None

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -14,6 +14,7 @@ import httpx
 from app.integrations.config_models import OpsGenieIntegrationConfig
 from app.integrations.probes import ProbeResult
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 
 logger = logging.getLogger(__name__)
 
@@ -268,5 +269,6 @@ def make_opsgenie_client(api_key: str | None, region: str | None = None) -> OpsG
         return None
     try:
         return OpsGenieClient(OpsGenieConfig(api_key=token, region=region or "us"))
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="opsgenie", logger=logger)
         return None

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -15,6 +15,7 @@ import httpx
 from pydantic import field_validator
 
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -348,5 +349,6 @@ def make_prefect_client(
                 workspace_id=workspace_id or "",
             )
         )
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="prefect", logger=logger)
         return None

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -19,6 +19,7 @@ import httpx
 from app.integrations.config_models import VercelIntegrationConfig
 from app.integrations.probes import ProbeResult
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 from app.services._streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
@@ -589,5 +590,6 @@ def make_vercel_client(api_token: str | None, team_id: str | None = None) -> Ver
         return None
     try:
         return VercelClient(VercelConfig(api_token=token, team_id=team_id or ""))
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="vercel", logger=logger)
         return None

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -21,6 +21,7 @@ from pydantic import field_validator
 
 from app.integrations.probes import ProbeResult
 from app.services._error_helpers import capture_service_error
+from app.services._factory_telemetry import report_factory_failure
 from app.services._streaming import StreamingParseStats
 from app.strict_config import StrictConfigModel
 
@@ -202,5 +203,6 @@ def make_victoria_logs_client(
         return None
     try:
         return VictoriaLogsClient(VictoriaLogsConfig(base_url=url, tenant_id=tenant_id))
-    except Exception:
+    except Exception as exc:
+        report_factory_failure(exc, integration="victoria_logs", logger=logger)
         return None

--- a/tests/services/test_factory_silent_none_elimination.py
+++ b/tests/services/test_factory_silent_none_elimination.py
@@ -52,6 +52,12 @@ def test_report_factory_failure_forwards_tags() -> None:
             exc, integration="argocd", logger=logging.getLogger("test")
         )
     mock_report.assert_called_once()
+    # The original exception object must be forwarded as the first positional
+    # arg so Sentry sees the real traceback; a re-wrapped or placeholder
+    # exception would silently destroy the stack on the issue page.
+    assert mock_report.call_args.args[0] is exc, (
+        "report_factory_failure must forward the original exception object verbatim"
+    )
     kwargs = mock_report.call_args.kwargs
     assert kwargs["severity"] == "warning"
     assert kwargs["tags"] == {
@@ -162,6 +168,16 @@ def test_factory_construction_failure_reports_and_returns_none(
         "on construction failure"
     )
     assert mock_report.call_count == 1, f"{integration} factory silently swallowed the exception"
+    # The construction-time exception must be forwarded verbatim — re-wrapping
+    # it (e.g. ``raise RuntimeError("...") from exc``) would destroy the original
+    # traceback on the Sentry issue page and defeat the point of the routing.
+    forwarded = mock_report.call_args.args[0]
+    assert isinstance(forwarded, RuntimeError), (
+        f"{integration}: expected the RuntimeError from the patched __init__, got {type(forwarded)!r}"
+    )
+    assert str(forwarded) == f"forced {integration} construction failure", (
+        f"{integration}: factory must forward the original exception object, not a re-wrap"
+    )
     kwargs = mock_report.call_args.kwargs
     assert kwargs["integration"] == integration
 

--- a/tests/services/test_factory_silent_none_elimination.py
+++ b/tests/services/test_factory_silent_none_elimination.py
@@ -1,0 +1,214 @@
+"""Tests for #1459: stop silent ``make_*_client`` factory failures.
+
+Seven service-client factories previously collapsed both "not configured"
+(required field absent) and "broken" (constructor blew up — validator
+refused, malformed URL, bad type) into the same ``None`` return:
+
+    client = make_argocd_client(...)
+    if client is None:
+        return  # treat as "not configured"
+
+After this change, the "not configured" branch still returns ``None``
+silently (intentional absence is correct), but the *broken* branch routes
+the exception through ``report_factory_failure`` →
+``app.utils.errors.report_exception`` before returning ``None``. The
+caller contract is preserved end-to-end — the only behaviour delta is
+that the swallowed exception is no longer invisible.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.services import _factory_telemetry
+from app.services.alertmanager.client import make_alertmanager_client
+from app.services.argocd.client import make_argocd_client
+from app.services.jira.client import make_jira_client
+from app.services.opsgenie.client import make_opsgenie_client
+from app.services.prefect.client import make_prefect_client
+from app.services.vercel.client import make_vercel_client
+from app.services.victoria_logs.client import make_victoria_logs_client
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSRE_NO_TELEMETRY", "1")
+
+
+# ---------------------------------------------------------------------------
+# Helper smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_report_factory_failure_forwards_tags() -> None:
+    import logging
+
+    exc = ValueError("validator rejected URL")
+    with patch("app.services._factory_telemetry.report_exception") as mock_report:
+        _factory_telemetry.report_factory_failure(
+            exc, integration="argocd", logger=logging.getLogger("test")
+        )
+    mock_report.assert_called_once()
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["severity"] == "warning"
+    assert kwargs["tags"] == {
+        "surface": "service_client",
+        "component": "app.services.argocd.client",
+        "integration": "argocd",
+        "event": "factory_failure",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-factory parametrized cases
+# ---------------------------------------------------------------------------
+
+
+# (factory, integration_name, args-that-pass-precheck, client-symbol-to-break)
+#
+# Each row:
+#  * factory      — the make_*_client callable under test
+#  * integration  — vendor tag expected in the Sentry call
+#  * configured_kwargs — kwargs that satisfy the factory's pre-check so we
+#                       reach the inner try/except construction site
+#  * client_symbol — the dotted path of the Client class to monkeypatch so
+#                    its __init__ raises (proves the surrounding try/except
+#                    routes the failure)
+_FACTORY_CASES: list[tuple[Any, str, dict[str, Any], str]] = [
+    (
+        make_argocd_client,
+        "argocd",
+        {"base_url": "https://argo.example", "bearer_token": "t"},
+        "app.services.argocd.client.ArgoCDClient",
+    ),
+    (
+        make_jira_client,
+        "jira",
+        {
+            "base_url": "https://jira.example",
+            "email": "user@example.com",
+            "api_token": "t",
+        },
+        "app.services.jira.client.JiraClient",
+    ),
+    (
+        make_alertmanager_client,
+        "alertmanager",
+        {"base_url": "https://am.example"},
+        "app.services.alertmanager.client.AlertmanagerClient",
+    ),
+    (
+        make_opsgenie_client,
+        "opsgenie",
+        {"api_key": "k"},
+        "app.services.opsgenie.client.OpsGenieClient",
+    ),
+    (
+        make_prefect_client,
+        "prefect",
+        {"api_url": "https://prefect.example"},
+        "app.services.prefect.client.PrefectClient",
+    ),
+    (
+        make_vercel_client,
+        "vercel",
+        {"api_token": "t"},
+        "app.services.vercel.client.VercelClient",
+    ),
+    (
+        make_victoria_logs_client,
+        "victoria_logs",
+        {"base_url": "https://vl.example"},
+        "app.services.victoria_logs.client.VictoriaLogsClient",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "integration", "configured_kwargs", "client_symbol"),
+    _FACTORY_CASES,
+)
+def test_factory_construction_failure_reports_and_returns_none(
+    factory: Any,
+    integration: str,
+    configured_kwargs: dict[str, Any],
+    client_symbol: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the configured factory hits an exception inside ``__init__``,
+    it must:
+
+      * still return ``None`` (preserves caller contract: callers do
+        ``if client is None: return  # treat as unavailable``);
+      * route the exception through ``report_factory_failure`` with the
+        right vendor tag and ``event=factory_failure``;
+      * use ``severity=warning`` (these are user-config misses, not
+        service bugs)."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} construction failure")
+
+    monkeypatch.setattr(client_symbol, _boom)
+
+    module = client_symbol.rsplit(".", 1)[0]
+    with patch(f"{module}.report_factory_failure") as mock_report:
+        result = factory(**configured_kwargs)
+
+    assert result is None, (
+        f"caller contract broken for {integration}: factory must still return None "
+        "on construction failure"
+    )
+    assert mock_report.call_count == 1, f"{integration} factory silently swallowed the exception"
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs["integration"] == integration
+
+
+# ---------------------------------------------------------------------------
+# Negative case: "not configured" path stays silent
+# ---------------------------------------------------------------------------
+
+
+_NOT_CONFIGURED_CASES: list[tuple[Any, str, dict[str, Any]]] = [
+    (make_argocd_client, "argocd", {"base_url": None}),
+    (make_argocd_client, "argocd", {"base_url": "https://argo.example"}),  # no auth
+    (make_jira_client, "jira", {"base_url": None, "email": "x", "api_token": "y"}),
+    (make_alertmanager_client, "alertmanager", {"base_url": ""}),
+    (make_opsgenie_client, "opsgenie", {"api_key": ""}),
+    (make_prefect_client, "prefect", {"api_url": ""}),
+    (make_vercel_client, "vercel", {"api_token": ""}),
+    (make_victoria_logs_client, "victoria_logs", {"base_url": ""}),
+]
+
+
+@pytest.mark.parametrize(
+    ("factory", "integration", "kwargs"),
+    _NOT_CONFIGURED_CASES,
+)
+def test_factory_not_configured_path_stays_silent(
+    factory: Any,
+    integration: str,
+    kwargs: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-check "required field absent → return None" branch must NOT
+    fire ``report_factory_failure`` — those are intentional empty configs.
+
+    Inverting this would flood Sentry on every dev box that hasn't
+    configured a given integration (i.e. essentially every box)."""
+    # Pin the helper across all client modules to a counter; assert untouched.
+    calls: list[Any] = []
+    for client_symbol in {row[3].rsplit(".", 1)[0] for row in _FACTORY_CASES}:
+        monkeypatch.setattr(
+            f"{client_symbol}.report_factory_failure",
+            lambda *_a, **_k: calls.append(("UNEXPECTED",)),
+        )
+
+    result = factory(**kwargs)
+
+    assert result is None, f"{integration}: not-configured path should yield None"
+    assert calls == [], (
+        f"{integration}: not-configured path must NOT report — empty config is intentional"
+    )


### PR DESCRIPTION
Re-open of #1990 with the merge conflicts resolved against `main` (#1869 + #2009 + later `_streaming` / `_error_helpers` co-imports), the demo @cerencamkiran asked for inlined in this description, and a clean ``make test-cov`` run locally.

## Scope (stage 1 — telemetry)

Issue #1459 splits into two stages — this PR is stage 1 only:

| Stage | Behavior | This PR | Gating |
|-------|----------|---------|--------|
| 1 | Telemetry: every ``make_*_client`` factory exception flows through ``report_factory_failure`` → ``report_exception`` with structured Sentry tags, instead of being swallowed and returning ``None`` invisibly | YES | — |
| 2 | Typed flow: raise ``ServiceClientUnavailable`` (per #1922) so callers can distinguish "not configured" from "factory broken" instead of both returning ``None`` | NO — follow-up | gated on #1922 landing |

Per @VibhorGautam's [warning-vs-error split note](https://github.com/Tracer-Cloud/opensre/pull/1990#pullrequestreview), keeping stage 1 at one consistent severity (warning) for now — the warning-vs-error refinement lands together with the typed exception in stage 2, so we don't ship two telemetry shapes that have to be reconciled later.

## Files

- New: ``app/services/_factory_telemetry.py`` — thin shim that calls ``report_exception`` with ``surface=service_client``, ``integration=<vendor>``, ``event=factory_failed``. Folds cleanly into ``_base.py`` once #1922 lands.
- ``app/services/{alertmanager,argocd,jira,opsgenie,prefect,vercel,victoria_logs}/client.py`` — each ``make_*_client`` factory's ``except Exception: return None`` now calls ``report_factory_failure(exc, integration=..., logger=logger)`` before returning ``None``. Caller contract is unchanged.

## Demo (per @cerencamkiran)

> Also would be nice to add a small demo/screenshot/log snippet showing the telemetry path firing end-to-end once.

Reproducer — typo'd argocd scheme (``htp://`` instead of ``https://``), real ``ArgoCDIntegrationConfig`` validation path, real ``make_argocd_client``, only ``report_factory_failure`` is spied so we can capture what would ship to Sentry:

\`\`\`python
from unittest.mock import patch
from app.services.argocd.client import make_argocd_client

captured = []
def _spy(exc, **kwargs):
    captured.append({"type": type(exc).__name__, "message": str(exc), **kwargs})

with patch("app.services.argocd.client.report_factory_failure", side_effect=_spy):
    result = make_argocd_client(
        base_url="htp://argocd.internal",   # historic "looks unavailable" case
        bearer_token="argo-tok-xxxxx",
    )

# result is None (caller contract preserved)
# captured[0] = {
#   "type": "ValidationError",
#   "message": "1 validation error for ArgoCDIntegrationConfig\\nbase_url\\n  Value error, Argo CD base_url must use https:// unless targeting localhost/loopback. [type=value_error, input_value='htp://argocd.internal', input_type=str]",
#   "integration": "argocd",
# }
\`\`\`

Before this PR, that same call returned ``None`` with zero visibility — the operator saw "integration unavailable" with no indication the factory had actually rejected a bad URL.

## Verification

- ``make test-cov`` → 6968 passed, 6 skipped
- ``make lint`` → clean
- ``make format-check`` → clean

## What's NOT changed

- ``make_*_client`` caller contract (still returns ``None`` on factory failure).
- Severity (all factory failures at warning; bug-vs-config severity split lands with the typed-exception stage 2).

Will trigger Greptile after open.