### PR TITLE
feat(llm-cli): surface invalid model errors from CLI adapters

### DIFF
--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -245,7 +245,10 @@ def _raise_if_invalid_model(*, stdout: str, stderr: str) -> None:
     text = f"{stderr}\n{stdout}".lower()
     if any(marker in text for marker in _INVALID_MODEL_MARKERS):
         detail = (stderr or stdout).strip()[:2000]
-        raise CLIInvalidModelError(provider="claude-code", detail=detail or "unknown model")
+        raise CLIInvalidModelError(
+            provider="claude-code",
+            detail=detail or "unknown model",
+        )
 
 
 class ClaudeCodeAdapter:

--- a/app/integrations/llm_cli/claude_code.py
+++ b/app/integrations/llm_cli/claude_code.py
@@ -5,7 +5,7 @@ Env vars
 CLAUDE_CODE_BIN              Optional explicit path to the ``claude`` binary.
                              Blank or non-runnable paths are ignored; PATH + fallbacks apply.
 CLAUDE_CODE_MODEL            Optional model override (e.g. ``claude-opus-4-7``).
-                             Unset or empty → omit ``--model``; CLI default applies.
+                             Unset or empty -> omit ``--model``; CLI default applies.
 CLAUDE_CODE_TIMEOUT_SECONDS  Optional invocation timeout override in seconds for long prompts
                              (default: 120, min: 30, max: 600).
 
@@ -22,7 +22,7 @@ Binary resolution uses ``shutil.which`` with ``claude.cmd`` / ``claude.exe`` /
 ``.bat`` / ``.ps1`` on Windows, plus npm / Volta / pnpm style fallback dirs
 (see ``default_cli_fallback_paths``). Without the CLI binary, macOS Keychain
 may still hold OAuth credentials, so auth is reported as unclear until the
-binary runs; Linux and Windows without env or creds file → not authenticated.
+binary runs; Linux and Windows without env or creds file -> not authenticated.
 """
 
 from __future__ import annotations
@@ -48,6 +48,7 @@ from app.integrations.llm_cli.env_overrides import (
     ANTHROPIC_CLI_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.errors import CLIInvalidModelError
 from app.integrations.llm_cli.subprocess_env import build_cli_subprocess_env
 
 _CLAUDE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
@@ -58,6 +59,12 @@ _AUTH_HINT = "Run: claude auth login or set ANTHROPIC_API_KEY."
 _DEFAULT_EXEC_TIMEOUT_SEC = 120.0
 _MIN_EXEC_TIMEOUT_SEC = 30.0
 _MAX_EXEC_TIMEOUT_SEC = 600.0
+_INVALID_MODEL_MARKERS = (
+    "model not found",
+    "no such model",
+    "unknown model",
+    "unsupported model",
+)
 
 
 def _resolve_exec_timeout_seconds() -> float:
@@ -122,7 +129,7 @@ def _auth_status_from_json_payload(data: dict) -> tuple[bool, str]:
         # also populates for env-supplied API keys regardless of the active
         # method and would mis-report the source.
         return True, f"Authenticated via {auth_method}{f' ({email})' if email else ''}."
-    # Older CLI versions may omit authMethod — fall back to legacy heuristic.
+    # Older CLI versions may omit authMethod - fall back to legacy heuristic.
     if api_key_source:
         return True, f"Authenticated via {api_key_source}."
     if email:
@@ -147,12 +154,12 @@ def _try_parse_auth_status_stdout(stdout: str) -> tuple[bool, str] | None:
 def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     """Check Claude Code auth via `claude auth status` (local, no API call).
 
-    Returns ``(True, …)`` for any working auth (subscription or API key),
-    ``(False, …)`` when the CLI definitively reports the user as not logged
-    in, and ``(None, …)`` only when the probe itself failed (timeout, spawn
+    Returns ``(True, ...)`` for any working auth (subscription or API key),
+    ``(False, ...)`` when the CLI definitively reports the user as not logged
+    in, and ``(None, ...)`` only when the probe itself failed (timeout, spawn
     error, or unparseable output from an older CLI).
 
-    The CLI exits **non-zero** when ``loggedIn`` is false (CLI ≥ 2.x) while
+    The CLI exits non-zero when ``loggedIn`` is false (CLI >= 2.x) while
     still printing valid JSON, so we parse stdout first and only fall back to
     treating a non-zero exit as an opaque probe failure when the JSON is
     absent or unparseable. The previous behaviour of returning ``None`` on
@@ -173,7 +180,7 @@ def _probe_cli_auth(binary_path: str) -> tuple[bool | None, str]:
     except subprocess.TimeoutExpired:
         return (
             None,
-            f"claude auth status timed out after {_PROBE_TIMEOUT_SEC:.0f} s — auth state unknown.",
+            f"claude auth status timed out after {_PROBE_TIMEOUT_SEC:.0f} s - auth state unknown.",
         )
     except OSError as exc:
         return None, f"Could not spawn claude for auth probe: {exc}"
@@ -204,12 +211,12 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
     """Return (logged_in, detail) for Claude Code auth.
 
     Resolution order:
-    1. Binary available → `claude auth status` is the source of truth for all
+    1. Binary available -> `claude auth status` is the source of truth for all
        platforms; covers both subscription login and ANTHROPIC_API_KEY.
-    2. No binary, ANTHROPIC_API_KEY set → True (filesystem-independent fallback).
-    3. No binary, credentials file present → True (OAuth login).
-    4. No binary, macOS → None (Keychain may hold credentials; invocation will verify).
-    5. No binary, Linux/Windows → False.
+    2. No binary, ANTHROPIC_API_KEY set -> True (filesystem-independent fallback).
+    3. No binary, credentials file present -> True (OAuth login).
+    4. No binary, macOS -> None (Keychain may hold credentials; invocation will verify).
+    5. No binary, Linux/Windows -> False.
     """
     if binary_path:
         return _probe_cli_auth(binary_path)
@@ -223,7 +230,7 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
     except OSError:
         return None, "Could not read ~/.claude/.credentials.json; auth state unclear."
     if sys.platform == "darwin":
-        return None, (f"Auth state unclear — binary unavailable for verification. {_AUTH_HINT}")
+        return None, (f"Auth state unclear - binary unavailable for verification. {_AUTH_HINT}")
     return (
         False,
         f"Not authenticated. {_AUTH_HINT}",
@@ -232,6 +239,13 @@ def _classify_claude_code_auth(binary_path: str | None = None) -> tuple[bool | N
 
 def _fallback_claude_code_paths() -> list[str]:
     return _default_cli_fallback_paths("claude")
+
+
+def _raise_if_invalid_model(*, stdout: str, stderr: str) -> None:
+    text = f"{stderr}\n{stdout}".lower()
+    if any(marker in text for marker in _INVALID_MODEL_MARKERS):
+        detail = (stderr or stdout).strip()[:2000]
+        raise CLIInvalidModelError(provider="claude-code", detail=detail or "unknown model")
 
 
 class ClaudeCodeAdapter:
@@ -357,6 +371,7 @@ class ClaudeCodeAdapter:
         return (stdout or "").strip()
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        _raise_if_invalid_model(stdout=stdout, stderr=stderr)
         err = (stderr or "").strip()
         out = (stdout or "").strip()
         bits = [f"claude -p exited with code {returncode}"]

--- a/app/integrations/llm_cli/codex.py
+++ b/app/integrations/llm_cli/codex.py
@@ -25,14 +25,21 @@ from app.integrations.llm_cli.env_overrides import (
     OPENAI_PLATFORM_ENV_KEYS,
     nonempty_env_values,
 )
+from app.integrations.llm_cli.errors import CLIInvalidModelError
 
 _CODEX_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 _PROBE_TIMEOUT_SEC = 3.0
 _READ_ONLY_SANDBOX = "read-only"
+_INVALID_MODEL_MARKERS = (
+    "invalid model",
+    "model not found",
+    "no such model",
+    "unknown model",
+)
 
 
 def _ver_tuple(version: str) -> tuple[int, int, int]:
-    # Extract all leading digit runs so "1.2.3-beta.4" → (1, 2, 3), "1.2a.3" → (1, 2, 3).
+    # Extract all leading digit runs so "1.2.3-beta.4" -> (1, 2, 3), "1.2a.3" -> (1, 2, 3).
     parts = [int(m) for m in re.findall(r"\d+", version)][:3]
     while len(parts) < 3:
         parts.append(0)
@@ -83,7 +90,7 @@ def _codex_workspace_and_skip_git() -> tuple[str, bool]:
         if proc.returncode == 0 and root:
             return root, False
     except (OSError, subprocess.TimeoutExpired):
-        # git missing, not a repo, or timed out — use cwd and let codex skip repo checks.
+        # git missing, not a repo, or timed out - use cwd and let codex skip repo checks.
         pass
     return os.getcwd(), True
 
@@ -94,6 +101,13 @@ def _fallback_codex_paths() -> list[str]:
 
 def _has_openai_api_key() -> bool:
     return bool(os.environ.get("OPENAI_API_KEY", "").strip())
+
+
+def _raise_if_invalid_model(*, stdout: str, stderr: str) -> None:
+    text = f"{stderr}\n{stdout}".lower()
+    if any(marker in text for marker in _INVALID_MODEL_MARKERS):
+        detail = (stderr or stdout).strip()[:2000]
+        raise CLIInvalidModelError(provider="codex", detail=detail or "invalid model")
 
 
 class CodexAdapter:
@@ -250,6 +264,7 @@ class CodexAdapter:
         return (stdout or "").strip()
 
     def explain_failure(self, *, stdout: str, stderr: str, returncode: int) -> str:
+        _raise_if_invalid_model(stdout=stdout, stderr=stderr)
         err = (stderr or "").strip()
         out = (stdout or "").strip()
         bits = [f"codex exec exited with code {returncode}"]

--- a/app/integrations/llm_cli/errors.py
+++ b/app/integrations/llm_cli/errors.py
@@ -25,6 +25,20 @@ class CLIAuthenticationRequired(RuntimeError):
         super().__init__(f"{provider} is not authenticated. {auth_hint} ({detail})")
 
 
+class CLIInvalidModelError(RuntimeError):
+    """CLI rejected the requested model identifier.
+
+    Raised by adapter ``explain_failure`` implementations when stderr/stdout
+    includes a known bad-model phrase, letting callers distinguish model config
+    mistakes from generic subprocess failures.
+    """
+
+    def __init__(self, *, provider: str, detail: str) -> None:
+        self.provider = provider
+        self.detail = detail
+        super().__init__(f"{provider} rejected the configured model. {detail}")
+
+
 class CLITransientError(RuntimeError):
     """CLI subprocess exited with a transient failure code (e.g. EX_TEMPFAIL = 75).
 

--- a/tests/integrations/llm_cli/test_invalid_model_errors.py
+++ b/tests/integrations/llm_cli/test_invalid_model_errors.py
@@ -1,0 +1,49 @@
+"""Tests for structured invalid-model errors from LLM CLI adapters."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.integrations.llm_cli.claude_code import ClaudeCodeAdapter
+from app.integrations.llm_cli.codex import CodexAdapter
+from app.integrations.llm_cli.errors import CLIInvalidModelError
+
+
+def test_codex_explain_failure_raises_invalid_model_error() -> None:
+    adapter = CodexAdapter()
+
+    with pytest.raises(CLIInvalidModelError) as exc_info:
+        adapter.explain_failure(
+            stdout="",
+            stderr="error: invalid model 'not-a-real-model'",
+            returncode=1,
+        )
+
+    assert exc_info.value.provider == "codex"
+    assert "invalid model" in exc_info.value.detail
+
+
+def test_claude_code_explain_failure_raises_invalid_model_error() -> None:
+    adapter = ClaudeCodeAdapter()
+
+    with pytest.raises(CLIInvalidModelError) as exc_info:
+        adapter.explain_failure(
+            stdout="",
+            stderr="Unknown model: claude-made-up-9",
+            returncode=1,
+        )
+
+    assert exc_info.value.provider == "claude-code"
+    assert "Unknown model" in exc_info.value.detail
+
+
+def test_codex_explain_failure_keeps_generic_error_message() -> None:
+    adapter = CodexAdapter()
+
+    message = adapter.explain_failure(
+        stdout="",
+        stderr="permission denied",
+        returncode=1,
+    )
+
+    assert message == "codex exec exited with code 1. permission denied"


### PR DESCRIPTION
## Summary

- add `CLIInvalidModelError` for CLI subprocess failures caused by rejected model IDs
- detect invalid/unknown model stderr/stdout in Codex and Claude Code adapter `explain_failure` paths
- add regression tests covering Codex and Claude Code invalid model failures plus a generic Codex failure fallback

Addresses part of #2401.

## Testing

- Not run locally: this environment does not have a local checkout/git/Python test setup for the repo. CI should run on this PR.