### PR TITLE
fix(hermes-cli): allow sub-2 escalation-threshold when --no-correlate…

### DIFF
--- a/app/cli/commands/hermes.py
+++ b/app/cli/commands/hermes.py
@@ -106,13 +106,14 @@ def hermes_command() -> None:
 )
 @click.option(
     "--escalation-threshold",
-    type=click.IntRange(min=2),
+    type=int,
     default=3,
     show_default=True,
     help=(
         "Number of repeat hits within --escalation-window-seconds that "
-        "bumps an incident's severity one rung (HIGH→CRITICAL). Must be ≥2. "
-        "Ignored when --no-correlate is set."
+        "bumps an incident's severity one rung (HIGH→CRITICAL). Must be ≥2 "
+        "when --correlate is active. Ignored when --no-correlate is set, "
+        "so any int is accepted in that path."
     ),
 )
 @click.option(
@@ -152,6 +153,11 @@ def hermes_watch(
     correlator: IncidentCorrelator | None = None
     sink: Any
     if correlate:
+        if escalation_threshold < 2:
+            raise click.BadParameter(
+                "must be >= 2 when --correlate is active",
+                param_hint="'--escalation-threshold'",
+            )
         correlator = IncidentCorrelator(
             dedup_window_s=dedup_window_seconds,
             escalation_window_s=escalation_window_seconds,


### PR DESCRIPTION
Closes the IntRange-trips-on-unused-value flag greptile raised on #2225.

When `--no-correlate` is passed, `escalation_threshold` is never consumed (the correlator is not built). But the original `click.IntRange(min=2)` type on the option fires at parse time regardless, so `opensre hermes watch --no-correlate --escalation-threshold 1` errors even though the value is ignored.

Moved the `>= 2` validation off the option type and into the `if correlate:` branch in the command body. `--no-correlate` paths now accept any int; `--correlate` paths still raise the same Click-shaped error via `click.BadParameter`.

### Describe the changes you have made in this PR
`app/cli/commands/hermes.py`: change `--escalation-threshold` type from `click.IntRange(min=2)` to `int`, update help text to reflect the new "≥2 when --correlate is active" condition, add a runtime guard inside the existing `if correlate:` branch that raises `click.BadParameter` if the threshold is below 2.

### Demo/Screenshot for feature changes and bug fixes
n/a, single-file CLI validation fix. Behaviour change in two cases:

- `opensre hermes watch --no-correlate --escalation-threshold 1` used to error; now succeeds.
- - `opensre hermes watch --correlate --escalation-threshold 1` still errors, with `click.BadParameter` text instead of `click.IntRange` text.
### Code Understanding and AI Usage
Scoped to the single option block and the existing `if correlate:` branch. No changes to the correlator, the sink wiring, or any other option.