### PR TITLE
fix: treat missing health integrations as non-fatal

### DIFF
--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -109,7 +109,7 @@ def health_command(watch: bool, rate: int) -> None:
                 results=results,
             )
 
-        if any(result.get("status") in {"missing", "failed"} for result in results):
+        if any(result.get("status") == "failed" for result in results):
             return ERROR
         return SUCCESS
 

--- a/app/cli/commands/general.py
+++ b/app/cli/commands/general.py
@@ -18,7 +18,7 @@ from app.analytics.cli import (
 from app.analytics.source import EntrypointSource, TriggerMode
 from app.cli.support.constants import ALERT_TEMPLATE_CHOICES
 from app.cli.support.context import is_json_output, is_yes
-from app.cli.support.exit_codes import ERROR, SUCCESS
+from app.cli.support.exit_codes import SUCCESS
 from app.version import get_version
 
 
@@ -87,7 +87,7 @@ def health_command(watch: bool, rate: int) -> None:
     from app.cli.support.health_view import render_health_json, render_health_report
     from app.config import get_environment
     from app.integrations.store import STORE_PATH
-    from app.integrations.verify import verify_integrations
+    from app.integrations.verify import verification_exit_code, verify_integrations
 
     def _run_once() -> int:
         results = verify_integrations()
@@ -109,9 +109,7 @@ def health_command(watch: bool, rate: int) -> None:
                 results=results,
             )
 
-        if any(result.get("status") == "failed" for result in results):
-            return ERROR
-        return SUCCESS
+        return verification_exit_code(results)
 
     if not watch:
         raise SystemExit(_run_once())

--- a/app/integrations/verify.py
+++ b/app/integrations/verify.py
@@ -147,9 +147,6 @@ def verification_exit_code(
         return 1
     if requested_service:
         return 1 if any(row.get("status") in {"missing", "failed"} for row in results) else 0
-    core_results = [row for row in results if row.get("service") in CORE_VERIFY_SERVICES]
-    if not any(row.get("status") == "passed" for row in core_results):
-        return 1
     return 0
 
 

--- a/tests/cli/test_health.py
+++ b/tests/cli/test_health.py
@@ -29,6 +29,50 @@ def test_health_command_runs() -> None:
     assert "aws" in result.output
 
 
+def test_health_command_missing_integrations_do_not_fail_fresh_install() -> None:
+    runner = CliRunner()
+
+    with patch("app.integrations.verify.verify_integrations") as mock_verify:
+        mock_verify.return_value = [
+            {
+                "service": "grafana",
+                "source": "-",
+                "status": "missing",
+                "detail": "Not configured in local store or env.",
+            }
+        ]
+
+        result = runner.invoke(cli, ["health"])
+
+    assert result.exit_code == 0
+    assert "Summary:" in result.output
+    assert "1 missing" in result.output
+    assert "grafana" in result.output
+    assert "MISSING" in result.output
+
+
+def test_health_command_failed_integrations_still_exit_nonzero() -> None:
+    runner = CliRunner()
+
+    with patch("app.integrations.verify.verify_integrations") as mock_verify:
+        mock_verify.return_value = [
+            {
+                "service": "grafana",
+                "source": "local store",
+                "status": "failed",
+                "detail": "HTTP 403: forbidden",
+            }
+        ]
+
+        result = runner.invoke(cli, ["health"])
+
+    assert result.exit_code == 1
+    assert "Summary:" in result.output
+    assert "1 failed" in result.output
+    assert "grafana" in result.output
+    assert "FAILED" in result.output
+
+
 def test_health_command_uses_real_datadog_verification_path(monkeypatch) -> None:
     runner = CliRunner()
     monkeypatch.setattr(
@@ -48,7 +92,7 @@ def test_health_command_uses_real_datadog_verification_path(monkeypatch) -> None
 
     result = runner.invoke(cli, ["health"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 0
     assert "Summary:" in result.output
     assert "datadog" in result.output
     assert "MISSING" in result.output

--- a/tests/integrations/test_verify.py
+++ b/tests/integrations/test_verify.py
@@ -436,19 +436,25 @@ def test_verify_sentry_passes_with_valid_config(monkeypatch: pytest.MonkeyPatch)
     assert result["service"] == "sentry"
 
 
-def test_verification_exit_code_requires_core_success() -> None:
+def test_verification_exit_code_allows_aggregate_missing_without_core_success() -> None:
     assert (
         verification_exit_code(
             [
                 {
-                    "service": "slack",
-                    "source": "local env",
-                    "status": "configured",
-                    "detail": "Incoming webhook configured.",
+                    "service": "grafana",
+                    "source": "-",
+                    "status": "missing",
+                    "detail": "Not configured.",
+                },
+                {
+                    "service": "datadog",
+                    "source": "-",
+                    "status": "missing",
+                    "detail": "Not configured.",
                 }
             ]
         )
-        == 1
+        == 0
     )
 
     assert (
@@ -491,6 +497,25 @@ def test_verification_exit_code_requires_core_success() -> None:
         == 1
     )
 
+
+def test_verification_exit_code_requested_service_missing_is_nonzero() -> None:
+    assert (
+        verification_exit_code(
+            [
+                {
+                    "service": "grafana",
+                    "source": "-",
+                    "status": "missing",
+                    "detail": "Not configured.",
+                }
+            ],
+            requested_service="grafana",
+        )
+        == 1
+    )
+
+
+def test_verification_exit_code_requested_service_configured_is_zero() -> None:
     assert (
         verification_exit_code(
             [


### PR DESCRIPTION
Fixes #2383

  Summary:
  - Updates `opensre health` so missing integrations are reported without causing a nonzero exit code.
  - Keeps failed integration checks as fatal, so real connectivity or credential failures still fail the command.
  - Adds regression coverage for both cases: missing integrations on a fresh install and failed integrations.

  Why:
  On a fresh install, most optional integrations are expected to be unconfigured. Previously, `opensre health` treated those missing optional integrations the
  same as failed checks, so a new setup exited with code 1 even when nothing was actually broken. This change makes the command reflect the difference between "not
  configured yet" and "configured but failing".

  Tests:
  - `uv run python -m pytest tests/cli/test_health.py`