### PR TITLE
fix(bench): reject pre-registration with unfilled placeholders

### DIFF
--- a/tests/benchmarks/_framework/integrity.py
+++ b/tests/benchmarks/_framework/integrity.py
@@ -52,6 +52,27 @@ class IntegrityViolation(RuntimeError):
 
 
 # --------------------------------------------------------------------------- #
+# Pre-registration placeholder sentinels                                      #
+# --------------------------------------------------------------------------- #
+
+
+# Sentinels that ship in the template pre-registration (see
+# ``tests/benchmarks/configs/preregistrations/example.yml``) and any cycle YAML
+# stamped from it. The framework refuses to start a run while any of these are
+# still present in the on-disk pre-registration, because the integrity story
+# depends on the file being a real commitment rather than a template.
+#
+# Flagged on #2234 — the existing M1 only checked existence and non-emptiness,
+# so a YAML with ``opensre_sha: REPLACE_AT_COMMIT_TIME`` or
+# ``date: 2026-05-XX`` would pass pre_flight and produce a run whose
+# provenance fields point at literally nothing.
+_PREREG_PLACEHOLDER_SENTINELS: tuple[str, ...] = (
+    "REPLACE_AT_COMMIT_TIME",
+    "-XX",  # catches both `2026-05-XX` and `XXXX-XX-XX` date stubs
+)
+
+
+# --------------------------------------------------------------------------- #
 # Report shape — what report_validation expects                                #
 # --------------------------------------------------------------------------- #
 
@@ -129,6 +150,20 @@ class IntegrityGuard:
                 f"M1: pre_registration_path={config.pre_registration_path} is empty. "
                 f"A real pre-registration with expected deltas is required."
             )
+        else:
+            # M1 (content) — the file exists and is non-empty, but unfilled
+            # template sentinels (REPLACE_AT_COMMIT_TIME, `2026-05-XX` dates)
+            # still pass the existence + size checks and produce runs with
+            # meaningless provenance. Reject them here.
+            content = config.pre_registration_path.read_text(encoding="utf-8")
+            found = [s for s in _PREREG_PLACEHOLDER_SENTINELS if s in content]
+            if found:
+                violations.append(
+                    f"M1: pre_registration_path={config.pre_registration_path} "
+                    f"still contains unfilled template sentinels: {found}. "
+                    f"Stamp the real commit SHA, dataset revision, and run "
+                    f"date before commit."
+                )
 
         # M3 — adapter declares enough metrics (multi-metric, no Streetlight)
         schema = adapter.metric_schema()


### PR DESCRIPTION
Closes the M1 content-check gap @greptile-apps flagged on #2234.

`IntegrityGuard.pre_flight` only verified the pre-registration file existed and was non-empty. A YAML with `opensre_sha: REPLACE_AT_COMMIT_TIME` or `date: 2026-05-XX` (the template sentinels in `cloudopsbench_v1.yml`) passed silently and produced runs with meaningless provenance.

Added `_PREREG_PLACEHOLDER_SENTINELS` scan after the size check. The sentinels cover both `REPLACE_AT_COMMIT_TIME` and the `-XX` date stub pattern.

### Describe the changes you have made in this PR
`tests/benchmarks/_framework/integrity.py`: add `_PREREG_PLACEHOLDER_SENTINELS` tuple, add `else` branch in `pre_flight` M1 check that reads file content and rejects any sentinel match.

### Demo/Screenshot for feature changes and bug fixes
n/a, defensive validation tightening. The existing `tests/benchmarks/_framework/test_integrity.py` is the validation surface. A follow-up should add a parametrised test that asserts each sentinel triggers `IntegrityViolation`, happy to add it in a second PR if reviewer prefers.

### Code Understanding and AI Usage
Scoped to the M1 content-check gap. New constant lives next to the `IntegrityViolation` class, new logic lives in the existing if/elif chain as an `else` branch. No new imports, no public API change.