### PR TITLE
fix(cli): treat missing integrations as informational in opensre health

### DIFF
--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -109,7 +109,7 @@ def health_command(watch: bool, rate: int) -> None:
                 results=results,
             )
 
-        if any(result.get("status") in {"missing", "failed"} for result in results):
+        if any(result.get("status") == "failed" for result in results):
             return ERROR
         return SUCCESS
 

--- a/tests/cli/test_health.py
+++ b/tests/cli/test_health.py
@@ -48,8 +48,53 @@ def test_health_command_uses_real_datadog_verification_path(monkeypatch) -> None
 
     result = runner.invoke(cli, ["health"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 0
     assert "Summary:" in result.output
     assert "datadog" in result.output
     assert "MISSING" in result.output
     assert "Missing API key or application key." in result.output
+
+
+def test_health_command_exits_zero_when_all_integrations_missing() -> None:
+    runner = CliRunner()
+
+    with patch("app.integrations.verify.verify_integrations") as mock_verify:
+        mock_verify.return_value = [
+            {
+                "service": svc,
+                "source": "-",
+                "status": "missing",
+                "detail": "Not configured in local store or env.",
+            }
+            for svc in ("aws", "datadog", "grafana", "slack")
+        ]
+
+        result = runner.invoke(cli, ["health"])
+
+    assert result.exit_code == 0
+    assert "4 missing" in result.output
+
+
+def test_health_command_exits_one_when_any_integration_failed() -> None:
+    runner = CliRunner()
+
+    with patch("app.integrations.verify.verify_integrations") as mock_verify:
+        mock_verify.return_value = [
+            {
+                "service": "aws",
+                "source": "local store",
+                "status": "passed",
+                "detail": "ok",
+            },
+            {
+                "service": "datadog",
+                "source": "local store",
+                "status": "failed",
+                "detail": "401 Unauthorized",
+            },
+        ]
+
+        result = runner.invoke(cli, ["health"])
+
+    assert result.exit_code == 1
+    assert "1 failed" in result.output

--- a/tests/cli_smoke_test.py
+++ b/tests/cli_smoke_test.py
@@ -407,7 +407,7 @@ def test_health_smoke_uses_real_datadog_store_config(cli_sandbox: CliSandbox) ->
 
     result = _run_cli(cli_sandbox, "health")
 
-    assert result.exit_code == 1
+    assert result.exit_code == 0
     assert "OpenSRE Health" in result.stdout
     assert "datadog" in result.stdout
     assert "Missing API key or application key." in result.stdout


### PR DESCRIPTION
Fixes #2383

#### Describe the changes you have made in this PR -

`opensre health` was returning exit code 1 on any row with status `missing` or `failed`. On a fresh install with no integrations configured, all 39 services report `missing`, so test harnesses and CI checks flagged a brand-new, unconfigured machine as a failure.

This PR narrows the rule in `health_command` so only `failed` rows trigger a non-zero exit. `missing` is now informational — the existing `Action:` footer at the bottom of the health table already prompts the user to configure things with `opensre integrations setup <service>`. The actually-broken case (e.g. configured credentials that fail to authenticate) still exits 1 as before.

This brings `opensre health` closer in spirit to `verification_exit_code()` in `app/integrations/verify.py`, which `opensre integrations verify` already uses.

Files touched:
- `app/cli/commands/general.py` — one-line rule change in `health_command` (line 112).
- `tests/cli/test_health.py` — updated the existing datadog test to assert exit 0 under the new rule, plus two new regression tests covering "all missing → exit 0" and "any failed → exit 1".
- `tests/cli_smoke_test.py` — same exit-code update on the smoke-test sibling.

### Demo/Screenshot for feature changes and bug fixes - 

Before the fix (on a fresh install with no integrations configured):

<img width="1512" height="982" alt="Screenshot 2026-05-22 at 01 02 22" src="https://github.com/user-attachments/assets/b973eb4e-f336-40d8-b692-4cb06e893132" />


After the fix, same machine, same state:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/f074a435-7f64-4edb-8d99-04afebd86b5e" />


The "any failed" case (configured but broken credentials) still exits 1 — covered by `test_health_command_exits_one_when_any_integration_failed`.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** `opensre health` is described as "Show a quick health summary of the local agent setup." It is a status display, not a strict pass/fail gate. But the exit-code rule treated "not yet configured" (status `missing`) the same as "configured but broken" (status `failed`), so a brand-new install with nothing configured exited 1. Test harnesses and CI checks reasonably interpret that as a product failure.

**Alternatives I considered:**

1. **Delegate to the existing `verification_exit_code()` in `app/integrations/verify.py:140-153`.** That is what `opensre integrations verify` uses. Rejected because its rule for the all-services case ("fail unless at least one core service passed") would still mark a fresh install as failed. `verify` is a stricter gate; `health` is a status view.
2. **Introduce a third exit code (e.g. 2 for "needs setup", 1 for "broken").** Rejected as scope creep — there are no callers that would benefit from the extra signal, and it would still leave the original harness behavior broken until they were updated.
3. **Make `health` always exit 0.** Rejected because that loses the useful failure signal when an integration is actually broken (e.g. a configured API key starts returning 401).

**Chosen approach:** narrow the existing rule to only fail on status `failed`. The smallest change that fixes the reported symptom without losing the case for actual failures.

**Key change:** `health_command` in `app/cli/commands/general.py`. The `_run_once` inner function builds the results list, renders the table, and then computes the exit code. The single condition that decides the exit code was the one wrong piece — `{"missing", "failed"}` became `"failed"`. Everything else (the rendering, the `Action:` footer, the watch loop) stays the same.

**Tests:** I updated the existing `test_health_command_uses_real_datadog_verification_path` (which previously asserted exit 1 for an empty-keys datadog config that produces `missing`) to assert exit 0 under the new rule. I also added two regression tests so the behavior is locked in going forward:
- `test_health_command_exits_zero_when_all_integrations_missing` — the exact fresh-install scenario from the bug report.
- `test_health_command_exits_one_when_any_integration_failed` — proves the failure path still works.

The smoke-test sibling in `tests/cli_smoke_test.py::test_health_smoke_uses_real_datadog_store_config` had the same outdated exit-code assertion and was updated in the same way.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


