### PR TITLE
fix(hermes): validate --escalation-threshold >= 2 at CLI layer

### DIFF
--- a/app/cli/commands/hermes.py
+++ b/app/cli/commands/hermes.py
@@ -106,7 +106,7 @@ def hermes_command() -> None:
 )
 @click.option(
     "--escalation-threshold",
-    type=int,
+    type=click.IntRange(min=2),
     default=3,
     show_default=True,
     help=(


### PR DESCRIPTION
## Summary

- Passing `--escalation-threshold 1` (or `0`) to `opensre hermes watch` raised an unhandled `ValueError` from `IncidentCorrelator.__init__`, surfacing as an ugly traceback (Sentry issue PYTHON-6M).
- Change the Click option type from `int` to `click.IntRange(min=2)` so the constraint is enforced at the CLI layer before the correlator is constructed. Users now get a clear `"Invalid value for '--escalation-threshold': 1 is not in the range x>=2."` error instead of a crash.

## Test plan

- [ ] `uv run pytest tests/ -k hermes` — 167 tests pass
- [ ] `uv run ruff check app/cli/commands/hermes.py` — no issues
- [ ] Manually verify: `opensre hermes watch --escalation-threshold 1` prints a Click range error and exits cleanly

Closes #2224

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHr8fJRgBDgP4veoNWgDwS)_