### PR TITLE
fix(agent): guard against empty OpenAI choices and thread pool shutdown crashes

### DIFF
--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -480,7 +480,11 @@ def _run_parallel(
 
     results: list[Any] = [None] * len(tool_calls)
     with ThreadPoolExecutor(max_workers=min(_TOOL_EXECUTOR_WORKERS, len(tool_calls))) as pool:
-        futures = {pool.submit(_call, tc): i for i, tc in enumerate(tool_calls)}
+        try:
+            futures = {pool.submit(_call, tc): i for i, tc in enumerate(tool_calls)}
+        except RuntimeError as exc:
+            logger.warning("[agent] tool execution aborted: %s", exc)
+            return [{"error": str(exc)}] * len(tool_calls)
         for fut in as_completed(futures):
             results[futures[fut]] = fut.result()
     return results

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -357,6 +357,10 @@ class OpenAIAgentClient:
         else:
             raise RuntimeError("OpenAI invocation failed") from last_err
 
+        if not hasattr(response, "choices") or not response.choices:
+            raise RuntimeError(
+                f"OpenAI API returned an unexpected response: {type(response).__name__}"
+            )
         choice = response.choices[0]
         msg = choice.message
         content = msg.content or ""


### PR DESCRIPTION
## Summary

Fixes four Sentry-reported crashes in the investigation pipeline:

- **`agent_llm_client.py`**: `response.choices[0]` was called without checking whether `choices` exists or is non-empty. When a proxied/compat provider returns an unexpected response type (string or object with `choices=None`), this produced an `AttributeError` or `TypeError` crash. Now raises a clear `RuntimeError` with the actual response type.

- **`investigation.py`**: `ThreadPoolExecutor.submit()` raises `RuntimeError: cannot schedule new futures after interpreter shutdown` when the agent is still running tool calls as Python tears down. This is now caught and converted to an error-result dict so the pipeline exits cleanly rather than crashing.

## Test plan

- [x] `uv run ruff check app/services/agent_llm_client.py app/agent/investigation.py` — passes
- [x] `uv run pytest tests/agent/test_investigation.py tests/services/ -q` — 704 passed, 3 pre-existing failures unrelated to this change

Closes #2190
Closes #2212
Closes #2193
Closes #2194

https://claude.ai/code/session_01TfTMtnrs2gARMzPFbMByqd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfTMtnrs2gARMzPFbMByqd)_