### PR TITLE
fix(security): close clear-text secret gap in env_sync and clear codeql noise

### DIFF
--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -11,8 +11,24 @@ from app.cli.wizard.config import PROJECT_ENV_PATH, ProviderOption
 from app.llm_credentials import delete_llm_api_key, has_llm_api_key, save_llm_api_key
 
 _ENV_ASSIGNMENT = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=")
-_SENSITIVE_KEY_SUFFIXES: tuple[str, ...] = ("_token", "_secret", "_password")
 _NON_SECRET_ENV_KEYS: frozenset[str] = frozenset({"DISCORD_PUBLIC_KEY"})
+# Underscore-separated terminal tokens that mark an env var as sensitive.
+# Matching the terminal component (rather than a substring or a fixed suffix
+# like ``_token``) catches both ``GITLAB_ACCESS_TOKEN`` and a bare ``TOKEN``
+# while leaving ``OPENAI_TOKEN_LIMIT`` (terminal ``limit``) alone.
+_SENSITIVE_TERMINAL_TOKENS: frozenset[str] = frozenset(
+    {
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "key",
+        "apikey",
+        "credential",
+        "credentials",
+    }
+)
+_SENSITIVE_SUBSTRINGS: tuple[str, ...] = ("connection_string",)
 
 
 def _is_sensitive_env_key(key: str) -> bool:
@@ -20,11 +36,10 @@ def _is_sensitive_env_key(key: str) -> bool:
     if key in _NON_SECRET_ENV_KEYS:
         return False
     lowered = key.lower()
-    if any(lowered.endswith(suffix) for suffix in _SENSITIVE_KEY_SUFFIXES):
+    terminal = lowered.rsplit("_", 1)[-1]
+    if terminal in _SENSITIVE_TERMINAL_TOKENS:
         return True
-    return (
-        lowered.endswith("_key") or "secret_access_key" in lowered or "connection_string" in lowered
-    )
+    return any(needle in lowered for needle in _SENSITIVE_SUBSTRINGS)
 
 
 def _strip_sensitive_env_lines(lines: list[str]) -> list[str]:
@@ -87,7 +102,6 @@ def _write_env(target_path: Path, lines: list[str]) -> None:
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         with target_path.open("w", encoding="utf-8", newline="") as env_file:
-            # codeql[py/clear-text-storage-sensitive-data]
             env_file.writelines(public_lines)
     except PermissionError as exc:
         raise PermissionError(

--- a/tests/benchmarks/_framework/adapters.py
+++ b/tests/benchmarks/_framework/adapters.py
@@ -228,12 +228,10 @@ class BenchmarkAdapter(ABC):
         """Stream cases matching the filter. Seeded random selection is the
         adapter's responsibility (integrity Mechanism 6).
         """
-        ...
 
     @abstractmethod
     def build_alert(self, case: BenchmarkCase) -> AlertPayload:
         """Convert a case into the alert opensre / LLM consume."""
-        ...
 
     @abstractmethod
     def build_opensre_integrations(self, case: BenchmarkCase) -> dict[str, Any]:
@@ -241,7 +239,6 @@ class BenchmarkAdapter(ABC):
         ``run_investigation``. For CloudOpsBench, this wires the replay
         backend in place of live AWS/K8s/Datadog clients.
         """
-        ...
 
     @abstractmethod
     def build_baseline_tools(self, case: BenchmarkCase) -> dict[str, Any]:
@@ -249,7 +246,6 @@ class BenchmarkAdapter(ABC):
         access as opensre+LLM (fairness) but no extract/context/diagnose
         pipeline — just direct LLM with tool-calling.
         """
-        ...
 
     @abstractmethod
     def score_case(self, case: BenchmarkCase, run: RunResult, context: RunContext) -> CaseScore:
@@ -262,11 +258,9 @@ class BenchmarkAdapter(ABC):
         Passing context explicitly (vs caching on the adapter) is what
         makes the adapter thread-safe for parallel runner execution.
         """
-        ...
 
     @abstractmethod
     def metric_schema(self) -> MetricSchema:
         """Declare which metrics this adapter emits, for CLI validation +
         comparable reporting across adapters.
         """
-        ...

--- a/tests/benchmarks/_framework/test_llm_dispatch.py
+++ b/tests/benchmarks/_framework/test_llm_dispatch.py
@@ -184,8 +184,16 @@ def test_activate_restores_env_when_body_raises(
     monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
     monkeypatch.setenv("LLM_PROVIDER", "before")
     dispatcher = LLMDispatcher()
-    with pytest.raises(RuntimeError, match="boom"), dispatcher.activate("claude-4-sonnet"):
-        raise RuntimeError("boom")
+
+    # Isolating the raise in a helper keeps the post-`with` assertion clearly
+    # reachable to static analysis (which does not model pytest.raises as an
+    # exception-suppressing context manager).
+    def _raise_inside_dispatch_context() -> None:
+        with dispatcher.activate("claude-4-sonnet"):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _raise_inside_dispatch_context()
     assert os.environ["LLM_PROVIDER"] == "before"
 
 

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -6,10 +6,58 @@ import stat
 import pytest
 
 from app.cli.wizard.config import PROVIDER_BY_VALUE
-from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
+from app.cli.wizard.env_sync import (
+    _is_sensitive_env_key,
+    sync_env_values,
+    sync_provider_env,
+)
 from app.llm_credentials import resolve_env_credential
 
 _SKIP_AS_ROOT = not hasattr(os, "getuid") or os.getuid() == 0
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        # Suffix-style sensitive keys (existing behavior).
+        "GITLAB_ACCESS_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "DB_PASSWORD",
+        # Bare sensitive keys (previously slipped past the suffix-only filter
+        # and reached plain-text .env, which CodeQL flagged as alert #1019).
+        "PASSWORD",
+        "TOKEN",
+        "SECRET",
+        "KEY",
+        "APIKEY",
+        "CREDENTIAL",
+        # Substring-based sensitives.
+        "DATABASE_CONNECTION_STRING",
+    ],
+)
+def test_is_sensitive_env_key_marks_secrets(key: str) -> None:
+    assert _is_sensitive_env_key(key) is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        # Non-secret configuration env vars must stay writable to .env.
+        "LLM_PROVIDER",
+        "OPENAI_REASONING_MODEL",
+        "OPENAI_MODEL",
+        "GITLAB_BASE_URL",
+        "ENV",
+        # Terminal token is not in the sensitive set even though "TOKEN"
+        # appears as a substring — the limit count is not itself a secret.
+        "OPENAI_TOKEN_LIMIT",
+        # Explicit exception: a public discord key is not sensitive.
+        "DISCORD_PUBLIC_KEY",
+    ],
+)
+def test_is_sensitive_env_key_leaves_non_secrets(key: str) -> None:
+    assert _is_sensitive_env_key(key) is False
 
 
 def test_sync_provider_env_updates_provider_specific_keys(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Resolves all eight open code-scanning alerts on `main`: https://github.com/Tracer-Cloud/opensre/security/code-scanning

- **#1019** (high, `py/clear-text-storage-sensitive-data`): tighten `_is_sensitive_env_key` in `app/cli/wizard/env_sync.py` to use **underscore-terminal-component matching** instead of suffix matching. Previously bare `PASSWORD=foo`, `TOKEN=foo`, `SECRET=foo`, and `KEY=foo` lines slipped past the filter and were written to plain-text `.env`. Standalone sensitive names are now caught while legitimate keys like `OPENAI_TOKEN_LIMIT` (terminal `limit`) and `OPENAI_REASONING_MODEL` stay non-sensitive. The `DISCORD_PUBLIC_KEY` exception is preserved. Drops the dead `# codeql[...]` suppression comment that was not being recognized.
- **#1027–#1032** (6× `py/ineffectual-statement`): drop the redundant `...` bodies after docstrings in `tests/benchmarks/_framework/adapters.py` abstract methods. The docstring alone is a valid empty body.
- **#1033** (`py/unreachable-statement`): isolate the `raise` in `test_activate_restores_env_when_body_raises` into a nested helper so the post-`with pytest.raises(...)` assertion is clearly reachable (CodeQL does not model `pytest.raises` as exception-suppressing).

## Why

`#1019` was a real (though edge-case) security gap, not a false positive: the suffix-only filter would let a `PASSWORD=foo` line slip through into `.env`. The other seven were static-analysis noise that's better resolved in code than dismissed.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy` clean on all four touched files
- [x] `uv run python -m pytest -q tests/cli/wizard/ tests/cli/interactive_shell/test_commands.py tests/cli/interactive_shell/chat/test_cli_agent.py` (250 pass) — broader env-sync caller sweep
- [x] `uv run python -m pytest -q tests/cli/wizard/test_env_sync.py tests/benchmarks/_framework/test_llm_dispatch.py` (41 pass), including 17 new parametrised cases locking in the tightened sensitive-key heuristic
- [ ] CodeQL re-scan after merge closes alerts #1019, #1027, #1028, #1029, #1030, #1031, #1032, #1033


Made with [Cursor](https://cursor.com)