### PR TITLE
Fix CodeQL import-cycle and mapper findings

### DIFF
--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -9,7 +9,7 @@ from app.cli.interactive_shell.command_registry.types import SlashCommand
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     object_schema,
     string_array_property,
     string_property,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/deterministic_action_mapper.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/slash_commands/deterministic_action_mapper.py
@@ -221,7 +221,7 @@ def _map_clause_actions_with_phase_internal(
     mapped, phase = run_first_match(
         (clause, seen_slash),
         _CLAUSE_MAPPING_PHASES,
-        is_match=lambda actions: bool(actions),
+        is_match=bool,
     )
     if mapped is None:
         return [], None

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_contracts.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_contracts.py
@@ -1,0 +1,95 @@
+"""Shared tool contracts and schema helpers for action orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from rich.console import Console
+
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
+    ExecutionTier,
+)
+from app.cli.interactive_shell.runtime.session import ReplSession
+
+ToolExecutor = Callable[[dict[str, Any], "ToolContext"], bool]
+ToolAvailability = Callable[[ReplSession], bool]
+ToolSchema = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolContext:
+    session: ReplSession
+    console: Console
+    confirm_fn: Callable[[str], str] | None = None
+    is_tty: bool | None = None
+    action_already_listed: bool = True
+
+
+def _tool_is_available(_session: ReplSession) -> bool:
+    return True
+
+
+@dataclass(frozen=True)
+class ToolEntry:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    execution_tier: ExecutionTier
+    execute: ToolExecutor
+    is_available: ToolAvailability = _tool_is_available
+
+
+def string_property(
+    *,
+    description: str,
+    enum: tuple[str, ...] | None = None,
+    min_length: int | None = None,
+) -> ToolSchema:
+    schema: ToolSchema = {"type": "string", "description": description}
+    if enum:
+        schema["enum"] = list(enum)
+    if min_length is not None:
+        schema["minLength"] = min_length
+    return schema
+
+
+def string_array_property(*, description: str) -> ToolSchema:
+    return {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": description,
+    }
+
+
+def object_schema(*, properties: dict[str, ToolSchema], required: tuple[str, ...]) -> ToolSchema:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+def capability_not_explicitly_disabled(session: ReplSession, capability_name: str) -> bool:
+    available_capabilities = getattr(session, "available_capabilities", {})
+    capability_values = (
+        available_capabilities.get(capability_name)
+        if isinstance(available_capabilities, dict)
+        else None
+    )
+    return not (isinstance(capability_values, tuple) and capability_values == ())
+
+
+__all__ = [
+    "ToolAvailability",
+    "ToolContext",
+    "ToolEntry",
+    "ToolExecutor",
+    "ToolSchema",
+    "capability_not_explicitly_disabled",
+    "object_schema",
+    "string_array_property",
+    "string_property",
+]

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tool_registry.py
@@ -3,83 +3,16 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any
 
-from rich.console import Console
-
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
-    ExecutionTier,
-)
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.interaction_models import (
     ActionKind,
 )
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
+    ToolContext,
+    ToolEntry,
+)
 from app.cli.interactive_shell.runtime.session import ReplSession
-
-ToolExecutor = Callable[[dict[str, Any], "ToolContext"], bool]
-ToolAvailability = Callable[[ReplSession], bool]
-ToolSchema = dict[str, Any]
-
-
-@dataclass(frozen=True)
-class ToolContext:
-    session: ReplSession
-    console: Console
-    confirm_fn: Callable[[str], str] | None = None
-    is_tty: bool | None = None
-    action_already_listed: bool = True
-
-
-@dataclass(frozen=True)
-class ToolEntry:
-    name: str
-    description: str
-    input_schema: dict[str, Any]
-    execution_tier: ExecutionTier
-    execute: ToolExecutor
-    is_available: ToolAvailability = lambda _session: True
-
-
-def string_property(
-    *,
-    description: str,
-    enum: tuple[str, ...] | None = None,
-    min_length: int | None = None,
-) -> ToolSchema:
-    schema: ToolSchema = {"type": "string", "description": description}
-    if enum:
-        schema["enum"] = list(enum)
-    if min_length is not None:
-        schema["minLength"] = min_length
-    return schema
-
-
-def string_array_property(*, description: str) -> ToolSchema:
-    return {
-        "type": "array",
-        "items": {"type": "string"},
-        "description": description,
-    }
-
-
-def object_schema(*, properties: dict[str, ToolSchema], required: tuple[str, ...]) -> ToolSchema:
-    return {
-        "type": "object",
-        "properties": properties,
-        "required": list(required),
-        "additionalProperties": False,
-    }
-
-
-def capability_not_explicitly_disabled(session: ReplSession, capability_name: str) -> bool:
-    available_capabilities = getattr(session, "available_capabilities", {})
-    capability_values = (
-        available_capabilities.get(capability_name)
-        if isinstance(available_capabilities, dict)
-        else None
-    )
-    return not (isinstance(capability_values, tuple) and capability_values == ())
 
 
 class ActionToolRegistry:

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/__init__.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolEntry,
 )
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tools import (

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/assistant_handoff_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/assistant_handoff_tool.py
@@ -7,7 +7,7 @@ from typing import Any
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/catalog.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/catalog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolEntry,
 )
 

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/cli_command_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/cli_command_tool.py
@@ -10,7 +10,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     capability_not_explicitly_disabled,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/implementation_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/implementation_tool.py
@@ -10,7 +10,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/investigation_tool.py
@@ -10,7 +10,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/llm_provider_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/llm_provider_tool.py
@@ -14,7 +14,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/mark_unhandled_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/mark_unhandled_tool.py
@@ -21,7 +21,7 @@ from typing import Any
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/sample_alert_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/sample_alert_tool.py
@@ -10,7 +10,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/shell_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/shell_tool.py
@@ -10,7 +10,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.a
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/slash_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/slash_tool.py
@@ -18,7 +18,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     capability_not_explicitly_disabled,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/synthetic_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/synthetic_tool.py
@@ -13,7 +13,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.synthetic_scenarios import (
     list_rds_postgres_scenarios,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     capability_not_explicitly_disabled,

--- a/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/task_cancel_tool.py
+++ b/app/cli/interactive_shell/routing/handle_message_with_agent/orchestration/tools/task_cancel_tool.py
@@ -15,7 +15,7 @@ from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.e
 from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.execution_tier import (
     ExecutionTier,
 )
-from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_registry import (
+from app.cli.interactive_shell.routing.handle_message_with_agent.orchestration.tool_contracts import (
     ToolContext,
     ToolEntry,
     object_schema,

--- a/app/cli/interactive_shell/routing/tests/prompt_turn_contracts.yml
+++ b/app/cli/interactive_shell/routing/tests/prompt_turn_contracts.yml
@@ -391,6 +391,36 @@
       text: "what caused the spike?"
       ok: true
 
+- id: follow_up_what_happened_with_state
+  input: "what happened?"
+  expected_route_kind: "cli_agent"
+  with_prior_state: true
+  expected_planned_actions:
+    - kind: "assistant_handoff"
+      content: "follow_up:last_investigation_summary"
+  expected_executed_actions: []
+  expected_terminal_response_contains:
+    - "incident"
+  expected_session_history_delta:
+    - type: "cli_agent"
+      text: "what happened?"
+      ok: true
+
+- id: follow_up_last_investigation_wording_with_state
+  input: "No, during the last investigation"
+  expected_route_kind: "cli_agent"
+  with_prior_state: true
+  expected_planned_actions:
+    - kind: "assistant_handoff"
+      content: "follow_up:last_investigation_summary"
+  expected_executed_actions: []
+  expected_terminal_response_contains:
+    - "investigation"
+  expected_session_history_delta:
+    - type: "cli_agent"
+      text: "No, during the last investigation"
+      ok: true
+
 - id: cli_help_latency_measurement
   input: "how do I measure latency with opensre?"
   expected_route_kind: "cli_agent"

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/602-follow-up-what-happened.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/602-follow-up-what-happened.yml
@@ -1,0 +1,43 @@
+id: 602-follow-up-what-happened
+title: Follow-up what happened
+intent_class: follow_up
+risk_level: medium
+input:
+  prompt: what happened?
+  surface: interactive_cli
+session:
+  has_prior_state: true
+  remote_connected: false
+  configured_integrations: []
+available_capabilities:
+  slash_commands: []
+  cli_commands: []
+  synthetic_suites: []
+notes: []
+
+route:
+  expected_kind: cli_agent
+  expected_signals: []
+  expected_command_text: null
+policy:
+  should_execute: false
+  has_unhandled_clause: true
+  fail_closed: true
+planned_actions:
+- kind: assistant_handoff
+  content: follow_up:last_investigation_summary
+  source: llm
+executed_actions: []
+response_contract:
+  must_contain_any:
+  - what happened
+  - follow-up
+  - alert text
+  must_not_contain:
+  - $ /
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+tier: full
+runs: 3

--- a/app/cli/interactive_shell/routing/tests/scenarios/follow_up/603-follow-up-last-investigation-wording.yml
+++ b/app/cli/interactive_shell/routing/tests/scenarios/follow_up/603-follow-up-last-investigation-wording.yml
@@ -1,0 +1,43 @@
+id: 603-follow-up-last-investigation-wording
+title: Follow-up last investigation wording
+intent_class: follow_up
+risk_level: medium
+input:
+  prompt: No, during the last investigation
+  surface: interactive_cli
+session:
+  has_prior_state: true
+  remote_connected: false
+  configured_integrations: []
+available_capabilities:
+  slash_commands: []
+  cli_commands: []
+  synthetic_suites: []
+notes: []
+
+route:
+  expected_kind: cli_agent
+  expected_signals: []
+  expected_command_text: null
+policy:
+  should_execute: false
+  has_unhandled_clause: true
+  fail_closed: true
+planned_actions:
+- kind: assistant_handoff
+  content: follow_up:last_investigation_summary
+  source: llm
+executed_actions: []
+response_contract:
+  must_contain_any:
+  - investigation
+  - follow-up
+  - alert text
+  must_not_contain:
+  - $ /
+history:
+  expected:
+  - type: cli_agent
+    ok: true
+tier: full
+runs: 3


### PR DESCRIPTION
## Summary\n- break interactive-shell orchestration import cycles by extracting shared tool contracts into a dedicated module\n- rewire orchestration tools and slash catalog to import contracts from the new module\n- replace unnecessary lambda in deterministic action mapper\n- include follow-up routing fixture updates required by current planner behavior\n\n## Validation\n- make lint\n- make format-check\n- make typecheck\n- uv run pytest tests/cli/ -v