### PR TITLE
fix(mongodb): suppress Sentry noise for admin command authorization failures

### DIFF
--- a/app/integrations/mongodb.py
+++ b/app/integrations/mongodb.py
@@ -193,6 +193,12 @@ def get_server_status(config: MongoDBConfig) -> dict[str, Any]:
         finally:
             client.close()
     except Exception as err:
+        if getattr(err, "code", None) == 13:
+            return {
+                "source": "mongodb",
+                "available": False,
+                "error": "MongoDB user lacks admin privileges for serverStatus. Grant the 'clusterMonitor' role.",
+            }
         report_validation_failure(
             err,
             logger=logger,
@@ -248,6 +254,12 @@ def get_current_ops(
         finally:
             client.close()
     except Exception as err:
+        if getattr(err, "code", None) == 13:
+            return {
+                "source": "mongodb",
+                "available": False,
+                "error": "MongoDB user lacks admin privileges for currentOp. Grant the 'clusterMonitor' role.",
+            }
         report_validation_failure(
             err,
             logger=logger,
@@ -303,6 +315,12 @@ def get_rs_status(config: MongoDBConfig) -> dict[str, Any]:
                 "set_name": "",
                 "members": [],
                 "note": "Server is not part of a replica set.",
+            }
+        if getattr(err, "code", None) == 13:
+            return {
+                "source": "mongodb",
+                "available": False,
+                "error": "MongoDB user lacks admin privileges for replSetGetStatus. Grant the 'clusterMonitor' role.",
             }
         report_validation_failure(
             err,

--- a/tests/test_mongodb_integration.py
+++ b/tests/test_mongodb_integration.py
@@ -7,6 +7,9 @@ from app.integrations.catalog import classify_integrations as _classify_integrat
 from app.integrations.mongodb import (
     MongoDBConfig,
     build_mongodb_config,
+    get_current_ops,
+    get_rs_status,
+    get_server_status,
     mongodb_config_from_env,
     validate_mongodb_config,
 )
@@ -105,6 +108,53 @@ class TestMongoDBValidation:
         result = validate_mongodb_config(config)
         assert result.ok is False
         assert "Conn error" in result.detail
+
+
+class TestMongoDBAdminUnauthorized:
+    """Admin commands should return graceful errors without Sentry reports when unauthorized."""
+
+    def _make_unauthorized(self) -> Exception:
+        err = Exception("not authorized on admin to execute command")
+        err.code = 13  # type: ignore[attr-defined]
+        return err
+
+    def _config(self) -> MongoDBConfig:
+        return MongoDBConfig(connection_string="mongodb://host")
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_get_server_status_unauthorized_no_sentry(self, mock_report, mock_client):
+        mock_client.return_value.admin.command.side_effect = self._make_unauthorized()
+        result = get_server_status(self._config())
+        assert result["available"] is False
+        assert "clusterMonitor" in result["error"]
+        mock_report.assert_not_called()
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_get_current_ops_unauthorized_no_sentry(self, mock_report, mock_client):
+        mock_client.return_value.admin.command.side_effect = self._make_unauthorized()
+        result = get_current_ops(self._config())
+        assert result["available"] is False
+        assert "clusterMonitor" in result["error"]
+        mock_report.assert_not_called()
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_get_rs_status_unauthorized_no_sentry(self, mock_report, mock_client):
+        mock_client.return_value.admin.command.side_effect = self._make_unauthorized()
+        result = get_rs_status(self._config())
+        assert result["available"] is False
+        assert "clusterMonitor" in result["error"]
+        mock_report.assert_not_called()
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_get_server_status_other_error_reports_sentry(self, mock_report, mock_client):
+        mock_client.return_value.admin.command.side_effect = Exception("connection timeout")
+        result = get_server_status(self._config())
+        assert result["available"] is False
+        mock_report.assert_called_once()
 
 
 class TestResolveIntegrations:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `get_server_status`, `get_current_ops`, and `get_rs_status` all execute MongoDB admin commands that require elevated privileges (`clusterMonitor` role). When the connected user lacks those privileges, PyMongo raises `OperationFailure(code=13)`.
- Previously these were caught by the broad `except Exception` handler and forwarded to Sentry via `report_validation_failure` — generating noise for a predictable configuration issue, not a code bug.
- This PR detects `code == 13` (Unauthorized) before reporting and returns a clear, actionable error message instead, keeping Sentry clean.

## Test plan

- [ ] `TestMongoDBAdminUnauthorized` — 4 new unit tests covering all three functions; verifies `report_validation_failure` is NOT called on code-13 errors and IS still called for other errors.
- [ ] `uv run python -m pytest tests/test_mongodb_integration.py -v` — all 14 tests pass.
- [ ] `uv run ruff check app/integrations/mongodb.py` — no lint errors.

Closes #2354
Closes #2355
Closes #2356

https://claude.ai/code/session_01LuxtymfSpixoT8aoLeyjMQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuxtymfSpixoT8aoLeyjMQ)_