### PR TITLE
fix(cli): capture and replay subprocess output in REPL to prevent rendering corruption

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -69,15 +69,14 @@ def run_cli_command(
         if result.returncode != 0:
             console.print(f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]")
     except subprocess.TimeoutExpired as exc:
-        if subprocess_timeout is not None:
-            _stdout = exc.stdout
-            if isinstance(_stdout, bytes):
-                _stdout = _stdout.decode("utf-8", errors="replace")
-            _stderr = exc.stderr
-            if isinstance(_stderr, bytes):
-                _stderr = _stderr.decode("utf-8", errors="replace")
-            print_command_output(console, _stdout or "")
-            print_command_output(console, _stderr or "", style=ERROR)
+        _stdout = exc.stdout
+        if isinstance(_stdout, bytes):
+            _stdout = _stdout.decode("utf-8", errors="replace")
+        _stderr = exc.stderr
+        if isinstance(_stderr, bytes):
+            _stderr = _stderr.decode("utf-8", errors="replace")
+        print_command_output(console, _stdout or "")
+        print_command_output(console, _stderr or "", style=ERROR)
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
     except KeyboardInterrupt:
         console.print(f"[{DIM}]CLI command cancelled (Ctrl+C).[/]")

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -70,8 +70,14 @@ def run_cli_command(
             console.print(f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]")
     except subprocess.TimeoutExpired as exc:
         if subprocess_timeout is not None:
-            print_command_output(console, exc.stdout or "")
-            print_command_output(console, exc.stderr or "", style=ERROR)
+            _stdout = exc.stdout
+            if isinstance(_stdout, bytes):
+                _stdout = _stdout.decode("utf-8", errors="replace")
+            _stderr = exc.stderr
+            if isinstance(_stderr, bytes):
+                _stderr = _stderr.decode("utf-8", errors="replace")
+            print_command_output(console, _stdout or "")
+            print_command_output(console, _stderr or "", style=ERROR)
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
     except KeyboardInterrupt:
         console.print(f"[{DIM}]CLI command cancelled (Ctrl+C).[/]")

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -22,7 +22,7 @@ from app.cli.interactive_shell.orchestration.action_executor import (
     start_background_cli_task,
 )
 from app.cli.interactive_shell.runtime import ReplSession, TaskKind
-from app.cli.interactive_shell.ui import DIM, ERROR
+from app.cli.interactive_shell.ui import DIM, ERROR, print_command_output
 
 _UPDATE_SUBPROCESS_TIMEOUT_SECONDS = 300
 _BACKGROUND_TEST_SUBCOMMANDS = frozenset({"run", "synthetic", "cloudopsbench"})
@@ -41,7 +41,9 @@ def run_cli_command(
     ``subprocess_timeout`` caps how long ``subprocess.run`` waits before raising
     :class:`~subprocess.TimeoutExpired`. Interactive flows use ``None`` so the
     child can prompt as long as needed; callers that hit the network without a
-    TTY (like ``opensre update``) pass a bounded timeout.
+    TTY (like ``opensre update``) pass a bounded timeout. When a timeout is set,
+    stdout/stderr are captured and replayed through ``console`` so output survives
+    prompt-toolkit ``patch_stdout`` redraws in the REPL.
 
     Ctrl+C sends :exc:`KeyboardInterrupt`, which subclasses :exc:`BaseException`
     rather than :exc:`Exception`; it is handled here so the REPL survives and the
@@ -50,10 +52,26 @@ def run_cli_command(
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
     try:
-        result = subprocess.run(cmd, check=False, timeout=subprocess_timeout)
+        if subprocess_timeout is not None:
+            result = subprocess.run(
+                cmd,
+                check=False,
+                timeout=subprocess_timeout,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            print_command_output(console, result.stdout or "")
+            print_command_output(console, result.stderr or "", style=ERROR)
+        else:
+            result = subprocess.run(cmd, check=False)
         if result.returncode != 0:
             console.print(f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]")
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
+        if subprocess_timeout is not None:
+            print_command_output(console, exc.stdout or "")
+            print_command_output(console, exc.stderr or "", style=ERROR)
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
     except KeyboardInterrupt:
         console.print(f"[{DIM}]CLI command cancelled (Ctrl+C).[/]")

--- a/app/cli/interactive_shell/runtime/terminal_runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/terminal_runtime/dispatch.py
@@ -63,7 +63,7 @@ _EXCLUSIVE_STDIN_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
         ("/mcp", "connect"),
     }
 )
-_WAIT_FOR_COMPLETION_COMMANDS: frozenset[str] = frozenset({"/exit", "/quit"})
+_WAIT_FOR_COMPLETION_COMMANDS: frozenset[str] = frozenset({"/exit", "/quit", "/update"})
 
 
 class DispatchCancelled(Exception):

--- a/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
+++ b/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
@@ -63,9 +63,13 @@ class StreamingConsole(Console):
         """
         if not self._spinner.streaming:
             from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
-            from app.cli.interactive_shell.ui.rendering import _repl_table_width
+            from app.cli.interactive_shell.ui.rendering import (
+                _repl_output_already_prepared,
+                _repl_table_width,
+            )
 
-            prepare_repl_output_line()
+            if not _repl_output_already_prepared():
+                prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)
         super().print(*args, **kwargs)

--- a/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
+++ b/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
@@ -62,13 +62,21 @@ class StreamingConsole(Console):
         section rules) must start at column zero or lines appear broken.
         """
         if not self._spinner.streaming:
-            from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
+            from app.cli.interactive_shell.ui.choice_menu import (
+                ensure_tty_column_zero,
+                prepare_repl_output_line,
+            )
             from app.cli.interactive_shell.ui.rendering import (
                 _repl_output_already_prepared,
                 _repl_table_width,
             )
 
-            if not _repl_output_already_prepared():
+            if not args and not kwargs:
+                # ``console.print()`` is used for intentional blank spacer lines.
+                # Only reset the column for those calls; do not prepend another
+                # line break or they expand into double blank lines.
+                ensure_tty_column_zero()
+            elif not _repl_output_already_prepared():
                 prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)

--- a/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
+++ b/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
@@ -67,7 +67,7 @@ class StreamingConsole(Console):
 
             ensure_tty_column_zero()
             if sys.stdout.isatty() and "width" not in kwargs:
-                kwargs.setdefault("width", _repl_table_width(self))
+                kwargs["width"] = _repl_table_width(self)
         super().print(*args, **kwargs)
 
 

--- a/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
+++ b/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 import threading
 from typing import Any
 
@@ -52,6 +53,22 @@ class StreamingConsole(Console):
     @property
     def cancel_requested(self) -> bool:
         return self._cancel_event.is_set()
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        """Reset the TTY column before each print when not streaming.
+
+        Inline menus pad rows to the terminal width, leaving the cursor on a
+        high column. Rich output that follows (tables, follow-up status lines,
+        section rules) must start at column zero or lines appear broken.
+        """
+        if not self._spinner.streaming:
+            from app.cli.interactive_shell.ui.choice_menu import ensure_tty_column_zero
+            from app.cli.interactive_shell.ui.rendering import _repl_table_width
+
+            ensure_tty_column_zero()
+            if sys.stdout.isatty() and "width" not in kwargs:
+                kwargs.setdefault("width", _repl_table_width(self))
+        super().print(*args, **kwargs)
 
 
 async def run_interactive(

--- a/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
+++ b/app/cli/interactive_shell/runtime/terminal_runtime/terminal_runtime.py
@@ -62,10 +62,10 @@ class StreamingConsole(Console):
         section rules) must start at column zero or lines appear broken.
         """
         if not self._spinner.streaming:
-            from app.cli.interactive_shell.ui.choice_menu import ensure_tty_column_zero
+            from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
             from app.cli.interactive_shell.ui.rendering import _repl_table_width
 
-            ensure_tty_column_zero()
+            prepare_repl_output_line()
             if sys.stdout.isatty() and "width" not in kwargs:
                 kwargs["width"] = _repl_table_width(self)
         super().print(*args, **kwargs)

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -80,9 +80,9 @@ def _prepare_tty_for_rich(console: Console) -> int:
     return _repl_table_width(console)
 
 
-def print_repl_table(console: Console, table: Table) -> None:
+def print_repl_table(console: Console, table: Table, *, width: int | None = None) -> None:
     """Print a Rich table using REPL-safe TTY width."""
-    width = _prepare_tty_for_rich(console)
+    width = width if width is not None else _prepare_tty_for_rich(console)
     if table.width is None:
         table.width = width
     _console_print_prepared(console, table, width=width)
@@ -122,7 +122,7 @@ def render_integrations_table(console: Console, results: list[dict[str, str]]) -
             f"[{status_style(st)}]{escape(st)}[/]",
             escape(row.get("detail", "")),
         )
-    print_repl_table(console, table)
+    print_repl_table(console, table, width=width)
 
 
 def render_mcp_table(console: Console, results: list[dict[str, str]]) -> None:
@@ -145,7 +145,7 @@ def render_mcp_table(console: Console, results: list[dict[str, str]]) -> None:
             f"[{status_style(st)}]{escape(st)}[/]",
             escape(row.get("detail", "")),
         )
-    print_repl_table(console, table)
+    print_repl_table(console, table, width=width)
 
 
 def render_models_table(console: Console, settings: Any) -> None:
@@ -164,7 +164,7 @@ def render_models_table(console: Console, settings: Any) -> None:
     table.add_row("provider", provider)
     table.add_row("reasoning model", reasoning_model)
     table.add_row("toolcall model", toolcall_model)
-    print_repl_table(console, table)
+    print_repl_table(console, table, width=width)
 
 
 def print_command_output(console: Console, output: str, *, style: str | None = None) -> None:

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+from contextvars import ContextVar
 from typing import Any
 
 from rich import box
@@ -49,6 +50,20 @@ def status_style(status: str) -> str:
 # MCP-type services are rendered separately under `/list mcp` so the default
 # `/list integrations` view stays focused on alert-source / data integrations.
 MCP_INTEGRATION_SERVICES = frozenset({"github", "openclaw"})
+_REPL_OUTPUT_PREPARED = ContextVar("_REPL_OUTPUT_PREPARED", default=False)
+
+
+def _repl_output_already_prepared() -> bool:
+    """Whether current call stack already prepared the TTY for Rich output."""
+    return _REPL_OUTPUT_PREPARED.get()
+
+
+def _console_print_prepared(console: Console, *objects: Any, **kwargs: Any) -> None:
+    token = _REPL_OUTPUT_PREPARED.set(True)
+    try:
+        console.print(*objects, **kwargs)
+    finally:
+        _REPL_OUTPUT_PREPARED.reset(token)
 
 
 def _repl_table_width(console: Console) -> int:
@@ -70,7 +85,7 @@ def print_repl_table(console: Console, table: Table) -> None:
     width = _prepare_tty_for_rich(console)
     if table.width is None:
         table.width = width
-    console.print(table, width=width)
+    _console_print_prepared(console, table, width=width)
 
 
 def repl_print(console: Console, *objects: Any, **kwargs: Any) -> None:
@@ -78,7 +93,7 @@ def repl_print(console: Console, *objects: Any, **kwargs: Any) -> None:
     from app.cli.interactive_shell.ui.choice_menu import prepare_repl_output_line
 
     prepare_repl_output_line()
-    console.print(*objects, **kwargs)
+    _console_print_prepared(console, *objects, **kwargs)
 
 
 def render_integrations_table(console: Console, results: list[dict[str, str]]) -> None:

--- a/app/cli/interactive_shell/ui/rendering.py
+++ b/app/cli/interactive_shell/ui/rendering.py
@@ -156,7 +156,7 @@ def print_command_output(console: Console, output: str, *, style: str | None = N
     if not output:
         return
     text = output.rstrip()
-    console.print(Text(text) if style is None else Text(text, style=style))
+    repl_print(console, Text(text) if style is None else Text(text, style=style))
 
 
 def print_planned_actions(console: Console, actions: list[PlannedAction]) -> None:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import subprocess
 import sys
 from pathlib import Path
 
@@ -1416,6 +1417,62 @@ class TestSlashValidatorFunctions:
     )
     def test_returns_none_when_args_present(self, validator: object, args: list[str]) -> None:
         assert validator(args) is None  # type: ignore[operator]
+
+
+class TestRunCliCommand:
+    """Regression: captured subprocess output must survive REPL prompt redraw."""
+
+    def test_timed_delegate_replays_stdout_through_console(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        def _fake_run(
+            cmd: list[str],
+            *,
+            check: bool,
+            timeout: float | None,
+            capture_output: bool,
+            text: bool,
+            encoding: str,
+            errors: str,
+        ) -> subprocess.CompletedProcess[str]:
+            del check, timeout, text, encoding, errors
+            assert capture_output is True
+            assert cmd[:3] == [sys.executable, "-m", "app.cli"]
+            assert cmd[3:] == ["update"]
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="  opensre 1.0.0 is already up to date.\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        console, buf = _capture()
+        assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is True
+        assert "already up to date" in buf.getvalue()
+
+    def test_interactive_delegate_does_not_capture_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        run_kwargs: list[dict[str, object]] = []
+
+        def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            run_kwargs.append({"cmd": cmd, **kwargs})
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        console, buf = _capture()
+        assert m.run_cli_command(console, ["config", "show"]) is True
+        assert run_kwargs == [
+            {"cmd": [sys.executable, "-m", "app.cli", "config", "show"], "check": False}
+        ]
+        assert buf.getvalue() == "\n\n"
 
 
 class TestCliDelegatedCommands:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1494,8 +1494,8 @@ class TestRunCliCommand:
             raise subprocess.TimeoutExpired(
                 cmd=[sys.executable, "-m", "app.cli", "update"],
                 timeout=30.0,
-                output="partial stdout\n".encode("utf-8"),
-                stderr="partial stderr\n".encode("utf-8"),
+                output=b"partial stdout\n",
+                stderr=b"partial stderr\n",
             )
 
         monkeypatch.setattr(m, "print_command_output", _fake_print_command_output)

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1474,6 +1474,38 @@ class TestRunCliCommand:
         ]
         assert buf.getvalue() == "\n\n"
 
+    def test_timeout_replays_decoded_partial_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        replayed: list[tuple[str, str | None]] = []
+
+        def _fake_print_command_output(
+            _console: Console,
+            output: str,
+            *,
+            style: str | None = None,
+        ) -> None:
+            replayed.append((output, style))
+
+        def _fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(
+                cmd=[sys.executable, "-m", "app.cli", "update"],
+                timeout=30.0,
+                output="partial stdout\n".encode("utf-8"),
+                stderr="partial stderr\n".encode("utf-8"),
+            )
+
+        monkeypatch.setattr(m, "print_command_output", _fake_print_command_output)
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+
+        console, buf = _capture()
+        assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is True
+        assert replayed == [("partial stdout\n", None), ("partial stderr\n", m.ERROR)]
+        assert "timed out" in buf.getvalue()
+
 
 class TestCliDelegatedCommands:
     """Coverage for commands that simply delegate to the underlying Click CLI."""

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -836,6 +836,34 @@ class TestStreamingConsole:
         cancel.clear()
         assert console.cancel_requested is False
 
+    def test_blank_print_resets_column_without_preparing_new_line(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import threading as _threading
+
+        spinner = loop._SpinnerState()
+        console = loop._StreamingConsole(
+            spinner,
+            _threading.Event(),
+            file=io.StringIO(),
+            force_terminal=False,
+            width=80,
+        )
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "app.cli.interactive_shell.ui.choice_menu.ensure_tty_column_zero",
+            lambda: calls.append("ensure"),
+        )
+        monkeypatch.setattr(
+            "app.cli.interactive_shell.ui.choice_menu.prepare_repl_output_line",
+            lambda: calls.append("prepare"),
+        )
+
+        console.print()
+        assert calls == ["ensure"]
+
 
 # ── ReplState dataclass tests ────────────────────────────────────────────────
 

--- a/tests/cli/interactive_shell/test_terminal_runtime_routing.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime_routing.py
@@ -88,6 +88,17 @@ def test_dispatch_needs_exclusive_stdin_for_exit_commands(
     assert loop._dispatch_needs_exclusive_stdin("quit", session) is True
 
 
+def test_dispatch_needs_exclusive_stdin_for_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/update`` hits the network; block the next prompt until output is printed."""
+    monkeypatch.setattr(loop, "repl_tty_interactive", lambda: True)
+    session = ReplSession()
+
+    assert loop._dispatch_needs_exclusive_stdin("/update", session) is True
+    assert loop._dispatch_needs_exclusive_stdin("update", session) is True
+
+
 def test_dispatch_needs_exclusive_stdin_for_integration_setup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import threading
 
+import pytest
 from rich.console import Console
 
 from app.cli.interactive_shell.runtime import terminal_runtime as loop
@@ -62,6 +63,42 @@ def test_repl_print_does_not_double_prepare_with_streaming_console(monkeypatch) 
     repl_print(console, "line")
 
     assert len(resets) == 1
+
+
+def test_repl_print_streaming_console_prepares_tty_once_when_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeStdout:
+        def __init__(self) -> None:
+            self.writes: list[str] = []
+
+        def write(self, text: str) -> int:
+            self.writes.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+        def isatty(self) -> bool:
+            return True
+
+    fake_stdout = _FakeStdout()
+    monkeypatch.setattr("sys.stdout", fake_stdout)
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.choice_menu.repl_tty_interactive",
+        lambda: True,
+    )
+
+    console = loop._StreamingConsole(
+        loop._SpinnerState(),
+        threading.Event(),
+        file=io.StringIO(),
+        force_terminal=False,
+        width=80,
+    )
+    repl_print(console, "line")
+
+    assert fake_stdout.writes == ["\r\n", "\r"]
 
 
 def test_render_integrations_table_resets_tty_before_print(monkeypatch) -> None:

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -12,6 +12,7 @@ from app.cli.interactive_shell.runtime import terminal_runtime as loop
 from app.cli.interactive_shell.ui.rendering import (
     print_planned_actions,
     render_integrations_table,
+    render_mcp_table,
     repl_print,
     repl_table,
 )
@@ -124,8 +125,34 @@ def test_render_integrations_table_resets_tty_before_print(monkeypatch) -> None:
         ],
     )
 
-    assert len(resets) >= 1
+    assert len(resets) == 1
     assert "grafana" in buf.getvalue()
+
+
+def test_render_mcp_table_prepares_tty_once(monkeypatch) -> None:
+    resets: list[bool] = []
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.choice_menu.prepare_repl_output_line",
+        lambda: resets.append(True),
+    )
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=80)
+    render_mcp_table(
+        console,
+        [
+            {
+                "service": "github",
+                "source": "local store",
+                "status": "configured",
+                "detail": "Connected",
+            }
+        ],
+    )
+
+    assert len(resets) == 1
+    assert "github" in buf.getvalue()
 
 
 def test_print_planned_actions_formats_kinds() -> None:

--- a/tests/cli/interactive_shell/ui/test_rendering.py
+++ b/tests/cli/interactive_shell/ui/test_rendering.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import io
+import threading
 
 from rich.console import Console
 
+from app.cli.interactive_shell.runtime import terminal_runtime as loop
 from app.cli.interactive_shell.ui.rendering import (
     print_planned_actions,
     render_integrations_table,
@@ -40,6 +42,26 @@ def test_repl_print_resets_before_each_line(monkeypatch) -> None:
     repl_print(console, "line two")
 
     assert len(resets) == 2
+
+
+def test_repl_print_does_not_double_prepare_with_streaming_console(monkeypatch) -> None:
+    resets: list[bool] = []
+
+    monkeypatch.setattr(
+        "app.cli.interactive_shell.ui.choice_menu.prepare_repl_output_line",
+        lambda: resets.append(True),
+    )
+
+    console = loop._StreamingConsole(
+        loop._SpinnerState(),
+        threading.Event(),
+        file=io.StringIO(),
+        force_terminal=False,
+        width=80,
+    )
+    repl_print(console, "line")
+
+    assert len(resets) == 1
 
 
 def test_render_integrations_table_resets_tty_before_print(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #2230 

#### Describe the changes you have made in this PR -

Interactive /update printed directly to sys.stdout while the REPL uses patch_stdout, so messages like “opensre <version> is already up to date” could be redrawn away when the prompt refreshed.

This PR fixes that:

- run_cli_command (timed path): when subprocess_timeout is set (used by /update), run the subprocess with capture_output=True and replay stdout/stderr through print_command_output → Rich console, so output stays visible with patch_stdout.
- Dispatch wait semantics: add /update to _WAIT_FOR_COMPLETION_COMMANDS so the main loop awaits queue.join() for it (same as /exit and /quit), preventing the next prompt from appearing while the version/GitHub check runs.

Tests:
- TestRunCliCommand: timed delegation captures output into the Rich buffer; non-timed delegates still call subprocess.run without capture.
- test_dispatch_needs_exclusive_stdin_for_update: /update (and alias) require waiting for dispatch to finish before the next prompt.

### Demo/Screenshot for feature changes and bug fixes -

From an interactive **`opensre`** session:

BEFORE:

https://github.com/user-attachments/assets/a3df0820-b156-4ec1-b064-1cfaf5c6208f


AFTER:

https://github.com/user-attachments/assets/6591166f-a1a9-4f64-b7ce-16edc0e69dc8

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

There were two different failures: lost output lines, and a prompt/spinner showing before a subprocess finished. Fixing only capture removed flicker but could still show the spinner while the subprocess was blocked on the network; fixing only queue.join() didn't reliably preserve lines when subprocess output bypassed Rich.

So we split behavior: keep TTY/inherited I/O for interactive delegates (subprocess_timeout=None), and use capture + console replay only for /update’s bounded-timeout (non-interactive, network-bound) path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

---


