### PR TITLE
fix(cli): surface saved-URL source in remote health timeout errors

### DIFF
--- a/app/cli/commands/remote_health.py
+++ b/app/cli/commands/remote_health.py
@@ -117,6 +117,7 @@ def run_remote_health_check(
     import httpx
     from rich.console import Console
 
+    from app.cli.wizard.store import describe_remote_url_source
     from app.version import get_version
 
     resolved_client = client
@@ -138,8 +139,6 @@ def run_remote_health_check(
         if save_url:
             _save_remote_base_url(resolved_client)
     except httpx.TimeoutException as exc:
-        from app.cli.wizard.store import describe_remote_url_source
-
         message = (
             "Connection timed out reaching "
             f"{resolved_client.base_url}. Instance may still be starting. Retry in 30s "
@@ -150,8 +149,6 @@ def run_remote_health_check(
             message = f"{message}\n{source_hint}"
         raise click.ClickException(message) from exc
     except httpx.ConnectError as exc:
-        from app.cli.wizard.store import describe_remote_url_source
-
         message = (
             "Could not connect to "
             f"{resolved_client.base_url}. The server process may not be running. "

--- a/app/cli/commands/remote_health.py
+++ b/app/cli/commands/remote_health.py
@@ -138,17 +138,29 @@ def run_remote_health_check(
         if save_url:
             _save_remote_base_url(resolved_client)
     except httpx.TimeoutException as exc:
-        raise click.ClickException(
+        from app.cli.wizard.store import describe_remote_url_source
+
+        message = (
             "Connection timed out reaching "
             f"{resolved_client.base_url}. Instance may still be starting. Retry in 30s "
             "or check AWS console/system logs."
-        ) from exc
+        )
+        source_hint = describe_remote_url_source(resolved_client.base_url)
+        if source_hint:
+            message = f"{message}\n{source_hint}"
+        raise click.ClickException(message) from exc
     except httpx.ConnectError as exc:
-        raise click.ClickException(
+        from app.cli.wizard.store import describe_remote_url_source
+
+        message = (
             "Could not connect to "
             f"{resolved_client.base_url}. The server process may not be running. "
             "SSH into the instance and check: `systemctl status opensre` and "
             "`cat /var/log/opensre-remote.log`."
-        ) from exc
+        )
+        source_hint = describe_remote_url_source(resolved_client.base_url)
+        if source_hint:
+            message = f"{message}\n{source_hint}"
+        raise click.ClickException(message) from exc
     except Exception as exc:
         raise click.ClickException(f"Health check failed: {exc}") from exc

--- a/app/cli/wizard/store.py
+++ b/app/cli/wizard/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import suppress
 from copy import deepcopy
 from datetime import UTC, datetime
 from pathlib import Path
@@ -112,11 +113,10 @@ def describe_remote_url_source(url: str, path: Path | None = None) -> str | None
     updated_at = active_remote.get("updated_at") if isinstance(active_remote, dict) else None
     saved_phrase = "saved"
     if isinstance(updated_at, str):
-        try:
+        # Fall back to the generic "saved" phrasing when the timestamp is malformed.
+        with suppress(ValueError):
             saved_dt = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
             saved_phrase = f"saved on {saved_dt.date().isoformat()}"
-        except ValueError:
-            pass
     return (
         f"This URL was {saved_phrase} in {store_path}. "
         "Pass --url to override or update the saved value via `opensre remote health <url>`."

--- a/app/cli/wizard/store.py
+++ b/app/cli/wizard/store.py
@@ -90,6 +90,39 @@ def save_remote_url(url: str, path: Path | None = None) -> None:
     store_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+def describe_remote_url_source(url: str, path: Path | None = None) -> str | None:
+    """Return a one-line hint about where ``url`` was saved, or ``None``.
+
+    Used in error paths so users see that a timed-out URL was loaded from
+    disk rather than appearing as a mysterious default. Returns ``None``
+    when ``url`` does not match the persisted active remote URL.
+    """
+    if not url:
+        return None
+    data = _load_raw(path)
+    remote = data.get("remote", {})
+    if not isinstance(remote, dict) or remote.get("url") != url:
+        return None
+    store_path = path or get_store_path()
+    active_name = remote.get("active_name")
+    remotes = remote.get("remotes", {})
+    active_remote = (
+        remotes.get(active_name, {}) if active_name and isinstance(remotes, dict) else {}
+    )
+    updated_at = active_remote.get("updated_at") if isinstance(active_remote, dict) else None
+    saved_phrase = "saved"
+    if isinstance(updated_at, str):
+        try:
+            saved_dt = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+            saved_phrase = f"saved on {saved_dt.date().isoformat()}"
+        except ValueError:
+            pass
+    return (
+        f"This URL was {saved_phrase} in {store_path}. "
+        "Pass --url to override or update the saved value via `opensre remote health <url>`."
+    )
+
+
 def load_named_remotes(path: Path | None = None) -> dict[str, str]:
     """Return all named remotes as ``{name: url}``."""
     data = _load_raw(path)

--- a/tests/cli/test_remote.py
+++ b/tests/cli/test_remote.py
@@ -107,12 +107,38 @@ def test_remote_health_reports_timeout_cleanly() -> None:
     client.base_url = "http://10.0.0.1:2024"
     client.probe_health.side_effect = httpx.TimeoutException("timed out")
 
-    with patch("app.remote.client.RemoteAgentClient", return_value=client):
+    with (
+        patch("app.remote.client.RemoteAgentClient", return_value=client),
+        patch("app.cli.wizard.store.describe_remote_url_source", return_value=None),
+    ):
         result = runner.invoke(cli, ["remote", "--url", "10.0.0.1", "health"])
 
     assert result.exit_code == 1
     assert "Connection timed out reaching http://10.0.0.1:2024." in result.output
     assert "Instance may still be starting" in result.output
+
+
+def test_remote_health_timeout_annotates_saved_url_source() -> None:
+    runner = CliRunner()
+    client = MagicMock()
+    client.base_url = "http://10.0.0.1:2024"
+    client.probe_health.side_effect = httpx.TimeoutException("timed out")
+    saved_hint = (
+        "This URL was saved on 2026-05-12 in /Users/test/.config/opensre/opensre.json. "
+        "Pass --url to override or update the saved value via `opensre remote health <url>`."
+    )
+
+    with (
+        patch("app.remote.client.RemoteAgentClient", return_value=client),
+        patch("app.cli.wizard.store.describe_remote_url_source", return_value=saved_hint),
+        patch("app.cli.wizard.store.load_remote_url", return_value="http://10.0.0.1:2024"),
+    ):
+        result = runner.invoke(cli, ["remote", "health"])
+
+    assert result.exit_code == 1
+    assert "Connection timed out reaching http://10.0.0.1:2024." in result.output
+    assert "saved on 2026-05-12" in result.output
+    assert "Pass --url to override" in result.output
 
 
 def test_remote_health_json_output() -> None:
@@ -138,12 +164,37 @@ def test_remote_health_connect_error_is_actionable() -> None:
     client.base_url = "http://10.0.0.1:2024"
     client.probe_health.side_effect = httpx.ConnectError("refused")
 
-    with patch("app.remote.client.RemoteAgentClient", return_value=client):
+    with (
+        patch("app.remote.client.RemoteAgentClient", return_value=client),
+        patch("app.cli.wizard.store.describe_remote_url_source", return_value=None),
+    ):
         result = runner.invoke(cli, ["remote", "--url", "10.0.0.1", "health"])
 
     assert result.exit_code == 1
     assert "Could not connect to http://10.0.0.1:2024." in result.output
     assert "systemctl status opensre" in result.output
+
+
+def test_remote_health_connect_error_annotates_saved_url_source() -> None:
+    runner = CliRunner()
+    client = MagicMock()
+    client.base_url = "http://10.0.0.1:2024"
+    client.probe_health.side_effect = httpx.ConnectError("refused")
+    saved_hint = (
+        "This URL was saved on 2026-05-12 in /Users/test/.config/opensre/opensre.json. "
+        "Pass --url to override or update the saved value via `opensre remote health <url>`."
+    )
+
+    with (
+        patch("app.remote.client.RemoteAgentClient", return_value=client),
+        patch("app.cli.wizard.store.describe_remote_url_source", return_value=saved_hint),
+        patch("app.cli.wizard.store.load_remote_url", return_value="http://10.0.0.1:2024"),
+    ):
+        result = runner.invoke(cli, ["remote", "health"])
+
+    assert result.exit_code == 1
+    assert "Could not connect to http://10.0.0.1:2024." in result.output
+    assert "saved on 2026-05-12" in result.output
 
 
 def test_remote_group_passes_api_key_to_client() -> None:

--- a/tests/cli/wizard/test_store.py
+++ b/tests/cli/wizard/test_store.py
@@ -4,6 +4,7 @@ import json
 
 from app.cli.wizard.store import (
     delete_named_remote,
+    describe_remote_url_source,
     load_local_config,
     load_named_remotes,
     load_remote_ops_config,
@@ -74,6 +75,31 @@ def test_save_named_remote_persists_url(tmp_path) -> None:
 
     assert load_remote_url(store_path) == "http://1.2.3.4:8080"
     assert load_named_remotes(store_path) == {"ec2": "http://1.2.3.4:8080"}
+
+
+def test_describe_remote_url_source_returns_dated_hint_for_saved_active_url(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+    save_named_remote("ec2", "http://1.2.3.4:8080", set_active=True, source="ec2", path=store_path)
+
+    hint = describe_remote_url_source("http://1.2.3.4:8080", store_path)
+
+    assert hint is not None
+    assert "saved on " in hint
+    assert str(store_path) in hint
+    assert "Pass --url to override" in hint
+
+
+def test_describe_remote_url_source_returns_none_for_unsaved_url(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+    save_named_remote("ec2", "http://1.2.3.4:8080", set_active=True, source="ec2", path=store_path)
+
+    assert describe_remote_url_source("http://5.6.7.8:9090", store_path) is None
+
+
+def test_describe_remote_url_source_returns_none_when_no_url_saved(tmp_path) -> None:
+    store_path = tmp_path / "opensre.json"
+
+    assert describe_remote_url_source("http://1.2.3.4:8080", store_path) is None
 
 
 def test_delete_named_remote_removes_entry_and_clears_active_url(tmp_path) -> None:


### PR DESCRIPTION
Fixes #2384

#### Describe the changes you have made in this PR -

`opensre remote health` was silently using a URL persisted from an earlier run in `~/.config/opensre/opensre.json` when `--url` was not passed. The previous timeout and connect-error messages did not mention this, so users seeing `Connection timed out reaching http://10.0.0.1:2024.` reasonably interpreted it as a bad hardcoded default in the CLI. The Sentry-auto-filed issue #2276 has the same root cause: the saved URL is invisible at the point of failure.

This PR adds a new helper `describe_remote_url_source(url)` in `app/cli/wizard/store.py`. When `url` matches the active persisted remote URL, the helper returns a one-line hint including the saved date and the store path. When the URL was passed explicitly via `--url` (or doesn't match the persisted value), the helper returns `None` so users don't see a confusing source reference for their own value.

The hint is wired into the `TimeoutException` and `ConnectError` handlers in `run_remote_health_check`. The first line of the error is unchanged; the source hint is appended on a second line.

Out of scope for this PR (worth a follow-up if useful): the same hint could be plumbed into the timeout handlers for `remote trigger`, `remote investigate`, and the other remote subcommands in `app/cli/commands/remote.py`. The issue specifically named `remote health` so I kept the change focused there.

### Demo/Screenshot for feature changes and bug fixes - 

Repro setup: this machine has a stale entry in `~/.config/opensre/opensre.json` from 2026-05-12 pointing at `http://10.0.0.1:2024` (unreachable), saved by an earlier run.

Before (on main):

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/924944cb-2def-4040-8791-ff7feb8955a6" />


After (on this branch):

<img width="1167" height="187" alt="image" src="https://github.com/user-attachments/assets/3a8513bd-5106-457d-a36d-0ad6e3f9e3c3" />


Same exit code, same first line, plus the new transparency line.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** The CLI persists a remote URL via `save_named_remote(..., set_active=True)` and later transparently reuses it when `--url` is not passed. The error path treats the URL as the only relevant fact ("Connection timed out reaching X") with no breadcrumb to the file the URL came from. From the user's perspective the URL looks hardcoded into the binary, so the natural reaction is to file a bug against the CLI instead of clearing the saved value.

**Alternatives I considered:**

1. **Add an `opensre remote forget` subcommand.** Would solve the long-term problem but does not change the immediate error UX. Out of scope for this issue; can be a follow-up.
2. **Always include the source hint, even when `--url` is passed.** Rejected because if the user passed `--url`, they already know the URL came from their CLI invocation. The hint would be noise.
3. **Plumb a `url_source` flag through `_load_remote_client` and `RemoteAgentClient`.** Rejected as too invasive — it would touch every caller of `_load_remote_client` (six call sites). The helper-based approach makes the source check a local decision in the error path.

**Chosen approach:** add a focused, opt-in helper `describe_remote_url_source(url, path=None)` that:
- Reads `~/.config/opensre/opensre.json` (or a test override path),
- Returns `None` immediately if `url` does not match the persisted active URL — so callers passing `--url` see no hint,
- Otherwise returns a one-line string mentioning the saved date (parsed from the active named remote's `updated_at` field) and the store path.

The two error handlers in `run_remote_health_check` (`TimeoutException` and `ConnectError`) each call the helper and append the hint to the existing message when non-None.

**Edge cases considered:**
- Empty/missing `url` → return None (defensive guard at start).
- Store file doesn't exist → `_load_raw` returns the empty config → no `remote` section → return None.
- Saved URL doesn't match the failing URL (e.g., user passed `--url example.com` but store has a different value) → return None. Verified by `test_describe_remote_url_source_returns_none_for_unsaved_url`.
- `updated_at` missing or unparseable → fall back to generic "saved" wording instead of "saved on YYYY-MM-DD".
- Defensive `isinstance` checks for the nested `remote`, `remotes`, and `active_remote` dicts so a malformed store file can't crash the error path.
- Existing tests `test_remote_health_reports_timeout_cleanly` and `test_remote_health_connect_error_is_actionable` patch the helper to return `None` so they don't accidentally pick up arbitrary host state on the developer's machine.

**Tests added:**
- 3 unit tests for the helper in `tests/cli/wizard/test_store.py` (dated hint, non-matching URL → None, no saved URL → None).
- 2 integration tests in `tests/cli/test_remote.py` asserting that the timeout and connect-error CLI output includes the source hint when the helper returns one.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
