### PR TITLE
test(env_sync): make keyring backend swap robust to import order

### DIFF
--- a/tests/cli/wizard/test_env_sync.py
+++ b/tests/cli/wizard/test_env_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import stat
 
+import keyring
 import pytest
 
 from app.cli.wizard.config import PROVIDER_BY_VALUE
@@ -13,6 +14,7 @@ from app.cli.wizard.env_sync import (
     sync_provider_env,
 )
 from app.llm_credentials import resolve_env_credential
+from tests.shared.keyring_backend import MemoryKeyring
 
 _SKIP_AS_ROOT = not hasattr(os, "getuid") or os.getuid() == 0
 
@@ -362,24 +364,28 @@ def test_sync_env_values_rejects_sensitive_keys(tmp_path) -> None:
 def test_sync_env_values_routes_secrets_to_keyring(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("GITLAB_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("OPENSRE_DISABLE_KEYRING", raising=False)
-    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "tests.shared.keyring_backend.MemoryKeyring")
 
-    env_path = tmp_path / ".env"
-    env_path.write_text(
-        "GITLAB_BASE_URL=https://gitlab.example.com\nGITLAB_ACCESS_TOKEN=legacy-plaintext\n",
-        encoding="utf-8",
-    )
+    previous_backend = keyring.get_keyring()
+    keyring.set_keyring(MemoryKeyring())
+    try:
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "GITLAB_BASE_URL=https://gitlab.example.com\nGITLAB_ACCESS_TOKEN=legacy-plaintext\n",
+            encoding="utf-8",
+        )
 
-    sync_env_secret("GITLAB_ACCESS_TOKEN", "gl-secret-token")
-    sync_env_values(
-        {"GITLAB_BASE_URL": "https://gitlab.corp.com"},
-        env_path=env_path,
-    )
+        sync_env_secret("GITLAB_ACCESS_TOKEN", "gl-secret-token")
+        sync_env_values(
+            {"GITLAB_BASE_URL": "https://gitlab.corp.com"},
+            env_path=env_path,
+        )
 
-    content = env_path.read_text(encoding="utf-8")
-    assert "GITLAB_BASE_URL=https://gitlab.corp.com\n" in content
-    assert "GITLAB_ACCESS_TOKEN=" not in content
-    assert resolve_env_credential("GITLAB_ACCESS_TOKEN") == "gl-secret-token"
+        content = env_path.read_text(encoding="utf-8")
+        assert "GITLAB_BASE_URL=https://gitlab.corp.com\n" in content
+        assert "GITLAB_ACCESS_TOKEN=" not in content
+        assert resolve_env_credential("GITLAB_ACCESS_TOKEN") == "gl-secret-token"
+    finally:
+        keyring.set_keyring(previous_backend)
 
 
 @pytest.mark.skipif(_SKIP_AS_ROOT, reason="root bypasses file permission checks")


### PR DESCRIPTION
Fixes #2395

#### Describe the changes you have made in this PR -

`tests/cli/wizard/test_env_sync.py::test_sync_env_values_routes_secrets_to_keyring` was flaky on Linux CI. It used `monkeypatch.setenv("PYTHON_KEYRING_BACKEND", ...)` to swap in the in-memory keyring backend, which only works if `keyring` has not yet been imported in the pytest session. On CI runs where another test imported `keyring` first, the env-var swap was silently ignored and the test exercised the real (non-functional) Linux keyring instead, causing `assert '' == 'gl-secret-token'`.

This PR switches the test to use `keyring.set_keyring(MemoryKeyring())` with cleanup, matching the pattern already used in `tests/test_llm_credentials.py:13-19`. That function call forcibly rebinds the global keyring singleton regardless of when `keyring` was first imported during the session.

Only the one flaky test is changed. The other 35 tests in the file are untouched.

### Demo/Screenshot for feature changes and bug fixes - 

This is a test-only flake fix; the demo is the CI behaviour. Before this PR, on PR #2393's CI run (job 77340821490 / run 26276173174):

FAILED tests/cli/wizard/test_env_sync.py::test_sync_env_values_routes_secrets_to_keyring - AssertionError: assert '' == 'gl-secret-token'


After this PR, the same test should pass on Linux CI regardless of execution order. Verified locally:

<img width="1138" height="471" alt="image" src="https://github.com/user-attachments/assets/728eb560-11a6-4e86-be1b-4e56c00d3ed6" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** The Python `keyring` library caches its backend in a module-level singleton on first access. The `PYTHON_KEYRING_BACKEND` environment variable is consulted only when that singleton is first instantiated. Once any test in the pytest session imports `keyring` and triggers backend resolution, later `monkeypatch.setenv("PYTHON_KEYRING_BACKEND", ...)` calls cannot change the backend for the rest of the process. On macOS the real keyring backend happens to round-trip storage correctly even when bound, which is why the test passed locally; on Linux CI without a GNOME keyring daemon, the default backend silently no-ops `set_password` and the test fails.

**Alternatives I considered:**

1. **Reset the keyring backend in `tests/conftest.py` via an autouse fixture.** Rejected — broader scope than the bug requires, and would affect every test that touches keyring (including ones that are intentionally checking the real disabled-keyring path).
2. **Force the test to run in a subprocess so the env var takes effect on a fresh import.** Rejected — significantly increases test runtime and complexity for one assertion.
3. **Use `keyring.set_keyring(MemoryKeyring())` directly with cleanup in a `try/finally`.** Chosen. This is the smallest possible change, matches the pattern already in use at `tests/test_llm_credentials.py:13-19`, and is robust regardless of pytest execution order or `keyring` import timing.

**Chosen approach:** copy the proven pattern from `test_llm_credentials.py` into the one failing test. Two new imports (`keyring`, `MemoryKeyring`), one `monkeypatch.setenv` removed, the test body wrapped in `try`/`finally` around `keyring.set_keyring(...)` so the original backend is restored even if an assertion fails.

**Edge cases considered:**
- If a future test in the same module runs after this one, the `finally` block restores the original backend so the next test isn't poisoned with `MemoryKeyring`.
- The two existing `monkeypatch.delenv` calls (`GITLAB_ACCESS_TOKEN`, `OPENSRE_DISABLE_KEYRING`) are kept — `OPENSRE_DISABLE_KEYRING=1` is set by the autouse `_disable_system_keyring` fixture in `tests/conftest.py`, and the test must undo it to exercise the keyring path.
- No assertion logic or fixture data was changed — same setup, same expectations, just a more reliable backend swap mechanism.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

