### PR TITLE
test(live-llm): skip planner tests when provider key is missing

### DIFF
--- a/tests/cli/interactive_shell/orchestration/test_llm_action_planner.py
+++ b/tests/cli/interactive_shell/orchestration/test_llm_action_planner.py
@@ -87,11 +87,16 @@ def _require_default_llm_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
         provider = get_configured_llm_provider()
         env_var = get_llm_provider_api_key_env(provider)
         msg = exc.errors()[0].get("msg", str(exc)) if exc.errors() else str(exc)
+
         hint = f" configured provider={provider!r}"
         if env_var is not None:
             hint += f", required key={env_var}"
+
         hint += f", fallback providers={DEFAULT_LLM_RESOLUTION_FALLBACK_PROVIDERS!r}"
-        pytest.fail(f"Live LLM planner tests require usable LLM configuration:{hint}. {msg}")
+
+        pytest.skip(
+            f"Skipping live LLM planner tests; missing usable LLM configuration:{hint}. {msg}"
+        )
 
     from app.services.llm_client import reset_llm_singletons
 


### PR DESCRIPTION
## Summary

Skip live LLM planner tests when the configured provider API key is missing.

## Changes

* replaced `pytest.fail()` with `pytest.skip()` in `test_llm_action_planner.py`
* prevents unrelated PRs from failing due to missing live provider secrets in CI
* keeps live planner tests runnable when valid provider configuration exists

## Why

Currently CI errors when `LLM_PROVIDER=anthropic` is set but `ANTHROPIC_API_KEY` is unavailable. These are environment/configuration failures rather than planner logic failures, so skipping is more appropriate than failing the full test run.
