### PR TITLE
fix(agent): _run_parallel survives interpreter shutdown race (#2194)

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import sys
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
@@ -478,11 +479,31 @@ def _run_parallel(
     if len(tool_calls) == 1:
         return [_call(tool_calls[0])]
 
+    # Interpreter teardown (Ctrl+C late in the run, atexit chain) races against
+    # ThreadPoolExecutor.submit and raises "cannot schedule new futures after
+    # interpreter shutdown" (#2194). Detect it up front, and treat any RuntimeError
+    # raised from submit during the same race as a signal to drop back to sequential
+    # execution so the investigation still completes instead of losing every tool call.
+    if sys.is_finalizing():
+        logger.debug("[_run_parallel] interpreter finalizing; running tools sequentially")
+        return [_call(tc) for tc in tool_calls]
+
     results: list[Any] = [None] * len(tool_calls)
-    with ThreadPoolExecutor(max_workers=min(_TOOL_EXECUTOR_WORKERS, len(tool_calls))) as pool:
-        futures = {pool.submit(_call, tc): i for i, tc in enumerate(tool_calls)}
-        for fut in as_completed(futures):
-            results[futures[fut]] = fut.result()
+    try:
+        with ThreadPoolExecutor(max_workers=min(_TOOL_EXECUTOR_WORKERS, len(tool_calls))) as pool:
+            futures = {pool.submit(_call, tc): i for i, tc in enumerate(tool_calls)}
+            for fut in as_completed(futures):
+                results[futures[fut]] = fut.result()
+    except RuntimeError as exc:
+        if "interpreter shutdown" not in str(exc):
+            raise
+        logger.warning(
+            "[_run_parallel] ThreadPoolExecutor raced with interpreter shutdown; "
+            "falling back to sequential tool execution",
+        )
+        for i, tc in enumerate(tool_calls):
+            if results[i] is None:
+                results[i] = _call(tc)
     return results
 
 

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -8,6 +8,7 @@ from app.agent.investigation import (
     ConnectedInvestigationAgent,
     _availability_view,
     _build_synthetic_assistant_tool_call_msg,
+    _run_parallel,
 )
 from app.services.agent_llm_client import CLIBackedAgentClient, ToolCall
 
@@ -182,3 +183,96 @@ def test_run_gracefully_handles_single_tool_call_only_model() -> None:
     assert "tool calling" in result["root_cause"].lower()
     assert result["remediation_steps"]
     assert result["causal_chain"]
+
+
+def _make_tool_call(name: str, id_: str = "call-1") -> ToolCall:
+    return ToolCall(id=id_, name=name, input={})
+
+
+def _registered_tool(name: str, run_value: object) -> MagicMock:
+    """Build a minimal stand-in for ``RegisteredTool`` that ``_run_parallel`` can drive."""
+    tool = MagicMock(name=f"tool[{name}]")
+    tool.name = name
+    tool.extract_params.return_value = {}
+    tool.run.return_value = run_value
+    return tool
+
+
+def test_run_parallel_falls_back_to_sequential_on_interpreter_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sentry-reported #2194: ``ThreadPoolExecutor.submit`` can race the interpreter
+    shutdown handlers and raise ``RuntimeError: cannot schedule new futures after
+    interpreter shutdown``. _run_parallel must catch that, drop back to sequential
+    execution, and surface real tool results instead of letting the investigation
+    lose every parallel tool call."""
+
+    def _boom_submit(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+    monkeypatch.setattr(
+        "app.agent.investigation.ThreadPoolExecutor.submit",
+        _boom_submit,
+    )
+
+    tool_calls = [_make_tool_call("alpha", id_="a"), _make_tool_call("beta", id_="b")]
+    tools = [
+        _registered_tool("alpha", {"out": "A"}),
+        _registered_tool("beta", {"out": "B"}),
+    ]
+
+    results = _run_parallel(tool_calls, tools, resolved_integrations={})
+
+    assert results == [{"out": "A"}, {"out": "B"}]
+
+
+def test_run_parallel_skips_executor_when_interpreter_is_finalizing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``sys.is_finalizing()`` is already true when _run_parallel is entered,
+    we should never touch the executor — go straight to sequential execution."""
+    monkeypatch.setattr("app.agent.investigation.sys.is_finalizing", lambda: True)
+
+    submit_calls: list[object] = []
+
+    def _track_submit(*args: object, **kwargs: object) -> None:
+        submit_calls.append((args, kwargs))
+        raise AssertionError("submit must not be called when sys.is_finalizing()")
+
+    monkeypatch.setattr(
+        "app.agent.investigation.ThreadPoolExecutor.submit",
+        _track_submit,
+    )
+
+    tool_calls = [_make_tool_call("alpha", id_="a"), _make_tool_call("beta", id_="b")]
+    tools = [
+        _registered_tool("alpha", "out-A"),
+        _registered_tool("beta", "out-B"),
+    ]
+
+    results = _run_parallel(tool_calls, tools, resolved_integrations={})
+
+    assert results == ["out-A", "out-B"]
+    assert submit_calls == []
+
+
+def test_run_parallel_re_raises_non_shutdown_runtime_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive: a generic RuntimeError that's *not* the interpreter-shutdown
+    race must still propagate so we don't accidentally swallow real bugs in
+    the executor wiring."""
+
+    def _boom_submit(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("queue is full")  # unrelated to shutdown
+
+    monkeypatch.setattr(
+        "app.agent.investigation.ThreadPoolExecutor.submit",
+        _boom_submit,
+    )
+
+    tool_calls = [_make_tool_call("alpha", id_="a"), _make_tool_call("beta", id_="b")]
+    tools = [_registered_tool("alpha", "x"), _registered_tool("beta", "y")]
+
+    with pytest.raises(RuntimeError, match="queue is full"):
+        _run_parallel(tool_calls, tools, resolved_integrations={})

--- a/tests/synthetic/schemas.py
+++ b/tests/synthetic/schemas.py
@@ -252,11 +252,18 @@ class TopologyMetadata(TypedDict, total=False):
 
     Present in fixtures that exercise the DNS → LB → Target Group → EC2 → RDS
     request path. Absent in legacy RDS-only scenarios (000–014).
+
+    ``target_group_arn`` accepts a single string (back-compat with scenarios
+    001–020) or a list of strings (multi-target-group scenarios like the
+    multi-tenant noisy-neighbour fixture flagged on #1832 review, #2100). The
+    scenario loader normalises both shapes into ``target_group_arns`` so
+    consumers below the field-shape boundary always see a list.
     """
 
     vpc_id: str
     load_balancer_arn: str
-    target_group_arn: str
+    target_group_arn: str | list[str]
+    target_group_arns: list[str]
     tiers: list[TopologyTier]
 
 
@@ -620,7 +627,49 @@ def validate_scenario_metadata(data: dict[str, Any]) -> ScenarioMetadataSchema:
             f"{ctx}: unknown evidence source(s) {unknown}; expected subset of {sorted(VALID_EVIDENCE_SOURCES)}"
         )
 
+    topology = data.get("topology")
+    if isinstance(topology, dict):
+        _normalize_topology_target_groups(topology, ctx=ctx)
+
     return data  # type: ignore[return-value]
+
+
+def _normalize_topology_target_groups(topology: dict[str, Any], *, ctx: str) -> None:
+    """Populate ``topology['target_group_arns']`` from the string-or-list field.
+
+    Scenarios 001–020 use a single ``target_group_arn: str``. Multi-target-group
+    scenarios pass either a list there or a separate ``target_group_arns`` list.
+    Downstream consumers (mock_aws_backend, candidate scoring, trajectory
+    grader) always read ``target_group_arns``; this helper guarantees the list
+    exists regardless of the input shape.
+    """
+    arn = topology.get("target_group_arn")
+    arns = topology.get("target_group_arns")
+
+    if arns is not None:
+        if not isinstance(arns, list) or not all(
+            isinstance(item, str) and item.strip() for item in arns
+        ):
+            raise ValueError(
+                f"{ctx}: 'topology.target_group_arns' must be a non-empty list of strings when set"
+            )
+        normalised = list(arns)
+    elif isinstance(arn, list):
+        if not all(isinstance(item, str) and item.strip() for item in arn):
+            raise ValueError(
+                f"{ctx}: 'topology.target_group_arn' list entries must be non-empty strings"
+            )
+        normalised = list(arn)
+    elif isinstance(arn, str):
+        normalised = [arn] if arn.strip() else []
+    elif arn is None:
+        normalised = []
+    else:
+        raise ValueError(
+            f"{ctx}: 'topology.target_group_arn' must be a string or a list of strings"
+        )
+
+    topology["target_group_arns"] = normalised
 
 
 # ---------------------------------------------------------------------------

--- a/tests/synthetic/test_topology_target_groups.py
+++ b/tests/synthetic/test_topology_target_groups.py
@@ -1,0 +1,113 @@
+"""Regression: topology.target_group_arn accepts string or list (#2100)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.synthetic.schemas import validate_scenario_metadata
+
+_BASE: dict[str, object] = {
+    "schema_version": "1.0",
+    "scenario_id": "999-multi-tg-test",
+    "engine": "postgres",
+    "engine_version": "15",
+    "instance_class": "db.r6g.large",
+    "region": "us-east-1",
+    "db_instance_identifier": "test-db",
+    "failure_mode": "cpu_saturation",
+    "severity": "P2",
+    "available_evidence": ["aws_cloudwatch_metrics"],
+}
+
+
+def test_string_form_target_group_arn_normalises_to_singleton_list() -> None:
+    """Back-compat: scenarios 001–020 pass a bare string; loader must surface
+    ``target_group_arns`` as a singleton list so downstream consumers don't
+    have to branch on the field shape."""
+    fixture = {
+        **_BASE,
+        "topology": {
+            "vpc_id": "vpc-aaa",
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:111:loadbalancer/app/web/abc",
+            "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/web-tg/abc",
+            "tiers": [{"name": "web", "instance_ids": ["i-1"]}],
+        },
+    }
+
+    validated = validate_scenario_metadata(fixture)
+    topology = validated["topology"]
+    assert topology["target_group_arns"] == [
+        "arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/web-tg/abc"
+    ]
+    # Original field is left in place so existing readers don't break.
+    assert topology["target_group_arn"] == (
+        "arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/web-tg/abc"
+    )
+
+
+def test_list_form_target_group_arn_preserves_order_and_count() -> None:
+    """Multi-tenant noisy-neighbour shape (#1832 review): the topology block
+    enumerates every tg arn explicitly so the trajectory-budget grader doesn't
+    need to lean on agent-side ``get_elb_target_health`` discovery."""
+    arns = [
+        "arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/acme-tg/abc",
+        "arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/zenith-tg/def",
+        "arn:aws:elasticloadbalancing:us-east-1:111:targetgroup/orbit-tg/ghi",
+    ]
+    fixture = {
+        **_BASE,
+        "topology": {
+            "vpc_id": "vpc-bbb",
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:111:loadbalancer/app/multi/xyz",
+            "target_group_arn": arns,
+            "tiers": [
+                {"name": "acme", "instance_ids": ["i-a"]},
+                {"name": "zenith", "instance_ids": ["i-z"]},
+                {"name": "orbit", "instance_ids": ["i-o"]},
+            ],
+        },
+    }
+
+    validated = validate_scenario_metadata(fixture)
+    assert validated["topology"]["target_group_arns"] == arns
+
+
+def test_explicit_target_group_arns_field_takes_precedence() -> None:
+    """If a scenario sets ``target_group_arns`` directly (no inline list in
+    ``target_group_arn``), the loader honours it as-is."""
+    arns = ["arn:tg-A", "arn:tg-B"]
+    fixture = {
+        **_BASE,
+        "topology": {
+            "vpc_id": "vpc-ccc",
+            "load_balancer_arn": "arn:lb",
+            "target_group_arns": arns,
+            "tiers": [{"name": "web", "instance_ids": ["i-1"]}],
+        },
+    }
+
+    validated = validate_scenario_metadata(fixture)
+    assert validated["topology"]["target_group_arns"] == arns
+
+
+def test_missing_topology_does_not_synthesise_target_group_arns() -> None:
+    """Legacy RDS-only scenarios (000–014) don't carry a topology block at all;
+    the loader must not invent one."""
+    validated = validate_scenario_metadata(dict(_BASE))
+    assert "topology" not in validated
+
+
+def test_invalid_target_group_arn_shape_raises() -> None:
+    """Numeric values or empty list entries must fail loud during loading."""
+    fixture = {
+        **_BASE,
+        "topology": {
+            "vpc_id": "vpc-ddd",
+            "load_balancer_arn": "arn:lb",
+            "target_group_arn": ["arn:tg-A", ""],
+            "tiers": [{"name": "web", "instance_ids": ["i-1"]}],
+        },
+    }
+
+    with pytest.raises(ValueError, match="target_group_arn"):
+        validate_scenario_metadata(fixture)


### PR DESCRIPTION
Closes #2194 (sentry [PYTHON-64](https://tracer-30.sentry.io/issues/7491120512/)).

## What's happening

\`\`\`
RuntimeError: cannot schedule new futures after interpreter shutdown
  File "app/pipeline/runners.py", line 213, in _run_pipeline
  File "app/agent/investigation.py", line 185, in run
    results = _run_parallel(response.tool_calls, tools, resolved)
  File "app/agent/investigation.py", line 416, in _run_parallel
    futures = {pool.submit(_call, tc): i for i, tc in enumerate(tool_calls)}
\`\`\`

When the user issues Ctrl+C late in an investigation (or the process enters \`atexit\` while a parallel tool dispatch is in flight), Python's threading internals start tearing down the executor pool. The very first \`pool.submit(_call, tc)\` in the dict-comprehension then raises and **none of the futures get queued** — every parallel tool call in that turn is lost and the investigation crashes at the call site in the trace.

Same issue appears as #2193 (same exception, different alert payload).

## Fix

Two guards in \`_run_parallel\`:

1. **Pre-check** \`sys.is_finalizing()\` at the top of the function. If teardown has already started, skip the executor entirely and run tool calls sequentially via the existing \`_call\` closure.
2. **Catch** \`RuntimeError\` whose message contains \`"interpreter shutdown"\` around the \`ThreadPoolExecutor\` block. Log a single warning and fall back to sequential execution for any slot not already filled, so partial parallel progress isn't thrown away.

Non-shutdown \`RuntimeError\` messages (e.g. \`"queue is full"\` or any other executor-wiring bug) still propagate — the catch is narrow on purpose, matching only the documented shutdown-race substring.

## Verification

- \`make test-cov\` → 6955 passed, 6 skipped
- \`make lint\` → clean
- \`make format-check\` → clean

## Test coverage in \`tests/agent/test_investigation.py\`

| Case | Asserts |
|---|---|
| \`test_run_parallel_falls_back_to_sequential_on_interpreter_shutdown\` | submit patched to raise the exact shutdown message → both tool calls execute sequentially, real results returned |
| \`test_run_parallel_skips_executor_when_interpreter_is_finalizing\` | \`sys.is_finalizing\` patched to \`True\` → \`pool.submit\` is never called |
| \`test_run_parallel_re_raises_non_shutdown_runtime_errors\` | submit raises generic \`"queue is full"\` → propagates (defensive: don't swallow real bugs) |

Will trigger Greptile after open.