### PR TITLE
CI: speed up main-branch test workflows and remove duplicate release verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
 
   test:
     name: test (${{ matrix.shard }})
-    needs: [quality]
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -214,7 +213,8 @@ jobs:
       - name: Upload shard coverage data
         if: >-
           always() &&
-          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ matrix.shard }}
@@ -229,7 +229,8 @@ jobs:
     needs: [test]
     if: >-
       always() &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
     timeout-minutes: 15
 
     steps:
@@ -274,7 +275,6 @@ jobs:
 
   test-kubernetes:
     runs-on: ubuntu-latest
-    needs: [quality]
     continue-on-error: true
     timeout-minutes: 15
 
@@ -314,10 +314,38 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: uv run python -m tests.e2e.kubernetes.test_local
 
+  should-run-thorough:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      thorough: ${{ steps.filter.outputs.thorough }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            thorough:
+              - ".github/workflows/ci.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "app/deployment/**"
+              - "app/integrations/**"
+              - "app/pipeline/**"
+              - "app/remote/**"
+              - "app/services/**"
+              - "app/tools/**"
+              - "tests/e2e/cloudwatch_demo/**"
+              - "tests/e2e/upstream_lambda/**"
+              - "tests/e2e/upstream_prefect_ecs_fargate/**"
+              - "tests/e2e/upstream_apache_flink_ecs/**"
+
   test-thorough:
     runs-on: ubuntu-latest
-    needs: [test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, should-run-thorough]
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.should-run-thorough.outputs.thorough == 'true'
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/e2e-openclaw.yml
+++ b/.github/workflows/e2e-openclaw.yml
@@ -82,6 +82,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-openclaw-npm-${{ hashFiles('.nvmrc') }}
+          restore-keys: |
+            ${{ runner.os }}-openclaw-npm-
+
       - name: Install OpenClaw CLI
         # ``continue-on-error: true`` so an npm-registry hiccup, a package-name
         # rename on OpenClaw's side, or a network blip does not kill the whole
@@ -90,7 +98,7 @@ jobs:
         # explanation rather than crashing.
         continue-on-error: true
         id: install_openclaw
-        run: npm install -g openclaw
+        run: npm install -g openclaw --prefer-offline --no-audit
 
       - name: Probe OpenClaw availability
         # Whether or not ``npm install`` succeeded, check if ``openclaw`` is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     needs: prepare
+    if: github.event_name != 'push'
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
This PR implements all requested CI/CD speedups for tests on `main`:

- Run `quality` and test shards in parallel in `ci.yml` (removed `test -> quality` dependency).
- Path-gate `test-thorough` behind a new `should-run-thorough` job using `dorny/paths-filter`, so heavy upstream suites only run when relevant files change.
- Restrict shard coverage artifact upload and coverage combine job to `push` on `main` (skip PR coverage aggregation overhead).
- Remove duplicate release verification work on push by skipping `release.yml` `verify` job for push events.
- Speed up OpenClaw workflow by caching npm download artifacts and using `--prefer-offline` / `--no-audit` for global CLI install.

## Validation
- Parsed all modified workflow YAML files with `yaml.safe_load` locally.

## Notes
- Changes are limited to workflow configuration files only.