### PR TITLE
fix: handle ServiceClientUnavailable at all make_*_client call sites

### DIFF
--- a/app/cli/wizard/integration_validators/client_validators.py
+++ b/app/cli/wizard/integration_validators/client_validators.py
@@ -377,7 +377,11 @@ def validate_alertmanager_integration(
             username=username or None,
             password=password or None,
         )
-    except (ServiceClientUnavailable, ValidationError):
+    except ValidationError as err:
+        return IntegrationHealthResult(
+            ok=False, detail=f"Alertmanager configuration is invalid: {err}"
+        )
+    except ServiceClientUnavailable:
         client = None  # already reported to Sentry
     if client is None:
         return IntegrationHealthResult(ok=False, detail="Invalid Alertmanager URL.")

--- a/app/cli/wizard/integration_validators/client_validators.py
+++ b/app/cli/wizard/integration_validators/client_validators.py
@@ -15,6 +15,7 @@ from app.integrations.models import (
     IncidentIoIntegrationConfig,
 )
 from app.integrations.sentry import build_sentry_config, validate_sentry_config
+from app.services._base import ServiceClientUnavailable
 from app.services.alertmanager import make_alertmanager_client
 from app.services.coralogix import CoralogixClient
 from app.services.datadog import DatadogClient, DatadogConfig
@@ -367,12 +368,15 @@ def validate_alertmanager_integration(
     """Validate Alertmanager connectivity via the /api/v2/status endpoint."""
     if not base_url:
         return IntegrationHealthResult(ok=False, detail="Alertmanager URL is required.")
-    client = make_alertmanager_client(
-        base_url=base_url,
-        bearer_token=bearer_token or None,
-        username=username or None,
-        password=password or None,
-    )
+    try:
+        client = make_alertmanager_client(
+            base_url=base_url,
+            bearer_token=bearer_token or None,
+            username=username or None,
+            password=password or None,
+        )
+    except ServiceClientUnavailable:
+        client = None  # already reported to Sentry
     if client is None:
         return IntegrationHealthResult(ok=False, detail="Invalid Alertmanager URL.")
     try:

--- a/app/cli/wizard/integration_validators/client_validators.py
+++ b/app/cli/wizard/integration_validators/client_validators.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from app.integrations.betterstack import build_betterstack_config, validate_betterstack_config
 from app.integrations.gitlab import build_gitlab_config, validate_gitlab_config
 from app.integrations.models import (
@@ -375,7 +377,7 @@ def validate_alertmanager_integration(
             username=username or None,
             password=password or None,
         )
-    except ServiceClientUnavailable:
+    except (ServiceClientUnavailable, ValidationError):
         client = None  # already reported to Sentry
     if client is None:
         return IntegrationHealthResult(ok=False, detail="Invalid Alertmanager URL.")

--- a/app/integrations/vercel_incidents.py
+++ b/app/integrations/vercel_incidents.py
@@ -19,6 +19,7 @@ from app.remote.vercel_poller import (
     collect_vercel_candidates,
     resolve_vercel_config,
 )
+from app.services._base import ServiceClientUnavailable
 from app.services.vercel import make_vercel_client
 
 _INCIDENT_CACHE_DIR: Path = STORE_PATH.parent / "investigations" / "vercel"
@@ -231,7 +232,10 @@ def _load_projects() -> list[dict[str, Any]]:
             "Set Vercel credentials before browsing incidents."
         )
 
-    client = make_vercel_client(config.api_token, config.team_id)
+    try:
+        client = make_vercel_client(config.api_token, config.team_id)
+    except ServiceClientUnavailable:
+        client = None  # already reported to Sentry
     if client is None:
         raise VercelResolutionError("Vercel integration is not configured.")
 

--- a/app/integrations/vercel_incidents.py
+++ b/app/integrations/vercel_incidents.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import questionary
+from pydantic import ValidationError
 
 from app.cli.investigation import run_investigation_cli, run_investigation_cli_streaming
 from app.cli.support.context import is_json_output
@@ -234,8 +235,8 @@ def _load_projects() -> list[dict[str, Any]]:
 
     try:
         client = make_vercel_client(config.api_token, config.team_id)
-    except ServiceClientUnavailable:
-        client = None  # already reported to Sentry
+    except (ServiceClientUnavailable, ValidationError) as exc:
+        raise VercelResolutionError(f"Vercel integration failed to initialize: {exc}") from exc
     if client is None:
         raise VercelResolutionError("Vercel integration is not configured.")
 

--- a/app/remote/vercel_poller.py
+++ b/app/remote/vercel_poller.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
+from pydantic import ValidationError
+
 from app.integrations.verify import resolve_effective_integrations
 from app.remote.error_reporting import report_remote_exception
 from app.services._base import ServiceClientUnavailable
@@ -329,8 +331,8 @@ def resolve_vercel_config() -> VercelConfig | None:
 def _make_client_from_config(config: VercelConfig) -> VercelClient:
     try:
         client = make_vercel_client(config.api_token, config.team_id)
-    except ServiceClientUnavailable:
-        client = None  # already reported to Sentry
+    except (ServiceClientUnavailable, ValidationError) as exc:
+        raise VercelResolutionError(f"Vercel integration failed to initialize: {exc}") from exc
     if client is None:
         raise VercelResolutionError("Vercel integration is not configured on this server.")
     return client

--- a/app/remote/vercel_poller.py
+++ b/app/remote/vercel_poller.py
@@ -15,6 +15,7 @@ from urllib.parse import parse_qs, urlparse
 
 from app.integrations.verify import resolve_effective_integrations
 from app.remote.error_reporting import report_remote_exception
+from app.services._base import ServiceClientUnavailable
 from app.services.vercel import VercelClient, VercelConfig, make_vercel_client
 
 logger = logging.getLogger(__name__)
@@ -326,7 +327,10 @@ def resolve_vercel_config() -> VercelConfig | None:
 
 
 def _make_client_from_config(config: VercelConfig) -> VercelClient:
-    client = make_vercel_client(config.api_token, config.team_id)
+    try:
+        client = make_vercel_client(config.api_token, config.team_id)
+    except ServiceClientUnavailable:
+        client = None  # already reported to Sentry
     if client is None:
         raise VercelResolutionError("Vercel integration is not configured on this server.")
     return client

--- a/app/services/_base.py
+++ b/app/services/_base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+class ServiceClientUnavailable(RuntimeError):
+    """Raised when an integration is configured but the client fails to construct."""
+
+    integration: str
+    reason: str
+
+    def __init__(
+        self, integration: str, reason: str, original: BaseException | None = None
+    ) -> None:
+        super().__init__(f"{integration}: {reason}")
+        self.integration = integration
+        self.reason = reason
+        self.__cause__ = original

--- a/app/services/_base.py
+++ b/app/services/_base.py
@@ -13,4 +13,3 @@ class ServiceClientUnavailable(RuntimeError):
         super().__init__(f"{integration}: {reason}")
         self.integration = integration
         self.reason = reason
-        self.__cause__ = original

--- a/app/services/_base.py
+++ b/app/services/_base.py
@@ -7,9 +7,7 @@ class ServiceClientUnavailable(RuntimeError):
     integration: str
     reason: str
 
-    def __init__(
-        self, integration: str, reason: str, original: BaseException | None = None
-    ) -> None:
+    def __init__(self, integration: str, reason: str) -> None:
         super().__init__(f"{integration}: {reason}")
         self.integration = integration
         self.reason = reason

--- a/app/services/alertmanager/client.py
+++ b/app/services/alertmanager/client.py
@@ -11,6 +11,8 @@ Supports three auth modes:
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import logging
 from typing import Any
 
@@ -18,7 +20,9 @@ import httpx
 
 from app.integrations.config_models import AlertmanagerIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 
@@ -234,5 +238,17 @@ def make_alertmanager_client(
                 password=password or "",
             )
         )
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="alertmanager client construction failed",
+            tags={
+                "surface": "service_client",
+                "integration": "alertmanager",
+                "event": "factory_failure",
+            },
+        )
+        raise ServiceClientUnavailable("alertmanager", "client construction failed", exc) from exc

--- a/app/services/alertmanager/client.py
+++ b/app/services/alertmanager/client.py
@@ -237,7 +237,17 @@ def make_alertmanager_client(
                 password=password or "",
             )
         )
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="alertmanager client construction failed (validation)",
+            tags={
+                "surface": "service_client",
+                "integration": "alertmanager",
+                "event": "factory_failure",
+            },
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -250,4 +260,4 @@ def make_alertmanager_client(
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("alertmanager", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("alertmanager", "client construction failed") from exc

--- a/app/services/alertmanager/client.py
+++ b/app/services/alertmanager/client.py
@@ -250,4 +250,4 @@ def make_alertmanager_client(
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("alertmanager", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("alertmanager", "client construction failed", ) from exc

--- a/app/services/alertmanager/client.py
+++ b/app/services/alertmanager/client.py
@@ -11,12 +11,11 @@ Supports three auth modes:
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import logging
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from app.integrations.config_models import AlertmanagerIntegrationConfig
 from app.integrations.probes import ProbeResult

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -545,7 +545,13 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="argocd client construction failed (validation)",
+            tags={"surface": "service_client", "integration": "argocd", "event": "factory_failure"},
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -554,4 +560,4 @@ def make_argocd_client(
             message="argocd client construction failed",
             tags={"surface": "service_client", "integration": "argocd", "event": "factory_failure"},
         )
-        raise ServiceClientUnavailable("argocd", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("argocd", "client construction failed") from exc

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -554,4 +554,4 @@ def make_argocd_client(
             message="argocd client construction failed",
             tags={"surface": "service_client", "integration": "argocd", "event": "factory_failure"},
         )
-        raise ServiceClientUnavailable("argocd", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("argocd", "client construction failed", ) from exc

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -7,6 +7,8 @@ from environment variables resolved by ``app.integrations.catalog``.
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import difflib
 import json
 import logging
@@ -18,7 +20,9 @@ import httpx
 
 from app.integrations.config_models import ArgoCDIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 
@@ -542,5 +546,13 @@ def make_argocd_client(
                 verify_ssl=_normalize_verify_ssl(verify_ssl),
             )
         )
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="argocd client construction failed",
+            tags={"surface": "service_client", "integration": "argocd", "event": "factory_failure"},
+        )
+        raise ServiceClientUnavailable("argocd", "client construction failed", exc) from exc

--- a/app/services/argocd/client.py
+++ b/app/services/argocd/client.py
@@ -7,8 +7,6 @@ from environment variables resolved by ``app.integrations.catalog``.
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import difflib
 import json
 import logging
@@ -17,6 +15,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
+from pydantic import ValidationError
 
 from app.integrations.config_models import ArgoCDIntegrationConfig
 from app.integrations.probes import ProbeResult

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -300,7 +300,13 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="jira client construction failed (validation)",
+            tags={"surface": "service_client", "integration": "jira", "event": "factory_failure"},
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -309,4 +315,4 @@ def make_jira_client(
             message="jira client construction failed",
             tags={"surface": "service_client", "integration": "jira", "event": "factory_failure"},
         )
-        raise ServiceClientUnavailable("jira", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("jira", "client construction failed") from exc

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import logging
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from app.integrations.models import JiraIntegrationConfig
 from app.services._base import ServiceClientUnavailable

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -309,4 +309,4 @@ def make_jira_client(
             message="jira client construction failed",
             tags={"surface": "service_client", "integration": "jira", "event": "factory_failure"},
         )
-        raise ServiceClientUnavailable("jira", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("jira", "client construction failed", ) from exc

--- a/app/services/jira/client.py
+++ b/app/services/jira/client.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import logging
 from typing import Any
 
 import httpx
 
 from app.integrations.models import JiraIntegrationConfig
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 
@@ -297,5 +301,13 @@ def make_jira_client(
             project_key=(project_key or "").strip(),
         )
         return JiraClient(config)
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="jira client construction failed",
+            tags={"surface": "service_client", "integration": "jira", "event": "factory_failure"},
+        )
+        raise ServiceClientUnavailable("jira", "client construction failed", exc) from exc

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -284,4 +284,4 @@ def make_opsgenie_client(api_key: str | None, region: str | None = None) -> OpsG
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("opsgenie", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("opsgenie", "client construction failed", ) from exc

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -6,12 +6,11 @@ Credentials come from the user's OpsGenie integration stored locally or via env 
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import logging
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from app.integrations.config_models import OpsGenieIntegrationConfig
 from app.integrations.probes import ProbeResult

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -6,6 +6,8 @@ Credentials come from the user's OpsGenie integration stored locally or via env 
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import logging
 from typing import Any
 
@@ -13,7 +15,9 @@ import httpx
 
 from app.integrations.config_models import OpsGenieIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 
@@ -268,5 +272,17 @@ def make_opsgenie_client(api_key: str | None, region: str | None = None) -> OpsG
         return None
     try:
         return OpsGenieClient(OpsGenieConfig(api_key=token, region=region or "us"))
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="opsgenie client construction failed",
+            tags={
+                "surface": "service_client",
+                "integration": "opsgenie",
+                "event": "factory_failure",
+            },
+        )
+        raise ServiceClientUnavailable("opsgenie", "client construction failed", exc) from exc

--- a/app/services/opsgenie/client.py
+++ b/app/services/opsgenie/client.py
@@ -271,7 +271,17 @@ def make_opsgenie_client(api_key: str | None, region: str | None = None) -> OpsG
         return None
     try:
         return OpsGenieClient(OpsGenieConfig(api_key=token, region=region or "us"))
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="opsgenie client construction failed (validation)",
+            tags={
+                "surface": "service_client",
+                "integration": "opsgenie",
+                "event": "factory_failure",
+            },
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -284,4 +294,4 @@ def make_opsgenie_client(api_key: str | None, region: str | None = None) -> OpsG
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("opsgenie", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("opsgenie", "client construction failed") from exc

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -350,7 +350,17 @@ def make_prefect_client(
                 workspace_id=workspace_id or "",
             )
         )
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="prefect client construction failed (validation)",
+            tags={
+                "surface": "service_client",
+                "integration": "prefect",
+                "event": "factory_failure",
+            },
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -363,4 +373,4 @@ def make_prefect_client(
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("prefect", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("prefect", "client construction failed") from exc

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -7,6 +7,8 @@ Credentials come from the user's Prefect integration stored locally or via env v
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import logging
 from typing import Any
 from urllib.parse import quote
@@ -14,7 +16,9 @@ from urllib.parse import quote
 import httpx
 from pydantic import field_validator
 
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 from app.strict_config import StrictConfigModel
 
 logger = logging.getLogger(__name__)
@@ -348,5 +352,17 @@ def make_prefect_client(
                 workspace_id=workspace_id or "",
             )
         )
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="prefect client construction failed",
+            tags={
+                "surface": "service_client",
+                "integration": "prefect",
+                "event": "factory_failure",
+            },
+        )
+        raise ServiceClientUnavailable("prefect", "client construction failed", exc) from exc

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -7,19 +7,17 @@ Credentials come from the user's Prefect integration stored locally or via env v
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import logging
 from typing import Any
 from urllib.parse import quote
 
 import httpx
-from pydantic import field_validator
+from pydantic import ValidationError, field_validator
 
 from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
-from app.utils.errors import report_exception
 from app.strict_config import StrictConfigModel
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/prefect/client.py
+++ b/app/services/prefect/client.py
@@ -363,4 +363,4 @@ def make_prefect_client(
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("prefect", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("prefect", "client construction failed", ) from exc

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -592,7 +592,13 @@ def make_vercel_client(api_token: str | None, team_id: str | None = None) -> Ver
         return None
     try:
         return VercelClient(VercelConfig(api_token=token, team_id=team_id or ""))
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="vercel client construction failed (validation)",
+            tags={"surface": "service_client", "integration": "vercel", "event": "factory_failure"},
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -601,4 +607,4 @@ def make_vercel_client(api_token: str | None, team_id: str | None = None) -> Ver
             message="vercel client construction failed",
             tags={"surface": "service_client", "integration": "vercel", "event": "factory_failure"},
         )
-        raise ServiceClientUnavailable("vercel", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("vercel", "client construction failed") from exc

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -601,4 +601,4 @@ def make_vercel_client(api_token: str | None, team_id: str | None = None) -> Ver
             message="vercel client construction failed",
             tags={"surface": "service_client", "integration": "vercel", "event": "factory_failure"},
         )
-        raise ServiceClientUnavailable("vercel", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("vercel", "client construction failed", ) from exc

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -6,8 +6,6 @@ Credentials come from the user's Vercel integration stored locally or via env va
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import json
 import logging
 import os
@@ -17,13 +15,14 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
+from pydantic import ValidationError
 
 from app.integrations.config_models import VercelIntegrationConfig
 from app.integrations.probes import ProbeResult
 from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
-from app.utils.errors import report_exception
 from app.services._streaming import StreamingParseStats
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/vercel/client.py
+++ b/app/services/vercel/client.py
@@ -6,6 +6,8 @@ Credentials come from the user's Vercel integration stored locally or via env va
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import json
 import logging
 import os
@@ -18,7 +20,9 @@ import httpx
 
 from app.integrations.config_models import VercelIntegrationConfig
 from app.integrations.probes import ProbeResult
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 from app.services._streaming import StreamingParseStats
 
 logger = logging.getLogger(__name__)
@@ -589,5 +593,13 @@ def make_vercel_client(api_token: str | None, team_id: str | None = None) -> Ver
         return None
     try:
         return VercelClient(VercelConfig(api_token=token, team_id=team_id or ""))
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="vercel client construction failed",
+            tags={"surface": "service_client", "integration": "vercel", "event": "factory_failure"},
+        )
+        raise ServiceClientUnavailable("vercel", "client construction failed", exc) from exc

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -217,4 +217,4 @@ def make_victoria_logs_client(
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("victoria_logs", "client construction failed", exc) from exc
+        raise ServiceClientUnavailable("victoria_logs", "client construction failed", ) from exc

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -204,7 +204,17 @@ def make_victoria_logs_client(
         return None
     try:
         return VictoriaLogsClient(VictoriaLogsConfig(base_url=url, tenant_id=tenant_id))
-    except ValidationError:
+    except ValidationError as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="victoria_logs client construction failed (validation)",
+            tags={
+                "surface": "service_client",
+                "integration": "victoria_logs",
+                "event": "factory_failure",
+            },
+        )
         raise
     except Exception as exc:
         report_exception(
@@ -217,4 +227,4 @@ def make_victoria_logs_client(
                 "event": "factory_failure",
             },
         )
-        raise ServiceClientUnavailable("victoria_logs", "client construction failed", ) from exc
+        raise ServiceClientUnavailable("victoria_logs", "client construction failed") from exc

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -12,21 +12,19 @@ implicitly, since that targets the default tenant on every request.
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import json
 import logging
 from typing import Any
 
 import httpx
-from pydantic import field_validator
+from pydantic import ValidationError, field_validator
 
 from app.integrations.probes import ProbeResult
 from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
-from app.utils.errors import report_exception
 from app.services._streaming import StreamingParseStats
 from app.strict_config import StrictConfigModel
+from app.utils.errors import report_exception
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/victoria_logs/client.py
+++ b/app/services/victoria_logs/client.py
@@ -12,6 +12,8 @@ implicitly, since that targets the default tenant on every request.
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+
 import json
 import logging
 from typing import Any
@@ -20,7 +22,9 @@ import httpx
 from pydantic import field_validator
 
 from app.integrations.probes import ProbeResult
+from app.services._base import ServiceClientUnavailable
 from app.services._error_helpers import capture_service_error
+from app.utils.errors import report_exception
 from app.services._streaming import StreamingParseStats
 from app.strict_config import StrictConfigModel
 
@@ -202,5 +206,17 @@ def make_victoria_logs_client(
         return None
     try:
         return VictoriaLogsClient(VictoriaLogsConfig(base_url=url, tenant_id=tenant_id))
-    except Exception:
-        return None
+    except ValidationError:
+        raise
+    except Exception as exc:
+        report_exception(
+            exc,
+            logger=logger,
+            message="victoria_logs client construction failed",
+            tags={
+                "surface": "service_client",
+                "integration": "victoria_logs",
+                "event": "factory_failure",
+            },
+        )
+        raise ServiceClientUnavailable("victoria_logs", "client construction failed", exc) from exc

--- a/app/tools/AlertmanagerAlertsTool/__init__.py
+++ b/app/tools/AlertmanagerAlertsTool/__init__.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.alertmanager import make_alertmanager_client
 from app.tools.base import BaseTool
@@ -120,7 +122,7 @@ class AlertmanagerAlertsTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_alertmanager_client(base_url, bearer_token, username, password)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/AlertmanagerAlertsTool/__init__.py
+++ b/app/tools/AlertmanagerAlertsTool/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.alertmanager import make_alertmanager_client
 from app.tools.base import BaseTool
 
@@ -117,7 +118,10 @@ class AlertmanagerAlertsTool(BaseTool):
         limit: int = 50,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_alertmanager_client(base_url, bearer_token, username, password)
+        try:
+            client = make_alertmanager_client(base_url, bearer_token, username, password)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "alertmanager",

--- a/app/tools/AlertmanagerSilencesTool/__init__.py
+++ b/app/tools/AlertmanagerSilencesTool/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.alertmanager import make_alertmanager_client
 from app.tools.base import BaseTool
 
@@ -83,7 +84,10 @@ class AlertmanagerSilencesTool(BaseTool):
         limit: int = 50,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_alertmanager_client(base_url, bearer_token, username, password)
+        try:
+            client = make_alertmanager_client(base_url, bearer_token, username, password)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "alertmanager_silences",

--- a/app/tools/AlertmanagerSilencesTool/__init__.py
+++ b/app/tools/AlertmanagerSilencesTool/__init__.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.alertmanager import make_alertmanager_client
 from app.tools.base import BaseTool
@@ -86,7 +88,7 @@ class AlertmanagerSilencesTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_alertmanager_client(base_url, bearer_token, username, password)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/ArgoCDApplicationDiffTool/__init__.py
+++ b/app/tools/ArgoCDApplicationDiffTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.argocd import make_argocd_client
 from app.tools.base import BaseTool
@@ -96,7 +98,7 @@ class ArgoCDApplicationDiffTool(BaseTool):
                 app_namespace=app_namespace,
                 verify_ssl=verify_ssl,
             )
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/ArgoCDApplicationDiffTool/__init__.py
+++ b/app/tools/ArgoCDApplicationDiffTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.argocd import make_argocd_client
 from app.tools.base import BaseTool
 
@@ -85,15 +86,18 @@ class ArgoCDApplicationDiffTool(BaseTool):
         verify_ssl: bool = True,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_argocd_client(
-            base_url,
-            bearer_token,
-            username,
-            password,
-            project=project,
-            app_namespace=app_namespace,
-            verify_ssl=verify_ssl,
-        )
+        try:
+            client = make_argocd_client(
+                base_url,
+                bearer_token,
+                username,
+                password,
+                project=project,
+                app_namespace=app_namespace,
+                verify_ssl=verify_ssl,
+            )
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "argocd",

--- a/app/tools/ArgoCDApplicationStatusTool/__init__.py
+++ b/app/tools/ArgoCDApplicationStatusTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.argocd import make_argocd_client
 from app.tools.base import BaseTool
 
@@ -88,15 +89,18 @@ class ArgoCDApplicationStatusTool(BaseTool):
         verify_ssl: bool = True,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_argocd_client(
-            base_url,
-            bearer_token,
-            username,
-            password,
-            project=project,
-            app_namespace=app_namespace,
-            verify_ssl=verify_ssl,
-        )
+        try:
+            client = make_argocd_client(
+                base_url,
+                bearer_token,
+                username,
+                password,
+                project=project,
+                app_namespace=app_namespace,
+                verify_ssl=verify_ssl,
+            )
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "argocd",

--- a/app/tools/ArgoCDApplicationStatusTool/__init__.py
+++ b/app/tools/ArgoCDApplicationStatusTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.argocd import make_argocd_client
 from app.tools.base import BaseTool
@@ -99,7 +101,7 @@ class ArgoCDApplicationStatusTool(BaseTool):
                 app_namespace=app_namespace,
                 verify_ssl=verify_ssl,
             )
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/JiraAddCommentTool/__init__.py
+++ b/app/tools/JiraAddCommentTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
 
@@ -86,7 +87,10 @@ class JiraAddCommentTool(BaseTool):
                 "comment_id": "",
             }
 
-        client = make_jira_client(base_url, email, api_token)
+        try:
+            client = make_jira_client(base_url, email, api_token)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "jira",

--- a/app/tools/JiraAddCommentTool/__init__.py
+++ b/app/tools/JiraAddCommentTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
@@ -89,7 +91,7 @@ class JiraAddCommentTool(BaseTool):
 
         try:
             client = make_jira_client(base_url, email, api_token)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/JiraCreateIssueTool/__init__.py
+++ b/app/tools/JiraCreateIssueTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
 
@@ -97,7 +98,10 @@ class JiraCreateIssueTool(BaseTool):
         labels: list[str] | None = None,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_jira_client(base_url, email, api_token, project_key)
+        try:
+            client = make_jira_client(base_url, email, api_token, project_key)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "jira",

--- a/app/tools/JiraCreateIssueTool/__init__.py
+++ b/app/tools/JiraCreateIssueTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
@@ -100,7 +102,7 @@ class JiraCreateIssueTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_jira_client(base_url, email, api_token, project_key)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/JiraIssueDetailTool/__init__.py
+++ b/app/tools/JiraIssueDetailTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
@@ -75,7 +77,7 @@ class JiraIssueDetailTool(BaseTool):
 
         try:
             client = make_jira_client(base_url, email, api_token)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/JiraIssueDetailTool/__init__.py
+++ b/app/tools/JiraIssueDetailTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
 
@@ -72,7 +73,10 @@ class JiraIssueDetailTool(BaseTool):
                 "issue": {},
             }
 
-        client = make_jira_client(base_url, email, api_token)
+        try:
+            client = make_jira_client(base_url, email, api_token)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "jira",

--- a/app/tools/JiraSearchIssuesTool/__init__.py
+++ b/app/tools/JiraSearchIssuesTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
 
@@ -80,7 +81,10 @@ class JiraSearchIssuesTool(BaseTool):
         max_results: int = 20,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_jira_client(base_url, email, api_token, project_key)
+        try:
+            client = make_jira_client(base_url, email, api_token, project_key)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "jira",

--- a/app/tools/JiraSearchIssuesTool/__init__.py
+++ b/app/tools/JiraSearchIssuesTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.jira import make_jira_client
 from app.tools.base import BaseTool
@@ -83,7 +85,7 @@ class JiraSearchIssuesTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_jira_client(base_url, email, api_token, project_key)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/OpsGenieAlertDetailTool/__init__.py
+++ b/app/tools/OpsGenieAlertDetailTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.opsgenie import make_opsgenie_client
 from app.tools.base import BaseTool
@@ -89,7 +91,7 @@ class OpsGenieAlertDetailTool(BaseTool):
 
         try:
             client = make_opsgenie_client(api_key, region)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/OpsGenieAlertDetailTool/__init__.py
+++ b/app/tools/OpsGenieAlertDetailTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.opsgenie import make_opsgenie_client
 from app.tools.base import BaseTool
 
@@ -86,7 +87,10 @@ class OpsGenieAlertDetailTool(BaseTool):
                 "activity_log": [],
             }
 
-        client = make_opsgenie_client(api_key, region)
+        try:
+            client = make_opsgenie_client(api_key, region)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "opsgenie",

--- a/app/tools/OpsGenieAlertsTool/__init__.py
+++ b/app/tools/OpsGenieAlertsTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.opsgenie import make_opsgenie_client
 from app.tools.base import BaseTool
@@ -77,7 +79,7 @@ class OpsGenieAlertsTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_opsgenie_client(api_key, region)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/OpsGenieAlertsTool/__init__.py
+++ b/app/tools/OpsGenieAlertsTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.opsgenie import make_opsgenie_client
 from app.tools.base import BaseTool
 
@@ -74,7 +75,10 @@ class OpsGenieAlertsTool(BaseTool):
         limit: int = 20,
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_opsgenie_client(api_key, region)
+        try:
+            client = make_opsgenie_client(api_key, region)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "opsgenie",

--- a/app/tools/PrefectFlowRunsTool/__init__.py
+++ b/app/tools/PrefectFlowRunsTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.prefect import make_prefect_client
 from app.tools.base import BaseTool
@@ -134,7 +136,7 @@ class PrefectFlowRunsTool(BaseTool):
                 account_id=account_id,
                 workspace_id=workspace_id,
             )
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/PrefectFlowRunsTool/__init__.py
+++ b/app/tools/PrefectFlowRunsTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.prefect import make_prefect_client
 from app.tools.base import BaseTool
 
@@ -126,12 +127,15 @@ class PrefectFlowRunsTool(BaseTool):
                 "error_log_lines": [],
             }
 
-        client = make_prefect_client(
-            api_url=api_url,
-            api_key=api_key,
-            account_id=account_id,
-            workspace_id=workspace_id,
-        )
+        try:
+            client = make_prefect_client(
+                api_url=api_url,
+                api_key=api_key,
+                account_id=account_id,
+                workspace_id=workspace_id,
+            )
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "prefect",

--- a/app/tools/PrefectWorkerHealthTool/__init__.py
+++ b/app/tools/PrefectWorkerHealthTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.prefect import make_prefect_client
 from app.tools.base import BaseTool
 
@@ -118,12 +119,15 @@ class PrefectWorkerHealthTool(BaseTool):
                 "unhealthy_workers": [],
             }
 
-        client = make_prefect_client(
-            api_url=api_url,
-            api_key=api_key,
-            account_id=account_id,
-            workspace_id=workspace_id,
-        )
+        try:
+            client = make_prefect_client(
+                api_url=api_url,
+                api_key=api_key,
+                account_id=account_id,
+                workspace_id=workspace_id,
+            )
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "prefect",

--- a/app/tools/PrefectWorkerHealthTool/__init__.py
+++ b/app/tools/PrefectWorkerHealthTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.prefect import make_prefect_client
 from app.tools.base import BaseTool
@@ -126,7 +128,7 @@ class PrefectWorkerHealthTool(BaseTool):
                 account_id=account_id,
                 workspace_id=workspace_id,
             )
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/VercelDeploymentStatusTool/__init__.py
+++ b/app/tools/VercelDeploymentStatusTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.vercel import make_vercel_client
 from app.tools.base import BaseTool
 
@@ -77,7 +78,10 @@ class VercelDeploymentStatusTool(BaseTool):
         state: str = "",
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_vercel_client(api_token, team_id)
+        try:
+            client = make_vercel_client(api_token, team_id)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "vercel",

--- a/app/tools/VercelDeploymentStatusTool/__init__.py
+++ b/app/tools/VercelDeploymentStatusTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.vercel import make_vercel_client
 from app.tools.base import BaseTool
@@ -80,7 +82,7 @@ class VercelDeploymentStatusTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_vercel_client(api_token, team_id)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/VercelLogsTool/__init__.py
+++ b/app/tools/VercelLogsTool/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.vercel import make_vercel_client
 from app.tools.base import BaseTool
@@ -97,7 +99,7 @@ class VercelLogsTool(BaseTool):
             }
         try:
             client = make_vercel_client(api_token, team_id)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/VercelLogsTool/__init__.py
+++ b/app/tools/VercelLogsTool/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.vercel import make_vercel_client
 from app.tools.base import BaseTool
 
@@ -94,7 +95,10 @@ class VercelLogsTool(BaseTool):
                 "error_events": [],
                 "deployment": {},
             }
-        client = make_vercel_client(api_token, team_id)
+        try:
+            client = make_vercel_client(api_token, team_id)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "vercel",

--- a/app/tools/VictoriaLogsTool/__init__.py
+++ b/app/tools/VictoriaLogsTool/__init__.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.services._base import ServiceClientUnavailable
 from app.services.victoria_logs import make_victoria_logs_client
 from app.tools.base import BaseTool
@@ -110,7 +112,7 @@ class VictoriaLogsTool(BaseTool):
     ) -> dict[str, Any]:
         try:
             client = make_victoria_logs_client(base_url, tenant_id=tenant_id)
-        except ServiceClientUnavailable:
+        except (ServiceClientUnavailable, ValidationError):
             client = None  # already reported to Sentry
         if client is None:
             return {

--- a/app/tools/VictoriaLogsTool/__init__.py
+++ b/app/tools/VictoriaLogsTool/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.services._base import ServiceClientUnavailable
 from app.services.victoria_logs import make_victoria_logs_client
 from app.tools.base import BaseTool
 
@@ -107,7 +108,10 @@ class VictoriaLogsTool(BaseTool):
         start: str = "-1h",
         **_kwargs: Any,
     ) -> dict[str, Any]:
-        client = make_victoria_logs_client(base_url, tenant_id=tenant_id)
+        try:
+            client = make_victoria_logs_client(base_url, tenant_id=tenant_id)
+        except ServiceClientUnavailable:
+            client = None  # already reported to Sentry
         if client is None:
             return {
                 "source": "victoria_logs",

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from app.integrations.models import JiraIntegrationConfig as JiraConfig
 from app.services._base import ServiceClientUnavailable
@@ -128,23 +128,14 @@ def test_make_jira_client_returns_none_all_none() -> None:
     assert make_jira_client(None, None, None) is None
 
 
-class _DummyModel(BaseModel):
-    x: int
-
-
-def _create_validation_error() -> ValidationError:
-    try:
-        _DummyModel(x="not an int")  # type: ignore[arg-type]
-    except ValidationError as e:
-        return e
-    raise RuntimeError("unreachable")
+from tests.utils.validation import create_validation_error
 
 
 def test_make_jira_client_raises_validation_error_on_invalid_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*_args: Any, **_kwargs: Any) -> Any:
-        raise _create_validation_error()
+        raise create_validation_error()
 
     monkeypatch.setattr("app.services.jira.client.JiraIntegrationConfig", _raise)
     with pytest.raises(ValidationError):

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from app.integrations.models import JiraIntegrationConfig as JiraConfig
-from app.services.jira.client import JiraClient, make_jira_client
 from app.services._base import ServiceClientUnavailable
-from pydantic import BaseModel, ValidationError
+from app.services.jira.client import JiraClient, make_jira_client
 
 
 @pytest.fixture

--- a/tests/integrations/test_jira_search_and_factory.py
+++ b/tests/integrations/test_jira_search_and_factory.py
@@ -9,6 +9,8 @@ import pytest
 
 from app.integrations.models import JiraIntegrationConfig as JiraConfig
 from app.services.jira.client import JiraClient, make_jira_client
+from app.services._base import ServiceClientUnavailable
+from pydantic import BaseModel, ValidationError
 
 
 @pytest.fixture
@@ -123,3 +125,37 @@ def test_make_jira_client_returns_none_missing_token() -> None:
 
 def test_make_jira_client_returns_none_all_none() -> None:
     assert make_jira_client(None, None, None) is None
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def _create_validation_error() -> ValidationError:
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")
+
+
+def test_make_jira_client_raises_validation_error_on_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise _create_validation_error()
+
+    monkeypatch.setattr("app.services.jira.client.JiraIntegrationConfig", _raise)
+    with pytest.raises(ValidationError):
+        make_jira_client("https://x.atlassian.net", "user@example.com", "token")
+
+
+def test_make_jira_client_raises_unavailable_on_other_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr("app.services.jira.client.JiraIntegrationConfig", _raise)
+    with pytest.raises(ServiceClientUnavailable):
+        make_jira_client("https://x.atlassian.net", "user@example.com", "token")

--- a/tests/integrations/test_victoria_logs.py
+++ b/tests/integrations/test_victoria_logs.py
@@ -23,6 +23,9 @@ from app.integrations._catalog_impl import _classify_service_instance
 from app.integrations._verification_adapters import _verify_victoria_logs
 from app.integrations.catalog import load_env_integrations
 from app.integrations.config_models import VictoriaLogsIntegrationConfig
+from app.services.victoria_logs.client import make_victoria_logs_client
+from app.services._base import ServiceClientUnavailable
+from pydantic import BaseModel, ValidationError
 
 
 class TestVictoriaLogsIntegrationConfig:
@@ -203,3 +206,37 @@ class TestVictoriaLogsIntegrationCanonicalShape:
         # Alias map: both spellings normalize to the canonical service.
         assert SERVICE_KEY_MAP["victoria_logs"] == "victoria_logs"
         assert SERVICE_KEY_MAP["victorialogs"] == "victoria_logs"
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def _create_validation_error() -> ValidationError:
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")
+
+
+class TestMakeVictoriaLogsClient:
+    def test_make_client_raises_validation_error_on_invalid_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_args: Any, **_kwargs: Any) -> Any:
+            raise _create_validation_error()
+
+        monkeypatch.setattr("app.services.victoria_logs.client.VictoriaLogsConfig", _raise)
+        with pytest.raises(ValidationError):
+            make_victoria_logs_client("http://vmlogs:9428")
+
+    def test_make_client_raises_unavailable_on_other_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_args: Any, **_kwargs: Any) -> Any:
+            raise ValueError("unexpected")
+
+        monkeypatch.setattr("app.services.victoria_logs.client.VictoriaLogsConfig", _raise)
+        with pytest.raises(ServiceClientUnavailable):
+            make_victoria_logs_client("http://vmlogs:9428")

--- a/tests/integrations/test_victoria_logs.py
+++ b/tests/integrations/test_victoria_logs.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from app.integrations._catalog_impl import _classify_service_instance
 from app.integrations._verification_adapters import _verify_victoria_logs
@@ -208,16 +208,7 @@ class TestVictoriaLogsIntegrationCanonicalShape:
         assert SERVICE_KEY_MAP["victorialogs"] == "victoria_logs"
 
 
-class _DummyModel(BaseModel):
-    x: int
-
-
-def _create_validation_error() -> ValidationError:
-    try:
-        _DummyModel(x="not an int")  # type: ignore[arg-type]
-    except ValidationError as e:
-        return e
-    raise RuntimeError("unreachable")
+from tests.utils.validation import create_validation_error
 
 
 class TestMakeVictoriaLogsClient:
@@ -225,7 +216,7 @@ class TestMakeVictoriaLogsClient:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def _raise(*_args: Any, **_kwargs: Any) -> Any:
-            raise _create_validation_error()
+            raise create_validation_error()
 
         monkeypatch.setattr("app.services.victoria_logs.client.VictoriaLogsConfig", _raise)
         with pytest.raises(ValidationError):

--- a/tests/integrations/test_victoria_logs.py
+++ b/tests/integrations/test_victoria_logs.py
@@ -18,14 +18,14 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from app.integrations._catalog_impl import _classify_service_instance
 from app.integrations._verification_adapters import _verify_victoria_logs
 from app.integrations.catalog import load_env_integrations
 from app.integrations.config_models import VictoriaLogsIntegrationConfig
-from app.services.victoria_logs.client import make_victoria_logs_client
 from app.services._base import ServiceClientUnavailable
-from pydantic import BaseModel, ValidationError
+from app.services.victoria_logs.client import make_victoria_logs_client
 
 
 class TestVictoriaLogsIntegrationConfig:

--- a/tests/services/argocd/test_client.py
+++ b/tests/services/argocd/test_client.py
@@ -84,7 +84,8 @@ def test_config_rejects_plain_http_except_loopback() -> None:
 
     ipv6_local = ArgoCDConfig(base_url="http://[::1]:8080", bearer_token="tok")
     assert ipv6_local.base_url == "http://[::1]:8080"
-    assert make_argocd_client("http://argocd.example.com", bearer_token="tok") is None
+    with pytest.raises(ValidationError):
+        make_argocd_client("http://argocd.example.com", bearer_token="tok")
 
 
 def test_config_rejects_ambiguous_auth_methods() -> None:
@@ -96,15 +97,13 @@ def test_config_rejects_ambiguous_auth_methods() -> None:
             password="pw",
         )
 
-    assert (
+    with pytest.raises(ValidationError):
         make_argocd_client(
             "https://argocd.example.com",
             bearer_token="tok_test",
             username="admin",
             password="pw",
         )
-        is None
-    )
 
 
 def test_config_only_strips_bearer_prefix_from_bearer_token() -> None:

--- a/tests/services/opsgenie/test_client.py
+++ b/tests/services/opsgenie/test_client.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
+from app.services._base import ServiceClientUnavailable
 from app.services.opsgenie.client import (
     OpsGenieClient,
     OpsGenieConfig,
     make_opsgenie_client,
 )
-from app.services._base import ServiceClientUnavailable
-from pydantic import BaseModel, ValidationError
 
 
 class _FakeResponse:

--- a/tests/services/opsgenie/test_client.py
+++ b/tests/services/opsgenie/test_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from app.services._base import ServiceClientUnavailable
 from app.services.opsgenie.client import (
@@ -331,23 +331,14 @@ def test_make_client_forwards_region() -> None:
     assert client.config.region == "eu"
 
 
-class _DummyModel(BaseModel):
-    x: int
-
-
-def _create_validation_error() -> ValidationError:
-    try:
-        _DummyModel(x="not an int")  # type: ignore[arg-type]
-    except ValidationError as e:
-        return e
-    raise RuntimeError("unreachable")
+from tests.utils.validation import create_validation_error
 
 
 def test_make_client_raises_validation_error_on_invalid_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*_args: Any, **_kwargs: Any) -> Any:
-        raise _create_validation_error()
+        raise create_validation_error()
 
     monkeypatch.setattr("app.services.opsgenie.client.OpsGenieConfig", _raise)
     with pytest.raises(ValidationError):

--- a/tests/services/opsgenie/test_client.py
+++ b/tests/services/opsgenie/test_client.py
@@ -9,6 +9,8 @@ from app.services.opsgenie.client import (
     OpsGenieConfig,
     make_opsgenie_client,
 )
+from app.services._base import ServiceClientUnavailable
+from pydantic import BaseModel, ValidationError
 
 
 class _FakeResponse:
@@ -327,3 +329,37 @@ def test_make_client_forwards_region() -> None:
     client = make_opsgenie_client("test-key", "eu")
     assert client is not None
     assert client.config.region == "eu"
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def _create_validation_error() -> ValidationError:
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")
+
+
+def test_make_client_raises_validation_error_on_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise _create_validation_error()
+
+    monkeypatch.setattr("app.services.opsgenie.client.OpsGenieConfig", _raise)
+    with pytest.raises(ValidationError):
+        make_opsgenie_client("test-key")
+
+
+def test_make_client_raises_unavailable_on_other_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr("app.services.opsgenie.client.OpsGenieConfig", _raise)
+    with pytest.raises(ServiceClientUnavailable):
+        make_opsgenie_client("test-key")

--- a/tests/services/test_alertmanager_client.py
+++ b/tests/services/test_alertmanager_client.py
@@ -6,14 +6,14 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from app.integrations.config_models import AlertmanagerIntegrationConfig
+from app.services._base import ServiceClientUnavailable
 from app.services.alertmanager.client import (
     AlertmanagerClient,
     make_alertmanager_client,
 )
-from app.services._base import ServiceClientUnavailable
-from pydantic import BaseModel, ValidationError
 
 AlertmanagerConfig = AlertmanagerIntegrationConfig
 

--- a/tests/services/test_alertmanager_client.py
+++ b/tests/services/test_alertmanager_client.py
@@ -12,6 +12,8 @@ from app.services.alertmanager.client import (
     AlertmanagerClient,
     make_alertmanager_client,
 )
+from app.services._base import ServiceClientUnavailable
+from pydantic import BaseModel, ValidationError
 
 AlertmanagerConfig = AlertmanagerIntegrationConfig
 
@@ -477,6 +479,40 @@ def test_make_client_strips_whitespace() -> None:
     )
     assert client is not None
     assert client.config.base_url == "https://alertmanager.example.com"
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def _create_validation_error() -> ValidationError:
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")
+
+
+def test_make_client_raises_validation_error_on_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise _create_validation_error()
+
+    monkeypatch.setattr("app.services.alertmanager.client.AlertmanagerConfig", _raise)
+    with pytest.raises(ValidationError):
+        make_alertmanager_client("https://example.com", "token")
+
+
+def test_make_client_raises_unavailable_on_other_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr("app.services.alertmanager.client.AlertmanagerConfig", _raise)
+    with pytest.raises(ServiceClientUnavailable):
+        make_alertmanager_client("https://example.com", "token")
 
 
 # --- Probe Access ---

--- a/tests/services/test_alertmanager_client.py
+++ b/tests/services/test_alertmanager_client.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from app.integrations.config_models import AlertmanagerIntegrationConfig
 from app.services._base import ServiceClientUnavailable
@@ -481,23 +481,14 @@ def test_make_client_strips_whitespace() -> None:
     assert client.config.base_url == "https://alertmanager.example.com"
 
 
-class _DummyModel(BaseModel):
-    x: int
-
-
-def _create_validation_error() -> ValidationError:
-    try:
-        _DummyModel(x="not an int")  # type: ignore[arg-type]
-    except ValidationError as e:
-        return e
-    raise RuntimeError("unreachable")
+from tests.utils.validation import create_validation_error
 
 
 def test_make_client_raises_validation_error_on_invalid_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*_args: Any, **_kwargs: Any) -> Any:
-        raise _create_validation_error()
+        raise create_validation_error()
 
     monkeypatch.setattr("app.services.alertmanager.client.AlertmanagerConfig", _raise)
     with pytest.raises(ValidationError):

--- a/tests/services/test_prefect_client.py
+++ b/tests/services/test_prefect_client.py
@@ -3,29 +3,18 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from app.services._base import ServiceClientUnavailable
 from app.services.prefect.client import make_prefect_client
-
-
-class _DummyModel(BaseModel):
-    x: int
-
-
-def _create_validation_error() -> ValidationError:
-    try:
-        _DummyModel(x="not an int")  # type: ignore[arg-type]
-    except ValidationError as e:
-        return e
-    raise RuntimeError("unreachable")
+from tests.utils.validation import create_validation_error
 
 
 def test_make_prefect_client_raises_validation_error_on_invalid_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*_args: Any, **_kwargs: Any) -> Any:
-        raise _create_validation_error()
+        raise create_validation_error()
 
     monkeypatch.setattr("app.services.prefect.client.PrefectConfig", _raise)
     with pytest.raises(ValidationError):

--- a/tests/services/test_prefect_client.py
+++ b/tests/services/test_prefect_client.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from typing import Any
+
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from app.services.prefect.client import make_prefect_client
 from app.services._base import ServiceClientUnavailable
+from app.services.prefect.client import make_prefect_client
 
 
 class _DummyModel(BaseModel):

--- a/tests/services/test_prefect_client.py
+++ b/tests/services/test_prefect_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from app.services.prefect.client import make_prefect_client
+from app.services._base import ServiceClientUnavailable
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def _create_validation_error() -> ValidationError:
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")
+
+
+def test_make_prefect_client_raises_validation_error_on_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise _create_validation_error()
+
+    monkeypatch.setattr("app.services.prefect.client.PrefectConfig", _raise)
+    with pytest.raises(ValidationError):
+        make_prefect_client(api_key="key", api_url="url")
+
+
+def test_make_prefect_client_raises_unavailable_on_other_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr("app.services.prefect.client.PrefectConfig", _raise)
+    with pytest.raises(ServiceClientUnavailable):
+        make_prefect_client(api_key="key", api_url="url")

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -15,6 +15,8 @@ from app.services.vercel.client import (
     _safe_vercel_path_segment,
     make_vercel_client,
 )
+from app.services._base import ServiceClientUnavailable
+from pydantic import BaseModel, ValidationError
 
 
 class _FakeResponse:
@@ -565,6 +567,40 @@ def test_make_vercel_client_forwards_team_id() -> None:
     client = make_vercel_client("tok_test", "team_xyz")
     assert client is not None
     assert client.config.team_id == "team_xyz"
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def _create_validation_error() -> ValidationError:
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")
+
+
+def test_make_vercel_client_raises_validation_error_on_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise _create_validation_error()
+
+    monkeypatch.setattr("app.services.vercel.client.VercelConfig", _raise)
+    with pytest.raises(ValidationError):
+        make_vercel_client("tok_test")
+
+
+def test_make_vercel_client_raises_unavailable_on_other_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr("app.services.vercel.client.VercelConfig", _raise)
+    with pytest.raises(ServiceClientUnavailable):
+        make_vercel_client("tok_test")
 
 
 def _raise_value_error() -> None:

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from app.services._base import ServiceClientUnavailable
 from app.services.vercel.client import (
@@ -569,23 +569,14 @@ def test_make_vercel_client_forwards_team_id() -> None:
     assert client.config.team_id == "team_xyz"
 
 
-class _DummyModel(BaseModel):
-    x: int
-
-
-def _create_validation_error() -> ValidationError:
-    try:
-        _DummyModel(x="not an int")  # type: ignore[arg-type]
-    except ValidationError as e:
-        return e
-    raise RuntimeError("unreachable")
+from tests.utils.validation import create_validation_error
 
 
 def test_make_vercel_client_raises_validation_error_on_invalid_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*_args: Any, **_kwargs: Any) -> Any:
-        raise _create_validation_error()
+        raise create_validation_error()
 
     monkeypatch.setattr("app.services.vercel.client.VercelConfig", _raise)
     with pytest.raises(ValidationError):

--- a/tests/services/vercel/test_client.py
+++ b/tests/services/vercel/test_client.py
@@ -5,7 +5,9 @@ from typing import Any
 
 import httpx
 import pytest
+from pydantic import BaseModel, ValidationError
 
+from app.services._base import ServiceClientUnavailable
 from app.services.vercel.client import (
     _MAX_VERCEL_PATH_SEGMENT_LEN,
     VercelClient,
@@ -15,8 +17,6 @@ from app.services.vercel.client import (
     _safe_vercel_path_segment,
     make_vercel_client,
 )
-from app.services._base import ServiceClientUnavailable
-from pydantic import BaseModel, ValidationError
 
 
 class _FakeResponse:

--- a/tests/utils/validation.py
+++ b/tests/utils/validation.py
@@ -1,0 +1,16 @@
+"""Validation test utilities."""
+
+from pydantic import BaseModel, ValidationError
+
+
+class _DummyModel(BaseModel):
+    x: int
+
+
+def create_validation_error() -> ValidationError:
+    """Create a sample Pydantic ValidationError for testing."""
+    try:
+        _DummyModel(x="not an int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise RuntimeError("unreachable")


### PR DESCRIPTION
Fixes #1459

#### Describe the changes you have made in this PR -
- Refactored `make_*_client` factories for ArgoCD, Jira, Alertmanager, OpsGenie, Prefect, Vercel, and VictoriaLogs.
- Factory functions now raise `ServiceClientUnavailable` on construction errors and return `None` only when not configured.
- Modified 18 caller sites (tools, validators, pollers) to wrap `make_*_client` in a `try/except ServiceClientUnavailable` block.
- Fixed import ordering (ruff I001) in the modified files.

### Demo/Screenshot for feature changes and bug fixes - 
N/A (Backend refactoring, all tests pass, `make check` succeeds)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
I updated the client factory functions to let `ValidationError` propagate and raise `ServiceClientUnavailable` for unexpected errors, rather than returning `None`. This allows us to capture Sentry events for failed constructions. On the caller side, I caught `ServiceClientUnavailable` and explicitly set `client = None` to ensure it falls back cleanly without crashing the integration, maintaining the expected behavior while improving telemetry.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
