### PR TITLE
fix(ci): unbreak tools-services and e2e-general after live-llm credential wiring

### DIFF
--- a/app/integrations/registry.py
+++ b/app/integrations/registry.py
@@ -166,6 +166,7 @@ INTEGRATION_SPECS: tuple[IntegrationSpec, ...] = (
     ),
     IntegrationSpec(
         service="rabbitmq",
+        aliases=("amqp",),
         verifier=_verify_rabbitmq,
         direct_effective=True,
         verify_order=17,

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1085,6 +1085,7 @@ def test_create_llm_client_missing_api_key_raises_runtime_error(monkeypatch) -> 
     """Sentry #1678: missing API key must surface as RuntimeError, not pydantic.ValidationError."""
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _env_var: "")
     llm_client.reset_llm_singletons()
     try:
         with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
@@ -1097,6 +1098,7 @@ def test_create_llm_client_missing_api_key_omits_pydantic_boilerplate(monkeypatc
     """Sentry #1815: the RuntimeError message must not include pydantic boilerplate."""
     monkeypatch.setenv("LLM_PROVIDER", "minimax")
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _env_var: "")
     llm_client.reset_llm_singletons()
     try:
         with pytest.raises(RuntimeError) as exc_info:


### PR DESCRIPTION
## Summary
- restore `amqp` as an alias of the canonical `rabbitmq` integration key in the registry
- make missing-key `_create_llm_client` tests deterministic by stubbing `app.config.resolve_llm_api_key` to return empty strings
- keep live-LLM fail-closed behavior from #2314 intact

## Why
- `e2e-general` failed because `classify_integrations` no longer resolved `service: amqp` into `rabbitmq`
- `tools-services` failed because CI now exports `OPENAI_API_KEY`; fallback provider resolution meant two tests no longer exercised the missing-key error path

## Validation
- `uv run python -m pytest tests/e2e/rabbitmq/test_rabbitmq_e2e.py::TestRabbitMQConfigResolution::test_amqp_service_alias_resolves_to_rabbitmq tests/services/test_llm_client.py::test_create_llm_client_missing_api_key_raises_runtime_error tests/services/test_llm_client.py::test_create_llm_client_missing_api_key_omits_pydantic_boilerplate -v`
- `uv run python -m pytest tests/services/test_llm_client.py tests/e2e/rabbitmq/test_rabbitmq_e2e.py -v`
