### PR TITLE
fix(ci): repair routing-live post-merge test collection

### DIFF
--- a/.github/workflows/routing-live-post-merge.yml
+++ b/.github/workflows/routing-live-post-merge.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
     paths:
       - "app/cli/interactive_shell/routing/**"
-      - "app/cli/interactive_shell/orchestration/**"
-      - "tests/cli/interactive_shell/orchestration/**"
+      - "tests/cli/interactive_shell/routing/**"
       - "pytest.ini"
       - "pyproject.toml"
       - "uv.lock"
@@ -59,5 +58,5 @@ jobs:
           uv run python -m pytest -n auto -v
           -m live_llm
           app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
-          -k "test_live_route_classification or test_live_turn_execution_oracle or test_live_action_planning"
-          tests/cli/interactive_shell/orchestration/test_llm_intent_classifier.py
+          -k "test_live_turn_execution_oracle or test_live_action_planning or TestLiveClassifierBehavior"
+          tests/cli/interactive_shell/routing/test_llm_intent_classifier.py

--- a/app/cli/interactive_shell/routing/AGENTS.md
+++ b/app/cli/interactive_shell/routing/AGENTS.md
@@ -58,7 +58,7 @@ If all answers are weak, keep the logic inline.
 | `app/cli/interactive_shell/routing/tests/scenario_loader.py` | Routing package owners | Load `scenarios/<behavior_class>/<id>/{scenario.yml,answer.yml}` |
 | `app/cli/interactive_shell/routing/tests/scenarios/**/scenario.yml` | Routing package owners | Input world: prompt, session, capabilities, intent metadata |
 | `app/cli/interactive_shell/routing/tests/scenarios/**/answer.yml` | Routing package owners | Expected behavior: route, policy, planned/executed actions, response contract |
-| `tests/cli/interactive_shell/orchestration/test_llm_intent_classifier.py` | Orchestration owners | Classifier internals (sanitization + live cache/override behavior) |
+| `tests/cli/interactive_shell/routing/test_llm_intent_classifier.py` | Routing package owners | Classifier internals (sanitization + live cache/override behavior) |
 
 ## Routing test isolation policy (no mocks)
 
@@ -81,8 +81,8 @@ If all answers are weak, keep the logic inline.
 - Regex fallback has been intentionally removed from routing. Do **not**
   re-introduce `regex_fallback`/`routes/route_regex_fallback`-style phases
   unless there is an explicit product decision to restore them.
-- Keep the LLM intent classifier canonical in orchestration (`app/cli/interactive_shell/orchestration/llm_intent_classifier.py`);
-  routing can wrap/import it, but should not duplicate classifier logic.
+- Keep the LLM intent classifier canonical in routing (`app/cli/interactive_shell/routing/llm_intent_classifier.py`);
+  do not duplicate classifier logic in other packages.
 - Preserve routing decision observability contracts used in tests:
   `fallback_reason` semantics and `matched_signals` (`cli_agent_action_plan`, etc.).
 
@@ -93,7 +93,7 @@ If all answers are weak, keep the logic inline.
 - Keep deterministic routing contracts (`test_routing_scenarios.py::test_deterministic_routing` and
   `test_routing_fixture_integrity.py`) in the default PR CI flow.
 - Run live-LLM suites (`test_routing_scenarios.py` live tests and
-  `tests/cli/interactive_shell/orchestration/test_llm_intent_classifier.py`)
+  `tests/cli/interactive_shell/routing/test_llm_intent_classifier.py`)
   in the post-merge sharded workflow.
 - Execute routing suites with heavy parallelism (`pytest-xdist`, e.g. `-n auto`)
   in both local and CI environments.

--- a/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_scenarios.py
@@ -24,6 +24,7 @@ from app.cli.interactive_shell.routing.tests._oracle_runtime import (
 )
 from app.cli.interactive_shell.routing.tests.scenario_loader import (
     ScenarioCase,
+    iter_scenarios_for_shard,
     load_all_scenarios,
     read_shard_config,
 )
@@ -47,7 +48,9 @@ _ALL_CASES = load_all_scenarios()
 _DETERMINISTIC_CASES = [
     case for case in _ALL_CASES if case.scenario.intent_class == "deterministic"
 ]
-_LIVE_CASES = [case for case in _ALL_CASES if case.scenario.intent_class != "deterministic"]
+_LIVE_CASES = iter_scenarios_for_shard(
+    [case for case in _ALL_CASES if case.scenario.intent_class != "deterministic"]
+)
 
 
 def _slash_content(command: str, args: list[str]) -> str:


### PR DESCRIPTION
## Summary

- Point the routing-live workflow at `tests/cli/interactive_shell/routing/test_llm_intent_classifier.py` (orchestration path was removed in #2257).
- Update path filters and `-k` expression to match current live tests.
- Wire `iter_scenarios_for_shard()` so each of the five matrix shards collects live scenario tests instead of pytest exit code 5 (`no tests ran`).

Fixes the failure seen in [routing-live shard 2](https://github.com/Tracer-Cloud/opensre/actions/runs/26189984617/job/77055563779) where every shard reported `2 workers [0 items]`.

## Test plan

- [x] Verified locally: each shard 0–4 collects 15 tests with the updated workflow command.
- [ ] Merge and confirm **Routing Live Post Merge** runs on `main` with non-zero collection per shard.

Made with [Cursor](https://cursor.com)