### PR TITLE
Fix bare hermes command help

### DIFF
--- a/app/cli/commands/hermes.py
+++ b/app/cli/commands/hermes.py
@@ -31,9 +31,13 @@ from app.hermes.sinks import TelegramSink
 from app.watch_dog.alarms import AlarmDispatcher, load_credentials_from_env
 
 
-@click.group(name="hermes")
-def hermes_command() -> None:
+@click.group(name="hermes", invoke_without_command=True)
+@click.pass_context
+def hermes_command(ctx: click.Context) -> None:
     """Live-tail Hermes logs and route detected incidents to Telegram."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(0)
 
 
 @hermes_command.command(name="watch")

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -159,6 +159,25 @@ class TestDispatchSlash:
         assert "/local-llm" not in SLASH_COMMANDS
         assert "/local_llm" not in SLASH_COMMANDS
 
+    def test_hermes_slash_command_delegates_to_bare_cli(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity
+
+        calls: list[list[str]] = []
+
+        def _fake_run_cli_command(_console: Console, args: list[str]) -> bool:
+            calls.append(args)
+            return True
+
+        monkeypatch.setattr(cli_parity, "run_cli_command", _fake_run_cli_command)
+
+        session = ReplSession()
+        console, _ = _capture()
+
+        assert dispatch_slash("/hermes", session, console) is True
+        assert calls == [["hermes"]]
+
     def test_slash_commands_proxy_reads_current_registry(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/test_hermes_command.py
+++ b/tests/cli/test_hermes_command.py
@@ -42,6 +42,14 @@ def _patch_agent_to_capture_sink():
     return patch("app.cli.commands.hermes.HermesAgent.__init__", _capture)
 
 
+def test_bare_hermes_prints_help_and_exits_zero() -> None:
+    runner = CliRunner()
+    result = runner.invoke(hermes_command, [])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "watch" in result.output
+
+
 def test_watch_help_shows_correlator_flags() -> None:
     runner = CliRunner()
     result = runner.invoke(hermes_command, ["watch", "--help"])


### PR DESCRIPTION
Fixes #2285

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

- Updated the bare `opensre hermes` Click group so invoking it without a subcommand prints the Hermes help text and exits successfully with code `0`.
- Matched the existing Click group pattern by passing `ctx` via `@click.pass_context`.
- Added regression coverage for both direct CLI invocation and the interactive shell `/hermes` slash command path.

### Demo/Screenshot for feature changes and bug fixes -

<img width="1360" height="524" alt="image" src="https://github.com/user-attachments/assets/cbf5122a-e660-4943-92d2-7cdbfb320b2c" />

![Hermes CLI and REPL working demo](https://raw.githubusercontent.com/PrakharJain345/opensre/pr-2429-demo-assets/demo_assets/hermes_cli_repl_demo.png)

Direct CLI command:

```powershell
uv run opensre hermes
$LASTEXITCODE
```

Output:

```text
Usage: opensre hermes [OPTIONS] COMMAND [ARGS]...

  Live-tail Hermes logs and route detected incidents to Telegram.

Options:
  -h, --help  Show this message and exit.

Commands:
  watch  Start the Hermes log watcher and block until interrupted.
0
```

Interactive shell slash-command path:

```powershell
uv run python -c "from rich.console import Console; from app.cli.interactive_shell.commands import dispatch_slash; from app.cli.interactive_shell.runtime.session import ReplSession; ok = dispatch_slash('/hermes', ReplSession(), Console(highlight=False, force_terminal=False)); print(f'REPL /hermes returned: {ok}')"
```

Output:

```text
Usage: python -m app.cli hermes [OPTIONS] COMMAND [ARGS]...

  Live-tail Hermes logs and route detected incidents to Telegram.

Options:
  -h, --help  Show this message and exit.

Commands:
  watch  Start the Hermes log watcher and block until interrupted.

REPL /hermes returned: True
```

Test:

```powershell
uv run pytest tests\cli\test_hermes_command.py tests\cli\interactive_shell\test_commands.py -q
```

Result:

```text
122 passed
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug happened because the `hermes` Click group required a subcommand. A bare `opensre hermes` invocation therefore surfaced Click's missing-command usage error instead of behaving like a helpful top-level command.

This PR enables `invoke_without_command=True` for the `hermes` group and passes Click context with `@click.pass_context`, matching the pattern used by sibling command groups. When no subcommand is invoked, the command prints `ctx.get_help()` and exits with code `0`. Existing subcommands, including `opensre hermes watch`, continue to dispatch normally.

The interactive shell `/hermes` command delegates to the same CLI path, so the same fix applies there too. I added focused regression tests for both the direct Click command and the slash-command delegation path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

