### PR TITLE
fix: missing tool type in Anthropic schema and parent dir in write_json

### DIFF
--- a/app/cli/support/args.py
+++ b/app/cli/support/args.py
@@ -51,6 +51,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def write_json(data: Any, path: str | None) -> None:
     """Write JSON to file or stdout."""
     if path:
-        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     else:
         print(json.dumps(data, indent=2))

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -53,6 +53,7 @@ class AgentLLMResponse:
 
 def _anthropic_tool_schema(tool: Any) -> dict[str, Any]:
     return {
+        "type": "custom",
         "name": tool.name,
         "description": tool.description,
         "input_schema": tool.public_input_schema,


### PR DESCRIPTION
## Summary

- **#2329** (`_anthropic_tool_schema`): Added `"type": "custom"` to the Anthropic tool schema. The Bedrock/Anthropic API rejects tool definitions missing this field with a 400 validation error (`Invalid 'tools': missing field 'type'`).
- **#2328** (`write_json`): Added `mkdir(parents=True, exist_ok=True)` before writing the output file, so paths like `tests/results/headless_qa2_precondition_failed_result.json` no longer raise `FileNotFoundError` when the parent directory doesn't exist.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pyright` on changed files — 0 errors
- [x] `uv run pytest tests/ -k "agent_llm or write_json or args"` — 97 passed

Closes #2329
Closes #2328

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5VVsVCzcAW6DupTEZMvbX)_