### PR TITLE
fix(integrations): degrade gracefully when env-derived integration config is invalid

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -1034,21 +1034,27 @@ def load_env_integrations() -> list[dict[str, Any]]:
         grafana_endpoint = os.getenv("GRAFANA_INSTANCE_URL", "").strip()
         grafana_api_key = os.getenv("GRAFANA_READ_TOKEN", "").strip()
     if grafana_endpoint and grafana_api_key:
-        grafana_config = GrafanaIntegrationConfig.model_validate(
-            {
-                "endpoint": grafana_endpoint,
-                "api_key": grafana_api_key,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "grafana",
+        try:
+            grafana_config = GrafanaIntegrationConfig.model_validate(
                 {
-                    "endpoint": grafana_config.endpoint,
-                    "api_key": grafana_config.api_key,
-                },
+                    "endpoint": grafana_endpoint,
+                    "api_key": grafana_api_key,
+                }
             )
-        )
+        except Exception as exc:
+            # Invalid env-derived config: skip Grafana entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="grafana")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "grafana",
+                    {
+                        "endpoint": grafana_config.endpoint,
+                        "api_key": grafana_config.api_key,
+                    },
+                )
+            )
 
     datadog_multi = _parse_instances_env("DD_INSTANCES", "datadog")
     if datadog_multi is not None:
@@ -1061,19 +1067,25 @@ def load_env_integrations() -> list[dict[str, Any]]:
         datadog_app_key = os.getenv("DD_APP_KEY", "").strip()
         datadog_site = os.getenv("DD_SITE", "datadoghq.com").strip() or "datadoghq.com"
     if datadog_api_key and datadog_app_key:
-        datadog_config = DatadogIntegrationConfig.model_validate(
-            {
-                "api_key": datadog_api_key,
-                "app_key": datadog_app_key,
-                "site": datadog_site,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "datadog",
-                datadog_config.model_dump(exclude={"integration_id"}),
+        try:
+            datadog_config = DatadogIntegrationConfig.model_validate(
+                {
+                    "api_key": datadog_api_key,
+                    "app_key": datadog_app_key,
+                    "site": datadog_site,
+                }
             )
-        )
+        except Exception as exc:
+            # Invalid env-derived config: skip Datadog entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="datadog")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "datadog",
+                    datadog_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     honeycomb_multi = _parse_instances_env("HONEYCOMB_INSTANCES", "honeycomb")
     if honeycomb_multi is not None:
@@ -1082,19 +1094,25 @@ def load_env_integrations() -> list[dict[str, Any]]:
     else:
         honeycomb_api_key = os.getenv("HONEYCOMB_API_KEY", "").strip()
     if honeycomb_api_key:
-        honeycomb_config = HoneycombIntegrationConfig.model_validate(
-            {
-                "api_key": honeycomb_api_key,
-                "dataset": os.getenv("HONEYCOMB_DATASET", "").strip(),
-                "base_url": os.getenv("HONEYCOMB_API_URL", "").strip(),
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "honeycomb",
-                honeycomb_config.model_dump(exclude={"integration_id"}),
+        try:
+            honeycomb_config = HoneycombIntegrationConfig.model_validate(
+                {
+                    "api_key": honeycomb_api_key,
+                    "dataset": os.getenv("HONEYCOMB_DATASET", "").strip(),
+                    "base_url": os.getenv("HONEYCOMB_API_URL", "").strip(),
+                }
             )
-        )
+        except Exception as exc:
+            # Invalid env-derived config: skip Honeycomb entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="honeycomb")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "honeycomb",
+                    honeycomb_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     coralogix_multi = _parse_instances_env("CORALOGIX_INSTANCES", "coralogix")
     if coralogix_multi is not None:
@@ -1103,20 +1121,26 @@ def load_env_integrations() -> list[dict[str, Any]]:
     else:
         coralogix_api_key = os.getenv("CORALOGIX_API_KEY", "").strip()
     if coralogix_api_key:
-        coralogix_config = CoralogixIntegrationConfig.model_validate(
-            {
-                "api_key": coralogix_api_key,
-                "base_url": os.getenv("CORALOGIX_API_URL", "").strip(),
-                "application_name": os.getenv("CORALOGIX_APPLICATION_NAME", "").strip(),
-                "subsystem_name": os.getenv("CORALOGIX_SUBSYSTEM_NAME", "").strip(),
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "coralogix",
-                coralogix_config.model_dump(exclude={"integration_id"}),
+        try:
+            coralogix_config = CoralogixIntegrationConfig.model_validate(
+                {
+                    "api_key": coralogix_api_key,
+                    "base_url": os.getenv("CORALOGIX_API_URL", "").strip(),
+                    "application_name": os.getenv("CORALOGIX_APPLICATION_NAME", "").strip(),
+                    "subsystem_name": os.getenv("CORALOGIX_SUBSYSTEM_NAME", "").strip(),
+                }
             )
-        )
+        except Exception as exc:
+            # Invalid env-derived config: skip Coralogix entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="coralogix")
+        else:
+            integrations.append(
+                _active_env_record(
+                    "coralogix",
+                    coralogix_config.model_dump(exclude={"integration_id"}),
+                )
+            )
 
     aws_multi = _parse_instances_env("AWS_INSTANCES", "aws")
     if aws_multi is not None:
@@ -1135,45 +1159,57 @@ def load_env_integrations() -> list[dict[str, Any]]:
         aws_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY", "").strip()
         aws_session_token = os.getenv("AWS_SESSION_TOKEN", "").strip()
     if aws_role_arn:
-        aws_config = AWSIntegrationConfig.model_validate(
-            {
-                "role_arn": aws_role_arn,
-                "external_id": aws_external_id,
-                "region": aws_region,
-            }
-        )
-        integrations.append(
-            _active_env_record(
-                "aws",
-                {"region": aws_config.region},
-                role_arn=aws_config.role_arn,
-                external_id=aws_config.external_id,
+        try:
+            aws_config = AWSIntegrationConfig.model_validate(
+                {
+                    "role_arn": aws_role_arn,
+                    "external_id": aws_external_id,
+                    "region": aws_region,
+                }
             )
-        )
-    elif aws_access_key_id and aws_secret_access_key:
-        aws_config = AWSIntegrationConfig.model_validate(
-            {
-                "region": aws_region,
-                "credentials": {
-                    "access_key_id": aws_access_key_id,
-                    "secret_access_key": aws_secret_access_key,
-                    "session_token": aws_session_token,
-                },
-            }
-        )
-        aws_credentials = aws_config.credentials
-        if aws_credentials is not None:
+        except Exception as exc:
+            # Invalid env-derived config: skip AWS entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="aws")
+        else:
             integrations.append(
                 _active_env_record(
                     "aws",
-                    {
-                        "access_key_id": aws_credentials.access_key_id,
-                        "secret_access_key": aws_credentials.secret_access_key,
-                        "session_token": aws_credentials.session_token,
-                        "region": aws_config.region,
-                    },
+                    {"region": aws_config.region},
+                    role_arn=aws_config.role_arn,
+                    external_id=aws_config.external_id,
                 )
             )
+    elif aws_access_key_id and aws_secret_access_key:
+        try:
+            aws_config = AWSIntegrationConfig.model_validate(
+                {
+                    "region": aws_region,
+                    "credentials": {
+                        "access_key_id": aws_access_key_id,
+                        "secret_access_key": aws_secret_access_key,
+                        "session_token": aws_session_token,
+                    },
+                }
+            )
+        except Exception as exc:
+            # Invalid env-derived config: skip AWS entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="aws")
+        else:
+            aws_credentials = aws_config.credentials
+            if aws_credentials is not None:
+                integrations.append(
+                    _active_env_record(
+                        "aws",
+                        {
+                            "access_key_id": aws_credentials.access_key_id,
+                            "secret_access_key": aws_credentials.secret_access_key,
+                            "session_token": aws_credentials.session_token,
+                            "region": aws_config.region,
+                        },
+                    )
+                )
 
     github_mode = os.getenv("GITHUB_MCP_MODE", "streamable-http").strip() or "streamable-http"
     github_url = os.getenv("GITHUB_MCP_URL", "").strip()
@@ -1453,15 +1489,21 @@ def load_env_integrations() -> list[dict[str, Any]]:
 
     whatsapp_from_number = os.getenv("TWILIO_WHATSAPP_FROM", "").strip()
     if twilio_account_sid and twilio_auth_token and whatsapp_from_number:
-        wa_config = WhatsAppConfig.model_validate(
-            {
-                "account_sid": twilio_account_sid,
-                "auth_token": twilio_auth_token,
-                "from_number": whatsapp_from_number,
-                "default_to": os.getenv("WHATSAPP_DEFAULT_TO", "").strip() or None,
-            }
-        )
-        integrations.append(_active_env_record("whatsapp", wa_config.model_dump()))
+        try:
+            wa_config = WhatsAppConfig.model_validate(
+                {
+                    "account_sid": twilio_account_sid,
+                    "auth_token": twilio_auth_token,
+                    "from_number": whatsapp_from_number,
+                    "default_to": os.getenv("WHATSAPP_DEFAULT_TO", "").strip() or None,
+                }
+            )
+        except Exception as exc:
+            # Invalid env-derived config: skip WhatsApp entry rather than fail
+            # discovery, but report so operators can see the misconfig.
+            _report_env_loader_failure(exc, integration="whatsapp")
+        else:
+            integrations.append(_active_env_record("whatsapp", wa_config.model_dump()))
 
     # Twilio SMS integration — independent of the legacy WhatsApp record.
     # Hydrated when account+token are present AND an SMS sender is set

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -261,6 +261,94 @@ _ENV_LOADER_CASES: list[tuple[str, dict[str, str], str]] = [
         },
         "build_mongodb_atlas_config",
     ),
+    # Six blocks that PR #2191 missed — still called ``model_validate``
+    # unguarded, so one bad env var aborted discovery of every integration.
+    (
+        "grafana",
+        {"GRAFANA_INSTANCE_URL": "https://grafana.example", "GRAFANA_READ_TOKEN": "t"},
+        "GrafanaIntegrationConfig",
+    ),
+    (
+        "datadog",
+        {"DD_API_KEY": "k", "DD_APP_KEY": "a"},
+        "DatadogIntegrationConfig",
+    ),
+    (
+        "honeycomb",
+        {"HONEYCOMB_API_KEY": "k"},
+        "HoneycombIntegrationConfig",
+    ),
+    (
+        "coralogix",
+        {"CORALOGIX_API_KEY": "k"},
+        "CoralogixIntegrationConfig",
+    ),
+    (
+        "aws",
+        {"AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/example"},
+        "AWSIntegrationConfig",
+    ),
+    (
+        "aws",
+        {"AWS_ACCESS_KEY_ID": "AKIA", "AWS_SECRET_ACCESS_KEY": "secret"},
+        "AWSIntegrationConfig",
+    ),
+    (
+        "whatsapp",
+        {
+            "TWILIO_ACCOUNT_SID": "sid",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_WHATSAPP_FROM": "+15555550100",
+        },
+        "WhatsAppConfig",
+    ),
+]
+
+
+# Each newly-wrapped vendor paired with a survivor that loads *after* it in
+# ``load_env_integrations``, plus the env needed to enable that survivor. A bad
+# env var for the first must not abort discovery of the second.
+_ENV_LOADER_SURVIVOR_CASES: list[tuple[str, str, dict[str, str], str]] = [
+    (
+        "grafana",
+        "GrafanaIntegrationConfig",
+        {"DD_API_KEY": "k", "DD_APP_KEY": "a"},
+        "datadog",
+    ),
+    (
+        "datadog",
+        "DatadogIntegrationConfig",
+        {"HONEYCOMB_API_KEY": "k"},
+        "honeycomb",
+    ),
+    (
+        "honeycomb",
+        "HoneycombIntegrationConfig",
+        {"CORALOGIX_API_KEY": "k"},
+        "coralogix",
+    ),
+    (
+        "coralogix",
+        "CoralogixIntegrationConfig",
+        {"AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/example"},
+        "aws",
+    ),
+    (
+        "aws",
+        "AWSIntegrationConfig",
+        {"VERCEL_API_TOKEN": "t"},
+        "vercel",
+    ),
+    (
+        "whatsapp",
+        "WhatsAppConfig",
+        {
+            "MONGODB_ATLAS_PUBLIC_KEY": "pub",
+            "MONGODB_ATLAS_PRIVATE_KEY": "priv",
+            "MONGODB_ATLAS_PROJECT_ID": "proj",
+        },
+        "mongodb_atlas",
+    ),
 ]
 
 
@@ -338,3 +426,57 @@ def test_one_failing_env_loader_does_not_abort_remaining_integrations(
         "incident_io was dropped — discovery aborted on the vercel failure instead of "
         "continuing past it (this is exactly the bug #2036 is about)"
     )
+
+
+@pytest.mark.parametrize(
+    ("integration", "patch_symbol", "survivor_env", "survivor"),
+    _ENV_LOADER_SURVIVOR_CASES,
+)
+def test_missed_env_loader_failure_does_not_abort_remaining_integrations(
+    integration: str,
+    patch_symbol: str,
+    survivor_env: dict[str, str],
+    survivor: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The six blocks PR #2191 missed (grafana, datadog, honeycomb, coralogix,
+    aws, whatsapp) called ``model_validate`` unguarded: a single bad env var
+    raised a raw exception that escaped ``load_env_integrations`` and aborted
+    discovery of every integration.
+
+    Enable both the failing vendor and a survivor that loads strictly after it;
+    the failing vendor must be skipped and reported, while the survivor still
+    loads. RED before the fix (the exception escapes the function), GREEN
+    after.
+    """
+    for var in list(os.environ):
+        monkeypatch.delenv(var, raising=False)
+    # Env to enable the failing vendor's loader path.
+    failing_env: dict[str, str] = next(
+        env for name, env, _ in _ENV_LOADER_CASES if name == integration
+    )
+    for var, value in {**failing_env, **survivor_env}.items():
+        monkeypatch.setenv(var, value)
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(f"forced {integration} failure")
+
+    monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = load_env_integrations()
+
+    services = {entry["service"] for entry in result}
+    assert integration not in services, f"{integration} must be skipped when its config is invalid"
+    assert survivor in services, (
+        f"{survivor} was dropped — discovery aborted on the {integration} failure "
+        "instead of degrading gracefully past it"
+    )
+
+    matching = [
+        call
+        for call in mock_report.call_args_list
+        if call.kwargs.get("tags", {}).get("integration") == integration
+    ]
+    assert matching, f"{integration} env-loader failure was swallowed silently"
+    assert matching[0].kwargs["tags"]["event"] == "env_loader_failed"


### PR DESCRIPTION
Refs #2421, #2191

#### Describe the changes you have made in this PR -

`load_env_integrations()` builds integration records from environment
variables. #2191 wrapped 17 env-loader blocks in a
`try / except Exception: _report_env_loader_failure(...) / else` idiom so a
malformed env var skips only that integration instead of aborting discovery.

Six blocks were missed and still called `model_validate` unguarded:

| Integration | Builder call |
|---|---|
| Grafana   | `GrafanaIntegrationConfig.model_validate(...)` |
| Datadog   | `DatadogIntegrationConfig.model_validate(...)` |
| Honeycomb | `HoneycombIntegrationConfig.model_validate(...)` |
| Coralogix | `CoralogixIntegrationConfig.model_validate(...)` |
| AWS       | `AWSIntegrationConfig.model_validate(...)` — both the role-arn and access-key branches |
| WhatsApp  | `WhatsAppConfig.model_validate(...)` |

For these six, a single malformed env var raised an exception that escaped
`load_env_integrations()` and aborted discovery of **every** integration —
the same user-facing failure tracked in #2421 for ArgoCD.

This PR wraps each of the six in the identical pattern already used by the
argocd block: the failure is reported via `_report_env_loader_failure` and
only that integration is skipped. Behaviour for valid configuration is
unchanged.

### Demo/Screenshot for feature changes and bug fixes -

Regression test `test_missed_env_loader_failure_does_not_abort_remaining_integrations`
run against the **unpatched** `_catalog_impl.py` (before) vs this branch (after):

```
# BEFORE — one bad integration aborts discovery of the rest
$ pytest tests/integrations/test_catalog_silent_fallback_elimination.py \
    -k missed_env_loader -q
FAILED ...[grafana-GrafanaIntegrationConfig-survivor_env0-datadog]
FAILED ...[datadog-DatadogIntegrationConfig-survivor_env1-honeycomb]
FAILED ...[honeycomb-HoneycombIntegrationConfig-survivor_env2-coralogix]
FAILED ...[coralogix-CoralogixIntegrationConfig-survivor_env3-aws]
FAILED ...[aws-AWSIntegrationConfig-survivor_env4-vercel]
FAILED ...[whatsapp-WhatsAppConfig-survivor_env5-mongodb_atlas]
6 failed, 58 deselected

# AFTER — a bad integration is reported and skipped, discovery continues
$ pytest tests/integrations/test_catalog_silent_fallback_elimination.py \
    -k "missed_env_loader or env_loader_failure" -q
31 passed, 33 deselected
```

---

## Code Understanding

- [x] I wrote all the code in this PR myself and reviewed every line.
- [x] I can explain the purpose and logic of each block I added.
- [x] I have tested edge cases and understand how the code handles them.

**Explain your implementation approach:**

The problem: `load_env_integrations()` should be best-effort — a misconfigured
env var for one integration must not take down discovery of all the others.
#2191 already established that contract and the exact mechanism for it, but six
integration blocks were left out.

I considered a single broad `try/except` around the whole function body, but
that would skip *all* remaining integrations after the first failure and lose
the per-integration attribution that `_report_env_loader_failure` provides. I
also considered validating env vars up front, but that would duplicate the
pydantic model constraints. The smallest, most consistent fix is to apply the
existing per-block `try / except / else` idiom to the six missed blocks, so
the change reads identically to the argocd block right below them — same
helper, same comment style, same `else`-clause placement. The AWS block has
two independent `model_validate` calls (role-arn and access-key paths); each is
wrapped separately so a failure in one path does not mask the other.

`model_validate` genuinely can raise here: `GrafanaIntegrationConfig` normalizes
its `endpoint`, `AWSIntegrationConfig` runs an auth-method model-validator, and
any field-constraint failure raises `pydantic.ValidationError`.

Tests: I extended `test_catalog_silent_fallback_elimination.py`, which already
parametrizes env-loader failure cases. The six newly guarded vendors are added
to the existing `_ENV_LOADER_CASES` table, and a new
`test_missed_env_loader_failure_does_not_abort_remaining_integrations` asserts
that a failing loader is reported and skipped while a later, valid integration
still loads. These cases fail on `main` and pass with this change.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
