### PR TITLE
fix(hermes-rca): isinstance-check list items in new validators

### DIFF
--- a/tests/synthetic/hermes_rca/hermes_schemas.py
+++ b/tests/synthetic/hermes_rca/hermes_schemas.py
@@ -459,6 +459,8 @@ def validate_hermes_orchestration_state(data: dict[str, Any]) -> dict[str, Any]:
 
     for index, role in enumerate(declared_roles):
         rctx = f"{ctx}:declared_roles[{index}]"
+        if not isinstance(role, dict):
+            raise ValueError(f"{rctx}: each declared_roles entry must be an object")
 
         _require_str(role, "name", rctx)
         _require_str(role, "model", rctx)
@@ -478,6 +480,8 @@ def validate_hermes_orchestration_state(data: dict[str, Any]) -> dict[str, Any]:
 
     for index, run in enumerate(actual_runs):
         actx = f"{ctx}:observed:actual_runs[{index}]"
+        if not isinstance(run, dict):
+            raise ValueError(f"{actx}: each actual_runs entry must be an object")
 
         _require_str(run, "role", actx)
         _require_str(run, "model", actx)
@@ -525,6 +529,8 @@ def validate_hermes_routing_decisions(data: dict[str, Any]) -> dict[str, Any]:
 
     for index, call in enumerate(calls):
         cctx = f"{ctx}:calls[{index}]"
+        if not isinstance(call, dict):
+            raise ValueError(f"{cctx}: each calls entry must be an object")
 
         for field in (
             "ts",
@@ -581,6 +587,8 @@ def validate_hermes_filesystem_state(data: dict[str, Any]) -> dict[str, Any]:
 
     for index, file_entry in enumerate(files):
         fctx = f"{ctx}:files[{index}]"
+        if not isinstance(file_entry, dict):
+            raise ValueError(f"{fctx}: each files entry must be an object")
 
         for field in ("path", "sha256", "last_modified"):
             _require_str(file_entry, field, fctx)


### PR DESCRIPTION
Closes the AttributeError-on-malformed-fixture flag @Devesh36 raised on #2183.

Four validators in `tests/synthetic/hermes_rca/hermes_schemas.py` iterate lists and call `_require_str(item, ...)` on each entry. `_require_str` does `item.get(key)`, so a non-dict list item (string, int, list, null) raises `AttributeError` instead of `ValueError`. The error message is opaque and the line number points at the validator helper, not the fixture file.

Added an `isinstance(entry, dict)` guard at the top of each iteration. Affected validators:

- `validate_hermes_orchestration_state` (`declared_roles`, `actual_runs`)
- - `validate_hermes_routing_decisions` (`calls`)
- - `validate_hermes_filesystem_state` (`files`)
Each guard raises `ValueError` with the same context-prefixed shape as the surrounding checks, so the error message points at the fixture position.

### Describe the changes you have made in this PR
`tests/synthetic/hermes_rca/hermes_schemas.py`: 4 isinstance checks added, one per iterating validator, immediately after the existing context-string setup and before `_require_str` is called.

### Demo/Screenshot for feature changes and bug fixes
n/a, defensive validator hardening. The existing fixture suite passes with the new guards because every fixture currently ships valid dict entries; the guards only fire on malformed input.

### Code Understanding and AI Usage
Scoped to the four list iterations in the validators added in #2183. Other validators in the file already had similar guards. No public API change.