### PR TITLE
feat(llm_cli): log argv at debug level before CLI subprocess spawn

### DIFF
--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -125,6 +125,10 @@ class CLIBackedLLMClient:
             reasoning_effort=get_active_reasoning_effort(),
         )
         merged_env = _build_subprocess_env(invocation.env)
+        logger.debug(
+            "cli_llm_spawn",
+            extra={"provider": self._adapter.name, "argv": list(invocation.argv)},
+        )
 
         backoff = _TEMPFAIL_BACKOFF_SEC
         for attempt in range(_TEMPFAIL_MAX_RETRIES + 1):


### PR DESCRIPTION
## Summary

- Adds a `cli_llm_spawn` debug log event in `CLIBackedLLMClient.invoke` immediately before `subprocess.run`, capturing `provider` and `argv`
- Makes it possible to see the exact command (including `--model` / `-p` flags) that was passed to each CLI subprocess during an investigation

## Motivation

Identified during review of #2069: there was no way to tell from logs which model flag was passed or what the exact CLI command looked like when a subprocess call was made. This fills that observability gap with a single debug-level event.

## Change

```python
logger.debug(
    "cli_llm_spawn",
    extra={"provider": self._adapter.name, "argv": list(invocation.argv)},
)
```

Placed after `_build_subprocess_env` (env is ready) and before the retry loop (fires once per invoke, not per retry attempt).

## Notes

- Debug-level only — no impact on production log volume unless debug logging is enabled
- `argv` may include the prompt text for providers that pass it as a CLI arg (rather than stdin); if that's a concern, a follow-up can redact it

🤖 Generated with [Claude Code](https://claude.com/claude-code)