### PR TITLE
fix(bedrock): Converse agent client with strict tool schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Before any push or PR creation, follow the mandatory checklist in [CI.md](CI.md)
 | `Makefile`            | Canonical local automation for install, test, verify, deploy, and cleanup targets.                 |
 | `README.md`           | Product overview, install, quick start, high-level capabilities, and links to deeper docs.         |
 | `docs/DEVELOPMENT.md` | Contributor workflows: CI parity commands, dev container, benchmark, deployment, telemetry detail. |
+| `docs/investigation-tool-calling.md` | Investigation ReAct tool schemas, LLM invoke payloads, and message shapes (all providers). |
 | `SETUP.md`            | Machine setup (all platforms, Windows, MCP/OpenClaw, troubleshooting).                             |
 | `CI.md`               | Mandatory pre-push checklist: lint, format, typecheck, tests — agents MUST follow before pushing. |
 | `CONTRIBUTING.md`     | Contribution workflow, branch/PR guidance, and quality expectations.                               |
@@ -163,7 +164,7 @@ Basic steps:
 - If a new feature is shipped (tool, CLI command, pipeline behavior, integration) -> add a `docs/` page or section covering usage, configuration, and examples before the PR is opened.
 - If a new `docs/` page is added or renamed -> register it in `docs/docs.json` under the correct `pages` array in the same PR (path without `.mdx`, e.g. `messaging/whatsapp` for `docs/messaging/whatsapp.mdx`).
 - If an existing feature changes behavior, flags, or config shape -> update the relevant `docs/` page in the same PR; docs and code must stay in sync.
-- If a tool's API or schema changes -> update docs in `docs/` and update the related unit tests, usually under `tests/tools/`.
+- If a tool's API or schema changes -> update docs in `docs/` and update the related unit tests, usually under `tests/tools/`. For investigation LLM tool-calling (any provider), follow [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md).
 - If an integration changes -> update `tests/integrations/` and verify with `make verify-integrations`.
 - If adding a new integration -> follow the New Integration Checklist below before opening the PR for review.
 - If adding new tests -> always place them in `tests/`, never in `app/` (no inline tests).
@@ -200,6 +201,7 @@ The fastest local loop is `make test-cov`, which exercises the non-live unit sui
 - Legacy graph dev server: removed; use `make dev` for a local uvicorn hint or run investigations via the CLI.
 - Docker requirement: Several targets, including the Grafana local stack and Chaos Mesh workflows, require a running Docker daemon.
 - Docs navigation: Adding an `.mdx` file under `docs/` is not enough — Mintlify only shows pages listed in `docs/docs.json`. Forgetting the `pages` entry leaves the doc unreachable from the site sidebar.
+- Investigation tool schemas: draft-07 JSON Schema (e.g. `"type": ["object", "null"]`) can pass loose checks but fail the LLM API on first invoke because **all** available investigation tools are sent together. Normalize in the provider adapter and extend registry contract tests; see [docs/investigation-tool-calling.md](docs/investigation-tool-calling.md).
 
 ## 6. New Integration Checklist
 

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -375,6 +375,8 @@ def _build_seed_calls(state: dict[str, Any], tools: list[RegisteredTool]) -> lis
     if not seed_tools:
         return []
 
+    from app.services.bedrock_converse import new_tool_use_id
+
     calls: list[ToolCall] = []
     for tool in seed_tools:
         try:
@@ -382,7 +384,7 @@ def _build_seed_calls(state: dict[str, Any], tools: list[RegisteredTool]) -> lis
         except Exception:
             injected = {}
         calls.append(
-            ToolCall(id=f"seed_{tool.name}", name=tool.name, input=_public_tool_input(injected))
+            ToolCall(id=new_tool_use_id(), name=tool.name, input=_public_tool_input(injected))
         )
 
     return calls
@@ -419,9 +421,15 @@ def _build_synthetic_assistant_tool_call_msg(
     """
     from app.services.agent_llm_client import (
         AnthropicAgentClient,
+        BedrockConverseAgentClient,
         CLIBackedAgentClient,
         OpenAIAgentClient,
     )
+
+    if isinstance(llm, BedrockConverseAgentClient):
+        from app.services.bedrock_converse import build_assistant_tool_use_message
+
+        return build_assistant_tool_use_message(tool_calls)
 
     if isinstance(llm, AnthropicAgentClient):
         content = [
@@ -587,9 +595,9 @@ def _merge_tool_evidence(
 
 
 def _build_assistant_msg(llm: Any, response: Any) -> dict[str, Any]:
-    from app.services.agent_llm_client import AnthropicAgentClient
+    from app.services.agent_llm_client import AnthropicAgentClient, BedrockConverseAgentClient
 
-    if isinstance(llm, AnthropicAgentClient):
+    if isinstance(llm, (AnthropicAgentClient, BedrockConverseAgentClient)):
         return llm.build_assistant_message(response.raw_content)
     # Use raw_content when set — preserves provider-specific fields such as
     # Gemini's thought_signature that must be echoed back in the next request.

--- a/app/agent/investigation.py
+++ b/app/agent/investigation.py
@@ -126,7 +126,7 @@ class ConnectedInvestigationAgent:
         # Before the LLM loop: deterministically run the primary integration tools
         # based on the alert source. This guarantees the LLM always sees real data
         # from the right integration first, regardless of what it would have chosen.
-        seed_calls = _build_seed_calls(state, tools)
+        seed_calls = _build_seed_calls(state, tools, llm)
         if seed_calls:
             logger.debug("[agent] seeding %d primary tool calls before LLM loop", len(seed_calls))
             for tc in seed_calls:
@@ -356,7 +356,11 @@ def _build_connected_tool_context(
     }
 
 
-def _build_seed_calls(state: dict[str, Any], tools: list[RegisteredTool]) -> list[ToolCall]:
+def _build_seed_calls(
+    state: dict[str, Any],
+    tools: list[RegisteredTool],
+    llm: Any,
+) -> list[ToolCall]:
     """Return tool calls to run before the LLM loop based on the alert source.
 
     Picks all available tools whose source matches the alert's primary integration.
@@ -375,17 +379,18 @@ def _build_seed_calls(state: dict[str, Any], tools: list[RegisteredTool]) -> lis
     if not seed_tools:
         return []
 
+    from app.services.agent_llm_client import BedrockConverseAgentClient
     from app.services.bedrock_converse import new_tool_use_id
 
+    use_converse_ids = isinstance(llm, BedrockConverseAgentClient)
     calls: list[ToolCall] = []
     for tool in seed_tools:
         try:
             injected = tool.extract_params(resolved)
         except Exception:
             injected = {}
-        calls.append(
-            ToolCall(id=new_tool_use_id(), name=tool.name, input=_public_tool_input(injected))
-        )
+        tool_id = new_tool_use_id() if use_converse_ids else f"seed_{tool.name}"
+        calls.append(ToolCall(id=tool_id, name=tool.name, input=_public_tool_input(injected)))
 
     return calls
 

--- a/app/services/AGENTS.md
+++ b/app/services/AGENTS.md
@@ -4,6 +4,9 @@ Use this directory when adding or updating an **API-backed** LLM provider (Anthr
 OpenAI-compatible, Bedrock, etc.). For subprocess CLIs, use
 `app/integrations/llm_cli/AGENTS.md`.
 
+For investigation **tool calling** (schemas, invoke payloads, message shapes—all providers), see
+[docs/investigation-tool-calling.md](../../docs/investigation-tool-calling.md).
+
 Primary reference for provider discovery:
 
 - [https://docs.openclaw.ai/providers](https://docs.openclaw.ai/providers)
@@ -15,6 +18,8 @@ Primary reference for provider discovery:
 | ---------------------------- | --------------------------------------------------------------------------------- |
 | `app/config.py`              | Declares `LLMProvider`, provider env vars, defaults, and validation requirements. |
 | `app/services/llm_client.py` | Routes `LLM_PROVIDER` to the runtime client implementation.                       |
+| `app/services/agent_llm_client.py` | Investigation ReAct loop: tool-calling clients (`get_agent_llm`).              |
+| `app/agent/investigation.py` | Seed tool calls and provider-specific assistant / tool-result messages.           |
 | `app/cli/wizard/config.py`   | Defines onboarding metadata (`SUPPORTED_PROVIDERS`) and model choices.            |
 | `app/cli/wizard/env_sync.py` | Keeps `.env` values in sync when provider/model changes.                          |
 
@@ -23,9 +28,8 @@ Primary reference for provider discovery:
 
 1. Add provider literal to `LLMProvider` and normalization/validation paths in `app/config.py`.
 2. Add provider metadata in `app/cli/wizard/config.py` (`ProviderOption`, model env vars, defaults).
-3. Add runtime routing in `app/services/llm_client.py`:
-  - OpenAI-compatible providers should use `OpenAILLMClient` with provider base URL + key env var.
-  - Provider-specific SDKs can use a dedicated client class if needed.
+3. Add runtime routing in `app/services/llm_client.py` and, for investigation tool calling,
+   `app/services/agent_llm_client.py` (see [investigation-tool-calling.md](../../docs/investigation-tool-calling.md)).
 4. Update `.env` sync behavior if you introduce new model/API env keys.
 5. Add or update tests under `tests/services/` (and wizard tests if onboarding changes) for the new provider path.
 
@@ -35,4 +39,3 @@ Primary reference for provider discovery:
 - Use one source of truth for provider defaults in `app/config.py`.
 - Treat API keys as secrets: store in keychain via existing credential helpers, not in plaintext docs.
 - Prefer OpenAI-compatible client path for providers exposing compatible APIs.
-

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -334,7 +334,7 @@ class BedrockConverseAgentClient:
                     raise map_bedrock_client_error(self._model, err) from err
                 last_err = err
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
-                    raise RuntimeError(f"Bedrock API request failed: {err}") from err
+                    raise map_bedrock_client_error(self._model, err) from err
                 time.sleep(backoff)
                 backoff *= 2
             except Exception as err:
@@ -343,8 +343,6 @@ class BedrockConverseAgentClient:
                     raise RuntimeError(f"Bedrock API request failed: {err}") from err
                 time.sleep(backoff)
                 backoff *= 2
-        else:
-            raise RuntimeError("Bedrock invocation failed without a concrete error") from last_err
 
         content, raw_tool_calls, stop_reason, raw_message = parse_converse_output(response)
         tool_calls = [

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -321,6 +321,7 @@ class BedrockConverseAgentClient:
             kwargs["toolConfig"] = {"tools": tools}
 
         backoff = _RETRY_INITIAL_BACKOFF_SEC
+        response: dict[str, Any] | None = None
         last_err: Exception | None = None
         for attempt in range(_RETRY_MAX_ATTEMPTS):
             try:
@@ -332,19 +333,22 @@ class BedrockConverseAgentClient:
                 code = err.response.get("Error", {}).get("Code", "")
                 if is_non_retryable_bedrock_code(code):
                     raise map_bedrock_client_error(self._model, err) from err
-                last_err = err
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
                     raise map_bedrock_client_error(self._model, err) from err
+                last_err = err
                 time.sleep(backoff)
                 backoff *= 2
             except Exception as err:
-                last_err = err
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
                     raise RuntimeError(f"Bedrock API request failed: {err}") from err
+                last_err = err
                 time.sleep(backoff)
                 backoff *= 2
         else:
             raise RuntimeError("Bedrock invocation failed without a concrete error") from last_err
+
+        if response is None:
+            raise RuntimeError("Bedrock invocation failed without a response") from last_err
 
         content, raw_tool_calls, stop_reason, raw_message = parse_converse_output(response)
         tool_calls = [

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -343,6 +343,8 @@ class BedrockConverseAgentClient:
                     raise RuntimeError(f"Bedrock API request failed: {err}") from err
                 time.sleep(backoff)
                 backoff *= 2
+        else:
+            raise RuntimeError("Bedrock invocation failed without a concrete error") from last_err
 
         content, raw_tool_calls, stop_reason, raw_message = parse_converse_output(response)
         tool_calls = [

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -266,6 +266,112 @@ class BedrockAgentClient(AnthropicAgentClient):
         return f"{self.provider_name} request rejected (HTTP 400): {err.message}"
 
 
+class BedrockConverseAgentClient:
+    """Bedrock investigation client using the boto3 Converse API (non-Anthropic models)."""
+
+    provider_name = "Bedrock"
+
+    def __init__(self, model: str, max_tokens: int = 4096) -> None:
+        import boto3
+
+        from app.services.bedrock_converse import require_aws_region
+
+        self._model = model
+        self._max_tokens = max_tokens
+        region = require_aws_region()
+        self._boto3_client = boto3.client("bedrock-runtime", region_name=region)
+
+    def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
+        from app.services.bedrock_converse import build_converse_tool_specs
+
+        return build_converse_tool_specs(tools)
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> AgentLLMResponse:
+        import botocore.exceptions
+
+        from app.guardrails.engine import GuardrailBlockedError
+        from app.services.bedrock_converse import (
+            apply_guardrails_to_converse_payload,
+            is_non_retryable_bedrock_code,
+            map_bedrock_client_error,
+            parse_converse_output,
+            to_converse_messages,
+        )
+
+        converse_messages = to_converse_messages(messages)
+        converse_messages, system = apply_guardrails_to_converse_payload(
+            messages=converse_messages,
+            system=system,
+        )
+
+        kwargs: dict[str, Any] = {
+            "modelId": self._model,
+            "inferenceConfig": {"maxTokens": self._max_tokens},
+            "messages": converse_messages,
+        }
+        if system:
+            kwargs["system"] = [{"text": system}]
+        if tools:
+            kwargs["toolConfig"] = {"tools": tools}
+
+        backoff = _RETRY_INITIAL_BACKOFF_SEC
+        last_err: Exception | None = None
+        for attempt in range(_RETRY_MAX_ATTEMPTS):
+            try:
+                response = self._boto3_client.converse(**kwargs)
+                break
+            except GuardrailBlockedError:
+                raise
+            except botocore.exceptions.ClientError as err:
+                code = err.response.get("Error", {}).get("Code", "")
+                if is_non_retryable_bedrock_code(code):
+                    raise map_bedrock_client_error(self._model, err) from err
+                last_err = err
+                if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                    raise RuntimeError(f"Bedrock API request failed: {err}") from err
+                time.sleep(backoff)
+                backoff *= 2
+            except Exception as err:
+                last_err = err
+                if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                    raise RuntimeError(f"Bedrock API request failed: {err}") from err
+                time.sleep(backoff)
+                backoff *= 2
+        else:
+            raise RuntimeError("Bedrock invocation failed without a concrete error") from last_err
+
+        content, raw_tool_calls, stop_reason, raw_message = parse_converse_output(response)
+        tool_calls = [
+            ToolCall(id=tool_id, name=name, input=inputs)
+            for tool_id, name, inputs in raw_tool_calls
+        ]
+        return AgentLLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            stop_reason=stop_reason,
+            raw_content=raw_message,
+        )
+
+    @staticmethod
+    def build_tool_result_message(tool_calls: list[ToolCall], results: list[Any]) -> dict[str, Any]:
+        from app.services.bedrock_converse import build_tool_result_message as _build
+
+        return _build(tool_calls, results)
+
+    @staticmethod
+    def build_assistant_message(raw_content: Any) -> dict[str, Any]:
+        """Preserve the full Converse assistant ``output.message`` for the next turn."""
+        if not isinstance(raw_content, dict):
+            return {"role": "assistant", "content": []}
+        return raw_content
+
+
 _OPENAI_O_SERIES_RE = re.compile(r"(?:^|[^A-Za-z0-9])o\d", re.IGNORECASE)
 _OPENAI_GPT5_RE = re.compile(r"(?:^|[^A-Za-z0-9])gpt-5", re.IGNORECASE)
 
@@ -578,7 +684,9 @@ def _try_parse_tool_call_json(text: str) -> dict[str, Any] | None:
     return None
 
 
-_AgentClientType = AnthropicAgentClient | OpenAIAgentClient | CLIBackedAgentClient
+_AgentClientType = (
+    AnthropicAgentClient | OpenAIAgentClient | CLIBackedAgentClient | BedrockConverseAgentClient
+)
 _agent_client: _AgentClientType | None = None
 
 
@@ -610,11 +718,19 @@ def get_agent_llm() -> _AgentClientType:
         _agent_client = _create_openai_compat_client(settings, provider)
     elif provider == "bedrock":
         from app.config import BEDROCK_LLM_CONFIG
+        from app.services.llm_client import _is_anthropic_bedrock_model
 
-        _agent_client = BedrockAgentClient(
-            model=settings.bedrock_reasoning_model,
-            max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
-        )
+        model = settings.bedrock_reasoning_model
+        if _is_anthropic_bedrock_model(model):
+            _agent_client = BedrockAgentClient(
+                model=model,
+                max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+            )
+        else:
+            _agent_client = BedrockConverseAgentClient(
+                model=model,
+                max_tokens=BEDROCK_LLM_CONFIG.max_tokens,
+            )
     elif (cli_reg := _get_cli_provider_registration(provider)) is not None:
         model_name = os.getenv(cli_reg.model_env_key, "").strip() or None
         _agent_client = CLIBackedAgentClient(cli_reg.adapter_factory(), model=model_name)

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -215,9 +215,7 @@ def apply_guardrails_to_converse_payload(
         role = message["role"]
         content = message.get("content", "")
         if isinstance(content, str):
-            guarded_messages.append(
-                {"role": role, "content": [{"text": engine.apply(content)}]}
-            )
+            guarded_messages.append({"role": role, "content": [{"text": engine.apply(content)}]})
             continue
         if not isinstance(content, list):
             guarded_messages.append(message)

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -1,0 +1,290 @@
+"""Shared helpers for the Amazon Bedrock Converse API (tool schemas and messages).
+
+Used by the investigation agent's :class:`~app.services.agent_llm_client.BedrockConverseAgentClient`
+and kept separate from :mod:`app.services.llm_client` so tool-schema normalization stays in one place.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# JSON Schema keys the Converse tool ``inputSchema.json`` rejects or cannot resolve.
+_UNSUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "title",
+        "$schema",
+        "$defs",
+        "definitions",
+        "$ref",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "not",
+    }
+)
+
+# Default element type when a tool exposes ``type: array`` without ``items`` (common for
+# inferred list params in :mod:`app.tools.registered_tool`).
+_DEFAULT_ARRAY_ITEMS: dict[str, str] = {"type": "string"}
+
+
+def require_aws_region() -> str:
+    """Return configured AWS region or raise with a clear configuration error."""
+    region = (os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "").strip()
+    if not region:
+        raise RuntimeError("Bedrock requires AWS_REGION or AWS_DEFAULT_REGION to be set.")
+    return region
+
+
+def new_tool_use_id() -> str:
+    """Return a short alphanumeric id suitable for Converse ``toolUseId`` fields."""
+    return secrets.token_hex(5)[:9]
+
+
+def sanitize_converse_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a Converse-compatible copy of *schema* with required ``type`` / ``items`` filled in."""
+    cleaned: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key in _UNSUPPORTED_SCHEMA_KEYS:
+            continue
+        if isinstance(value, dict):
+            cleaned[key] = sanitize_converse_schema(value)
+        elif isinstance(value, list):
+            cleaned[key] = [
+                sanitize_converse_schema(item) if isinstance(item, dict) else item for item in value
+            ]
+        else:
+            cleaned[key] = value
+
+    _ensure_schema_node(cleaned)
+    return cleaned
+
+
+def _ensure_schema_node(node: dict[str, Any]) -> None:
+    """Mutate *node* so Bedrock's strict JSON Schema validation receives explicit types."""
+    if "properties" in node and "type" not in node:
+        node["type"] = "object"
+
+    schema_type = node.get("type")
+    if schema_type == "object" and "properties" not in node:
+        node["properties"] = {}
+
+    if schema_type == "array":
+        items = node.get("items")
+        if items is None:
+            node["items"] = dict(_DEFAULT_ARRAY_ITEMS)
+        elif isinstance(items, dict):
+            if "type" not in items and "properties" not in items:
+                node["items"] = dict(_DEFAULT_ARRAY_ITEMS)
+            else:
+                _ensure_schema_node(items)
+        return
+
+    items = node.get("items")
+    if isinstance(items, dict):
+        _ensure_schema_node(items)
+
+
+def normalize_tool_input_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize a tool's public input schema for ``toolSpec.inputSchema.json``.
+
+    Converse tool inputs must be JSON objects at the top level. Non-object roots are
+    replaced with an empty object schema so validation stays strict but safe.
+    """
+    cleaned = sanitize_converse_schema(dict(schema or {}))
+    if cleaned.get("type") != "object":
+        return {"type": "object", "properties": {}}
+    if "properties" not in cleaned:
+        cleaned["properties"] = {}
+    return cleaned
+
+
+def build_converse_tool_specs(tools: list[Any]) -> list[dict[str, Any]]:
+    """Build ``toolConfig.tools`` entries from registered tool objects."""
+    specs: list[dict[str, Any]] = []
+    for tool in tools:
+        specs.append(
+            {
+                "toolSpec": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "inputSchema": {"json": normalize_tool_input_schema(tool.public_input_schema)},
+                }
+            }
+        )
+    return specs
+
+
+def to_converse_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert investigation messages to Converse ``messages`` shape."""
+    converted: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content", "")
+        if isinstance(content, str):
+            converted.append({"role": message["role"], "content": [{"text": content}]})
+        else:
+            converted.append(message)
+    return converted
+
+
+def apply_guardrails_to_converse_payload(
+    *,
+    messages: list[dict[str, Any]],
+    system: str | None,
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Apply active guardrails to string or text-block message content."""
+    from app.guardrails.engine import get_guardrail_engine
+
+    engine = get_guardrail_engine()
+    if not engine.is_active:
+        return messages, system
+
+    guarded_messages: list[dict[str, Any]] = []
+    for message in messages:
+        role = message["role"]
+        content = message.get("content", "")
+        if isinstance(content, str):
+            guarded_messages.append({"role": role, "content": engine.apply(content)})
+            continue
+        if not isinstance(content, list):
+            guarded_messages.append(message)
+            continue
+        blocks: list[dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                blocks.append(block)
+                continue
+            if "text" in block and isinstance(block["text"], str):
+                blocks.append({"text": engine.apply(block["text"])})
+            else:
+                blocks.append(block)
+        guarded_messages.append({"role": role, "content": blocks})
+
+    guarded_system = engine.apply(system) if system else None
+    return guarded_messages, guarded_system
+
+
+def build_assistant_tool_use_message(tool_calls: list[Any]) -> dict[str, Any]:
+    """Build a Converse assistant message containing ``toolUse`` blocks."""
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "toolUse": {
+                    "toolUseId": tc.id,
+                    "name": tc.name,
+                    "input": tc.input,
+                }
+            }
+            for tc in tool_calls
+        ],
+    }
+
+
+def build_tool_result_message(tool_calls: list[Any], results: list[Any]) -> dict[str, Any]:
+    """Build the Converse ``toolResult`` user message for one round of tool calls."""
+    content: list[dict[str, Any]] = []
+    for tc, result in zip(tool_calls, results):
+        is_error = isinstance(result, dict) and "error" in result
+        if isinstance(result, dict):
+            sanitized = json.loads(json.dumps(result, default=str))
+            result_content: list[dict[str, Any]] = [{"json": sanitized}]
+        else:
+            result_content = [{"text": json.dumps(result, default=str)}]
+        tool_result: dict[str, Any] = {
+            "toolUseId": tc.id,
+            "content": result_content,
+        }
+        if is_error:
+            tool_result["status"] = "error"
+        content.append({"toolResult": tool_result})
+    return {"role": "user", "content": content}
+
+
+def parse_converse_output(
+    response: dict[str, Any],
+) -> tuple[str, list[tuple[str, str, dict[str, Any]]], str, dict[str, Any]]:
+    """Parse a Converse API response into text, tool calls, stop reason, and raw message."""
+    output_message = response.get("output", {}).get("message", {})
+    if not isinstance(output_message, dict):
+        output_message = {"role": "assistant", "content": []}
+
+    text_parts: list[str] = []
+    tool_calls: list[tuple[str, str, dict[str, Any]]] = []
+    for block in output_message.get("content", []):
+        if not isinstance(block, dict):
+            continue
+        if "text" in block:
+            text_parts.append(str(block["text"]))
+            continue
+        tool_use = block.get("toolUse")
+        if not isinstance(tool_use, dict):
+            continue
+        raw_input = tool_use.get("input")
+        tool_calls.append(
+            (
+                str(tool_use["toolUseId"]),
+                str(tool_use["name"]),
+                raw_input if isinstance(raw_input, dict) else {},
+            )
+        )
+
+    stop_reason = str(response.get("stopReason", "end_turn"))
+    return "".join(text_parts), tool_calls, stop_reason, output_message
+
+
+def map_bedrock_client_error(model: str, err: Any) -> RuntimeError:
+    """Map a ``botocore`` ``ClientError`` to a user-facing ``RuntimeError``."""
+    code = err.response.get("Error", {}).get("Code", "")
+    message = err.response.get("Error", {}).get("Message", "") or str(err)
+
+    if code == "ValidationException":
+        return RuntimeError(f"Bedrock request rejected (HTTP 400): {message}")
+    if code == "ResourceNotFoundException":
+        return RuntimeError(
+            f"Bedrock model '{model}' was not found in the configured region. "
+            "Check the model ID, region, or inference profile."
+        )
+    if code == "ThrottlingException":
+        return RuntimeError(
+            f"Bedrock rate limit exceeded for model '{model}'. "
+            "Reduce request frequency or request a quota increase."
+        )
+    if code in ("AccessDeniedException", "UnauthorizedException"):
+        err_msg_str = str(message)
+        if (
+            "INVALID_PAYMENT_INSTRUMENT" in err_msg_str
+            or "payment instrument" in err_msg_str.lower()
+        ):
+            aws_message = err_msg_str.strip().rstrip(".")
+            detail = f" Cause: {aws_message}." if aws_message else ""
+            return RuntimeError(
+                f"Access denied for Bedrock model '{model}'.{detail} "
+                "A valid AWS payment instrument is required."
+            )
+        aws_message = err_msg_str.strip().rstrip(".")
+        detail = f" Cause: {aws_message}." if aws_message else ""
+        return RuntimeError(
+            f"Access denied for Bedrock model '{model}'.{detail} "
+            "Check Bedrock model access (per-region opt-in), your "
+            "AWS Marketplace subscription / payment method, and "
+            "IAM permissions."
+        )
+    return RuntimeError(f"Bedrock API request failed: {message}")
+
+
+def is_non_retryable_bedrock_code(code: str) -> bool:
+    """Return True when retrying the same request will not help."""
+    return code in (
+        "ValidationException",
+        "ResourceNotFoundException",
+        "AccessDeniedException",
+        "UnauthorizedException",
+        "ThrottlingException",
+    )

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -14,7 +14,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# JSON Schema keys the Converse tool ``inputSchema.json`` rejects or cannot resolve.
+# Keys that Converse toolSpec.inputSchema.json rejects or cannot resolve.
 _UNSUPPORTED_SCHEMA_KEYS = frozenset(
     {
         "title",
@@ -24,14 +24,11 @@ _UNSUPPORTED_SCHEMA_KEYS = frozenset(
         "$ref",
         "allOf",
         "not",
-        # OpenAPI-style nullable; Converse uses explicit types — type is kept, flag removed.
-        "nullable",
+        "nullable",  # OpenAPI nullable — Converse uses explicit types; anyOf/oneOf are flattened instead
     }
 )
-# ``anyOf`` / ``oneOf`` are resolved in :func:`_flatten_composite_keywords`, not stripped.
 
-# Default element type when a tool exposes ``type: array`` without ``items`` (common for
-# inferred list params in :mod:`app.tools.registered_tool`).
+# Injected when a tool exposes ``type: array`` without ``items``.
 _DEFAULT_ARRAY_ITEMS: dict[str, str] = {"type": "string"}
 
 
@@ -199,7 +196,7 @@ def apply_guardrails_to_converse_payload(
                 blocks.append(block)
         guarded_messages.append({"role": role, "content": blocks})
 
-    guarded_system = engine.apply(system) if system else None
+    guarded_system = engine.apply(system) if system is not None else None
     return guarded_messages, guarded_system
 
 
@@ -319,5 +316,4 @@ def is_non_retryable_bedrock_code(code: str) -> bool:
         "ResourceNotFoundException",
         "AccessDeniedException",
         "UnauthorizedException",
-        "ThrottlingException",
     )

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -215,7 +215,9 @@ def apply_guardrails_to_converse_payload(
         role = message["role"]
         content = message.get("content", "")
         if isinstance(content, str):
-            guarded_messages.append({"role": role, "content": engine.apply(content)})
+            guarded_messages.append(
+                {"role": role, "content": [{"text": engine.apply(content)}]}
+            )
             continue
         if not isinstance(content, list):
             guarded_messages.append(message)

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -44,13 +44,42 @@ def require_aws_region() -> str:
 
 def new_tool_use_id() -> str:
     """Return a short alphanumeric id suitable for Converse ``toolUseId`` fields."""
-    return secrets.token_hex(5)[:9]
+    return secrets.token_hex(5)
+
+
+def _pick_non_null_schema_variant(variants: list[Any]) -> dict[str, Any] | None:
+    """Return the first ``anyOf`` / ``oneOf`` branch with a concrete non-null type."""
+    for item in variants:
+        if not isinstance(item, dict):
+            continue
+        branch_type = item.get("type")
+        if branch_type and branch_type != "null":
+            return item
+    return None
+
+
+def _flatten_composite_keywords(schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve ``anyOf`` / ``oneOf`` (e.g. Optional) into explicit ``type`` fields."""
+    flattened = dict(schema)
+    for composite in ("anyOf", "oneOf"):
+        if composite not in flattened:
+            continue
+        variants = flattened.pop(composite)
+        if not isinstance(variants, list):
+            continue
+        picked = _pick_non_null_schema_variant(variants)
+        if picked:
+            for key, value in picked.items():
+                flattened.setdefault(key, value)
+        elif "type" not in flattened:
+            flattened["type"] = "string"
+    return flattened
 
 
 def sanitize_converse_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Return a Converse-compatible copy of *schema* with required ``type`` / ``items`` filled in."""
     cleaned: dict[str, Any] = {}
-    for key, value in schema.items():
+    for key, value in _flatten_composite_keywords(schema).items():
         if key in _UNSUPPORTED_SCHEMA_KEYS:
             continue
         if isinstance(value, dict):

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -258,7 +258,7 @@ def build_tool_result_message(tool_calls: list[Any], results: list[Any]) -> dict
     """Build the Converse ``toolResult`` user message for one round of tool calls."""
     content: list[dict[str, Any]] = []
     for tc, result in zip(tool_calls, results, strict=True):
-        is_error = isinstance(result, dict) and "error" in result
+        is_error = isinstance(result, dict) and bool(result.get("error"))
         if isinstance(result, dict):
             sanitized = json.loads(json.dumps(result, default=str))
             result_content: list[dict[str, Any]] = [{"json": sanitized}]

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -22,7 +22,6 @@ _UNSUPPORTED_SCHEMA_KEYS = frozenset(
         "$defs",
         "definitions",
         "$ref",
-        "allOf",
         "not",
         "nullable",  # OpenAPI nullable — Converse uses explicit types; anyOf/oneOf are flattened instead
     }
@@ -59,9 +58,45 @@ def _pick_non_null_schema_variant(variants: list[Any]) -> dict[str, Any] | None:
     return None
 
 
+def _merge_all_of_subschemas(variants: list[Any]) -> dict[str, Any]:
+    """Merge ``allOf`` branches (e.g. Pydantic constrained fields) into one schema dict."""
+    merged: dict[str, Any] = {}
+    for item in variants:
+        if not isinstance(item, dict):
+            continue
+        for key, value in item.items():
+            if key == "properties" and isinstance(value, dict):
+                props = merged.setdefault("properties", {})
+                if isinstance(props, dict):
+                    props.update(value)
+                else:
+                    merged["properties"] = dict(value)
+            elif key == "required" and isinstance(value, list):
+                required = merged.setdefault("required", [])
+                if isinstance(required, list):
+                    for name in value:
+                        if name not in required:
+                            required.append(name)
+            elif key not in merged:
+                merged[key] = value
+    return merged
+
+
 def _flatten_composite_keywords(schema: dict[str, Any]) -> dict[str, Any]:
-    """Resolve ``anyOf`` / ``oneOf`` (e.g. Optional) into explicit ``type`` fields."""
+    """Resolve ``allOf`` / ``anyOf`` / ``oneOf`` into explicit ``type`` fields."""
     flattened = dict(schema)
+    if "allOf" in flattened:
+        variants = flattened.pop("allOf")
+        if isinstance(variants, list):
+            for key, value in _merge_all_of_subschemas(variants).items():
+                if key == "properties" and isinstance(value, dict):
+                    existing = flattened.get("properties")
+                    if isinstance(existing, dict):
+                        existing.update(value)
+                    else:
+                        flattened["properties"] = dict(value)
+                elif key not in flattened:
+                    flattened[key] = value
     for composite in ("anyOf", "oneOf"):
         if composite not in flattened:
             continue
@@ -220,7 +255,7 @@ def build_assistant_tool_use_message(tool_calls: list[Any]) -> dict[str, Any]:
 def build_tool_result_message(tool_calls: list[Any], results: list[Any]) -> dict[str, Any]:
     """Build the Converse ``toolResult`` user message for one round of tool calls."""
     content: list[dict[str, Any]] = []
-    for tc, result in zip(tool_calls, results):
+    for tc, result in zip(tool_calls, results, strict=True):
         is_error = isinstance(result, dict) and "error" in result
         if isinstance(result, dict):
             sanitized = json.loads(json.dumps(result, default=str))

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -131,12 +131,27 @@ def sanitize_converse_schema(schema: dict[str, Any]) -> dict[str, Any]:
     return cleaned
 
 
+def _coerce_schema_type(node: dict[str, Any]) -> str | None:
+    """Return a single Converse-compatible ``type`` string (Bedrock rejects ``type`` arrays)."""
+    schema_type = node.get("type")
+    if isinstance(schema_type, list):
+        for candidate in schema_type:
+            if isinstance(candidate, str) and candidate != "null":
+                node["type"] = candidate
+                return candidate
+        node["type"] = "string"
+        return "string"
+    if isinstance(schema_type, str):
+        return schema_type
+    return None
+
+
 def _ensure_schema_node(node: dict[str, Any]) -> None:
     """Mutate *node* so Bedrock's strict JSON Schema validation receives explicit types."""
     if "properties" in node and "type" not in node:
         node["type"] = "object"
 
-    schema_type = node.get("type")
+    schema_type = _coerce_schema_type(node)
     if schema_type == "object" and "properties" not in node:
         node["properties"] = {}
 

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -22,12 +22,13 @@ _UNSUPPORTED_SCHEMA_KEYS = frozenset(
         "$defs",
         "definitions",
         "$ref",
-        "oneOf",
-        "anyOf",
         "allOf",
         "not",
+        # OpenAPI-style nullable; Converse uses explicit types — type is kept, flag removed.
+        "nullable",
     }
 )
+# ``anyOf`` / ``oneOf`` are resolved in :func:`_flatten_composite_keywords`, not stripped.
 
 # Default element type when a tool exposes ``type: array`` without ``items`` (common for
 # inferred list params in :mod:`app.tools.registered_tool`).

--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -56,6 +56,9 @@ def _pick_non_null_schema_variant(variants: list[Any]) -> dict[str, Any] | None:
         branch_type = item.get("type")
         if branch_type and branch_type != "null":
             return item
+        # Accept an implicit object schema (properties present, no explicit type).
+        if "properties" in item:
+            return item
     return None
 
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,6 +36,10 @@ Before a PR, run at least `make lint`, `make format-check`, `make typecheck`, an
 
 Routing precedence, postprocessing transforms, compatibility seams, and the rule-extension checklist are documented in [`docs/routing-policy-architecture.md`](https://github.com/Tracer-Cloud/opensre/blob/main/docs/routing-policy-architecture.md).
 
+## Investigation tool calling
+
+Tool schemas, provider adapters (`agent_llm_client.py`), and investigation message shapes are documented in [`docs/investigation-tool-calling.md`](investigation-tool-calling.md) (all LLM providers, not vendor-specific).
+
 ## Interactive shell: REPL watchdog demo
 
 PR reviewers expect a **visible demo** (terminal log or screenshot) in the PR under **Demo/Screenshot**, not only tests. Copy the exact steps from this section into your PR description, then attach your terminal output or recording.

--- a/docs/investigation-tool-calling.md
+++ b/docs/investigation-tool-calling.md
@@ -1,0 +1,135 @@
+# Investigation tool calling
+
+Contributor guide for the investigation ReAct loop: tool schemas, LLM invoke payloads, and
+conversation messages. Applies to **every** provider the agent uses (Anthropic, OpenAI-compatible,
+CLI-backed, Bedrock, and future clients)—not one vendor.
+
+## Architecture
+
+The investigation agent does **not** call integration APIs through the LLM. The flow is:
+
+1. **Tools** — `get_registered_tools("investigation")`, filtered with `tool.is_available(...)`.
+2. **Schemas** — `llm.tool_schemas(tools)` from `get_agent_llm()` in `app/services/agent_llm_client.py`.
+   Each client class shapes schemas for its API (function definitions, tool specs, CLI prompt JSON, etc.).
+3. **Invoke** — `llm.invoke(messages, system=..., tools=tool_schemas)`; the model returns tool calls.
+4. **Execute** — Tools run locally; results are appended as user/assistant turns the **same** client can read on the next invoke.
+5. **Seed path** — Before the loop, `_build_seed_calls` may inject deterministic tool runs; synthetic
+   assistant + tool-result messages must match the active client (`app/agent/investigation.py`).
+
+```text
+investigation.py  →  get_agent_llm()  →  *AgentClient.tool_schemas / invoke
+                    ↓
+              app/tools/*  (input_schema, extract_params, run)
+```
+
+### Where code lives
+
+| Concern | Location |
+| -------- | -------- |
+| Provider routing | `app/services/agent_llm_client.py` (`get_agent_llm`, client classes) |
+| Chat / non-agent LLM | `app/services/llm_client.py` (separate path—changes here do not fix investigation) |
+| Investigation loop & message dispatch | `app/agent/investigation.py` |
+| Provider-specific schema/message helpers | Next to the client implementing `tool_schemas()` (strict normalizers live beside that client) |
+| Tool definitions | `app/tools/` (`input_schema`, `public_input_schema`) |
+
+When adding a provider, implement **both** `tool_schemas()` and the message shapes `investigation.py`
+already branches on (or extend those branches). Do not assume one vendor’s JSON tool format works elsewhere.
+
+## Why bugs are easy to miss
+
+- **JSON Schema draft-07 vs API strictness** — Tool authors often use patterns that validate in draft-07
+  (`"type": ["object", "null"]`, `anyOf`, `nullable`, implicit objects, bare `items: {}`). A given
+  LLM API may require a **single string** `type`, explicit `items`, and a closed set of keys. Unit
+  tests that only check “has properties” miss union `type` arrays.
+- **All tools in one request** — Investigation sends **every available** tool schema in a single invoke.
+  One invalid schema fails the whole call (HTTP 400, “invalid tools”, etc.) even when the alert never
+  uses that tool.
+- **Multiple code paths** — Fixes in `llm_client.py`, chat, or routing do not apply to
+  `agent_llm_client.py` unless wired there. Provider-specific normalizers must run in `tool_schemas()`
+  (or shared helpers the client calls).
+- **Contract tests can lag APIs** — Registry-wide schema tests must encode the **strictest** rules your
+  shipped adapters enforce. Extend assertions when production shows a new rejection reason.
+
+## Tool `input_schema` (authoring)
+
+When adding or changing tools under `app/tools/`:
+
+- [ ] **Top-level** — Investigation tools use `type: object` with a `properties` dict.
+- [ ] **Single `type`** — Prefer one string per node (`"string"`, `"object"`, `"array"`). Avoid
+      `"type": ["object", "null"]`; use optional fields via `anyOf`/`oneOf`, omit from `required`, or
+      document that a provider adapter will normalize (and add adapter + test in the same PR).
+- [ ] **Arrays** — Always set `items` with an explicit `type` or `properties` (never empty `{}`).
+- [ ] **Composites** — `$ref`, `$defs`, `allOf`, `anyOf`, `oneOf`, `nullable` may need a normalizer
+      in the client adapter; do not add them to public schemas without updating that adapter and tests.
+- [ ] **Stability** — Tool call `id` values must stay consistent between the assistant turn that
+      requests tools and the following tool-result turn for that provider’s format.
+
+Run tool unit tests under `tests/tools/`. After schema changes, run the registry **strict adapter**
+contract (uses the strictest normalizer currently wired in the repo):
+
+```bash
+uv run python -m pytest tests/services/test_investigation_tool_schemas.py -q
+```
+
+Shared assertions live in `tests/services/investigation_tool_schema_contract.py`. When you add a
+stricter provider adapter, point `test_investigation_tool_schemas.py` at its normalizer and extend
+the contract module if the API rejects new patterns. Bedrock-specific unit tests stay in
+`tests/services/test_bedrock_converse.py` (no duplicate registry test there).
+
+## Provider adapters (`agent_llm_client.py`)
+
+Each `*AgentClient` should own:
+
+| Responsibility | Notes |
+| ---------------- | ----- |
+| `tool_schemas(tools)` | Map `RegisteredTool` / `public_input_schema` → API payload. Never pass raw schemas if the API is strict. |
+| `invoke(..., tools=...)` | Attach schemas the API expects; handle retries and map errors to `RuntimeError` with actionable text. |
+| Message compatibility | Investigation builds history via `_build_synthetic_assistant_tool_call_msg`, `_build_assistant_msg`, `_build_tool_result_messages`—each must match your invoke parser. |
+
+Checklist when adding or changing a client:
+
+- [ ] `tool_schemas` output matches what `invoke` sends (no duplicate or divergent normalization).
+- [ ] New JSON Schema patterns in tools → update the adapter normalizer **and** contract tests in the same PR.
+- [ ] Serialized payload round-trips like the SDK will send it (e.g. `json.dumps` on the tools list).
+- [ ] Validation errors from the API (“missing field type”, “invalid tools”) → treat as schema/adapter bugs first.
+- [ ] Throttling / rate limits: align with existing retry policy in sibling clients.
+
+Provider-specific modules (e.g. strict JSON Schema helpers) stay beside the client; keep investigation
+logic in `investigation.py` as dispatch only.
+
+## Investigation messages (`investigation.py`)
+
+- [ ] **Same `ToolCall.id`** across synthetic seed assistant message, tool results, and evidence keys.
+- [ ] **Provider-specific IDs** — Use opaque ids only when the client requires them (e.g. length/format);
+      keep stable `seed_{tool.name}` (or equivalent) where history/tests expect predictable ids.
+- [ ] **Block vs string content** — Some APIs require content as structured blocks, not raw strings
+      (including after guardrails). Match what `invoke` already produced earlier in the thread.
+- [ ] **`zip(tool_calls, results, strict=True)`** when pairing calls to results.
+
+Extend `tests/agent/test_investigation.py` when you add a client branch for synthetic/assistant messages.
+
+## Verification
+
+Minimum before merging schema or client changes:
+
+```bash
+uv run python -m pytest tests/services/test_investigation_tool_schemas.py -q
+uv run python -m pytest tests/services/test_agent_llm_client.py tests/agent/test_investigation.py -q
+```
+
+When touching a specific provider, also verify end-to-end with that provider configured:
+
+```bash
+uv run opensre
+# /investigate <fixture.json>   # interactive shell
+# or: opensre investigate -i <fixture.json>
+```
+
+Use the same `LLM_PROVIDER` / model users report in issues; unit tests alone are not enough for
+adapter strictness gaps.
+
+## Related docs
+
+- [app/services/AGENTS.md](../app/services/AGENTS.md) — API provider wiring and env keys
+- [app/integrations/llm_cli/AGENTS.md](../app/integrations/llm_cli/AGENTS.md) — subprocess CLI providers
+- [AGENTS.md](../AGENTS.md) — repo map and PR checklist

--- a/tests/agent/test_investigation.py
+++ b/tests/agent/test_investigation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -213,3 +215,30 @@ def test_run_parallel_handles_interpreter_shutdown() -> None:
     # The concurrent path raises RuntimeError; fallback sequential execution succeeds
     assert len(results) == 2
     assert all(r == {"result": "ok"} for r in results)
+
+
+def test_build_synthetic_assistant_msg_for_bedrock_converse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Seed assistant turn must use Converse toolUse blocks, not plain text fallback."""
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setitem(
+        sys.modules,
+        "boto3",
+        types.SimpleNamespace(
+            client=lambda *_args, **_kwargs: types.SimpleNamespace(converse=lambda **_: {})
+        ),
+    )
+
+    from app.services.agent_llm_client import BedrockConverseAgentClient
+
+    llm = BedrockConverseAgentClient(model="mistral.mistral-large-3-675b-instruct")
+    calls = [
+        ToolCall(id="abc12def3", name="query_logs", input={"query": "error"}),
+    ]
+    msg = _build_synthetic_assistant_tool_call_msg(llm, calls)
+
+    assert msg["role"] == "assistant"
+    assert msg["content"][0]["toolUse"]["toolUseId"] == "abc12def3"
+    assert msg["content"][0]["toolUse"]["name"] == "query_logs"
+    assert "I will start by querying" not in str(msg)

--- a/tests/services/investigation_tool_schema_contract.py
+++ b/tests/services/investigation_tool_schema_contract.py
@@ -1,0 +1,72 @@
+"""Shared strict JSON Schema contract for investigation tool definitions.
+
+Used by provider-specific normalizers (e.g. strict HTTP tool-spec APIs) and by the
+registry-wide test in ``test_investigation_tool_schemas.py``. Not tied to a single vendor.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from app.tools.registry import get_registered_tools
+
+# Keys stripped by the strictest investigation schema normalizer in the tree today.
+# When a new adapter is stricter, extend this set and the assertions below together.
+STRICT_UNSUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "title",
+        "$schema",
+        "$defs",
+        "definitions",
+        "$ref",
+        "not",
+        "nullable",
+    }
+)
+
+
+def assert_strict_tool_schema_node(node: Any, *, path: str) -> None:
+    """Enforce invariants strict LLM tool-schema APIs expect (string ``type``, typed arrays)."""
+    if not isinstance(node, dict):
+        return
+    for key in node:
+        assert key not in STRICT_UNSUPPORTED_SCHEMA_KEYS, f"{path}: unsupported key {key!r}"
+
+    schema_type = node.get("type")
+    assert not isinstance(schema_type, list), f"{path}: type must not be a list {schema_type!r}"
+    if "properties" in node:
+        assert schema_type == "object", f"{path}: properties without type object"
+        properties = node["properties"]
+        assert isinstance(properties, dict), f"{path}: properties must be a dict"
+        for name, child in properties.items():
+            assert_strict_tool_schema_node(child, path=f"{path}.{name}")
+
+    if schema_type == "array":
+        items = node.get("items")
+        assert isinstance(items, dict), f"{path}: array missing typed items"
+        assert "type" in items or "properties" in items, f"{path}: array items lack type"
+        assert_strict_tool_schema_node(items, path=f"{path}[]")
+    elif isinstance(node.get("items"), dict):
+        assert_strict_tool_schema_node(node["items"], path=f"{path}[]")
+
+
+def assert_all_investigation_tools_satisfy_strict_adapter(
+    *,
+    normalize_schema: Callable[[dict[str, Any] | None], dict[str, Any]],
+    build_tool_specs: Callable[[list[Any]], list[dict[str, Any]]],
+) -> None:
+    """Every investigation tool must normalize and serialize under *strict* adapter rules."""
+    tools = get_registered_tools("investigation")
+    assert tools, "expected at least one investigation tool"
+
+    for tool in tools:
+        schema = normalize_schema(tool.public_input_schema)
+        assert schema.get("type") == "object", tool.name
+        assert isinstance(schema.get("properties"), dict), tool.name
+        assert_strict_tool_schema_node(schema, path=tool.name)
+
+    specs = build_tool_specs(tools)
+    assert len(specs) == len(tools)
+    json.dumps({"tools": specs})

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -876,3 +876,106 @@ def test_openai_empty_choices_raises_runtime_error(
 
     with pytest.raises(RuntimeError, match="unexpected response"):
         client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+
+_MISTRAL_MODEL = "mistral.mistral-large-3-675b-instruct"
+
+
+def _make_converse_response(
+    *,
+    text: str = "",
+    tool_uses: list[dict[str, object]] | None = None,
+    stop_reason: str = "end_turn",
+) -> dict[str, object]:
+    content: list[dict[str, object]] = []
+    if text:
+        content.append({"text": text})
+    for tool_use in tool_uses or []:
+        content.append({"toolUse": tool_use})
+    return {
+        "output": {"message": {"role": "assistant", "content": content}},
+        "stopReason": stop_reason,
+    }
+
+
+def _stub_boto3_converse(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    converse_response: dict[str, object] | None = None,
+    converse_side_effect: Exception | None = None,
+) -> None:
+    def converse(**_: object) -> dict[str, object]:
+        if converse_side_effect is not None:
+            raise converse_side_effect
+        return converse_response or _make_converse_response(text="ok")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "boto3",
+        types.SimpleNamespace(
+            client=lambda *_args, **_kwargs: types.SimpleNamespace(converse=converse)
+        ),
+    )
+
+
+def test_bedrock_converse_requires_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    _stub_boto3_converse(monkeypatch)
+
+    from app.services.agent_llm_client import BedrockConverseAgentClient
+
+    with pytest.raises(RuntimeError, match="Bedrock requires AWS_REGION or AWS_DEFAULT_REGION"):
+        BedrockConverseAgentClient(model=_MISTRAL_MODEL)
+
+
+def test_bedrock_converse_invoke_parses_tool_use(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _stub_boto3_converse(
+        monkeypatch,
+        converse_response=_make_converse_response(
+            text="Checking.",
+            tool_uses=[{"toolUseId": "tu1", "name": "query_logs", "input": {"q": "err"}}],
+            stop_reason="tool_use",
+        ),
+    )
+
+    from app.services.agent_llm_client import BedrockConverseAgentClient
+
+    result = BedrockConverseAgentClient(model=_MISTRAL_MODEL).invoke(
+        messages=[{"role": "user", "content": [{"text": "hi"}]}]
+    )
+    assert result.content == "Checking."
+    assert result.has_tool_calls
+    assert result.tool_calls[0].id == "tu1"
+    assert result.stop_reason == "tool_use"
+
+
+def test_get_agent_llm_routes_non_anthropic_bedrock_to_converse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_PROVIDER", "bedrock")
+    monkeypatch.setenv("BEDROCK_REASONING_MODEL", _MISTRAL_MODEL)
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _stub_boto3_converse(monkeypatch)
+
+    from app.services.agent_llm_client import (
+        BedrockConverseAgentClient,
+        get_agent_llm,
+        reset_agent_client,
+    )
+
+    reset_agent_client()
+    assert isinstance(get_agent_llm(), BedrockConverseAgentClient)
+
+
+def test_get_agent_llm_routes_anthropic_bedrock_to_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("LLM_PROVIDER", "bedrock")
+    monkeypatch.setenv("BEDROCK_REASONING_MODEL", "us.anthropic.claude-sonnet-4-6")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    from app.services.agent_llm_client import BedrockAgentClient, get_agent_llm, reset_agent_client
+
+    reset_agent_client()
+    assert isinstance(get_agent_llm(), BedrockAgentClient)

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -979,3 +979,73 @@ def test_get_agent_llm_routes_anthropic_bedrock_to_sdk(monkeypatch: pytest.Monke
 
     reset_agent_client()
     assert isinstance(get_agent_llm(), BedrockAgentClient)
+
+
+def test_bedrock_converse_throttling_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ThrottlingException must be retried, not hard-failed on first occurrence."""
+    import botocore.exceptions
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    throttle_err = botocore.exceptions.ClientError(
+        {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+        "Converse",
+    )
+    call_count = 0
+
+    def converse(**_: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise throttle_err
+        return _make_converse_response(text="ok")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "boto3",
+        types.SimpleNamespace(
+            client=lambda *_args, **_kwargs: types.SimpleNamespace(converse=converse)
+        ),
+    )
+
+    from app.services.agent_llm_client import BedrockConverseAgentClient
+
+    result = BedrockConverseAgentClient(model=_MISTRAL_MODEL).invoke(
+        messages=[{"role": "user", "content": [{"text": "hi"}]}]
+    )
+    assert result.content == "ok"
+    assert call_count == 2
+
+
+def test_bedrock_converse_throttling_all_retries_exhausted_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After all retries are exhausted on ThrottlingException, a clear error is raised."""
+    import botocore.exceptions
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    throttle_err = botocore.exceptions.ClientError(
+        {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+        "Converse",
+    )
+
+    def always_throttle(**_: object) -> dict[str, object]:
+        raise throttle_err
+
+    monkeypatch.setitem(
+        sys.modules,
+        "boto3",
+        types.SimpleNamespace(
+            client=lambda *_args, **_kwargs: types.SimpleNamespace(converse=always_throttle)
+        ),
+    )
+
+    from app.services.agent_llm_client import BedrockConverseAgentClient
+
+    with pytest.raises(RuntimeError, match="rate limit"):
+        BedrockConverseAgentClient(model=_MISTRAL_MODEL).invoke(
+            messages=[{"role": "user", "content": [{"text": "hi"}]}]
+        )

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -12,6 +12,7 @@ import pytest
 from app.services.agent_llm_client import ToolCall
 from app.services.bedrock_converse import (
     _UNSUPPORTED_SCHEMA_KEYS,
+    apply_guardrails_to_converse_payload,
     build_assistant_tool_use_message,
     build_converse_tool_specs,
     build_tool_result_message,
@@ -171,6 +172,23 @@ def test_build_converse_tool_specs_preserves_object_properties() -> None:
 def test_to_converse_messages_converts_string_content() -> None:
     converted = to_converse_messages([{"role": "user", "content": "hello"}])
     assert converted == [{"role": "user", "content": [{"text": "hello"}]}]
+
+
+def test_apply_guardrails_wraps_string_content_in_text_blocks() -> None:
+    from unittest.mock import MagicMock, patch
+
+    engine = MagicMock()
+    engine.is_active = True
+    engine.apply.side_effect = lambda text: f"guarded:{text}"
+
+    with patch("app.guardrails.engine.get_guardrail_engine", return_value=engine):
+        messages, system = apply_guardrails_to_converse_payload(
+            messages=[{"role": "user", "content": "hello"}],
+            system="sys",
+        )
+
+    assert messages == [{"role": "user", "content": [{"text": "guarded:hello"}]}]
+    assert system == "guarded:sys"
 
 
 def test_build_assistant_tool_use_message() -> None:

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -23,39 +23,13 @@ from app.services.bedrock_converse import (
     sanitize_converse_schema,
     to_converse_messages,
 )
-from app.tools.registry import clear_tool_registry_cache, get_registered_tools
-
-
 @pytest.fixture(autouse=True)
 def _reset_tool_registry() -> Generator[None]:
+    from app.tools.registry import clear_tool_registry_cache
+
     clear_tool_registry_cache()
     yield
     clear_tool_registry_cache()
-
-
-def _assert_converse_schema_node(node: Any, *, path: str) -> None:
-    """Enforce invariants Bedrock Converse strict JSON Schema validation expects."""
-    if not isinstance(node, dict):
-        return
-    for key in node:
-        assert key not in _UNSUPPORTED_SCHEMA_KEYS, f"{path}: unsupported key {key!r}"
-
-    schema_type = node.get("type")
-    assert not isinstance(schema_type, list), f"{path}: type must not be a list {schema_type!r}"
-    if "properties" in node:
-        assert schema_type == "object", f"{path}: properties without type object"
-        properties = node["properties"]
-        assert isinstance(properties, dict), f"{path}: properties must be a dict"
-        for name, child in properties.items():
-            _assert_converse_schema_node(child, path=f"{path}.{name}")
-
-    if schema_type == "array":
-        items = node.get("items")
-        assert isinstance(items, dict), f"{path}: array missing typed items"
-        assert "type" in items or "properties" in items, f"{path}: array items lack type"
-        _assert_converse_schema_node(items, path=f"{path}[]")
-    elif isinstance(node.get("items"), dict):
-        _assert_converse_schema_node(node["items"], path=f"{path}[]")
 
 
 def test_sanitize_injects_object_type_when_properties_present() -> None:
@@ -283,20 +257,3 @@ def test_map_bedrock_client_error_throttling() -> None:
     )
     mapped = map_bedrock_client_error("mistral.test", err)
     assert "rate limit" in str(mapped).lower()
-
-
-def test_all_investigation_tool_schemas_satisfy_converse_invariants() -> None:
-    """Every registered investigation tool must normalize to a strict Converse-safe schema."""
-    tools = get_registered_tools("investigation")
-    assert tools, "expected at least one investigation tool"
-
-    for tool in tools:
-        schema = normalize_tool_input_schema(tool.public_input_schema)
-        assert schema.get("type") == "object", tool.name
-        assert isinstance(schema.get("properties"), dict), tool.name
-        _assert_converse_schema_node(schema, path=tool.name)
-
-    specs = build_converse_tool_specs(tools)
-    assert len(specs) == len(tools)
-    # Must round-trip through JSON like boto3 will serialize toolConfig.
-    json.dumps({"tools": specs})

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -76,6 +76,11 @@ def test_sanitize_nested_array_property() -> None:
     assert cleaned["properties"]["tags"]["items"] == {"type": "string"}
 
 
+def test_sanitize_resolves_anyof_optional_string() -> None:
+    cleaned = sanitize_converse_schema({"anyOf": [{"type": "string"}, {"type": "null"}]})
+    assert cleaned["type"] == "string"
+
+
 def test_sanitize_strips_unsupported_keys() -> None:
     schema = {
         "title": "Root",
@@ -190,7 +195,7 @@ def test_parse_converse_output_text_and_tool_use() -> None:
 
 def test_new_tool_use_id_is_short_alphanumeric() -> None:
     tool_id = new_tool_use_id()
-    assert 1 <= len(tool_id) <= 12
+    assert len(tool_id) == 10
     assert tool_id.isalnum()
 
 

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -82,6 +82,33 @@ def test_sanitize_resolves_anyof_optional_string() -> None:
     assert cleaned["type"] == "string"
 
 
+def test_sanitize_resolves_anyof_implicit_object() -> None:
+    cleaned = sanitize_converse_schema(
+        {
+            "anyOf": [
+                {"properties": {"name": {"type": "string"}}},
+                {"type": "null"},
+            ]
+        }
+    )
+    assert cleaned["type"] == "object"
+    assert cleaned["properties"]["name"]["type"] == "string"
+
+
+def test_sanitize_merges_allof_constraints() -> None:
+    cleaned = sanitize_converse_schema(
+        {
+            "allOf": [
+                {"type": "object", "properties": {"name": {"type": "string"}}},
+                {"properties": {"age": {"type": "integer"}}},
+            ]
+        }
+    )
+    assert cleaned["type"] == "object"
+    assert cleaned["properties"]["name"]["type"] == "string"
+    assert cleaned["properties"]["age"]["type"] == "integer"
+
+
 def test_sanitize_strips_nullable_keeps_type() -> None:
     cleaned = sanitize_converse_schema({"type": "string", "nullable": True})
     assert cleaned == {"type": "string"}

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -41,6 +41,7 @@ def _assert_converse_schema_node(node: Any, *, path: str) -> None:
         assert key not in _UNSUPPORTED_SCHEMA_KEYS, f"{path}: unsupported key {key!r}"
 
     schema_type = node.get("type")
+    assert not isinstance(schema_type, list), f"{path}: type must not be a list {schema_type!r}"
     if "properties" in node:
         assert schema_type == "object", f"{path}: properties without type object"
         properties = node["properties"]
@@ -94,6 +95,18 @@ def test_sanitize_resolves_anyof_implicit_object() -> None:
     )
     assert cleaned["type"] == "object"
     assert cleaned["properties"]["name"]["type"] == "string"
+
+
+def test_sanitize_collapses_type_union_list() -> None:
+    cleaned = sanitize_converse_schema(
+        {
+            "type": "object",
+            "properties": {
+                "credentials": {"type": ["object", "null"], "default": None},
+            },
+        }
+    )
+    assert cleaned["properties"]["credentials"]["type"] == "object"
 
 
 def test_sanitize_merges_allof_constraints() -> None:

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -81,6 +81,11 @@ def test_sanitize_resolves_anyof_optional_string() -> None:
     assert cleaned["type"] == "string"
 
 
+def test_sanitize_strips_nullable_keeps_type() -> None:
+    cleaned = sanitize_converse_schema({"type": "string", "nullable": True})
+    assert cleaned == {"type": "string"}
+
+
 def test_sanitize_strips_unsupported_keys() -> None:
     schema = {
         "title": "Root",

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Generator
 from datetime import datetime
-from typing import Any
 
 import pytest
 
 from app.services.agent_llm_client import ToolCall
 from app.services.bedrock_converse import (
-    _UNSUPPORTED_SCHEMA_KEYS,
     apply_guardrails_to_converse_payload,
     build_assistant_tool_use_message,
     build_converse_tool_specs,
@@ -23,6 +20,8 @@ from app.services.bedrock_converse import (
     sanitize_converse_schema,
     to_converse_messages,
 )
+
+
 @pytest.fixture(autouse=True)
 def _reset_tool_registry() -> Generator[None]:
     from app.tools.registry import clear_tool_registry_cache

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
+from typing import Any
+
+import pytest
 
 from app.services.agent_llm_client import ToolCall
 from app.services.bedrock_converse import (
+    _UNSUPPORTED_SCHEMA_KEYS,
     build_assistant_tool_use_message,
     build_converse_tool_specs,
     build_tool_result_message,
@@ -16,6 +21,38 @@ from app.services.bedrock_converse import (
     sanitize_converse_schema,
     to_converse_messages,
 )
+from app.tools.registry import clear_tool_registry_cache, get_registered_tools
+
+
+@pytest.fixture(autouse=True)
+def _reset_tool_registry() -> None:
+    clear_tool_registry_cache()
+    yield
+    clear_tool_registry_cache()
+
+
+def _assert_converse_schema_node(node: Any, *, path: str) -> None:
+    """Enforce invariants Bedrock Converse strict JSON Schema validation expects."""
+    if not isinstance(node, dict):
+        return
+    for key in node:
+        assert key not in _UNSUPPORTED_SCHEMA_KEYS, f"{path}: unsupported key {key!r}"
+
+    schema_type = node.get("type")
+    if "properties" in node:
+        assert schema_type == "object", f"{path}: properties without type object"
+        properties = node["properties"]
+        assert isinstance(properties, dict), f"{path}: properties must be a dict"
+        for name, child in properties.items():
+            _assert_converse_schema_node(child, path=f"{path}.{name}")
+
+    if schema_type == "array":
+        items = node.get("items")
+        assert isinstance(items, dict), f"{path}: array missing typed items"
+        assert "type" in items or "properties" in items, f"{path}: array items lack type"
+        _assert_converse_schema_node(items, path=f"{path}[]")
+    elif isinstance(node.get("items"), dict):
+        _assert_converse_schema_node(node["items"], path=f"{path}[]")
 
 
 def test_sanitize_injects_object_type_when_properties_present() -> None:
@@ -177,3 +214,20 @@ def test_map_bedrock_client_error_throttling() -> None:
     )
     mapped = map_bedrock_client_error("mistral.test", err)
     assert "rate limit" in str(mapped).lower()
+
+
+def test_all_investigation_tool_schemas_satisfy_converse_invariants() -> None:
+    """Every registered investigation tool must normalize to a strict Converse-safe schema."""
+    tools = get_registered_tools("investigation")
+    assert tools, "expected at least one investigation tool"
+
+    for tool in tools:
+        schema = normalize_tool_input_schema(tool.public_input_schema)
+        assert schema.get("type") == "object", tool.name
+        assert isinstance(schema.get("properties"), dict), tool.name
+        _assert_converse_schema_node(schema, path=tool.name)
+
+    specs = build_converse_tool_specs(tools)
+    assert len(specs) == len(tools)
+    # Must round-trip through JSON like boto3 will serialize toolConfig.
+    json.dumps({"tools": specs})

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from datetime import datetime
 from typing import Any
 
@@ -25,7 +26,7 @@ from app.tools.registry import clear_tool_registry_cache, get_registered_tools
 
 
 @pytest.fixture(autouse=True)
-def _reset_tool_registry() -> None:
+def _reset_tool_registry() -> Generator[None, None, None]:
     clear_tool_registry_cache()
     yield
     clear_tool_registry_cache()

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -1,0 +1,179 @@
+"""Tests for Bedrock Converse schema normalization and message helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.services.agent_llm_client import ToolCall
+from app.services.bedrock_converse import (
+    build_assistant_tool_use_message,
+    build_converse_tool_specs,
+    build_tool_result_message,
+    map_bedrock_client_error,
+    new_tool_use_id,
+    normalize_tool_input_schema,
+    parse_converse_output,
+    sanitize_converse_schema,
+    to_converse_messages,
+)
+
+
+def test_sanitize_injects_object_type_when_properties_present() -> None:
+    schema = {"properties": {"query": {"type": "string"}}}
+    cleaned = sanitize_converse_schema(schema)
+    assert cleaned["type"] == "object"
+    assert cleaned["properties"]["query"]["type"] == "string"
+
+
+def test_sanitize_injects_array_items_type_string() -> None:
+    cleaned = sanitize_converse_schema({"type": "array"})
+    assert cleaned == {"type": "array", "items": {"type": "string"}}
+
+
+def test_sanitize_nested_array_property() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"tags": {"type": "array"}},
+    }
+    cleaned = sanitize_converse_schema(schema)
+    assert cleaned["properties"]["tags"]["items"] == {"type": "string"}
+
+
+def test_sanitize_strips_unsupported_keys() -> None:
+    schema = {
+        "title": "Root",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$defs": {"X": {"type": "string"}},
+        "oneOf": [{"type": "string"}, {"type": "integer"}],
+        "type": "object",
+        "properties": {"name": {"type": "string", "title": "Name"}},
+    }
+    cleaned = sanitize_converse_schema(schema)
+    assert "title" not in cleaned
+    assert "$schema" not in cleaned
+    assert "$defs" not in cleaned
+    assert "oneOf" not in cleaned
+    assert "title" not in cleaned["properties"]["name"]
+
+
+def test_normalize_empty_schema_is_object_with_properties() -> None:
+    assert normalize_tool_input_schema({}) == {"type": "object", "properties": {}}
+    assert normalize_tool_input_schema(None) == {"type": "object", "properties": {}}
+
+
+def test_build_converse_tool_specs_coerces_non_object_root() -> None:
+    import types
+
+    tool = types.SimpleNamespace(
+        name="query_logs",
+        description="Query logs",
+        public_input_schema={"type": "array"},
+    )
+    specs = build_converse_tool_specs([tool])
+    json_schema = specs[0]["toolSpec"]["inputSchema"]["json"]
+    assert json_schema == {"type": "object", "properties": {}}
+
+
+def test_build_converse_tool_specs_preserves_object_properties() -> None:
+    import types
+
+    tool = types.SimpleNamespace(
+        name="query_logs",
+        description="Query logs",
+        public_input_schema={
+            "type": "object",
+            "properties": {
+                "tags": {"type": "array"},
+                "query": {"type": "string"},
+            },
+        },
+    )
+    json_schema = build_converse_tool_specs([tool])[0]["toolSpec"]["inputSchema"]["json"]
+    assert json_schema["type"] == "object"
+    assert json_schema["properties"]["tags"]["items"] == {"type": "string"}
+
+
+def test_to_converse_messages_converts_string_content() -> None:
+    converted = to_converse_messages([{"role": "user", "content": "hello"}])
+    assert converted == [{"role": "user", "content": [{"text": "hello"}]}]
+
+
+def test_build_assistant_tool_use_message() -> None:
+    calls = [ToolCall(id="abc123456", name="ping", input={"x": 1})]
+    msg = build_assistant_tool_use_message(calls)
+    assert msg["role"] == "assistant"
+    assert msg["content"][0]["toolUse"]["toolUseId"] == "abc123456"
+
+
+def test_build_tool_result_message_error_status() -> None:
+    msg = build_tool_result_message(
+        [ToolCall(id="id1", name="fail", input={})],
+        [{"error": "timeout"}],
+    )
+    tr = msg["content"][0]["toolResult"]
+    assert tr["status"] == "error"
+    assert tr["content"] == [{"json": {"error": "timeout"}}]
+
+
+def test_build_tool_result_message_serializes_datetime() -> None:
+    dt = datetime(2026, 5, 22, 12, 0, 0)
+    msg = build_tool_result_message(
+        [ToolCall(id="id2", name="t", input={})],
+        [{"timestamp": dt}],
+    )
+    payload = msg["content"][0]["toolResult"]["content"][0]["json"]
+    assert isinstance(payload["timestamp"], str)
+
+
+def test_parse_converse_output_text_and_tool_use() -> None:
+    response = {
+        "stopReason": "tool_use",
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"text": "Checking logs."},
+                    {
+                        "toolUse": {
+                            "toolUseId": "tu1",
+                            "name": "query_logs",
+                            "input": {"q": "err"},
+                        }
+                    },
+                ],
+            }
+        },
+    }
+    text, tool_calls, stop_reason, raw = parse_converse_output(response)
+    assert text == "Checking logs."
+    assert stop_reason == "tool_use"
+    assert tool_calls == [("tu1", "query_logs", {"q": "err"})]
+    assert raw["role"] == "assistant"
+
+
+def test_new_tool_use_id_is_short_alphanumeric() -> None:
+    tool_id = new_tool_use_id()
+    assert 1 <= len(tool_id) <= 12
+    assert tool_id.isalnum()
+
+
+def test_map_bedrock_client_error_validation() -> None:
+    import botocore.exceptions
+
+    err = botocore.exceptions.ClientError(
+        {"Error": {"Code": "ValidationException", "Message": "missing field type"}},
+        "Converse",
+    )
+    mapped = map_bedrock_client_error("mistral.test", err)
+    assert "HTTP 400" in str(mapped)
+
+
+def test_map_bedrock_client_error_throttling() -> None:
+    import botocore.exceptions
+
+    err = botocore.exceptions.ClientError(
+        {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+        "Converse",
+    )
+    mapped = map_bedrock_client_error("mistral.test", err)
+    assert "rate limit" in str(mapped).lower()

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -26,7 +26,7 @@ from app.tools.registry import clear_tool_registry_cache, get_registered_tools
 
 
 @pytest.fixture(autouse=True)
-def _reset_tool_registry() -> Generator[None, None, None]:
+def _reset_tool_registry() -> Generator[None]:
     clear_tool_registry_cache()
     yield
     clear_tool_registry_cache()

--- a/tests/services/test_investigation_tool_schemas.py
+++ b/tests/services/test_investigation_tool_schemas.py
@@ -1,0 +1,33 @@
+"""Registry-wide contract: investigation tool schemas vs strict LLM adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from app.services.bedrock_converse import build_converse_tool_specs, normalize_tool_input_schema
+from app.tools.registry import clear_tool_registry_cache
+from tests.services.investigation_tool_schema_contract import (
+    assert_all_investigation_tools_satisfy_strict_adapter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_tool_registry() -> Generator[None]:
+    clear_tool_registry_cache()
+    yield
+    clear_tool_registry_cache()
+
+
+def test_all_investigation_tool_schemas_satisfy_strict_adapter_invariants() -> None:
+    """All investigation tools must pass the strictest shipped schema normalizer.
+
+    Today that normalizer lives in ``bedrock_converse`` (strict JSON Schema tool specs).
+    When a stricter provider adapter is added, point this test at its
+    ``normalize_*`` / ``build_*_tool_specs`` helpers instead.
+    """
+    assert_all_investigation_tools_satisfy_strict_adapter(
+        normalize_schema=normalize_tool_input_schema,
+        build_tool_specs=build_converse_tool_specs,
+    )


### PR DESCRIPTION
Fixes #2333

#### Describe the changes you have made in this PR -

Replaces the approach in #2368 with a focused implementation:

- **`app/services/bedrock_converse.py`** — shared Converse helpers: schema normalization, message conversion, tool-result formatting, error mapping, guardrails on text blocks.
- **`BedrockConverseAgentClient`** — investigation ReAct client via `boto3` Converse for non-Anthropic Bedrock models (Mistral, Llama, inference profiles, etc.).
- **`get_agent_llm()` routing** — uses existing `_is_anthropic_bedrock_model()` so Claude stays on `BedrockAgentClient` (Anthropic SDK).
- **Investigation seed/synthetic turns** — Converse `toolUse` / `toolResult` message shapes and short alphanumeric `toolUseId` values.
- **Schema fixes** — top-level tool input is always `type: object`; nested arrays get `items: {type: string}`; unsupported JSON Schema keys (`$ref`, `oneOf`, …) are stripped.

### Demo/Screenshot for feature changes and bug fixes -

```bash
# Unit tests (no AWS credentials)
uv run python -m pytest tests/services/test_bedrock_converse.py -q
uv run python -m pytest tests/services/test_agent_llm_client.py -k bedrock_converse -q

# Live smoke (AWS creds + model access in region)
export LLM_PROVIDER=bedrock
export AWS_REGION=us-east-1
export BEDROCK_REASONING_MODEL=mistral.mistral-large-3-675b-instruct
aws bedrock-runtime converse --region "$AWS_REGION" --model-id "$BEDROCK_REASONING_MODEL" \
  --messages '[{"role":"user","content":[{"text":"ok"}]}]' --inference-config '{"maxTokens":32}'
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** Non-Anthropic Bedrock models reject tool JSON schemas missing explicit `type` / `items`, breaking investigation loops with HTTP 400 `ValidationException`.

**Alternatives:** Patching every tool schema in the registry (brittle), or duplicating Converse logic inside `agent_llm_client.py` (hard to test).

**Chosen approach:** A small `bedrock_converse` module owns schema + message normalization; `BedrockConverseAgentClient` is a thin wrapper. Key behaviors:
- `sanitize_converse_schema()` — recursive strip + inject `type: object` and `items: {type: string}`.
- `normalize_tool_input_schema()` — enforce object root for `toolSpec.inputSchema.json`.
- Investigation wiring emits valid `toolUse` blocks for seeded tools.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.