### PR TITLE
fix(bedrock): strip additionalProperties from Converse tool schemas

### DIFF
--- a/app/services/bedrock_converse.py
+++ b/app/services/bedrock_converse.py
@@ -24,6 +24,10 @@ _UNSUPPORTED_SCHEMA_KEYS = frozenset(
         "$ref",
         "not",
         "nullable",  # OpenAPI nullable — Converse uses explicit types; anyOf/oneOf are flattened instead
+        # Non-Anthropic Bedrock models (Mistral, Llama, etc.) reject additionalProperties even
+        # when it carries a valid boolean value such as false.  Tool calling never relies on this
+        # constraint, so stripping it is safe and avoids HTTP 400 ValidationException errors.
+        "additionalProperties",
     }
 )
 

--- a/tests/services/test_bedrock_converse.py
+++ b/tests/services/test_bedrock_converse.py
@@ -101,6 +101,28 @@ def test_sanitize_strips_nullable_keeps_type() -> None:
     assert cleaned == {"type": "string"}
 
 
+def test_sanitize_strips_additional_properties_false() -> None:
+    cleaned = sanitize_converse_schema(
+        {"type": "object", "properties": {"x": {"type": "string"}}, "additionalProperties": False}
+    )
+    assert "additionalProperties" not in cleaned
+    assert cleaned["type"] == "object"
+
+
+def test_sanitize_strips_additional_properties_schema() -> None:
+    cleaned = sanitize_converse_schema(
+        {"type": "object", "properties": {}, "additionalProperties": {"type": "string"}}
+    )
+    assert "additionalProperties" not in cleaned
+
+
+def test_sanitize_strips_invalid_additional_properties_string() -> None:
+    cleaned = sanitize_converse_schema(
+        {"type": "object", "properties": {}, "additionalProperties": "string"}
+    )
+    assert "additionalProperties" not in cleaned
+
+
 def test_sanitize_strips_unsupported_keys() -> None:
     schema = {
         "title": "Root",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Non-Anthropic Bedrock models (Mistral, Llama, etc.) reject tool schemas that contain `additionalProperties` even when the value is the valid boolean `false`, returning HTTP 400 `ValidationException: 'string' is not of type 'object', 'boolean'`
- Pydantic models with `extra="forbid"` (used by several investigation tools) automatically emit `additionalProperties: false` in their JSON Schema output
- Adding `"additionalProperties"` to `_UNSUPPORTED_SCHEMA_KEYS` strips it before the schema reaches the Converse API — this is safe because tool calling never relies on this constraint

## Test plan

- [ ] `uv run pytest tests/services/test_bedrock_converse.py` — 24 tests pass, including 3 new cases covering `false`, schema-object, and invalid-string values for `additionalProperties`
- [ ] `uv run pytest tests/services/test_investigation_tool_schemas.py tests/tools/test_registry.py` — all pass; `test_v2_registry_schemas_are_closed_objects` still passes because it checks `public_input_schema` (pre-normalization), not the Converse-normalized form
- [ ] `uv run ruff check app/ tests/` and `uv run ruff format --check app/ tests/` — clean

Closes #2391

https://claude.ai/code/session_018HUB4fHfrxvvNBmStbiiZU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018HUB4fHfrxvvNBmStbiiZU)_