### PR TITLE
fix(routing): stabilize compound and handoff live LLM scenarios

### DIFF
--- a/app/cli/interactive_shell/chat/cli_agent.py
+++ b/app/cli/interactive_shell/chat/cli_agent.py
@@ -12,6 +12,7 @@ from rich.markdown import Markdown
 from rich.markup import escape
 
 from app.cli.interactive_shell.prompt_logging import LlmRunInfo
+from app.cli.interactive_shell.prompting.follow_up import _summarize_last_state
 from app.cli.interactive_shell.prompting.prompt_rules import (
     CLI_ASSISTANT_MARKDOWN_RULE,
     INTERACTIVE_SHELL_TERMINOLOGY_RULE,
@@ -123,6 +124,7 @@ def _build_system_prompt(
     history: str,
     agents_md: str = "",
     investigation_flow: str = "",
+    prior_investigation: str = "",
 ) -> str:
     """Build the system prompt for one assistant turn.
 
@@ -137,6 +139,11 @@ def _build_system_prompt(
     investigation_flow_block = (
         f"--- Investigation flow reference ---\n{investigation_flow}\n\n"
         if investigation_flow
+        else ""
+    )
+    prior_investigation_block = (
+        f"--- Prior investigation in this session ---\n{prior_investigation}\n\n"
+        if prior_investigation
         else ""
     )
     return (
@@ -157,10 +164,14 @@ def _build_system_prompt(
         "Be brief and friendly. Ground CLI facts in the reference below; do "
         "not invent subcommands. For investigation-flow questions, use the "
         "investigation flow reference below and do not claim the pipeline "
-        "definition is unavailable.\n\n"
+        "definition is unavailable.\n"
+        "For vague operational questions (for example why a database is slow) "
+        "with no pasted alert, restate the user's question in your reply and "
+        "ask for the target system, service, or alert context.\n\n"
         f"{_TERMINOLOGY_RULE}\n{_MARKDOWN_RULE}\n{_ACTION_RULE}\n\n"
         f"--- CLI reference ---\n{reference}\n\n"
         f"{investigation_flow_block}"
+        f"{prior_investigation_block}"
         f"{repo_map_block}"
         f"--- Recent CLI conversation ---\n{history}\n"
     )
@@ -428,11 +439,15 @@ def answer_cli_agent(
     investigation_flow = build_investigation_flow_reference_text()
     log_grounding_cache_diagnostics("cli_agent_grounding")
     history = _format_history_for_prompt(session)
+    prior_investigation = (
+        _summarize_last_state(session.last_state) if session.last_state is not None else ""
+    )
     system = _build_system_prompt(
         reference,
         history,
         agents_md=agents_md,
         investigation_flow=investigation_flow,
+        prior_investigation=prior_investigation,
     )
     user_block = f"--- User message ---\n{message}"
     synthetic_block = ""

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/intent_parser/patterns.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/intent_parser/patterns.py
@@ -128,7 +128,8 @@ SAMPLE_ALERT_RE = re.compile(
     re.IGNORECASE,
 )
 QUOTED_INVESTIGATION_RE = re.compile(
-    r"\b(?:send|start|run|launch|trigger)\b.{0,80}?\binvestigation\b.{0,260}?"
+    r"(?:\b(?:send|start|run|launch|trigger)\b.{0,80}?\binvestigation\b.{0,260}?|"
+    r"\binvestigate\b\s+)"
     r"(?:\"(?P<double>[^\"]+)\"|'(?P<single>[^']+)'|`(?P<backtick>[^`]+)`)",
     re.IGNORECASE | re.DOTALL,
 )
@@ -224,3 +225,13 @@ _NON_COMMAND_STARTS = frozenset(
 # Shell builtins that may not be discoverable via `shutil.which()` on all platforms.
 # Keep this list intentionally small and add tests when extending it.
 _SHELL_BUILTINS = frozenset({"cd", "pwd"})
+
+# Imported by extractors.py; bundle for static analysis.
+_EXTRACTOR_PATTERNS = (
+    _LLM_PROVIDER_RE,
+    _LLM_PROVIDER_SWITCH_RE,
+    _EXPLICIT_SHELL_RE,
+    _SHELL_PROMPT_RE,
+    _NON_COMMAND_STARTS,
+    _SHELL_BUILTINS,
+)

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner.py
@@ -7,13 +7,15 @@ import logging
 import re
 from typing import Any
 
-# Load tool registrations.
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration import (  # noqa: F401
-    tools,
-)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PlannedAction,
     default_target_surface,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.intent_parser import (
+    split_prompt_clauses,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
+    map_actions_with_unhandled,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
     ACTION_KIND_TO_TOOL,
@@ -393,6 +395,23 @@ def _parse_tool_plan(
     return actions, has_unhandled
 
 
+def _reconcile_compound_actions(
+    message: str,
+    actions: list[PlannedAction],
+    has_unhandled: bool,
+) -> tuple[list[PlannedAction], bool]:
+    """Prefer deterministic multi-clause plans when the LLM under-plans compounds."""
+    if len(split_prompt_clauses(message)) <= 1:
+        return actions, has_unhandled
+    if actions and all(action.kind == "assistant_handoff" for action in actions):
+        return actions, has_unhandled
+
+    det_actions, det_unhandled = map_actions_with_unhandled(message)
+    if not det_actions or len(det_actions) <= len(actions):
+        return actions, has_unhandled
+    return det_actions, det_unhandled
+
+
 def plan_actions_with_llm(
     message: str,
     *,
@@ -403,7 +422,11 @@ def plan_actions_with_llm(
     raw = _call_llm(sanitised, session)
     if raw is None:
         return None
-    return _parse_tool_plan(raw, session=session)
+    parsed = _parse_tool_plan(raw, session=session)
+    if parsed is None:
+        return None
+    actions, has_unhandled = parsed
+    return _reconcile_compound_actions(sanitised, actions, has_unhandled)
 
 
 __all__ = ["plan_actions_with_llm"]

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/601-follow-up-spike-cause.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/601-follow-up-spike-cause.yml
@@ -39,7 +39,5 @@ history:
   expected:
   - type: cli_agent
     ok: true
-  - type: cli_agent
-    ok: true
 tier: full
 runs: 1

--- a/tests/cli/interactive_shell/orchestration/test_intent_parser.py
+++ b/tests/cli/interactive_shell/orchestration/test_intent_parser.py
@@ -7,10 +7,14 @@ import pytest
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.intent_parser import (
     SAMPLE_ALERT_RE,
     extract_implementation_request,
+    extract_quoted_investigation_request,
     extract_shell_command,
     normalize_shell_command,
     shutil,
     split_prompt_clauses,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
+    map_actions_with_unhandled,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PromptClause,
@@ -98,3 +102,34 @@ class TestSampleAlertRE:
             assert SAMPLE_ALERT_RE.search(phrase) is None, (
                 f"SAMPLE_ALERT_RE should NOT match: {phrase!r}"
             )
+
+
+def test_extract_quoted_investigation_request_matches_bare_investigate_verb() -> None:
+    action = extract_quoted_investigation_request(
+        PromptClause(text='investigate "hello world"', position=0)
+    )
+    assert action is not None
+    assert action.kind == "investigation"
+    assert action.content == "hello world"
+
+
+def test_map_actions_with_unhandled_remote_then_investigate_compound() -> None:
+    actions, has_unhandled = map_actions_with_unhandled(
+        'run /remote and then investigate "hello world"'
+    )
+    assert not has_unhandled
+    assert [(item.kind, item.content) for item in actions] == [
+        ("slash", "/remote"),
+        ("investigation", "hello world"),
+    ]
+
+
+def test_map_actions_with_unhandled_health_then_connected_services() -> None:
+    actions, has_unhandled = map_actions_with_unhandled(
+        "check the health of my opensre and then show me all connected services"
+    )
+    assert not has_unhandled
+    assert [(item.kind, item.content) for item in actions] == [
+        ("slash", "/health"),
+        ("slash", "/list integrations"),
+    ]


### PR DESCRIPTION
## Summary

- Match bare `investigate "…"` clauses in `QUOTED_INVESTIGATION_RE` so compound remote→investigate prompts map to slash + investigation.
- Reconcile multi-clause LLM plans with the deterministic mapper when the model returns fewer actions than the prompt requires (fixes `501-nitro-connect-then-investigate` and `202-health-then-connected-services`).
- Ground `answer_cli_agent` in `session.last_state` for follow-up handoffs and guide vague operational questions (`601-follow-up-spike-cause`, `309-freeform-database-slow`).
- Correct `601` history fixture to a single `cli_agent` entry.

## Test plan

- [x] `uv run python -m pytest tests/cli/interactive_shell/orchestration/test_intent_parser.py`
- [x] Live routing scenarios: `501-nitro`, `202-health`, `601-follow-up`, `309-freeform` (8/8 passed locally)
- [ ] Routing Live Post Merge workflow on `main` after merge

Made with [Cursor](https://cursor.com)