### PR TITLE
fix(cli): capture REPL CLI parity output

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -242,7 +242,7 @@ def _cmd_uninstall(session: ReplSession, console: Console, args: list[str]) -> b
 
 
 def _cmd_config(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["config", *args])
+    return run_cli_command(console, ["config", *args], capture_output=True)
 
 
 def _cmd_messaging(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -42,6 +42,7 @@ def run_cli_command(
     args: list[str],
     *,
     subprocess_timeout: float | None = None,
+    capture_output: bool = False,
 ) -> bool:
     """Helper to delegate complex or interactive Click commands to a child process.
 
@@ -49,8 +50,9 @@ def run_cli_command(
     :class:`~subprocess.TimeoutExpired`. Interactive flows use ``None`` so the
     child can prompt as long as needed; callers that hit the network without a
     TTY (like ``opensre update``) pass a bounded timeout. When a timeout is set,
-    stdout/stderr are captured and replayed through ``console`` so output survives
-    prompt-toolkit ``patch_stdout`` redraws in the REPL.
+    or ``capture_output`` is true, stdout/stderr are captured and replayed
+    through ``console`` so output survives prompt-toolkit ``patch_stdout``
+    redraws in the REPL.
 
     Ctrl+C sends :exc:`KeyboardInterrupt`, which subclasses :exc:`BaseException`
     rather than :exc:`Exception`; it is handled here so the REPL survives and the
@@ -59,8 +61,9 @@ def run_cli_command(
     console.print()
     cmd = [sys.executable, "-m", "app.cli", *args]
     try:
-        if subprocess_timeout is not None:
-            timed_result = subprocess.run(
+        should_capture = capture_output or subprocess_timeout is not None
+        if should_capture:
+            result = subprocess.run(
                 cmd,
                 check=False,
                 timeout=subprocess_timeout,
@@ -69,11 +72,11 @@ def run_cli_command(
                 encoding="utf-8",
                 errors="replace",
             )
-            print_command_output(console, timed_result.stdout or "")
-            print_command_output(console, timed_result.stderr or "", style=ERROR)
-            if timed_result.returncode != 0:
+            print_command_output(console, result.stdout or "")
+            print_command_output(console, result.stderr or "", style=ERROR)
+            if result.returncode != 0:
                 console.print(
-                    f"[{ERROR}]CLI command exited with non-zero code {timed_result.returncode}[/]"
+                    f"[{ERROR}]CLI command exited with non-zero code {result.returncode}[/]"
                 )
         else:
             interactive_result = subprocess.run(cmd, check=False)
@@ -223,7 +226,7 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
 
 
 def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["guardrails", *args])
+    return run_cli_command(console, ["guardrails", *args], capture_output=True)
 
 
 def _cmd_update(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1517,6 +1517,41 @@ class TestRunCliCommand:
         assert m.run_cli_command(console, ["update"], subprocess_timeout=30.0) is True
         assert "already up to date" in buf.getvalue()
 
+    def test_capture_output_replays_stdout_through_console_without_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        def _fake_run(
+            cmd: list[str],
+            *,
+            check: bool,
+            timeout: float | None,
+            capture_output: bool,
+            text: bool,
+            encoding: str,
+            errors: str,
+        ) -> subprocess.CompletedProcess[str]:
+            del check, text, encoding, errors
+            assert timeout is None
+            assert capture_output is True
+            assert cmd[:3] == [sys.executable, "-m", "app.cli"]
+            assert cmd[3:] == ["guardrails"]
+            return subprocess.CompletedProcess(
+                cmd,
+                2,
+                stdout="Usage: opensre guardrails [OPTIONS] COMMAND [ARGS]...\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(m.subprocess, "run", _fake_run)
+        console, buf = _capture()
+        assert m.run_cli_command(console, ["guardrails"], capture_output=True) is True
+        output = buf.getvalue()
+        assert "Usage: opensre guardrails" in output
+        assert "non-zero code 2" in output
+
     def test_interactive_delegate_does_not_capture_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1641,6 +1676,28 @@ class TestCliDelegatedCommands:
         dispatch_slash("/onboard local_llm", session, console)
 
         assert captured == [["onboard", "local_llm"]]
+
+    def test_slash_guardrails_opts_into_output_capture(self, monkeypatch: object) -> None:
+        """Bare ``/guardrails`` must replay Click usage through the REPL console."""
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        captured: list[tuple[list[str], dict[str, object]]] = []
+
+        def _fake_run_cli_command(
+            _console: Console,
+            args: list[str],
+            **kwargs: object,
+        ) -> bool:
+            captured.append((args, kwargs))
+            return True
+
+        monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash("/guardrails", session, console)
+
+        assert captured == [(["guardrails"], {"capture_output": True})]
 
     def test_tests_run_subcommand_starts_background_task(self, monkeypatch: object) -> None:
         from app.cli.interactive_shell.command_registry import cli_parity as m

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1699,6 +1699,28 @@ class TestCliDelegatedCommands:
 
         assert captured == [(["guardrails"], {"capture_output": True})]
 
+    def test_slash_config_opts_into_output_capture(self, monkeypatch: object) -> None:
+        """``/config`` output must not write over the pinned REPL prompt."""
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        captured: list[tuple[list[str], dict[str, object]]] = []
+
+        def _fake_run_cli_command(
+            _console: Console,
+            args: list[str],
+            **kwargs: object,
+        ) -> bool:
+            captured.append((args, kwargs))
+            return True
+
+        monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash("/config", session, console)
+
+        assert captured == [(["config"], {"capture_output": True})]
+
     def test_tests_run_subcommand_starts_background_task(self, monkeypatch: object) -> None:
         from app.cli.interactive_shell.command_registry import cli_parity as m
 


### PR DESCRIPTION
Fixes #2388
Fixes #2287

## Summary
- add opt-in subprocess output capture to `run_cli_command` without changing interactive command defaults
- route `/guardrails` through the captured path so bare usage output appears in the REPL buffer before the exit-code line
- route `/config` through the captured path so config output renders above the pinned REPL input instead of writing over the prompt
- add regression coverage for capture without a timeout plus `/guardrails` and `/config` delegation

## Testing
- `uv run pytest tests/cli/interactive_shell/test_commands.py::TestRunCliCommand tests/cli/interactive_shell/test_commands.py::TestCliDelegatedCommands -q`
- `uv run ruff check app/cli/interactive_shell/command_registry/cli_parity.py tests/cli/interactive_shell/test_commands.py`
- `uv run ruff format --check app/cli/interactive_shell/command_registry/cli_parity.py tests/cli/interactive_shell/test_commands.py`
- `uv run mypy app/cli/interactive_shell/command_registry/cli_parity.py`