### PR TITLE
fix(mcp): suppress ANSI output on stdio MCP server subprocesses

### DIFF
--- a/app/integrations/github_mcp.py
+++ b/app/integrations/github_mcp.py
@@ -435,6 +435,12 @@ async def _open_github_mcp_session(config: GitHubMCPConfig) -> AsyncIterator[Cli
                 args=list(config.args),
                 env={
                     **os.environ,
+                    # Suppress terminal control codes (cursor, color) so the MCP
+                    # server's stdout stays clean JSON-RPC. Some server binaries
+                    # output ANSI escape sequences when TERM is set, breaking
+                    # the stdio reader with a JSONRPCMessage parse error.
+                    "NO_COLOR": "1",
+                    "TERM": "dumb",
                     **(
                         {"GITHUB_PERSONAL_ACCESS_TOKEN": config.auth_token}
                         if config.auth_token

--- a/app/integrations/openclaw.py
+++ b/app/integrations/openclaw.py
@@ -418,6 +418,10 @@ async def _open_openclaw_session(config: OpenClawConfig) -> AsyncIterator[Client
                 args=list(config.args),
                 env={
                     **os.environ,
+                    # Suppress terminal control codes so the MCP server's stdout
+                    # stays clean JSON-RPC (mirrors github_mcp.py mitigation).
+                    "NO_COLOR": "1",
+                    "TERM": "dumb",
                     **({"OPENCLAW_AUTH_TOKEN": config.auth_token} if config.auth_token else {}),
                 },
             )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Some MCP server binaries (e.g. `github-mcp-server`) write ANSI escape sequences (`\x1b[?25l`, box-drawing characters) to stdout when the parent environment advertises a colour-capable terminal.
- The MCP stdio client reads stdout expecting JSON-RPC and raises `ValidationError: 1 validation error for JSONRPCMessage` / `Failed to parse JSONRPC message from server`.
- Fix: add `NO_COLOR=1` and `TERM=dumb` to the subprocess environment in both `github_mcp.py` and `openclaw.py`, causing well-behaved CLI programs to suppress terminal control codes on their stdout.

## Test plan

- [ ] All existing MCP-related tests pass (161 passed).
- [ ] `ruff check` passes on changed files.

Closes #2237

https://claude.ai/code/session_01G9KLL3jzYoEG1GjKci5KCL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9KLL3jzYoEG1GjKci5KCL)_