### PR TITLE
CI hotfix: restore release main builds and fix thorough path filter job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
     outputs:
       thorough: ${{ steps.filter.outputs.thorough }}
     steps:
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v4
         id: filter
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         run: make test-cli-smoke
 
   build-python-dist:
-    if: needs.prepare.outputs.channel == 'release'
+    if: needs.prepare.outputs.channel == 'release' && needs.verify.result == 'success'
     runs-on: ubuntu-latest
     needs: [verify, prepare]
     env:
@@ -173,6 +173,7 @@ jobs:
           if-no-files-found: error
 
   build-binaries:
+    if: needs.prepare.outputs.channel == 'main' || needs.verify.result == 'success'
     needs: [verify, prepare]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
Follow-up hotfix for #2319 to keep CI speedups while restoring expected behavior:

- Add `actions/checkout@v5` to `should-run-thorough` so `dorny/paths-filter` can run in a git repo context.
- Keep `verify` skipped on `push` in `release.yml`, but update downstream conditions so main-channel binary builds still run:
  - `build-binaries` now runs when channel is `main` OR `verify` succeeded.
  - `build-python-dist` now requires channel `release` AND successful `verify`.

## Why
- The first post-merge main CI run failed in `should-run-thorough` with `fatal: not a git repository`.
- Release runs on main were completing quickly but skipping build jobs due to `needs: verify` + skipped verify.

## Validation
- Parsed modified workflow YAML files with `yaml.safe_load`.
- Scoped change to workflow files only.