### PR TITLE
chore: remove slash-catalog pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,4 @@
 repos:
-  - repo: local
-    hooks:
-      - id: slash-catalog-parity
-        name: slash catalog covers all REPL slash commands
-        entry: uv run python -m pytest tests/cli/interactive_shell/command_registry/test_slash_catalog.py::test_slash_catalog_covers_all_registered_commands -q
-        language: system
-        pass_filenames: false
-        files: ^app/cli/interactive_shell/command_registry/.*\.py$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:


### PR DESCRIPTION
## Summary

- Remove the local `slash-catalog-parity` pre-commit hook added in #2222
- Keep existing ruff check/format hooks in `.pre-commit-config.yaml`

Slash catalog coverage is already enforced by CI (`test_slash_catalog_covers_all_registered_commands` in the cli-runtime shard) and documented in `app/cli/interactive_shell/AGENTS.md`.

## Test plan

- [ ] CI passes (no behavior change beyond pre-commit config)