### PR TITLE
refactor(routing): explicit policy phases and deterministic tool composition

### DIFF
--- a/app/cli/interactive_shell/routing/handle_message_with_agent/evaluator.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/evaluator.py
@@ -11,6 +11,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.errors import (
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
     map_actions_with_unhandled,
 )
+from app.cli.interactive_shell.routing.policy_tags import RouteSignal
 from app.cli.interactive_shell.routing.types import RouteDecision, RouteKind, RoutingSession
 from app.cli.support.exception_reporting import report_exception
 
@@ -27,13 +28,13 @@ def _degraded_route_decision(exc: RoutingDegradeError, *, text: str) -> RouteDec
             "degrade_reason_tag": reason_tag,
             "degrade_exception_class": type(exc).__name__,
             "text_length": len(text),
-            "matched_signals": "cli_agent_degraded",
+            "matched_signals": RouteSignal.CLI_AGENT_DEGRADED.value,
         },
     )
     return RouteDecision(
         RouteKind.CLI_AGENT,
         _DEGRADE_CONFIDENCE,
-        ("cli_agent_degraded", reason_tag),
+        (RouteSignal.CLI_AGENT_DEGRADED.value, reason_tag),
         reason_tag,
     )
 
@@ -51,7 +52,9 @@ def handle_message_with_agent(
         return _degraded_route_decision(exc, text=text)
 
     matched_signals = (
-        ("cli_agent_action_plan",) if mapped_actions and not has_unhandled_clause else ()
+        (RouteSignal.CLI_AGENT_ACTION_PLAN.value,)
+        if mapped_actions and not has_unhandled_clause
+        else ()
     )
 
     return RouteDecision(

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/__init__.py
@@ -37,6 +37,12 @@ from .investigation_runner import run_sample_alert, run_text_investigation
 from .opensre_cli_runner import (
     _INTERACTIVE_OPENSRE_COMMAND_PATHS,
     _OPENSRE_BLOCKED_SUBCOMMANDS,
+    OpensreCommandClass,
+    OpensreExecutionMode,
+    OpensreExecutionPlan,
+    OpensreRunOutcome,
+    OpensreRunResult,
+    _build_opensre_execution_plan,
     _classify_opensre_command,
     _is_interactive_wizard,
     _opensre_confirmation_reason,
@@ -45,6 +51,7 @@ from .opensre_cli_runner import (
     _should_run_opensre_in_foreground,
     print_interactive_wizard_handoff,
     run_opensre_cli_command,
+    run_opensre_cli_command_result,
 )
 from .shell_runner import run_cd_command, run_pwd_command, run_shell_command
 from .synthetic_tasks import (
@@ -79,6 +86,11 @@ __all__ = [
     "CLAUDE_CODE_IMPLEMENTATION_TIMEOUT_SECONDS",
     "SHELL_COMMAND_TIMEOUT_SECONDS",
     "SYNTHETIC_TEST_TIMEOUT_SECONDS",
+    "OpensreCommandClass",
+    "OpensreExecutionMode",
+    "OpensreExecutionPlan",
+    "OpensreRunOutcome",
+    "OpensreRunResult",
     "_INTERACTIVE_OPENSRE_COMMAND_PATHS",
     "_MAX_COMMAND_OUTPUT_CHARS",
     "_MIN_SUBPROCESS_TERMINAL_WIDTH",
@@ -88,6 +100,7 @@ __all__ = [
     "_TASK_OUTPUT_JOIN_TIMEOUT_SECONDS",
     "_TASK_OUTPUT_PREFIX_WIDTH",
     "_classify_opensre_command",
+    "_build_opensre_execution_plan",
     "_console_file_is_tty",
     "_is_interactive_wizard",
     "_join_task_output_streams",
@@ -108,6 +121,7 @@ __all__ = [
     "run_claude_code_implementation",
     "run_cd_command",
     "run_opensre_cli_command",
+    "run_opensre_cli_command_result",
     "run_pwd_command",
     "run_sample_alert",
     "run_text_investigation",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/investigation_runner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/investigation_runner.py
@@ -8,8 +8,8 @@ from rich.console import Console
 from rich.markup import escape
 
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
-    evaluate_investigation_launch,
     execution_allowed,
+    plan_investigation_execution,
 )
 from app.cli.interactive_shell.runtime import ReplSession, TaskKind
 from app.cli.interactive_shell.ui import ERROR, WARNING
@@ -28,9 +28,9 @@ def run_sample_alert(
 ) -> None:
     from app.cli.investigation import run_sample_alert_for_session
 
-    policy = evaluate_investigation_launch(action_type="sample_alert")
+    plan = plan_investigation_execution(action_type="sample_alert")
     if not execution_allowed(
-        policy,
+        plan.policy,
         session=session,
         console=console,
         action_summary=f"sample alert investigation ({template_name})",
@@ -89,9 +89,9 @@ def run_text_investigation(
 ) -> None:
     from app.cli.investigation import run_investigation_for_session
 
-    policy = evaluate_investigation_launch(action_type="investigation")
+    plan = plan_investigation_execution(action_type="investigation")
     if not execution_allowed(
-        policy,
+        plan.policy,
         session=session,
         console=console,
         action_summary=f'investigation from text "{alert_text}"',

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/opensre_cli_runner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/opensre_cli_runner.py
@@ -6,10 +6,18 @@ import shlex
 import subprocess
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
 
 from rich.console import Console
 from rich.markup import escape
 
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
+    ActionExecutionMode,
+    ActionExecutionPlan,
+    ExecutionPolicyResult,
+    execution_allowed,
+)
 from app.cli.interactive_shell.runtime import ReplSession
 from app.cli.interactive_shell.ui import DIM, ERROR, WARNING, print_command_output
 from app.cli.support.exception_reporting import report_exception
@@ -94,19 +102,55 @@ _READ_ONLY_OPENSRE_SUBCOMMANDS: frozenset[str] = frozenset(
 _INVESTIGATION_OPENSRE_SUBCOMMANDS: frozenset[str] = frozenset({"investigate"})
 
 
+class OpensreCommandClass(StrEnum):
+    READ_ONLY = "read_only"
+    INVESTIGATION = "investigation"
+    MUTATING = "mutating"
+
+
+class OpensreExecutionMode(StrEnum):
+    FOREGROUND = "foreground"
+    FOREGROUND_STREAMING = "foreground_streaming"
+    BACKGROUND = "background"
+
+
+class OpensreRunOutcome(StrEnum):
+    BLOCKED = "blocked"
+    HANDED_OFF = "handed_off"
+    EXECUTED_FOREGROUND = "executed_foreground"
+    EXECUTED_BACKGROUND = "executed_background"
+    DECLINED = "declined"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class OpensreExecutionPlan:
+    classification: OpensreCommandClass
+    execution_mode: OpensreExecutionMode
+    requires_confirmation: bool
+    confirmation_reason: str | None
+
+
+@dataclass(frozen=True)
+class OpensreRunResult:
+    outcome: OpensreRunOutcome
+    attempted: bool
+    display_command: str | None = None
+
+
 def _classify_opensre_command(tokens: list[str]) -> str:
     first_token = tokens[0].lower()
     if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS:
-        return "read_only"
+        return OpensreCommandClass.READ_ONLY.value
     if first_token in _INVESTIGATION_OPENSRE_SUBCOMMANDS:
-        return "investigation"
+        return OpensreCommandClass.INVESTIGATION.value
     if first_token == "agents":
         subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
         if subcommand in {"list"}:
-            return "read_only"
+            return OpensreCommandClass.READ_ONLY.value
         if subcommand == "scan" and "--register" not in tokens[2:]:
-            return "read_only"
-    return "mutating"
+            return OpensreCommandClass.READ_ONLY.value
+    return OpensreCommandClass.MUTATING.value
 
 
 def _opensre_confirmation_reason(tokens: list[str]) -> str:
@@ -118,13 +162,69 @@ def _opensre_confirmation_reason(tokens: list[str]) -> str:
 
 
 def _should_run_opensre_in_foreground(tokens: list[str]) -> bool:
+    return _build_opensre_execution_plan(tokens).execution_mode in {
+        OpensreExecutionMode.FOREGROUND,
+        OpensreExecutionMode.FOREGROUND_STREAMING,
+    }
+
+
+def _build_opensre_execution_plan(tokens: list[str]) -> OpensreExecutionPlan:
+    """Compute classification + execution mode from one canonical policy table."""
+    classification = OpensreCommandClass(_classify_opensre_command(tokens))
     first_token = tokens[0].lower()
+
+    execution_mode = OpensreExecutionMode.BACKGROUND
     if first_token in _READ_ONLY_OPENSRE_SUBCOMMANDS:
-        return True
-    if first_token == "agents":
+        execution_mode = OpensreExecutionMode.FOREGROUND
+    elif first_token == "agents":
         subcommand = tokens[1].lower() if len(tokens) > 1 else "list"
-        return subcommand in {"list", "register", "forget", "scan", "watch"}
-    return False
+        if subcommand == "watch":
+            execution_mode = OpensreExecutionMode.FOREGROUND_STREAMING
+        elif subcommand in {"list", "register", "forget", "scan"}:
+            execution_mode = OpensreExecutionMode.FOREGROUND
+
+    requires_confirmation = classification is OpensreCommandClass.MUTATING
+    reason = (
+        _opensre_confirmation_reason([token.lower() for token in tokens])
+        if requires_confirmation
+        else None
+    )
+    return OpensreExecutionPlan(
+        classification=classification,
+        execution_mode=execution_mode,
+        requires_confirmation=requires_confirmation,
+        confirmation_reason=reason,
+    )
+
+
+def _to_action_execution_plan(plan: OpensreExecutionPlan) -> ActionExecutionPlan:
+    mode = ActionExecutionMode.BACKGROUND
+    if plan.execution_mode is OpensreExecutionMode.FOREGROUND:
+        mode = ActionExecutionMode.FOREGROUND
+    elif plan.execution_mode is OpensreExecutionMode.FOREGROUND_STREAMING:
+        mode = ActionExecutionMode.FOREGROUND_STREAMING
+    if not plan.requires_confirmation:
+        policy = ExecutionPolicyResult(
+            verdict="allow",
+            action_type="cli_command",
+            reason=None,
+            hint=None,
+            shell_classification=plan.classification.value,
+        )
+    else:
+        policy = ExecutionPolicyResult(
+            verdict="ask",
+            action_type="cli_command",
+            reason=plan.confirmation_reason,
+            hint="Use a read-only subcommand (health, version, list, status, show)",
+            shell_classification=plan.classification.value,
+        )
+    return ActionExecutionPlan(
+        action_type="cli_command",
+        classification=plan.classification.value,
+        execution_mode=mode,
+        policy=policy,
+    )
 
 
 def _run_opensre_foreground(
@@ -206,10 +306,28 @@ def run_opensre_cli_command(
     confirm_fn: Callable[[str], str] | None = None,
     is_tty: bool | None = None,
 ) -> bool:
+    result = run_opensre_cli_command_result(
+        args,
+        session,
+        console,
+        confirm_fn=confirm_fn,
+        is_tty=is_tty,
+    )
+    return result.attempted
+
+
+def run_opensre_cli_command_result(
+    args: str,
+    session: ReplSession,
+    console: Console,
+    *,
+    confirm_fn: Callable[[str], str] | None = None,
+    is_tty: bool | None = None,
+) -> OpensreRunResult:
     """Run an opensre subcommand (not agent).
 
-    Returns True if the command was attempted (regardless of success),
-    False if the subcommand is blocked or args are empty.
+    Returns a typed outcome so callers can distinguish blocked/declined/
+    handed-off/executed states without overloading ``bool``.
 
     ``confirm_fn`` is forwarded to :func:`execution_allowed` so the
     interactive REPL can route mid-dispatch ``Proceed? [y/N]`` prompts
@@ -221,46 +339,28 @@ def run_opensre_cli_command(
     except ValueError:
         tokens = args.split()
     if not tokens:
-        return False
+        return OpensreRunResult(outcome=OpensreRunOutcome.INVALID, attempted=False)
 
     first_token = tokens[0].lower()
     if first_token in _OPENSRE_BLOCKED_SUBCOMMANDS:
         console.print(f"[{ERROR}]Cannot run `opensre {first_token}`: subcommand is blocked.[/]")
-        return False
+        return OpensreRunResult(outcome=OpensreRunOutcome.BLOCKED, attempted=False)
 
     if _is_interactive_wizard(tokens):
         command_str = " ".join(tokens)
         print_interactive_wizard_handoff(console, command_str)
         session.record("cli_command", f"opensre {command_str}", ok=False)
-        # True = wizard exists and was handed off; the ``_OPENSRE_BLOCKED_SUBCOMMANDS`` branch
-        # above returns False for "shouldn't run at all".
-        return True
-
-    command_classification = _classify_opensre_command(tokens)
-    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
-        ExecutionPolicyResult,
-        execution_allowed,
-    )
-
-    if command_classification in {"read_only", "investigation"}:
-        policy_result = ExecutionPolicyResult(
-            verdict="allow",
-            action_type="cli_command",
-            reason=None,
-            hint=None,
-            shell_classification=command_classification,
+        return OpensreRunResult(
+            outcome=OpensreRunOutcome.HANDED_OFF,
+            attempted=True,
+            display_command=f"opensre {command_str}",
         )
-    else:
-        policy_result = ExecutionPolicyResult(
-            verdict="ask",
-            action_type="cli_command",
-            reason=_opensre_confirmation_reason([token.lower() for token in tokens]),
-            hint="Use a read-only subcommand (health, version, list, status, show)",
-            shell_classification=command_classification,
-        )
+
+    plan = _build_opensre_execution_plan(tokens)
+    execution_plan = _to_action_execution_plan(plan)
 
     if not execution_allowed(
-        policy_result,
+        execution_plan.policy,
         session=session,
         console=console,
         action_summary=f"$ opensre {' '.join(tokens)}",
@@ -269,16 +369,31 @@ def run_opensre_cli_command(
         action_already_listed=True,
     ):
         session.record("cli_command", f"opensre {' '.join(tokens)}", ok=False)
-        return True
+        return OpensreRunResult(
+            outcome=OpensreRunOutcome.DECLINED,
+            attempted=True,
+            display_command=f"opensre {' '.join(tokens)}",
+        )
 
     argv_list = [sys.executable, "-m", "app.cli"] + tokens
     display_command = f"opensre {' '.join(tokens)}"
-    if _should_run_opensre_in_foreground(tokens):
-        if [token.lower() for token in tokens[:2]] == ["agents", "watch"]:
+    if execution_plan.execution_mode in {
+        ActionExecutionMode.FOREGROUND,
+        ActionExecutionMode.FOREGROUND_STREAMING,
+    }:
+        if execution_plan.execution_mode is ActionExecutionMode.FOREGROUND_STREAMING:
             _run_opensre_foreground_streaming(argv_list, display_command, session, console)
-            return True
+            return OpensreRunResult(
+                outcome=OpensreRunOutcome.EXECUTED_FOREGROUND,
+                attempted=True,
+                display_command=display_command,
+            )
         _run_opensre_foreground(argv_list, display_command, session, console)
-        return True
+        return OpensreRunResult(
+            outcome=OpensreRunOutcome.EXECUTED_FOREGROUND,
+            attempted=True,
+            display_command=display_command,
+        )
 
     session.record("cli_command", display_command)
     _ae_resolve("start_background_cli_task", _start_background_cli_task_default)(
@@ -287,4 +402,8 @@ def run_opensre_cli_command(
         session=session,
         console=console,
     )
-    return True
+    return OpensreRunResult(
+        outcome=OpensreRunOutcome.EXECUTED_BACKGROUND,
+        attempted=True,
+        display_command=display_command,
+    )

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/shell_runner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/action_executor/shell_runner.py
@@ -13,8 +13,8 @@ from rich.text import Text
 
 import app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.intent_parser as _intent_parser
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
-    evaluate_shell_from_parsed,
     execution_allowed,
+    plan_shell_execution,
 )
 from app.cli.interactive_shell.runtime import ReplSession
 from app.cli.interactive_shell.shell import (
@@ -43,9 +43,9 @@ def run_shell_command(
     action_already_listed: bool = False,
 ) -> None:
     parsed = parse_shell_command(command, is_windows=_intent_parser.IS_WINDOWS)
-    policy = evaluate_shell_from_parsed(parsed)
+    plan = plan_shell_execution(parsed)
     if not execution_allowed(
-        policy,
+        plan.policy,
         session=session,
         console=console,
         action_summary=f"$ {command}",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/agent_actions.py
@@ -13,6 +13,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.i
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner import (
     plan_actions_with_llm,
+    plan_actions_with_llm_result,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
     map_cli_actions,
@@ -27,6 +28,8 @@ from app.cli.interactive_shell.runtime import ReplSession
 from app.cli.interactive_shell.ui import DIM, print_planned_actions
 from app.cli.interactive_shell.ui.streaming import render_response_header
 
+_DEFAULT_PLAN_ACTIONS_WITH_LLM = plan_actions_with_llm
+
 
 @dataclass(frozen=True)
 class TerminalActionExecutionResult:
@@ -37,7 +40,36 @@ class TerminalActionExecutionResult:
     handled: bool
 
 
-def _plan_actions(message: str, session: ReplSession) -> tuple[list[PlannedAction], bool, bool]:
+@dataclass(frozen=True)
+class _ActionPlanningDecision:
+    actions: tuple[PlannedAction, ...]
+    has_unhandled_clause: bool
+    denied: bool
+    policy_trace: tuple[str, ...]
+
+
+def _coerce_action_plan_decision(
+    raw: _ActionPlanningDecision
+    | tuple[list[PlannedAction], bool]
+    | tuple[list[PlannedAction], bool, bool],
+) -> _ActionPlanningDecision:
+    """Back-compat adapter for tests that monkeypatch _plan_actions to tuple output."""
+    if isinstance(raw, _ActionPlanningDecision):
+        return raw
+    if len(raw) == 2:
+        actions, has_unhandled_clause = raw
+        denied = False
+    else:
+        actions, has_unhandled_clause, denied = raw
+    return _ActionPlanningDecision(
+        actions=tuple(actions),
+        has_unhandled_clause=has_unhandled_clause,
+        denied=denied,
+        policy_trace=(),
+    )
+
+
+def _plan_actions(message: str, session: ReplSession) -> _ActionPlanningDecision:
     """Plan actions for a free-text message using LLM-first planning.
 
     Used to wrap the call in a ``rich.Live`` spinner for in-place
@@ -61,26 +93,41 @@ def _plan_actions(message: str, session: ReplSession) -> tuple[list[PlannedActio
 
         cmd = " ".join(stripped[1:].split())  # normalise internal whitespace/newlines
         if cmd:
-            return [shell_action(f"!{cmd}", 0)], False, False
+            return _ActionPlanningDecision(
+                actions=(shell_action(f"!{cmd}", 0),),
+                has_unhandled_clause=False,
+                denied=False,
+                policy_trace=("deterministic_bang_shell",),
+            )
 
-    llm_plan = plan_actions_with_llm(message, session=session)
-    if llm_plan is None:
-        return [], True, True
-    actions, has_unhandled_clause = llm_plan
+    if plan_actions_with_llm is _DEFAULT_PLAN_ACTIONS_WITH_LLM:
+        llm_plan_result = plan_actions_with_llm_result(message, session=session)
+        if llm_plan_result is None:
+            return _ActionPlanningDecision((), True, True, ("planner_unavailable",))
+        actions = list(llm_plan_result.actions)
+        has_unhandled_clause = llm_plan_result.has_unhandled_clause
+        policy_trace = llm_plan_result.policy_trace
+    else:
+        # Preserve existing monkeypatch seam used by unit tests and debug harnesses.
+        llm_plan_legacy = plan_actions_with_llm(message, session=session)
+        if llm_plan_legacy is None:
+            return _ActionPlanningDecision((), True, True, ("planner_unavailable",))
+        actions, has_unhandled_clause = llm_plan_legacy
+        policy_trace = ()
     if not actions:
-        return [], has_unhandled_clause, False
+        return _ActionPlanningDecision((), has_unhandled_clause, False, policy_trace)
     if all(action.kind == "assistant_handoff" for action in actions):
         # If the planner surfaced an assistant handoff *and* flagged unhandled
         # content, treat this as a fail-closed deny path. This handles partial
         # prompts where only some clauses were actionable.
         if has_unhandled_clause:
-            return [], True, True
+            return _ActionPlanningDecision((), True, True, policy_trace)
         # Pure handoff: let the caller invoke the LLM reply directly without
         # printing a noisy "Requested actions: assistant handoff …" header.
-        return [], False, False
+        return _ActionPlanningDecision((), False, False, policy_trace)
     if has_unhandled_clause:
-        return [], True, True
-    return actions, False, False
+        return _ActionPlanningDecision((), True, True, policy_trace)
+    return _ActionPlanningDecision(tuple(actions), False, False, policy_trace)
 
 
 def _render_plan_denied(console: Console) -> None:
@@ -183,7 +230,10 @@ def execute_cli_actions(
     denials). Returns False only for legacy/test paths that pass through with no
     planned actions and no deny signal.
     """
-    actions, has_unhandled_clause, denied = _plan_actions(message, session)
+    plan = _coerce_action_plan_decision(_plan_actions(message, session))
+    actions = list(plan.actions)
+    has_unhandled_clause = plan.has_unhandled_clause
+    denied = plan.denied
     if denied:
         _render_plan_denied(console)
         session.record("cli_agent", message, ok=False)
@@ -216,14 +266,27 @@ def execute_cli_actions_with_metrics(
     ``input()`` (which deadlocks against the running ``prompt_async``).
     """
     from app.analytics.cli import (
+        capture_repl_execution_policy_decision,
         capture_terminal_actions_executed,
         capture_terminal_actions_planned,
     )
 
-    actions, has_unhandled_clause, denied = _plan_actions(message, session)
+    plan = _coerce_action_plan_decision(_plan_actions(message, session))
+    actions = list(plan.actions)
+    has_unhandled_clause = plan.has_unhandled_clause
+    denied = plan.denied
     capture_terminal_actions_planned(
         planned_count=len(actions),
         has_unhandled_clause=has_unhandled_clause,
+    )
+    capture_repl_execution_policy_decision(
+        {
+            "policy_stage": "terminal_action_planning",
+            "policy_trace": ",".join(plan.policy_trace),
+            "planned_count": len(actions),
+            "has_unhandled_clause": has_unhandled_clause,
+            "denied": denied,
+        }
     )
     if denied:
         _render_plan_denied(console)

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/execution_policy.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/execution_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Literal
 
 from rich.console import Console
@@ -27,6 +28,12 @@ from app.cli.interactive_shell.ui import DIM, WARNING
 ExecutionVerdict = Literal["allow", "ask", "deny"]
 
 
+class ActionExecutionMode(StrEnum):
+    FOREGROUND = "foreground"
+    BACKGROUND = "background"
+    FOREGROUND_STREAMING = "foreground_streaming"
+
+
 @dataclass(frozen=True)
 class ExecutionPolicyResult:
     """Result of evaluating whether an action may run."""
@@ -36,6 +43,16 @@ class ExecutionPolicyResult:
     reason: str | None
     hint: str | None = None
     shell_classification: str | None = None
+
+
+@dataclass(frozen=True)
+class ActionExecutionPlan:
+    """Unified execution plan contract shared across action executors."""
+
+    action_type: str
+    classification: str
+    execution_mode: ActionExecutionMode
+    policy: ExecutionPolicyResult
 
 
 def _default_confirm_fn(prompt: str) -> str:
@@ -252,6 +269,17 @@ def evaluate_shell_from_parsed(parsed: ParsedShellCommand) -> ExecutionPolicyRes
     )
 
 
+def plan_shell_execution(parsed: ParsedShellCommand) -> ActionExecutionPlan:
+    policy = evaluate_shell_from_parsed(parsed)
+    classification = policy.shell_classification or "unknown"
+    return ActionExecutionPlan(
+        action_type="shell",
+        classification=classification,
+        execution_mode=ActionExecutionMode.FOREGROUND,
+        policy=policy,
+    )
+
+
 def evaluate_shell_command(command: str) -> ExecutionPolicyResult:
     """Map shell policy + passthrough rules into allow/ask/deny."""
     parsed = parse_shell_command(command, is_windows=_intent_parser.IS_WINDOWS)
@@ -269,6 +297,19 @@ def evaluate_slash_tier(tier: ExecutionTier) -> ExecutionPolicyResult:
     )
 
 
+def plan_slash_execution(
+    command_name: str, args: list[str], registered: ExecutionTier
+) -> ActionExecutionPlan:
+    tier = resolve_slash_execution_tier(command_name, args, registered)
+    policy = evaluate_slash_tier(tier)
+    return ActionExecutionPlan(
+        action_type="slash",
+        classification=tier.value,
+        execution_mode=ActionExecutionMode.FOREGROUND,
+        policy=policy,
+    )
+
+
 def evaluate_investigation_launch(
     *, action_type: Literal["investigation", "sample_alert"]
 ) -> ExecutionPolicyResult:
@@ -277,6 +318,18 @@ def evaluate_investigation_launch(
         verdict="ask",
         action_type=action_type,
         reason="investigations call external tools and consume LLM quota",
+    )
+
+
+def plan_investigation_execution(
+    *, action_type: Literal["investigation", "sample_alert"]
+) -> ActionExecutionPlan:
+    policy = evaluate_investigation_launch(action_type=action_type)
+    return ActionExecutionPlan(
+        action_type=action_type,
+        classification="investigation_launch",
+        execution_mode=ActionExecutionMode.FOREGROUND,
+        policy=policy,
     )
 
 

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/__init__.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
-from .planner import plan_actions_with_llm
+from .planner import LlmActionPlanResult, plan_actions_with_llm, plan_actions_with_llm_result
 from .postprocessing import (
+    PlannerPolicyResult,
+    PlannerPostprocessPolicyTag,
     _fail_closed_vague_local_model,
     _finalize_planner_result,
     _reconcile_compound_actions,
+    finalize_planner_result_with_trace,
 )
 
 __all__ = [
+    "PlannerPolicyResult",
+    "PlannerPostprocessPolicyTag",
+    "LlmActionPlanResult",
     "_fail_closed_vague_local_model",
     "_finalize_planner_result",
     "_reconcile_compound_actions",
+    "finalize_planner_result_with_trace",
     "plan_actions_with_llm",
+    "plan_actions_with_llm_result",
 ]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/planner.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/planner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
@@ -10,20 +11,37 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.i
 
 from .llm_client import _call_llm
 from .parsing import _parse_tool_plan
-from .postprocessing import _fail_closed_vague_local_model, _finalize_planner_result
+from .postprocessing import (
+    _fail_closed_vague_local_model,
+    finalize_planner_result_with_trace,
+)
 from .prompting import _sanitise_text
 
 
-def plan_actions_with_llm(
+@dataclass(frozen=True)
+class LlmActionPlanResult:
+    """Structured result for one LLM planning pass with postprocess trace."""
+
+    actions: tuple[PlannedAction, ...]
+    has_unhandled_clause: bool
+    policy_trace: tuple[str, ...]
+
+
+def plan_actions_with_llm_result(
     message: str,
     *,
     session: Any | None = None,
-) -> tuple[list[PlannedAction], bool] | None:
-    """Plan actions from *message* using native tool-calling."""
+) -> LlmActionPlanResult | None:
+    """Plan actions and return typed policy trace metadata."""
     sanitised = _sanitise_text(message.strip())
     early = _fail_closed_vague_local_model(sanitised)
     if early is not None:
-        return early
+        actions, has_unhandled = early
+        return LlmActionPlanResult(
+            actions=tuple(actions),
+            has_unhandled_clause=has_unhandled,
+            policy_trace=("fail_closed_vague_local_model",),
+        )
 
     raw = _call_llm(sanitised, session)
     if raw is None:
@@ -33,4 +51,26 @@ def plan_actions_with_llm(
     if parsed is None:
         return None
     actions, has_unhandled = parsed
-    return _finalize_planner_result(sanitised, actions, has_unhandled, session=session)
+    finalized = finalize_planner_result_with_trace(
+        sanitised,
+        actions,
+        has_unhandled,
+        session=session,
+    )
+    return LlmActionPlanResult(
+        actions=tuple(finalized.actions),
+        has_unhandled_clause=finalized.has_unhandled,
+        policy_trace=tuple(tag.value for tag in finalized.applied_policies),
+    )
+
+
+def plan_actions_with_llm(
+    message: str,
+    *,
+    session: Any | None = None,
+) -> tuple[list[PlannedAction], bool] | None:
+    """Plan actions from *message* using native tool-calling."""
+    planned = plan_actions_with_llm_result(message, session=session)
+    if planned is None:
+        return None
+    return list(planned.actions), planned.has_unhandled_clause

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/postprocessing.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/llm_action_planner/postprocessing.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any
 
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.intent_parser import (
@@ -12,9 +12,14 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.i
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     PlannedAction,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
-    map_actions_with_unhandled,
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.policy_engine import (
+    TransformPhase,
+    apply_transform_phases,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
+    map_actions_result,
+)
+from app.cli.interactive_shell.routing.policy_tags import PlannerPostprocessPolicyTag
 
 from .constants import (
     _HTTP_INCIDENT_PASTE_RE,
@@ -22,6 +27,28 @@ from .constants import (
     _LOCAL_LLAMA_CONNECT_RE,
     is_rich_pasted_incident,
 )
+
+
+class PlannerPolicyResult:
+    """Finalized planner output with an explicit policy trace."""
+
+    __slots__ = ("actions", "has_unhandled", "applied_policies")
+
+    def __init__(
+        self,
+        actions: list[PlannedAction],
+        has_unhandled: bool,
+        applied_policies: tuple[PlannerPostprocessPolicyTag, ...],
+    ) -> None:
+        self.actions = actions
+        self.has_unhandled = has_unhandled
+        self.applied_policies = applied_policies
+
+
+@dataclass(frozen=True)
+class _PlannerPostprocessState:
+    actions: list[PlannedAction]
+    has_unhandled: bool
 
 
 def _as_llm_sourced(actions: list[PlannedAction]) -> list[PlannedAction]:
@@ -44,7 +71,9 @@ def _reconcile_compound_actions(
     if actions and all(action.kind == "assistant_handoff" for action in actions):
         return actions, has_unhandled
 
-    det_actions, det_unhandled = map_actions_with_unhandled(message)
+    det_result = map_actions_result(message)
+    det_actions = list(det_result.actions)
+    det_unhandled = det_result.has_unhandled_clause
     if not det_actions or len(det_actions) <= len(actions):
         return actions, has_unhandled
     return _as_llm_sourced(det_actions), det_unhandled
@@ -144,19 +173,76 @@ def _finalize_planner_result(
     *,
     session: Any | None = None,
 ) -> tuple[list[PlannedAction], bool]:
-    early = _fail_closed_vague_local_model(message)
-    if early is not None:
-        return early
-
-    actions, has_unhandled = _fail_closed_unconfigured_integration_detail(
+    result = finalize_planner_result_with_trace(
         message,
-        session,
         actions,
         has_unhandled,
+        session=session,
     )
-    if not actions and has_unhandled:
-        return actions, has_unhandled
+    return result.actions, result.has_unhandled
 
-    actions, has_unhandled = _reconcile_compound_actions(message, actions, has_unhandled)
-    actions, has_unhandled = _upgrade_handoff_to_incident(message, actions, has_unhandled)
-    return _coerce_incident_paste_handoff(message, actions, has_unhandled)
+
+def finalize_planner_result_with_trace(
+    message: str,
+    actions: list[PlannedAction],
+    has_unhandled: bool,
+    *,
+    session: Any | None = None,
+) -> PlannerPolicyResult:
+    early = _fail_closed_vague_local_model(message)
+    if early is not None:
+        early_actions, early_unhandled = early
+        return PlannerPolicyResult(
+            early_actions,
+            early_unhandled,
+            (PlannerPostprocessPolicyTag.FAIL_CLOSED_VAGUE_LOCAL_MODEL,),
+        )
+
+    initial = _PlannerPostprocessState(actions=actions, has_unhandled=has_unhandled)
+    phases: tuple[TransformPhase[_PlannerPostprocessState, PlannerPostprocessPolicyTag], ...] = (
+        TransformPhase(
+            PlannerPostprocessPolicyTag.FAIL_CLOSED_UNCONFIGURED_INTEGRATION_DETAIL,
+            lambda state: _PlannerPostprocessState(
+                *_fail_closed_unconfigured_integration_detail(
+                    message,
+                    session,
+                    state.actions,
+                    state.has_unhandled,
+                )
+            ),
+        ),
+        TransformPhase(
+            PlannerPostprocessPolicyTag.RECONCILE_COMPOUND_WITH_DETERMINISTIC,
+            lambda state: _PlannerPostprocessState(
+                *_reconcile_compound_actions(message, state.actions, state.has_unhandled)
+            ),
+        ),
+        TransformPhase(
+            PlannerPostprocessPolicyTag.UPGRADE_HANDOFF_TO_INCIDENT,
+            lambda state: _PlannerPostprocessState(
+                *_upgrade_handoff_to_incident(message, state.actions, state.has_unhandled)
+            ),
+        ),
+        TransformPhase(
+            PlannerPostprocessPolicyTag.COERCE_INCIDENT_PASTE_HANDOFF,
+            lambda state: _PlannerPostprocessState(
+                *_coerce_incident_paste_handoff(message, state.actions, state.has_unhandled)
+            ),
+        ),
+    )
+    final_state, applied = apply_transform_phases(
+        initial,
+        phases,
+        changed=lambda prev, nxt: (
+            (prev.actions, prev.has_unhandled) != (nxt.actions, nxt.has_unhandled)
+        ),
+        stop_when=lambda state: not state.actions and state.has_unhandled,
+    )
+    applied_list = list(applied)
+    if not final_state.actions and final_state.has_unhandled:
+        applied_list.append(PlannerPostprocessPolicyTag.FAIL_CLOSED_AFTER_POLICY)
+    return PlannerPolicyResult(
+        final_state.actions,
+        final_state.has_unhandled,
+        tuple(applied_list),
+    )

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/policy_engine.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/policy_engine.py
@@ -1,0 +1,64 @@
+"""Small reusable policy-phase execution helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MatchPhase[TContext, TResult, TTag]:
+    """Policy phase that maps context to a result and may or may not match."""
+
+    tag: TTag
+    run: Callable[[TContext], TResult]
+
+
+def run_first_match[TContext, TResult, TTag](
+    context: TContext,
+    phases: Iterable[MatchPhase[TContext, TResult, TTag]],
+    *,
+    is_match: Callable[[TResult], bool],
+) -> tuple[TResult, TTag] | tuple[None, None]:
+    """Run phases in order and return the first matching result and phase tag."""
+    for phase in phases:
+        result = phase.run(context)
+        if is_match(result):
+            return result, phase.tag
+    return None, None
+
+
+@dataclass(frozen=True)
+class TransformPhase[TState, TTag]:
+    """Policy transform phase that maps one state to another."""
+
+    tag: TTag
+    apply: Callable[[TState], TState]
+
+
+def apply_transform_phases[TState, TTag](
+    state: TState,
+    phases: Iterable[TransformPhase[TState, TTag]],
+    *,
+    changed: Callable[[TState, TState], bool],
+    stop_when: Callable[[TState], bool] | None = None,
+) -> tuple[TState, tuple[TTag, ...]]:
+    """Apply ordered transforms, collecting tags for phases that changed state."""
+    applied: list[TTag] = []
+    current = state
+    for phase in phases:
+        next_state = phase.apply(current)
+        if changed(current, next_state):
+            applied.append(phase.tag)
+        current = next_state
+        if stop_when is not None and stop_when(current):
+            break
+    return current, tuple(applied)
+
+
+__all__ = [
+    "MatchPhase",
+    "TransformPhase",
+    "apply_transform_phases",
+    "run_first_match",
+]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/__init__.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
-    map_actions,
+    DeterministicMapperPolicyTag,
+    DeterministicMappingResult,
+    map_actions_result,
     map_actions_with_unhandled,
     map_clause_actions,
     map_cli_actions,
@@ -11,7 +13,9 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.s
 )
 
 __all__ = [
-    "map_actions",
+    "DeterministicMapperPolicyTag",
+    "DeterministicMappingResult",
+    "map_actions_result",
     "map_actions_with_unhandled",
     "map_clause_actions",
     "map_cli_actions",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/deterministic_action_mapper.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/deterministic_action_mapper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 from app.cli.interactive_shell.routing.handle_message_with_agent.errors import (
     ParseError,
@@ -11,9 +12,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.errors import (
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.intent_parser import (
     ACTION_PATTERNS,
-    INTEGRATION_CAPABILITY_RE,
-    INTEGRATION_CONFIG_DETAIL_RE,
-    INTEGRATION_DETAIL_RE,
     SAMPLE_ALERT_RE,
     SYNTHETIC_RDS_TEST_RE,
     cli_command_action,
@@ -31,108 +29,70 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.i
     synthetic_test_action,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
+    ActionKind,
     PlannedAction,
     PromptClause,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.policy_engine import (
+    MatchPhase,
+    run_first_match,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.integration_detail_policy import (
+    map_integration_detail_actions,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.synthetic_resolution import (
+    resolve_synthetic_action_content,
+)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.synthetic_scenarios import (
-    DEFAULT_SYNTHETIC_SCENARIO,
     SYNTHETIC_UNKNOWN_PREFIX,
     list_rds_postgres_scenarios,
 )
+from app.cli.interactive_shell.routing.policy_tags import (
+    ClauseMappingPhaseTag,
+    DeterministicMapperPolicyTag,
+)
 from app.cli.support.exception_reporting import report_exception
 
-_SYNTHETIC_SCENARIO_ID_RE = re.compile(
-    r"\b(?P<scenario>\d{3}-[a-z0-9][a-z0-9-]*)\b",
-    re.IGNORECASE,
-)
-_SYNTHETIC_NUMERIC_HINT_RE = re.compile(r"\b(?P<num>\d{1,4})\b")
-_SYNTHETIC_ALL_RE = re.compile(
-    r"\b(?:all|entire)\b.{0,40}\b(?:synthetic|benchmark|tests?)\b"
-    r"|"
-    r"\b(?:synthetic|benchmark|tests?)\b.{0,40}\b(?:all|entire)\b"
-    r"|"
-    r"\bfull\s+(?:synthetic(?:\s+tests?)?|benchmark|suite)\b"
-    r"|"
-    r"\b(?:synthetic|benchmark|tests?)\b.{0,40}\bfull\s+suite\b",
-    re.IGNORECASE,
-)
+
+@dataclass(frozen=True)
+class DeterministicMappingResult:
+    """Structured deterministic mapping result with policy trace metadata."""
+
+    actions: tuple[PlannedAction, ...]
+    has_unhandled_clause: bool
+    applied_policies: tuple[DeterministicMapperPolicyTag, ...]
+    phase_trace: tuple[ClausePhaseTraceEntry, ...] = ()
 
 
-def _resolve_numeric_hint(text: str, scenarios: tuple[str, ...]) -> tuple[str, int] | None:
-    for match in _SYNTHETIC_NUMERIC_HINT_RE.finditer(text):
-        raw = match.group("num")
-        padded = raw.zfill(3) if len(raw) <= 3 else raw
-        matched = [name for name in scenarios if name.startswith(f"{padded}-")]
-        if matched:
-            return matched[0], match.start()
-    return None
+@dataclass(frozen=True)
+class ClausePhaseTraceEntry:
+    """Typed trace entry emitted by one matched clause-mapping phase."""
+
+    phase: ClauseMappingPhaseTag
+    emitted_kinds: tuple[ActionKind, ...]
+    clause_position: int
 
 
-def _detect_unresolved_numeric_hint(text: str, scenarios: tuple[str, ...]) -> str | None:
-    for match in _SYNTHETIC_NUMERIC_HINT_RE.finditer(text):
-        raw = match.group("num")
-        padded = raw.zfill(3) if len(raw) <= 3 else raw
-        if not any(name.startswith(f"{padded}-") for name in scenarios):
-            return raw
-    return None
-
-
-def _synthetic_action_content(clause: PromptClause, *, synthetic_start: int) -> tuple[str, int]:
-    if _SYNTHETIC_ALL_RE.search(clause.text) is not None:
-        return (
-            "rds_postgres:all",
-            clause.position + synthetic_start,
-        )
-
-    full_match = _SYNTHETIC_SCENARIO_ID_RE.search(clause.text)
-    if full_match is not None:
-        scenario_id = full_match.group("scenario").lower()
-        return (
-            f"rds_postgres:{scenario_id}",
-            clause.position + full_match.start("scenario"),
-        )
-
-    scenarios = list_rds_postgres_scenarios()
-    resolved = _resolve_numeric_hint(clause.text, scenarios)
-    if resolved is not None:
-        scenario_id, match_start = resolved
-        return (
-            f"rds_postgres:{scenario_id}",
-            clause.position + match_start,
-        )
-
-    unresolved_hint = _detect_unresolved_numeric_hint(clause.text, scenarios)
-    if unresolved_hint is not None:
-        return (
-            f"{SYNTHETIC_UNKNOWN_PREFIX}{unresolved_hint}",
-            clause.position + synthetic_start,
-        )
-
-    return (
-        f"rds_postgres:{DEFAULT_SYNTHETIC_SCENARIO}",
-        clause.position + synthetic_start,
+def _map_synthetic_clause(clause: PromptClause, _seen_slash: set[str]) -> list[PlannedAction]:
+    normalized_text = normalize_intent_text(clause.text)
+    synthetic_match = SYNTHETIC_RDS_TEST_RE.search(normalized_text)
+    if synthetic_match is None:
+        return []
+    normalized_clause = PromptClause(text=normalized_text, position=clause.position)
+    synthetic_content, synthetic_position = resolve_synthetic_action_content(
+        normalized_clause,
+        synthetic_start=synthetic_match.start(),
     )
+    return [synthetic_test_action(synthetic_content, synthetic_position)]
 
 
-def map_clause_actions(
+def _map_registry_actions(
     clause: PromptClause,
     *,
+    mentioned_services: list[str],
     seen_slash: set[str],
 ) -> list[PlannedAction]:
     mapped: list[PlannedAction] = []
-
-    normalized_text = normalize_intent_text(clause.text)
-    synthetic_match = SYNTHETIC_RDS_TEST_RE.search(normalized_text)
-    if synthetic_match is not None:
-        normalized_clause = PromptClause(text=normalized_text, position=clause.position)
-        synthetic_content, synthetic_position = _synthetic_action_content(
-            normalized_clause,
-            synthetic_start=synthetic_match.start(),
-        )
-        mapped.append(synthetic_test_action(synthetic_content, synthetic_position))
-        return mapped
-
-    mentioned_services = mentioned_integration_services(clause.text)
     matched_slash_registry = False
 
     for pattern, command in ACTION_PATTERNS:
@@ -157,71 +117,174 @@ def map_clause_actions(
         mapped.append(slash_action(command, clause.position + match.start()))
         seen_slash.add(command)
         matched_slash_registry = True
-
-    lower = clause.text.lower()
-    for service in mentioned_services:
-        match = re.search(rf"\b{re.escape(service.replace('_', ' '))}\b", lower)
-        position = clause.position + (match.start() if match else 0)
-        relative_position = position - clause.position
-        window_start = max(0, relative_position - 80)
-        window_end = min(len(clause.text), relative_position + 120)
-        window = clause.text[window_start:window_end]
-        detail_window = clause.text[
-            max(0, relative_position - 30) : min(len(clause.text), relative_position + 70)
-        ]
-
-        slash = f"/integrations show {service}"
-        wants_config_detail = INTEGRATION_CONFIG_DETAIL_RE.search(detail_window) is not None
-        capability_only = INTEGRATION_CAPABILITY_RE.search(window) is not None
-        if (
-            slash not in seen_slash
-            and INTEGRATION_DETAIL_RE.search(window)
-            and wants_config_detail
-            and not capability_only
-        ):
-            mapped.append(slash_action(slash, position))
-            seen_slash.add(slash)
-
-    if mapped:
-        return mapped
-
-    provider_switch_action = extract_llm_provider_switch(clause)
-    if provider_switch_action is not None:
-        mapped.append(provider_switch_action)
-        return mapped
-
-    sample_match = SAMPLE_ALERT_RE.search(clause.text)
-    if sample_match is not None:
-        mapped.append(sample_alert_action("generic", clause.position + sample_match.start()))
-        return mapped
-
-    investigation = extract_quoted_investigation_request(clause)
-    if investigation is not None:
-        mapped.append(investigation)
-        return mapped
-
-    implementation = extract_implementation_request(clause)
-    if implementation is not None:
-        mapped.append(implementation)
-        return mapped
-
-    task_cancel = extract_task_cancel_request(clause)
-    if task_cancel is not None:
-        mapped.append(task_cancel)
-        return mapped
-
-    mapped_shell = extract_shell_command(clause)
-    if mapped_shell is not None:
-        mapped.append(mapped_shell)
-
     return mapped
 
 
+def _map_fallback_actions(clause: PromptClause, _seen_slash: set[str]) -> list[PlannedAction]:
+    provider_switch_action = extract_llm_provider_switch(clause)
+    if provider_switch_action is not None:
+        return [provider_switch_action]
+
+    sample_match = SAMPLE_ALERT_RE.search(clause.text)
+    if sample_match is not None:
+        return [sample_alert_action("generic", clause.position + sample_match.start())]
+
+    investigation = extract_quoted_investigation_request(clause)
+    if investigation is not None:
+        return [investigation]
+
+    implementation = extract_implementation_request(clause)
+    if implementation is not None:
+        return [implementation]
+
+    task_cancel = extract_task_cancel_request(clause)
+    if task_cancel is not None:
+        return [task_cancel]
+
+    mapped_shell = extract_shell_command(clause)
+    return [mapped_shell] if mapped_shell is not None else []
+
+
+def _map_registry_and_integration_detail(
+    clause: PromptClause,
+    seen_slash: set[str],
+) -> list[PlannedAction]:
+    services = mentioned_integration_services(clause.text)
+    registry_mapped = _map_registry_actions(
+        clause,
+        mentioned_services=services,
+        seen_slash=seen_slash,
+    )
+    detail_mapped = map_integration_detail_actions(
+        clause,
+        mentioned_services=services,
+        seen_slash=seen_slash,
+    )
+    if registry_mapped or detail_mapped:
+        return [*registry_mapped, *detail_mapped]
+    return []
+
+
+_CLAUSE_MAPPING_PHASES: tuple[
+    MatchPhase[tuple[PromptClause, set[str]], list[PlannedAction], ClauseMappingPhaseTag], ...
+] = (
+    MatchPhase(ClauseMappingPhaseTag.SYNTHETIC, lambda ctx: _map_synthetic_clause(ctx[0], ctx[1])),
+    MatchPhase(
+        ClauseMappingPhaseTag.REGISTRY_AND_INTEGRATION_DETAIL,
+        lambda ctx: _map_registry_and_integration_detail(ctx[0], ctx[1]),
+    ),
+    MatchPhase(
+        ClauseMappingPhaseTag.FALLBACK_EXTRACTORS,
+        lambda ctx: _map_fallback_actions(ctx[0], ctx[1]),
+    ),
+)
+
+
+def map_clause_actions(
+    clause: PromptClause,
+    *,
+    seen_slash: set[str],
+) -> list[PlannedAction]:
+    mapped, _phase_name = _map_clause_actions_with_phase_internal(
+        clause,
+        seen_slash=seen_slash,
+    )
+    return mapped
+
+
+def map_clause_actions_with_phase(
+    clause: PromptClause,
+    *,
+    seen_slash: set[str],
+) -> tuple[list[PlannedAction], ClauseMappingPhaseTag | None]:
+    # Preserve map_clause_actions as a monkeypatch seam used by degrade-path tests.
+    # If callers patch map_clause_actions to raise, this wrapper should raise too.
+    original_seen_slash = set(seen_slash)
+    mapped = map_clause_actions(clause, seen_slash=seen_slash)
+    if not mapped:
+        return [], None
+
+    replay_mapped, replay_phase = _map_clause_actions_with_phase_internal(
+        clause,
+        seen_slash=original_seen_slash,
+    )
+    if replay_mapped == mapped:
+        return mapped, replay_phase
+    return mapped, None
+
+
+def _map_clause_actions_with_phase_internal(
+    clause: PromptClause,
+    *,
+    seen_slash: set[str],
+) -> tuple[list[PlannedAction], ClauseMappingPhaseTag | None]:
+    mapped, phase = run_first_match(
+        (clause, seen_slash),
+        _CLAUSE_MAPPING_PHASES,
+        is_match=lambda actions: bool(actions),
+    )
+    if mapped is None:
+        return [], None
+    return mapped, phase
+
+
+_INVESTIGATION_ONLY_UNHANDLED_ALLOW_RE = re.compile(
+    r'^\s*send\s+it\s+(?:"|\'|`)',
+    re.IGNORECASE,
+)
+
+
+def _clause_is_investigation_only_follow_up(clause: PromptClause) -> bool:
+    text = clause.text.lower()
+    return (
+        "investigation" in text
+        or _INVESTIGATION_ONLY_UNHANDLED_ALLOW_RE.match(clause.text) is not None
+    )
+
+
+def _apply_text_level_investigation_policy(
+    message: str,
+    mapped: list[PlannedAction],
+    applied_policies: list[DeterministicMapperPolicyTag],
+) -> bool:
+    has_investigation = any(action.kind == "investigation" for action in mapped)
+    if has_investigation:
+        return True
+    text_level_investigation = extract_quoted_investigation_request_text(message)
+    if text_level_investigation is None:
+        return False
+    mapped.append(text_level_investigation)
+    applied_policies.append(DeterministicMapperPolicyTag.TEXT_LEVEL_INVESTIGATION_ADDED)
+    return True
+
+
+def _apply_investigation_only_unhandled_waiver_policy(
+    *,
+    has_unhandled_clause: bool,
+    has_investigation: bool,
+    unmatched_clauses: list[PromptClause],
+    applied_policies: list[DeterministicMapperPolicyTag],
+) -> bool:
+    if not has_unhandled_clause or not has_investigation:
+        return has_unhandled_clause
+    if all(_clause_is_investigation_only_follow_up(clause) for clause in unmatched_clauses):
+        applied_policies.append(DeterministicMapperPolicyTag.INVESTIGATION_ONLY_UNHANDLED_WAIVED)
+        return False
+    return has_unhandled_clause
+
+
 def map_actions_with_unhandled(message: str) -> tuple[list[PlannedAction], bool]:
+    result = map_actions_result(message)
+    return list(result.actions), result.has_unhandled_clause
+
+
+def map_actions_result(message: str) -> DeterministicMappingResult:
     mapped: list[PlannedAction] = []
     seen_slash: set[str] = set()
     has_unhandled_clause = False
     unmatched_clauses: list[PromptClause] = []
+    applied_policies: list[DeterministicMapperPolicyTag] = []
+    phase_trace: list[ClausePhaseTraceEntry] = []
 
     try:
         clauses = split_prompt_clauses(message)
@@ -235,13 +298,23 @@ def map_actions_with_unhandled(message: str) -> tuple[list[PlannedAction], bool]
 
     try:
         for clause in clauses:
-            clause_actions = map_clause_actions(
+            clause_actions, phase_name = map_clause_actions_with_phase(
                 clause,
                 seen_slash=seen_slash,
             )
+            if phase_name is not None:
+                phase_trace.append(
+                    ClausePhaseTraceEntry(
+                        phase=phase_name,
+                        emitted_kinds=tuple(action.kind for action in clause_actions),
+                        clause_position=clause.position,
+                    )
+                )
             if not clause_actions:
                 has_unhandled_clause = True
                 unmatched_clauses.append(clause)
+                if DeterministicMapperPolicyTag.UNHANDLED_CLAUSE_DETECTED not in applied_policies:
+                    applied_policies.append(DeterministicMapperPolicyTag.UNHANDLED_CLAUSE_DETECTED)
             mapped.extend(clause_actions)
     except Exception as exc:
         report_exception(
@@ -252,25 +325,22 @@ def map_actions_with_unhandled(message: str) -> tuple[list[PlannedAction], bool]
         raise PolicyError("Failed to apply routing policy to one or more prompt clauses.") from exc
 
     try:
-        has_investigation = any(action.kind == "investigation" for action in mapped)
-        if not has_investigation:
-            text_level_investigation = extract_quoted_investigation_request_text(message)
-            if text_level_investigation is not None:
-                mapped.append(text_level_investigation)
-                has_investigation = True
+        has_investigation = _apply_text_level_investigation_policy(
+            message, mapped, applied_policies
+        )
+        has_unhandled_clause = _apply_investigation_only_unhandled_waiver_policy(
+            has_unhandled_clause=has_unhandled_clause,
+            has_investigation=has_investigation,
+            unmatched_clauses=unmatched_clauses,
+            applied_policies=applied_policies,
+        )
 
-        if (
-            has_unhandled_clause
-            and has_investigation
-            and all(
-                "investigation" in clause.text.lower()
-                or re.match(r'^\s*send\s+it\s+(?:"|\')', clause.text, re.IGNORECASE) is not None
-                for clause in unmatched_clauses
-            )
-        ):
-            has_unhandled_clause = False
-
-        return sorted(mapped, key=lambda action: action.position), has_unhandled_clause
+        return DeterministicMappingResult(
+            actions=tuple(sorted(mapped, key=lambda action: action.position)),
+            has_unhandled_clause=has_unhandled_clause,
+            applied_policies=tuple(applied_policies),
+            phase_trace=tuple(phase_trace),
+        )
     except Exception as exc:
         report_exception(
             exc,
@@ -283,27 +353,27 @@ def map_actions_with_unhandled(message: str) -> tuple[list[PlannedAction], bool]
         raise PlannerUnavailable("Routing planner became unavailable during finalization.") from exc
 
 
-def map_actions(message: str) -> list[PlannedAction]:
-    actions, _has_unhandled_clause = map_actions_with_unhandled(message)
-    return actions
-
-
 def map_cli_actions(message: str) -> list[str]:
     """Return safe read-only slash commands and CLI commands requested by a natural-language turn."""
-    return [
-        action.content for action in map_actions(message) if action.kind in ("slash", "cli_command")
-    ]
+    actions = map_actions_result(message).actions
+    return [action.content for action in actions if action.kind in ("slash", "cli_command")]
 
 
 def map_terminal_tasks(message: str) -> list[str]:
     """Return a test-friendly view of all deterministic terminal tasks."""
-    return [action.kind for action in map_actions(message)]
+    return [action.kind for action in map_actions_result(message).actions]
 
 
 __all__ = [
-    "map_actions",
+    "DeterministicMapperPolicyTag",
+    "ClausePhaseTraceEntry",
+    "DeterministicMappingResult",
+    "map_actions_result",
     "map_actions_with_unhandled",
     "map_clause_actions",
+    "map_clause_actions_with_phase",
     "map_cli_actions",
     "map_terminal_tasks",
+    "SYNTHETIC_UNKNOWN_PREFIX",
+    "list_rds_postgres_scenarios",
 ]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/integration_detail_policy.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/integration_detail_policy.py
@@ -1,0 +1,105 @@
+"""Declarative integration-detail mapping policy for deterministic routing."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.intent_parser import (
+    INTEGRATION_CAPABILITY_RE,
+    INTEGRATION_CONFIG_DETAIL_RE,
+    INTEGRATION_DETAIL_RE,
+    slash_action,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
+    PlannedAction,
+    PromptClause,
+)
+
+
+@dataclass(frozen=True)
+class IntegrationDetailPolicy:
+    """Configures context windows and regex gates for integration detail routing."""
+
+    name: str
+    detail_context_before: int
+    detail_context_after: int
+    config_context_before: int
+    config_context_after: int
+    detail_pattern: re.Pattern[str]
+    config_detail_pattern: re.Pattern[str]
+    capability_pattern: re.Pattern[str]
+
+
+DEFAULT_INTEGRATION_DETAIL_POLICIES: tuple[IntegrationDetailPolicy, ...] = (
+    IntegrationDetailPolicy(
+        name="service_detail_with_config_intent",
+        detail_context_before=80,
+        detail_context_after=120,
+        config_context_before=30,
+        config_context_after=70,
+        detail_pattern=INTEGRATION_DETAIL_RE,
+        config_detail_pattern=INTEGRATION_CONFIG_DETAIL_RE,
+        capability_pattern=INTEGRATION_CAPABILITY_RE,
+    ),
+)
+
+
+def _service_position(clause_text: str, service: str) -> int:
+    service_match = re.search(
+        rf"\b{re.escape(service.replace('_', ' '))}\b",
+        clause_text.lower(),
+    )
+    return service_match.start() if service_match else 0
+
+
+def _context_window(text: str, *, center: int, before: int, after: int) -> str:
+    start = max(0, center - before)
+    end = min(len(text), center + after)
+    return text[start:end]
+
+
+def map_integration_detail_actions(
+    clause: PromptClause,
+    *,
+    mentioned_services: list[str],
+    seen_slash: set[str],
+    policies: tuple[IntegrationDetailPolicy, ...] = DEFAULT_INTEGRATION_DETAIL_POLICIES,
+) -> list[PlannedAction]:
+    """Map integration-detail natural language to `/integrations show <service>` actions."""
+    mapped: list[PlannedAction] = []
+    for service in mentioned_services:
+        service_offset = _service_position(clause.text, service)
+        absolute_position = clause.position + service_offset
+        slash = f"/integrations show {service}"
+        if slash in seen_slash:
+            continue
+
+        for policy in policies:
+            detail_window = _context_window(
+                clause.text,
+                center=service_offset,
+                before=policy.detail_context_before,
+                after=policy.detail_context_after,
+            )
+            config_window = _context_window(
+                clause.text,
+                center=service_offset,
+                before=policy.config_context_before,
+                after=policy.config_context_after,
+            )
+            wants_detail = policy.detail_pattern.search(detail_window) is not None
+            wants_config = policy.config_detail_pattern.search(config_window) is not None
+            capability_only = policy.capability_pattern.search(detail_window) is not None
+            if wants_detail and wants_config and not capability_only:
+                mapped.append(slash_action(slash, absolute_position))
+                seen_slash.add(slash)
+                break
+    return mapped
+
+
+__all__ = [
+    "DEFAULT_INTEGRATION_DETAIL_POLICIES",
+    "IntegrationDetailPolicy",
+    "map_integration_detail_actions",
+]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/synthetic_resolution.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/synthetic_resolution.py
@@ -1,0 +1,92 @@
+"""Synthetic scenario resolution for deterministic action mapping."""
+
+from __future__ import annotations
+
+import re
+
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
+    PromptClause,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.synthetic_scenarios import (
+    DEFAULT_SYNTHETIC_SCENARIO,
+    SYNTHETIC_UNKNOWN_PREFIX,
+    list_rds_postgres_scenarios,
+)
+
+_SYNTHETIC_SCENARIO_ID_RE = re.compile(
+    r"\b(?P<scenario>\d{3}-[a-z0-9][a-z0-9-]*)\b",
+    re.IGNORECASE,
+)
+_SYNTHETIC_NUMERIC_HINT_RE = re.compile(r"\b(?P<num>\d{1,4})\b")
+_SYNTHETIC_ALL_RE = re.compile(
+    r"\b(?:all|entire)\b.{0,40}\b(?:synthetic|benchmark|tests?)\b"
+    r"|"
+    r"\b(?:synthetic|benchmark|tests?)\b.{0,40}\b(?:all|entire)\b"
+    r"|"
+    r"\bfull\s+(?:synthetic(?:\s+tests?)?|benchmark|suite)\b"
+    r"|"
+    r"\b(?:synthetic|benchmark|tests?)\b.{0,40}\bfull\s+suite\b",
+    re.IGNORECASE,
+)
+
+
+def _resolve_numeric_hint(text: str, scenarios: tuple[str, ...]) -> tuple[str, int] | None:
+    for match in _SYNTHETIC_NUMERIC_HINT_RE.finditer(text):
+        raw = match.group("num")
+        padded = raw.zfill(3) if len(raw) <= 3 else raw
+        matched = [name for name in scenarios if name.startswith(f"{padded}-")]
+        if matched:
+            return matched[0], match.start()
+    return None
+
+
+def _detect_unresolved_numeric_hint(text: str, scenarios: tuple[str, ...]) -> str | None:
+    for match in _SYNTHETIC_NUMERIC_HINT_RE.finditer(text):
+        raw = match.group("num")
+        padded = raw.zfill(3) if len(raw) <= 3 else raw
+        if not any(name.startswith(f"{padded}-") for name in scenarios):
+            return raw
+    return None
+
+
+def resolve_synthetic_action_content(
+    clause: PromptClause, *, synthetic_start: int
+) -> tuple[str, int]:
+    """Resolve scenario content and action position for a synthetic-test clause."""
+    if _SYNTHETIC_ALL_RE.search(clause.text) is not None:
+        return (
+            "rds_postgres:all",
+            clause.position + synthetic_start,
+        )
+
+    full_match = _SYNTHETIC_SCENARIO_ID_RE.search(clause.text)
+    if full_match is not None:
+        scenario_id = full_match.group("scenario").lower()
+        return (
+            f"rds_postgres:{scenario_id}",
+            clause.position + full_match.start("scenario"),
+        )
+
+    scenarios = list_rds_postgres_scenarios()
+    resolved = _resolve_numeric_hint(clause.text, scenarios)
+    if resolved is not None:
+        scenario_id, match_start = resolved
+        return (
+            f"rds_postgres:{scenario_id}",
+            clause.position + match_start,
+        )
+
+    unresolved_hint = _detect_unresolved_numeric_hint(clause.text, scenarios)
+    if unresolved_hint is not None:
+        return (
+            f"{SYNTHETIC_UNKNOWN_PREFIX}{unresolved_hint}",
+            clause.position + synthetic_start,
+        )
+
+    return (
+        f"rds_postgres:{DEFAULT_SYNTHETIC_SCENARIO}",
+        clause.position + synthetic_start,
+    )
+
+
+__all__ = ["resolve_synthetic_action_content"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import functools
-import importlib
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -145,15 +144,25 @@ ACTION_KIND_TO_TOOL: dict[ActionKind, str] = {
 
 REGISTRY = ActionToolRegistry()
 
-_ACTION_TOOLS_MODULE = (
-    "app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools"
-)
-
 
 @functools.cache
+def register_action_tools() -> tuple[str, ...]:
+    """Explicitly register all action tools from the composition root."""
+    from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools.catalog import (
+        ACTION_TOOL_CATALOG,
+    )
+
+    for entry in ACTION_TOOL_CATALOG:
+        if not isinstance(entry, ToolEntry):
+            msg = f"action tool entry must be ToolEntry, got {type(entry)!r}"
+            raise TypeError(msg)
+        REGISTRY.register(entry)
+    return REGISTRY.names()
+
+
+register_action_tools()
+
+
 def ensure_action_tools_loaded() -> None:
-    """Import tool modules so ``REGISTRY`` side-effect registrations run."""
-    importlib.import_module(_ACTION_TOOLS_MODULE)
-
-
-ensure_action_tools_loaded()
+    """Backward-compatible no-op alias for callers/tests expecting this hook."""
+    register_action_tools()

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+    ToolEntry,
+)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools import (
     assistant_handoff_tool,
     cli_command_tool,
@@ -15,8 +18,19 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.t
     synthetic_tool,
     task_cancel_tool,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools.catalog import (
+    ACTION_TOOL_CATALOG,
+)
+
+
+def action_tool_entries() -> tuple[ToolEntry, ...]:
+    """Return all tool entries in one explicit, deterministic order."""
+    return ACTION_TOOL_CATALOG
+
 
 __all__ = [
+    "ACTION_TOOL_CATALOG",
+    "action_tool_entries",
     "assistant_handoff_tool",
     "cli_command_tool",
     "implementation_tool",

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/assistant_handoff_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/assistant_handoff_tool.py
@@ -8,7 +8,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -24,23 +23,24 @@ def execute_assistant_handoff_action(args: dict[str, Any], ctx: ToolContext) -> 
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="assistant_handoff",
-        description="Mark a request as non-executable and hand off to assistant response generation.",
-        input_schema=object_schema(
-            properties={
-                "content": string_property(
-                    description=(
-                        "Concise assistant handoff text for informational, ambiguous, "
-                        "or non-executable requests."
-                    ),
-                    min_length=1,
-                )
-            },
-            required=("content",),
-        ),
-        execution_tier=ExecutionTier.SAFE,
-        execute=execute_assistant_handoff_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="assistant_handoff",
+    description="Mark a request as non-executable and hand off to assistant response generation.",
+    input_schema=object_schema(
+        properties={
+            "content": string_property(
+                description=(
+                    "Concise assistant handoff text for informational, ambiguous, "
+                    "or non-executable requests."
+                ),
+                min_length=1,
+            )
+        },
+        required=("content",),
+    ),
+    execution_tier=ExecutionTier.SAFE,
+    execute=execute_assistant_handoff_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_assistant_handoff_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/catalog.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/catalog.py
@@ -1,0 +1,39 @@
+"""Central tool catalog for interactive-shell action execution."""
+
+from __future__ import annotations
+
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+    ToolEntry,
+)
+
+from . import (
+    assistant_handoff_tool,
+    cli_command_tool,
+    implementation_tool,
+    investigation_tool,
+    llm_provider_tool,
+    mark_unhandled_tool,
+    sample_alert_tool,
+    shell_tool,
+    slash_tool,
+    synthetic_tool,
+    task_cancel_tool,
+)
+
+# One explicit composition root for tool ordering and availability.
+ACTION_TOOL_CATALOG: tuple[ToolEntry, ...] = (
+    slash_tool.TOOL_ENTRY,
+    shell_tool.TOOL_ENTRY,
+    investigation_tool.TOOL_ENTRY,
+    sample_alert_tool.TOOL_ENTRY,
+    synthetic_tool.TOOL_ENTRY,
+    task_cancel_tool.TOOL_ENTRY,
+    cli_command_tool.TOOL_ENTRY,
+    implementation_tool.TOOL_ENTRY,
+    llm_provider_tool.TOOL_ENTRY,
+    assistant_handoff_tool.TOOL_ENTRY,
+    mark_unhandled_tool.TOOL_ENTRY,
+)
+
+
+__all__ = ["ACTION_TOOL_CATALOG"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/cli_command_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/cli_command_tool.py
@@ -11,7 +11,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     capability_not_explicitly_disabled,
@@ -34,29 +33,30 @@ def execute_cli_command_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="cli_exec",
-        description=(
-            "Run an `opensre` CLI subcommand payload (without the leading `opensre ` prefix). "
-            "Prefer allowed operational families such as health/status/list/show/integrations/"
-            "synthetic checks; avoid unrelated or dangerous payloads."
-        ),
-        input_schema=object_schema(
-            properties={
-                "payload": string_property(
-                    description=(
-                        "CLI payload passed to `opensre` without the leading command prefix "
-                        "(for example: `integrations list`, `health`, `synthetic run ...`). "
-                        "Must not start with `opensre `."
-                    ),
-                    min_length=1,
-                )
-            },
-            required=("payload",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_cli_command_action,
-        is_available=lambda session: capability_not_explicitly_disabled(session, "cli_commands"),
-    )
+TOOL_ENTRY = ToolEntry(
+    name="cli_exec",
+    description=(
+        "Run an `opensre` CLI subcommand payload (without the leading `opensre ` prefix). "
+        "Prefer allowed operational families such as health/status/list/show/integrations/"
+        "synthetic checks; avoid unrelated or dangerous payloads."
+    ),
+    input_schema=object_schema(
+        properties={
+            "payload": string_property(
+                description=(
+                    "CLI payload passed to `opensre` without the leading command prefix "
+                    "(for example: `integrations list`, `health`, `synthetic run ...`). "
+                    "Must not start with `opensre `."
+                ),
+                min_length=1,
+            )
+        },
+        required=("payload",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_cli_command_action,
+    is_available=lambda session: capability_not_explicitly_disabled(session, "cli_commands"),
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_cli_command_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/implementation_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/implementation_tool.py
@@ -11,7 +11,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -34,20 +33,21 @@ def execute_implementation_action(args: dict[str, Any], ctx: ToolContext) -> boo
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="code_implement",
-        description="Run code implementation workflow using Claude Code.",
-        input_schema=object_schema(
-            properties={
-                "task": string_property(
-                    description="Implementation task to execute in the codebase.",
-                    min_length=1,
-                )
-            },
-            required=("task",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_implementation_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="code_implement",
+    description="Run code implementation workflow using Claude Code.",
+    input_schema=object_schema(
+        properties={
+            "task": string_property(
+                description="Implementation task to execute in the codebase.",
+                min_length=1,
+            )
+        },
+        required=("task",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_implementation_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_implementation_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
@@ -11,7 +11,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -34,20 +33,21 @@ def execute_investigation_action(args: dict[str, Any], ctx: ToolContext) -> bool
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="investigation_start",
-        description="Start an investigation with the provided alert text.",
-        input_schema=object_schema(
-            properties={
-                "alert_text": string_property(
-                    description="Alert text or incident details to investigate.",
-                    min_length=1,
-                )
-            },
-            required=("alert_text",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_investigation_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="investigation_start",
+    description="Start an investigation with the provided alert text.",
+    input_schema=object_schema(
+        properties={
+            "alert_text": string_property(
+                description="Alert text or incident details to investigate.",
+                min_length=1,
+            )
+        },
+        required=("alert_text",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_investigation_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_investigation_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/llm_provider_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/llm_provider_tool.py
@@ -15,7 +15,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -74,15 +73,16 @@ def execute_llm_provider_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="llm_set_provider",
-        description="Switch the active LLM provider or reasoning model.",
-        input_schema=object_schema(
-            properties={"target": _target_property_schema()},
-            required=("target",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_llm_provider_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="llm_set_provider",
+    description="Switch the active LLM provider or reasoning model.",
+    input_schema=object_schema(
+        properties={"target": _target_property_schema()},
+        required=("target",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_llm_provider_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_llm_provider_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/mark_unhandled_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/mark_unhandled_tool.py
@@ -22,7 +22,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -36,33 +35,34 @@ def execute_mark_unhandled_action(args: dict[str, Any], ctx: ToolContext) -> boo
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="mark_unhandled",
-        description=(
-            "Signal that part of the user's request could not be mapped to an "
-            "executable tool. Call this in addition to any matched tool calls "
-            "whenever the prompt contains a clause (joined by 'and', 'then', "
-            "etc.) that is nonsensical, ambiguous, or outside OpenSRE's scope. "
-            'MUST be called for partial-handling requests like "show me '
-            'connected services and sing a song" — emitting the matched '
-            "slash_invoke alone is treated as a fully-handled request and "
-            "silently drops the unmatched clause."
-        ),
-        input_schema=object_schema(
-            properties={
-                "reason": string_property(
-                    description=(
-                        "Brief description of which portion of the request "
-                        "was not mapped and why (e.g. \"'sing a song' is not "
-                        'an executable OpenSRE operation").'
-                    ),
-                    min_length=1,
-                )
-            },
-            required=("reason",),
-        ),
-        execution_tier=ExecutionTier.SAFE,
-        execute=execute_mark_unhandled_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="mark_unhandled",
+    description=(
+        "Signal that part of the user's request could not be mapped to an "
+        "executable tool. Call this in addition to any matched tool calls "
+        "whenever the prompt contains a clause (joined by 'and', 'then', "
+        "etc.) that is nonsensical, ambiguous, or outside OpenSRE's scope. "
+        'MUST be called for partial-handling requests like "show me '
+        'connected services and sing a song" — emitting the matched '
+        "slash_invoke alone is treated as a fully-handled request and "
+        "silently drops the unmatched clause."
+    ),
+    input_schema=object_schema(
+        properties={
+            "reason": string_property(
+                description=(
+                    "Brief description of which portion of the request "
+                    "was not mapped and why (e.g. \"'sing a song' is not "
+                    'an executable OpenSRE operation").'
+                ),
+                min_length=1,
+            )
+        },
+        required=("reason",),
+    ),
+    execution_tier=ExecutionTier.SAFE,
+    execute=execute_mark_unhandled_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_mark_unhandled_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/sample_alert_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/sample_alert_tool.py
@@ -11,7 +11,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -36,20 +35,21 @@ def execute_sample_alert_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="alert_sample",
-        description="Run a sample alert template.",
-        input_schema=object_schema(
-            properties={
-                "template": string_property(
-                    description="Sample alert template name to run.",
-                    enum=_SAMPLE_ALERT_TEMPLATES,
-                )
-            },
-            required=("template",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_sample_alert_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="alert_sample",
+    description="Run a sample alert template.",
+    input_schema=object_schema(
+        properties={
+            "template": string_property(
+                description="Sample alert template name to run.",
+                enum=_SAMPLE_ALERT_TEMPLATES,
+            )
+        },
+        required=("template",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_sample_alert_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_sample_alert_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/shell_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/shell_tool.py
@@ -11,7 +11,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -34,28 +33,29 @@ def execute_shell_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="shell_run",
-        description=(
-            "Run a narrowly scoped local diagnostic shell command. Use for read-only inspection "
-            "or controlled operational steps already requested by the user; avoid destructive, "
-            "credential-exfiltrating, or unrelated commands."
-        ),
-        input_schema=object_schema(
-            properties={
-                "command": string_property(
-                    description=(
-                        "Exact shell command to execute. Prefer safe diagnostics (for example: "
-                        "`ls`, `pwd`, `git status`, `uv run python -m pytest ...`). Do not use "
-                        "commands that wipe data or alter unrelated system state."
-                    ),
-                    min_length=1,
-                )
-            },
-            required=("command",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_shell_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="shell_run",
+    description=(
+        "Run a narrowly scoped local diagnostic shell command. Use for read-only inspection "
+        "or controlled operational steps already requested by the user; avoid destructive, "
+        "credential-exfiltrating, or unrelated commands."
+    ),
+    input_schema=object_schema(
+        properties={
+            "command": string_property(
+                description=(
+                    "Exact shell command to execute. Prefer safe diagnostics (for example: "
+                    "`ls`, `pwd`, `git status`, `uv run python -m pytest ...`). Do not use "
+                    "commands that wipe data or alter unrelated system state."
+                ),
+                min_length=1,
+            )
+        },
+        required=("command",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_shell_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_shell_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/slash_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/slash_tool.py
@@ -12,15 +12,13 @@ from app.cli.interactive_shell.command_registry.slash_catalog import (
 )
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
-    evaluate_slash_tier,
     execution_allowed,
-    resolve_slash_execution_tier,
+    plan_slash_execution,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     capability_not_explicitly_disabled,
@@ -59,10 +57,9 @@ def execute_slash_action(args: dict[str, Any], ctx: ToolContext) -> bool:
             )
         )
 
-    tier = resolve_slash_execution_tier(name, slash_args, cmd.execution_tier)
-    policy = evaluate_slash_tier(tier)
+    plan = plan_slash_execution(name, slash_args, cmd.execution_tier)
     if not execution_allowed(
-        policy,
+        plan.policy,
         session=ctx.session,
         console=ctx.console,
         action_summary=stripped,
@@ -86,13 +83,14 @@ def execute_slash_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     )
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="slash_invoke",
-        description=slash_invoke_tool_description(),
-        input_schema=slash_invoke_input_schema(),
-        execution_tier=ExecutionTier.SAFE,
-        execute=execute_slash_action,
-        is_available=lambda session: capability_not_explicitly_disabled(session, "slash_commands"),
-    )
+TOOL_ENTRY = ToolEntry(
+    name="slash_invoke",
+    description=slash_invoke_tool_description(),
+    input_schema=slash_invoke_input_schema(),
+    execution_tier=ExecutionTier.SAFE,
+    execute=execute_slash_action,
+    is_available=lambda session: capability_not_explicitly_disabled(session, "slash_commands"),
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_slash_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/synthetic_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/synthetic_tool.py
@@ -14,7 +14,6 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.s
     list_rds_postgres_scenarios,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     capability_not_explicitly_disabled,
@@ -39,27 +38,26 @@ def execute_synthetic_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="synthetic_run",
-        description="Run a synthetic scenario in a suite.",
-        input_schema=object_schema(
-            properties={
-                "suite": string_property(
-                    description="Synthetic suite name.",
-                    enum=("rds_postgres",),
-                ),
-                "scenario": string_property(
-                    description="Synthetic scenario id within the selected suite or `all`.",
-                    enum=("all", *list_rds_postgres_scenarios()),
-                ),
-            },
-            required=("suite", "scenario"),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_synthetic_action,
-        is_available=lambda session: capability_not_explicitly_disabled(
-            session, "synthetic_suites"
-        ),
-    )
+TOOL_ENTRY = ToolEntry(
+    name="synthetic_run",
+    description="Run a synthetic scenario in a suite.",
+    input_schema=object_schema(
+        properties={
+            "suite": string_property(
+                description="Synthetic suite name.",
+                enum=("rds_postgres",),
+            ),
+            "scenario": string_property(
+                description="Synthetic scenario id within the selected suite or `all`.",
+                enum=("all", *list_rds_postgres_scenarios()),
+            ),
+        },
+        required=("suite", "scenario"),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_synthetic_action,
+    is_available=lambda session: capability_not_explicitly_disabled(session, "synthetic_suites"),
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_synthetic_action"]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/task_cancel_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/task_cancel_tool.py
@@ -9,15 +9,13 @@ from rich.markup import escape
 
 from app.cli.interactive_shell.commands import SLASH_COMMANDS, dispatch_slash
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_policy import (
-    evaluate_slash_tier,
     execution_allowed,
-    resolve_slash_execution_tier,
+    plan_slash_execution,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
-    REGISTRY,
     ToolContext,
     ToolEntry,
     object_schema,
@@ -81,10 +79,9 @@ def execute_task_cancel_action(args: dict[str, Any], ctx: ToolContext) -> bool:
         return True
     command = f"/cancel {task_id}"
     cmd = SLASH_COMMANDS["/cancel"]
-    tier = resolve_slash_execution_tier("/cancel", [task_id], cmd.execution_tier)
-    policy = evaluate_slash_tier(tier)
+    plan = plan_slash_execution("/cancel", [task_id], cmd.execution_tier)
     if not execution_allowed(
-        policy,
+        plan.policy,
         session=ctx.session,
         console=ctx.console,
         action_summary=command,
@@ -106,27 +103,28 @@ def execute_task_cancel_action(args: dict[str, Any], ctx: ToolContext) -> bool:
     return True
 
 
-REGISTRY.register(
-    ToolEntry(
-        name="task_cancel",
-        description="Cancel a running task by id or kind.",
-        input_schema=object_schema(
-            properties={
-                "target": {
-                    "oneOf": [
-                        {"type": "string", "enum": ["synthetic_test", "task"]},
-                        {"type": "string", "pattern": "^[A-Za-z0-9_-]{3,}$"},
-                    ],
-                    "description": (
-                        "Task selector: `synthetic_test` to cancel the one running synthetic task, "
-                        "`task` to cancel a single running task of any kind, or a task id/prefix "
-                        "for `/cancel <id>` resolution."
-                    ),
-                }
-            },
-            required=("target",),
-        ),
-        execution_tier=ExecutionTier.ELEVATED,
-        execute=execute_task_cancel_action,
-    )
+TOOL_ENTRY = ToolEntry(
+    name="task_cancel",
+    description="Cancel a running task by id or kind.",
+    input_schema=object_schema(
+        properties={
+            "target": {
+                "oneOf": [
+                    {"type": "string", "enum": ["synthetic_test", "task"]},
+                    {"type": "string", "pattern": "^[A-Za-z0-9_-]{3,}$"},
+                ],
+                "description": (
+                    "Task selector: `synthetic_test` to cancel the one running synthetic task, "
+                    "`task` to cancel a single running task of any kind, or a task id/prefix "
+                    "for `/cancel <id>` resolution."
+                ),
+            }
+        },
+        required=("target",),
+    ),
+    execution_tier=ExecutionTier.ELEVATED,
+    execute=execute_task_cancel_action,
 )
+
+
+__all__ = ["TOOL_ENTRY", "execute_task_cancel_action"]

--- a/app/cli/interactive_shell/routing/policy_tags.py
+++ b/app/cli/interactive_shell/routing/policy_tags.py
@@ -1,0 +1,57 @@
+"""Shared policy/signal tags across routing command and agent paths."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import StrEnum
+
+
+class RouteSignal(StrEnum):
+    """Top-level routing matched-signal tags."""
+
+    SLASH_PREFIX = "slash_prefix"
+    BARE_COMMAND_ALIAS = "bare_command_alias"
+    OPENSRE_INVESTIGATE = "opensre_investigate"
+    CLI_AGENT_ACTION_PLAN = "cli_agent_action_plan"
+    CLI_AGENT_DEGRADED = "cli_agent_degraded"
+
+
+class DeterministicMapperPolicyTag(StrEnum):
+    """Policy tags emitted by deterministic clause mapping."""
+
+    UNHANDLED_CLAUSE_DETECTED = "unhandled_clause_detected"
+    TEXT_LEVEL_INVESTIGATION_ADDED = "text_level_investigation_added"
+    INVESTIGATION_ONLY_UNHANDLED_WAIVED = "investigation_only_unhandled_waived"
+
+
+class ClauseMappingPhaseTag(StrEnum):
+    """Ordered clause-mapping phases for deterministic routing."""
+
+    SYNTHETIC = "synthetic"
+    REGISTRY_AND_INTEGRATION_DETAIL = "registry_and_integration_detail"
+    FALLBACK_EXTRACTORS = "fallback_extractors"
+
+
+class PlannerPostprocessPolicyTag(StrEnum):
+    """Policy identifiers for planner postprocessing decisions."""
+
+    FAIL_CLOSED_VAGUE_LOCAL_MODEL = "fail_closed_vague_local_model"
+    FAIL_CLOSED_UNCONFIGURED_INTEGRATION_DETAIL = "fail_closed_unconfigured_integration_detail"
+    RECONCILE_COMPOUND_WITH_DETERMINISTIC = "reconcile_compound_with_deterministic"
+    UPGRADE_HANDOFF_TO_INCIDENT = "upgrade_handoff_to_incident"
+    COERCE_INCIDENT_PASTE_HANDOFF = "coerce_incident_paste_handoff"
+    FAIL_CLOSED_AFTER_POLICY = "fail_closed_after_policy"
+
+
+def encode_policy_trace(tags: Iterable[StrEnum | str]) -> str:
+    """Stable comma-delimited policy trace for analytics payloads."""
+    return ",".join(str(tag.value if isinstance(tag, StrEnum) else tag) for tag in tags)
+
+
+__all__ = [
+    "ClauseMappingPhaseTag",
+    "DeterministicMapperPolicyTag",
+    "PlannerPostprocessPolicyTag",
+    "RouteSignal",
+    "encode_policy_trace",
+]

--- a/app/cli/interactive_shell/routing/resolve_cli_command/evaluator.py
+++ b/app/cli/interactive_shell/routing/resolve_cli_command/evaluator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.cli.interactive_shell.routing.policy_tags import RouteSignal
 from app.cli.interactive_shell.routing.resolve_cli_command.matcher import (
     is_bare_command_alias,
     opensre_investigate_slash_text,
@@ -26,13 +27,13 @@ def _is_bare_command_alias_rule(text: str, _session: RoutingSession) -> bool:
 
 CLI_COMMAND_RULES: tuple[RouteRule, ...] = (
     RouteRule(
-        "slash_prefix",
+        RouteSignal.SLASH_PREFIX.value,
         RouteKind.SLASH,
         1.0,
         _is_slash_prefix,
     ),
     RouteRule(
-        "bare_command_alias",
+        RouteSignal.BARE_COMMAND_ALIAS.value,
         RouteKind.SLASH,
         0.98,
         _is_bare_command_alias_rule,
@@ -52,7 +53,7 @@ def resolve_cli_command(
         return RouteDecision(
             route_kind=RouteKind.SLASH,
             confidence=0.99,
-            matched_signals=("opensre_investigate",),
+            matched_signals=(RouteSignal.OPENSRE_INVESTIGATE.value,),
             command_text=investigate_slash,
         )
 

--- a/app/cli/interactive_shell/routing/tests/test_policy_traces.py
+++ b/app/cli/interactive_shell/routing/tests/test_policy_traces.py
@@ -1,0 +1,111 @@
+"""Policy-trace contracts for deterministic mapper and planner postprocessing."""
+
+from __future__ import annotations
+
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
+    PlannedAction,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.llm_action_planner import (
+    finalize_planner_result_with_trace,
+)
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.slash_commands.deterministic_action_mapper import (
+    map_actions_result,
+)
+from app.cli.interactive_shell.routing.policy_tags import (
+    DeterministicMapperPolicyTag,
+    PlannerPostprocessPolicyTag,
+)
+from app.cli.interactive_shell.runtime.session import ReplSession
+
+
+def test_mapper_result_emits_unhandled_clause_policy_tag() -> None:
+    result = map_actions_result("please do this thing for me")
+    assert result.has_unhandled_clause is True
+    assert DeterministicMapperPolicyTag.UNHANDLED_CLAUSE_DETECTED in result.applied_policies
+
+
+def test_mapper_result_waives_investigation_only_unhandled_clauses() -> None:
+    result = map_actions_result('investigate "checkout errors" and send it "last 15 minutes"')
+    assert result.has_unhandled_clause is False
+    assert (
+        DeterministicMapperPolicyTag.INVESTIGATION_ONLY_UNHANDLED_WAIVED in result.applied_policies
+    )
+
+
+def test_planner_policy_trace_marks_vague_local_model_fail_closed() -> None:
+    result = finalize_planner_result_with_trace(
+        "please connect to local llama",
+        [],
+        False,
+    )
+    assert result.actions == []
+    assert result.has_unhandled is True
+    assert result.applied_policies == (PlannerPostprocessPolicyTag.FAIL_CLOSED_VAGUE_LOCAL_MODEL,)
+
+
+def test_planner_policy_trace_marks_compound_reconciliation() -> None:
+    llm_actions = [
+        PlannedAction(
+            kind="slash",
+            content="/health",
+            position=0,
+            source="llm",
+            target_surface="slash",
+        )
+    ]
+    result = finalize_planner_result_with_trace(
+        "check opensre health and show connected services",
+        llm_actions,
+        False,
+    )
+    assert [action.content for action in result.actions] == ["/health", "/list integrations"]
+    assert (
+        PlannerPostprocessPolicyTag.RECONCILE_COMPOUND_WITH_DETERMINISTIC in result.applied_policies
+    )
+
+
+def test_planner_policy_trace_marks_unconfigured_integration_fail_closed() -> None:
+    session = ReplSession(
+        configured_integrations_known=True,
+        configured_integrations=(),
+    )
+    result = finalize_planner_result_with_trace(
+        "show datadog integration details",
+        [
+            PlannedAction(
+                kind="slash",
+                content="/integrations show datadog",
+                position=0,
+                source="llm",
+                target_surface="slash",
+            )
+        ],
+        False,
+        session=session,
+    )
+    assert len(result.actions) == 1
+    assert result.actions[0].kind == "assistant_handoff"
+    assert (
+        PlannerPostprocessPolicyTag.FAIL_CLOSED_UNCONFIGURED_INTEGRATION_DETAIL
+        in result.applied_policies
+    )
+
+
+def test_planner_policy_trace_marks_incident_paste_coercion() -> None:
+    message = "checkout API is returning HTTP 500 for 30% of requests in us-east-1"
+    result = finalize_planner_result_with_trace(
+        message,
+        [
+            PlannedAction(
+                kind="investigation",
+                content=message,
+                position=0,
+                source="llm",
+                target_surface="investigation",
+            )
+        ],
+        False,
+    )
+    assert len(result.actions) == 1
+    assert result.actions[0].kind == "assistant_handoff"
+    assert PlannerPostprocessPolicyTag.COERCE_INCIDENT_PASTE_HANDOFF in result.applied_policies

--- a/app/cli/interactive_shell/routing/tests/test_routing_metamorphic.py
+++ b/app/cli/interactive_shell/routing/tests/test_routing_metamorphic.py
@@ -1,0 +1,54 @@
+"""Metamorphic routing invariants for command and non-command paths."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.cli.interactive_shell.routing.policy_tags import RouteSignal
+from app.cli.interactive_shell.routing.router import RouteKind, route_input
+from app.cli.interactive_shell.runtime.session import ReplSession
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "help",
+        " HELP ",
+        "\thelp\t",
+    ],
+)
+def test_help_alias_whitespace_and_case_variants_route_to_slash_help(prompt: str) -> None:
+    decision = route_input(prompt, ReplSession())
+    assert decision.route_kind is RouteKind.SLASH
+    assert decision.command_text == "/help"
+    assert decision.matched_signals == (RouteSignal.BARE_COMMAND_ALIAS.value,)
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "opensre investigate -i alert.json",
+        "  OPENSRE investigate -i alert.json  ",
+        "\topensre   investigate   -i   alert.json\t",
+    ],
+)
+def test_opensre_investigate_variants_keep_deterministic_route(prompt: str) -> None:
+    decision = route_input(prompt, ReplSession())
+    assert decision.route_kind is RouteKind.SLASH
+    assert decision.command_text is not None
+    assert decision.command_text.startswith("/investigate")
+    assert decision.matched_signals == (RouteSignal.OPENSRE_INVESTIGATE.value,)
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "check opensre health and show connected services",
+        "CHECK OPENsRE HEALTH and SHOW connected SERVICES",
+        "  check opensre health and show connected services  ",
+    ],
+)
+def test_non_command_action_plan_variants_keep_cli_agent_signal(prompt: str) -> None:
+    decision = route_input(prompt, ReplSession())
+    assert decision.route_kind is RouteKind.CLI_AGENT
+    assert RouteSignal.CLI_AGENT_ACTION_PLAN.value in decision.matched_signals

--- a/app/hermes/errors.py
+++ b/app/hermes/errors.py
@@ -1,0 +1,23 @@
+"""Typed Hermes operational outcomes and exceptions.
+
+This module centralises stable enums used by Hermes internals so state
+transitions are explicit and less stringly-typed.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class InvestigationOutcome(StrEnum):
+    """Outcome states for Hermes investigation bridge execution."""
+
+    NOT_ATTEMPTED = "not_attempted"
+    SUCCESS = "success"
+    EMPTY = "empty"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    SINK_CLOSED = "sink_closed"
+
+
+__all__ = ["InvestigationOutcome"]

--- a/app/hermes/sinks.py
+++ b/app/hermes/sinks.py
@@ -53,6 +53,7 @@ from dataclasses import dataclass
 from typing import Final
 
 from app.hermes.agent import IncidentSink
+from app.hermes.errors import InvestigationOutcome
 from app.hermes.incident import HermesIncident, IncidentSeverity, LogRecord
 from app.watch_dog.alarms import AlarmDispatcher
 
@@ -366,44 +367,44 @@ class _InvestigationResult:
     operator-visible marker for each state easy to audit in tests.
     """
 
-    state: str  # not_attempted | success | empty | failed | timed_out | sink_closed
+    state: InvestigationOutcome
     summary: str | None = None
     timeout_s: float | None = None
 
     @classmethod
     def not_attempted(cls) -> _InvestigationResult:
-        return cls(state="not_attempted")
+        return cls(state=InvestigationOutcome.NOT_ATTEMPTED)
 
     @classmethod
     def success(cls, summary: str) -> _InvestigationResult:
-        return cls(state="success", summary=summary)
+        return cls(state=InvestigationOutcome.SUCCESS, summary=summary)
 
     @classmethod
     def empty(cls) -> _InvestigationResult:
-        return cls(state="empty")
+        return cls(state=InvestigationOutcome.EMPTY)
 
     @classmethod
     def failed(cls) -> _InvestigationResult:
-        return cls(state="failed")
+        return cls(state=InvestigationOutcome.FAILED)
 
     @classmethod
     def timed_out(cls, timeout_s: float) -> _InvestigationResult:
-        return cls(state="timed_out", timeout_s=timeout_s)
+        return cls(state=InvestigationOutcome.TIMED_OUT, timeout_s=timeout_s)
 
     @classmethod
     def sink_closed(cls) -> _InvestigationResult:
-        return cls(state="sink_closed")
+        return cls(state=InvestigationOutcome.SINK_CLOSED)
 
     def render(self, severity: IncidentSeverity) -> str:
-        if self.state == "sink_closed":
+        if self.state is InvestigationOutcome.SINK_CLOSED:
             return "investigation: skipped (Hermes sink closed — notification only)"
-        if self.state == "success" and self.summary is not None:
+        if self.state is InvestigationOutcome.SUCCESS and self.summary is not None:
             return "investigation summary:\n" + self.summary
-        if self.state == "empty":
+        if self.state is InvestigationOutcome.EMPTY:
             return "investigation: attempted (no summary produced)"
-        if self.state == "failed":
+        if self.state is InvestigationOutcome.FAILED:
             return "investigation: attempted (failed — see server logs)"
-        if self.state == "timed_out" and self.timeout_s is not None:
+        if self.state is InvestigationOutcome.TIMED_OUT and self.timeout_s is not None:
             return (
                 f"investigation: attempted (timed out after "
                 f"{self.timeout_s:.1f}s — see server logs)"

--- a/tests/cli/interactive_shell/orchestration/test_action_planner.py
+++ b/tests/cli/interactive_shell/orchestration/test_action_planner.py
@@ -161,6 +161,16 @@ def test_plan_task_cancel_before_shell_kill() -> None:
     assert action_planner_module.map_cli_actions(msg) == []
 
 
+def test_plan_integration_detail_request_maps_to_integrations_show() -> None:
+    msg = "show me what configured datadog integration connections I have"
+    assert action_planner_module.map_cli_actions(msg) == ["/integrations show datadog"]
+
+
+def test_plan_integration_capability_only_request_does_not_map_detail_command() -> None:
+    msg = "what can the datadog integration do for me?"
+    assert action_planner_module.map_cli_actions(msg) == []
+
+
 def test_stop_process_prompt_is_not_task_cancel() -> None:
     msg = "stop the process of auto-investigation and give me a manual runbook"
     actions, unhandled = action_planner_module.map_actions_with_unhandled(msg)

--- a/tests/hermes/test_rules.py
+++ b/tests/hermes/test_rules.py
@@ -34,6 +34,16 @@ def _rec(
     )
 
 
+def _message_variants(message: str) -> tuple[str, ...]:
+    """Benign transforms that should not change rule match outcomes."""
+    return (
+        message,
+        message.upper(),
+        f"[ingest] {message}",
+        f"{message} [trace_id=abc123]",
+    )
+
+
 @pytest.mark.parametrize(
     "rule_name,message",
     [
@@ -60,6 +70,29 @@ def test_default_pattern_rules_match_expected_messages(rule_name: str, message: 
     incident = rule.evaluate(record)
     assert incident is not None
     assert incident.rule == rule_name
+
+
+@pytest.mark.parametrize(
+    "rule_name,message",
+    [
+        ("oom_killed", "MemoryError: out of memory while allocating buffer"),
+        ("context_window_exceeded", "context_length_exceeded: 65798 tokens > 32768"),
+        ("auth_failure", "401 Unauthorized: invalid api_key"),
+        ("rate_limit", "429 Too Many Requests"),
+        ("database_wal_growth", "WAL backlog growing: 1284 MB"),
+        ("deadlock", "deadlock detected, transaction rolled back"),
+        ("disk_full", "no space left on device"),
+    ],
+)
+def test_default_pattern_rules_match_metamorphic_message_variants(
+    rule_name: str, message: str
+) -> None:
+    rules = {r.name: r for r in default_pattern_rules()}
+    rule = rules[rule_name]
+    for variant in _message_variants(message):
+        incident = rule.evaluate(_rec(variant))
+        assert incident is not None, f"rule={rule_name} failed for variant={variant!r}"
+        assert incident.rule == rule_name
 
 
 def test_pattern_rules_respect_min_level() -> None:

--- a/tests/hermes/test_sinks.py
+++ b/tests/hermes/test_sinks.py
@@ -403,7 +403,7 @@ class TestDispatcherIntegration:
 
         # Calling the pooled bridge path directly must return sink_closed, not raise.
         result = sink._run_bridge_in_pool(_bridge, _incident(severity=IncidentSeverity.HIGH))  # type: ignore[attr-defined]
-        assert "sink_closed" in result.state
+        assert result.state.value == "sink_closed"
 
     def test_submit_runtime_error_still_dispatches_telegram(
         self, monkeypatch: pytest.MonkeyPatch
@@ -470,7 +470,7 @@ class TestDispatcherIntegration:
         result = sink._run_bridge_in_pool(  # type: ignore[attr-defined]
             _bridge, _incident(severity=IncidentSeverity.HIGH)
         )
-        assert result.state == "sink_closed", (
-            f"CancelledError should yield sink_closed, got: {result.state}"
+        assert result.state.value == "sink_closed", (
+            f"CancelledError should yield sink_closed, got: {result.state.value}"
         )
         sink.close()


### PR DESCRIPTION
## Summary
- make routing policy phases explicit with reusable policy engine primitives for first-match and transform passes
- harden deterministic mapping/planner postprocessing with typed policy traces and clearer finalization semantics
- centralize action tool registration into an explicit catalog/composition root instead of import side-effects
- unify action execution policy planning across shell/slash/investigation/opensre execution paths
- add policy-trace and metamorphic routing tests, plus supporting Hermes typed outcome enum updates

## Validation
- make lint
- make format-check
- make typecheck
- uv run pytest tests/cli/interactive_shell/orchestration/test_action_planner.py tests/cli/interactive_shell/orchestration/test_agent_actions.py tests/cli/interactive_shell/orchestration/test_action_executor.py app/cli/interactive_shell/routing/tests/test_tool_registry.py app/cli/interactive_shell/routing/tests/test_policy_traces.py app/cli/interactive_shell/routing/tests/test_routing_metamorphic.py
- uv run pytest app/cli/interactive_shell/routing/tests/test_routing_scenarios.py -k deterministic_routing
- make test-cov (local failure: tests/cli_smoke_test.py::test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated[codex-7-OpenAI Codex CLI-60.0], environment-auth dependent)
