### PR TITLE
fix(mcp): suppress BrokenPipeError on server exit

### DIFF
--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -119,7 +119,7 @@ def run_rca(
 
 
 def main() -> None:
-    with contextlib.suppress(BrokenPipeError):
+    with contextlib.suppress(BrokenPipeError, ConnectionResetError):
         mcp.run()
 
 

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 from dotenv import load_dotenv
@@ -118,7 +119,8 @@ def run_rca(
 
 
 def main() -> None:
-    mcp.run()
+    with contextlib.suppress(BrokenPipeError):
+        mcp.run()
 
 
 if __name__ == "__main__":

--- a/app/entrypoints/mcp.py
+++ b/app/entrypoints/mcp.py
@@ -119,6 +119,9 @@ def run_rca(
 
 
 def main() -> None:
+    # anyio.run() (called inside mcp.run()) unwraps single-item ExceptionGroups at the
+    # sync boundary, so BrokenPipeError / ConnectionResetError arrive as bare exceptions
+    # here even though they originate inside an anyio TaskGroup.
     with contextlib.suppress(BrokenPipeError, ConnectionResetError):
         mcp.run()
 


### PR DESCRIPTION
## Summary

- When an MCP stdio client disconnects while the server is still writing, the OS raises `BrokenPipeError` through FastMCP's `stdout_writer`
- This is expected behaviour on client disconnect but was propagating as an unhandled exception and generating spurious Sentry alerts (PYTHON-7C)
- Fix wraps `mcp.run()` in `contextlib.suppress(BrokenPipeError)` so the server exits cleanly without noise

## Test plan

- [ ] Lint passes (`ruff check`)
- [ ] MCP server exits cleanly when client disconnects mid-write — no Sentry alert generated

Closes #2293

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZjFJycyFacBjSb4hVs9gm)_