### PR TITLE
fix(llm_cli): redact prompt args in cli_llm_spawn debug logs

### DIFF
--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -56,7 +56,7 @@ def _sanitize_argv_for_debug(argv: tuple[str, ...], *, prompt: str) -> list[str]
             redacted.append(_REDACTED_PROMPT_ARG)
             continue
         if arg == prompt_equals_form:
-            redacted.append("--prompt=<redacted-prompt>")
+            redacted.append(f"--prompt={_REDACTED_PROMPT_ARG}")
             continue
         redacted.append(arg)
     return redacted

--- a/app/integrations/llm_cli/runner.py
+++ b/app/integrations/llm_cli/runner.py
@@ -26,6 +26,7 @@ from app.services.llm_client import LLMResponse
 logger = logging.getLogger(__name__)
 
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+_REDACTED_PROMPT_ARG = "<redacted-prompt>"
 # Avoid re-running `detect()` (two subprocess probes) on every invoke during long investigations.
 _PROBE_CACHE_TTL_SEC = 45.0
 
@@ -41,6 +42,24 @@ _build_subprocess_env = build_cli_subprocess_env
 
 def _strip_ansi(text: str) -> str:
     return _ANSI_ESCAPE.sub("", text)
+
+
+def _sanitize_argv_for_debug(argv: tuple[str, ...], *, prompt: str) -> list[str]:
+    """Redact prompt text from debug argv logs when passed as a CLI argument."""
+    if not prompt:
+        return list(argv)
+
+    redacted: list[str] = []
+    prompt_equals_form = f"--prompt={prompt}"
+    for arg in argv:
+        if arg == prompt:
+            redacted.append(_REDACTED_PROMPT_ARG)
+            continue
+        if arg == prompt_equals_form:
+            redacted.append("--prompt=<redacted-prompt>")
+            continue
+        redacted.append(arg)
+    return redacted
 
 
 class CLIBackedLLMClient:
@@ -127,7 +146,10 @@ class CLIBackedLLMClient:
         merged_env = _build_subprocess_env(invocation.env)
         logger.debug(
             "cli_llm_spawn",
-            extra={"provider": self._adapter.name, "argv": list(invocation.argv)},
+            extra={
+                "provider": self._adapter.name,
+                "argv": _sanitize_argv_for_debug(invocation.argv, prompt=flat),
+            },
         )
 
         backoff = _TEMPFAIL_BACKOFF_SEC

--- a/tests/integrations/llm_cli/test_runner.py
+++ b/tests/integrations/llm_cli/test_runner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from app.integrations.llm_cli.runner import CLIBackedLLMClient
+
+
+def _mock_probe() -> MagicMock:
+    return MagicMock(installed=True, bin_path="/usr/bin/mock-cli", logged_in=True, detail="ok")
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_llm_spawn_log_redacts_prompt_in_argv(mock_run: MagicMock, caplog) -> None:
+    prompt = "customer secret investigation context"
+    mock_adapter = MagicMock()
+    mock_adapter.name = "copilot"
+    mock_adapter.detect.return_value = _mock_probe()
+    mock_adapter.build.return_value = MagicMock(
+        argv=("/usr/bin/mock-cli", "-p", prompt, "--model", "gpt-5.1"),
+        stdin=None,
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.parse.return_value = "answer"
+    mock_run.return_value = MagicMock(returncode=0, stdout="answer\n", stderr="")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        with caplog.at_level(logging.DEBUG, logger="app.integrations.llm_cli.runner"):
+            client = CLIBackedLLMClient(mock_adapter)
+            client.invoke(prompt)
+
+    spawn = next(record for record in caplog.records if record.msg == "cli_llm_spawn")
+    assert spawn.provider == "copilot"
+    assert spawn.argv == ["/usr/bin/mock-cli", "-p", "<redacted-prompt>", "--model", "gpt-5.1"]
+    assert prompt not in spawn.argv
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_llm_spawn_log_keeps_non_prompt_argv_args(mock_run: MagicMock, caplog) -> None:
+    prompt = "customer secret investigation context"
+    mock_adapter = MagicMock()
+    mock_adapter.name = "claude-code"
+    mock_adapter.detect.return_value = _mock_probe()
+    mock_adapter.build.return_value = MagicMock(
+        argv=("/usr/bin/mock-cli", "-p", "--output-format", "text"),
+        stdin=prompt,
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.parse.return_value = "answer"
+    mock_run.return_value = MagicMock(returncode=0, stdout="answer\n", stderr="")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        with caplog.at_level(logging.DEBUG, logger="app.integrations.llm_cli.runner"):
+            client = CLIBackedLLMClient(mock_adapter)
+            client.invoke(prompt)
+
+    spawn = next(record for record in caplog.records if record.msg == "cli_llm_spawn")
+    assert spawn.provider == "claude-code"
+    assert spawn.argv == ["/usr/bin/mock-cli", "-p", "--output-format", "text"]

--- a/tests/integrations/llm_cli/test_runner.py
+++ b/tests/integrations/llm_cli/test_runner.py
@@ -63,3 +63,31 @@ def test_cli_llm_spawn_log_keeps_non_prompt_argv_args(mock_run: MagicMock, caplo
     spawn = next(record for record in caplog.records if record.msg == "cli_llm_spawn")
     assert spawn.provider == "claude-code"
     assert spawn.argv == ["/usr/bin/mock-cli", "-p", "--output-format", "text"]
+
+
+@patch("app.integrations.llm_cli.runner.subprocess.run")
+def test_cli_llm_spawn_log_redacts_prompt_equals_form(mock_run: MagicMock, caplog) -> None:
+    prompt = "customer secret investigation context"
+    mock_adapter = MagicMock()
+    mock_adapter.name = "mock-cli"
+    mock_adapter.detect.return_value = _mock_probe()
+    mock_adapter.build.return_value = MagicMock(
+        argv=("/usr/bin/mock-cli", f"--prompt={prompt}", "--model", "gpt-5.1"),
+        stdin=None,
+        cwd="/tmp",
+        env=None,
+        timeout_sec=30.0,
+    )
+    mock_adapter.parse.return_value = "answer"
+    mock_run.return_value = MagicMock(returncode=0, stdout="answer\n", stderr="")
+
+    with patch("app.guardrails.engine.get_guardrail_engine") as gr:
+        gr.return_value.is_active = False
+        with caplog.at_level(logging.DEBUG, logger="app.integrations.llm_cli.runner"):
+            client = CLIBackedLLMClient(mock_adapter)
+            client.invoke(prompt)
+
+    spawn = next(record for record in caplog.records if record.msg == "cli_llm_spawn")
+    assert spawn.provider == "mock-cli"
+    assert spawn.argv == ["/usr/bin/mock-cli", "--prompt=<redacted-prompt>", "--model", "gpt-5.1"]
+    assert all(prompt not in arg for arg in spawn.argv)


### PR DESCRIPTION
## Summary
- redact prompt content from `cli_llm_spawn` debug event argv payloads
- keep command-shape visibility (`--model`, provider binary, flags) while removing sensitive prompt text
- add runner tests for both prompt-in-argv and prompt-via-stdin adapters

## Why
PR #2399 added debug logging for CLI spawn argv, but providers that pass prompts as CLI args (for example `-p <prompt>`) can leak investigation content to retained debug logs.

## Validation
- `uv run python -m pytest tests/integrations/llm_cli/test_runner.py -q`
- `uv run ruff check app/integrations/llm_cli/runner.py tests/integrations/llm_cli/test_runner.py`
- `uv run ruff format --check app/integrations/llm_cli/runner.py tests/integrations/llm_cli/test_runner.py`
