### PR TITLE
fix(llm): detect OpenRouter invalid-model-name 400 as model-not-found

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -621,19 +621,22 @@ def _format_anthropic_retry_error(err: Exception) -> str:
     return f"Anthropic API request failed after multiple retries: {error_name}."
 
 
-# LiteLLM/Anthropic surfaces an unrecognized model ID as an HTTP 400 with a
-# message containing "The provided model identifier is invalid." (note: the
-# OpenAI-compatible 404 code-path is preferred, but LiteLLM relays 400 here).
-# Detection is intentionally a substring match because there is no stable error
-# code for this case across LiteLLM/Anthropic. Update this constant if upstream
-# rewords the message — the failure mode is "fall through to a generic HTTP 400
-# message that is not Sentry-filtered" (see issue #1806).
-_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE = "model identifier"
+# Substrings that signal an unknown/invalid model name in a 400 response.
+# OpenAI:    "The provided model identifier is invalid."
+# OpenRouter: "Invalid model name passed in model=<name>. Call `/v1/models`…"
+# Detection is an any-match because there is no stable error code across
+# providers. Add phrases here when a new provider uses different wording —
+# the failure mode is "fall through to a generic HTTP 400 message" (#1806).
+_OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES = (
+    "model identifier",  # OpenAI / LiteLLM
+    "invalid model name",  # OpenRouter
+)
 
 
 def _is_openai_invalid_model_identifier(err: OpenAIBadRequestError) -> bool:
     """True if the OpenAIBadRequestError message indicates an unknown model id."""
-    return _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASE in (err.message or "").lower()
+    msg = (err.message or "").lower()
+    return any(phrase in msg for phrase in _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES)
 
 
 def _format_openai_connection_error(err: Exception, provider_label: str) -> str:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `_is_openai_invalid_model_identifier` only matched OpenAI's phrase `"model identifier"` in 400 responses
- OpenRouter returns `"Invalid model name passed in model=<name>. Call /v1/models to view available models for your key."` — this phrase did not match, so the error fell through to the generic `"request rejected (HTTP 400)"` message
- Users passing an Anthropic model name (e.g. `claude-sonnet-4-6`) to an OpenRouter endpoint got a confusing raw JSON blob instead of a clear "model not found" message

Fix extends the detection to a tuple of phrases, adding `"invalid model name"` for OpenRouter alongside the existing `"model identifier"` for OpenAI/LiteLLM.

## Test plan

- [x] `uv run ruff check app/services/llm_client.py` — passes
- [x] `uv run pytest tests/ -k "llm_client or llm"` — 533 passed, 3 skipped
- [x] `git diff` reviewed — one-file change to constants + detection function only

Closes #2250

https://claude.ai/code/session_0137UP6FysV8YKvptZSViRB6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0137UP6FysV8YKvptZSViRB6)_