### PR TITLE
feat: implement Datadog metrics tool

### DIFF
--- a/app/services/datadog/client.py
+++ b/app/services/datadog/client.py
@@ -150,27 +150,60 @@ class DatadogClient:
             payload = resp.json()
             series_list = payload.get("series") or []
             if not isinstance(series_list, list) or not series_list:
-                return {"success": True, "timestamps": [], "values": []}
+                return {
+                    "success": True,
+                    "timestamps": [],
+                    "values": [],
+                    "series": [],
+                    "total_series": 0,
+                }
 
-            first = series_list[0] if isinstance(series_list[0], dict) else {}
-            pointlist = first.get("pointlist") or []
-
-            timestamps: list[str] = []
-            values: list[float] = []
-            for point in pointlist:
-                if not (isinstance(point, list | tuple) and len(point) >= 2):
-                    continue
-                ts_ms, value = point[0], point[1]
-                if value is None:
-                    continue
-                try:
-                    ts = datetime.fromtimestamp(float(ts_ms) / 1000.0, tz=UTC)
-                    timestamps.append(ts.isoformat().replace("+00:00", "Z"))
-                    values.append(float(value))
-                except Exception:
+            parsed_series: list[dict[str, Any]] = []
+            for raw_series in series_list:
+                if not isinstance(raw_series, dict):
                     continue
 
-            return {"success": True, "timestamps": timestamps, "values": values}
+                timestamps: list[str] = []
+                values: list[float] = []
+                points: list[dict[str, Any]] = []
+                pointlist = raw_series.get("pointlist") or []
+                for point in pointlist:
+                    if not (isinstance(point, list | tuple) and len(point) >= 2):
+                        continue
+                    ts_ms, value = point[0], point[1]
+                    if value is None:
+                        continue
+                    try:
+                        ts = datetime.fromtimestamp(float(ts_ms) / 1000.0, tz=UTC)
+                        timestamp = ts.isoformat().replace("+00:00", "Z")
+                        numeric_value = float(value)
+                    except Exception:
+                        continue
+                    timestamps.append(timestamp)
+                    values.append(numeric_value)
+                    points.append({"timestamp": timestamp, "value": numeric_value})
+
+                parsed_series.append(
+                    {
+                        "metric": raw_series.get("metric", ""),
+                        "scope": raw_series.get("scope", ""),
+                        "tags": raw_series.get("tag_set") or raw_series.get("tags") or [],
+                        "unit": raw_series.get("unit"),
+                        "point_count": len(points),
+                        "points": points,
+                        "timestamps": timestamps,
+                        "values": values,
+                    }
+                )
+
+            first_series = parsed_series[0] if parsed_series else {}
+            return {
+                "success": True,
+                "timestamps": first_series.get("timestamps", []),
+                "values": first_series.get("values", []),
+                "series": parsed_series,
+                "total_series": len(parsed_series),
+            }
         except httpx.HTTPStatusError as e:
             logger.warning(
                 "[datadog] Metrics query HTTP failure status=%s query=%r",

--- a/app/tools/DataDogMetricsTool/__init__.py
+++ b/app/tools/DataDogMetricsTool/__init__.py
@@ -70,7 +70,9 @@ def _datadog_metric_query(metric_name: str, query: str | None) -> str:
     if not metric:
         return ""
     if metric.startswith(_AGGREGATION_PREFIXES):
-        return metric
+        if "{" in metric and "}" in metric:
+            return metric
+        return f"{metric}{{*}}"
     if "{" in metric and "}" in metric:
         return f"avg:{metric}"
     return f"avg:{metric}{{*}}"
@@ -108,6 +110,8 @@ def _summarize_values(values: Sequence[float]) -> dict[str, Any]:
     }
     if first != 0:
         summary["delta_pct"] = _round_metric_value(((latest - first) / abs(first)) * 100)
+    else:
+        summary["delta_pct"] = None
     return summary
 
 

--- a/app/tools/DataDogMetricsTool/__init__.py
+++ b/app/tools/DataDogMetricsTool/__init__.py
@@ -123,30 +123,60 @@ def _summarize_values(values: Sequence[float]) -> dict[str, Any]:
     return summary
 
 
+def _numeric_values(values: Sequence[Any]) -> list[float]:
+    return [float(value) for value in values if isinstance(value, int | float)]
+
+
+def _recent_points_and_values(
+    item: dict[str, Any],
+    *,
+    max_points: int,
+) -> tuple[list[dict[str, Any]], list[float], int]:
+    raw_points = item.get("points") or []
+    points = [point for point in raw_points if isinstance(point, dict)]
+
+    raw_values = item.get("values") or []
+    all_values = _numeric_values(raw_values)
+    point_count = int(item.get("point_count", len(points) or len(all_values)) or 0)
+    if point_count <= 0:
+        point_count = max(len(points), len(all_values))
+
+    recent_points = points[-max_points:] if len(points) > max_points else points
+    if recent_points:
+        recent_values = _numeric_values([point.get("value") for point in recent_points])
+    else:
+        recent_values = all_values[-max_points:] if len(all_values) > max_points else all_values
+    return recent_points, recent_values, point_count
+
+
 def _format_metric_series(
     series: list[dict[str, Any]],
     *,
     fallback_metric_name: str,
+    max_points_per_series: int,
 ) -> list[dict[str, Any]]:
     metrics: list[dict[str, Any]] = []
     for item in series:
         if not isinstance(item, dict):
             continue
 
-        raw_values = item.get("values") or []
-        values = [float(value) for value in raw_values if isinstance(value, int | float)]
-        metric_name = str(item.get("metric") or fallback_metric_name)
-        metrics.append(
-            {
-                "metric_name": metric_name,
-                "scope": item.get("scope", ""),
-                "tags": item.get("tags", []),
-                "unit": item.get("unit"),
-                "point_count": int(item.get("point_count", len(values)) or 0),
-                "points": item.get("points", []),
-                "summary": _summarize_values(values),
-            }
+        points, values, point_count = _recent_points_and_values(
+            item,
+            max_points=max_points_per_series,
         )
+        metric_name = str(item.get("metric") or fallback_metric_name)
+        formatted = {
+            "metric_name": metric_name,
+            "scope": item.get("scope", ""),
+            "tags": item.get("tags", []),
+            "unit": item.get("unit"),
+            "point_count": point_count,
+            "points": points,
+            "summary": _summarize_values(values),
+        }
+        if points and point_count > len(points):
+            formatted["points_total"] = point_count
+        metrics.append(formatted)
     return metrics
 
 
@@ -261,7 +291,11 @@ def query_datadog_metrics(
             }
         ]
 
-    metrics = _format_metric_series(series, fallback_metric_name=metric_name)
+    metrics = _format_metric_series(
+        series,
+        fallback_metric_name=metric_name,
+        max_points_per_series=_MAX_POINTS_PER_SERIES,
+    )
     compacted_metrics = compact_metrics(
         metrics,
         limit=_MAX_SERIES,

--- a/app/tools/DataDogMetricsTool/__init__.py
+++ b/app/tools/DataDogMetricsTool/__init__.py
@@ -11,7 +11,8 @@ from pydantic import BaseModel, Field
 from app.tools.DataDogLogsTool import _dd_creds
 from app.tools.DataDogLogsTool._client import make_client, unavailable
 from app.tools.tool_decorator import tool
-from app.tools.utils.compaction import compact_metrics
+from app.tools.utils.availability import datadog_available_or_backend
+from app.tools.utils.compaction import compact_metrics, summarize_counts
 
 _AGGREGATION_PREFIXES = ("avg:", "sum:", "min:", "max:", "count:")
 _MAX_SERIES = 20
@@ -40,13 +41,20 @@ class QueryDatadogMetricsOutput(BaseModel):
     time_range_minutes: int = Field(default=60, description="Lookback window used.")
     total_series: int = Field(default=0, description="Number of timeseries returned.")
     metrics: list[dict[str, Any]] = Field(default_factory=list, description="Returned metric data.")
+    truncation_note: str | None = Field(
+        default=None, description="Notice when returned series are compacted."
+    )
     window: dict[str, str] | None = Field(default=None, description="Query time window.")
     error: str | None = Field(default=None, description="Error details when unavailable.")
 
 
 def _metrics_is_available(sources: dict[str, dict]) -> bool:
+    if not datadog_available_or_backend(sources):
+        return False
+
     dd = sources.get("datadog", {})
     backend = dd.get("_backend")
+    # Real Datadog credentials can query metrics; fixture backends must expose the metrics API.
     return bool(dd.get("connection_verified") or hasattr(backend, "query_metrics"))
 
 
@@ -119,7 +127,6 @@ def _format_metric_series(
     series: list[dict[str, Any]],
     *,
     fallback_metric_name: str,
-    query: str,
 ) -> list[dict[str, Any]]:
     metrics: list[dict[str, Any]] = []
     for item in series:
@@ -132,7 +139,6 @@ def _format_metric_series(
         metrics.append(
             {
                 "metric_name": metric_name,
-                "query": query,
                 "scope": item.get("scope", ""),
                 "tags": item.get("tags", []),
                 "unit": item.get("unit"),
@@ -255,22 +261,27 @@ def query_datadog_metrics(
             }
         ]
 
-    metrics = _format_metric_series(series, fallback_metric_name=metric_name, query=query_to_run)
+    metrics = _format_metric_series(series, fallback_metric_name=metric_name)
     compacted_metrics = compact_metrics(
         metrics,
         limit=_MAX_SERIES,
         max_datapoints=_MAX_POINTS_PER_SERIES,
     )
-    return {
+    total_series = int(result.get("total_series", len(metrics)) or 0)
+    result_data: dict[str, Any] = {
         "source": "datadog_metrics",
         "available": True,
         "metric_name": metric_name,
         "time_range_minutes": time_range_minutes,
         "query": query_to_run,
         "metrics": compacted_metrics,
-        "total_series": int(result.get("total_series", len(metrics)) or 0),
+        "total_series": total_series,
         "window": {
             "from": start.isoformat().replace("+00:00", "Z"),
             "to": end.isoformat().replace("+00:00", "Z"),
         },
     }
+    summary = summarize_counts(total_series, len(compacted_metrics), "metric series")
+    if summary:
+        result_data["truncation_note"] = summary
+    return result_data

--- a/app/tools/DataDogMetricsTool/__init__.py
+++ b/app/tools/DataDogMetricsTool/__init__.py
@@ -131,12 +131,14 @@ def _recent_points_and_values(
     item: dict[str, Any],
     *,
     max_points: int,
-) -> tuple[list[dict[str, Any]], list[float], int]:
+) -> tuple[list[dict[str, Any]], list[float], list[float], int]:
     raw_points = item.get("points") or []
     points = [point for point in raw_points if isinstance(point, dict)]
 
     raw_values = item.get("values") or []
     all_values = _numeric_values(raw_values)
+    if not all_values and points:
+        all_values = _numeric_values([point.get("value") for point in points])
     point_count = int(item.get("point_count", len(points) or len(all_values)) or 0)
     if point_count <= 0:
         point_count = max(len(points), len(all_values))
@@ -146,7 +148,7 @@ def _recent_points_and_values(
         recent_values = _numeric_values([point.get("value") for point in recent_points])
     else:
         recent_values = all_values[-max_points:] if len(all_values) > max_points else all_values
-    return recent_points, recent_values, point_count
+    return recent_points, recent_values, all_values, point_count
 
 
 def _format_metric_series(
@@ -160,21 +162,24 @@ def _format_metric_series(
         if not isinstance(item, dict):
             continue
 
-        points, values, point_count = _recent_points_and_values(
+        points, returned_values, all_values, point_count = _recent_points_and_values(
             item,
             max_points=max_points_per_series,
         )
         metric_name = str(item.get("metric") or fallback_metric_name)
+        returned_point_count = len(points) if points else len(returned_values)
         formatted = {
             "metric_name": metric_name,
             "scope": item.get("scope", ""),
             "tags": item.get("tags", []),
             "unit": item.get("unit"),
             "point_count": point_count,
+            "returned_point_count": returned_point_count,
             "points": points,
-            "summary": _summarize_values(values),
+            "summary": _summarize_values(all_values),
+            "summary_scope": "full_series",
         }
-        if points and point_count > len(points):
+        if point_count > returned_point_count:
             formatted["points_total"] = point_count
         metrics.append(formatted)
     return metrics

--- a/app/tools/DataDogMetricsTool/__init__.py
+++ b/app/tools/DataDogMetricsTool/__init__.py
@@ -1,12 +1,21 @@
-"""Datadog metrics query tool (stub — implementation pending)."""
+"""Datadog metrics query tool."""
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
+from app.tools.DataDogLogsTool import _dd_creds
+from app.tools.DataDogLogsTool._client import make_client, unavailable
 from app.tools.tool_decorator import tool
+from app.tools.utils.compaction import compact_metrics
+
+_AGGREGATION_PREFIXES = ("avg:", "sum:", "min:", "max:", "count:")
+_MAX_SERIES = 20
+_MAX_POINTS_PER_SERIES = 60
 
 
 class QueryDatadogMetricsInput(BaseModel):
@@ -27,31 +36,116 @@ class QueryDatadogMetricsOutput(BaseModel):
     source: str = Field(description="Evidence source label.")
     available: bool = Field(description="Whether Datadog metrics query is available.")
     metric_name: str = Field(description="Metric name requested.")
+    query: str | None = Field(default=None, description="Datadog metrics query that was executed.")
+    time_range_minutes: int = Field(default=60, description="Lookback window used.")
+    total_series: int = Field(default=0, description="Number of timeseries returned.")
     metrics: list[dict[str, Any]] = Field(default_factory=list, description="Returned metric data.")
+    window: dict[str, str] | None = Field(default=None, description="Query time window.")
     error: str | None = Field(default=None, description="Error details when unavailable.")
 
 
-def _metrics_is_available(_sources: dict[str, dict]) -> bool:
-    # Hidden from the planner until the Metrics API v2 implementation lands (see #669).
-    # Flip back to `bool(sources.get("datadog", {}).get("connection_verified"))` once
-    # the stub body below is replaced with a real request.
-    return False
+def _metrics_is_available(sources: dict[str, dict]) -> bool:
+    dd = sources.get("datadog", {})
+    backend = dd.get("_backend")
+    return bool(dd.get("connection_verified") or hasattr(backend, "query_metrics"))
 
 
 def _metrics_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     dd = sources["datadog"]
     return {
-        "metric_name": dd.get("metric_name", ""),
+        "metric_name": dd.get("metric_name") or dd.get("default_metric") or "system.cpu.user",
+        "query": dd.get("metric_query"),
         "time_range_minutes": dd.get("time_range_minutes", 60),
-        "api_key": dd.get("api_key"),
-        "app_key": dd.get("app_key"),
-        "site": dd.get("site", "datadoghq.com"),
+        "datadog_backend": dd.get("_backend"),
+        **_dd_creds(dd),
     }
+
+
+def _datadog_metric_query(metric_name: str, query: str | None) -> str:
+    query_override = (query or "").strip()
+    if query_override:
+        return query_override
+
+    metric = metric_name.strip()
+    if not metric:
+        return ""
+    if metric.startswith(_AGGREGATION_PREFIXES):
+        return metric
+    if "{" in metric and "}" in metric:
+        return f"avg:{metric}"
+    return f"avg:{metric}{{*}}"
+
+
+def _round_metric_value(value: float) -> float:
+    return round(value, 4)
+
+
+def _trend(first: float, latest: float) -> str:
+    if latest > first:
+        return "increased"
+    if latest < first:
+        return "decreased"
+    return "flat"
+
+
+def _summarize_values(values: Sequence[float]) -> dict[str, Any]:
+    if not values:
+        return {}
+
+    first = float(values[0])
+    latest = float(values[-1])
+    minimum = min(values)
+    maximum = max(values)
+    average = sum(values) / len(values)
+    summary: dict[str, Any] = {
+        "first": _round_metric_value(first),
+        "latest": _round_metric_value(latest),
+        "min": _round_metric_value(minimum),
+        "max": _round_metric_value(maximum),
+        "avg": _round_metric_value(average),
+        "delta": _round_metric_value(latest - first),
+        "trend": _trend(first, latest),
+    }
+    if first != 0:
+        summary["delta_pct"] = _round_metric_value(((latest - first) / abs(first)) * 100)
+    return summary
+
+
+def _format_metric_series(
+    series: list[dict[str, Any]],
+    *,
+    fallback_metric_name: str,
+    query: str,
+) -> list[dict[str, Any]]:
+    metrics: list[dict[str, Any]] = []
+    for item in series:
+        if not isinstance(item, dict):
+            continue
+
+        raw_values = item.get("values") or []
+        values = [float(value) for value in raw_values if isinstance(value, int | float)]
+        metric_name = str(item.get("metric") or fallback_metric_name)
+        metrics.append(
+            {
+                "metric_name": metric_name,
+                "query": query,
+                "scope": item.get("scope", ""),
+                "tags": item.get("tags", []),
+                "unit": item.get("unit"),
+                "point_count": int(item.get("point_count", len(values)) or 0),
+                "points": item.get("points", []),
+                "summary": _summarize_values(values),
+            }
+        )
+    return metrics
 
 
 @tool(
     name="query_datadog_metrics",
+    display_name="Datadog metrics",
     source="datadog",
+    tags=("metrics", "observability"),
+    cost_tier="moderate",
     description="Query Datadog metrics for infrastructure and application performance data.",
     use_cases=[
         "Investigating CPU or memory spikes correlated with an alert",
@@ -69,7 +163,7 @@ def _metrics_extract_params(sources: dict[str, dict]) -> dict[str, Any]:
     anti_examples=["Use this tool for log content or deployment timeline evidence."],
     input_model=QueryDatadogMetricsInput,
     output_model=QueryDatadogMetricsOutput,
-    injected_params=("api_key", "app_key", "site"),
+    injected_params=("api_key", "app_key", "site", "datadog_backend"),
     is_available=_metrics_is_available,
     extract_params=_metrics_extract_params,
 )
@@ -77,20 +171,102 @@ def query_datadog_metrics(
     metric_name: str,
     time_range_minutes: int = 60,
     query: str | None = None,
-    **_kwargs: Any,
+    api_key: str | None = None,
+    app_key: str | None = None,
+    site: str = "datadoghq.com",
+    datadog_backend: Any = None,
+    **kwargs: Any,
 ) -> dict[str, Any]:
-    """Query Datadog metrics for infrastructure and application performance data.
+    """Query Datadog metrics for infrastructure and application performance data."""
+    query_to_run = _datadog_metric_query(metric_name, query)
+    if not query_to_run:
+        return unavailable(
+            "datadog_metrics",
+            "metrics",
+            "A Datadog metric name or query is required",
+            metric_name=metric_name,
+            query=query,
+            time_range_minutes=time_range_minutes,
+        )
+    if time_range_minutes < 1:
+        return unavailable(
+            "datadog_metrics",
+            "metrics",
+            "time_range_minutes must be at least 1",
+            metric_name=metric_name,
+            query=query_to_run,
+            time_range_minutes=time_range_minutes,
+        )
 
-    NOTE: This tool is a stub. A full implementation will query the Datadog
-    Metrics API (v2) to retrieve time-series data for pipeline performance,
-    host resource utilisation, and custom business metrics.
-    """
+    if datadog_backend is not None and hasattr(datadog_backend, "query_metrics"):
+        return cast(
+            "dict[str, Any]",
+            datadog_backend.query_metrics(
+                metric_name=metric_name,
+                query=query_to_run,
+                time_range_minutes=time_range_minutes,
+                **kwargs,
+            ),
+        )
+
+    client = make_client(api_key, app_key, site)
+    if not client:
+        return unavailable(
+            "datadog_metrics",
+            "metrics",
+            "Datadog integration not configured",
+            metric_name=metric_name,
+            query=query_to_run,
+            time_range_minutes=time_range_minutes,
+        )
+
+    end = datetime.now(UTC)
+    start = end - timedelta(minutes=time_range_minutes)
+    result = client.query_metrics(query_to_run, start=start, end=end)
+    if not result.get("success"):
+        return unavailable(
+            "datadog_metrics",
+            "metrics",
+            result.get("error", "Unknown error"),
+            metric_name=metric_name,
+            query=query_to_run,
+            time_range_minutes=time_range_minutes,
+        )
+
+    series = result.get("series")
+    if not isinstance(series, list):
+        series = [
+            {
+                "metric": metric_name,
+                "timestamps": result.get("timestamps") or [],
+                "values": result.get("values") or [],
+                "points": [
+                    {"timestamp": timestamp, "value": value}
+                    for timestamp, value in zip(
+                        result.get("timestamps") or [],
+                        result.get("values") or [],
+                        strict=False,
+                    )
+                ],
+            }
+        ]
+
+    metrics = _format_metric_series(series, fallback_metric_name=metric_name, query=query_to_run)
+    compacted_metrics = compact_metrics(
+        metrics,
+        limit=_MAX_SERIES,
+        max_datapoints=_MAX_POINTS_PER_SERIES,
+    )
     return {
         "source": "datadog_metrics",
-        "available": False,
-        "error": "DataDogMetricsTool is not yet implemented.",
+        "available": True,
         "metric_name": metric_name,
         "time_range_minutes": time_range_minutes,
-        "query": query,
-        "metrics": [],
+        "query": query_to_run,
+        "metrics": compacted_metrics,
+        "total_series": int(result.get("total_series", len(metrics)) or 0),
+        "window": {
+            "from": start.isoformat().replace("+00:00", "Z"),
+            "to": end.isoformat().replace("+00:00", "Z"),
+        },
     }

--- a/docs/datadog.mdx
+++ b/docs/datadog.mdx
@@ -34,6 +34,7 @@ To create an Application Key, go to your personal settings in Datadog and click 
    - events_read
    - logs_read_data
    - logs_read_index_data
+   - metrics_read
    - monitors_read
 
    <Frame>

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -181,6 +182,110 @@ def test_list_monitors_generic_exception(client, mock_httpx_client):
 
     assert result["success"] is False
     assert result["error"] == "boom"
+
+
+# -------------------------
+# query_metrics
+# -------------------------
+
+
+def test_query_metrics_success_preserves_first_series_and_returns_all_series(
+    client,
+    mock_httpx_client,
+):
+    mock_instance = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "series": [
+            {
+                "metric": "system.cpu.user",
+                "scope": "host:web-01",
+                "tag_set": ["host:web-01"],
+                "unit": [{"family": "percentage"}],
+                "pointlist": [
+                    [1779453600000, 10.0],
+                    [1779453660000, None],
+                    [1779453720000, "20.5"],
+                    ["bad-ts", 30.0],
+                ],
+            },
+            {
+                "metric": "system.mem.used",
+                "scope": "host:web-01",
+                "pointlist": [[1779453600000, 1024]],
+            },
+        ]
+    }
+    mock_instance.get.return_value = mock_response
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.query_metrics(
+        "avg:system.cpu.user{*}",
+        start=datetime(2026, 5, 22, 10, 0, tzinfo=UTC),
+        end=datetime(2026, 5, 22, 10, 15, tzinfo=UTC),
+    )
+
+    mock_instance.get.assert_called_once()
+    assert result["success"] is True
+    assert result["timestamps"] == ["2026-05-22T12:40:00Z", "2026-05-22T12:42:00Z"]
+    assert result["values"] == [10.0, 20.5]
+    assert result["total_series"] == 2
+    assert result["series"][0]["metric"] == "system.cpu.user"
+    assert result["series"][0]["points"] == [
+        {"timestamp": "2026-05-22T12:40:00Z", "value": 10.0},
+        {"timestamp": "2026-05-22T12:42:00Z", "value": 20.5},
+    ]
+    assert result["series"][1]["values"] == [1024.0]
+
+
+def test_query_metrics_empty_series(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"series": []}
+    mock_response.raise_for_status.return_value = None
+    mock_instance.get.return_value = mock_response
+    mock_httpx_client.return_value = mock_instance
+
+    result = client.query_metrics(
+        "avg:system.cpu.user{*}",
+        start=datetime(2026, 5, 22, 10, 0, tzinfo=UTC),
+        end=datetime(2026, 5, 22, 10, 15, tzinfo=UTC),
+    )
+
+    assert result == {
+        "success": True,
+        "timestamps": [],
+        "values": [],
+        "series": [],
+        "total_series": 0,
+    }
+
+
+def test_query_metrics_http_error(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.text = "forbidden"
+
+    error = httpx.HTTPStatusError(
+        "error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_response.raise_for_status.side_effect = error
+    mock_instance.get.return_value = mock_response
+
+    result = client.query_metrics(
+        "avg:system.cpu.user{*}",
+        start=datetime(2026, 5, 22, 10, 0, tzinfo=UTC),
+        end=datetime(2026, 5, 22, 10, 15, tzinfo=UTC),
+    )
+
+    assert result["success"] is False
+    assert "HTTP 403" in result["error"]
 
 
 # -------------------------

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -1,6 +1,9 @@
-"""Tests for DataDogMetricsTool (function-based stub, @tool decorated)."""
+"""Tests for DataDogMetricsTool (function-based, @tool decorated)."""
 
 from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
 from app.tools.DataDogMetricsTool import query_datadog_metrics
 from tests.tools.conftest import BaseToolContract, mock_agent_state
@@ -11,13 +14,15 @@ class TestDataDogMetricsToolContract(BaseToolContract):
         return query_datadog_metrics.__opensre_registered_tool__
 
 
-def test_is_available_returns_false_until_implemented() -> None:
-    # Stub is hidden from the planner (see issue #669) so that the LLM never
-    # burns a tool-call budget slot on a tool that always returns a "not yet
-    # implemented" error.  Flip this expectation back to the connection_verified
-    # gate once the Metrics API v2 body is in place.
+class _MetricsBackend:
+    def query_metrics(self, **_kwargs: object) -> dict[str, object]:
+        return {"source": "datadog_metrics", "available": True, "metrics": []}
+
+
+def test_is_available_requires_connection_or_metrics_backend() -> None:
     rt = query_datadog_metrics.__opensre_registered_tool__
-    assert rt.is_available({"datadog": {"connection_verified": True}}) is False
+    assert rt.is_available({"datadog": {"connection_verified": True}}) is True
+    assert rt.is_available({"datadog": {"_backend": _MetricsBackend()}}) is True
     assert rt.is_available({"datadog": {}}) is False
     assert rt.is_available({}) is False
 
@@ -28,14 +33,135 @@ def test_extract_params_maps_fields() -> None:
     params = rt.extract_params(sources)
     assert "metric_name" in params
     assert params["api_key"] == "dd_api_key_test"
+    assert params["app_key"] == "dd_app_key_test"
+    assert params["datadog_backend"] is None
 
 
-def test_run_returns_stub_unavailable() -> None:
-    # This tool is a stub
-    result = query_datadog_metrics(metric_name="system.cpu.user")
+def test_run_returns_unavailable_when_no_client() -> None:
+    result = query_datadog_metrics(metric_name="system.cpu.user", api_key=None, app_key=None)
     assert result["available"] is False
     assert result["metric_name"] == "system.cpu.user"
+    assert result["query"] == "avg:system.cpu.user{*}"
     assert result["metrics"] == []
+
+
+def test_run_requires_metric_or_query() -> None:
+    result = query_datadog_metrics(metric_name="", query=" ")
+    assert result["available"] is False
+    assert "metric name or query" in result["error"]
+
+
+def test_run_rejects_invalid_time_range() -> None:
+    result = query_datadog_metrics(metric_name="system.cpu.user", time_range_minutes=0)
+    assert result["available"] is False
+    assert "time_range_minutes" in result["error"]
+
+
+def test_run_happy_path_queries_client_and_summarizes_series() -> None:
+    mock_client = MagicMock()
+    mock_client.query_metrics.return_value = {
+        "success": True,
+        "total_series": 1,
+        "series": [
+            {
+                "metric": "system.cpu.user",
+                "scope": "host:web-01",
+                "tags": ["host:web-01"],
+                "unit": [{"family": "percentage"}],
+                "point_count": 3,
+                "points": [
+                    {"timestamp": "2026-05-22T10:00:00Z", "value": 10.0},
+                    {"timestamp": "2026-05-22T10:01:00Z", "value": 20.0},
+                    {"timestamp": "2026-05-22T10:02:00Z", "value": 40.0},
+                ],
+                "values": [10.0, 20.0, 40.0],
+            }
+        ],
+    }
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="system.cpu.user",
+            time_range_minutes=15,
+            api_key="key",
+            app_key="app",
+        )
+
+    assert result["available"] is True
+    assert result["query"] == "avg:system.cpu.user{*}"
+    assert result["total_series"] == 1
+    assert result["metrics"][0]["metric_name"] == "system.cpu.user"
+    assert result["metrics"][0]["summary"] == {
+        "first": 10.0,
+        "latest": 40.0,
+        "min": 10.0,
+        "max": 40.0,
+        "avg": 23.3333,
+        "delta": 30.0,
+        "trend": "increased",
+        "delta_pct": 300.0,
+    }
+
+    _, kwargs = mock_client.query_metrics.call_args
+    assert kwargs["start"].tzinfo == UTC
+    assert kwargs["end"].tzinfo == UTC
+    assert isinstance(kwargs["start"], datetime)
+    assert mock_client.query_metrics.call_args.args == ("avg:system.cpu.user{*}",)
+
+
+def test_run_preserves_full_query_override() -> None:
+    mock_client = MagicMock()
+    mock_client.query_metrics.return_value = {"success": True, "series": [], "total_series": 0}
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="ignored.metric",
+            query="sum:custom.errors{service:api}.as_count()",
+            api_key="key",
+            app_key="app",
+        )
+
+    assert result["available"] is True
+    assert result["query"] == "sum:custom.errors{service:api}.as_count()"
+    assert mock_client.query_metrics.call_args.args == (
+        "sum:custom.errors{service:api}.as_count()",
+    )
+
+
+def test_run_returns_backend_result_when_available() -> None:
+    backend = MagicMock()
+    backend.query_metrics.return_value = {
+        "source": "datadog_metrics",
+        "available": True,
+        "metrics": [{"metric_name": "custom.metric"}],
+    }
+
+    result = query_datadog_metrics(
+        metric_name="custom.metric",
+        datadog_backend=backend,
+    )
+
+    assert result["available"] is True
+    backend.query_metrics.assert_called_once_with(
+        metric_name="custom.metric",
+        query="avg:custom.metric{*}",
+        time_range_minutes=60,
+    )
+
+
+def test_run_api_error_returns_unavailable() -> None:
+    mock_client = MagicMock()
+    mock_client.query_metrics.return_value = {"success": False, "error": "forbidden"}
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="system.cpu.user",
+            api_key="key",
+            app_key="app",
+        )
+
+    assert result["available"] is False
+    assert result["error"] == "forbidden"
 
 
 def test_run_metadata() -> None:

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -109,6 +109,47 @@ def test_run_happy_path_queries_client_and_summarizes_series() -> None:
     assert mock_client.query_metrics.call_args.args == ("avg:system.cpu.user{*}",)
 
 
+def test_run_adds_wildcard_scope_to_aggregation_prefixed_metric() -> None:
+    mock_client = MagicMock()
+    mock_client.query_metrics.return_value = {"success": True, "series": [], "total_series": 0}
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="avg:system.cpu.user",
+            api_key="key",
+            app_key="app",
+        )
+
+    assert result["available"] is True
+    assert result["query"] == "avg:system.cpu.user{*}"
+    assert mock_client.query_metrics.call_args.args == ("avg:system.cpu.user{*}",)
+
+
+def test_run_summary_includes_null_delta_pct_when_first_value_is_zero() -> None:
+    mock_client = MagicMock()
+    mock_client.query_metrics.return_value = {
+        "success": True,
+        "total_series": 1,
+        "series": [
+            {
+                "metric": "custom.zero_start",
+                "point_count": 2,
+                "values": [0.0, 5.0],
+            }
+        ],
+    }
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="custom.zero_start",
+            api_key="key",
+            app_key="app",
+        )
+
+    assert result["available"] is True
+    assert result["metrics"][0]["summary"]["delta_pct"] is None
+
+
 def test_run_preserves_full_query_override() -> None:
     mock_client = MagicMock()
     mock_client.query_metrics.return_value = {"success": True, "series": [], "total_series": 0}

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -91,6 +91,7 @@ def test_run_happy_path_queries_client_and_summarizes_series() -> None:
     assert result["query"] == "avg:system.cpu.user{*}"
     assert result["total_series"] == 1
     assert result["metrics"][0]["metric_name"] == "system.cpu.user"
+    assert "query" not in result["metrics"][0]
     assert result["metrics"][0]["summary"] == {
         "first": 10.0,
         "latest": 40.0,
@@ -148,6 +149,33 @@ def test_run_summary_includes_null_delta_pct_when_first_value_is_zero() -> None:
 
     assert result["available"] is True
     assert result["metrics"][0]["summary"]["delta_pct"] is None
+
+
+def test_run_includes_truncation_note_when_series_are_compacted() -> None:
+    mock_client = MagicMock()
+    mock_client.query_metrics.return_value = {
+        "success": True,
+        "total_series": 25,
+        "series": [
+            {
+                "metric": f"custom.metric.{index}",
+                "point_count": 1,
+                "values": [float(index)],
+            }
+            for index in range(25)
+        ],
+    }
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="custom.metric",
+            api_key="key",
+            app_key="app",
+        )
+
+    assert result["total_series"] == 25
+    assert len(result["metrics"]) == 20
+    assert result["truncation_note"] == "Showing 20 of 25 metric series"
 
 
 def test_run_preserves_full_query_override() -> None:

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -178,6 +178,53 @@ def test_run_includes_truncation_note_when_series_are_compacted() -> None:
     assert result["truncation_note"] == "Showing 20 of 25 metric series"
 
 
+def test_run_summarizes_returned_recent_datapoints_after_point_compaction() -> None:
+    mock_client = MagicMock()
+    points = [
+        {
+            "timestamp": f"2026-05-22T{10 + index // 60:02d}:{index % 60:02d}:00Z",
+            "value": float(index),
+        }
+        for index in range(100)
+    ]
+    mock_client.query_metrics.return_value = {
+        "success": True,
+        "total_series": 1,
+        "series": [
+            {
+                "metric": "custom.long_window",
+                "point_count": 100,
+                "points": points,
+                "values": [float(index) for index in range(100)],
+            }
+        ],
+    }
+
+    with patch("app.tools.DataDogMetricsTool.make_client", return_value=mock_client):
+        result = query_datadog_metrics(
+            metric_name="custom.long_window",
+            api_key="key",
+            app_key="app",
+        )
+
+    metric = result["metrics"][0]
+    assert len(metric["points"]) == 60
+    assert metric["point_count"] == 100
+    assert metric["points_total"] == 100
+    assert metric["points"][0]["value"] == 40.0
+    assert metric["points"][-1]["value"] == 99.0
+    assert metric["summary"] == {
+        "first": 40.0,
+        "latest": 99.0,
+        "min": 40.0,
+        "max": 99.0,
+        "avg": 69.5,
+        "delta": 59.0,
+        "trend": "increased",
+        "delta_pct": 147.5,
+    }
+
+
 def test_run_preserves_full_query_override() -> None:
     mock_client = MagicMock()
     mock_client.query_metrics.return_value = {"success": True, "series": [], "total_series": 0}

--- a/tests/tools/test_datadog_metrics_tool.py
+++ b/tests/tools/test_datadog_metrics_tool.py
@@ -92,6 +92,8 @@ def test_run_happy_path_queries_client_and_summarizes_series() -> None:
     assert result["total_series"] == 1
     assert result["metrics"][0]["metric_name"] == "system.cpu.user"
     assert "query" not in result["metrics"][0]
+    assert result["metrics"][0]["returned_point_count"] == 3
+    assert result["metrics"][0]["summary_scope"] == "full_series"
     assert result["metrics"][0]["summary"] == {
         "first": 10.0,
         "latest": 40.0,
@@ -210,18 +212,20 @@ def test_run_summarizes_returned_recent_datapoints_after_point_compaction() -> N
     metric = result["metrics"][0]
     assert len(metric["points"]) == 60
     assert metric["point_count"] == 100
+    assert metric["returned_point_count"] == 60
     assert metric["points_total"] == 100
     assert metric["points"][0]["value"] == 40.0
     assert metric["points"][-1]["value"] == 99.0
+    assert metric["summary_scope"] == "full_series"
     assert metric["summary"] == {
-        "first": 40.0,
+        "first": 0.0,
         "latest": 99.0,
-        "min": 40.0,
+        "min": 0.0,
         "max": 99.0,
-        "avg": 69.5,
-        "delta": 59.0,
+        "avg": 49.5,
+        "delta": 99.0,
         "trend": "increased",
-        "delta_pct": 147.5,
+        "delta_pct": None,
     }
 
 


### PR DESCRIPTION
Related to #669

#### Describe the changes you have made in this PR -

This PR turns `query_datadog_metrics` from a hidden stub into a real Datadog metrics evidence tool.

What changed:
- The Datadog metrics tool now becomes available when Datadog is connected, or when a synthetic backend explicitly exposes `query_metrics`.
- The tool builds safe Datadog metric queries from a metric name, while still allowing a full Datadog query override.
- Metric responses are returned as compact time-series evidence with query metadata, the requested window, per-series points, and summary statistics such as first/latest/min/max/avg/delta/trend.
- The shared Datadog client still preserves its existing `timestamps` and `values` response shape for upstream correlation, and now also returns all parsed series for tool consumers.
- Datadog setup docs now include the `metrics_read` application-key scope required by Datadog's metrics APIs.

The implementation is intentionally small and follows the existing Datadog logs/events/monitors tool pattern: reuse the shared client factory, hide injected credentials from the model-visible schema, return the standard unavailable envelope on configuration/API failures, and keep the tool read-only.

### Demo/Screenshot for feature changes and bug fixes - 

Unit-level demo from the new happy-path coverage:

```py
query_datadog_metrics(
    metric_name="system.cpu.user",
    time_range_minutes=15,
    api_key="key",
    app_key="app",
)
```

returns an available Datadog metrics envelope like:

```py
{
    "source": "datadog_metrics",
    "available": True,
    "query": "avg:system.cpu.user{*}",
    "total_series": 1,
    "metrics": [
        {
            "metric_name": "system.cpu.user",
            "scope": "host:web-01",
            "point_count": 3,
            "summary": {
                "first": 10.0,
                "latest": 40.0,
                "min": 10.0,
                "max": 40.0,
                "avg": 23.3333,
                "delta": 30.0,
                "trend": "increased",
                "delta_pct": 300.0,
            },
        }
    ],
}
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The previous tool was deliberately unavailable because it always returned a "not implemented" response. I kept the existing function-tool shape and replaced only the stub behavior. The tool now normalizes a metric name into a Datadog v1 query (`avg:<metric>{*}` when no aggregator/scope is present), validates the lookback window, delegates to the existing Datadog client, and compacts the result before returning it to the agent.

I considered adding a separate metrics client, but that would duplicate existing Datadog API setup and make the change larger than necessary. Extending `DatadogClient.query_metrics` was cleaner because upstream correlation already depends on it; the method still returns the existing first-series `timestamps` and `values` fields, with additive `series` metadata for the new tool.

Key edge cases covered by tests: missing credentials, blank metric/query, invalid time range, full query override, API failures, synthetic backend delegation, empty series, multiple Datadog series, skipped null/invalid datapoints, and hidden credential/backend params in the model-visible schema.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

## Validation

Passed:
- `make install`
- `make lint`
- `make format-check`
- `make typecheck`
- `uv run pytest tests/tools/test_datadog_metrics_tool.py tests/services/test_datadog_client.py -v` — 38 passed
- `uv run pytest tests/services/ tests/tools/ -v` — 2466 passed
- `uv run pytest tests/cli_smoke_test.py::test_opensre_help_smoke tests/cli_smoke_test.py::test_opensre_version_smoke tests/cli_smoke_test.py::test_health_smoke_uses_real_datadog_store_config tests/cli_smoke_test.py::test_onboard_interactive_smoke_cli_provider_repick_when_unauthenticated --maxfail=1 -vv` — 4 passed, 1 skipped
- `uv run pytest tests/cli_smoke_test.py::test_integrations_remove_datadog_interactive_smoke -vv` — 1 passed

Attempted but blocked by local environment:
- `uv run opensre integrations verify` scanned integrations, but this machine has no local integration credentials configured, so every service reported `missing`.
- `make test-cov` ran 7452 passing tests before failing on live LLM routing/planner tests because the local default provider is `anthropic` and `ANTHROPIC_API_KEY` is not set. The same parallel run also showed a few CLI smoke failures that passed when rerun in isolation, as listed above.
