### PR TITLE
ci: fix live LLM credential wiring for routing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       JWT_TOKEN: ${{ secrets.JWT_TOKEN }}
       GRAFANA_READ_TOKEN: ${{ secrets.GRAFANA_READ_TOKEN }}
       GCLOUD_HOSTED_METRICS_ID: ${{ secrets.GCLOUD_HOSTED_METRICS_ID }}

--- a/.github/workflows/routing-live-post-merge.yml
+++ b/.github/workflows/routing-live-post-merge.yml
@@ -36,6 +36,9 @@ jobs:
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      LLM_PROVIDER: openai
+      OPENSRE_DISABLE_KEYRING: "1"
       ROUTING_SHARD_TOTAL: "5"
       ROUTING_SHARD_INDEX: ${{ matrix.shard_index }}
       PYTHONUTF8: "1"
@@ -58,6 +61,13 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev
+
+      - name: Validate live LLM credential wiring
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "::error::OPENAI_API_KEY is missing for live routing tests."
+            exit 1
+          fi
 
       - name: Run sharded live routing suite
         run: >-

--- a/app/cli/interactive_shell/routing/tests/conftest.py
+++ b/app/cli/interactive_shell/routing/tests/conftest.py
@@ -69,7 +69,9 @@ def _resolve_live_llm_configuration(
         if env_var is not None:
             hint += f", required key={env_var}"
         hint += f", fallback providers={DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS!r}"
-        pytest.skip(f"Live LLM routing tests skipped (no usable LLM configuration):{hint}. {msg}")
+        # Keep live_llm tests fail-closed for credential/config regressions.
+        # Live suites must run with real credentials and fail on misconfiguration.
+        pytest.fail(f"Live LLM routing tests require usable LLM configuration:{hint}. {msg}")
 
     from app.services.llm_client import reset_llm_singletons
 


### PR DESCRIPTION
## Summary
- keep `live_llm` tests fail-closed in routing fixture setup
- wire `OPENAI_API_KEY` into CI test job env so fallback provider resolution can succeed when Anthropic key is unavailable
- wire `OPENAI_API_KEY` into `routing-live-post-merge` and pin `LLM_PROVIDER=openai` with `OPENSRE_DISABLE_KEYRING=1`
- add explicit preflight check in live-routing workflow to fail fast with clear error when `OPENAI_API_KEY` is missing

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run python -m pytest tests/cli/ -v`
- `uv run python -m pytest app/cli/interactive_shell/routing/tests/test_routing_scenarios.py -m 'not live_llm' -v`
