### PR TITLE
ci: fix shard coverage artifact upload for hidden/suffixed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ matrix.shard }}
-          path: .coverage.${{ matrix.shard }}
+          path: .coverage.${{ matrix.shard }}*
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 7
 
   coverage-report:


### PR DESCRIPTION
## Summary
- upload shard coverage artifacts using `path: .coverage.${{ matrix.shard }}*`
- enable `include-hidden-files: true` for `actions/upload-artifact@v4`

## Why
All test shards are currently passing tests but failing in `Upload shard coverage data` with:
`No files were found with the provided path: .coverage.<shard>`

This happens because coverage outputs are dotfiles and (with xdist/cov) may include suffixed filenames. The prior exact filename path plus hidden-file exclusion caused all shard uploads to fail, which then caused `coverage-report` to fail with `No data to combine`.
