### PR TITLE
fix(config): normalize OLLAMA_HOST protocol to prevent UnsupportedProtocol errors

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -198,6 +198,14 @@ class LLMSettings(StrictConfigModel):
     bedrock_toolcall_model: str = BEDROCK_TOOLCALL_MODEL
     max_tokens: int = Field(default=DEFAULT_MAX_TOKENS, gt=0)
 
+    @field_validator("ollama_host", mode="before")
+    @classmethod
+    def _normalize_ollama_host(cls, value: object) -> str:
+        host = str(value or DEFAULT_OLLAMA_HOST).strip() or DEFAULT_OLLAMA_HOST
+        if not host.startswith(("http://", "https://")):
+            host = f"http://{host}"
+        return host
+
     @field_validator("provider", mode="before")
     @classmethod
     def _normalize_provider(cls, value: object) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,21 @@ def test_llm_settings_from_env_minimax(monkeypatch) -> None:
     assert settings.minimax_api_key == "mm-stored-key"
 
 
+@pytest.mark.parametrize(
+    "raw_host, expected",
+    [
+        ("localhost:11434", "http://localhost:11434"),
+        ("192.168.1.5:11434", "http://192.168.1.5:11434"),
+        ("my-server:11434", "http://my-server:11434"),
+        ("http://localhost:11434", "http://localhost:11434"),
+        ("https://ollama.internal", "https://ollama.internal"),
+    ],
+)
+def test_llm_settings_ollama_host_protocol_normalized(raw_host: str, expected: str) -> None:
+    settings = LLMSettings.model_validate({"provider": "ollama", "ollama_host": raw_host})
+    assert settings.ollama_host == expected
+
+
 def test_llm_settings_from_env_max_tokens_override(monkeypatch) -> None:
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setenv("LLM_MAX_TOKENS", "8192")


### PR DESCRIPTION
## Summary

- When `OLLAMA_HOST` is set without a protocol prefix (e.g. `localhost:11434` or `192.168.1.5:11434`), the OpenAI-compatible client receives a bare URL and raises `httpcore.UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol` at runtime.
- Adds a `field_validator` on `ollama_host` in `LLMSettings` that prepends `http://` when no protocol is present.
- Hosts that already start with `http://` or `https://` are left unchanged.

## Test plan

- [ ] New parametrized test `test_llm_settings_ollama_host_protocol_normalized` covers bare hostnames, IP:port combos, and already-prefixed URLs.
- [ ] All existing `tests/test_config.py` tests pass (`24 passed`).
- [ ] `ruff check` and `pyright` pass on changed files.

Closes #2238

https://claude.ai/code/session_01PautNZjW7ukF7WAj8AVCMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PautNZjW7ukF7WAj8AVCMt)_