### PR TITLE
fix(integrations): match Copilot MCP root URL regardless of port

### DIFF
--- a/app/integrations/github_mcp.py
+++ b/app/integrations/github_mcp.py
@@ -74,9 +74,10 @@ def _is_github_copilot_generic_mcp_root(url: str) -> bool:
     if not raw:
         return False
     parsed = urlparse(raw)
-    host = parsed.netloc.lower()
-    if "@" in host:
-        host = host.split("@", 1)[-1]
+    # ``parsed.hostname`` is already lowercased and strips any ``user@`` prefix
+    # or ``:port`` suffix, so equivalent root URLs such as
+    # ``https://api.githubcopilot.com:443/mcp/`` (default-port form) match.
+    host = parsed.hostname or ""
     if host != "api.githubcopilot.com":
         return False
     path_norm = (parsed.path or "/").rstrip("/").lower() or "/"

--- a/tests/integrations/test_config_validation.py
+++ b/tests/integrations/test_config_validation.py
@@ -135,6 +135,36 @@ def test_remote_github_mcp_other_hosts_unchanged() -> None:
     assert _remote_github_mcp_session_url(url) == url
 
 
+def test_remote_github_mcp_root_url_with_explicit_port_rewrites() -> None:
+    # An explicit ``:443`` (or any default port) is the same logical root URL
+    # and must receive the same ``/mcp/x/all/readonly`` rewrite, otherwise the
+    # client silently negotiates a smaller default tool surface.
+    assert (
+        _remote_github_mcp_session_url("https://api.githubcopilot.com:443/mcp/")
+        == "https://api.githubcopilot.com:443/mcp/x/all/readonly"
+    )
+    assert (
+        _remote_github_mcp_session_url("https://api.githubcopilot.com:443/mcp")
+        == "https://api.githubcopilot.com:443/mcp/x/all/readonly"
+    )
+
+
+def test_remote_github_mcp_root_url_with_uppercase_host_rewrites() -> None:
+    # ``urlparse`` lowercases ``hostname`` but ``netloc`` preserves case;
+    # the root-URL detection must remain case-insensitive either way.
+    assert (
+        _remote_github_mcp_session_url("https://API.GitHubCopilot.com/mcp/")
+        == "https://API.GitHubCopilot.com/mcp/x/all/readonly"
+    )
+
+
+def test_remote_github_mcp_userinfo_host_treated_as_other_host() -> None:
+    # ``https://api.githubcopilot.com@evil.test/mcp/`` parses with host
+    # ``evil.test`` — it must NOT be treated as the Copilot MCP root.
+    url = "https://api.githubcopilot.com@evil.test/mcp/"
+    assert _remote_github_mcp_session_url(url) == url
+
+
 def test_github_mcp_custom_headers_can_override_x_mcp_toolsets() -> None:
     cfg = build_github_mcp_config(
         {


### PR DESCRIPTION
Fixes # <!-- no linked issue; surfaced by static-analysis sweep -->

#### Describe the changes you have made in this PR -

`_is_github_copilot_generic_mcp_root` in `app/integrations/github_mcp.py` decides whether the user-supplied URL is the **default Copilot MCP root** — and that decision drives two downstream behaviors:

1. `_remote_github_mcp_session_url` rewrites the path to `/mcp/x/all/readonly` so the session exposes the full read-only tool surface.
2. `GitHubMCPConfig.request_headers` (line 177) *suppresses* the `X-MCP-Toolsets` header when the URL is the generic root, because otherwise the server narrows the tool list below the read-only surface (e.g. drops `search_repositories`).

The host check was:

```python
host = parsed.netloc.lower()
if "@" in host:
    host = host.split("@", 1)[-1]
if host != "api.githubcopilot.com":
    return False
```

`parsed.netloc` preserves the port, so an explicit `:443` (or any other port) breaks the equality:

| URL | `parsed.netloc` | match? |
| --- | --- | --- |
| `https://api.githubcopilot.com/mcp/` | `api.githubcopilot.com` | ✅ |
| `https://api.githubcopilot.com:443/mcp/` | `api.githubcopilot.com:443` | ❌ (bug) |

A user who pastes the default-port form silently negotiated the smaller default tool surface *and* had `X-MCP-Toolsets` re-applied — a double regression in the surface they actually get.

**Fix:** use `parsed.hostname`, which is already lowercased and strips both the `user@` prefix and `:port` suffix. The custom `@`-handling code becomes unnecessary and is removed.

### Demo/Screenshot for feature changes and bug fixes -

Before the fix (current `main`):

```
$ uv run python -c "from app.integrations.github_mcp import _remote_github_mcp_session_url; print(_remote_github_mcp_session_url('https://api.githubcopilot.com:443/mcp/'))"
https://api.githubcopilot.com:443/mcp/      ← NOT rewritten
```

After the fix:

```
$ uv run python -c "from app.integrations.github_mcp import _remote_github_mcp_session_url; print(_remote_github_mcp_session_url('https://api.githubcopilot.com:443/mcp/'))"
https://api.githubcopilot.com:443/mcp/x/all/readonly   ← rewritten as expected
```

### Test plan

Added three regression tests in `tests/integrations/test_config_validation.py`:

- `test_remote_github_mcp_root_url_with_explicit_port_rewrites` — the failing case before this fix.
- `test_remote_github_mcp_root_url_with_uppercase_host_rewrites` — pins down case-insensitive matching that the prior `netloc.lower()` covered (must remain green after switching to `hostname`).
- `test_remote_github_mcp_userinfo_host_treated_as_other_host` — ensures `https://api.githubcopilot.com@evil.test/mcp/` is still rejected (no host spoofing).

```
$ .venv/bin/pytest tests/integrations/test_config_validation.py -v
======================= 27 passed in 1.17s =======================
```

Per `CI.md` (`app/integrations/` → `tests/integrations/`):

```
$ .venv/bin/pytest tests/integrations/ -v
======================= 1081 passed, 1 failed in 12.62s =======================
```

The one failure — `tests/integrations/llm_cli/test_copilot_adapter.py::test_detect_when_binary_not_found` — also fails on a clean `upstream/main` checkout when `copilot` CLI is present in PATH on the local machine (verified by `git stash` + re-run). It is unrelated to this change.

Other CI gates:

```
$ make lint           → All checks passed!
$ make format-check   → 1396 files already formatted
$ make typecheck      → Success: no issues found in 587 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **Problem:** the Copilot MCP "default root" detector was string-comparing `parsed.netloc.lower()` to `"api.githubcopilot.com"`. `netloc` includes the port, so default-port forms (`:443`) silently failed the check and produced a *smaller* tool surface than intended for an equivalent URL.
- **Alternatives considered:**
  1. Strip the port manually with `host.rsplit(":", 1)[0]` — fragile for IPv6 (`[::1]:443`).
  2. Match against a set including the `:443` variant — incomplete; users can paste `:443/`, `:443//`, etc.
  3. **Chosen:** use `parsed.hostname`. The stdlib already normalizes case, strips `user@`, and strips `:port` (including the IPv6 bracket form). This makes the manual `@` handling obsolete, which is also removed.
- **Why this implementation:** matches the URL-host-validation pattern previously merged in PR #1988 (Slack webhook) and #2009 (Vercel poller) — both switched from substring/`netloc` comparisons to `parsed.hostname` for equivalence checking.
- **Edge cases covered by the new tests:** explicit port, uppercase host, and `user@host` spoofing (still rejected).

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions