### PR TITLE
fix(cli): prevent interactive shell from overwriting parity command output

### DIFF
--- a/app/cli/interactive_shell/loop.py
+++ b/app/cli/interactive_shell/loop.py
@@ -195,6 +195,19 @@ _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
         ("/mcp", "connect"),
     }
 )
+_EXCLUSIVE_STDIN_PARITY_COMMANDS: frozenset[str] = frozenset(
+    {
+        "/config",
+        "/guardrails",
+        "/hermes",
+        "/messaging",
+        "/remote",
+        "/tests",
+        "/uninstall",
+        "/update",
+        "/watchdog",
+    }
+)
 _WAIT_FOR_COMPLETION_COMMANDS: frozenset[str] = frozenset({"/exit", "/quit"})
 
 
@@ -204,12 +217,13 @@ def _dispatch_needs_exclusive_stdin(text: str, session: ReplSession) -> bool:
     Most turns can run while prompt-toolkit immediately opens the next input
     frame, which is what gives the shell type-ahead during streaming. A few
     slash commands, however, temporarily own stdin themselves: inline
-    ``repl_choose_one`` menus and subprocess-backed interactive wizards. If the
+    ``repl_choose_one`` menus, subprocess-backed interactive wizards, and CLI
+    parity commands that write directly to the terminal PTY (like /update). If the
     next prompt starts underneath those, prompt-toolkit can send a cursor
     position request and the terminal's reply (for example ``[32;1R``) leaks
-    into the prompt or menu input. Exit commands also pause so the shell does
-    not draw one more prompt after printing goodbye. Waiting only for these
-    known cases preserves type-ahead everywhere else.
+    into the prompt or menu input, or redrawing the prompt overwrites the child
+    process's output. Waiting only for these known cases preserves type-ahead
+    everywhere else.
     """
     if not repl_tty_interactive():
         return False
@@ -232,9 +246,9 @@ def _dispatch_needs_exclusive_stdin(text: str, session: ReplSession) -> bool:
 
     if name in _WAIT_FOR_COMPLETION_COMMANDS:
         return True
-    if name in _EXCLUSIVE_STDIN_MENU_COMMANDS and not args:
+    if name in _EXCLUSIVE_STDIN_PARITY_COMMANDS:
         return True
-    if name == "/tests" and not args:
+    if name in _EXCLUSIVE_STDIN_MENU_COMMANDS and not args:
         return True
     return bool(args and (name, args[0]) in _EXCLUSIVE_STDIN_SUBCOMMANDS)
 

--- a/tests/cli/interactive_shell/test_loop.py
+++ b/tests/cli/interactive_shell/test_loop.py
@@ -524,6 +524,19 @@ def test_dispatch_needs_exclusive_stdin_for_exit_commands(
     assert loop._dispatch_needs_exclusive_stdin("quit", session) is True
 
 
+def test_dispatch_needs_exclusive_stdin_for_parity_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(loop, "repl_tty_interactive", lambda: True)
+    session = ReplSession()
+
+    assert loop._dispatch_needs_exclusive_stdin("/update", session) is True
+    assert loop._dispatch_needs_exclusive_stdin("/update --check", session) is True
+    assert loop._dispatch_needs_exclusive_stdin("/remote status", session) is True
+    assert loop._dispatch_needs_exclusive_stdin("/tests", session) is True
+    assert loop._dispatch_needs_exclusive_stdin("/tests list", session) is True
+
+
 def test_dispatch_needs_exclusive_stdin_for_integration_setup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #2230

#### Describe the changes you have made in this PR -
- Added a new `_EXCLUSIVE_STDIN_PARITY_COMMANDS` frozenset to track CLI parity commands (`/update`, `/remote`, `/config`, `/watchdog`, etc.) that execute raw subprocesses.
- Updated `_dispatch_needs_exclusive_stdin` to return `True` for these commands, ensuring the interactive shell waits for the child process to complete before redrawing the `prompt_toolkit` input frame.
- Added a new unit test `test_dispatch_needs_exclusive_stdin_for_parity_commands` in `tests/cli/interactive_shell/test_loop.py` to verify this routing.

### Demo/Screenshot for feature changes and bug fixes - 
**Before:** Running `/update` prints `opensre <version> is already up to date.`, but it is immediately overwritten when the `❯` prompt redraws.
**After:** The update text successfully prints and remains in the terminal scrollback history above the new `❯` prompt.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
the dispatcher already has a way to pause the prompt when something needs exclusive input (the _dispatch_needs_exclusive_stdin mechanism used for interactive menus). I reused that by registering parity commands like /update and /remote in a new set (_EXCLUSIVE_STDIN_PARITY_COMMANDS). Now, when one of those commands runs, the dispatcher blocks the prompt from refreshing until the subprocess finishes. That lets the subprocess print to the terminal cleanly and keeps its output visible.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
