### PR TITLE
fix(cli): resolve mypy errors breaking main CI

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -30,6 +30,14 @@ _TEST_SUBCOMMANDS = ("list", "run", "synthetic", "cloudopsbench")
 _TEST_PICKER_SELECTION_FILE_ENV = "OPENSRE_TEST_PICKER_SELECTION_FILE"
 
 
+def _decode_subprocess_stream(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def run_cli_command(
     console: Console,
     args: list[str],
@@ -53,7 +61,7 @@ def run_cli_command(
     cmd = [sys.executable, "-m", "app.cli", *args]
     try:
         if subprocess_timeout is not None:
-            result = subprocess.run(
+            timed_result = subprocess.run(
                 cmd,
                 check=False,
                 timeout=subprocess_timeout,
@@ -62,21 +70,21 @@ def run_cli_command(
                 encoding="utf-8",
                 errors="replace",
             )
-            print_command_output(console, result.stdout or "")
-            print_command_output(console, result.stderr or "", style=ERROR)
+            print_command_output(console, timed_result.stdout or "")
+            print_command_output(console, timed_result.stderr or "", style=ERROR)
+            if timed_result.returncode != 0:
+                console.print(
+                    f"[{ERROR}]CLI command exited with non-zero code {timed_result.returncode}[/]"
+                )
         else:
-            result = subprocess.run(cmd, check=False)
-        if result.returncode != 0:
-            console.print(f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]")
+            interactive_result = subprocess.run(cmd, check=False)
+            if interactive_result.returncode != 0:
+                console.print(
+                    f"[{ERROR}]CLI command exited with non-zero code {interactive_result.returncode}[/]"
+                )
     except subprocess.TimeoutExpired as exc:
-        _stdout = exc.stdout
-        if isinstance(_stdout, bytes):
-            _stdout = _stdout.decode("utf-8", errors="replace")
-        _stderr = exc.stderr
-        if isinstance(_stderr, bytes):
-            _stderr = _stderr.decode("utf-8", errors="replace")
-        print_command_output(console, _stdout or "")
-        print_command_output(console, _stderr or "", style=ERROR)
+        print_command_output(console, _decode_subprocess_stream(exc.stdout))
+        print_command_output(console, _decode_subprocess_stream(exc.stderr), style=ERROR)
         console.print(f"[{ERROR}]error:[/] CLI command timed out")
     except KeyboardInterrupt:
         console.print(f"[{DIM}]CLI command cancelled (Ctrl+C).[/]")


### PR DESCRIPTION
Fixes CI issue introduced due to  ##2262

#### Describe the changes you have made in this PR -

- Fix mypy failures on `main` in `cli_parity.run_cli_command` 
### Demo/Screenshot for feature changes and bug fixes -

N/A — typecheck-only fix; behavior unchanged.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`subprocess.run(..., text=True)` and the no-capture interactive path produce different `CompletedProcess` generic types. Mypy rejected reusing one `result` variable and narrowing `TimeoutExpired` streams via reassignment. The fix uses separate result variables per branch and a small decode helper for timeout partial output.

---

## Checklist before requesting a review
- [ ] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
