### PR TITLE
fix(repl): route CLI parity output through REPL console

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -42,14 +42,15 @@ def run_cli_command(
     args: list[str],
     *,
     subprocess_timeout: float | None = None,
+    capture_output: bool | None = None,
 ) -> bool:
     """Helper to delegate complex or interactive Click commands to a child process.
 
     ``subprocess_timeout`` caps how long ``subprocess.run`` waits before raising
     :class:`~subprocess.TimeoutExpired`. Interactive flows use ``None`` so the
     child can prompt as long as needed; callers that hit the network without a
-    TTY (like ``opensre update``) pass a bounded timeout. When a timeout is set,
-    stdout/stderr are captured and replayed through ``console`` so output survives
+    TTY (like ``opensre update``) pass a bounded timeout. When output is
+    captured, stdout/stderr are replayed through ``console`` so output survives
     prompt-toolkit ``patch_stdout`` redraws in the REPL.
 
     Ctrl+C sends :exc:`KeyboardInterrupt`, which subclasses :exc:`BaseException`
@@ -58,9 +59,10 @@ def run_cli_command(
     """
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
+    should_capture_output = subprocess_timeout is not None if capture_output is None else capture_output
     try:
-        if subprocess_timeout is not None:
-            timed_result = subprocess.run(
+        if should_capture_output:
+            result = subprocess.run(
                 cmd,
                 check=False,
                 timeout=subprocess_timeout,
@@ -69,14 +71,18 @@ def run_cli_command(
                 encoding="utf-8",
                 errors="replace",
             )
-            print_command_output(console, timed_result.stdout or "")
-            print_command_output(console, timed_result.stderr or "", style=ERROR)
-            if timed_result.returncode != 0:
+            print_command_output(console, result.stdout or "")
+            print_command_output(console, result.stderr or "", style=ERROR)
+            if result.returncode != 0:
                 console.print(
-                    f"[{ERROR}]CLI command exited with non-zero code {timed_result.returncode}[/]"
+                    f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]"
                 )
         else:
-            interactive_result = subprocess.run(cmd, check=False)
+            interactive_result = subprocess.run(
+                cmd,
+                check=False,
+                timeout=subprocess_timeout,
+            )
             if interactive_result.returncode != 0:
                 console.print(
                     f"[{ERROR}]CLI command exited with non-zero code {interactive_result.returncode}[/]"
@@ -96,7 +102,7 @@ def run_cli_command(
 def _cmd_onboard(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
     # The REPL loop adds ``/onboard`` to ``_WAIT_FOR_COMPLETION_COMMANDS``
     # (dispatch.py) so the prompt_toolkit Application is torn down before
-    # this handler runs — the wizard subprocess therefore gets exclusive
+    # this handler runs - the wizard subprocess therefore gets exclusive
     # stdin and can drive its own interactive prompts without conflicting
     # with the shell's UI.
     return run_cli_command(console, ["onboard", *args])
@@ -201,7 +207,7 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if subcommand.startswith("-"):
-        return run_cli_command(console, ["tests", *args])
+        return run_cli_command(console, ["tests", *args], capture_output=True)
 
     if subcommand not in _TEST_SUBCOMMANDS:
         suggestion = closest_choice(subcommand, _TEST_SUBCOMMANDS)
@@ -219,11 +225,11 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    return run_cli_command(console, ["tests", *args])
+    return run_cli_command(console, ["tests", *args], capture_output=True)
 
 
 def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["guardrails", *args])
+    return run_cli_command(console, ["guardrails", *args], capture_output=True)
 
 
 def _cmd_update(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -59,7 +59,10 @@ def run_cli_command(
     """
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
-    should_capture_output = subprocess_timeout is not None if capture_output is None else capture_output
+    if capture_output is None:
+        should_capture_output = subprocess_timeout is not None
+    else:
+        should_capture_output = capture_output
     try:
         if should_capture_output:
             result = subprocess.run(

--- a/tests/cli/interactive_shell/command_registry/test_cli_parity.py
+++ b/tests/cli/interactive_shell/command_registry/test_cli_parity.py
@@ -1,0 +1,59 @@
+"""Tests for CLI-parity slash command subprocess delegation."""
+
+from __future__ import annotations
+
+import io
+import subprocess
+
+from rich.console import Console
+
+from app.cli.interactive_shell.command_registry import cli_parity
+
+
+def _console_buffer() -> tuple[Console, io.StringIO]:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, color_system=None, width=80)
+    return console, buffer
+
+
+def test_run_cli_command_replays_captured_stdout_and_stderr(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        calls.update(kwargs)
+        return subprocess.CompletedProcess(
+            cmd,
+            returncode=0,
+            stdout="catalog output\n",
+            stderr="warning output\n",
+        )
+
+    monkeypatch.setattr(cli_parity.subprocess, "run", fake_run)
+    console, buffer = _console_buffer()
+
+    assert cli_parity.run_cli_command(console, ["tests", "list"], capture_output=True)
+
+    assert calls["capture_output"] is True
+    assert calls["text"] is True
+    output = buffer.getvalue()
+    assert "catalog output" in output
+    assert "warning output" in output
+
+
+def test_run_cli_command_replays_captured_failure(monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):  # noqa: ARG001
+        return subprocess.CompletedProcess(
+            cmd,
+            returncode=2,
+            stdout="",
+            stderr="Usage: python -m app.cli guardrails [OPTIONS] COMMAND [ARGS]...\n",
+        )
+
+    monkeypatch.setattr(cli_parity.subprocess, "run", fake_run)
+    console, buffer = _console_buffer()
+
+    assert cli_parity.run_cli_command(console, ["guardrails"], capture_output=True)
+
+    output = buffer.getvalue()
+    assert "Usage: python -m app.cli guardrails" in output
+    assert "CLI command exited with non-zero code 2" in output


### PR DESCRIPTION
## Summary

- add an opt-in capture path to `run_cli_command` so delegated CLI stdout/stderr can be replayed through the REPL `Console`
- use that path for `/tests` foreground subcommands and `/guardrails`, fixing blank/missing output in the REPL buffer
- add regression coverage for replaying captured stdout, stderr, and non-zero usage output

Fixes #2387
Fixes #2388

## Testing

- Not run locally: this environment has no local checkout/git/Python test environment for the forked repo. CI should run on this PR.