### PR TITLE
enforce routing import/test co-location rules

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/__init__.py
@@ -1,13 +1,5 @@
-"""High-level non-command message routing package."""
+"""Non-command routing package.
 
-from __future__ import annotations
-
-from app.cli.interactive_shell.routing.handle_message_with_agent.evaluator import (
-    handle_message_with_agent,
-    llm_phase_route,
-)
-
-__all__ = [
-    "handle_message_with_agent",
-    "llm_phase_route",
-]
+Canonical imports in routing should target `evaluator.py` directly
+to avoid compatibility-style forwarding layers.
+"""

--- a/app/cli/interactive_shell/routing/llm_intent_classifier.py
+++ b/app/cli/interactive_shell/routing/llm_intent_classifier.py
@@ -98,18 +98,13 @@ def _cached_classify(sanitised_text: str) -> str | None:
     return _parse_route(raw)
 
 
-def _classify_cached(sanitised_text: str) -> str | None:
-    """Classify with bounded caching and no global eviction side effects."""
-    return _cached_classify(sanitised_text)
-
-
 def classify_intent_with_llm(
     text: str,
     session: RoutingSession,  # noqa: ARG001
 ) -> RouteDecision | None:
     """Classify *text* using the mid-tier classification LLM."""
     sanitised = _sanitise_text(text.strip())
-    route_word = _classify_cached(sanitised)
+    route_word = _cached_classify(sanitised)
     if route_word is None:
         return None
 

--- a/app/cli/interactive_shell/routing/resolve_cli_command/__init__.py
+++ b/app/cli/interactive_shell/routing/resolve_cli_command/__init__.py
@@ -1,17 +1,5 @@
-"""Deterministic resolver for slash and bare-alias command input."""
+"""Deterministic slash/alias command routing package.
 
-from __future__ import annotations
-
-from app.cli.interactive_shell.routing.resolve_cli_command.evaluator import resolve_cli_command
-from app.cli.interactive_shell.routing.resolve_cli_command.matcher import (
-    is_bare_command_alias,
-    opensre_investigate_slash_text,
-    slash_dispatch_text,
-)
-
-__all__ = [
-    "is_bare_command_alias",
-    "opensre_investigate_slash_text",
-    "resolve_cli_command",
-    "slash_dispatch_text",
-]
+Canonical imports in routing should target concrete modules
+(`evaluator.py`, `matcher.py`) rather than package-level forwarding re-exports.
+"""

--- a/app/cli/interactive_shell/routing/router.py
+++ b/app/cli/interactive_shell/routing/router.py
@@ -11,11 +11,13 @@ and delegates all implementation details to sibling modules:
 
 from __future__ import annotations
 
-from app.cli.interactive_shell.routing.handle_message_with_agent import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.evaluator import (
     handle_message_with_agent,
     llm_phase_route,
 )
-from app.cli.interactive_shell.routing.resolve_cli_command import resolve_cli_command
+from app.cli.interactive_shell.routing.resolve_cli_command.evaluator import (
+    resolve_cli_command,
+)
 from app.cli.interactive_shell.routing.types import (
     RouteDecision,
     RouteKind,

--- a/app/cli/interactive_shell/routing/tests/test_resolve_opensre_investigate.py
+++ b/app/cli/interactive_shell/routing/tests/test_resolve_opensre_investigate.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from app.cli.interactive_shell.routing.resolve_cli_command import (
-    opensre_investigate_slash_text,
+from app.cli.interactive_shell.routing.resolve_cli_command.evaluator import (
     resolve_cli_command,
+)
+from app.cli.interactive_shell.routing.resolve_cli_command.matcher import (
+    opensre_investigate_slash_text,
 )
 from app.cli.interactive_shell.routing.router import RouteKind, route_input
 from app.cli.interactive_shell.runtime.session import ReplSession

--- a/app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py
@@ -22,6 +22,8 @@ from app.cli.interactive_shell.routing.tests.scenario_loader import (
 
 TESTS_DIR = Path(__file__).resolve().parent
 ROUTING_SCENARIOS_TEST = TESTS_DIR / "test_routing_scenarios.py"
+LEGACY_ROUTING_TESTS_DIR = TESTS_DIR.parents[4] / "tests" / "cli" / "interactive_shell" / "routing"
+ALLOWED_LEGACY_TESTS = {"test_llm_intent_classifier.py"}
 ORACLE_RUNTIME = TESTS_DIR / "_oracle_runtime.py"
 
 
@@ -166,4 +168,19 @@ def test_routing_test_modules_do_not_use_mock_patterns() -> None:
     assert not violations, (
         "No-mocks policy violated in routing tests. "
         "Remove mock usage from canonical routing suites.\n" + "\n".join(violations)
+    )
+
+
+def test_routing_tests_are_colocated_except_classifier_internal_suite() -> None:
+    if not LEGACY_ROUTING_TESTS_DIR.exists():
+        return
+    unexpected = sorted(
+        path.name
+        for path in LEGACY_ROUTING_TESTS_DIR.glob("test_*.py")
+        if path.name not in ALLOWED_LEGACY_TESTS
+    )
+    assert not unexpected, (
+        "Routing tests must be colocated under app/cli/interactive_shell/routing/tests/. "
+        "Only classifier-internal coverage remains under tests/cli/interactive_shell/routing/: "
+        + ", ".join(unexpected)
     )


### PR DESCRIPTION
## Summary
- remove routing package-level forwarding shims from active import paths
- switch router/tests to canonical concrete-module imports
- co-locate `test_resolve_opensre_investigate.py` under routing package tests
- add fixture-integrity guard to prevent routing test drift back into legacy `tests/cli/.../routing`

## Validation
- `make lint` (from repo root)
- `make format-check` (from repo root)
- `make typecheck` (from repo root)
- `uv run pytest -n auto app/cli/interactive_shell/routing/tests/test_resolve_opensre_investigate.py app/cli/interactive_shell/routing/tests/test_routing_fixture_integrity.py`
- `uv run pytest tests/cli/ -v -n auto` (1 live-LLM contract failure persisted in `test_llm_action_planner.py::...cli_agent_connect_local_llama`)
