### PR TITLE
fix(repl): capture delegated CLI output

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -41,16 +41,17 @@ def run_cli_command(
     console: Console,
     args: list[str],
     *,
+    capture_output: bool = False,
     subprocess_timeout: float | None = None,
 ) -> bool:
     """Helper to delegate complex or interactive Click commands to a child process.
 
     ``subprocess_timeout`` caps how long ``subprocess.run`` waits before raising
-    :class:`~subprocess.TimeoutExpired`. Interactive flows use ``None`` so the
-    child can prompt as long as needed; callers that hit the network without a
-    TTY (like ``opensre update``) pass a bounded timeout. When a timeout is set,
-    stdout/stderr are captured and replayed through ``console`` so output survives
-    prompt-toolkit ``patch_stdout`` redraws in the REPL.
+    :class:`~subprocess.TimeoutExpired`. Interactive flows keep the default
+    passthrough behavior so the child can prompt as long as needed. Finite
+    output commands pass ``capture_output=True`` so stdout/stderr are replayed
+    through ``console`` and survive prompt-toolkit ``patch_stdout`` redraws in
+    the REPL. Timed commands are always captured for the same reason.
 
     Ctrl+C sends :exc:`KeyboardInterrupt`, which subclasses :exc:`BaseException`
     rather than :exc:`Exception`; it is handled here so the REPL survives and the
@@ -59,8 +60,8 @@ def run_cli_command(
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
     try:
-        if subprocess_timeout is not None:
-            timed_result = subprocess.run(
+        if capture_output or subprocess_timeout is not None:
+            captured_result = subprocess.run(
                 cmd,
                 check=False,
                 timeout=subprocess_timeout,
@@ -69,11 +70,11 @@ def run_cli_command(
                 encoding="utf-8",
                 errors="replace",
             )
-            print_command_output(console, timed_result.stdout or "")
-            print_command_output(console, timed_result.stderr or "", style=ERROR)
-            if timed_result.returncode != 0:
+            print_command_output(console, captured_result.stdout or "")
+            print_command_output(console, captured_result.stderr or "", style=ERROR)
+            if captured_result.returncode != 0:
                 console.print(
-                    f"[{ERROR}]CLI command exited with non-zero code {timed_result.returncode}[/]"
+                    f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
         else:
             interactive_result = subprocess.run(cmd, check=False)
@@ -201,7 +202,7 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if subcommand.startswith("-"):
-        return run_cli_command(console, ["tests", *args])
+        return run_cli_command(console, ["tests", *args], capture_output=True)
 
     if subcommand not in _TEST_SUBCOMMANDS:
         suggestion = closest_choice(subcommand, _TEST_SUBCOMMANDS)
@@ -219,11 +220,11 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    return run_cli_command(console, ["tests", *args])
+    return run_cli_command(console, ["tests", *args], capture_output=True)
 
 
 def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["guardrails", *args])
+    return run_cli_command(console, ["guardrails", *args], capture_output=True)
 
 
 def _cmd_update(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
@@ -239,7 +240,7 @@ def _cmd_uninstall(session: ReplSession, console: Console, args: list[str]) -> b
 
 
 def _cmd_config(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["config", *args])
+    return run_cli_command(console, ["config", *args], capture_output=True)
 
 
 def _cmd_messaging(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1518,6 +1518,43 @@ class TestRunCliCommand:
         ]
         assert buf.getvalue() == "\n\n"
 
+    def test_captured_delegate_replays_output_without_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        def _fake_run(
+            cmd: list[str],
+            *,
+            check: bool,
+            timeout: float | None,
+            capture_output: bool,
+            text: bool,
+            encoding: str,
+            errors: str,
+        ) -> subprocess.CompletedProcess[str]:
+            del check, text, encoding, errors
+            assert timeout is None
+            assert capture_output is True
+            assert cmd == [sys.executable, "-m", "app.cli", "tests", "list"]
+            return subprocess.CompletedProcess(
+                cmd,
+                2,
+                stdout="openclaw-synthetic\n",
+                stderr="Usage: python -m app.cli tests [OPTIONS]\n",
+            )
+
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        console, buf = _capture()
+
+        assert m.run_cli_command(console, ["tests", "list"], capture_output=True) is True
+
+        output = buf.getvalue()
+        assert "openclaw-synthetic" in output
+        assert "Usage: python -m app.cli tests" in output
+        assert "CLI command exited with non-zero code 2" in output
+
     def test_timeout_replays_decoded_partial_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1555,30 +1592,38 @@ class TestCliDelegatedCommands:
     """Coverage for commands that simply delegate to the underlying Click CLI."""
 
     @pytest.mark.parametrize(
-        "command,expected_args",
+        "command,expected_args,expected_kwargs",
         [
-            ("/config show", ["config", "show"]),
-            ("/remote health", ["remote", "health"]),
-            ("/tests list", ["tests", "list"]),
-            ("/guardrails audit", ["guardrails", "audit"]),
-            ("/update", ["update"]),
-            ("/uninstall", ["uninstall"]),
+            ("/config show", ["config", "show"], {"capture_output": True}),
+            ("/remote health", ["remote", "health"], {}),
+            ("/tests list", ["tests", "list"], {"capture_output": True}),
+            ("/guardrails", ["guardrails"], {"capture_output": True}),
+            ("/guardrails audit", ["guardrails", "audit"], {"capture_output": True}),
+            ("/update", ["update"], {"subprocess_timeout": 300}),
+            ("/uninstall", ["uninstall"], {}),
         ],
     )
     def test_command_delegation(
-        self, monkeypatch: object, command: str, expected_args: list[str]
+        self,
+        monkeypatch: object,
+        command: str,
+        expected_args: list[str],
+        expected_kwargs: dict[str, object],
     ) -> None:
         from app.cli.interactive_shell.command_registry import cli_parity as m
 
         captured: list[list[str]] = []
+        captured_kwargs: list[dict[str, object]] = []
 
         def _fake_run_cli_command(_console: Console, args: list[str], **kwargs: object) -> bool:
             captured.append(args)
+            captured_kwargs.append(kwargs)
             return True
 
         monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
         dispatch_slash(command, ReplSession(), Console())
         assert captured == [expected_args]
+        assert captured_kwargs == [expected_kwargs]
 
     def test_slash_onboard_delegates_to_run_cli_command(self, monkeypatch: object) -> None:
         """``/onboard`` must delegate to ``run_cli_command`` so the wizard runs


### PR DESCRIPTION
Fixes #2387
Fixes #2388
Fixes #2287

#### Describe the changes you have made in this PR -

REPL slash commands that delegate to finite Click subcommands now opt in to captured subprocess output. The shared `run_cli_command` helper keeps passthrough mode as the default for interactive flows, but adds `capture_output=True` for commands whose stdout/stderr should be replayed through the REPL `Console`.

This wires captured output into:

- `/tests ...`, including `/tests list`
- `/guardrails ...`, including bare `/guardrails`
- `/config ...`

Interactive delegated commands such as `/onboard`, `/remote`, and `/uninstall` keep the existing passthrough behavior so prompts and long-running streams are not hidden behind a pipe.

### Demo/Screenshot for feature changes and bug fixes -

Before, these commands delegated with `subprocess.run(cmd, check=False)`, so child stdout/stderr bypassed the REPL console. In non-TTY harnesses `/tests list` captured essentially nothing, and bare `/guardrails` only showed the non-zero exit line.

After, the finite-output slash commands call:

```text
run_cli_command(..., capture_output=True)
```

and `run_cli_command` replays both stdout and stderr through `print_command_output(...)` before printing any non-zero exit status.

Verification performed locally:

```text
python3 -m py_compile app/cli/interactive_shell/command_registry/cli_parity.py tests/cli/interactive_shell/test_commands.py

git diff --check
```

Focused pytest target attempted:

```text
uv run pytest tests/cli/interactive_shell/test_commands.py::TestRunCliCommand tests/cli/interactive_shell/test_commands.py::TestCliDelegatedCommands -q
```

Local result: `uv` is not installed on this machine. A fallback with system Python is blocked because the machine has Python 3.9 and lacks project test dependencies such as `prompt_toolkit`; the project requires Python >=3.12. Syntax and whitespace checks passed.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue is that some slash commands delegate to `python -m app.cli ...` and expect a finite block of output to appear inside the REPL. The previous helper only captured output when a timeout was provided. Without capture, the child process inherited stdout/stderr, which bypasses the REPL `Console` and can race with prompt-toolkit redraws.

I kept passthrough as the default because some delegated commands are interactive or long-running. Then I added an explicit `capture_output` option and enabled it only for the finite-output commands covered by these reports. Captured commands use the same replay path already used by timed commands, including decoded stdout/stderr and the existing non-zero exit-code message.

Tests cover both sides of the behavior: passthrough remains the default, captured delegates replay stdout/stderr even without a timeout, and `/config`, `/tests list`, and `/guardrails` request captured output when dispatched from the REPL.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
