### PR TITLE
fix(routing): keep checkout HTTP pastes on assistant handoff path

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner.py
@@ -33,8 +33,9 @@ _RICH_PASTED_INCIDENT_RE = re.compile(
     r"^(?:.*\n){1,}.*\b(?:service|region)\s*:",
     re.IGNORECASE | re.DOTALL,
 )
-_ALERT_SYMPTOM_RE = re.compile(
-    r"\b(?:cpu|spiking|spike|latency|error|5\d\d|pods?|firing|checkout|database)\b",
+# Narrow symptoms only: checkout/HTTP/database pastes should stay assistant handoff.
+_INCIDENT_UPGRADE_SYMPTOM_RE = re.compile(
+    r"\b(?:cpu|spiking|spike|pods?|firing)\b",
     re.IGNORECASE,
 )
 
@@ -449,7 +450,7 @@ def _upgrade_handoff_to_incident(
         return actions, has_unhandled
     if "?" in message or re.search(r"\bhow\s+(?:do|to)\b", message, re.IGNORECASE):
         return actions, has_unhandled
-    if not _ALERT_SYMPTOM_RE.search(message):
+    if not _INCIDENT_UPGRADE_SYMPTOM_RE.search(message):
         return actions, has_unhandled
     alert_text = message.strip()
     return [

--- a/tests/cli/interactive_shell/orchestration/test_intent_parser.py
+++ b/tests/cli/interactive_shell/orchestration/test_intent_parser.py
@@ -159,6 +159,25 @@ def test_fail_closed_vague_local_llama_connect() -> None:
     assert result == ([], True)
 
 
+def test_finalize_preserves_handoff_for_checkout_http_errors() -> None:
+    handoff = [
+        PlannedAction(
+            kind="assistant_handoff",
+            content="incident_description:checkout_502_rate",
+            position=0,
+            source="llm",
+        )
+    ]
+    actions, has_unhandled = _finalize_planner_result(
+        "the checkout service is returning 502 errors for 30% of requests",
+        handoff,
+        True,
+    )
+    assert has_unhandled is True
+    assert len(actions) == 1
+    assert actions[0].kind == "assistant_handoff"
+
+
 def test_finalize_upgrades_handoff_to_investigation_for_cpu_spike() -> None:
     handoff = [
         PlannedAction(


### PR DESCRIPTION
## Summary
Post-merge Routing Live run on #2303 failed shards 1 and 2:
- **307** — planner upgraded `assistant_handoff` → `investigation` because `checkout`/`502` matched the broad symptom regex.
- **311** — same upgrade path broke the oracle (expects handoff for rich paste without integrations).

Narrows `_INCIDENT_UPGRADE_SYMPTOM_RE` to CPU/pod spike wording only (308 still upgrades).

## Test plan
- [x] `test_finalize_preserves_handoff_for_checkout_http_errors`
- [x] Live `307` and `311` scenarios pass locally


Made with [Cursor](https://cursor.com)