### PR TITLE
fix(agents): handle missing AF_UNIX bus support

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -11,7 +11,7 @@ discovery — without it the ``app.agents.*`` subpackages would be
 silently omitted from the built wheel.
 """
 
-from app.agents.bus import BusMessage, publish, subscribe
+from app.agents.bus import AgentBusUnavailableError, BusMessage, publish, subscribe
 from app.agents.coordination import BranchClaim, BranchClaims
 from app.agents.discovery import ProcessRow, discover_agents, registered_and_discovered_agents
 from app.agents.lifecycle import TerminateResult, terminate
@@ -20,6 +20,7 @@ from app.agents.registry import AgentRecord, AgentRegistry
 
 __all__ = [
     "AgentRecord",
+    "AgentBusUnavailableError",
     "AgentRegistry",
     "BranchClaim",
     "BranchClaims",

--- a/app/agents/bus.py
+++ b/app/agents/bus.py
@@ -28,6 +28,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from app.constants import OPENSRE_HOME_DIR
 
@@ -58,6 +59,25 @@ _MAX_FRAME_BYTES: int = 64 * 1024
 #: unresponsive and evicted, so one wedged client cannot stall fan-out for
 #: every other publisher's reader thread.
 _BROADCAST_WRITE_TIMEOUT_SECONDS: float = 0.2
+
+
+class AgentBusUnavailableError(OSError):
+    """Raised when this Python/platform cannot open the local agent bus."""
+
+
+def agent_bus_supported() -> bool:
+    """Return True when the runtime exposes Unix-domain socket support."""
+    return getattr(socket, "AF_UNIX", None) is not None
+
+
+def _unix_socket_family() -> socket.AddressFamily:
+    family = getattr(socket, "AF_UNIX", None)
+    if family is None:
+        raise AgentBusUnavailableError(
+            "agent bus requires Unix-domain sockets, but this Python build does not expose "
+            "socket.AF_UNIX"
+        )
+    return cast(socket.AddressFamily, family)
 
 
 @dataclass(frozen=True)
@@ -261,7 +281,7 @@ class BusServer:
         if self._running.is_set():
             return
         _ensure_parent_dir(self._path)
-        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener = socket.socket(_unix_socket_family(), socket.SOCK_STREAM)
         try:
             listener.bind(str(self._path))
         except OSError:
@@ -548,7 +568,7 @@ def _ensure_broker(path: Path) -> BusServer | None:
 
 def _connect_client(path: Path, timeout: float) -> socket.socket:
     """Open a blocking UDS connection to the broker at ``path``."""
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client = socket.socket(_unix_socket_family(), socket.SOCK_STREAM)
     client.settimeout(timeout)
     try:
         client.connect(str(path))
@@ -767,10 +787,12 @@ def subscribe(
 
 
 __all__ = [
+    "AgentBusUnavailableError",
     "BUS_SCHEMA_VERSION",
     "BusMessage",
     "BusServer",
     "DEFAULT_BUS_SOCKET_PATH",
+    "agent_bus_supported",
     "publish",
     "subscribe",
 ]

--- a/app/cli/interactive_shell/command_registry/agents.py
+++ b/app/cli/interactive_shell/command_registry/agents.py
@@ -23,7 +23,7 @@ from rich.markup import escape
 from rich.text import Text
 from rich.tree import Tree
 
-from app.agents.bus import BusMessage, subscribe
+from app.agents.bus import AgentBusUnavailableError, BusMessage, subscribe
 from app.agents.config import (
     agents_config_path,
     load_agents_config,
@@ -152,7 +152,7 @@ def _format_bus_message(msg: BusMessage) -> str:
     return " ".join(parts)
 
 
-def _cmd_agents_bus(console: Console) -> bool:
+def _cmd_agents_bus(session: ReplSession, console: Console) -> bool:
     """Live-tail the cross-agent context bus until ``Ctrl-C`` or broker exit.
 
     Self-elects a broker if none is running, then streams each ``BusMessage``
@@ -169,9 +169,14 @@ def _cmd_agents_bus(console: Console) -> bool:
     except KeyboardInterrupt:
         console.print(f"[{DIM}](detached)[/]")
         return True
+    except AgentBusUnavailableError as exc:
+        console.print(f"[{ERROR}]agent bus unavailable:[/] {escape(str(exc))}")
+        session.mark_latest(ok=False, kind="slash")
+        return True
     except OSError as exc:
         console.print(f"[{ERROR}]bus error:[/] {escape(str(exc))}")
-        return False
+        session.mark_latest(ok=False, kind="slash")
+        return True
     # ``subscribe()`` returned cleanly — the broker closed our connection
     # (e.g. it stopped, or its host process exited). Surface that explicitly
     # so the user isn't left wondering why the prompt came back.
@@ -657,7 +662,7 @@ def _cmd_agents(session: ReplSession, console: Console, args: list[str]) -> bool
     if sub == "budget":
         return _cmd_agents_budget(session, console, args[1:])
     if sub == "bus":
-        return _cmd_agents_bus(console)
+        return _cmd_agents_bus(session, console)
     if sub == "conflicts":
         return _cmd_agents_conflicts(console)
 

--- a/tests/agents/test_bus.py
+++ b/tests/agents/test_bus.py
@@ -19,13 +19,21 @@ _POSIX_FCNTL_AVAILABLE = importlib.util.find_spec("fcntl") is not None
 from app.agents import bus as bus_module
 from app.agents.bus import (
     BUS_SCHEMA_VERSION,
+    AgentBusUnavailableError,
     BusMessage,
     BusServer,
     _pid_file_for,
     _read_broker_pid,
     _socket_is_live,
+    agent_bus_supported,
     publish,
     subscribe,
+)
+
+_BUS_SOCKET_AVAILABLE = agent_bus_supported()
+_needs_bus_socket = pytest.mark.skipif(
+    not _BUS_SOCKET_AVAILABLE,
+    reason="agent bus requires socket.AF_UNIX",
 )
 
 
@@ -147,6 +155,27 @@ class TestBusMessage:
         assert msg.data["k"] == 1
 
 
+class TestBusPlatformSupport:
+    def test_agent_bus_supported_reflects_socket_af_unix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+        assert not bus_module.agent_bus_supported()
+
+    def test_start_reports_unavailable_when_af_unix_missing(
+        self, sock_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+        server = BusServer(sock_path)
+
+        with pytest.raises(AgentBusUnavailableError, match="socket.AF_UNIX"):
+            server.start()
+
+        assert not server.is_running
+        assert not sock_path.exists()
+
+
+@_needs_bus_socket
 class TestBusServerLifecycle:
     def test_start_binds_socket_and_stop_unlinks(self, sock_path: Path) -> None:
         server = BusServer(sock_path)
@@ -223,6 +252,7 @@ class TestBusServerLifecycle:
             bus_module._ensure_broker(sock_path)
 
 
+@_needs_bus_socket
 class TestLivenessProbe:
     def test_socket_is_live_does_not_create_phantom_subscriber(self, sock_path: Path) -> None:
         # _socket_is_live used to make a real connection on every probe; under
@@ -252,6 +282,7 @@ class TestLivenessProbe:
         assert not _socket_is_live(sock_path)
 
 
+@_needs_bus_socket
 class TestPublisherCache:
     def test_burst_of_publishes_reuses_one_connection(self, sock_path: Path) -> None:
         # Each publish() previously opened a fresh UDS connection, which the
@@ -413,6 +444,7 @@ class TestPublisherCache:
         assert len(seen) == total, f"frame loss or corruption: got {len(seen)} unique of {total}"
 
 
+@_needs_bus_socket
 class TestPublishSubscribe:
     def test_round_trip_one_publisher_one_subscriber(self, sock_path: Path) -> None:
         received: queue.Queue[BusMessage] = queue.Queue()
@@ -677,6 +709,7 @@ class TestPublishSubscribe:
             server.stop()
 
 
+@_needs_bus_socket
 class TestBrokerElectionRace:
     def test_concurrent_cold_start_election_does_not_orphan_a_broker(self, sock_path: Path) -> None:
         # Cold-start race: two processes both observe ``_socket_is_live``
@@ -827,6 +860,7 @@ class TestBrokerElectionRace:
             child.wait(timeout=5.0)
 
 
+@_needs_bus_socket
 class TestBrokerSelfElection:
     def test_stale_socket_file_is_unlinked_and_rebound(self, sock_path: Path) -> None:
         sock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/cli/interactive_shell/test_agents_commands.py
+++ b/tests/cli/interactive_shell/test_agents_commands.py
@@ -181,6 +181,21 @@ class TestAgentsDispatch:
         assert "bus" in out
         assert "trace" in out
 
+    def test_bus_unavailable_prints_friendly_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise_unavailable() -> None:
+            raise agents_mod.AgentBusUnavailableError("socket.AF_UNIX is unavailable")
+
+        monkeypatch.setattr(agents_mod, "subscribe", _raise_unavailable)
+
+        session = ReplSession()
+        console, buf = _capture()
+        assert dispatch_slash("/agents bus", session, console) is True
+
+        out = buf.getvalue()
+        assert "agent bus unavailable" in out.lower()
+        assert "socket.AF_UNIX" in out
+        assert session.history[-1]["ok"] is False
+
     def test_dollar_hr_cell_does_not_read_budget_from_agents_yaml(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Fixes #1850

## Summary
- add an explicit agent-bus unsupported error when the Python runtime has no `socket.AF_UNIX`
- keep `/agents bus` in the REPL instead of crashing/exiting on unsupported bus platforms
- skip Unix-socket-only bus integration tests when `socket.AF_UNIX` is unavailable while keeping pure message/formatter tests active

## Tests
- `uv run pytest tests\agents\test_bus.py tests\cli\interactive_shell\test_agents_commands.py::TestAgentsDispatch::test_bus_unavailable_prints_friendly_error -q`
- `uv run ruff check app\agents\bus.py app\agents\__init__.py app\cli\interactive_shell\command_registry\agents.py tests\agents\test_bus.py tests\cli\interactive_shell\test_agents_commands.py`
- `uv run ruff format --check app\agents\bus.py app\agents\__init__.py app\cli\interactive_shell\command_registry\agents.py tests\agents\test_bus.py tests\cli\interactive_shell\test_agents_commands.py`
- `uv run mypy app\agents\bus.py app\agents\__init__.py app\cli\interactive_shell\command_registry\agents.py`