### PR TITLE
feat(signoz): Query API for metrics, logs, traces; drop ClickHouse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,12 @@ CORALOGIX_SUBSYSTEM_NAME=
 # CORALOGIX_INSTANCES='[{"name":"prod","api_key":"...","base_url":"https://api.coralogix.com"}]'
 CORALOGIX_INSTANCES=
 
+# SigNoz (Query API — logs, metrics, traces)
+# Local Docker stack: http://localhost:8080 (see infra/scripts/signoz/)
+# API key: Settings → Service Accounts → Keys
+SIGNOZ_URL=
+SIGNOZ_API_KEY=
+
 # AWS
 AWS_REGION=us-east-1
 AWS_ROLE_ARN=

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -845,18 +845,12 @@ def _classify_service_instance(
                 {
                     "url": credentials.get("url", ""),
                     "api_key": credentials.get("api_key", ""),
-                    "clickhouse_host": credentials.get("clickhouse_host", ""),
-                    "clickhouse_port": int(credentials.get("clickhouse_port", 8123) or 8123),
-                    "clickhouse_database": credentials.get("clickhouse_database", "default"),
-                    "clickhouse_user": credentials.get("clickhouse_user", "default"),
-                    "clickhouse_password": credentials.get("clickhouse_password", ""),
-                    "secure": credentials.get("secure", False),
                     "integration_id": record_id,
                 }
             )
         except Exception:
             return None, None
-        if signoz_config.clickhouse_host or signoz_config.has_metrics_api:
+        if signoz_config.is_configured:
             return signoz_config.model_dump(), "signoz"
         return None, None
 
@@ -1710,9 +1704,7 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     try:
         signoz_config = signoz_config_from_env()
-        if signoz_config is not None and (
-            signoz_config.is_configured or signoz_config.has_metrics_api
-        ):
+        if signoz_config is not None and signoz_config.is_configured:
             integrations.append(
                 _active_env_record(
                     "signoz",

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -856,7 +856,7 @@ def _classify_service_instance(
             )
         except Exception:
             return None, None
-        if signoz_config.clickhouse_host:
+        if signoz_config.clickhouse_host or signoz_config.has_metrics_api:
             return signoz_config.model_dump(), "signoz"
         return None, None
 
@@ -1710,7 +1710,9 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     try:
         signoz_config = signoz_config_from_env()
-        if signoz_config is not None and signoz_config.is_configured:
+        if signoz_config is not None and (
+            signoz_config.is_configured or signoz_config.has_metrics_api
+        ):
             integrations.append(
                 _active_env_record(
                     "signoz",

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -751,15 +751,20 @@ def _setup_alertmanager() -> None:
 
 
 def _setup_signoz() -> None:
-    clickhouse_host = _p("ClickHouse host")
+    url = _p("SigNoz URL (required for Metrics API mode, e.g. http://localhost:3301)")
+    api_key = _p("SigNoz API key (required for Metrics API mode)", secret=True)
+    clickhouse_host = _p("ClickHouse host (optional, needed for logs/traces)")
     clickhouse_port = _p("ClickHouse port", default="8123")
     clickhouse_user = _p("ClickHouse user", default="default")
     clickhouse_password = _p("ClickHouse password", secret=True)
     clickhouse_database = _p("ClickHouse database", default="default")
-    url = _p("SigNoz URL (optional)")
-    api_key = _p("SigNoz API key (optional)", secret=True)
-    if not clickhouse_host:
-        _die("clickhouse_host is required.")
+
+    if not (clickhouse_host or (url and api_key)):
+        _die(
+            "Provide either SigNoz URL + API key (Metrics API mode) "
+            "or ClickHouse host (ClickHouse mode)."
+        )
+
     upsert_integration(
         "signoz",
         {

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -751,29 +751,16 @@ def _setup_alertmanager() -> None:
 
 
 def _setup_signoz() -> None:
-    url = _p("SigNoz URL (required for Metrics API mode, e.g. http://localhost:3301)")
-    api_key = _p("SigNoz API key (required for Metrics API mode)", secret=True)
-    clickhouse_host = _p("ClickHouse host (optional, needed for logs/traces)")
-    clickhouse_port = _p("ClickHouse port", default="8123")
-    clickhouse_user = _p("ClickHouse user", default="default")
-    clickhouse_password = _p("ClickHouse password", secret=True)
-    clickhouse_database = _p("ClickHouse database", default="default")
+    url = _p("SigNoz URL (e.g. http://localhost:8080 for local Docker)")
+    api_key = _p("SigNoz API key (service account key)", secret=True)
 
-    if not (clickhouse_host or (url and api_key)):
-        _die(
-            "Provide either SigNoz URL + API key (Metrics API mode) "
-            "or ClickHouse host (ClickHouse mode)."
-        )
+    if not (url and api_key):
+        _die("SigNoz URL and API key are required.")
 
     upsert_integration(
         "signoz",
         {
             "credentials": {
-                "clickhouse_host": clickhouse_host,
-                "clickhouse_port": int(clickhouse_port) if clickhouse_port.isdigit() else 8123,
-                "clickhouse_user": clickhouse_user,
-                "clickhouse_password": clickhouse_password,
-                "clickhouse_database": clickhouse_database,
                 "url": url,
                 "api_key": api_key,
             }

--- a/app/integrations/signoz.py
+++ b/app/integrations/signoz.py
@@ -147,7 +147,7 @@ def validate_signoz_config(config: SigNozConfig) -> SigNozValidationResult:
         base_url = config.url.rstrip("/")
 
         try:
-            response = httpx.post(
+            response = httpx.get(
                 f"{base_url}/api/v2/metrics",
                 headers={
                     "SigNoz-Api-Key": config.api_key,

--- a/app/integrations/signoz.py
+++ b/app/integrations/signoz.py
@@ -1,9 +1,7 @@
 """SigNoz integration helpers.
 
-Provides configuration and connectivity validation for SigNoz.
-
-Metrics use the SigNoz Query Range API when URL + API key are provided.
-Logs/traces currently continue to use the ClickHouse-backed path.
+Provides configuration and connectivity validation for SigNoz via the
+Query Range API (``SIGNOZ_URL`` + ``SIGNOZ_API_KEY``).
 """
 
 from __future__ import annotations
@@ -14,89 +12,29 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from app.integrations._validation_helpers import report_validation_failure
-from app.integrations.clickhouse import ClickHouseConfig, _get_client
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SIGNOZ_PORT = 8123
-DEFAULT_SIGNOZ_DATABASE = "default"
-DEFAULT_SIGNOZ_USER = "default"
 DEFAULT_SIGNOZ_TIMEOUT_SECONDS = 10.0
 DEFAULT_SIGNOZ_MAX_RESULTS = 50
 
-REQUIRED_TABLES = (
-    "signoz_logs.distributed_logs_v2",
-    "signoz_metrics.distributed_samples_v4",
-    "signoz_metrics.distributed_time_series_v4",
-    "signoz_traces.distributed_signoz_index_v3",
-)
-
 
 class SigNozConfig(StrictConfigModel):
-    """Normalized SigNoz connection settings.
-
-    Credentials can come from dedicated ``SIGNOZ_*`` env vars or from the
-    shared ClickHouse path when SigNoz is co-located with a generic
-    ClickHouse instance.
-    """
+    """Normalized SigNoz Query API connection settings."""
 
     url: str = ""
     api_key: str = ""
-    clickhouse_host: str = ""
-    clickhouse_port: int = DEFAULT_SIGNOZ_PORT
-    clickhouse_database: str = DEFAULT_SIGNOZ_DATABASE
-    clickhouse_user: str = DEFAULT_SIGNOZ_USER
-    clickhouse_password: str = ""
-    secure: bool = False
     timeout_seconds: float = Field(default=DEFAULT_SIGNOZ_TIMEOUT_SECONDS, gt=0)
     max_results: int = Field(default=DEFAULT_SIGNOZ_MAX_RESULTS, gt=0, le=200)
     integration_id: str = ""
 
-    @field_validator("clickhouse_host", mode="before")
-    @classmethod
-    def _normalize_host(cls, value: Any) -> str:
-        return str(value or "").strip()
-
-    @field_validator("clickhouse_database", mode="before")
-    @classmethod
-    def _normalize_database(cls, value: Any) -> str:
-        normalized = str(value or DEFAULT_SIGNOZ_DATABASE).strip()
-        return normalized or DEFAULT_SIGNOZ_DATABASE
-
-    @field_validator("clickhouse_user", mode="before")
-    @classmethod
-    def _normalize_user(cls, value: Any) -> str:
-        normalized = str(value or DEFAULT_SIGNOZ_USER).strip()
-        return normalized or DEFAULT_SIGNOZ_USER
-
     @property
     def is_configured(self) -> bool:
-        return bool(self.clickhouse_host)
-
-    @property
-    def has_metrics_api(self) -> bool:
-        """Whether SigNoz Metrics API credentials are available."""
         return bool(self.url and self.api_key)
-
-    def to_clickhouse_config(self) -> ClickHouseConfig:
-        """Project self into the generic ClickHouse config shape."""
-        return ClickHouseConfig.model_validate(
-            {
-                "host": self.clickhouse_host,
-                "port": self.clickhouse_port,
-                "database": self.clickhouse_database,
-                "username": self.clickhouse_user,
-                "password": self.clickhouse_password,
-                "secure": self.secure,
-                "timeout_seconds": self.timeout_seconds,
-                "max_results": self.max_results,
-                "integration_id": self.integration_id,
-            }
-        )
 
 
 @dataclass(frozen=True)
@@ -114,123 +52,62 @@ def build_signoz_config(raw: dict[str, Any] | None) -> SigNozConfig:
 
 def signoz_config_from_env() -> SigNozConfig | None:
     """Load a SigNoz config from env vars."""
-    host = os.getenv("SIGNOZ_CLICKHOUSE_HOST", "").strip()
     url = os.getenv("SIGNOZ_URL", "").strip()
     api_key = os.getenv("SIGNOZ_API_KEY", "").strip()
 
-    if not host and not (url and api_key):
+    if not (url and api_key):
         return None
 
     return build_signoz_config(
         {
             "url": url,
             "api_key": api_key,
-            "clickhouse_host": host,
-            "clickhouse_port": int(
-                os.getenv("SIGNOZ_CLICKHOUSE_PORT", str(DEFAULT_SIGNOZ_PORT))
-                or str(DEFAULT_SIGNOZ_PORT)
-            ),
-            "clickhouse_database": os.getenv(
-                "SIGNOZ_CLICKHOUSE_DATABASE", DEFAULT_SIGNOZ_DATABASE
-            ).strip(),
-            "clickhouse_user": os.getenv("SIGNOZ_CLICKHOUSE_USER", DEFAULT_SIGNOZ_USER).strip(),
-            "clickhouse_password": os.getenv("SIGNOZ_CLICKHOUSE_PASSWORD", "").strip(),
-            "secure": os.getenv("SIGNOZ_CLICKHOUSE_SECURE", "false").strip().lower()
-            in ("true", "1", "yes"),
         }
     )
 
 
 def validate_signoz_config(config: SigNozConfig) -> SigNozValidationResult:
-    """Validate SigNoz connectivity and schema presence."""
-    if config.has_metrics_api:
-        base_url = config.url.rstrip("/")
-
-        try:
-            response = httpx.get(
-                f"{base_url}/api/v2/metrics",
-                headers={
-                    "SigNoz-Api-Key": config.api_key,
-                    "Accept": "application/json",
-                },
-                params={"limit": 1, "offset": 0},
-                timeout=config.timeout_seconds,
-            )
-            response.raise_for_status()
-            return SigNozValidationResult(
-                ok=True,
-                detail="Connected to SigNoz Metrics API (/api/v2/metrics, /api/v5/query_range).",
-            )
-        except httpx.HTTPStatusError as err:
-            snippet = err.response.text[:200].strip()
-            detail = (
-                f"HTTP {err.response.status_code}: {snippet}"
-                if snippet
-                else f"HTTP {err.response.status_code}"
-            )
-            return SigNozValidationResult(
-                ok=False,
-                detail=f"SigNoz Metrics API validation failed: {detail}",
-            )
-        except Exception as err:
-            report_validation_failure(
-                err,
-                logger=logger,
-                integration="signoz",
-                method="validate_signoz_config.metrics_api",
-            )
-            return SigNozValidationResult(
-                ok=False,
-                detail=f"SigNoz Metrics API validation failed: {err}",
-            )
-
-    if not config.clickhouse_host:
+    """Validate SigNoz Query API connectivity."""
+    if not config.is_configured:
         return SigNozValidationResult(
             ok=False,
             detail=(
-                "SigNoz configuration is incomplete. Provide SIGNOZ_URL + SIGNOZ_API_KEY "
-                "for Metrics API mode, or SIGNOZ_CLICKHOUSE_HOST for ClickHouse mode."
+                "SigNoz configuration is incomplete. "
+                "Provide SIGNOZ_URL and SIGNOZ_API_KEY (service account key)."
             ),
         )
 
-    ch = config.to_clickhouse_config()
+    base_url = config.url.rstrip("/")
+
     try:
-        client = _get_client(ch)
-        try:
-            # Ping
-            result = client.query("SELECT version()")
-            version = result.first_row[0] if result.row_count > 0 else "unknown"
-
-            # Schema probe
-            missing: list[str] = []
-            for table in REQUIRED_TABLES:
-                try:
-                    exists_result = client.query(
-                        f"SELECT count() FROM system.tables WHERE database || '.' || name = '{table}'"
-                    )
-                    if exists_result.first_row[0] == 0:
-                        missing.append(table)
-                except Exception:
-                    missing.append(table)
-
-            if missing:
-                return SigNozValidationResult(
-                    ok=False,
-                    detail=(
-                        f"Connected to ClickHouse {version}, "
-                        f"but missing tables: {', '.join(missing)}."
-                    ),
-                )
-
-            return SigNozValidationResult(
-                ok=True,
-                detail=(
-                    f"Connected to ClickHouse {version}; "
-                    f"SigNoz schema verified ({len(REQUIRED_TABLES)} tables present)."
-                ),
-            )
-        finally:
-            client.close()
+        response = httpx.get(
+            f"{base_url}/api/v2/metrics",
+            headers={
+                "SigNoz-Api-Key": config.api_key,
+                "Accept": "application/json",
+            },
+            params={"limit": 1, "offset": 0},
+            timeout=config.timeout_seconds,
+        )
+        response.raise_for_status()
+        return SigNozValidationResult(
+            ok=True,
+            detail=(
+                "Connected to SigNoz Query API "
+                "(/api/v2/metrics, /api/v5/query_range for logs/metrics/traces)."
+            ),
+        )
+    except httpx.HTTPStatusError as err:
+        snippet = err.response.text[:200].strip()
+        detail = (
+            f"HTTP {err.response.status_code}: {snippet}"
+            if snippet
+            else f"HTTP {err.response.status_code}"
+        )
+        return SigNozValidationResult(
+            ok=False,
+            detail=f"SigNoz Query API validation failed: {detail}",
+        )
     except Exception as err:
         report_validation_failure(
             err,
@@ -238,7 +115,10 @@ def validate_signoz_config(config: SigNozConfig) -> SigNozValidationResult:
             integration="signoz",
             method="validate_signoz_config",
         )
-        return SigNozValidationResult(ok=False, detail=f"SigNoz connection failed: {err}")
+        return SigNozValidationResult(
+            ok=False,
+            detail=f"SigNoz Query API validation failed: {err}",
+        )
 
 
 def signoz_is_available(sources: dict[str, dict]) -> bool:
@@ -250,16 +130,10 @@ def signoz_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     """Extract SigNoz connection params from resolved integrations.
 
     Credentials are resolved from the integration store or environment, so the
-    LLM never needs to supply host or password directly.
+    LLM never needs to supply URL or API key directly.
     """
     sz = sources.get("signoz", {})
     return {
-        "clickhouse_host": str(sz.get("clickhouse_host", "")).strip(),
-        "clickhouse_port": int(sz.get("clickhouse_port") or DEFAULT_SIGNOZ_PORT),
-        "clickhouse_database": str(sz.get("clickhouse_database", DEFAULT_SIGNOZ_DATABASE)).strip(),
-        "clickhouse_user": str(sz.get("clickhouse_user", DEFAULT_SIGNOZ_USER)).strip(),
-        "clickhouse_password": str(sz.get("clickhouse_password", "")).strip(),
-        "secure": bool(sz.get("secure", False)),
         "url": str(sz.get("url", "")).strip(),
         "api_key": str(sz.get("api_key", "")).strip(),
     }

--- a/app/integrations/signoz.py
+++ b/app/integrations/signoz.py
@@ -1,12 +1,9 @@
 """SigNoz integration helpers.
 
-Provides configuration, connectivity validation, and read-only diagnostic
-queries for SigNoz ClickHouse instances.  All operations are production-safe:
-read-only, timeouts enforced, result sizes capped.
+Provides configuration and connectivity validation for SigNoz.
 
-SigNoz stores logs, metrics, and traces in ClickHouse using predictable
-schemas.  This module wraps the shared ClickHouse transport and adds
-schema-aware validation and query helpers.
+Metrics use the SigNoz Query Range API when URL + API key are provided.
+Logs/traces currently continue to use the ClickHouse-backed path.
 """
 
 from __future__ import annotations
@@ -16,6 +13,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
+import httpx
 from pydantic import Field, field_validator
 
 from app.integrations._validation_helpers import report_validation_failure
@@ -79,6 +77,11 @@ class SigNozConfig(StrictConfigModel):
     def is_configured(self) -> bool:
         return bool(self.clickhouse_host)
 
+    @property
+    def has_metrics_api(self) -> bool:
+        """Whether SigNoz Metrics API credentials are available."""
+        return bool(self.url and self.api_key)
+
     def to_clickhouse_config(self) -> ClickHouseConfig:
         """Project self into the generic ClickHouse config shape."""
         return ClickHouseConfig.model_validate(
@@ -112,12 +115,16 @@ def build_signoz_config(raw: dict[str, Any] | None) -> SigNozConfig:
 def signoz_config_from_env() -> SigNozConfig | None:
     """Load a SigNoz config from env vars."""
     host = os.getenv("SIGNOZ_CLICKHOUSE_HOST", "").strip()
-    if not host:
+    url = os.getenv("SIGNOZ_URL", "").strip()
+    api_key = os.getenv("SIGNOZ_API_KEY", "").strip()
+
+    if not host and not (url and api_key):
         return None
+
     return build_signoz_config(
         {
-            "url": os.getenv("SIGNOZ_URL", "").strip(),
-            "api_key": os.getenv("SIGNOZ_API_KEY", "").strip(),
+            "url": url,
+            "api_key": api_key,
             "clickhouse_host": host,
             "clickhouse_port": int(
                 os.getenv("SIGNOZ_CLICKHOUSE_PORT", str(DEFAULT_SIGNOZ_PORT))
@@ -136,8 +143,55 @@ def signoz_config_from_env() -> SigNozConfig | None:
 
 def validate_signoz_config(config: SigNozConfig) -> SigNozValidationResult:
     """Validate SigNoz connectivity and schema presence."""
+    if config.has_metrics_api:
+        base_url = config.url.rstrip("/")
+
+        try:
+            response = httpx.post(
+                f"{base_url}/api/v2/metrics",
+                headers={
+                    "SigNoz-Api-Key": config.api_key,
+                    "Accept": "application/json",
+                },
+                params={"limit": 1, "offset": 0},
+                timeout=config.timeout_seconds,
+            )
+            response.raise_for_status()
+            return SigNozValidationResult(
+                ok=True,
+                detail="Connected to SigNoz Metrics API (/api/v2/metrics, /api/v5/query_range).",
+            )
+        except httpx.HTTPStatusError as err:
+            snippet = err.response.text[:200].strip()
+            detail = (
+                f"HTTP {err.response.status_code}: {snippet}"
+                if snippet
+                else f"HTTP {err.response.status_code}"
+            )
+            return SigNozValidationResult(
+                ok=False,
+                detail=f"SigNoz Metrics API validation failed: {detail}",
+            )
+        except Exception as err:
+            report_validation_failure(
+                err,
+                logger=logger,
+                integration="signoz",
+                method="validate_signoz_config.metrics_api",
+            )
+            return SigNozValidationResult(
+                ok=False,
+                detail=f"SigNoz Metrics API validation failed: {err}",
+            )
+
     if not config.clickhouse_host:
-        return SigNozValidationResult(ok=False, detail="SigNoz ClickHouse host is required.")
+        return SigNozValidationResult(
+            ok=False,
+            detail=(
+                "SigNoz configuration is incomplete. Provide SIGNOZ_URL + SIGNOZ_API_KEY "
+                "for Metrics API mode, or SIGNOZ_CLICKHOUSE_HOST for ClickHouse mode."
+            ),
+        )
 
     ch = config.to_clickhouse_config()
     try:

--- a/app/services/signoz/client.py
+++ b/app/services/signoz/client.py
@@ -85,8 +85,7 @@ class SigNozClient:
     ) -> dict[str, Any]:
         start_ms = int(start.timestamp() * 1000)
         end_ms = int(end.timestamp() * 1000)
-        escaped_service = (service or "").replace("\\", "\\\\").replace("'", "\\'")
-        filter_expression = f"service.name = '{escaped_service}'" if escaped_service else ""
+        step_interval = max(60, (end_ms - start_ms) // (1000 * 300))
 
         if resolved_metric == "signoz_calls_total":
             time_aggregation = "rate"
@@ -110,7 +109,7 @@ class SigNozClient:
                         "spec": {
                             "name": "A",
                             "signal": "metrics",
-                            "stepInterval": 60,
+                            "stepInterval": step_interval,
                             "aggregations": [
                                 {
                                     "metricName": resolved_metric,
@@ -128,9 +127,16 @@ class SigNozClient:
             },
             "noCache": True,
         }
-        if filter_expression:
+        if service:
             payload["compositeQuery"]["queries"][0]["spec"]["filter"] = {
-                "expression": filter_expression
+                "items": [
+                    {
+                        "key": {"name": "service.name", "type": "tag"},
+                        "op": "=",
+                        "value": service,
+                    }
+                ],
+                "op": "AND",
             }
 
         try:
@@ -201,7 +207,7 @@ class SigNozClient:
         ):
             query_data = query_response.get("data", {})
         else:
-            query_data = response_json.get("data", {})
+            query_data = query_response
 
         results = query_data.get("results", []) if isinstance(query_data, dict) else []
 

--- a/app/services/signoz/client.py
+++ b/app/services/signoz/client.py
@@ -1,7 +1,7 @@
 """SigNoz query client.
 
-Uses SigNoz Metrics API for metrics when API credentials are present, and
-retains ClickHouse-backed paths for logs/traces and metrics fallback.
+Queries logs, metrics, and traces via SigNoz Query Range API
+(``POST /api/v5/query_range``).
 """
 
 from __future__ import annotations
@@ -9,19 +9,20 @@ from __future__ import annotations
 import logging
 import math
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
-from app.integrations.clickhouse import _get_client
 from app.integrations.signoz import SigNozConfig
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIME_RANGE_MINUTES = 60
+_NOT_CONFIGURED_ERROR = (
+    "SigNoz not configured. Set SIGNOZ_URL and SIGNOZ_API_KEY (service account key)."
+)
 
 # Curated infrastructure metrics for V1.
-# Each maps to a SigNoz metric name pattern stored in distributed_time_series_v4.
 _CURATED_METRICS: dict[str, str] = {
     "cpu_usage": "system_cpu_usage",
     "memory_usage": "system_memory_usage",
@@ -30,11 +31,6 @@ _CURATED_METRICS: dict[str, str] = {
     # or query signoz_traces directly for error-rate semantics.
     "request_rate": "signoz_calls_total",
 }
-
-
-def _make_client(config: SigNozConfig) -> Any:
-    """Create a clickhouse_connect client from SigNoz config."""
-    return _get_client(config.to_clickhouse_config())
 
 
 def _clamp_limit(limit: int, config: SigNozConfig) -> int:
@@ -48,29 +44,190 @@ def _time_bounds(minutes: int) -> tuple[datetime, datetime]:
     return start, end
 
 
-def _bucket_bounds_seconds(start: datetime, end: datetime) -> tuple[int, int]:
-    """Return SigNoz ts_bucket_start bounds (seconds, with 30-minute guard band)."""
-    start_sec = int(start.timestamp())
-    end_sec = int(end.timestamp())
-    return start_sec - 1800, end_sec
-
-
 def _iso_from_epoch_ms(timestamp_ms: int) -> str:
     """Render epoch milliseconds as an ISO-8601 UTC timestamp."""
     return datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat().replace("+00:00", "Z")
 
 
+def _escape_signoz_filter_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _signoz_filter_expression(parts: list[str]) -> dict[str, str] | None:
+    if not parts:
+        return None
+    return {"expression": " AND ".join(parts)}
+
+
+def _coerce_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _field_from_data(data: dict[str, Any], *keys: str, default: Any = "") -> Any:
+    for key in keys:
+        if key in data and data[key] is not None:
+            return data[key]
+    return default
+
+
+def _extract_http_error_message(err: httpx.HTTPStatusError) -> str:
+    error_payload: dict[str, Any] = {}
+    try:
+        parsed = err.response.json()
+        if isinstance(parsed, dict):
+            error_payload = parsed
+    except Exception:
+        error_payload = {}
+    nested = error_payload.get("error")
+    if isinstance(nested, dict):
+        message = nested.get("message")
+        if message:
+            return str(message)
+    snippet = err.response.text[:200].strip()
+    return snippet or f"HTTP {err.response.status_code}"
+
+
+def _row_data(row: dict[str, Any]) -> dict[str, Any]:
+    nested = row.get("data")
+    if isinstance(nested, dict):
+        return cast(dict[str, Any], nested)
+    return row
+
+
+def _parse_log_row(row: dict[str, Any]) -> dict[str, Any]:
+    data = _row_data(row)
+    attributes_raw = data.get("attributes_string") or {}
+    resources_raw = data.get("resources_string") or {}
+    attributes = dict(attributes_raw) if isinstance(attributes_raw, dict) else {}
+    resources = dict(resources_raw) if isinstance(resources_raw, dict) else {}
+    return {
+        "timestamp": _coerce_str(row.get("timestamp") or data.get("timestamp")),
+        "severity": _coerce_str(_field_from_data(data, "severity_text")),
+        "severity_number": _field_from_data(data, "severity_number", default=0),
+        "message": _coerce_str(_field_from_data(data, "body")),
+        "trace_id": _coerce_str(_field_from_data(data, "trace_id", "traceID")),
+        "span_id": _coerce_str(_field_from_data(data, "span_id", "spanID")),
+        "attributes": dict(attributes) if isinstance(attributes, dict) else {},
+        "resources": dict(resources) if isinstance(resources, dict) else {},
+    }
+
+
+def _parse_trace_row(row: dict[str, Any]) -> dict[str, Any]:
+    data = _row_data(row)
+    duration_nano = _field_from_data(data, "duration_nano", "durationNano", default=0)
+    try:
+        duration_ms = float(duration_nano) / 1_000_000
+    except (TypeError, ValueError):
+        duration_ms = 0.0
+    has_error = _field_from_data(data, "has_error", "hasError", default=False)
+    return {
+        "timestamp": _coerce_str(row.get("timestamp") or data.get("timestamp")),
+        "trace_id": _coerce_str(_field_from_data(data, "trace_id", "traceID")),
+        "span_id": _coerce_str(_field_from_data(data, "span_id", "spanID")),
+        "name": _coerce_str(_field_from_data(data, "name")),
+        "duration_ms": duration_ms,
+        "has_error": bool(has_error),
+        "status_code": _field_from_data(data, "status_code", "statusCode", default=0),
+        "status_code_string": _coerce_str(
+            _field_from_data(data, "status_code_string", "statusCodeString")
+        ),
+        "http_method": _coerce_str(_field_from_data(data, "http_method", "httpMethod")),
+        "http_url": _coerce_str(_field_from_data(data, "http_url", "httpUrl")),
+        "kind_string": _coerce_str(_field_from_data(data, "kind_string", "kindString")),
+        "service_name": _coerce_str(_field_from_data(data, "service_name", "serviceName")),
+    }
+
+
 class SigNozClient:
-    """Read-only SigNoz ClickHouse client."""
+    """Read-only SigNoz client using the Query Range API."""
 
     def __init__(self, config: SigNozConfig) -> None:
         self.config = config
 
-    def _has_metrics_api_config(self) -> bool:
-        return bool(self.config.url and self.config.api_key)
+    def _configuration_error(self) -> str | None:
+        if self.config.is_configured:
+            return None
+        return _NOT_CONFIGURED_ERROR
 
-    def _metrics_api_base_url(self) -> str:
+    def _query_api_base_url(self) -> str:
         return self.config.url.rstrip("/")
+
+    def _query_range_post(
+        self, payload: dict[str, Any]
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        try:
+            response = httpx.post(
+                f"{self._query_api_base_url()}/api/v5/query_range",
+                headers={
+                    "SigNoz-Api-Key": self.config.api_key,
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                json=payload,
+                timeout=self.config.timeout_seconds,
+            )
+            response.raise_for_status()
+            parsed = response.json()
+            return (parsed if isinstance(parsed, dict) else {}), None
+        except httpx.HTTPStatusError as err:
+            message = _extract_http_error_message(err)
+            if err.response.status_code == 404:
+                return None, f"404: {message or 'not found'}"
+            return None, message
+        except Exception as err:
+            return None, str(err)
+
+    @staticmethod
+    def _unwrap_v5_query_data(response_json: dict[str, Any]) -> dict[str, Any]:
+        query_response = response_json.get("data", {})
+        if (
+            isinstance(query_response, dict)
+            and "type" in query_response
+            and "data" in query_response
+        ):
+            inner = query_response.get("data", {})
+            return inner if isinstance(inner, dict) else {}
+        return query_response if isinstance(query_response, dict) else {}
+
+    @staticmethod
+    def _parse_raw_rows(response_json: dict[str, Any]) -> list[dict[str, Any]]:
+        query_data = SigNozClient._unwrap_v5_query_data(response_json)
+        results = query_data.get("results", []) if isinstance(query_data, dict) else []
+        rows: list[dict[str, Any]] = []
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            for row in result.get("rows") or []:
+                if isinstance(row, dict):
+                    rows.append(row)
+        return rows
+
+    @staticmethod
+    def _parse_scalar_by_query_name(response_json: dict[str, Any]) -> dict[str, float]:
+        query_data = SigNozClient._unwrap_v5_query_data(response_json)
+        results = query_data.get("results", []) if isinstance(query_data, dict) else []
+        values_by_query: dict[str, float] = {}
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            columns = result.get("columns") or []
+            data_rows = result.get("data") or []
+            if not data_rows or not isinstance(data_rows[0], list):
+                continue
+            first_row = data_rows[0]
+            for idx, column in enumerate(columns):
+                if not isinstance(column, dict):
+                    continue
+                query_name = str(column.get("queryName") or "")
+                if not query_name or idx >= len(first_row):
+                    continue
+                try:
+                    values_by_query[query_name] = float(first_row[idx])
+                except (TypeError, ValueError):
+                    values_by_query[query_name] = 0.0
+        return values_by_query
 
     def _query_metrics_via_api(
         self,
@@ -139,33 +296,9 @@ class SigNozClient:
                 "op": "AND",
             }
 
-        try:
-            response = httpx.post(
-                f"{self._metrics_api_base_url()}/api/v5/query_range",
-                headers={
-                    "SigNoz-Api-Key": self.config.api_key,
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                },
-                json=payload,
-                timeout=self.config.timeout_seconds,
-            )
-            response.raise_for_status()
-            response_json = response.json()
-        except httpx.HTTPStatusError as err:
-            error_payload: dict[str, Any] = {}
-            try:
-                parsed = err.response.json()
-                if isinstance(parsed, dict):
-                    error_payload = parsed
-            except Exception:
-                error_payload = {}
-            error_message = (
-                error_payload.get("error", {}).get("message")
-                if isinstance(error_payload.get("error"), dict)
-                else ""
-            )
-            if err.response.status_code == 404:
+        response_json, error_message = self._query_range_post(payload)
+        if error_message:
+            if "not found" in error_message.lower() or "404" in error_message:
                 return {
                     "source": "signoz_metrics",
                     "available": True,
@@ -174,7 +307,7 @@ class SigNozClient:
                     "resolved_metric": resolved_metric,
                     "aggregation": aggregation,
                     "metrics": [],
-                    "query_backend": "signoz_metrics_api",
+                    "query_backend": "signoz_query_api",
                     "warning": error_message or f"Metric not found: {resolved_metric}",
                 }
             return {
@@ -184,31 +317,12 @@ class SigNozClient:
                 "resolved_metric": resolved_metric,
                 "aggregation": aggregation,
                 "metrics": [],
-                "query_backend": "signoz_metrics_api",
-                "error": error_message or f"HTTP {err.response.status_code}",
-            }
-        except Exception as err:
-            return {
-                "source": "signoz_metrics",
-                "available": False,
-                "metric_name": metric_name,
-                "resolved_metric": resolved_metric,
-                "aggregation": aggregation,
-                "metrics": [],
-                "query_backend": "signoz_metrics_api",
-                "error": str(err),
+                "query_backend": "signoz_query_api",
+                "error": error_message,
             }
 
-        query_response = response_json.get("data", {})
-        if (
-            isinstance(query_response, dict)
-            and "type" in query_response
-            and "data" in query_response
-        ):
-            query_data = query_response.get("data", {})
-        else:
-            query_data = query_response
-
+        response_json = response_json or {}
+        query_data = self._unwrap_v5_query_data(response_json)
         results = query_data.get("results", []) if isinstance(query_data, dict) else []
 
         metrics: list[dict[str, Any]] = []
@@ -267,7 +381,218 @@ class SigNozClient:
             "resolved_metric": resolved_metric,
             "aggregation": aggregation,
             "metrics": metrics,
-            "query_backend": "signoz_metrics_api",
+            "query_backend": "signoz_query_api",
+        }
+
+    def _query_logs_via_api(
+        self,
+        *,
+        service: str | None,
+        start: datetime,
+        end: datetime,
+        severity: str | None,
+        effective_limit: int,
+    ) -> dict[str, Any]:
+        filter_parts: list[str] = []
+        if service:
+            filter_parts.append(f"service.name = '{_escape_signoz_filter_value(service)}'")
+        if severity:
+            filter_parts.append(
+                f"severity_text = '{_escape_signoz_filter_value(severity.upper())}'"
+            )
+
+        spec: dict[str, Any] = {
+            "name": "A",
+            "signal": "logs",
+            "order": [
+                {"key": {"name": "timestamp"}, "direction": "desc"},
+                {"key": {"name": "id"}, "direction": "desc"},
+            ],
+            "offset": 0,
+            "limit": effective_limit,
+            "disabled": False,
+        }
+        log_filter = _signoz_filter_expression(filter_parts)
+        if log_filter is not None:
+            spec["filter"] = log_filter
+
+        payload: dict[str, Any] = {
+            "start": int(start.timestamp() * 1000),
+            "end": int(end.timestamp() * 1000),
+            "requestType": "raw",
+            "compositeQuery": {"queries": [{"type": "builder_query", "spec": spec}]},
+            "noCache": True,
+        }
+
+        response_json, error_message = self._query_range_post(payload)
+        if error_message:
+            return {
+                "source": "signoz_logs",
+                "available": False,
+                "total": 0,
+                "logs": [],
+                "query_backend": "signoz_query_api",
+                "error": error_message,
+            }
+
+        logs = [_parse_log_row(row) for row in self._parse_raw_rows(response_json or {})]
+        return {
+            "source": "signoz_logs",
+            "available": True,
+            "total": len(logs),
+            "logs": logs,
+            "query_backend": "signoz_query_api",
+        }
+
+    def _query_traces_via_api(
+        self,
+        *,
+        service: str | None,
+        start: datetime,
+        end: datetime,
+        error_only: bool,
+        effective_limit: int,
+    ) -> dict[str, Any]:
+        filter_parts: list[str] = []
+        if service:
+            filter_parts.append(f"serviceName = '{_escape_signoz_filter_value(service)}'")
+        if error_only:
+            filter_parts.append("hasError = true")
+
+        spec: dict[str, Any] = {
+            "name": "A",
+            "signal": "traces",
+            "selectFields": [
+                {"name": "serviceName"},
+                {"name": "name"},
+                {"name": "traceID"},
+                {"name": "spanID"},
+                {"name": "durationNano"},
+                {"name": "hasError"},
+                {"name": "statusCode"},
+                {"name": "statusCodeString"},
+                {"name": "httpMethod"},
+                {"name": "httpUrl"},
+                {"name": "kindString"},
+            ],
+            "order": [{"key": {"name": "timestamp"}, "direction": "desc"}],
+            "offset": 0,
+            "limit": effective_limit,
+            "disabled": False,
+        }
+        trace_filter = _signoz_filter_expression(filter_parts)
+        if trace_filter is not None:
+            spec["filter"] = trace_filter
+
+        payload: dict[str, Any] = {
+            "start": int(start.timestamp() * 1000),
+            "end": int(end.timestamp() * 1000),
+            "requestType": "raw",
+            "compositeQuery": {"queries": [{"type": "builder_query", "spec": spec}]},
+            "noCache": True,
+        }
+
+        response_json, error_message = self._query_range_post(payload)
+        if error_message:
+            return {
+                "source": "signoz_traces",
+                "available": False,
+                "total": 0,
+                "traces": [],
+                "query_backend": "signoz_query_api",
+                "error": error_message,
+            }
+
+        traces = [_parse_trace_row(row) for row in self._parse_raw_rows(response_json or {})]
+        return {
+            "source": "signoz_traces",
+            "available": True,
+            "total": len(traces),
+            "traces": traces,
+            "query_backend": "signoz_query_api",
+        }
+
+    def _query_trace_summary_via_api(
+        self,
+        *,
+        service: str | None,
+        start: datetime,
+        end: datetime,
+    ) -> dict[str, Any]:
+        filter_parts: list[str] = []
+        if service:
+            filter_parts.append(f"service.name = '{_escape_signoz_filter_value(service)}'")
+        base_filter = _signoz_filter_expression(filter_parts)
+
+        error_filter_parts = list(filter_parts)
+        error_filter_parts.append("has_error = true")
+        error_filter = _signoz_filter_expression(error_filter_parts)
+
+        def _trace_scalar_spec(
+            name: str, expression: str, trace_filter: dict[str, str] | None
+        ) -> dict[str, Any]:
+            spec: dict[str, Any] = {
+                "name": name,
+                "signal": "traces",
+                "stepInterval": 60,
+                "aggregations": [{"expression": expression}],
+                "disabled": False,
+            }
+            if trace_filter is not None:
+                spec["filter"] = trace_filter
+            return {"type": "builder_query", "spec": spec}
+
+        payload: dict[str, Any] = {
+            "start": int(start.timestamp() * 1000),
+            "end": int(end.timestamp() * 1000),
+            "requestType": "scalar",
+            "compositeQuery": {
+                "queries": [
+                    _trace_scalar_spec("A", "count()", base_filter),
+                    _trace_scalar_spec("B", "count()", error_filter),
+                    _trace_scalar_spec("C", "p99(duration_nano)", base_filter),
+                    _trace_scalar_spec("D", "p95(duration_nano)", base_filter),
+                    _trace_scalar_spec("E", "avg(duration_nano)", base_filter),
+                    _trace_scalar_spec("F", "max(duration_nano)", base_filter),
+                ]
+            },
+            "noCache": True,
+        }
+
+        response_json, error_message = self._query_range_post(payload)
+        if error_message:
+            return {
+                "source": "signoz_traces",
+                "available": False,
+                "query_backend": "signoz_query_api",
+                "error": error_message,
+            }
+
+        values = self._parse_scalar_by_query_name(response_json or {})
+
+        def _nano_to_ms(value: float) -> float:
+            return round(value / 1_000_000, 4)
+
+        def _safe_float(value: float, default: float = 0.0) -> float:
+            try:
+                parsed = float(value)
+                return parsed if not math.isnan(parsed) else default
+            except (TypeError, ValueError):
+                return default
+
+        total = int(values.get("A", 0))
+        errors = int(values.get("B", 0))
+        return {
+            "source": "signoz_traces",
+            "available": True,
+            "total_spans": total,
+            "error_spans": errors,
+            "error_rate": round(errors / total, 4) if total else 0.0,
+            "p99_ms": _nano_to_ms(_safe_float(values.get("C", 0.0))),
+            "p95_ms": _nano_to_ms(_safe_float(values.get("D", 0.0))),
+            "avg_ms": _nano_to_ms(_safe_float(values.get("E", 0.0))),
+            "max_ms": _nano_to_ms(_safe_float(values.get("F", 0.0))),
+            "query_backend": "signoz_query_api",
         }
 
     # ------------------------------------------------------------------ logs
@@ -279,76 +604,26 @@ class SigNozClient:
         severity: str | None = None,
         limit: int = 50,
     ) -> dict[str, Any]:
-        """Query ``signoz_logs.distributed_logs_v2``."""
-        effective_limit = _clamp_limit(limit, self.config)
-        start, end = _time_bounds(time_range_minutes)
-        bucket_start, bucket_end = _bucket_bounds_seconds(start, end)
-
-        conditions: list[str] = [
-            "timestamp >= %(start)s",
-            "timestamp <= %(end)s",
-            "ts_bucket_start >= %(bucket_start)s",
-            "ts_bucket_start <= %(bucket_end)s",
-        ]
-        params: dict[str, Any] = {
-            "start": int(start.timestamp() * 1e9),
-            "end": int(end.timestamp() * 1e9),
-            "bucket_start": bucket_start,
-            "bucket_end": bucket_end,
-            "limit": effective_limit,
-        }
-
-        if service:
-            conditions.append("resources_string['service.name'] = %(service)s")
-            params["service"] = service
-
-        if severity:
-            conditions.append("severity_text = %(severity)s")
-            params["severity"] = severity.upper()
-
-        where_clause = " AND ".join(conditions)
-
-        query = (
-            "SELECT "
-            "  timestamp, "
-            "  severity_text, "
-            "  severity_number, "
-            "  body, "
-            "  trace_id, "
-            "  span_id, "
-            "  attributes_string, "
-            "  resources_string "
-            f"FROM signoz_logs.distributed_logs_v2 "
-            f"WHERE {where_clause} "
-            "ORDER BY timestamp DESC "
-            "LIMIT %(limit)s"
-        )
-
-        client = _make_client(self.config)
-        try:
-            result = client.query(query, parameters=params)
-            logs: list[dict[str, Any]] = []
-            for row in result.named_results():
-                logs.append(
-                    {
-                        "timestamp": str(row["timestamp"]),
-                        "severity": row["severity_text"],
-                        "severity_number": row["severity_number"],
-                        "message": row["body"],
-                        "trace_id": row["trace_id"] or "",
-                        "span_id": row["span_id"] or "",
-                        "attributes": dict(row["attributes_string"] or {}),
-                        "resources": dict(row["resources_string"] or {}),
-                    }
-                )
+        """Query SigNoz logs via Query Range API."""
+        config_error = self._configuration_error()
+        if config_error:
             return {
                 "source": "signoz_logs",
-                "available": True,
-                "total": len(logs),
-                "logs": logs,
+                "available": False,
+                "total": 0,
+                "logs": [],
+                "error": config_error,
             }
-        finally:
-            client.close()
+
+        effective_limit = _clamp_limit(limit, self.config)
+        start, end = _time_bounds(time_range_minutes)
+        return self._query_logs_via_api(
+            service=service,
+            start=start,
+            end=end,
+            severity=severity,
+            effective_limit=effective_limit,
+        )
 
     # ---------------------------------------------------------------- metrics
 
@@ -360,95 +635,31 @@ class SigNozClient:
         aggregation: str = "avg",
         limit: int = 50,
     ) -> dict[str, Any]:
-        """Query SigNoz metrics API (preferred) or ClickHouse (fallback)."""
-        effective_limit = _clamp_limit(limit, self.config)
-        start, end = _time_bounds(time_range_minutes)
-
-        # Map curated aliases to actual metric names
+        """Query SigNoz metrics via Query Range API."""
         resolved_metric = _CURATED_METRICS.get(metric_name, metric_name)
-
-        if self._has_metrics_api_config():
-            return self._query_metrics_via_api(
-                metric_name=metric_name,
-                resolved_metric=resolved_metric,
-                service=service,
-                start=start,
-                end=end,
-                aggregation=aggregation,
-                effective_limit=effective_limit,
-            )
-
-        conditions = [
-            "s.unix_milli >= %(start_ms)s",
-            "s.unix_milli <= %(end_ms)s",
-            "ts.metric_name = %(metric_name)s",
-        ]
-        params: dict[str, Any] = {
-            "start_ms": int(start.timestamp() * 1000),
-            "end_ms": int(end.timestamp() * 1000),
-            "metric_name": resolved_metric,
-            "limit": effective_limit,
-        }
-
-        if service:
-            conditions.append("simpleJSONExtractString(ts.labels, 'service_name') = %(service)s")
-            params["service"] = service
-
-        agg_expr = "avg(s.value)"
-        if aggregation == "sum":
-            agg_expr = "sum(s.value)"
-        elif aggregation == "max":
-            agg_expr = "max(s.value)"
-        elif aggregation == "min":
-            agg_expr = "min(s.value)"
-        elif aggregation == "count":
-            agg_expr = "count(s.value)"
-
-        where_clause = " AND ".join(conditions)
-
-        query = (
-            "SELECT "
-            "  toStartOfInterval(fromUnixTimestamp64Milli(s.unix_milli), INTERVAL 1 MINUTE) AS interval, "
-            f"  {agg_expr} AS value, "
-            "  ts.metric_name, "
-            "  simpleJSONExtractString(ts.labels, 'service_name') AS service_name "
-            "FROM signoz_metrics.distributed_samples_v4 AS s "
-            "INNER JOIN signoz_metrics.distributed_time_series_v4 AS ts "
-            "  ON s.fingerprint = ts.fingerprint "
-            " AND s.metric_name = ts.metric_name "
-            " AND s.temporality = ts.temporality "
-            " AND coalesce(s.env, '') = coalesce(ts.env, '') "
-            f"WHERE {where_clause} "
-            "GROUP BY interval, ts.metric_name, service_name "
-            "ORDER BY interval ASC "
-            "LIMIT %(limit)s"
-        )
-
-        client = _make_client(self.config)
-        try:
-            result = client.query(query, parameters=params)
-            metrics: list[dict[str, Any]] = []
-            for row in result.named_results():
-                metrics.append(
-                    {
-                        "interval": str(row["interval"]),
-                        "value": row["value"],
-                        "metric_name": row["metric_name"],
-                        "service_name": row["service_name"] or "",
-                    }
-                )
+        config_error = self._configuration_error()
+        if config_error:
             return {
                 "source": "signoz_metrics",
-                "available": True,
-                "total": len(metrics),
+                "available": False,
                 "metric_name": metric_name,
                 "resolved_metric": resolved_metric,
                 "aggregation": aggregation,
-                "metrics": metrics,
-                "query_backend": "clickhouse",
+                "metrics": [],
+                "error": config_error,
             }
-        finally:
-            client.close()
+
+        effective_limit = _clamp_limit(limit, self.config)
+        start, end = _time_bounds(time_range_minutes)
+        return self._query_metrics_via_api(
+            metric_name=metric_name,
+            resolved_metric=resolved_metric,
+            service=service,
+            start=start,
+            end=end,
+            aggregation=aggregation,
+            effective_limit=effective_limit,
+        )
 
     # ---------------------------------------------------------------- traces
 
@@ -459,83 +670,26 @@ class SigNozClient:
         error_only: bool = False,
         limit: int = 50,
     ) -> dict[str, Any]:
-        """Query ``signoz_traces.distributed_signoz_index_v3``."""
-        effective_limit = _clamp_limit(limit, self.config)
-        start, end = _time_bounds(time_range_minutes)
-        bucket_start, bucket_end = _bucket_bounds_seconds(start, end)
-
-        conditions: list[str] = [
-            "timestamp >= %(start)s",
-            "timestamp <= %(end)s",
-            "ts_bucket_start >= %(bucket_start)s",
-            "ts_bucket_start <= %(bucket_end)s",
-        ]
-        params: dict[str, Any] = {
-            "start": int(start.timestamp() * 1e9),
-            "end": int(end.timestamp() * 1e9),
-            "bucket_start": bucket_start,
-            "bucket_end": bucket_end,
-            "limit": effective_limit,
-        }
-
-        if service:
-            conditions.append("resource_string_service$$name = %(service)s")
-            params["service"] = service
-
-        if error_only:
-            conditions.append("has_error = true")
-
-        where_clause = " AND ".join(conditions)
-
-        query = (
-            "SELECT "
-            "  timestamp, "
-            "  trace_id, "
-            "  span_id, "
-            "  name, "
-            "  duration_nano / 1000000 AS duration_ms, "
-            "  has_error, "
-            "  status_code, "
-            "  status_code_string, "
-            "  http_method, "
-            "  http_url, "
-            "  kind_string, "
-            "  resource_string_service$$name AS service_name "
-            "FROM signoz_traces.distributed_signoz_index_v3 "
-            f"WHERE {where_clause} "
-            "ORDER BY timestamp DESC "
-            "LIMIT %(limit)s"
-        )
-
-        client = _make_client(self.config)
-        try:
-            result = client.query(query, parameters=params)
-            traces: list[dict[str, Any]] = []
-            for row in result.named_results():
-                traces.append(
-                    {
-                        "timestamp": str(row["timestamp"]),
-                        "trace_id": row["trace_id"] or "",
-                        "span_id": row["span_id"] or "",
-                        "name": row["name"] or "",
-                        "duration_ms": row["duration_ms"],
-                        "has_error": bool(row["has_error"]),
-                        "status_code": row["status_code"],
-                        "status_code_string": row["status_code_string"] or "",
-                        "http_method": row["http_method"] or "",
-                        "http_url": row["http_url"] or "",
-                        "kind_string": row["kind_string"] or "",
-                        "service_name": row["service_name"] or "",
-                    }
-                )
+        """Query SigNoz traces via Query Range API."""
+        config_error = self._configuration_error()
+        if config_error:
             return {
                 "source": "signoz_traces",
-                "available": True,
-                "total": len(traces),
-                "traces": traces,
+                "available": False,
+                "total": 0,
+                "traces": [],
+                "error": config_error,
             }
-        finally:
-            client.close()
+
+        effective_limit = _clamp_limit(limit, self.config)
+        start, end = _time_bounds(time_range_minutes)
+        return self._query_traces_via_api(
+            service=service,
+            start=start,
+            end=end,
+            error_only=error_only,
+            effective_limit=effective_limit,
+        )
 
     # ---------------------------------------------------------------- summary
 
@@ -545,64 +699,13 @@ class SigNozClient:
         time_range_minutes: int = DEFAULT_TIME_RANGE_MINUTES,
     ) -> dict[str, Any]:
         """Return aggregate trace stats (error rate, p99 latency, call count)."""
-        start, end = _time_bounds(time_range_minutes)
-        bucket_start, bucket_end = _bucket_bounds_seconds(start, end)
-
-        conditions: list[str] = [
-            "timestamp >= %(start)s",
-            "timestamp <= %(end)s",
-            "ts_bucket_start >= %(bucket_start)s",
-            "ts_bucket_start <= %(bucket_end)s",
-        ]
-        params: dict[str, Any] = {
-            "start": int(start.timestamp() * 1e9),
-            "end": int(end.timestamp() * 1e9),
-            "bucket_start": bucket_start,
-            "bucket_end": bucket_end,
-        }
-
-        if service:
-            conditions.append("resource_string_service$$name = %(service)s")
-            params["service"] = service
-
-        where_clause = " AND ".join(conditions)
-
-        query = (
-            "SELECT "
-            "  count() AS total_spans, "
-            "  countIf(has_error = true) AS error_spans, "
-            "  quantile(0.99)(duration_nano / 1000000) AS p99_ms, "
-            "  quantile(0.95)(duration_nano / 1000000) AS p95_ms, "
-            "  avg(duration_nano / 1000000) AS avg_ms, "
-            "  max(duration_nano / 1000000) AS max_ms "
-            "FROM signoz_traces.distributed_signoz_index_v3 "
-            f"WHERE {where_clause}"
-        )
-
-        client = _make_client(self.config)
-        try:
-            result = client.query(query, parameters=params)
-            row = result.first_row if result.row_count > 0 else (0, 0, 0.0, 0.0, 0.0, 0.0)
-            total = int(row[0] or 0)
-            errors = int(row[1] or 0)
-
-            def _safe_float(value: Any, default: float = 0.0) -> float:
-                try:
-                    parsed = float(value)
-                    return parsed if not math.isnan(parsed) else default
-                except (TypeError, ValueError):
-                    return default
-
+        config_error = self._configuration_error()
+        if config_error:
             return {
                 "source": "signoz_traces",
-                "available": True,
-                "total_spans": total,
-                "error_spans": errors,
-                "error_rate": round(errors / total, 4) if total else 0.0,
-                "p99_ms": _safe_float(row[2]),
-                "p95_ms": _safe_float(row[3]),
-                "avg_ms": _safe_float(row[4]),
-                "max_ms": _safe_float(row[5]),
+                "available": False,
+                "error": config_error,
             }
-        finally:
-            client.close()
+
+        start, end = _time_bounds(time_range_minutes)
+        return self._query_trace_summary_via_api(service=service, start=start, end=end)

--- a/app/services/signoz/client.py
+++ b/app/services/signoz/client.py
@@ -1,7 +1,7 @@
-"""SigNoz ClickHouse query client.
+"""SigNoz query client.
 
-Thin wrapper around ``clickhouse_connect`` that knows the SigNoz schema and
-enforces read-only, timeouts, and result caps.
+Uses SigNoz Metrics API for metrics when API credentials are present, and
+retains ClickHouse-backed paths for logs/traces and metrics fallback.
 """
 
 from __future__ import annotations
@@ -10,6 +10,8 @@ import logging
 import math
 from datetime import UTC, datetime, timedelta
 from typing import Any
+
+import httpx
 
 from app.integrations.clickhouse import _get_client
 from app.integrations.signoz import SigNozConfig
@@ -53,11 +55,214 @@ def _bucket_bounds_seconds(start: datetime, end: datetime) -> tuple[int, int]:
     return start_sec - 1800, end_sec
 
 
+def _iso_from_epoch_ms(timestamp_ms: int) -> str:
+    """Render epoch milliseconds as an ISO-8601 UTC timestamp."""
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
 class SigNozClient:
     """Read-only SigNoz ClickHouse client."""
 
     def __init__(self, config: SigNozConfig) -> None:
         self.config = config
+
+    def _has_metrics_api_config(self) -> bool:
+        return bool(self.config.url and self.config.api_key)
+
+    def _metrics_api_base_url(self) -> str:
+        return self.config.url.rstrip("/")
+
+    def _query_metrics_via_api(
+        self,
+        *,
+        metric_name: str,
+        resolved_metric: str,
+        service: str | None,
+        start: datetime,
+        end: datetime,
+        aggregation: str,
+        effective_limit: int,
+    ) -> dict[str, Any]:
+        start_ms = int(start.timestamp() * 1000)
+        end_ms = int(end.timestamp() * 1000)
+        escaped_service = (service or "").replace("\\", "\\\\").replace("'", "\\'")
+        filter_expression = f"service.name = '{escaped_service}'" if escaped_service else ""
+
+        if resolved_metric == "signoz_calls_total":
+            time_aggregation = "rate"
+            space_aggregation = "sum"
+        else:
+            time_aggregation = (
+                aggregation if aggregation in {"sum", "avg", "min", "max", "count"} else "avg"
+            )
+            space_aggregation = (
+                aggregation if aggregation in {"sum", "avg", "min", "max", "count"} else "avg"
+            )
+
+        payload: dict[str, Any] = {
+            "start": start_ms,
+            "end": end_ms,
+            "requestType": "time_series",
+            "compositeQuery": {
+                "queries": [
+                    {
+                        "type": "builder_query",
+                        "spec": {
+                            "name": "A",
+                            "signal": "metrics",
+                            "stepInterval": 60,
+                            "aggregations": [
+                                {
+                                    "metricName": resolved_metric,
+                                    "temporality": "unspecified",
+                                    "timeAggregation": time_aggregation,
+                                    "spaceAggregation": space_aggregation,
+                                }
+                            ],
+                            "groupBy": [{"name": "service.name"}],
+                            "disabled": False,
+                            "limit": effective_limit,
+                        },
+                    }
+                ]
+            },
+            "noCache": True,
+        }
+        if filter_expression:
+            payload["compositeQuery"]["queries"][0]["spec"]["filter"] = {
+                "expression": filter_expression
+            }
+
+        try:
+            response = httpx.post(
+                f"{self._metrics_api_base_url()}/api/v5/query_range",
+                headers={
+                    "SigNoz-Api-Key": self.config.api_key,
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                json=payload,
+                timeout=self.config.timeout_seconds,
+            )
+            response.raise_for_status()
+            response_json = response.json()
+        except httpx.HTTPStatusError as err:
+            error_payload: dict[str, Any] = {}
+            try:
+                parsed = err.response.json()
+                if isinstance(parsed, dict):
+                    error_payload = parsed
+            except Exception:
+                error_payload = {}
+            error_message = (
+                error_payload.get("error", {}).get("message")
+                if isinstance(error_payload.get("error"), dict)
+                else ""
+            )
+            if err.response.status_code == 404:
+                return {
+                    "source": "signoz_metrics",
+                    "available": True,
+                    "total": 0,
+                    "metric_name": metric_name,
+                    "resolved_metric": resolved_metric,
+                    "aggregation": aggregation,
+                    "metrics": [],
+                    "query_backend": "signoz_metrics_api",
+                    "warning": error_message or f"Metric not found: {resolved_metric}",
+                }
+            return {
+                "source": "signoz_metrics",
+                "available": False,
+                "metric_name": metric_name,
+                "resolved_metric": resolved_metric,
+                "aggregation": aggregation,
+                "metrics": [],
+                "query_backend": "signoz_metrics_api",
+                "error": error_message or f"HTTP {err.response.status_code}",
+            }
+        except Exception as err:
+            return {
+                "source": "signoz_metrics",
+                "available": False,
+                "metric_name": metric_name,
+                "resolved_metric": resolved_metric,
+                "aggregation": aggregation,
+                "metrics": [],
+                "query_backend": "signoz_metrics_api",
+                "error": str(err),
+            }
+
+        query_response = response_json.get("data", {})
+        if (
+            isinstance(query_response, dict)
+            and "type" in query_response
+            and "data" in query_response
+        ):
+            query_data = query_response.get("data", {})
+        else:
+            query_data = response_json.get("data", {})
+
+        results = query_data.get("results", []) if isinstance(query_data, dict) else []
+
+        metrics: list[dict[str, Any]] = []
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            aggregations = result.get("aggregations") or []
+            for aggregation_bucket in aggregations:
+                if not isinstance(aggregation_bucket, dict):
+                    continue
+                series_list = aggregation_bucket.get("series") or []
+                for series in series_list:
+                    if not isinstance(series, dict):
+                        continue
+                    labels = series.get("labels", [])
+                    service_name = ""
+                    for label in labels:
+                        if not isinstance(label, dict):
+                            continue
+                        key = label.get("key", {})
+                        key_name = key.get("name") if isinstance(key, dict) else ""
+                        if key_name in {"service.name", "service_name"}:
+                            service_name = str(label.get("value") or "")
+                            break
+
+                    values = series.get("values") or []
+                    for point in values:
+                        if not isinstance(point, dict):
+                            continue
+                        timestamp_ms = int(point.get("timestamp") or 0)
+                        value = point.get("value")
+                        metrics.append(
+                            {
+                                "interval": _iso_from_epoch_ms(timestamp_ms)
+                                if timestamp_ms
+                                else "",
+                                "value": value,
+                                "metric_name": resolved_metric,
+                                "service_name": service_name,
+                            }
+                        )
+                        if len(metrics) >= effective_limit:
+                            break
+                    if len(metrics) >= effective_limit:
+                        break
+                if len(metrics) >= effective_limit:
+                    break
+            if len(metrics) >= effective_limit:
+                break
+
+        return {
+            "source": "signoz_metrics",
+            "available": True,
+            "total": len(metrics),
+            "metric_name": metric_name,
+            "resolved_metric": resolved_metric,
+            "aggregation": aggregation,
+            "metrics": metrics,
+            "query_backend": "signoz_metrics_api",
+        }
 
     # ------------------------------------------------------------------ logs
 
@@ -149,12 +354,23 @@ class SigNozClient:
         aggregation: str = "avg",
         limit: int = 50,
     ) -> dict[str, Any]:
-        """Query ``signoz_metrics.distributed_samples_v4`` joined with ``time_series_v4``."""
+        """Query SigNoz metrics API (preferred) or ClickHouse (fallback)."""
         effective_limit = _clamp_limit(limit, self.config)
         start, end = _time_bounds(time_range_minutes)
 
         # Map curated aliases to actual metric names
         resolved_metric = _CURATED_METRICS.get(metric_name, metric_name)
+
+        if self._has_metrics_api_config():
+            return self._query_metrics_via_api(
+                metric_name=metric_name,
+                resolved_metric=resolved_metric,
+                service=service,
+                start=start,
+                end=end,
+                aggregation=aggregation,
+                effective_limit=effective_limit,
+            )
 
         conditions = [
             "s.unix_milli >= %(start_ms)s",
@@ -223,6 +439,7 @@ class SigNozClient:
                 "resolved_metric": resolved_metric,
                 "aggregation": aggregation,
                 "metrics": metrics,
+                "query_backend": "clickhouse",
             }
         finally:
             client.close()

--- a/app/tools/SignozLogsTool/__init__.py
+++ b/app/tools/SignozLogsTool/__init__.py
@@ -12,7 +12,10 @@ from app.tools.utils.compaction import compact_logs, summarize_counts
 
 
 def _logs_is_available(sources: dict[str, dict]) -> bool:
-    return signoz_available_or_backend(sources)
+    if signoz_available_or_backend(sources):
+        return True
+    signoz = sources.get("signoz", {})
+    return bool(signoz.get("url") and signoz.get("api_key"))
 
 
 def _logs_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -112,7 +115,7 @@ def query_signoz_logs(
         return {
             "source": "signoz_logs",
             "available": False,
-            "error": "SigNoz integration not configured",
+            "error": "SigNoz logs not configured. Provide SIGNOZ_URL and SIGNOZ_API_KEY.",
             "logs": [],
         }
 

--- a/app/tools/SignozMetricsTool/__init__.py
+++ b/app/tools/SignozMetricsTool/__init__.py
@@ -11,7 +11,10 @@ from app.tools.utils.availability import signoz_available_or_backend
 
 
 def _metrics_is_available(sources: dict[str, dict]) -> bool:
-    return signoz_available_or_backend(sources)
+    if signoz_available_or_backend(sources):
+        return True
+    signoz = sources.get("signoz", {})
+    return bool(signoz.get("url") and signoz.get("api_key"))
 
 
 def _metrics_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -87,11 +90,14 @@ def query_signoz_metrics(
         )
 
     config = SigNozConfig.model_validate(_kwargs)
-    if not config.is_configured:
+    if not (config.has_metrics_api or config.is_configured):
         return {
             "source": "signoz_metrics",
             "available": False,
-            "error": "SigNoz integration not configured",
+            "error": (
+                "SigNoz metrics not configured. Provide SIGNOZ_URL + SIGNOZ_API_KEY "
+                "(preferred) or ClickHouse settings."
+            ),
             "metrics": [],
         }
 

--- a/app/tools/SignozMetricsTool/__init__.py
+++ b/app/tools/SignozMetricsTool/__init__.py
@@ -90,14 +90,11 @@ def query_signoz_metrics(
         )
 
     config = SigNozConfig.model_validate(_kwargs)
-    if not (config.has_metrics_api or config.is_configured):
+    if not config.is_configured:
         return {
             "source": "signoz_metrics",
             "available": False,
-            "error": (
-                "SigNoz metrics not configured. Provide SIGNOZ_URL + SIGNOZ_API_KEY "
-                "(preferred) or ClickHouse settings."
-            ),
+            "error": ("SigNoz metrics not configured. Provide SIGNOZ_URL and SIGNOZ_API_KEY."),
             "metrics": [],
         }
 

--- a/app/tools/SignozTracesTool/__init__.py
+++ b/app/tools/SignozTracesTool/__init__.py
@@ -11,7 +11,10 @@ from app.tools.utils.availability import signoz_available_or_backend
 
 
 def _traces_is_available(sources: dict[str, dict]) -> bool:
-    return signoz_available_or_backend(sources)
+    if signoz_available_or_backend(sources):
+        return True
+    signoz = sources.get("signoz", {})
+    return bool(signoz.get("url") and signoz.get("api_key"))
 
 
 def _traces_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
@@ -81,7 +84,7 @@ def query_signoz_traces(
         return {
             "source": "signoz_traces",
             "available": False,
-            "error": "SigNoz integration not configured",
+            "error": "SigNoz traces not configured. Provide SIGNOZ_URL and SIGNOZ_API_KEY.",
             "traces": [],
         }
 

--- a/app/tools/utils/availability.py
+++ b/app/tools/utils/availability.py
@@ -65,7 +65,7 @@ def signoz_available_or_backend(sources: dict[str, dict]) -> bool:
     signoz = sources.get("signoz", {})
     if signoz.get("_backend"):
         return True
-    return bool(signoz.get("connection_verified") and signoz.get("clickhouse_host"))
+    return bool(signoz.get("connection_verified") and signoz.get("url") and signoz.get("api_key"))
 
 
 def hermes_available_or_backend(sources: dict[str, dict]) -> bool:

--- a/app/tools/utils/availability.py
+++ b/app/tools/utils/availability.py
@@ -63,7 +63,9 @@ def signoz_available_or_backend(sources: dict[str, dict]) -> bool:
     mock ``signoz_backend`` for synthetic tests.
     """
     signoz = sources.get("signoz", {})
-    return bool(signoz.get("connection_verified") or signoz.get("_backend"))
+    if signoz.get("_backend"):
+        return True
+    return bool(signoz.get("connection_verified") and signoz.get("clickhouse_host"))
 
 
 def hermes_available_or_backend(sources: dict[str, dict]) -> bool:

--- a/docs/signoz.mdx
+++ b/docs/signoz.mdx
@@ -1,57 +1,65 @@
 # SigNoz Integration
 
-Query logs, metrics, and traces from [SigNoz](https://signoz.io).
+Query logs, metrics, and traces from [SigNoz](https://signoz.io) via the Query Range API.
 
-OpenSRE now prefers the SigNoz **Metrics API** (`/api/v5/query_range`) for
-`query_signoz_metrics` instead of querying SigNoz ClickHouse tables directly.
+OpenSRE uses `POST /api/v5/query_range` for `query_signoz_logs`, `query_signoz_metrics`, and
+`query_signoz_traces`. Configure **`SIGNOZ_URL`** and **`SIGNOZ_API_KEY`** (service account key).
 
 ## Quick Start
 
 If you already run SigNoz, skip to env setup below.
-If you want a local stack, use the official SigNoz Docker setup (or the thin wrappers in `infra/scripts/signoz/` that mirror it):
+If you want a local stack, use the official SigNoz Docker setup (or the thin wrappers in `infra/scripts/signoz/`):
 
 ```bash
-# optional convenience wrappers (mirror official docs)
 bash infra/scripts/signoz/start-local.sh
 # ... later
 bash infra/scripts/signoz/stop-local.sh
 ```
 
-### 1. Configure Environment Variables
+Local Docker serves the UI and API on **http://localhost:8080** (not 3301).
 
-Set your SigNoz API credentials (preferred) and optional ClickHouse fallback:
+### 1. Create an API key
+
+In SigNoz: **Settings → Service Accounts** → create a service account → **Keys** → **Add Key**.
+Copy the key (shown once).
+
+### 2. Configure environment variables
 
 ```bash
-export SIGNOZ_URL="http://localhost:3301"
+export SIGNOZ_URL="http://localhost:8080"
 export SIGNOZ_API_KEY="<service-account-api-key>"
-
-# Optional fallback credentials (currently used by logs/traces):
-export SIGNOZ_CLICKHOUSE_HOST="localhost"
-export SIGNOZ_CLICKHOUSE_PORT="8123"
-export SIGNOZ_CLICKHOUSE_USER="default"
-export SIGNOZ_CLICKHOUSE_PASSWORD=""
-export SIGNOZ_CLICKHOUSE_DATABASE="default"
 ```
 
-### 2. Verify Connectivity
+Or source the helper:
 
 ```bash
-opensre integrations verify signoz
+source infra/scripts/signoz/env.sh
+export SIGNOZ_API_KEY="<your-key>"
 ```
 
-Expected output:
+### 3. Verify connectivity
 
-```
-Connected to SigNoz Metrics API (/api/v5/query_range).
+```bash
+bash infra/scripts/signoz/verify.sh
+# or: uv run opensre integrations verify signoz
 ```
 
-### 3. Use the Tools
+Expected output mentions the SigNoz Query API (`/api/v2/metrics`, `/api/v5/query_range`).
+
+### 4. Live smoke test (optional)
+
+```bash
+export SIGNOZ_API_KEY="<your-key>"
+bash infra/scripts/signoz/test-query-api.sh
+```
+
+### 5. Use the tools
 
 When `alert_source` is `signoz`, the agent auto-seeds three tools before the ReAct loop:
 
-- **`query_signoz_logs`** — Search `signoz_logs.distributed_logs_v2` by service, severity, and time window.
-- **`query_signoz_metrics`** — Query SigNoz Metrics API (`/api/v5/query_range`) for CPU, memory, and request-rate signals.
-- **`query_signoz_traces`** — Query `signoz_traces.distributed_signoz_index_v3` for error spans, p99 latency, and inter-service dependencies.
+- **`query_signoz_logs`** — Search logs by service, severity, and time window.
+- **`query_signoz_metrics`** — Query CPU, memory, and request-rate signals.
+- **`query_signoz_traces`** — Query error spans, latency percentiles, and dependencies.
 
 ## Webhook Configuration
 
@@ -64,56 +72,15 @@ SigNoz emits Prometheus-style webhook payloads. To trigger OpenSRE investigation
    ```
 3. The agent will detect `alert_source: signoz` from the payload and auto-query logs, metrics, and traces.
 
-### Example Webhook Payload
-
-```json
-{
-  "receiver": "opensre",
-  "status": "firing",
-  "alerts": [
-    {
-      "status": "firing",
-      "labels": {
-        "alertname": "HighErrorRate",
-        "service_name": "payment-service",
-        "severity": "critical"
-      },
-      "annotations": {
-        "summary": "Error rate exceeded 5% for payment-service"
-      },
-      "startsAt": "2024-01-15T10:00:00Z"
-    }
-  ],
-  "groupLabels": { "alertname": "HighErrorRate" },
-  "commonLabels": {
-    "alertname": "HighErrorRate",
-    "service_name": "payment-service",
-    "severity": "critical"
-  },
-  "commonAnnotations": {
-    "summary": "Error rate exceeded 5% for payment-service"
-  }
-}
-```
-
 ## CLI Setup
 
 ```bash
 opensre integrations setup signoz
 ```
 
-You will be prompted for:
-- SigNoz URL
-- SigNoz API key
-- ClickHouse host (optional; currently needed for logs/traces)
-- ClickHouse port (default: 8123)
-- ClickHouse user (default: default)
-- ClickHouse password
-- ClickHouse database (default: default)
+You will be prompted for SigNoz URL and API key only.
 
 ## Supported Metrics (V1)
-
-The metrics tool supports a curated list of common infrastructure metrics:
 
 | Alias | Actual SigNoz Metric |
 |-------|---------------------|
@@ -122,43 +89,18 @@ The metrics tool supports a curated list of common infrastructure metrics:
 | `request_rate` | `signoz_calls_total` |
 
 You can also pass any raw metric name known to SigNoz.
-For latency percentiles (p95/p99), prefer `query_signoz_traces`, which computes
-percentile estimates directly from span durations.
+For latency percentiles (p95/p99), prefer `query_signoz_traces`.
 
-## Compatibility Notes
+## API reference
 
-### Metrics (preferred path)
-
-Metrics queries use the SigNoz Metrics API endpoint:
-
-- `POST /api/v5/query_range`
-
-Authentication uses:
-
-- `SigNoz-Api-Key: <YOUR_API_KEY>`
-
-### Logs/Traces (current fallback path)
-
-Logs and traces currently continue to use direct ClickHouse reads. That means
-ClickHouse credentials are still needed if you want `query_signoz_logs` and
-`query_signoz_traces` to run.
-
-## Schema Compatibility (ClickHouse fallback)
-
-The integration targets SigNoz v0.x+ with the following ClickHouse tables:
-
-- `signoz_logs.distributed_logs_v2`
-- `signoz_metrics.distributed_samples_v4`
-- `signoz_metrics.distributed_time_series_v4`
-- `signoz_traces.distributed_signoz_index_v3`
-
-Verification probes for table existence and fails gracefully if schema drift is detected.
+- Endpoint: `POST {SIGNOZ_URL}/api/v5/query_range`
+- Auth header: `SigNoz-Api-Key: <YOUR_API_KEY>`
+- Validation probe: `GET {SIGNOZ_URL}/api/v2/metrics`
 
 ## Example Investigation
 
 ```bash
-# Manually trigger a SigNoz investigation
-opensre investigate --input-json '{
+uv run opensre investigate --input-json '{
   "alert_source": "signoz",
   "alert_name": "HighErrorRate",
   "pipeline_name": "payment-service",
@@ -173,17 +115,11 @@ opensre investigate --input-json '{
 }'
 ```
 
-The agent will:
-1. Extract `alert_source: signoz`
-2. Seed `query_signoz_logs`, `query_signoz_metrics`, `query_signoz_traces`
-3. Run the ReAct loop to synthesize a diagnosis
-4. Deliver the RCA to Slack (if configured)
-
 ## Troubleshooting
 
 | Symptom | Fix |
 |---------|-----|
-| `SigNoz connection failed` | Verify `SIGNOZ_CLICKHOUSE_HOST` and port. For Docker, use the container IP or `host.docker.internal`. |
-| `Missing tables` | Ensure SigNoz has been running long enough to create the distributed tables. Check `system.tables` in ClickHouse. |
-| `No logs returned` | Confirm the service name matches `resources_string['service.name']` in SigNoz. |
-| `No metrics returned` | Verify the metric exists in `signoz_metrics.distributed_time_series_v4`. |
+| `SigNoz configuration is incomplete` | Set both `SIGNOZ_URL` and `SIGNOZ_API_KEY`. |
+| `HTTP 401` on verify | Regenerate the service account key; check URL (local Docker: port **8080**). |
+| `No logs returned` | Confirm telemetry exists in SigNoz and filter fields match (`service.name` for logs). |
+| `No metrics returned` | Verify the metric name in SigNoz Metrics Explorer; empty results return a warning for unknown metrics. |

--- a/docs/signoz.mdx
+++ b/docs/signoz.mdx
@@ -1,6 +1,9 @@
 # SigNoz Integration
 
-Query logs, metrics, and traces from [SigNoz](https://signoz.io) — an OpenTelemetry-native observability platform that stores everything in ClickHouse.
+Query logs, metrics, and traces from [SigNoz](https://signoz.io).
+
+OpenSRE now prefers the SigNoz **Metrics API** (`/api/v5/query_range`) for
+`query_signoz_metrics` instead of querying SigNoz ClickHouse tables directly.
 
 ## Quick Start
 
@@ -16,16 +19,18 @@ bash infra/scripts/signoz/stop-local.sh
 
 ### 1. Configure Environment Variables
 
-Set your SigNoz ClickHouse credentials:
+Set your SigNoz API credentials (preferred) and optional ClickHouse fallback:
 
 ```bash
+export SIGNOZ_URL="http://localhost:3301"
+export SIGNOZ_API_KEY="<service-account-api-key>"
+
+# Optional fallback credentials (currently used by logs/traces):
 export SIGNOZ_CLICKHOUSE_HOST="localhost"
 export SIGNOZ_CLICKHOUSE_PORT="8123"
 export SIGNOZ_CLICKHOUSE_USER="default"
 export SIGNOZ_CLICKHOUSE_PASSWORD=""
 export SIGNOZ_CLICKHOUSE_DATABASE="default"
-export SIGNOZ_URL="http://localhost:3301"      # optional
-export SIGNOZ_API_KEY=""                        # optional
 ```
 
 ### 2. Verify Connectivity
@@ -37,7 +42,7 @@ opensre integrations verify signoz
 Expected output:
 
 ```
-Connected to ClickHouse 24.x; SigNoz schema verified (4 tables present).
+Connected to SigNoz Metrics API (/api/v5/query_range).
 ```
 
 ### 3. Use the Tools
@@ -45,7 +50,7 @@ Connected to ClickHouse 24.x; SigNoz schema verified (4 tables present).
 When `alert_source` is `signoz`, the agent auto-seeds three tools before the ReAct loop:
 
 - **`query_signoz_logs`** — Search `signoz_logs.distributed_logs_v2` by service, severity, and time window.
-- **`query_signoz_metrics`** — Query `signoz_metrics.distributed_samples_v4` for CPU, memory, and request-rate signals.
+- **`query_signoz_metrics`** — Query SigNoz Metrics API (`/api/v5/query_range`) for CPU, memory, and request-rate signals.
 - **`query_signoz_traces`** — Query `signoz_traces.distributed_signoz_index_v3` for error spans, p99 latency, and inter-service dependencies.
 
 ## Webhook Configuration
@@ -98,13 +103,13 @@ opensre integrations setup signoz
 ```
 
 You will be prompted for:
-- ClickHouse host
+- SigNoz URL
+- SigNoz API key
+- ClickHouse host (optional; currently needed for logs/traces)
 - ClickHouse port (default: 8123)
 - ClickHouse user (default: default)
 - ClickHouse password
 - ClickHouse database (default: default)
-- SigNoz URL (optional)
-- SigNoz API key (optional)
 
 ## Supported Metrics (V1)
 
@@ -116,11 +121,29 @@ The metrics tool supports a curated list of common infrastructure metrics:
 | `memory_usage` | `system_memory_usage` |
 | `request_rate` | `signoz_calls_total` |
 
-You can also pass any raw metric name stored in `signoz_metrics.distributed_time_series_v4`.
+You can also pass any raw metric name known to SigNoz.
 For latency percentiles (p95/p99), prefer `query_signoz_traces`, which computes
 percentile estimates directly from span durations.
 
-## Schema Compatibility
+## Compatibility Notes
+
+### Metrics (preferred path)
+
+Metrics queries use the SigNoz Metrics API endpoint:
+
+- `POST /api/v5/query_range`
+
+Authentication uses:
+
+- `SigNoz-Api-Key: <YOUR_API_KEY>`
+
+### Logs/Traces (current fallback path)
+
+Logs and traces currently continue to use direct ClickHouse reads. That means
+ClickHouse credentials are still needed if you want `query_signoz_logs` and
+`query_signoz_traces` to run.
+
+## Schema Compatibility (ClickHouse fallback)
 
 The integration targets SigNoz v0.x+ with the following ClickHouse tables:
 

--- a/infra/scripts/signoz/env.sh
+++ b/infra/scripts/signoz/env.sh
@@ -1,21 +1,10 @@
 #!/usr/bin/env bash
 # infra/scripts/signoz/env.sh
-# Source this file to export the minimum SigNoz env vars for OpenSRE.
+# Source this file to export SigNoz Query API env vars for OpenSRE.
 
-export SIGNOZ_URL="${SIGNOZ_URL:-http://localhost:3301}"
+export SIGNOZ_URL="${SIGNOZ_URL:-http://localhost:8080}"
 export SIGNOZ_API_KEY="${SIGNOZ_API_KEY:-}"
 
-# Optional ClickHouse fallback (still used for logs/traces in the current integration).
-export SIGNOZ_CLICKHOUSE_HOST="${SIGNOZ_CLICKHOUSE_HOST:-localhost}"
-export SIGNOZ_CLICKHOUSE_PORT="${SIGNOZ_CLICKHOUSE_PORT:-8123}"
-export SIGNOZ_CLICKHOUSE_USER="${SIGNOZ_CLICKHOUSE_USER:-default}"
-export SIGNOZ_CLICKHOUSE_PASSWORD="${SIGNOZ_CLICKHOUSE_PASSWORD:-}"
-export SIGNOZ_CLICKHOUSE_DATABASE="${SIGNOZ_CLICKHOUSE_DATABASE:-default}"
-
 echo "SigNoz environment configured:"
-echo "  SIGNOZ_CLICKHOUSE_HOST=$SIGNOZ_CLICKHOUSE_HOST"
-echo "  SIGNOZ_CLICKHOUSE_PORT=$SIGNOZ_CLICKHOUSE_PORT"
-echo "  SIGNOZ_CLICKHOUSE_USER=$SIGNOZ_CLICKHOUSE_USER"
-echo "  SIGNOZ_CLICKHOUSE_DATABASE=$SIGNOZ_CLICKHOUSE_DATABASE"
 echo "  SIGNOZ_URL=$SIGNOZ_URL"
 echo "  SIGNOZ_API_KEY=${SIGNOZ_API_KEY:+***set***}"

--- a/infra/scripts/signoz/env.sh
+++ b/infra/scripts/signoz/env.sh
@@ -2,13 +2,15 @@
 # infra/scripts/signoz/env.sh
 # Source this file to export the minimum SigNoz env vars for OpenSRE.
 
+export SIGNOZ_URL="${SIGNOZ_URL:-http://localhost:3301}"
+export SIGNOZ_API_KEY="${SIGNOZ_API_KEY:-}"
+
+# Optional ClickHouse fallback (still used for logs/traces in the current integration).
 export SIGNOZ_CLICKHOUSE_HOST="${SIGNOZ_CLICKHOUSE_HOST:-localhost}"
 export SIGNOZ_CLICKHOUSE_PORT="${SIGNOZ_CLICKHOUSE_PORT:-8123}"
 export SIGNOZ_CLICKHOUSE_USER="${SIGNOZ_CLICKHOUSE_USER:-default}"
 export SIGNOZ_CLICKHOUSE_PASSWORD="${SIGNOZ_CLICKHOUSE_PASSWORD:-}"
 export SIGNOZ_CLICKHOUSE_DATABASE="${SIGNOZ_CLICKHOUSE_DATABASE:-default}"
-export SIGNOZ_URL="${SIGNOZ_URL:-http://localhost:3301}"
-export SIGNOZ_API_KEY="${SIGNOZ_API_KEY:-}"
 
 echo "SigNoz environment configured:"
 echo "  SIGNOZ_CLICKHOUSE_HOST=$SIGNOZ_CLICKHOUSE_HOST"
@@ -16,3 +18,4 @@ echo "  SIGNOZ_CLICKHOUSE_PORT=$SIGNOZ_CLICKHOUSE_PORT"
 echo "  SIGNOZ_CLICKHOUSE_USER=$SIGNOZ_CLICKHOUSE_USER"
 echo "  SIGNOZ_CLICKHOUSE_DATABASE=$SIGNOZ_CLICKHOUSE_DATABASE"
 echo "  SIGNOZ_URL=$SIGNOZ_URL"
+echo "  SIGNOZ_API_KEY=${SIGNOZ_API_KEY:+***set***}"

--- a/infra/scripts/signoz/test-query-api.sh
+++ b/infra/scripts/signoz/test-query-api.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# infra/scripts/signoz/test-query-api.sh
+# Live smoke test for SigNoz Query API integration (logs, metrics, traces).
+# Requires a running SigNoz stack and SIGNOZ_API_KEY.
+#
+# Usage (from repo root):
+#   export SIGNOZ_API_KEY="<service-account-key>"
+#   bash infra/scripts/signoz/test-query-api.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=infra/scripts/signoz/env.sh
+source "$SCRIPT_DIR/env.sh"
+
+if [[ -z "${SIGNOZ_API_KEY:-}" ]]; then
+  echo "SIGNOZ_API_KEY is required. Create one in SigNoz: Settings → Service Accounts → Keys."
+  exit 1
+fi
+
+echo "==> Verifying integration"
+uv run opensre integrations verify signoz
+
+echo ""
+echo "==> Query API smoke (logs, metrics, traces)"
+uv run python - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from app.integrations.signoz import SigNozConfig
+from app.services.signoz.client import SigNozClient
+
+config = SigNozConfig(
+    url=os.environ.get("SIGNOZ_URL", "http://localhost:8080"),
+    api_key=os.environ["SIGNOZ_API_KEY"],
+)
+client = SigNozClient(config)
+
+checks = [
+    ("metrics", client.query_metrics(metric_name="signoz_calls_total", limit=5)),
+    ("logs", client.query_logs(limit=5)),
+    ("traces", client.query_traces(limit=5)),
+    ("trace_summary", client.query_trace_summary()),
+]
+
+failed = False
+for name, result in checks:
+    print(f"\n--- {name} ---")
+    print(json.dumps({k: v for k, v in result.items() if k not in ("logs", "metrics", "traces")}, indent=2))
+    if name == "metrics":
+        print(f"metrics rows: {len(result.get('metrics', []))}")
+    elif name == "logs":
+        print(f"log rows: {len(result.get('logs', []))}")
+    elif name == "traces":
+        print(f"trace rows: {len(result.get('traces', []))}")
+    if not result.get("available"):
+        print(f"FAIL: {result.get('error', 'unavailable')}", file=sys.stderr)
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("\nAll Query API calls succeeded (empty result sets are OK if no telemetry yet).")
+PY
+
+echo ""
+echo "Smoke test complete."

--- a/tests/integrations/test_signoz.py
+++ b/tests/integrations/test_signoz.py
@@ -3,7 +3,6 @@
 from app.integrations.catalog import load_env_integrations
 from app.integrations.signoz import (
     SigNozConfig,
-    SigNozValidationResult,
     build_signoz_config,
     signoz_config_from_env,
     signoz_extract_params,
@@ -13,248 +12,118 @@ from app.integrations.signoz import (
 
 
 class TestSigNozConfig:
-    """Tests for SigNozConfig model."""
-
     def test_defaults(self) -> None:
-        config = SigNozConfig(clickhouse_host="localhost")
-        assert config.clickhouse_host == "localhost"
-        assert config.clickhouse_port == 8123
-        assert config.clickhouse_database == "default"
-        assert config.clickhouse_user == "default"
-        assert config.clickhouse_password == ""
-        assert config.secure is False
-        assert config.timeout_seconds == 10.0
-        assert config.max_results == 50
+        config = SigNozConfig()
         assert config.url == ""
         assert config.api_key == ""
+        assert config.timeout_seconds == 10.0
+        assert config.max_results == 50
 
-    def test_is_configured_with_host(self) -> None:
-        config = SigNozConfig(clickhouse_host="ch.example.com")
+    def test_is_configured_with_url_and_key(self) -> None:
+        config = SigNozConfig(url="http://localhost:8080", api_key="test-key")
         assert config.is_configured is True
 
-    def test_is_configured_without_host(self) -> None:
-        config = SigNozConfig()
+    def test_is_configured_without_credentials(self) -> None:
+        config = SigNozConfig(url="http://localhost:8080")
         assert config.is_configured is False
-
-    def test_normalize_host_strips_whitespace(self) -> None:
-        config = SigNozConfig(clickhouse_host="  ch.example.com  ")
-        assert config.clickhouse_host == "ch.example.com"
-
-    def test_normalize_database_default(self) -> None:
-        config = SigNozConfig(clickhouse_host="localhost", clickhouse_database="")
-        assert config.clickhouse_database == "default"
-
-    def test_normalize_user_default(self) -> None:
-        config = SigNozConfig(clickhouse_host="localhost", clickhouse_user="")
-        assert config.clickhouse_user == "default"
-
-    def test_to_clickhouse_config(self) -> None:
-        config = SigNozConfig(
-            clickhouse_host="ch.prod.internal",
-            clickhouse_port=9440,
-            clickhouse_database="analytics",
-            clickhouse_user="reader",
-            clickhouse_password="secret",
-            secure=True,
-            timeout_seconds=30.0,
-            max_results=100,
-        )
-        ch = config.to_clickhouse_config()
-        assert ch.host == "ch.prod.internal"
-        assert ch.port == 9440
-        assert ch.database == "analytics"
-        assert ch.username == "reader"
-        assert ch.password == "secret"
-        assert ch.secure is True
-        assert ch.timeout_seconds == 30.0
-        assert ch.max_results == 100
+        config = SigNozConfig(api_key="test-key")
+        assert config.is_configured is False
 
 
 class TestBuildSigNozConfig:
-    """Tests for build_signoz_config helper."""
-
     def test_from_dict(self) -> None:
-        config = build_signoz_config({"clickhouse_host": "ch.example.com", "clickhouse_port": 8123})
-        assert config.clickhouse_host == "ch.example.com"
-        assert config.clickhouse_port == 8123
+        config = build_signoz_config({"url": "http://signoz.example.com", "api_key": "secret"})
+        assert config.url == "http://signoz.example.com"
+        assert config.api_key == "secret"
 
     def test_from_none(self) -> None:
         config = build_signoz_config(None)
-        assert config.clickhouse_host == ""
-        assert config.is_configured is False
-
-    def test_from_empty_dict(self) -> None:
-        config = build_signoz_config({})
-        assert config.clickhouse_host == ""
         assert config.is_configured is False
 
 
 class TestSigNozConfigFromEnv:
-    """Tests for signoz_config_from_env helper."""
-
-    def test_returns_none_without_host(self) -> None:
+    def test_returns_none_without_credentials(self) -> None:
         import os
 
-        old = os.environ.get("SIGNOZ_CLICKHOUSE_HOST")
-        os.environ.pop("SIGNOZ_CLICKHOUSE_HOST", None)
-        try:
-            result = signoz_config_from_env()
-            assert result is None
-        finally:
-            if old is not None:
-                os.environ["SIGNOZ_CLICKHOUSE_HOST"] = old
+        for key in ("SIGNOZ_URL", "SIGNOZ_API_KEY"):
+            os.environ.pop(key, None)
+        assert signoz_config_from_env() is None
 
-    def test_returns_config_with_host(self) -> None:
+    def test_returns_config_with_url_and_key(self) -> None:
         import os
 
-        os.environ["SIGNOZ_CLICKHOUSE_HOST"] = "ch.test.local"
-        os.environ["SIGNOZ_CLICKHOUSE_PORT"] = "9440"
-        os.environ["SIGNOZ_CLICKHOUSE_DATABASE"] = "testdb"
-        os.environ["SIGNOZ_CLICKHOUSE_USER"] = "testuser"
-        os.environ["SIGNOZ_CLICKHOUSE_PASSWORD"] = "testpass"
-        os.environ["SIGNOZ_CLICKHOUSE_SECURE"] = "true"
-        os.environ["SIGNOZ_URL"] = "http://localhost:3301"
-        os.environ["SIGNOZ_API_KEY"] = "sk-test"
-        try:
-            config = signoz_config_from_env()
-            assert config is not None
-            assert config.clickhouse_host == "ch.test.local"
-            assert config.clickhouse_port == 9440
-            assert config.clickhouse_database == "testdb"
-            assert config.clickhouse_user == "testuser"
-            assert config.clickhouse_password == "testpass"
-            assert config.secure is True
-            assert config.url == "http://localhost:3301"
-            assert config.api_key == "sk-test"
-        finally:
-            for key in [
-                "SIGNOZ_CLICKHOUSE_HOST",
-                "SIGNOZ_CLICKHOUSE_PORT",
-                "SIGNOZ_CLICKHOUSE_DATABASE",
-                "SIGNOZ_CLICKHOUSE_USER",
-                "SIGNOZ_CLICKHOUSE_PASSWORD",
-                "SIGNOZ_CLICKHOUSE_SECURE",
-                "SIGNOZ_URL",
-                "SIGNOZ_API_KEY",
-            ]:
-                os.environ.pop(key, None)
-
-    def test_returns_config_with_metrics_api_only(self) -> None:
-        import os
-
-        os.environ.pop("SIGNOZ_CLICKHOUSE_HOST", None)
-        os.environ["SIGNOZ_URL"] = "http://localhost:3301"
+        os.environ["SIGNOZ_URL"] = "http://localhost:8080"
         os.environ["SIGNOZ_API_KEY"] = "api-key"
         try:
             config = signoz_config_from_env()
             assert config is not None
-            assert config.url == "http://localhost:3301"
+            assert config.url == "http://localhost:8080"
             assert config.api_key == "api-key"
-            assert config.clickhouse_host == ""
-            assert config.has_metrics_api is True
+            assert config.is_configured is True
         finally:
             os.environ.pop("SIGNOZ_URL", None)
             os.environ.pop("SIGNOZ_API_KEY", None)
 
 
-class TestSigNozValidationResult:
-    """Tests for SigNozValidationResult dataclass."""
-
-    def test_ok_result(self) -> None:
-        result = SigNozValidationResult(ok=True, detail="Connected.")
-        assert result.ok is True
-        assert result.detail == "Connected."
-
-    def test_error_result(self) -> None:
-        result = SigNozValidationResult(ok=False, detail="Connection refused.")
-        assert result.ok is False
-        assert result.detail == "Connection refused."
-
-
-class TestSigNozIsAvailable:
-    """Tests for signoz_is_available helper."""
-
-    def test_available_when_connection_verified(self) -> None:
-        sources = {"signoz": {"connection_verified": True}}
-        assert signoz_is_available(sources) is True
-
-    def test_unavailable_without_connection_verified(self) -> None:
-        sources = {"signoz": {"clickhouse_host": "localhost"}}
-        assert signoz_is_available(sources) is False
-
-    def test_unavailable_when_missing(self) -> None:
-        sources = {}
-        assert signoz_is_available(sources) is False
-
-
-class TestSigNozExtractParams:
-    """Tests for signoz_extract_params helper."""
-
-    def test_extracts_params(self) -> None:
-        sources = {
-            "signoz": {
-                "clickhouse_host": "ch.example.com",
-                "clickhouse_port": 8123,
-                "clickhouse_database": "default",
-                "clickhouse_user": "default",
-                "clickhouse_password": "secret",
-                "secure": True,
-                "url": "http://signoz.example.com",
-                "api_key": "key",
-            }
-        }
-        params = signoz_extract_params(sources)
-        assert params["clickhouse_host"] == "ch.example.com"
-        assert params["clickhouse_port"] == 8123
-        assert params["clickhouse_database"] == "default"
-        assert params["clickhouse_user"] == "default"
-        assert params["clickhouse_password"] == "secret"
-        assert params["secure"] is True
-        assert params["url"] == "http://signoz.example.com"
-        assert params["api_key"] == "key"
-
-    def test_uses_defaults_when_missing(self) -> None:
-        sources = {}
-        params = signoz_extract_params(sources)
-        assert params["clickhouse_host"] == ""
-        assert params["clickhouse_port"] == 8123
-        assert params["clickhouse_database"] == "default"
-        assert params["clickhouse_user"] == "default"
-        assert params["clickhouse_password"] == ""
-        assert params["secure"] is False
-        assert params["url"] == ""
-        assert params["api_key"] == ""
-
-
-class TestSigNozEnvCatalogLoading:
-    """Tests for SigNoz env loading in load_env_integrations."""
-
-    def test_invalid_port_does_not_raise(self, monkeypatch) -> None:
-        monkeypatch.setenv("SIGNOZ_CLICKHOUSE_HOST", "localhost")
-        monkeypatch.setenv("SIGNOZ_CLICKHOUSE_PORT", "abc")
-        records = load_env_integrations()
-        assert isinstance(records, list)
-        assert all(record.get("service") != "signoz" for record in records)
-
-
 class TestSigNozValidation:
-    def test_validate_metrics_api_mode(self, monkeypatch) -> None:
+    def test_validate_requires_credentials(self) -> None:
+        result = validate_signoz_config(SigNozConfig())
+        assert result.ok is False
+        assert "SIGNOZ_URL" in result.detail
+
+    def test_validate_query_api_mode(self, monkeypatch) -> None:
         class _FakeResponse:
             def raise_for_status(self) -> None:
                 return None
 
         captured: dict[str, object] = {}
 
-        def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+        def _fake_get(url: str, **kwargs: object) -> _FakeResponse:
             captured["url"] = url
             captured["headers"] = kwargs.get("headers")
             return _FakeResponse()
 
-        monkeypatch.setattr("app.integrations.signoz.httpx.get", _fake_post)
+        monkeypatch.setattr("app.integrations.signoz.httpx.get", _fake_get)
 
-        config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+        config = SigNozConfig(url="http://localhost:8080", api_key="test-key")
         result = validate_signoz_config(config)
 
         assert result.ok is True
-        assert "Metrics API" in result.detail
+        assert "Query API" in result.detail
         assert str(captured["url"]).endswith("/api/v2/metrics")
+
+
+class TestSigNozExtractParams:
+    def test_extracts_params(self) -> None:
+        sources = {
+            "signoz": {
+                "url": "http://signoz.example.com",
+                "api_key": "key",
+            }
+        }
+        params = signoz_extract_params(sources)
+        assert params["url"] == "http://signoz.example.com"
+        assert params["api_key"] == "key"
+
+    def test_uses_defaults_when_missing(self) -> None:
+        params = signoz_extract_params({})
+        assert params["url"] == ""
+        assert params["api_key"] == ""
+
+
+class TestSigNozIsAvailable:
+    def test_available_when_connection_verified(self) -> None:
+        assert signoz_is_available({"signoz": {"connection_verified": True}}) is True
+
+    def test_unavailable_without_connection_verified(self) -> None:
+        assert signoz_is_available({"signoz": {"url": "http://localhost:8080"}}) is False
+
+
+class TestSigNozEnvCatalogLoading:
+    def test_loads_from_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("SIGNOZ_URL", "http://localhost:8080")
+        monkeypatch.setenv("SIGNOZ_API_KEY", "test-key")
+        records = load_env_integrations()
+        signoz_records = [r for r in records if r.get("service") == "signoz"]
+        assert len(signoz_records) == 1
+        assert signoz_records[0]["credentials"]["url"] == "http://localhost:8080"

--- a/tests/integrations/test_signoz.py
+++ b/tests/integrations/test_signoz.py
@@ -8,6 +8,7 @@ from app.integrations.signoz import (
     signoz_config_from_env,
     signoz_extract_params,
     signoz_is_available,
+    validate_signoz_config,
 )
 
 
@@ -138,6 +139,23 @@ class TestSigNozConfigFromEnv:
             ]:
                 os.environ.pop(key, None)
 
+    def test_returns_config_with_metrics_api_only(self) -> None:
+        import os
+
+        os.environ.pop("SIGNOZ_CLICKHOUSE_HOST", None)
+        os.environ["SIGNOZ_URL"] = "http://localhost:3301"
+        os.environ["SIGNOZ_API_KEY"] = "api-key"
+        try:
+            config = signoz_config_from_env()
+            assert config is not None
+            assert config.url == "http://localhost:3301"
+            assert config.api_key == "api-key"
+            assert config.clickhouse_host == ""
+            assert config.has_metrics_api is True
+        finally:
+            os.environ.pop("SIGNOZ_URL", None)
+            os.environ.pop("SIGNOZ_API_KEY", None)
+
 
 class TestSigNozValidationResult:
     """Tests for SigNozValidationResult dataclass."""
@@ -217,3 +235,26 @@ class TestSigNozEnvCatalogLoading:
         records = load_env_integrations()
         assert isinstance(records, list)
         assert all(record.get("service") != "signoz" for record in records)
+
+
+class TestSigNozValidation:
+    def test_validate_metrics_api_mode(self, monkeypatch) -> None:
+        class _FakeResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+        captured: dict[str, object] = {}
+
+        def _fake_post(url: str, **kwargs: object) -> _FakeResponse:
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers")
+            return _FakeResponse()
+
+        monkeypatch.setattr("app.integrations.signoz.httpx.post", _fake_post)
+
+        config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+        result = validate_signoz_config(config)
+
+        assert result.ok is True
+        assert "Metrics API" in result.detail
+        assert str(captured["url"]).endswith("/api/v2/metrics")

--- a/tests/integrations/test_signoz.py
+++ b/tests/integrations/test_signoz.py
@@ -250,7 +250,7 @@ class TestSigNozValidation:
             captured["headers"] = kwargs.get("headers")
             return _FakeResponse()
 
-        monkeypatch.setattr("app.integrations.signoz.httpx.post", _fake_post)
+        monkeypatch.setattr("app.integrations.signoz.httpx.get", _fake_post)
 
         config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
         result = validate_signoz_config(config)

--- a/tests/services/test_signoz_client.py
+++ b/tests/services/test_signoz_client.py
@@ -10,25 +10,6 @@ from app.integrations.signoz import SigNozConfig
 from app.services.signoz.client import SigNozClient
 
 
-class _FakeResult:
-    def __init__(self, row: tuple[Any, ...]) -> None:
-        self.row_count = 1
-        self.first_row = row
-
-
-class _FakeClient:
-    def __init__(self, row: tuple[Any, ...]) -> None:
-        self._row = row
-        self.closed = False
-
-    def query(self, _query: str, parameters: dict[str, Any] | None = None) -> _FakeResult:
-        assert parameters is not None
-        return _FakeResult(self._row)
-
-    def close(self) -> None:
-        self.closed = True
-
-
 class _FakeMetricsResult:
     def __init__(self, rows: list[dict[str, Any]]) -> None:
         self._rows = rows
@@ -37,21 +18,6 @@ class _FakeMetricsResult:
 
     def named_results(self) -> list[dict[str, Any]]:
         return self._rows
-
-
-class _CaptureMetricsClient:
-    def __init__(self) -> None:
-        self.closed = False
-        self.last_query = ""
-        self.last_params: dict[str, Any] | None = None
-
-    def query(self, query: str, parameters: dict[str, Any] | None = None) -> _FakeMetricsResult:
-        self.last_query = query
-        self.last_params = parameters or {}
-        return _FakeMetricsResult([])
-
-    def close(self) -> None:
-        self.closed = True
 
 
 class _FakeHTTPResponse:
@@ -83,37 +49,13 @@ class _ErrorHTTPResponse:
         return self._payload
 
 
-def test_query_trace_summary_sanitizes_nan(monkeypatch) -> None:
-    fake_client = _FakeClient((0, 0, float("nan"), float("nan"), float("nan"), float("nan")))
-    monkeypatch.setattr("app.services.signoz.client._make_client", lambda _config: fake_client)
-
-    config = SigNozConfig(clickhouse_host="localhost")
-    result = SigNozClient(config).query_trace_summary(service="svc", time_range_minutes=60)
-
-    assert result["total_spans"] == 0
-    assert result["error_spans"] == 0
-    assert result["error_rate"] == 0.0
-    assert result["p99_ms"] == 0.0
-    assert result["p95_ms"] == 0.0
-    assert result["avg_ms"] == 0.0
-    assert result["max_ms"] == 0.0
-    assert fake_client.closed is True
+def test_query_logs_requires_configuration() -> None:
+    result = SigNozClient(SigNozConfig()).query_logs()
+    assert result["available"] is False
+    assert "SIGNOZ_URL" in result.get("error", "")
 
 
-def test_query_metrics_uses_null_safe_env_join(monkeypatch) -> None:
-    fake_client = _CaptureMetricsClient()
-    monkeypatch.setattr("app.services.signoz.client._make_client", lambda _config: fake_client)
-
-    config = SigNozConfig(clickhouse_host="localhost")
-    result = SigNozClient(config).query_metrics(metric_name="cpu_usage", service="svc")
-
-    assert result["available"] is True
-    assert result["metric_name"] == "cpu_usage"
-    assert "coalesce(s.env, '') = coalesce(ts.env, '')" in fake_client.last_query
-    assert fake_client.closed is True
-
-
-def test_query_metrics_uses_metrics_api_when_configured(monkeypatch) -> None:
+def test_query_metrics_uses_query_api_when_configured(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
     def _fake_post(url: str, **kwargs: Any) -> _FakeHTTPResponse:
@@ -157,14 +99,11 @@ def test_query_metrics_uses_metrics_api_when_configured(monkeypatch) -> None:
 
     monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
 
-    config = SigNozConfig(
-        url="http://localhost:3301",
-        api_key="test-key",
-    )
+    config = SigNozConfig(url="http://localhost:8080", api_key="test-key")
     result = SigNozClient(config).query_metrics(metric_name="cpu_usage", service="payments")
 
     assert result["available"] is True
-    assert result["query_backend"] == "signoz_metrics_api"
+    assert result["query_backend"] == "signoz_query_api"
     assert result["resolved_metric"] == "system_cpu_usage"
     assert result["metrics"][0]["service_name"] == "payments"
     assert captured["url"].endswith("/api/v5/query_range")
@@ -214,4 +153,149 @@ def test_query_metrics_handles_not_found_via_metrics_api(monkeypatch) -> None:
 
     assert result["available"] is True
     assert result["total"] == 0
+    assert result["query_backend"] == "signoz_query_api"
     assert "warning" in result
+
+
+def test_query_logs_uses_query_api_when_configured(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(_url: str, **kwargs: Any) -> _FakeHTTPResponse:
+        captured["payload"] = kwargs.get("json")
+        return _FakeHTTPResponse(
+            {
+                "status": "success",
+                "data": {
+                    "type": "raw",
+                    "data": {
+                        "results": [
+                            {
+                                "queryName": "A",
+                                "rows": [
+                                    {
+                                        "timestamp": "2024-01-01T00:00:00Z",
+                                        "data": {
+                                            "body": "connection refused",
+                                            "severity_text": "ERROR",
+                                            "severity_number": 17,
+                                            "trace_id": "abc",
+                                            "span_id": "def",
+                                            "attributes_string": {},
+                                            "resources_string": {"service.name": "api"},
+                                        },
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
+
+    config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+    result = SigNozClient(config).query_logs(service="api", severity="ERROR", limit=5)
+
+    assert result["available"] is True
+    assert result["query_backend"] == "signoz_query_api"
+    assert result["total"] == 1
+    assert result["logs"][0]["message"] == "connection refused"
+    payload = captured["payload"]
+    assert payload["requestType"] == "raw"
+    assert payload["compositeQuery"]["queries"][0]["spec"]["signal"] == "logs"
+
+
+def test_query_traces_uses_query_api_when_configured(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(_url: str, **kwargs: Any) -> _FakeHTTPResponse:
+        captured["payload"] = kwargs.get("json")
+        return _FakeHTTPResponse(
+            {
+                "status": "success",
+                "data": {
+                    "type": "raw",
+                    "data": {
+                        "results": [
+                            {
+                                "queryName": "A",
+                                "rows": [
+                                    {
+                                        "timestamp": "2024-01-01T00:00:00Z",
+                                        "data": {
+                                            "serviceName": "api",
+                                            "name": "GET /health",
+                                            "traceID": "trace-1",
+                                            "spanID": "span-1",
+                                            "durationNano": 150_000_000,
+                                            "hasError": True,
+                                            "statusCode": 2,
+                                            "statusCodeString": "Error",
+                                            "httpMethod": "GET",
+                                            "httpUrl": "/health",
+                                            "kindString": "Server",
+                                        },
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
+
+    config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+    result = SigNozClient(config).query_traces(service="api", error_only=True, limit=5)
+
+    assert result["available"] is True
+    assert result["query_backend"] == "signoz_query_api"
+    assert result["traces"][0]["duration_ms"] == 150.0
+    assert result["traces"][0]["has_error"] is True
+    payload = captured["payload"]
+    assert payload["compositeQuery"]["queries"][0]["spec"]["signal"] == "traces"
+    assert (
+        "hasError = true" in payload["compositeQuery"]["queries"][0]["spec"]["filter"]["expression"]
+    )
+
+
+def test_query_trace_summary_uses_query_api_when_configured(monkeypatch) -> None:
+    def _fake_post(_url: str, **kwargs: Any) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(
+            {
+                "status": "success",
+                "data": {
+                    "type": "scalar",
+                    "data": {
+                        "results": [
+                            {
+                                "columns": [
+                                    {"name": "__result_0", "queryName": "A"},
+                                    {"name": "__result_0", "queryName": "B"},
+                                    {"name": "__result_0", "queryName": "C"},
+                                    {"name": "__result_0", "queryName": "D"},
+                                    {"name": "__result_0", "queryName": "E"},
+                                    {"name": "__result_0", "queryName": "F"},
+                                ],
+                                "data": [
+                                    [100, 5, 250_000_000, 180_000_000, 120_000_000, 500_000_000]
+                                ],
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
+
+    config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+    result = SigNozClient(config).query_trace_summary(service="api")
+
+    assert result["available"] is True
+    assert result["query_backend"] == "signoz_query_api"
+    assert result["total_spans"] == 100
+    assert result["error_spans"] == 5
+    assert result["p99_ms"] == 250.0

--- a/tests/services/test_signoz_client.py
+++ b/tests/services/test_signoz_client.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import httpx
+
 from app.integrations.signoz import SigNozConfig
 from app.services.signoz.client import SigNozClient
 
@@ -52,6 +54,35 @@ class _CaptureMetricsClient:
         self.closed = True
 
 
+class _FakeHTTPResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _ErrorHTTPResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+        self.request = httpx.Request("POST", "http://localhost")
+
+    def raise_for_status(self) -> None:
+        raise httpx.HTTPStatusError(
+            f"error {self.status_code}",
+            request=self.request,
+            response=httpx.Response(self.status_code, request=self.request, json=self._payload),
+        )
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
 def test_query_trace_summary_sanitizes_nan(monkeypatch) -> None:
     fake_client = _FakeClient((0, 0, float("nan"), float("nan"), float("nan"), float("nan")))
     monkeypatch.setattr("app.services.signoz.client._make_client", lambda _config: fake_client)
@@ -80,3 +111,107 @@ def test_query_metrics_uses_null_safe_env_join(monkeypatch) -> None:
     assert result["metric_name"] == "cpu_usage"
     assert "coalesce(s.env, '') = coalesce(ts.env, '')" in fake_client.last_query
     assert fake_client.closed is True
+
+
+def test_query_metrics_uses_metrics_api_when_configured(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_post(url: str, **kwargs: Any) -> _FakeHTTPResponse:
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _FakeHTTPResponse(
+            {
+                "status": "success",
+                "data": {
+                    "type": "time_series",
+                    "data": {
+                        "results": [
+                            {
+                                "queryName": "A",
+                                "aggregations": [
+                                    {
+                                        "series": [
+                                            {
+                                                "labels": [
+                                                    {
+                                                        "key": {"name": "service.name"},
+                                                        "value": "payments",
+                                                    }
+                                                ],
+                                                "values": [
+                                                    {
+                                                        "timestamp": 1_700_000_000_000,
+                                                        "value": 12.34,
+                                                    }
+                                                ],
+                                            }
+                                        ]
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
+
+    config = SigNozConfig(
+        url="http://localhost:3301",
+        api_key="test-key",
+    )
+    result = SigNozClient(config).query_metrics(metric_name="cpu_usage", service="payments")
+
+    assert result["available"] is True
+    assert result["query_backend"] == "signoz_metrics_api"
+    assert result["resolved_metric"] == "system_cpu_usage"
+    assert result["metrics"][0]["service_name"] == "payments"
+    assert captured["url"].endswith("/api/v5/query_range")
+    headers = captured["kwargs"]["headers"]
+    assert headers["SigNoz-Api-Key"] == "test-key"
+
+
+def test_query_metrics_handles_empty_aggregation_series(monkeypatch) -> None:
+    def _fake_post(_url: str, **_kwargs: Any) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(
+            {
+                "status": "success",
+                "data": {
+                    "type": "time_series",
+                    "data": {
+                        "results": [
+                            {
+                                "queryName": "A",
+                                "aggregations": None,
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
+
+    config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+    result = SigNozClient(config).query_metrics(metric_name="cpu_usage")
+
+    assert result["available"] is True
+    assert result["total"] == 0
+
+
+def test_query_metrics_handles_not_found_via_metrics_api(monkeypatch) -> None:
+    def _fake_post(_url: str, **_kwargs: Any) -> _ErrorHTTPResponse:
+        return _ErrorHTTPResponse(
+            404,
+            {"status": "error", "error": {"message": "could not find metric"}},
+        )
+
+    monkeypatch.setattr("app.services.signoz.client.httpx.post", _fake_post)
+
+    config = SigNozConfig(url="http://localhost:3301", api_key="test-key")
+    result = SigNozClient(config).query_metrics(metric_name="cpu_usage")
+
+    assert result["available"] is True
+    assert result["total"] == 0
+    assert "warning" in result

--- a/tests/tools/test_signoz_tools.py
+++ b/tests/tools/test_signoz_tools.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from app.tools.SignozLogsTool import query_signoz_logs
-from app.tools.SignozMetricsTool import query_signoz_metrics
+from app.tools.SignozMetricsTool import _metrics_is_available, query_signoz_metrics
 from app.tools.SignozTracesTool import query_signoz_traces
 
 
@@ -139,6 +139,20 @@ class TestQuerySignozMetrics:
         assert result["source"] == "signoz_metrics"
         assert result["available"] is False
         assert "not configured" in result.get("error", "").lower()
+
+    def test_available_with_metrics_api_credentials_only(self) -> None:
+        assert (
+            _metrics_is_available(
+                {
+                    "signoz": {
+                        "url": "http://localhost:3301",
+                        "api_key": "test-key",
+                        "connection_verified": False,
+                    }
+                }
+            )
+            is True
+        )
 
 
 class TestQuerySignozTraces:

--- a/tests/tools/test_signoz_tools.py
+++ b/tests/tools/test_signoz_tools.py
@@ -95,6 +95,22 @@ class _FakeSigNozBackend:
 
 
 class TestQuerySignozLogs:
+    def test_available_with_query_api_credentials_only(self) -> None:
+        from app.tools.SignozLogsTool import _logs_is_available
+
+        assert (
+            _logs_is_available(
+                {
+                    "signoz": {
+                        "url": "http://localhost:8080",
+                        "api_key": "test-key",
+                        "connection_verified": False,
+                    }
+                }
+            )
+            is True
+        )
+
     def test_backend_injection(self) -> None:
         backend = _FakeSigNozBackend()
         result = query_signoz_logs(
@@ -145,7 +161,7 @@ class TestQuerySignozMetrics:
             _metrics_is_available(
                 {
                     "signoz": {
-                        "url": "http://localhost:3301",
+                        "url": "http://localhost:8080",
                         "api_key": "test-key",
                         "connection_verified": False,
                     }
@@ -156,6 +172,22 @@ class TestQuerySignozMetrics:
 
 
 class TestQuerySignozTraces:
+    def test_available_with_query_api_credentials_only(self) -> None:
+        from app.tools.SignozTracesTool import _traces_is_available
+
+        assert (
+            _traces_is_available(
+                {
+                    "signoz": {
+                        "url": "http://localhost:8080",
+                        "api_key": "test-key",
+                        "connection_verified": False,
+                    }
+                }
+            )
+            is True
+        )
+
     def test_backend_injection(self) -> None:
         backend = _FakeSigNozBackend()
         result = query_signoz_traces(


### PR DESCRIPTION
Fixes #

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

Follow-up to the SigNoz integration from #2110.

This PR moves **all** SigNoz reads (metrics, logs, traces, trace summary) to the official Query API and removes direct ClickHouse access.

### What changed

- **Query API only** — `SigNozClient` uses `POST {SIGNOZ_URL}/api/v5/query_range` for:
  - `query_metrics` (time-series, `requestType: timeseries`)
  - `query_logs` (raw logs)
  - `query_traces` (raw spans)
  - `query_trace_summary` (scalar aggregations)
- **Config simplified** — only `SIGNOZ_URL` + `SIGNOZ_API_KEY` (service account key). ClickHouse host/user/password env vars and fallback paths removed.
- **Validation** — `GET /api/v2/metrics` with `SigNoz-Api-Key` header.
- **Integration / CLI / catalog** — setup prompts, availability, and catalog entries updated for API-only mode.
- **Docs** — `docs/signoz.mdx` and `.env.example` document the two env vars; local Docker default URL is `http://localhost:8080`.
- **Infra scripts** — `infra/scripts/signoz/test-query-api.sh` live smoke (verify + metrics/logs/traces/summary); `env.sh` default port 8080.
- **Trace field fix** — SigNoz v0.124+ rejects `kindString` in raw trace selects; use `kind_string` (parser also accepts `spanKind` / `kind`).

### Breaking change

Deployments that relied on ClickHouse-only SigNoz config (no API key) must add `SIGNOZ_API_KEY`. Logs/traces no longer query ClickHouse directly.

### Demo/Screenshot for feature changes and bug fixes -

**Local SigNoz Docker (v0.124 EE, `localhost:8080`)**

```text
$ export SIGNOZ_URL=http://localhost:8080
$ export SIGNOZ_API_KEY="<service-account-key>"
$ bash infra/scripts/signoz/verify.sh

  SERVICE    SOURCE       STATUS      DETAIL
  signoz     local env    passed      Connected to SigNoz Query API (/api/v2/metrics, /api/v5/query_range for logs/metrics/traces).

$ bash infra/scripts/signoz/test-query-api.sh

All Query API calls succeeded (empty result sets are OK if no telemetry yet).
```

API key: SigNoz UI **Settings → Service Accounts → Keys**, or REST (`POST /api/v1/service_accounts` + keys) after email/password login.

**CI / unit**

- `make lint`, `make format-check`, `make typecheck` ✅
- `uv run pytest tests/services/test_signoz_client.py tests/integrations/test_signoz.py tests/tools/test_signoz_tools.py -q` ✅
- `uv run pytest tests/synthetic/test_signoz_scenario.py -q` ✅

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- **Problem:** Direct ClickHouse queries tied OpenSRE to SigNoz internal schema and required extra credentials; metrics were already moving to `query_range` but logs/traces still used CH.
- **Alternatives:** (1) Keep ClickHouse for logs/traces only — rejected for maintainability and dual config. (2) Stay on CH for everything — rejected; official API is stable and documented.
- **Chosen approach:** Single API client path with shared `_query_range_post`, signal-specific payload builders, and parsers for raw vs scalar responses. Metric aliases and 404 → empty + warning preserved.
- **Key modules:** `app/services/signoz/client.py` (HTTP + parsing), `app/integrations/signoz.py` (config/validate), tools under `Signoz*Tool/`, `infra/scripts/signoz/` for local verification.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
