### PR TITLE
fix(security): resolve open CodeQL alerts #1085–#1088

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/task_streaming.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/task_streaming.py
@@ -44,8 +44,6 @@ SYNTHETIC_TEST_TIMEOUT_SECONDS = 1800
 CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS = 1800
 _SYNTHETIC_POLL_SECONDS = 0.25
 _MAX_COMMAND_OUTPUT_CHARS = 24_000
-# Referenced by shell_runner, background_tasks, synthetic_tasks, and implementation_runner.
-_STREAMING_LIMITS = (_SYNTHETIC_POLL_SECONDS, _MAX_COMMAND_OUTPUT_CHARS)
 _SYNTHETIC_DIAG_CHARS = 2_000  # max stderr bytes captured from a failing synthetic run
 _SIGTERM_GRACE_SECONDS = 10  # wait for clean exit after SIGTERM before escalating to SIGKILL
 _TASK_OUTPUT_JOIN_TIMEOUT_SECONDS = 2

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/intent_parser/patterns.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/intent_parser/patterns.py
@@ -225,13 +225,3 @@ _NON_COMMAND_STARTS = frozenset(
 # Shell builtins that may not be discoverable via `shutil.which()` on all platforms.
 # Keep this list intentionally small and add tests when extending it.
 _SHELL_BUILTINS = frozenset({"cd", "pwd"})
-
-# Imported by extractors.py; bundle for static analysis.
-_EXTRACTOR_PATTERNS = (
-    _LLM_PROVIDER_RE,
-    _LLM_PROVIDER_SWITCH_RE,
-    _EXPLICIT_SHELL_RE,
-    _SHELL_PROMPT_RE,
-    _NON_COMMAND_STARTS,
-    _SHELL_BUILTINS,
-)

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import importlib
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -147,16 +148,12 @@ REGISTRY = ActionToolRegistry()
 _ACTION_TOOLS_MODULE = (
     "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools"
 )
-_action_tools_loaded = False
 
 
+@functools.cache
 def ensure_action_tools_loaded() -> None:
     """Import tool modules so ``REGISTRY`` side-effect registrations run."""
-    global _action_tools_loaded
-    if _action_tools_loaded:
-        return
     importlib.import_module(_ACTION_TOOLS_MODULE)
-    _action_tools_loaded = True
 
 
 ensure_action_tools_loaded()

--- a/app/cli/wizard/env_sync.py
+++ b/app/cli/wizard/env_sync.py
@@ -67,6 +67,10 @@ def _persist_env_secret(key: str, value: str) -> bool:
 
 
 def _set_env_value(lines: list[str], key: str, value: str) -> list[str]:
+    if _is_sensitive_env_key(key):
+        raise RuntimeError(
+            f"Refusing to write sensitive env key {key!r} to .env; use sync_env_secret()."
+        )
     updated: list[str] = []
     replaced = False
     for line in lines:
@@ -102,8 +106,7 @@ def _write_env(target_path: Path, lines: list[str]) -> None:
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         with target_path.open("w", encoding="utf-8", newline="") as env_file:
-            # Sensitive keys are stripped above; only non-secret config is persisted.
-            env_file.writelines(public_lines)  # codeql[py/clear-text-storage-sensitive-data]
+            env_file.writelines(public_lines)
     except PermissionError as exc:
         raise PermissionError(
             f"Cannot write to {target_path}: permission denied. "
@@ -114,16 +117,28 @@ def _write_env(target_path: Path, lines: list[str]) -> None:
             target_path.chmod(0o600)
 
 
+def sync_env_secret(key: str, value: str) -> None:
+    """Persist a sensitive env value in the system keyring, not in ``.env``."""
+    if not _is_sensitive_env_key(key):
+        raise ValueError(f"{key!r} is not classified as sensitive; use sync_env_values instead.")
+    _persist_env_secret(key, value)
+
+
 def sync_env_values(
     values: dict[str, str],
     *,
     env_path: Path | None = None,
 ) -> Path:
-    """Write multiple environment values into the target .env file.
+    """Write multiple non-sensitive environment values into the target .env file.
 
-    Sensitive keys are persisted in the system keyring instead of plain text.
+    Sensitive keys must be persisted with :func:`sync_env_secret` instead.
     When keyring storage is unavailable, sensitive values are not written to ``.env``.
     """
+    sensitive_keys = [key for key in values if _is_sensitive_env_key(key)]
+    if sensitive_keys:
+        joined = ", ".join(repr(key) for key in sensitive_keys)
+        raise ValueError(f"Refusing to sync sensitive env keys {joined}; use sync_env_secret().")
+
     target_path = env_path or PROJECT_ENV_PATH
     existing = (
         target_path.read_text(encoding="utf-8").splitlines(keepends=True)
@@ -133,10 +148,6 @@ def sync_env_values(
 
     lines = _strip_sensitive_env_lines(existing)
     for key, value in values.items():
-        if _is_sensitive_env_key(key):
-            _persist_env_secret(key, value)
-            lines = _remove_keys(lines, {key})
-            continue
         lines = _set_env_value(lines, key, value)
 
     _write_env(target_path, lines)

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -27,7 +27,7 @@ from app.cli.interactive_shell.ui.theme import (
     WARNING,
 )
 from app.cli.wizard.config import PROVIDER_BY_VALUE, SUPPORTED_PROVIDERS, ProviderOption
-from app.cli.wizard.env_sync import sync_env_values, sync_provider_env
+from app.cli.wizard.env_sync import sync_env_secret, sync_env_values, sync_provider_env
 from app.cli.wizard.integration_health import IntegrationHealthResult
 from app.cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
 from app.cli.wizard.prompts import select as select_prompt
@@ -1150,11 +1150,11 @@ def _configure_openclaw() -> tuple[str, str]:
                 "args": args,
             }
             upsert_integration("openclaw", {"credentials": credentials_dict})
+            sync_env_secret("OPENCLAW_MCP_AUTH_TOKEN", auth_token)
             env_path = sync_env_values(
                 {
                     "OPENCLAW_MCP_URL": url,
                     "OPENCLAW_MCP_MODE": mode,
-                    "OPENCLAW_MCP_AUTH_TOKEN": auth_token,
                     "OPENCLAW_MCP_COMMAND": command,
                     "OPENCLAW_MCP_ARGS": " ".join(args),
                 }
@@ -1194,10 +1194,10 @@ def _configure_gitlab() -> tuple[str, str]:
         if result.ok:
             credentials = {"base_url": base_url, "auth_token": auth_token}
             upsert_integration("gitlab", {"credentials": credentials})
+            sync_env_secret("GITLAB_ACCESS_TOKEN", auth_token)
             env_path = sync_env_values(
                 {
                     "GITLAB_BASE_URL": base_url,
-                    "GITLAB_ACCESS_TOKEN": auth_token,
                 }
             )
             return "Gitlab", str(env_path)
@@ -1531,9 +1531,9 @@ def _configure_incident_io() -> tuple[str, str]:
                 "base_url": base_url,
             }
             upsert_integration("incident_io", {"credentials": credentials_payload})
+            sync_env_secret("INCIDENT_IO_API_KEY", api_key)
             env_path = sync_env_values(
                 {
-                    "INCIDENT_IO_API_KEY": api_key,
                     "INCIDENT_IO_BASE_URL": base_url,
                 }
             )
@@ -1584,9 +1584,9 @@ def _configure_discord() -> tuple[str, str]:
             from app.integrations.cli import _register_discord_slash_command
 
             _register_discord_slash_command(application_id, bot_token)
+            sync_env_secret("DISCORD_BOT_TOKEN", bot_token)
             env_path = sync_env_values(
                 {
-                    "DISCORD_BOT_TOKEN": bot_token,
                     "DISCORD_APPLICATION_ID": application_id,
                     "DISCORD_PUBLIC_KEY": public_key,
                     "DISCORD_DEFAULT_CHANNEL_ID": default_channel_id,
@@ -1744,10 +1744,10 @@ def _configure_opensearch() -> tuple[str, str]:
                 "OPENSEARCH_URL": url,
             }
             if api_key:
-                env_values["OPENSEARCH_API_KEY"] = api_key
+                sync_env_secret("OPENSEARCH_API_KEY", api_key)
             if username:
                 env_values["OPENSEARCH_USERNAME"] = username
-                env_values["OPENSEARCH_PASSWORD"] = password
+                sync_env_secret("OPENSEARCH_PASSWORD", password)
             env_path = sync_env_values(env_values)
             return "OpenSearch", str(env_path)
         _console.print(f"[{DIM}]Try again or press Ctrl+C to cancel.[/]")

--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -8,6 +8,7 @@ import pytest
 from app.cli.wizard.config import PROVIDER_BY_VALUE
 from app.cli.wizard.env_sync import (
     _is_sensitive_env_key,
+    sync_env_secret,
     sync_env_values,
     sync_provider_env,
 )
@@ -350,6 +351,14 @@ def test_sync_provider_env_permission_error(tmp_path) -> None:
         env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
+def test_sync_env_values_rejects_sensitive_keys(tmp_path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("FOO=bar\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="sync_env_secret"):
+        sync_env_values({"GITLAB_ACCESS_TOKEN": "secret"}, env_path=env_path)
+
+
 def test_sync_env_values_routes_secrets_to_keyring(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("GITLAB_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
@@ -361,11 +370,9 @@ def test_sync_env_values_routes_secrets_to_keyring(tmp_path, monkeypatch) -> Non
         encoding="utf-8",
     )
 
+    sync_env_secret("GITLAB_ACCESS_TOKEN", "gl-secret-token")
     sync_env_values(
-        {
-            "GITLAB_BASE_URL": "https://gitlab.corp.com",
-            "GITLAB_ACCESS_TOKEN": "gl-secret-token",
-        },
+        {"GITLAB_BASE_URL": "https://gitlab.corp.com"},
         env_path=env_path,
     )
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -1084,6 +1084,7 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
     text_responses = iter(["https://gitlab.example.com/api/v4"])
     saved_integrations: list[tuple[str, dict]] = []
     synced_env_values: list[dict[str, str]] = []
+    synced_env_secrets: list[tuple[str, str]] = []
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -1118,7 +1119,11 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
         synced_env_values.append(values)
         return tmp_path / ".env"
 
+    def _sync_env_secret(key: str, value: str) -> None:
+        synced_env_secrets.append((key, value))
+
     monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(flow, "sync_env_secret", _sync_env_secret)
     monkeypatch.setattr(
         flow,
         "upsert_integration",
@@ -1139,10 +1144,10 @@ def test_run_wizard_configures_gitlab(monkeypatch, tmp_path) -> None:
             },
         )
     ]
+    assert synced_env_secrets == [("GITLAB_ACCESS_TOKEN", "glpat_test")]
     assert synced_env_values == [
         {
             "GITLAB_BASE_URL": "https://gitlab.example.com/api/v4",
-            "GITLAB_ACCESS_TOKEN": "glpat_test",
         }
     ]
 
@@ -1161,6 +1166,7 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
     )
     saved_integrations: list[tuple[str, dict]] = []
     synced_env_values: list[dict[str, str]] = []
+    synced_env_secrets: list[tuple[str, str]] = []
     validation_call_count = 0
 
     def _mock_select(*_args, **_kwargs):
@@ -1199,7 +1205,11 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
         synced_env_values.append(values)
         return tmp_path / ".env"
 
+    def _sync_env_secret(key: str, value: str) -> None:
+        synced_env_secrets.append((key, value))
+
     monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(flow, "sync_env_secret", _sync_env_secret)
     monkeypatch.setattr(
         flow,
         "upsert_integration",
@@ -1221,10 +1231,10 @@ def test_run_wizard_gitlab_retries_on_validation_failure(monkeypatch, tmp_path) 
             },
         )
     ]
+    assert synced_env_secrets == [("GITLAB_ACCESS_TOKEN", "glpat_good")]
     assert synced_env_values == [
         {
             "GITLAB_BASE_URL": "https://gitlab.com/api/v4",
-            "GITLAB_ACCESS_TOKEN": "glpat_good",
         }
     ]
 
@@ -1320,6 +1330,7 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
     text_responses = iter(["https://my-cluster.example.com", "admin"])
     saved_integrations: list[tuple[str, dict]] = []
     synced_env_values: list[dict[str, str]] = []
+    synced_env_secrets: list[tuple[str, str]] = []
 
     def _mock_select(*_args, **_kwargs):
         m = MagicMock()
@@ -1354,7 +1365,11 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
         synced_env_values.append(values)
         return tmp_path / ".env"
 
+    def _sync_env_secret(key: str, value: str) -> None:
+        synced_env_secrets.append((key, value))
+
     monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(flow, "sync_env_secret", _sync_env_secret)
     monkeypatch.setattr(
         flow,
         "upsert_integration",
@@ -1381,11 +1396,11 @@ def test_run_wizard_configures_opensearch(monkeypatch, tmp_path) -> None:
             },
         )
     ]
+    assert synced_env_secrets == [("OPENSEARCH_PASSWORD", "secret-pass")]
     assert synced_env_values == [
         {
             "OPENSEARCH_URL": "https://my-cluster.example.com",
             "OPENSEARCH_USERNAME": "admin",
-            "OPENSEARCH_PASSWORD": "secret-pass",
         }
     ]
 


### PR DESCRIPTION
## Summary

- Split wizard secret persistence into `sync_env_secret()` so passwords and API keys go to the keyring only; `sync_env_values()` now rejects sensitive keys and never writes them to `.env`, closing alert **#1086** (clear-text storage).
- Remove unused module globals `_STREAMING_LIMITS` and `_EXTRACTOR_PATTERNS` (**#1087**, **#1085**).
- Replace `_action_tools_loaded` with `@functools.cache` on `ensure_action_tools_loaded()` (**#1088**).

## Test plan

- [x] `uv run python -m pytest tests/cli/wizard/test_env_sync.py tests/cli/wizard/test_flow.py -q`
- [x] `make lint`
- [ ] Confirm CodeQL workflow closes alerts #1085–#1088 after merge


Made with [Cursor](https://cursor.com)