### PR TITLE
fix(cli): capture /tests subcommand output for the REPL buffer

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -42,15 +42,22 @@ def run_cli_command(
     args: list[str],
     *,
     subprocess_timeout: float | None = None,
+    capture_output: bool = False,
 ) -> bool:
     """Helper to delegate complex or interactive Click commands to a child process.
 
     ``subprocess_timeout`` caps how long ``subprocess.run`` waits before raising
     :class:`~subprocess.TimeoutExpired`. Interactive flows use ``None`` so the
     child can prompt as long as needed; callers that hit the network without a
-    TTY (like ``opensre update``) pass a bounded timeout. When a timeout is set,
-    stdout/stderr are captured and replayed through ``console`` so output survives
-    prompt-toolkit ``patch_stdout`` redraws in the REPL.
+    TTY (like ``opensre update``) pass a bounded timeout.
+
+    ``capture_output`` (default ``False``) makes the helper capture stdout/stderr
+    and replay them through ``console`` even without a timeout. Set this for
+    non-interactive delegated commands (e.g. ``opensre tests list``) so their
+    output appears inside the REPL buffer instead of bypassing ``console.print``
+    via the child's inherited stdout FD. Interactive commands like ``onboard``
+    must leave this ``False`` so the child's prompts stay attached to the real
+    TTY. Capture is also enabled automatically whenever a timeout is set.
 
     Ctrl+C sends :exc:`KeyboardInterrupt`, which subclasses :exc:`BaseException`
     rather than :exc:`Exception`; it is handled here so the REPL survives and the
@@ -58,9 +65,10 @@ def run_cli_command(
     """
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
+    should_capture = capture_output or subprocess_timeout is not None
     try:
-        if subprocess_timeout is not None:
-            timed_result = subprocess.run(
+        if should_capture:
+            captured_result = subprocess.run(
                 cmd,
                 check=False,
                 timeout=subprocess_timeout,
@@ -69,11 +77,11 @@ def run_cli_command(
                 encoding="utf-8",
                 errors="replace",
             )
-            print_command_output(console, timed_result.stdout or "")
-            print_command_output(console, timed_result.stderr or "", style=ERROR)
-            if timed_result.returncode != 0:
+            print_command_output(console, captured_result.stdout or "")
+            print_command_output(console, captured_result.stderr or "", style=ERROR)
+            if captured_result.returncode != 0:
                 console.print(
-                    f"[{ERROR}]CLI command exited with non-zero code {timed_result.returncode}[/]"
+                    f"[{ERROR}]CLI command exited with non-zero code {captured_result.returncode}[/]"
                 )
         else:
             interactive_result = subprocess.run(cmd, check=False)
@@ -201,7 +209,7 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         return True
 
     if subcommand.startswith("-"):
-        return run_cli_command(console, ["tests", *args])
+        return run_cli_command(console, ["tests", *args], capture_output=True)
 
     if subcommand not in _TEST_SUBCOMMANDS:
         suggestion = closest_choice(subcommand, _TEST_SUBCOMMANDS)
@@ -219,7 +227,7 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
         session.mark_latest(ok=False, kind="slash")
         return True
 
-    return run_cli_command(console, ["tests", *args])
+    return run_cli_command(console, ["tests", *args], capture_output=True)
 
 
 def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1518,6 +1518,42 @@ class TestRunCliCommand:
         ]
         assert buf.getvalue() == "\n\n"
 
+    def test_capture_output_replays_stdout_through_console_without_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``capture_output=True`` must route child stdout through ``console`` even
+        when no timeout is set, so non-interactive slash commands like ``/tests
+        list`` do not lose their output to the parent stdout FD.
+        """
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        def _fake_run(
+            cmd: list[str],
+            *,
+            check: bool,
+            timeout: float | None,
+            capture_output: bool,
+            text: bool,
+            encoding: str,
+            errors: str,
+        ) -> subprocess.CompletedProcess[str]:
+            del check, text, encoding, errors
+            assert capture_output is True
+            assert timeout is None
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="catalog row one\ncatalog row two\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        console, buf = _capture()
+        assert m.run_cli_command(console, ["tests", "list"], capture_output=True) is True
+        assert "catalog row one" in buf.getvalue()
+        assert "catalog row two" in buf.getvalue()
+
     def test_timeout_replays_decoded_partial_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1603,6 +1639,25 @@ class TestCliDelegatedCommands:
         dispatch_slash("/onboard", session, console)
 
         assert captured == [["onboard"]], "run_cli_command must be called with onboard args"
+
+    def test_slash_tests_subcommand_opts_into_output_capture(self, monkeypatch: object) -> None:
+        """``/tests <subcommand>`` must call ``run_cli_command`` with
+        ``capture_output=True`` so the delegated CLI output is replayed
+        through the REPL console instead of vanishing onto the parent
+        process's stdout FD.
+        """
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        captured_kwargs: list[dict[str, object]] = []
+
+        def _fake_run_cli_command(_console: Console, _args: list[str], **kwargs: object) -> bool:
+            captured_kwargs.append(kwargs)
+            return True
+
+        monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
+        dispatch_slash("/tests list", ReplSession(), Console())
+
+        assert captured_kwargs == [{"capture_output": True}]
 
     def test_slash_onboard_with_args_forwards_them_to_subprocess(self, monkeypatch: object) -> None:
         """Args passed to ``/onboard`` must be forwarded to the subprocess."""

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1640,11 +1640,15 @@ class TestCliDelegatedCommands:
 
         assert captured == [["onboard"]], "run_cli_command must be called with onboard args"
 
-    def test_slash_tests_subcommand_opts_into_output_capture(self, monkeypatch: object) -> None:
-        """``/tests <subcommand>`` must call ``run_cli_command`` with
-        ``capture_output=True`` so the delegated CLI output is replayed
-        through the REPL console instead of vanishing onto the parent
-        process's stdout FD.
+    @pytest.mark.parametrize("slash_input", ["/tests list", "/tests --help"])
+    def test_slash_tests_subcommand_opts_into_output_capture(
+        self, monkeypatch: object, slash_input: str
+    ) -> None:
+        """Both the known-subcommand fall-through (e.g. ``/tests list``) and
+        the flag-style branch (e.g. ``/tests --help``) must call
+        ``run_cli_command`` with ``capture_output=True`` so the delegated CLI
+        output is replayed through the REPL console instead of vanishing onto
+        the parent process's stdout FD.
         """
         from app.cli.interactive_shell.command_registry import cli_parity as m
 
@@ -1655,7 +1659,7 @@ class TestCliDelegatedCommands:
             return True
 
         monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
-        dispatch_slash("/tests list", ReplSession(), Console())
+        dispatch_slash(slash_input, ReplSession(), Console())
 
         assert captured_kwargs == [{"capture_output": True}]
 


### PR DESCRIPTION
Fixes #2387

#### Describe the changes you have made in this PR -

`/tests list` (and any other `/tests` subcommand that falls through to `run_cli_command`) was losing its output in the REPL. The child subprocess inherited the parent's stdout FD and wrote there directly, bypassing the REPL's `console.print` entirely. Only the "exited with code N" banner ever made it into the REPL buffer. Running `opensre tests list` directly in the shell worked correctly, which is exactly why the bug was confusing — the contract between the REPL and the underlying CLI looked broken, when really only the REPL's output capture was.

This PR adds a `capture_output: bool = False` parameter to `run_cli_command`. When True, stdout/stderr are captured and replayed through the REPL `console` even without a timeout — the same path that already worked for timeout-bounded calls (e.g. `opensre update`). The default stays False so interactive commands like `/onboard` continue to inherit stdin/stdout/stderr and prompt the user normally.

Both `_cmd_tests` call sites now pass `capture_output=True`. No other slash handlers are touched — `/guardrails` (#2388) will be a one-line follow-up using the same param.

### Demo/Screenshot for feature changes and bug fixes - 

This is a REPL-rendering bug — the demo is a unit-test assertion rather than a screenshot. The new `test_slash_tests_subcommand_opts_into_output_capture` proves the slash handler now passes `capture_output=True`, and the new `test_capture_output_replays_stdout_through_console_without_timeout` proves the helper now routes the captured output through `console` so it lands in the REPL buffer instead of the parent's stdout FD.

Local quality gate:

<img width="1162" height="403" alt="image" src="https://github.com/user-attachments/assets/53832e4a-d859-49fa-973d-36eeb984b698" />
<img width="1040" height="443" alt="Screenshot 2026-05-22 at 11 25 57" src="https://github.com/user-attachments/assets/a305bb39-43aa-4eb4-bfee-3ea865d82c2d" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** `run_cli_command` in `app/cli/interactive_shell/command_registry/cli_parity.py` has two execution branches. The timeout branch uses `capture_output=True` and replays the child's stdout/stderr through `console`. The default (no-timeout) branch uses bare `subprocess.run(cmd, check=False)`, which inherits the parent's stdout/stderr file descriptors. For non-interactive commands like `/tests list`, the child writes to the inherited FD — bypassing `console.print` entirely. Inside a real REPL with `prompt_toolkit.patch_stdout` active, that output either interleaves badly with the prompt redraw or lands outside the REPL pane. Inside a non-TTY harness, it appears on the harness's stdout instead of the REPL buffer. Either way, the user sees a blank buffer.

**Alternatives I considered:**

1. **Make capture the default for everything.** Rejected because interactive commands like `/onboard` need the child to be attached to the real TTY — its `prompt_toolkit` wizard reads from stdin. Capture would break that path (and `_WAIT_FOR_COMPLETION_COMMANDS` in dispatch.py exists specifically to keep that path interactive).
2. **Pick capture vs. interactive based on the command name inside `run_cli_command`.** Rejected as fragile — every new command would silently get the wrong behavior unless the helper learned about it.
3. **Make each slash handler do its own `subprocess.run` with capture.** Rejected as duplicating non-trivial error handling (TimeoutExpired, KeyboardInterrupt, generic Exception, exit-code banner) across N call sites.

**Chosen approach:** add an opt-in `capture_output: bool = False` parameter. The helper's branching becomes "do I need to capture?" rather than "do I have a timeout?". `capture_output=True` enables the same capture/replay code path that the timeout branch already uses; the only difference is `timeout=None` is passed through to `subprocess.run`. Callers that need interactive stdin (the default) get the original behavior unchanged.

Only the `_cmd_tests` handler is wired up in this PR. Other handlers (`/guardrails`, `/config`, etc.) remain on the default and will be flipped one at a time as their respective issues are fixed.

**Edge cases considered:**
- Existing interactive commands (`/onboard`, `/uninstall`, etc.) keep `capture_output=False` so the child still inherits stdin/stdout/stderr. Verified by the existing `test_interactive_delegate_does_not_capture_output` test, which still passes — the no-capture branch's `subprocess.run` call signature is unchanged.
- Timeout-bounded commands (`/update`) implicitly enable capture as before — `should_capture = capture_output or subprocess_timeout is not None`. Verified by the existing `test_timed_delegate_replays_stdout_through_console` test.
- Background `/tests` subcommands (`run`, `synthetic`, `cloudopsbench`) go through `_start_test_command`, not `run_cli_command`, and are unaffected.
- The capture branch's exit-code banner ("CLI command exited with non-zero code N") still fires after the captured output is replayed, so error visibility is preserved.

**Tests added:**
- `test_capture_output_replays_stdout_through_console_without_timeout` (unit) — asserts that calling `run_cli_command(..., capture_output=True)` with no timeout results in `subprocess.run` being called with `capture_output=True`, `timeout=None`, and that the captured stdout is replayed into the REPL console.
- `test_slash_tests_subcommand_opts_into_output_capture` (integration) — drives `dispatch_slash("/tests list", ...)` and asserts the slash handler calls `run_cli_command` with `capture_output=True`. This is the regression guard for the bug itself.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
