### PR TITLE
fix(llm): fallback to toolcall model when reasoning model is invalid

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -677,6 +677,7 @@ def _format_anthropic_retry_error(err: Exception) -> str:
 # the failure mode is "fall through to a generic HTTP 400 message" (#1806).
 _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES = (
     "model identifier",  # OpenAI / LiteLLM
+    "invalid model id",  # OpenAI
     "invalid model name",  # OpenRouter
 )
 
@@ -756,6 +757,7 @@ class OpenAILLMClient:
         self,
         *,
         model: str,
+        model_fallback: str | None = None,
         max_tokens: int = 1024,
         temperature: float | None = None,
         base_url: str | None = None,
@@ -772,9 +774,26 @@ class OpenAILLMClient:
         self._provider_label = api_key_env.removesuffix("_API_KEY").replace("_", " ").title()
         self._client: OpenAI | None = None
         self._model = model
+        fallback = (model_fallback or "").strip()
+        self._model_fallback = fallback if fallback and fallback != model else None
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._bound_tools: list[dict[str, Any]] = []
+
+    def _activate_model_fallback(self) -> bool:
+        """Switch to the configured fallback model once and report it."""
+        fallback = self._model_fallback
+        if not fallback or fallback == self._model:
+            return False
+        previous = self._model
+        self._model = fallback
+        logger.warning(
+            "%s model '%s' unavailable; falling back to toolcall model '%s'.",
+            self._provider_label,
+            previous,
+            fallback,
+        )
+        return True
 
     def _build_client(self, api_key: str) -> OpenAI:
         return OpenAI(
@@ -863,11 +882,17 @@ class OpenAILLMClient:
                     f"{self._provider_label} authentication failed. Check {self._api_key_env} in your environment, .env, or secure local keychain."
                 ) from err
             except OpenAINotFoundError as err:
+                if self._activate_model_fallback():
+                    kwargs = self._build_request_kwargs(prompt_or_messages)
+                    continue
                 raise RuntimeError(
                     f"{self._provider_label} model '{self._model}' was not found. "
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
+                if _is_openai_invalid_model_identifier(err) and self._activate_model_fallback():
+                    kwargs = self._build_request_kwargs(prompt_or_messages)
+                    continue
                 if _is_openai_invalid_model_identifier(err):
                     raise RuntimeError(
                         f"{self._provider_label} model '{self._model}' was not found. "
@@ -984,11 +1009,21 @@ class OpenAILLMClient:
                     f"{self._provider_label} authentication failed. Check {self._api_key_env} in your environment, .env, or secure local keychain."
                 ) from err
             except OpenAINotFoundError as err:
+                if not emitted and self._activate_model_fallback():
+                    kwargs = self._build_request_kwargs(prompt_or_messages)
+                    continue
                 raise RuntimeError(
                     f"{self._provider_label} model '{self._model}' was not found. "
                     "Check your configured model name or endpoint."
                 ) from err
             except OpenAIBadRequestError as err:
+                if (
+                    not emitted
+                    and _is_openai_invalid_model_identifier(err)
+                    and self._activate_model_fallback()
+                ):
+                    kwargs = self._build_request_kwargs(prompt_or_messages)
+                    continue
                 if _is_openai_invalid_model_identifier(err):
                     raise RuntimeError(
                         f"{self._provider_label} model '{self._model}' was not found. "
@@ -1234,10 +1269,17 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
             raise RuntimeError(msg or str(exc)) from exc
         raise RuntimeError(str(exc)) from exc
     provider = settings.provider
+
+    def _fallback_model(provider_prefix: str) -> str | None:
+        if model_type == "toolcall":
+            return None
+        return _select_model(settings, provider_prefix, "toolcall")
+
     if provider == "openai":
         config = OPENAI_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "openai", model_type),
+            model_fallback=_fallback_model("openai"),
             max_tokens=config.max_tokens,
         )
     elif provider == "openrouter":
@@ -1246,6 +1288,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
         config = OPENROUTER_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "openrouter", model_type),
+            model_fallback=_fallback_model("openrouter"),
             max_tokens=config.max_tokens,
             base_url=OPENROUTER_BASE_URL,
             api_key_env="OPENROUTER_API_KEY",
@@ -1256,6 +1299,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
         config = GEMINI_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "gemini", model_type),
+            model_fallback=_fallback_model("gemini"),
             max_tokens=config.max_tokens,
             base_url=GEMINI_BASE_URL,
             api_key_env="GEMINI_API_KEY",
@@ -1266,6 +1310,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
         config = NVIDIA_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "nvidia", model_type),
+            model_fallback=_fallback_model("nvidia"),
             max_tokens=config.max_tokens,
             base_url=NVIDIA_BASE_URL,
             api_key_env="NVIDIA_API_KEY",
@@ -1276,6 +1321,7 @@ def _create_llm_client(model_type: ModelType) -> _LLMClientType:
         config = MINIMAX_LLM_CONFIG
         return OpenAILLMClient(
             model=_select_model(settings, "minimax", model_type),
+            model_fallback=_fallback_model("minimax"),
             max_tokens=config.max_tokens,
             base_url=MINIMAX_BASE_URL,
             api_key_env="MINIMAX_API_KEY",

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -864,6 +864,94 @@ def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypa
         list(client.invoke_stream("hello"))
 
 
+def test_openai_invoke_invalid_reasoning_model_falls_back_to_toolcall(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.message = type("_Msg", (), {"content": content})()
+
+    class _Response:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **kwargs):
+            calls.append(str(kwargs.get("model", "")))
+            if len(calls) == 1:
+                raise _make_fake_openai_bad_request_error(
+                    "Error code: 400 - {'error': {'message': 'invalid model ID'}}"
+                )
+            return _Response("fallback-ok")
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(
+        model="gpt-5.4 mini",
+        model_fallback="gpt-5.4-mini",
+    )
+    response = client.invoke("hello")
+
+    assert response.content == "fallback-ok"
+    assert calls == ["gpt-5.4 mini", "gpt-5.4-mini"]
+    assert client._model == "gpt-5.4-mini"
+
+
+def test_openai_invoke_stream_invalid_reasoning_model_falls_back_to_toolcall(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _Delta:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content: str) -> None:
+            self.delta = _Delta(content)
+
+    class _Chunk:
+        def __init__(self, content: str) -> None:
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **kwargs):
+            calls.append(str(kwargs.get("model", "")))
+            if len(calls) == 1:
+                raise _make_fake_openai_bad_request_error(
+                    "Error code: 400 - {'error': {'message': 'invalid model ID'}}"
+                )
+            return iter([_Chunk("fallback"), _Chunk("-ok")])
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(
+        model="gpt-5.4 mini",
+        model_fallback="gpt-5.4-mini",
+    )
+    chunks = list(client.invoke_stream("hello"))
+
+    assert chunks == ["fallback", "-ok"]
+    assert calls == ["gpt-5.4 mini", "gpt-5.4-mini"]
+    assert client._model == "gpt-5.4-mini"
+
+
 def test_openai_invoke_stream_yields_delta_content_chunks(monkeypatch) -> None:
     """invoke_stream() routes through the same builder and yields delta.content in order."""
     fake, captured = _make_capturing_openai(chunk_contents=["Hel", "lo, ", "world"])
@@ -1020,6 +1108,22 @@ def test_openai_invoke_stream_does_not_retry_after_yielding(monkeypatch) -> None
 # ---------------------------------------------------------------------------
 
 
+def test_create_llm_client_openai_reasoning_sets_toolcall_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_REASONING_MODEL", "gpt-5.4 mini")
+    monkeypatch.setenv("OPENAI_TOOLCALL_MODEL", "gpt-5.4-mini")
+    llm_client.reset_llm_singletons()
+    try:
+        client = llm_client._create_llm_client("reasoning")
+
+        assert isinstance(client, llm_client.OpenAILLMClient)
+        assert client._model == "gpt-5.4 mini"
+        assert client._model_fallback == "gpt-5.4-mini"
+    finally:
+        llm_client.reset_llm_singletons()
+
+
 def test_create_llm_client_claude_code_wires_cli_adapter(monkeypatch) -> None:
     """Investigation uses ``_create_llm_client`` → registry → ``CLIBackedLLMClient``."""
     monkeypatch.setenv("LLM_PROVIDER", "claude-code")
@@ -1085,7 +1189,6 @@ def test_create_llm_client_missing_api_key_raises_runtime_error(monkeypatch) -> 
     """Sentry #1678: missing API key must surface as RuntimeError, not pydantic.ValidationError."""
     monkeypatch.setenv("LLM_PROVIDER", "anthropic")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _env_var: "")
     llm_client.reset_llm_singletons()
     try:
         with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
@@ -1098,7 +1201,6 @@ def test_create_llm_client_missing_api_key_omits_pydantic_boilerplate(monkeypatc
     """Sentry #1815: the RuntimeError message must not include pydantic boilerplate."""
     monkeypatch.setenv("LLM_PROVIDER", "minimax")
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
-    monkeypatch.setattr("app.config.resolve_llm_api_key", lambda _env_var: "")
     llm_client.reset_llm_singletons()
     try:
         with pytest.raises(RuntimeError) as exc_info:


### PR DESCRIPTION
## Summary
- add a runtime fallback path in `OpenAILLMClient` so invalid/not-found reasoning-model IDs automatically retry using the configured toolcall model
- keep fallback sticky for the session after first activation
- wire `_create_llm_client` to pass per-provider toolcall fallback for non-toolcall tiers on OpenAI-compatible providers
- extend invalid-model detection to include OpenAI's `invalid model ID` 400 wording
- add regression tests for invoke/invoke_stream fallback behavior and client construction fallback wiring

## Validation
- `uv run make lint` ✅
- `uv run make format-check` ✅
- `uv run make typecheck` ✅
- `uv run python -m pytest tests/services/test_llm_client.py -k "invalid_reasoning_model_falls_back_to_toolcall or create_llm_client_openai_reasoning_sets_toolcall_fallback or invalid_model_identifier_raises_not_found"` ✅ (5 passed)
- `uv run make test-cov` ❌ (3 unrelated failures)
  - `tests/agents/test_token_rate.py::TestThreadSafety::test_concurrent_record_and_read_does_not_corrupt` (thread hung)
  - `tests/cli_smoke_test.py::test_opensre_landing_page_smoke` (subprocess timeout)
  - `tests/cli_smoke_test.py::test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated[codex-7-OpenAI Codex CLI-60.0]` (interactive flow timeout)
