### PR TITLE
fix(errors): skip Sentry capture for info-severity exceptions

### DIFF
--- a/app/utils/errors.py
+++ b/app/utils/errors.py
@@ -40,6 +40,9 @@ def report_exception(
     # Some expected fallback paths (e.g. remote network probe timeouts) should
     # remain visible in logs without dumping a full traceback into the terminal UI.
     log_fn("%s", message, exc_info=exc if include_traceback else False)
+    # Info-severity reports are expected/graceful fallbacks; skip Sentry to avoid noise.
+    if severity == "info":
+        return
     combined: dict[str, Any] = {}
     if tags:
         combined.update({f"tag.{k}": v for k, v in tags.items()})

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -45,6 +45,14 @@ class TestReportException:
         mock_log.warning.assert_called_once()
         mock_log.error.assert_not_called()
 
+    def test_info_severity_skips_sentry(self) -> None:
+        mock_log = _mock_logger()
+        exc = OSError("expected fallback")
+        with patch("app.utils.errors.capture_exception") as mock_cap:
+            report_exception(exc, logger=mock_log, message="handled", severity="info")
+        mock_log.info.assert_called_once()
+        mock_cap.assert_not_called()
+
     def test_tags_are_prefixed(self) -> None:
         mock_log = _mock_logger()
         exc = RuntimeError("boom")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `report_exception` was unconditionally calling `capture_exception` even when `severity="info"`, causing expected graceful fallbacks to generate high-priority Sentry issues
- Root cause: IMDS `_imds_get` / `_imds_token_get` in `app/remote/server.py` catch `HTTPError 404` and call `_report_remote_once(..., severity="info")` — intended as a logged-only fallback, but Sentry was still receiving the event
- Fix: skip `capture_exception` when `severity == "info"`; info-level means the exception is handled and the caller returns a safe degraded value

## Test plan

- [ ] `uv run pytest tests/utils/test_errors.py -v` — all 15 tests pass including new `test_info_severity_skips_sentry`
- [ ] `ruff check` and `ruff format --check` pass
- [ ] Manually verify no Sentry issues are created for IMDS failures on non-EC2 hosts after deploy

Closes #2279

https://claude.ai/code/session_01RBRK1qbphit29fkuG3Az1r
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBRK1qbphit29fkuG3Az1r)_