### PR TITLE
fix(wizard): sync onboarding model choice to .env and process env

### DIFF
--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -121,8 +121,7 @@ def switch_llm_provider(
                 provider.value, selected_toolcall, provider.models
             ):
                 console.print(
-                    f"[{ERROR}]unknown model for {provider.value}:[/] "
-                    f"{escape(selected_toolcall)}"
+                    f"[{ERROR}]unknown model for {provider.value}:[/] {escape(selected_toolcall)}"
                 )
                 console.print(
                     f"[{DIM}]known toolcall models:[/] "

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -61,7 +61,7 @@ def switch_llm_provider(
     toolcall_model: str | None = None,
 ) -> bool:
     from app.cli.wizard.config import PROVIDER_BY_VALUE
-    from app.cli.wizard.env_sync import sync_env_values
+    from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
     from app.llm_credentials import has_llm_api_key
 
     provider_key = provider_name.strip().lower()
@@ -108,10 +108,6 @@ def switch_llm_provider(
         )
         return False
 
-    values = {"LLM_PROVIDER": provider.value, provider.model_env: selected_model}
-    if provider.legacy_model_env:
-        values[provider.legacy_model_env] = selected_model
-
     selected_toolcall: str | None = None
     if toolcall_model is not None:
         if not provider.toolcall_model_env:
@@ -121,21 +117,23 @@ def switch_llm_provider(
             )
         else:
             selected_toolcall = toolcall_model.strip()
-            if selected_toolcall:
-                if not _is_model_supported(provider.value, selected_toolcall, provider.models):
-                    console.print(
-                        f"[{ERROR}]unknown model for {provider.value}:[/] "
-                        f"{escape(selected_toolcall)}"
-                    )
-                    console.print(
-                        f"[{DIM}]known toolcall models:[/] "
-                        f"{escape(_format_supported_models(provider.models))}"
-                    )
-                    return False
-                values[provider.toolcall_model_env] = selected_toolcall
+            if selected_toolcall and not _is_model_supported(
+                provider.value, selected_toolcall, provider.models
+            ):
+                console.print(
+                    f"[{ERROR}]unknown model for {provider.value}:[/] "
+                    f"{escape(selected_toolcall)}"
+                )
+                console.print(
+                    f"[{DIM}]known toolcall models:[/] "
+                    f"{escape(_format_supported_models(provider.models))}"
+                )
+                return False
 
-    env_path = sync_env_values(values)
-    os.environ.update(values)
+    env_path = sync_provider_env(provider=provider, model=selected_model)
+    if selected_toolcall and provider.toolcall_model_env:
+        env_path = sync_env_values({provider.toolcall_model_env: selected_toolcall})
+        os.environ[provider.toolcall_model_env] = selected_toolcall
     _reset_runtime_llm_caches()
 
     # Be explicit about which slot each model lands in.

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -132,7 +132,7 @@ def switch_llm_provider(
     env_path = sync_provider_env(
         provider=provider,
         model=selected_model,
-        toolcall_model=selected_toolcall,
+        toolcall_model=selected_toolcall or None,
     )
     _reset_runtime_llm_caches()
 

--- a/app/cli/interactive_shell/command_registry/model.py
+++ b/app/cli/interactive_shell/command_registry/model.py
@@ -61,7 +61,7 @@ def switch_llm_provider(
     toolcall_model: str | None = None,
 ) -> bool:
     from app.cli.wizard.config import PROVIDER_BY_VALUE
-    from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
+    from app.cli.wizard.env_sync import sync_provider_env
     from app.llm_credentials import has_llm_api_key
 
     provider_key = provider_name.strip().lower()
@@ -129,10 +129,11 @@ def switch_llm_provider(
                 )
                 return False
 
-    env_path = sync_provider_env(provider=provider, model=selected_model)
-    if selected_toolcall and provider.toolcall_model_env:
-        env_path = sync_env_values({provider.toolcall_model_env: selected_toolcall})
-        os.environ[provider.toolcall_model_env] = selected_toolcall
+    env_path = sync_provider_env(
+        provider=provider,
+        model=selected_model,
+        toolcall_model=selected_toolcall,
+    )
     _reset_runtime_llm_caches()
 
     # Be explicit about which slot each model lands in.

--- a/app/cli/wizard/config.py
+++ b/app/cli/wizard/config.py
@@ -52,6 +52,10 @@ class ProviderOption:
     #: providers that don't expose a separate toolcall model (e.g. CLI-backed
     #: providers like ``codex``/``claude-code``, or Ollama).
     toolcall_model_env: str | None = None
+    #: Env var that holds the *classification* model for this provider. When
+    #: unset, ``sync_provider_env`` falls back to replacing ``_REASONING_MODEL``
+    #: with ``_CLASSIFICATION_MODEL`` in ``model_env``.
+    classification_model_env: str | None = None
     #: Human-readable name for the credential requested during onboarding. Most
     #: providers want an API key; Ollama wants a host URL. Used as the wizard
     #: prompt label, e.g. ``{label} {credential_label} ({api_key_env})``.
@@ -353,6 +357,7 @@ SUPPORTED_PROVIDERS = (
         models=ANTHROPIC_MODELS,
         legacy_model_env="ANTHROPIC_MODEL",
         toolcall_model_env="ANTHROPIC_TOOLCALL_MODEL",
+        classification_model_env="ANTHROPIC_CLASSIFICATION_MODEL",
     ),
     ProviderOption(
         value="openai",
@@ -364,6 +369,7 @@ SUPPORTED_PROVIDERS = (
         models=OPENAI_MODELS,
         legacy_model_env="OPENAI_MODEL",
         toolcall_model_env="OPENAI_TOOLCALL_MODEL",
+        classification_model_env="OPENAI_CLASSIFICATION_MODEL",
     ),
     ProviderOption(
         value="openrouter",
@@ -375,6 +381,7 @@ SUPPORTED_PROVIDERS = (
         models=OPENROUTER_MODELS,
         legacy_model_env="OPENROUTER_MODEL",
         toolcall_model_env="OPENROUTER_TOOLCALL_MODEL",
+        classification_model_env="OPENROUTER_CLASSIFICATION_MODEL",
     ),
     ProviderOption(
         value="requesty",
@@ -385,6 +392,7 @@ SUPPORTED_PROVIDERS = (
         default_model=REQUESTY_REASONING_MODEL,
         models=REQUESTY_MODELS,
         legacy_model_env="REQUESTY_MODEL",
+        classification_model_env="REQUESTY_CLASSIFICATION_MODEL",
     ),
     ProviderOption(
         value="gemini",
@@ -396,6 +404,7 @@ SUPPORTED_PROVIDERS = (
         models=GEMINI_MODELS,
         legacy_model_env="GEMINI_MODEL",
         toolcall_model_env="GEMINI_TOOLCALL_MODEL",
+        classification_model_env="GEMINI_CLASSIFICATION_MODEL",
     ),
     ProviderOption(
         value="nvidia",
@@ -407,6 +416,7 @@ SUPPORTED_PROVIDERS = (
         models=NVIDIA_MODELS,
         legacy_model_env="NVIDIA_MODEL",
         toolcall_model_env="NVIDIA_TOOLCALL_MODEL",
+        classification_model_env="NVIDIA_CLASSIFICATION_MODEL",
     ),
     ProviderOption(
         value="bedrock",
@@ -421,6 +431,7 @@ SUPPORTED_PROVIDERS = (
         default_model=BEDROCK_REASONING_MODEL,
         models=BEDROCK_MODELS,
         toolcall_model_env="BEDROCK_TOOLCALL_MODEL",
+        classification_model_env="BEDROCK_CLASSIFICATION_MODEL",
         credential_label="AWS region (uses IAM credentials)",
         credential_secret=False,
         # credential_kind="none" causes flow.py to skip the credential prompt

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -142,6 +142,14 @@ def sync_env_values(
     return target_path
 
 
+def _classification_model_env(p: ProviderOption) -> str | None:
+    if p.classification_model_env:
+        return p.classification_model_env
+    if p.model_env.endswith("_REASONING_MODEL"):
+        return p.model_env.replace("_REASONING_MODEL", "_CLASSIFICATION_MODEL")
+    return None
+
+
 def _provider_specific_keys(p: ProviderOption) -> set[str]:
     """Return all env keys owned by a provider (api key + model keys)."""
     keys: set[str] = {p.model_env}
@@ -151,8 +159,9 @@ def _provider_specific_keys(p: ProviderOption) -> set[str]:
         keys.add(p.legacy_model_env)
     if p.toolcall_model_env:
         keys.add(p.toolcall_model_env)
-    if p.model_env.endswith("_REASONING_MODEL"):
-        keys.add(p.model_env.replace("_REASONING_MODEL", "_CLASSIFICATION_MODEL"))
+    classification_env = _classification_model_env(p)
+    if classification_env:
+        keys.add(classification_env)
     return keys
 
 
@@ -189,6 +198,7 @@ def sync_provider_env(
     *,
     provider: ProviderOption,
     model: str,
+    toolcall_model: str | None = None,
     env_path: Path | None = None,
 ) -> Path:
     """Write non-secret provider settings into the project .env.
@@ -220,10 +230,9 @@ def sync_provider_env(
         active_non_secret.add(provider.legacy_model_env)
     if provider.toolcall_model_env:
         active_non_secret.add(provider.toolcall_model_env)
-    if provider.model_env.endswith("_REASONING_MODEL"):
-        active_non_secret.add(
-            provider.model_env.replace("_REASONING_MODEL", "_CLASSIFICATION_MODEL")
-        )
+    classification_env = _classification_model_env(provider)
+    if classification_env:
+        active_non_secret.add(classification_env)
     keys_to_remove -= active_non_secret
 
     prior_provider = _llm_provider_value_from_lines(existing)
@@ -240,6 +249,8 @@ def sync_provider_env(
     values: dict[str, str] = {"LLM_PROVIDER": provider.value, provider.model_env: model}
     if provider.legacy_model_env:
         values[provider.legacy_model_env] = model
+    if toolcall_model is not None and provider.toolcall_model_env:
+        values[provider.toolcall_model_env] = toolcall_model
 
     for key, value in values.items():
         lines = _set_env_value(lines, key, value)

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -165,6 +165,15 @@ def _llm_provider_value_from_lines(lines: list[str]) -> str | None:
     return None
 
 
+def _env_value_from_lines(lines: list[str], key: str) -> str | None:
+    for line in lines:
+        match = _ENV_ASSIGNMENT.match(line)
+        if match and match.group(1) == key:
+            _, _, rhs = line.partition("=")
+            return rhs.strip().strip("\"'")
+    return None
+
+
 def _remove_keys(lines: list[str], keys_to_remove: set[str]) -> list[str]:
     """Drop lines whose env key is in *keys_to_remove*."""
     result: list[str] = []
@@ -239,6 +248,10 @@ def sync_provider_env(
 
     for key in keys_to_remove:
         os.environ.pop(key, None)
+    for key in active_non_secret:
+        preserved = _env_value_from_lines(lines, key)
+        if preserved is not None:
+            values[key] = preserved
     os.environ.update(values)
 
     return target_path

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -149,6 +149,10 @@ def _provider_specific_keys(p: ProviderOption) -> set[str]:
         keys.add(p.api_key_env)
     if p.legacy_model_env:
         keys.add(p.legacy_model_env)
+    if p.toolcall_model_env:
+        keys.add(p.toolcall_model_env)
+    if p.model_env.endswith("_REASONING_MODEL"):
+        keys.add(p.model_env.replace("_REASONING_MODEL", "_CLASSIFICATION_MODEL"))
     return keys
 
 
@@ -226,4 +230,9 @@ def sync_provider_env(
         lines = _set_env_value(lines, key, value)
 
     _write_env(target_path, lines)
+
+    for key in keys_to_remove:
+        os.environ.pop(key, None)
+    os.environ.update(values)
+
     return target_path

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -249,7 +249,7 @@ def sync_provider_env(
     values: dict[str, str] = {"LLM_PROVIDER": provider.value, provider.model_env: model}
     if provider.legacy_model_env:
         values[provider.legacy_model_env] = model
-    if toolcall_model is not None and provider.toolcall_model_env:
+    if toolcall_model and provider.toolcall_model_env:
         values[provider.toolcall_model_env] = toolcall_model
 
     for key, value in values.items():

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -209,6 +209,12 @@ def sync_provider_env(
     active_non_secret: set[str] = {provider.model_env}
     if provider.legacy_model_env:
         active_non_secret.add(provider.legacy_model_env)
+    if provider.toolcall_model_env:
+        active_non_secret.add(provider.toolcall_model_env)
+    if provider.model_env.endswith("_REASONING_MODEL"):
+        active_non_secret.add(
+            provider.model_env.replace("_REASONING_MODEL", "_CLASSIFICATION_MODEL")
+        )
     keys_to_remove -= active_non_secret
 
     prior_provider = _llm_provider_value_from_lines(existing)

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -179,7 +179,7 @@ def _env_value_from_lines(lines: list[str], key: str) -> str | None:
         match = _ENV_ASSIGNMENT.match(line)
         if match and match.group(1) == key:
             _, _, rhs = line.partition("=")
-            return rhs.strip().strip("\"'")
+            return rhs.strip().strip("\"'") or None
     return None
 
 

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -324,12 +324,17 @@ def _questionary_choice(choice: Choice) -> questionary.Choice:
     )
 
 
-def _choose_model(provider: ProviderOption, *, default: str) -> str:
+def _choose_model(provider: ProviderOption, *, default: str | None) -> str:
     """Prompt for a model from the provider's wizard catalog."""
+    resolved_default = (default or "").strip() or provider.default_model
     if not provider.models:
-        return default
+        return resolved_default
     choices = [Choice(value=opt.value, label=opt.label) for opt in provider.models]
-    default_choice = default if any(c.value == default for c in choices) else provider.default_model
+    default_choice = (
+        resolved_default
+        if any(c.value == resolved_default for c in choices)
+        else provider.default_model
+    )
     if not any(c.value == default_choice for c in choices):
         default_choice = choices[0].value
     _step("Model")

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -324,6 +324,22 @@ def _questionary_choice(choice: Choice) -> questionary.Choice:
     )
 
 
+def _choose_model(provider: ProviderOption, *, default: str) -> str:
+    """Prompt for a model from the provider's wizard catalog."""
+    if not provider.models:
+        return default
+    choices = [Choice(value=opt.value, label=opt.label) for opt in provider.models]
+    default_choice = default if any(c.value == default for c in choices) else provider.default_model
+    if not any(c.value == default_choice for c in choices):
+        default_choice = choices[0].value
+    _step("Model")
+    return _choose(
+        f"Choose {provider.label} model",
+        choices,
+        default=default_choice,
+    )
+
+
 def _choose(prompt: str, choices: list[Choice], *, default: str | None = None) -> str:
     q_choices = [_questionary_choice(choice) for choice in choices]
 
@@ -2157,6 +2173,14 @@ def run_wizard(_argv: list[str] | None = None) -> int:
                         return 1
                     if not _persist_llm_api_key(provider.api_key_env, api_key):
                         return 1
+
+        if change_provider:
+            model = _choose_model(provider, default=model)
+        elif provider.models:
+            current_display = model or "CLI default"
+            _console.print(f"[{SECONDARY}]current model  {current_display}[/]")
+            if _confirm("Change model?", default=False):
+                model = _choose_model(provider, default=model)
 
         if provider.credential_kind == "cli":
             cli_out = _run_cli_llm_onboarding(provider)

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -134,6 +134,56 @@ def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:
     assert "GEMINI_CLI_MODEL=\n" in content
 
 
+def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n"
+        "OPENAI_CLASSIFICATION_MODEL=gpt-5.4-mini\n"
+        "CODEX_MODEL=\n",
+        encoding="utf-8",
+    )
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["codex"],
+        model="gpt-5.4",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=codex\n" in content
+    assert "CODEX_MODEL=gpt-5.4\n" in content
+    assert "OPENAI_TOOLCALL_MODEL=" not in content
+    assert "OPENAI_CLASSIFICATION_MODEL=" not in content
+    assert "OPENAI_REASONING_MODEL=" not in content
+
+
+def test_sync_provider_env_updates_os_environ(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4")
+    monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "gpt-5.4-mini")
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["codex"],
+        model="gpt-5.4-mini",
+        env_path=env_path,
+    )
+
+    assert os.environ["LLM_PROVIDER"] == "codex"
+    assert os.environ["CODEX_MODEL"] == "gpt-5.4-mini"
+    assert "OPENAI_TOOLCALL_MODEL" not in os.environ
+    assert "OPENAI_REASONING_MODEL" not in os.environ
+
+
 @pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -264,6 +264,30 @@ def test_sync_provider_env_skips_empty_preserved_values_in_os_environ(
     assert "OPENAI_TOOLCALL_MODEL" not in os.environ
 
 
+def test_sync_provider_env_skips_empty_toolcall_model_override(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "gpt-5.4-mini")
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5.4",
+        toolcall_model="",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n" in content
+    assert os.environ["OPENAI_TOOLCALL_MODEL"] == "gpt-5.4-mini"
+
+
 def test_sync_provider_env_writes_toolcall_model_atomically(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text(

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -240,6 +240,31 @@ def test_sync_provider_env_updates_os_environ(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
+def test_sync_provider_env_skips_empty_preserved_values_in_os_environ(
+    tmp_path, monkeypatch
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4")
+    monkeypatch.delenv("OPENAI_TOOLCALL_MODEL", raising=False)
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5.4",
+        env_path=env_path,
+    )
+
+    assert os.environ["OPENAI_REASONING_MODEL"] == "gpt-5.4"
+    assert "OPENAI_TOOLCALL_MODEL" not in os.environ
+
+
 def test_sync_provider_env_writes_toolcall_model_atomically(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text(

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -166,6 +166,33 @@ def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(
     assert "OPENAI_TOOLCALL_MODEL" not in os.environ
 
 
+def test_sync_provider_env_loads_preserved_keys_from_env_file(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n"
+        "OPENAI_CLASSIFICATION_MODEL=gpt-5.4-mini\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OPENAI_TOOLCALL_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_CLASSIFICATION_MODEL", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "stale")
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5.4",
+        env_path=env_path,
+    )
+
+    assert os.environ["LLM_PROVIDER"] == "openai"
+    assert os.environ["OPENAI_REASONING_MODEL"] == "gpt-5.4"
+    assert os.environ["OPENAI_TOOLCALL_MODEL"] == "gpt-5.4-mini"
+    assert os.environ["OPENAI_CLASSIFICATION_MODEL"] == "gpt-5.4-mini"
+
+
 def test_sync_provider_env_preserves_active_provider_toolcall_key(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text(

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -163,9 +163,7 @@ def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(tmp_pa
 def test_sync_provider_env_updates_os_environ(tmp_path, monkeypatch) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text(
-        "LLM_PROVIDER=openai\n"
-        "OPENAI_REASONING_MODEL=gpt-5.4\n"
-        "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n",
+        "LLM_PROVIDER=openai\nOPENAI_REASONING_MODEL=gpt-5.4\nOPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("LLM_PROVIDER", "openai")

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -240,6 +240,33 @@ def test_sync_provider_env_updates_os_environ(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
+def test_sync_provider_env_writes_toolcall_model_atomically(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=old-toolcall\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4")
+    monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "old-toolcall")
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5.4-mini",
+        toolcall_model="gpt-5.4-nano",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "OPENAI_REASONING_MODEL=gpt-5.4-mini\n" in content
+    assert "OPENAI_TOOLCALL_MODEL=gpt-5.4-nano\n" in content
+    assert os.environ["OPENAI_REASONING_MODEL"] == "gpt-5.4-mini"
+    assert os.environ["OPENAI_TOOLCALL_MODEL"] == "gpt-5.4-nano"
+
+
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -16,6 +16,15 @@ from app.llm_credentials import resolve_env_credential
 _SKIP_AS_ROOT = not hasattr(os, "getuid") or os.getuid() == 0
 
 
+@pytest.fixture(autouse=True)
+def _isolate_os_environ() -> None:
+    """Restore os.environ after each test that mutates process env."""
+    saved = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(saved)
+
+
 @pytest.mark.parametrize(
     "key",
     [

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -134,7 +134,9 @@ def test_sync_provider_env_gemini_cli_writes_model(tmp_path) -> None:
     assert "GEMINI_CLI_MODEL=\n" in content
 
 
-def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(tmp_path) -> None:
+def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(
+    tmp_path, monkeypatch
+) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text(
         "LLM_PROVIDER=openai\n"
@@ -145,6 +147,9 @@ def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(tmp_pa
         "CODEX_MODEL=\n",
         encoding="utf-8",
     )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4")
+    monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "gpt-5.4-mini")
 
     sync_provider_env(
         provider=PROVIDER_BY_VALUE["codex"],
@@ -158,6 +163,31 @@ def test_sync_provider_env_removes_stale_toolcall_and_classification_keys(tmp_pa
     assert "OPENAI_TOOLCALL_MODEL=" not in content
     assert "OPENAI_CLASSIFICATION_MODEL=" not in content
     assert "OPENAI_REASONING_MODEL=" not in content
+    assert "OPENAI_TOOLCALL_MODEL" not in os.environ
+
+
+def test_sync_provider_env_preserves_active_provider_toolcall_key(tmp_path, monkeypatch) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=openai\n"
+        "OPENAI_REASONING_MODEL=gpt-5.4\n"
+        "OPENAI_MODEL=gpt-5.4\n"
+        "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4")
+    monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "gpt-5.4-mini")
+
+    sync_provider_env(
+        provider=PROVIDER_BY_VALUE["openai"],
+        model="gpt-5.4",
+        env_path=env_path,
+    )
+
+    content = env_path.read_text(encoding="utf-8")
+    assert "OPENAI_TOOLCALL_MODEL=gpt-5.4-mini\n" in content
+    assert os.environ.get("OPENAI_TOOLCALL_MODEL") == "gpt-5.4-mini"
 
 
 def test_sync_provider_env_updates_os_environ(tmp_path, monkeypatch) -> None:

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -239,7 +239,6 @@ def test_sync_provider_env_updates_os_environ(tmp_path, monkeypatch) -> None:
     assert "OPENAI_REASONING_MODEL" not in os.environ
 
 
-@pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_provider_env_skips_empty_preserved_values_in_os_environ(
     tmp_path, monkeypatch
 ) -> None:
@@ -292,6 +291,7 @@ def test_sync_provider_env_writes_toolcall_model_atomically(tmp_path, monkeypatc
     assert os.environ["OPENAI_TOOLCALL_MODEL"] == "gpt-5.4-nano"
 
 
+@pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")
 def test_sync_provider_env_permission_error(tmp_path) -> None:
     env_path = tmp_path / ".env"
     env_path.write_text("LLM_PROVIDER=anthropic\n", encoding="utf-8")

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -13,7 +13,7 @@ from tests.integrations.llm_cli.testing_helpers import write_fake_runnable_cli_b
 
 def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, capsys) -> None:
     # advanced -> falls back to local -> change provider? Yes -> pick anthropic -> skip integrations
-    select_responses = iter(["advanced", "remote", "anthropic", "skip"])
+    select_responses = iter(["advanced", "remote", "anthropic", "claude-opus-4-7", "skip"])
     confirm_responses = iter([True, True])  # "use local instead?" and "Change provider?"
 
     def _mock_select(*_args, **_kwargs):
@@ -70,7 +70,7 @@ def test_run_wizard_advanced_remote_falls_back_to_local(monkeypatch, tmp_path, c
 
 def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> None:
     """With no saved config the provider list is shown immediately (no confirm prompt)."""
-    select_responses = iter(["quickstart", "anthropic", "skip"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "skip"])
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -97,7 +97,7 @@ def test_run_wizard_no_saved_provider_shows_selection(monkeypatch, tmp_path) -> 
 def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
     monkeypatch, tmp_path, capsys
 ) -> None:
-    select_responses = iter(["quickstart", "anthropic"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7"])
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -141,7 +141,7 @@ def test_run_wizard_shows_keyring_fix_steps_when_secure_storage_is_unavailable(
 
 
 def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, capsys) -> None:
-    select_responses = iter(["quickstart", "anthropic", "grafana"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "grafana"])
     saved_integrations: list[tuple[str, dict]] = []
     synced_env_values: list[dict[str, str]] = []
 
@@ -222,7 +222,7 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
 
 
 def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "honeycomb"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "honeycomb"])
     password_responses = iter(["llm-secret", "hny_test"])
     text_responses = iter(["prod-api", "https://api.honeycomb.io"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -292,7 +292,7 @@ def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
 
 
 def test_run_wizard_configures_coralogix(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "coralogix"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "coralogix"])
     password_responses = iter(["llm-secret", "cx_test"])
     text_responses = iter(
         [
@@ -374,6 +374,7 @@ def test_run_wizard_configures_github_mcp_and_sentry(monkeypatch, tmp_path, caps
         [
             "quickstart",
             "anthropic",
+            "claude-opus-4-7",
             "github",
             flow.DEFAULT_GITHUB_MCP_MODE,
             "auto",
@@ -539,7 +540,7 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
 
 
 def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "openai", "skip"])
+    select_responses = iter(["quickstart", "openai", "gpt-5.4", "skip"])
     saved_llm_keys: list[tuple[str, str]] = []
 
     def _mock_select(*_args, **_kwargs):
@@ -594,7 +595,7 @@ def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path
 
 
 def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "codex", "skip"])
+    select_responses = iter(["quickstart", "codex", "", "skip"])
     saved_llm_keys: list[tuple[str, str]] = []
     cli_onboarding_providers: list[str] = []
 
@@ -648,7 +649,7 @@ def test_run_wizard_codex_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp
 def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
     monkeypatch, tmp_path
 ) -> None:
-    select_responses = iter(["quickstart", "claude-code", "skip"])
+    select_responses = iter(["quickstart", "claude-code", "", "skip"])
     saved_llm_keys: list[tuple[str, str]] = []
     cli_onboarding_providers: list[str] = []
 
@@ -700,7 +701,7 @@ def test_run_wizard_claude_code_skips_api_key_and_runs_cli_onboarding(
 
 
 def test_run_wizard_gemini_cli_skips_api_key_and_runs_cli_onboarding(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "gemini-cli", "skip"])
+    select_responses = iter(["quickstart", "gemini-cli", "", "skip"])
     saved_llm_keys: list[tuple[str, str]] = []
     cli_onboarding_providers: list[str] = []
 
@@ -1014,7 +1015,7 @@ def test_credential_line_for_saved_summary_cli_without_factory() -> None:
 
 
 def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
-    select_responses = iter(["quickstart", "anthropic", "gitlab"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "gitlab"])
     password_responses = iter(["llm-secret", "glpat_test"])
     text_responses = iter(["https://gitlab.example.com/api/v4"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -1084,7 +1085,7 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
 
 def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
     """When GitLab validation fails the first time, the wizard retries and succeeds."""
-    select_responses = iter(["quickstart", "anthropic", "gitlab"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "gitlab"])
     # First attempt: wrong token; second attempt: correct token
     password_responses = iter(["llm-secret", "bad_token", "glpat_good"])
     # base_url is prompted on each retry
@@ -1168,7 +1169,7 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
     monkeypatch, tmp_path
 ) -> None:
     # Saved: anthropic. User says yes to "Change provider?" and picks openai.
-    select_responses = iter(["quickstart", "openai", "skip"])
+    select_responses = iter(["quickstart", "openai", "gpt-5.4", "skip"])
     confirm_responses = iter([True])  # "Change provider?" -> Yes
     saved_llm_keys: list[tuple[str, str]] = []
 
@@ -1250,7 +1251,7 @@ def test_run_wizard_switches_provider_and_keeps_store_and_env_in_sync(
 
 def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     """Happy path: user picks opensearch, enters URL + basic auth, all gets persisted."""
-    select_responses = iter(["quickstart", "anthropic", "opensearch", "basic"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic"])
     password_responses = iter(["llm-secret", "secret-pass"])
     text_responses = iter(["https://my-cluster.example.com", "admin"])
     saved_integrations: list[tuple[str, dict]] = []
@@ -1327,7 +1328,7 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
 
 def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
     """When OpenSearch validation fails the first time, the wizard retries and succeeds."""
-    select_responses = iter(["quickstart", "anthropic", "opensearch", "basic", "basic"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"])
     password_responses = iter(["llm-secret", "wrong-pass", "correct-pass"])
     text_responses = iter(
         [
@@ -1420,7 +1421,7 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     that validation is only called once the user supplies a non-empty key.
     """
     # User picks: opensearch -> api_key auth -> (rejected, empty) -> api_key auth retry
-    select_responses = iter(["quickstart", "anthropic", "opensearch", "api_key", "api_key"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "api_key", "api_key"])
     # First api_key prompt: empty (rejected). Second: valid key.
     password_responses = iter(["llm-secret", "", "valid-api-key"])
     text_responses = iter(
@@ -1511,7 +1512,7 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     validation is only called once the user supplies both halves.
     """
     # User picks: opensearch -> basic auth -> (rejected, empty pass) -> basic auth retry
-    select_responses = iter(["quickstart", "anthropic", "opensearch", "basic", "basic"])
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"])
     # First password prompt: empty (rejected). Second attempt: valid password.
     password_responses = iter(["llm-secret", "", "real-pass"])
     text_responses = iter(

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -539,6 +539,70 @@ def test_run_wizard_reuses_saved_defaults_when_user_keeps_provider(monkeypatch, 
     assert saved_llm_keys == [("OPENAI_API_KEY", "saved-secret")]
 
 
+def test_run_wizard_changes_model_when_user_keeps_provider(monkeypatch, tmp_path) -> None:
+    """When provider is kept but user opts to change model, the new choice is saved."""
+    saved: dict[str, object] = {}
+    confirm_prompts: list[str] = []
+
+    def _mock_select(*_args, choices=None, default=None, **_kwargs):
+        m = MagicMock()
+        prompt = str(_args[0]) if _args else ""
+        if "Choose your LLM provider" in prompt:
+            m.ask.return_value = "openai"
+        elif "Choose OpenAI model" in prompt:
+            m.ask.return_value = "gpt-5.4-mini"
+        else:
+            m.ask.return_value = default
+        return m
+
+    def _mock_confirm(*_args, **_kwargs):
+        m = MagicMock()
+        prompt = str(_args[0]) if _args else ""
+        confirm_prompts.append(prompt)
+        if "Change provider?" in prompt:
+            m.ask.return_value = False
+        elif "Change model?" in prompt:
+            m.ask.return_value = True
+        else:
+            m.ask.return_value = False
+        return m
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "confirm", _mock_confirm)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(
+        flow,
+        "load_local_config",
+        lambda _path: {
+            "wizard": {"mode": "quickstart"},
+            "targets": {
+                "local": {
+                    "provider": "openai",
+                    "model": "gpt-5.4",
+                    "api_key_env": "OPENAI_API_KEY",
+                    "api_key": "saved-secret",
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(flow, "has_llm_api_key", lambda _env: True)
+
+    def _save_local_config(**kwargs):
+        saved.update(kwargs)
+        return tmp_path / "opensre.json"
+
+    monkeypatch.setattr(flow, "save_local_config", _save_local_config)
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert saved["provider"] == "openai"
+    assert saved["model"] == "gpt-5.4-mini"
+    assert "Change model?" in confirm_prompts
+
+
 def test_run_wizard_persists_matching_local_config_and_env(monkeypatch, tmp_path) -> None:
     select_responses = iter(["quickstart", "openai", "gpt-5.4", "skip"])
     saved_llm_keys: list[tuple[str, str]] = []

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -1328,7 +1328,9 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
 
 def test_run_wizard_opensearch_retries_on_validation_failure(monkeypatch, tmp_path) -> None:
     """When OpenSearch validation fails the first time, the wizard retries and succeeds."""
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"])
+    select_responses = iter(
+        ["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"]
+    )
     password_responses = iter(["llm-secret", "wrong-pass", "correct-pass"])
     text_responses = iter(
         [
@@ -1421,7 +1423,9 @@ def test_run_wizard_opensearch_rejects_empty_api_key(monkeypatch, tmp_path) -> N
     that validation is only called once the user supplies a non-empty key.
     """
     # User picks: opensearch -> api_key auth -> (rejected, empty) -> api_key auth retry
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "api_key", "api_key"])
+    select_responses = iter(
+        ["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "api_key", "api_key"]
+    )
     # First api_key prompt: empty (rejected). Second: valid key.
     password_responses = iter(["llm-secret", "", "valid-api-key"])
     text_responses = iter(
@@ -1512,7 +1516,9 @@ def test_run_wizard_opensearch_rejects_empty_basic_password(monkeypatch, tmp_pat
     validation is only called once the user supplies both halves.
     """
     # User picks: opensearch -> basic auth -> (rejected, empty pass) -> basic auth retry
-    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"])
+    select_responses = iter(
+        ["quickstart", "anthropic", "claude-opus-4-7", "opensearch", "basic", "basic"]
+    )
     # First password prompt: empty (rejected). Second attempt: valid password.
     password_responses = iter(["llm-secret", "", "real-pass"])
     text_responses = iter(

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -513,6 +513,7 @@ def test_onboard_interactive_smoke(cli_sandbox: CliSandbox) -> None:
             PtyAction(expect="How do you want to get started?", send=b"\r"),
             PtyAction(expect="Choose your LLM provider", send=b"\r"),
             PtyAction(expect="Anthropic API key", send=b"smoke-test-key\r"),
+            PtyAction(expect="Choose Anthropic model", send=b"\r"),
             PtyAction(
                 expect="Choose an integration to configure",
                 send=b"\r",
@@ -593,6 +594,7 @@ def test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated(
                 ),
                 PtyAction(expect="Choose your LLM provider", send=b"\r"),
                 PtyAction(expect="Anthropic API key", send=b"smoke-test-key\r"),
+                PtyAction(expect="Choose Anthropic model", send=b"\r"),
                 PtyAction(
                     expect="Choose an integration to configure",
                     send=b"\r",


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -

- Restore model selection during `opensre onboard` when switching LLM providers (including CLI backends like Codex)
- Extend `sync_provider_env` to remove stale `*_TOOLCALL_MODEL` and `*_CLASSIFICATION_MODEL` keys when changing providers
- Apply active provider settings to `os.environ` after writing `.env`, so the running process sees the new provider immediately
- Route REPL `/model set` through `sync_provider_env` instead of `sync_env_values` so cross-provider keys are cleaned up


### Demo/Screenshot for feature changes and bug fixes -

**Before:** switching from OpenAI to Codex during onboard left stale keys in `.env`:

```bash
LLM_PROVIDER=codex
CODEX_MODEL=
OPENAI_TOOLCALL_MODEL=gpt-5.4-mini   # stale
```

**After:** onboard writes the chosen model and removes other providers' model keys:

```bash
LLM_PROVIDER=codex
CODEX_MODEL=gpt-5.4
# no OPENAI_* model keys
```

**Verify locally:**

```bash
uv run opensre onboard
# Change provider → pick Codex CLI → pick model
grep -E '^(LLM_PROVIDER|CODEX_MODEL|OPENAI_)' .env
uv run python -m pytest tests/cli/wizard/test_env_sync.py tests/cli/wizard/test_flow.py -q
```

---

## Root cause context

- **Primary regression:** [#284](https://github.com/Tracer-Cloud/opensre/pull/284) removed the dedicated model-selection step from onboarding and silently used `provider.default_model` (empty for CLI providers = use CLI default). That is why onboarding stopped persisting the user's model choice.
- **#1192 amplified stale env keys:** [#1192](https://github.com/Tracer-Cloud/opensre/pull/1192) added `*_TOOLCALL_MODEL` (and related) env keys. `sync_provider_env` already did not clean those up on provider switch, so users could end up with stale keys like `OPENAI_TOOLCALL_MODEL=gpt-5.4-mini` after switching to Codex. #1192 did not introduce the core onboarding regression — it exposed an existing cleanup gap.
- **REPL-only gap:** [#1167](https://github.com/Tracer-Cloud/opensre/pull/1167) added `/model set` using `sync_env_values` (partial upsert, no cross-provider cleanup). That affected the REPL only, not onboarding. Before #1167, `/model set` was unsupported in the REPL.

This PR fixes both surfaces: onboarding and REPL `/model set` now route through `sync_provider_env`, so provider switches remove stale model keys and persist the chosen model consistently.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Onboarding was writing `LLM_PROVIDER` but not always the user's model choice (CLI providers defaulted to empty `CODEX_MODEL`), and `sync_provider_env` did not remove all provider-owned keys. Runtime `/model set` only upserted keys via `sync_env_values`, leaving stale entries. The fix adds an explicit model step in the wizard, extends `_provider_specific_keys`, updates `os.environ` in `sync_provider_env`, and reuses that helper from `/model set`.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.