### PR TITLE
fix(agents): detect bare claude code CLI; exclude Claude Desktop

### DIFF
--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -48,11 +48,9 @@ _CLAUDE_CODE_CLI_ARG_TOKENS: frozenset[str] = frozenset(
 )
 _CLAUDE_DESKTOP_PATH_HINTS: tuple[str, ...] = (
     "claude.app/contents/",
-    "/macos/claude",
-    "claude helper",
-    "claude-desktop",
+    "/claude-desktop/",
     "/snap/claude/",
-    "/usr/lib/claude-desktop",
+    "/usr/lib/claude-desktop/",
     "/.mount_claude",
     "\\program files\\claude\\",
     "\\appdata\\local\\programs\\claude\\",
@@ -420,6 +418,10 @@ def _classify_agent(
             return None
         if _claude_code_cli_matches_cmdline(cmdline):
             return "claude-code"
+        # Intentional fall-through: an unrecognised `claude …` shape still
+        # reaches the noise / loose-classification path below so that `--all`
+        # surfaces it via the `claude` token signature. Do not add an early
+        # `return None` here — it would silently break `opensre agents scan --all`.
 
     if _is_noise_process(process_name, cmdline):
         return _classify_agent_loose(process_name, cmdline) if include_all else None
@@ -458,9 +460,13 @@ def _is_claude_desktop_artifact(cmdline: list[str]) -> bool:
     # Match desktop-bundle / installer hints against argv[0] only — never against
     # the full command. Prompt-bearing flags (e.g. `claude --print "inspect
     # /Applications/Claude.app/..."`) must not falsely trip the negative filter.
+    #
+    # The trailing-slash sentinel lets `/claude-desktop/` match both directories
+    # (`/usr/lib/claude-desktop/...`) and end-of-string binaries
+    # (`/.../bin/claude-desktop`) while rejecting `/.../my-claude-desktop-tools/`.
     if not cmdline:
         return False
-    lowered = cmdline[0].lower()
+    lowered = cmdline[0].lower() + "/"
     return any(hint in lowered for hint in _CLAUDE_DESKTOP_PATH_HINTS)
 
 

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -43,6 +43,20 @@ _LOOSE_AGENT_SIGNATURES: tuple[tuple[str, str], ...] = (
     ("codex", "codex"),
     ("gemini", "gemini-cli"),
 )
+_CLAUDE_CODE_CLI_ARG_TOKENS: frozenset[str] = frozenset(
+    {"--resume", "--prefill", "--print", "--continue", "-p", "-c", "-r"}
+)
+_CLAUDE_DESKTOP_PATH_HINTS: tuple[str, ...] = (
+    "claude.app/contents/",
+    "/macos/claude",
+    "claude helper",
+    "claude-desktop",
+    "/snap/claude/",
+    "/usr/lib/claude-desktop",
+    "/.mount_claude",
+    "\\program files\\claude\\",
+    "\\appdata\\local\\programs\\claude\\",
+)
 
 
 @dataclass(frozen=True)
@@ -350,6 +364,7 @@ def _record_from_cursor_terminal(path: Path) -> AgentRecord | None:
 
 def _agent_name_for_command(command: str) -> str | None:
     lower = command.lower()
+    cmdline = _split_command(command)
 
     if ".cursor/extensions/anthropic.claude-code" in lower:
         return "cursor-claude-code"
@@ -357,7 +372,7 @@ def _agent_name_for_command(command: str) -> str | None:
         return "cursor-agent-exec"
     if "cursor-agent" in lower or "cursor agent" in lower:
         return "cursor-agent"
-    if _has_command_token(lower, "claude") and _has_command_token(lower, "code"):
+    if not _is_claude_desktop_artifact(cmdline) and _claude_code_cli_matches_cmdline(cmdline):
         return "claude-code"
     if _is_codex_command(command):
         return "codex"
@@ -368,22 +383,47 @@ def _agent_name_for_command(command: str) -> str | None:
     return None
 
 
-def _classify_agent(process_name: str, cmdline: list[str], *, include_all: bool) -> str | None:
+def _claude_code_cli_matches_cmdline(cmdline: list[str]) -> bool:
+    if not cmdline:
+        return False
+    if _normalized_token(cmdline[0]) != "claude":
+        return False
+    lowered = [part.lower() for part in cmdline]
+    args = [_normalized_token(part) for part in cmdline[1:]]
+    if "code" in args:
+        return True
+    if _has_option_pair(lowered, "--input-format", "stream-json"):
+        return True
+    if _has_option_pair(lowered, "--output-format", "stream-json"):
+        return True
+    if any(_option_name(token) in _CLAUDE_CODE_CLI_ARG_TOKENS for token in lowered[1:]):
+        return True
+    return len(cmdline) == 1
+
+
+def _option_name(arg: str) -> str:
+    return arg.split("=", 1)[0]
+
+
+def _classify_agent(
+    process_name: str,
+    cmdline: list[str],
+    *,
+    include_all: bool,
+) -> str | None:
     if not cmdline:
         return None
+    executable = _normalized_token(cmdline[0])
+
+    if executable == "claude":
+        if _is_claude_desktop_artifact(cmdline):
+            return None
+        if _claude_code_cli_matches_cmdline(cmdline):
+            return "claude-code"
+
     if _is_noise_process(process_name, cmdline):
         return _classify_agent_loose(process_name, cmdline) if include_all else None
 
-    executable = _normalized_token(cmdline[0])
-    args = [_normalized_token(part) for part in cmdline[1:]]
-    lowered = [part.lower() for part in cmdline]
-
-    if executable == "claude" and (
-        "code" in args
-        or _has_option_pair(lowered, "--input-format", "stream-json")
-        or _has_option_pair(lowered, "--output-format", "stream-json")
-    ):
-        return "claude-code"
     if executable == "aider":
         return "aider"
     if executable == "codex":
@@ -398,6 +438,8 @@ def _classify_agent(process_name: str, cmdline: list[str], *, include_all: bool)
 
 
 def _classify_agent_loose(process_name: str, cmdline: list[str]) -> str | None:
+    if _is_claude_desktop_artifact(cmdline):
+        return None
     haystack = f"{process_name} {' '.join(cmdline)}".lower()
     tokens = {_normalized_token(part) for part in cmdline}
     tokens.add(_normalized_token(process_name))
@@ -412,11 +454,22 @@ def _classify_agent_loose(process_name: str, cmdline: list[str]) -> str | None:
     return None
 
 
+def _is_claude_desktop_artifact(cmdline: list[str]) -> bool:
+    # Match desktop-bundle / installer hints against argv[0] only — never against
+    # the full command. Prompt-bearing flags (e.g. `claude --print "inspect
+    # /Applications/Claude.app/..."`) must not falsely trip the negative filter.
+    if not cmdline:
+        return False
+    lowered = cmdline[0].lower()
+    return any(hint in lowered for hint in _CLAUDE_DESKTOP_PATH_HINTS)
+
+
 def _is_noise_process(process_name: str, cmdline: list[str]) -> bool:
-    haystack_parts = [
-        _normalized_token(process_name),
-        *(_normalized_token(part) for part in cmdline),
-    ]
+    # Restrict the haystack to process_name + argv[0] so prompt-bearing flags
+    # like `claude --print "...helper..."` do not falsely trip the noise filter.
+    haystack_parts = [_normalized_token(process_name)]
+    if cmdline:
+        haystack_parts.append(_normalized_token(cmdline[0]))
     haystack = " ".join(part for part in haystack_parts if part)
     if any(token in haystack for token in _NOISE_PROCESS_TOKENS):
         return True

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -14,7 +14,62 @@ fleet view lives behind one slash command in the interactive shell:
 > /agents
 ```
 
-Subcommands drill into specific surfaces. Below: live tail of agent stdout (`/agents trace`), then the cross-agent context bus (`/agents bus`).
+Subcommands drill into specific surfaces. Below: how the agent fleet is
+discovered (`opensre agents scan`), live tail of agent stdout
+(`/agents trace`), then the cross-agent context bus (`/agents bus`).
+
+## `opensre agents scan` — discover running agent sessions
+
+`opensre agents scan` enumerates running AI-coding-agent sessions visible to
+the current user. The classifier inspects the process table (via `ps -axo
+pid,ppid,args`) and labels each candidate by executable plus known argv
+shapes — no PID is registered until you ask for it with `--register`.
+
+### Strict mode (default)
+
+Recognizes the typical CLI invocations for Claude Code, Cursor, Aider, Codex,
+and Gemini. For Claude Code specifically, all of the following process
+shapes are treated as a session:
+
+```text
+claude
+claude --resume <session-id>      claude -r <session-id>
+claude --prefill "<prompt>"
+claude --print "<prompt>"          claude -p "<prompt>"
+claude --continue                  claude -c
+claude code …
+claude --input-format stream-json …
+claude --output-format stream-json …
+```
+
+Equals-form flags (e.g. `claude --resume=<session-id>`,
+`claude --print=<prompt>`) are accepted for any flag in the list above.
+
+The Claude Desktop GUI and its Electron helpers are filtered out
+cross-platform — `Claude.app/Contents/`, `Claude Helper (Renderer)`,
+`/snap/claude/`, `/usr/lib/claude-desktop`, AppImage mount points
+(`/.mount_Claude…`), and the Windows `Program Files\Claude\` /
+`AppData\Local\Programs\Claude\` install locations are recognized as
+desktop artifacts and never labeled as `claude-code`. The negative filter
+matches against `argv[0]` only, so a CLI installed under a Claude-flavored
+prefix (for example `/opt/Claude/claude`) is still surfaced.
+
+### Loose mode (`--all`)
+
+`opensre agents scan --all` relaxes the argv requirements so that helper and
+broker processes whose argv contains agent-shaped tokens are also surfaced.
+The Claude Desktop / Electron negative filter is still applied — `--all`
+never mislabels desktop processes as `claude-code`.
+
+### Registering discovered sessions
+
+```text
+opensre agents scan --register
+```
+
+writes every discovered session into the local agent registry so that the
+rest of the fleet surface (`/agents`, `/agents trace`, `/agents bus`) can
+target it by PID. Without `--register`, the command is read-only.
 
 ## `/agents trace` — live stdout tail
 

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -369,6 +369,10 @@ def test_is_claude_desktop_artifact_recognises_known_packaging_paths(
             "--print",
             "inspect /Applications/Claude.app/Contents/MacOS/Claude logs",
         ],
+        ["/Users/me/macos/claude"],
+        ["/opt/tools/macos/claude"],
+        ["/home/user/my-claude-desktop-wrapper/bin/claude"],
+        ["/usr/lib/claude-desktop-tools/cli/claude"],
     ],
 )
 def test_is_claude_desktop_artifact_passes_through_cli_invocations(

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -95,7 +95,38 @@ def test_discover_agent_processes_filters_desktop_helper_noise(
     assert discovery.discover_agent_processes() == []
 
 
-def test_discover_agent_processes_all_mode_includes_filtered_helpers(
+def test_discover_agent_processes_all_mode_does_not_mislabel_desktop_as_claude_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=201, command="/Applications/Claude.app/Contents/MacOS/Claude"),
+            ProcessRow(
+                pid=202,
+                command=(
+                    "/Applications/Claude.app/Contents/Frameworks/Electron "
+                    "Framework.framework/Helpers/chrome_crashpad_handler"
+                ),
+            ),
+            ProcessRow(
+                pid=203,
+                command=(
+                    "/Applications/Claude.app/Contents/Frameworks/Claude Helper "
+                    "(Renderer).app/Contents/MacOS/Claude Helper (Renderer) --type=renderer"
+                ),
+            ),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes(include_all=True)
+
+    assert candidates == []
+
+
+def test_discover_agent_processes_all_mode_still_keeps_non_desktop_loose_matches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
@@ -104,10 +135,11 @@ def test_discover_agent_processes_all_mode_includes_filtered_helpers(
         "_current_process_rows",
         lambda: [
             ProcessRow(
-                pid=202,
+                pid=311,
                 command=(
-                    "/Applications/Claude.app/Contents/Frameworks/Electron "
-                    "Framework.framework/Helpers/chrome_crashpad_handler"
+                    "/Applications/Cursor.app/Contents/Frameworks/"
+                    "Cursor Helper (Plugin).app/Contents/MacOS/Cursor Helper (Plugin) "
+                    "--cursor-agent-launch"
                 ),
             ),
         ],
@@ -115,7 +147,262 @@ def test_discover_agent_processes_all_mode_includes_filtered_helpers(
 
     candidates = discovery.discover_agent_processes(include_all=True)
 
-    assert [(item.name, item.pid) for item in candidates] == [("claude-code-202", 202)]
+    assert [(item.name, item.pid) for item in candidates] == [("cursor-311", 311)]
+
+
+def test_discover_agent_processes_matches_bare_claude_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=10, command="opensre"),
+            ProcessRow(pid=501, command="claude"),
+            ProcessRow(pid=502, command="/Users/me/.npm-global/bin/claude"),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [
+        ("claude-code-501", 501),
+        ("claude-code-502", 502),
+    ]
+
+
+def test_discover_agent_processes_matches_claude_cli_flag_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=10, command="opensre"),
+            ProcessRow(pid=601, command="claude --resume abc-123"),
+            ProcessRow(pid=602, command="claude --prefill 'demo prompt'"),
+            ProcessRow(pid=603, command="claude --print 'one shot'"),
+            ProcessRow(pid=604, command="claude --continue"),
+            ProcessRow(pid=605, command="claude -p 'short flag print'"),
+            ProcessRow(pid=606, command="claude -c"),
+            ProcessRow(pid=607, command="claude -r abc-123"),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [
+        ("claude-code-601", 601),
+        ("claude-code-602", 602),
+        ("claude-code-603", 603),
+        ("claude-code-604", 604),
+        ("claude-code-605", 605),
+        ("claude-code-606", 606),
+        ("claude-code-607", 607),
+    ]
+
+
+def test_discover_agent_processes_matches_claude_cli_equals_form_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=10, command="opensre"),
+            ProcessRow(pid=651, command="claude --resume=abc-123"),
+            ProcessRow(pid=652, command="claude --prefill=demo"),
+            ProcessRow(pid=653, command="claude --print=one-shot"),
+            ProcessRow(pid=654, command="claude -r=abc-123"),
+            ProcessRow(pid=655, command="claude -p=short"),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [
+        ("claude-code-651", 651),
+        ("claude-code-652", 652),
+        ("claude-code-653", 653),
+        ("claude-code-654", 654),
+        ("claude-code-655", 655),
+    ]
+
+
+def test_discover_agent_processes_rejects_claude_desktop_main_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=701, command="/Applications/Claude.app/Contents/MacOS/Claude"),
+        ],
+    )
+
+    assert discovery.discover_agent_processes() == []
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "/snap/claude/current/usr/bin/claude",
+        "/usr/lib/claude-desktop/claude-desktop",
+        "/tmp/.mount_Claude_xyz123/usr/bin/claude",
+        "'C:\\Program Files\\Claude\\Claude.exe'",
+        "'C:\\Users\\me\\AppData\\Local\\Programs\\Claude\\Claude.exe'",
+    ],
+)
+def test_discover_agent_processes_rejects_claude_desktop_cross_platform_paths(
+    monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [ProcessRow(pid=801, command=command)],
+    )
+
+    assert discovery.discover_agent_processes() == []
+    assert discovery.discover_agent_processes(include_all=True) == []
+
+
+def test_discover_agent_processes_does_not_drop_claude_print_with_helper_in_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(
+                pid=910,
+                command="claude --print 'look at the helper output from pty-host yesterday'",
+            ),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [("claude-code-910", 910)]
+
+
+def test_discover_agent_processes_does_not_drop_claude_print_with_desktop_path_in_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(
+                pid=915,
+                command=(
+                    "claude --print 'inspect /Applications/Claude.app/Contents/MacOS/Claude logs'"
+                ),
+            ),
+        ],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [("claude-code-915", 915)]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "/opt/Claude/claude",
+        "/opt/Claude/claude --resume id",
+        "/opt/claude-cli/bin/claude --resume sess",
+    ],
+)
+def test_discover_agent_processes_allows_cli_installed_under_opt_claude_prefix(
+    monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [ProcessRow(pid=920, command=command)],
+    )
+
+    candidates = discovery.discover_agent_processes()
+
+    assert [(item.name, item.pid) for item in candidates] == [("claude-code-920", 920)]
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        ["C:\\Program Files\\Claude\\Claude.exe"],
+        ["C:\\Users\\me\\AppData\\Local\\Programs\\Claude\\Claude.exe"],
+        ["/Applications/Claude.app/Contents/MacOS/Claude"],
+        ["/snap/claude/current/usr/bin/claude"],
+        ["/usr/lib/claude-desktop/claude-desktop"],
+        ["/tmp/.mount_Claude_xyz123/usr/bin/claude"],
+    ],
+)
+def test_is_claude_desktop_artifact_recognises_known_packaging_paths(
+    cmdline: list[str],
+) -> None:
+    assert discovery._is_claude_desktop_artifact(cmdline) is True
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        ["claude"],
+        ["claude", "--resume", "abc"],
+        ["/Users/me/.npm-global/bin/claude"],
+        ["/Users/me/.local/bin/claude", "--prefill", "demo"],
+        ["/usr/local/bin/claude"],
+        ["/opt/claude-rs/claude", "--resume", "id"],
+        ["/opt/snap/claude-cli/bin/claude"],
+        ["/opt/Claude/claude"],
+        [
+            "claude",
+            "--print",
+            "inspect /Applications/Claude.app/Contents/MacOS/Claude logs",
+        ],
+    ],
+)
+def test_is_claude_desktop_artifact_passes_through_cli_invocations(
+    cmdline: list[str],
+) -> None:
+    assert discovery._is_claude_desktop_artifact(cmdline) is False
+
+
+def test_discover_agents_legacy_path_matches_bare_claude_via_cursor_terminal(
+    tmp_path: Path,
+) -> None:
+    terminal = tmp_path / "project" / "terminals" / "72.txt"
+    terminal.parent.mkdir(parents=True)
+    terminal.write_text(
+        "---\npid: 67890\ncwd: /repo\nactive_command: claude --resume sess-1\n---\n",
+        encoding="utf-8",
+    )
+
+    records = discover_agents(process_rows=[], cursor_projects_dir=tmp_path)
+
+    assert [(record.name, record.pid, record.source) for record in records] == [
+        ("claude-code", 67890, "discovered")
+    ]
+
+
+def test_discover_agents_legacy_path_rejects_claude_desktop_main(tmp_path: Path) -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=901, command="/Applications/Claude.app/Contents/MacOS/Claude"),
+        ],
+        cursor_projects_dir=tmp_path,
+    )
+
+    assert records == []
 
 
 def test_display_command_truncates_long_commands() -> None:


### PR DESCRIPTION
Fixes #2155

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`opensre agents scan` (strict mode) was missing Claude Code CLI sessions whose process command is plain `claude`, `claude --resume <id>`, or `claude --prefill …`, and `opensre agents scan --all` (loose mode) was mislabeling Claude Desktop and Electron helper processes as `claude-code-*`.

This PR teaches the classifier to recognise the full set of Claude Code CLI shapes — bare `claude`, `--resume` / `-r`, `--prefill`, `--print` / `-p`, `--continue` / `-c`, equals-form variants (`--resume=<id>`, …), plus the existing `claude code` and `stream-json` paths — and adds a cross-platform Claude Desktop negative filter that runs against `argv[0]` only (macOS `.app` bundles + helper binaries, Linux Snap / `/usr/lib/claude-desktop` / AppImage, Windows `Program Files\Claude\` and `AppData\Local\Programs\Claude\`). The filter applies in both strict and `--all` modes, so the desktop main process is never mislabeled, even in loose discovery.

The legacy `discover_agents` path (used by Cursor terminal metadata + `registered_and_discovered_agents`) and the modern `discover_agent_processes` now share a single `_claude_code_cli_matches_cmdline` helper, so both surfaces agree on classification. The noise filter haystack is restricted to `process_name + argv[0]` so prompt-bearing flags such as `claude --print "...helper..."` are no longer dropped because the prompt content contains a noise token.

Docs: new "Discovering local agent sessions" section in `docs/agents.mdx` describing the strict mode, `--all` loose mode, `--register`, and the cross-platform desktop filter.

### Demo/Screenshot for feature changes and bug fixes -

![opensre agents scan — issue #2155 demo](https://vhs.charm.sh/vhs-hUnmskJNdqELdwOAHh2k0.gif)

The demo spawns three fake Claude Code CLI processes via `exec -a` (`claude`, `claude --resume demo-1`, `claude --prefill fix-auth-bug`) and one fake Claude Desktop main process (`/Applications/Claude.app/Contents/MacOS/Claude`). The strict `opensre agents scan` surfaces the three CLI rows; the desktop PID is filtered out. `opensre agents scan --all` still does not mislabel the desktop. The trailing assertion confirms the desktop PID is absent from both outputs. (Extra `claude-code-*` rows in the table belong to other Claude Code sessions running on the recording machine and are themselves a demonstration of the fix surfacing real bare-`claude` invocations.)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- The bug has two parts: (a) the strict classifier in `_classify_agent` required `code` in argv or `stream-json` formatting flags, missing bare `claude` and its `--resume` / `--prefill` / `--print` / `--continue` variants; (b) the loose classifier matched any `claude` token anywhere in the haystack, mislabeling Claude Desktop + Electron helper processes as `claude-code` in `--all` mode.
- Considered three approaches for the desktop filter: (i) macOS-only `/Applications/Claude.app` exclusion; (ii) negative argv-shape heuristics only (e.g. helper noise tokens); (iii) cross-platform path hints matched against `argv[0]`. Went with (iii) because the issue explicitly asks for a cross-platform signal and lists platform-specific paths as secondary negative filters rather than primary positives.
- Key helpers introduced:
  - `_claude_code_cli_matches_cmdline(cmdline)` — single source of truth for "is this a Claude Code CLI invocation". Used by both the modern (`_classify_agent`) and legacy (`_agent_name_for_command`) paths so they cannot diverge again.
  - `_is_claude_desktop_artifact(cmdline)` — matches desktop bundle / installer hints against `argv[0]` only. Matching against `argv[0]` (and not the full command) prevents prompt content like `claude --print "inspect /Applications/Claude.app/..."` from being misclassified as a desktop process.
  - `_option_name(arg)` — normalises `--flag=value` to `--flag` so equals-form options participate in the allowlist check.
- The noise filter (`_is_noise_process`) used to scan the full argv for tokens like `helper` / `shipit` / `pty-host`, which would falsely drop `claude --print "...helper..."`. Restricted the haystack to `process_name + argv[0]` to keep desktop / Electron helpers filtered while letting CLI prompt content through.
- Tests cover every new shape (bare / long flags / short flags / equals form), cross-platform desktop rejection (macOS .app bundle + Linux Snap / `/usr/lib/claude-desktop` / AppImage + Windows quoted paths), opt-prefix CLI pass-through (`/opt/Claude/claude` and `/opt/claude-cli/bin/claude` are accepted), the prompt-content false-negative regression, and legacy-path parity via Cursor terminal metadata.
- Pre-merge gates: `make lint`, `make format-check`, `make typecheck` clean; `tests/agents/` + `tests/cli/` (1905 tests) green.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.