### PR TITLE
feat(twilio): tighten SMS validation (E.164, verify default_to, docs)

### DIFF
--- a/app/integrations/_verification_adapters.py
+++ b/app/integrations/_verification_adapters.py
@@ -375,12 +375,12 @@ def _verify_whatsapp(source: str, config: dict[str, Any]) -> dict[str, str]:
 
 
 def _verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
-    """Verify the Twilio integration: account auth + SMS channel readiness.
+    """Live Twilio account check plus SMS readiness for auto-delivery.
 
-    A "passed" result confirms the account credentials authenticate and the
-    SMS channel has a usable sender (``from_number`` or
-    ``messaging_service_sid``). WhatsApp is verified separately via the
-    standalone ``whatsapp`` integration.
+    Confirms credentials against the Twilio Account API, that the SMS channel
+    has a sender, and that ``sms.default_to`` is set so end-of-investigation
+    publish can deliver. Phone number formats are validated at config load, not
+    here. Does not send a test SMS or look up Messaging Service records in Twilio.
     """
     account_sid = str(config.get("account_sid", "")).strip()
     auth_token = str(config.get("auth_token", "")).strip()
@@ -419,11 +419,28 @@ def _verify_twilio(source: str, config: dict[str, Any]) -> dict[str, str]:
             ),
         )
 
+    default_to = str(sms_cfg.get("default_to") or "").strip()
+    if not default_to:
+        return result(
+            "twilio",
+            source,
+            "failed",
+            (
+                "SMS has no default_to recipient, so automatic delivery at the end of an "
+                "investigation will not run. Set sms.default_to (e.g. TWILIO_SMS_DEFAULT_TO). "
+                "The twilio_notify tool can still send when each call supplies an explicit `to`. "
+                "No test SMS was sent."
+            ),
+        )
+
     return result(
         "twilio",
         source,
         "passed",
-        f"Connected to Twilio account {friendly_name}; SMS channel ready.",
+        (
+            f"Connected to Twilio account {friendly_name}; SMS sender and default_to are set "
+            "for auto-delivery. No test SMS was sent."
+        ),
     )
 
 

--- a/app/integrations/cli.py
+++ b/app/integrations/cli.py
@@ -581,7 +581,11 @@ def _setup_twilio() -> None:
                     "enabled": True,
                     "from_number": sms_from,
                     "messaging_service_sid": messaging_service_sid,
-                    "default_to": _p("Default SMS recipient (optional, E.164)") or None,
+                    "default_to": _p(
+                        "Default SMS recipient (E.164; required for auto-delivery after investigations; "
+                        "omit only if you will use twilio_notify with explicit `to` only)"
+                    )
+                    or None,
                 },
             }
         },

--- a/app/integrations/config_models.py
+++ b/app/integrations/config_models.py
@@ -755,6 +755,23 @@ class WhatsAppConfig(StrictConfigModel):
         return stripped
 
 
+_SMS_E164_PLAIN = re.compile(r"^\+[1-9]\d{1,14}$")
+
+
+def _validate_sms_e164_plain(value: str, field_label: str) -> str:
+    if not value:
+        return value
+    if value.lower().startswith("whatsapp:"):
+        raise ValueError(
+            f"{field_label} must be a plain SMS E.164 number (+digits), not a whatsapp: address"
+        )
+    if not _SMS_E164_PLAIN.fullmatch(value):
+        raise ValueError(
+            f"{field_label} must be E.164 (+ and country code, up to 15 digits total)"
+        )
+    return value
+
+
 class TwilioSMSChannelConfig(StrictConfigModel):
     """SMS channel sub-config inside a unified Twilio integration.
 
@@ -772,6 +789,33 @@ class TwilioSMSChannelConfig(StrictConfigModel):
         normalize_str()
     )
     _normalize_enabled = field_validator("enabled", mode="before")(normalize_bool_str())
+
+    @field_validator("default_to", mode="before")
+    @classmethod
+    def _normalize_default_to(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        stripped = str(value).strip()
+        return stripped or None
+
+    @field_validator("from_number", mode="after")
+    @classmethod
+    def _validate_from_number_sms(cls, value: str) -> str:
+        return _validate_sms_e164_plain(value, "sms.from_number") if value else value
+
+    @field_validator("default_to", mode="after")
+    @classmethod
+    def _validate_default_to_sms(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _validate_sms_e164_plain(value, "sms.default_to")
+
+    @field_validator("messaging_service_sid", mode="after")
+    @classmethod
+    def _validate_messaging_service_sid(cls, value: str) -> str:
+        if value and not value.upper().startswith("MG"):
+            raise ValueError("messaging_service_sid must start with MG when set")
+        return value
 
     @property
     def is_configured(self) -> bool:

--- a/docs/messaging/twilio-sms.mdx
+++ b/docs/messaging/twilio-sms.mdx
@@ -68,21 +68,40 @@ present. The legacy `whatsapp` record is bootstrapped independently from
 opensre integrations verify twilio
 ```
 
+This command performs **live** checks only: it calls the Twilio Account API with
+your credentials, then checks that the SMS channel has a sender and a
+`default_to` recipient for automatic end-of-investigation delivery. It does **not**
+send a test SMS, re-validate E.164 (that happens when config is loaded), or
+confirm that a Messaging Service exists in Twilio.
+
 A passing verification confirms:
 
 - The Twilio account credentials authenticate against the Twilio Account API.
 - The SMS channel is enabled and has a usable sender (`from_number` or
   `messaging_service_sid`).
+- `sms.default_to` is set so publish can deliver the RCA summary without a
+  per-run `twilio_sms_context.to` override.
 
 Sample passing output:
 
 ```
-twilio: passed — Connected to Twilio account My Company; SMS channel ready.
+twilio: passed — Connected to Twilio account My Company; SMS sender and default_to are set for auto-delivery. No test SMS was sent.
 ```
 
 If the account authenticates but the SMS channel has no sender,
 verification returns `failed` with a message telling you to set a
 `from_number` or `messaging_service_sid`.
+
+If the sender is set but `default_to` is missing, verification returns `failed`
+and notes that the `twilio_notify` tool can still send when each call supplies
+`to`.
+
+### Config load vs verify
+
+| Check | When |
+| --- | --- |
+| E.164 on `sms.from_number` / `sms.default_to`, `MG` prefix on `messaging_service_sid` | Wizard save, env bootstrap, catalog YAML — Pydantic models |
+| Account API auth, sender present, `default_to` present | `opensre integrations verify twilio` only |
 
 ---
 
@@ -128,12 +147,13 @@ via SMS and returns the Twilio Message SID for traceability.
 | `Missing auth_token` | `TWILIO_AUTH_TOKEN` is unset. |
 | `Twilio API check failed: 401` | The SID/token pair is invalid. |
 | `SMS channel is not ready` | No SMS sender — set `TWILIO_SMS_FROM` or `TWILIO_SMS_MESSAGING_SERVICE_SID`. |
+| `default_to` / `automatic delivery` | No default recipient — set `TWILIO_SMS_DEFAULT_TO` (or `sms.default_to` in saved config) for auto-delivery; `twilio_notify` can still work with explicit `to`. |
 
 ### SMS never arrives but verify passes
 
 - Confirm `TWILIO_SMS_FROM` (or the Messaging Service SID) is provisioned
   for the destination country.
-- Confirm the recipient is in E.164 format (`+14155550000`).
+- Confirm the recipient is in E.164 format (`+14155550000`); invalid formats are rejected at config load.
 - For trial accounts: the recipient must be a verified caller ID.
 - Inspect `Messages` in the Twilio Console for an error code; common
   failures (`30007`, `21610`, etc.) are documented at

--- a/tests/integrations/test_twilio.py
+++ b/tests/integrations/test_twilio.py
@@ -67,7 +67,7 @@ def test_config_rejects_blank_account_sid() -> None:
         TwilioIntegrationConfig(
             account_sid="   ",
             auth_token="tok",
-            sms=TwilioSMSChannelConfig(enabled=True, from_number="+1"),
+            sms=TwilioSMSChannelConfig(enabled=True, from_number="+14155550001"),
         )
 
 
@@ -76,7 +76,47 @@ def test_config_rejects_blank_auth_token() -> None:
         TwilioIntegrationConfig(
             account_sid="AC1",
             auth_token="  ",
-            sms=TwilioSMSChannelConfig(enabled=True, from_number="+1"),
+            sms=TwilioSMSChannelConfig(enabled=True, from_number="+14155550001"),
+        )
+
+
+def test_config_rejects_non_e164_sms_from_number() -> None:
+    with pytest.raises(ValueError, match="sms.from_number"):
+        TwilioIntegrationConfig(
+            account_sid="AC1",
+            auth_token="tok",
+            sms=TwilioSMSChannelConfig(enabled=True, from_number="4155551212"),
+        )
+
+
+def test_config_rejects_whatsapp_style_from_number_on_sms_channel() -> None:
+    with pytest.raises(ValueError, match="whatsapp"):
+        TwilioIntegrationConfig(
+            account_sid="AC1",
+            auth_token="tok",
+            sms=TwilioSMSChannelConfig(enabled=True, from_number="whatsapp:+14155550001"),
+        )
+
+
+def test_config_rejects_invalid_default_to() -> None:
+    with pytest.raises(ValueError, match="sms.default_to"):
+        TwilioIntegrationConfig(
+            account_sid="AC1",
+            auth_token="tok",
+            sms=TwilioSMSChannelConfig(
+                enabled=True,
+                from_number="+14155550001",
+                default_to="+abc",
+            ),
+        )
+
+
+def test_config_rejects_messaging_service_sid_bad_prefix() -> None:
+    with pytest.raises(ValueError, match="messaging_service_sid"):
+        TwilioIntegrationConfig(
+            account_sid="AC1",
+            auth_token="tok",
+            sms=TwilioSMSChannelConfig(enabled=True, messaging_service_sid="MSdeadbeefdeadbeefdeadbeefdeadbeef"),
         )
 
 
@@ -106,12 +146,16 @@ def test_verify_passed_when_sms_ready(monkeypatch: pytest.MonkeyPatch) -> None:
         {
             "account_sid": "AC1",
             "auth_token": "tok",
-            "sms": {"enabled": True, "from_number": "+14155551111"},
+            "sms": {
+                "enabled": True,
+                "from_number": "+14155551111",
+                "default_to": "+14155550000",
+            },
         },
     )
 
     assert result["status"] == "passed"
-    assert "sms" in result["detail"].lower()
+    assert "default_to" in result["detail"].lower()
 
 
 def test_verify_passed_with_messaging_service_sid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -125,11 +169,58 @@ def test_verify_passed_with_messaging_service_sid(monkeypatch: pytest.MonkeyPatc
         {
             "account_sid": "AC1",
             "auth_token": "tok",
-            "sms": {"enabled": True, "messaging_service_sid": "MG1"},
+            "sms": {
+                "enabled": True,
+                "messaging_service_sid": "MG1",
+                "default_to": "+14155550000",
+            },
         },
     )
 
     assert result["status"] == "passed"
+
+
+def test_verify_failed_when_default_to_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.integrations._verification_adapters.requests.get",
+        lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
+    )
+
+    result = _verify_twilio(
+        "env",
+        {
+            "account_sid": "AC1",
+            "auth_token": "tok",
+            "sms": {"enabled": True, "from_number": "+14155551111"},
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert "default_to" in result["detail"].lower()
+    assert "twilio_notify" in result["detail"].lower()
+
+
+def test_verify_failed_when_default_to_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.integrations._verification_adapters.requests.get",
+        lambda *_a, **_kw: _FakeResponse({"friendly_name": "Demo"}),
+    )
+
+    result = _verify_twilio(
+        "env",
+        {
+            "account_sid": "AC1",
+            "auth_token": "tok",
+            "sms": {
+                "enabled": True,
+                "from_number": "+14155551111",
+                "default_to": "",
+            },
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert "default_to" in result["detail"].lower()
 
 
 def test_verify_failed_when_sms_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -212,6 +303,21 @@ def test_catalog_skips_twilio_without_sms_env(
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC1")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "tok")
     monkeypatch.delenv("TWILIO_SMS_FROM", raising=False)
+    monkeypatch.delenv("TWILIO_SMS_MESSAGING_SERVICE_SID", raising=False)
+
+    from app.integrations.catalog import resolve_effective_integrations
+
+    effective = resolve_effective_integrations()
+
+    assert "twilio" not in effective
+
+
+def test_catalog_skips_twilio_when_sms_from_invalid_e164(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC1")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "tok")
+    monkeypatch.setenv("TWILIO_SMS_FROM", "not-e164")
     monkeypatch.delenv("TWILIO_SMS_MESSAGING_SERVICE_SID", raising=False)
 
     from app.integrations.catalog import resolve_effective_integrations


### PR DESCRIPTION
fixes : #2341

#### Describe the changes you have made in this PR -
- SMS E.164 at config load.
- Verify requires default_to.
- Tests and docs.

##### Demo/Screenshot for feature changes and bug fixes -
N/A

#### Code Understanding and AI Usage

- Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?
[x] Yes, I used AI assistance (continue below)

- If you used AI assistance:
[x] I have reviewed every single line of the AI-generated code
[x] I can explain the purpose and logic of each function/component I added
[x] I have tested edge cases and understand how the code handles them
[x] I have modified the AI output to follow this project's coding standards and conventions

#### Explain your implementation approach:
- Formats in Pydantic; live checks in verify.
- Strict fail without default_to.

#### Checklist before requesting a review
[x] I have added proper PR title and linked to the issue
[x] I have performed a self-review of my code
[x] I can explain the purpose of every function, class, and logic block I added
[x] I understand why my changes work and have tested them thoroughly
[x] I have considered potential edge cases and how my code handles them
[x] If it is a core feature, I have added thorough tests
[x] My code follows the project's style guidelines and conventions