### PR TITLE
fix(agents): make tail tests Windows-safe

### DIFF
--- a/app/agents/tail.py
+++ b/app/agents/tail.py
@@ -99,14 +99,16 @@ def _resolve_linux_target(pid: int) -> _ResolvedTarget:
         raise AttachUnsupported("stdout is a pipe; live tail not supported")
     if target.startswith("anon_inode:"):
         raise AttachUnsupported(f"stdout is {target}; live tail not supported")
-    if not target.startswith("/"):
-        raise AttachUnsupported(f"stdout target {target!r} is not a filesystem path")
     if target.startswith(("/dev/pts/", "/dev/tty")):
         raise AttachUnsupported("stdout is on a terminal; live tail not supported")
     if target == "/dev/null":
         raise AttachUnsupported("stdout is /dev/null; nothing to tail")
 
-    return _ResolvedTarget(pid=pid, path=_check_regular_file(Path(target), what="stdout"))
+    target_path = Path(target)
+    if not target_path.is_absolute():
+        raise AttachUnsupported(f"stdout target {target!r} is not a filesystem path")
+
+    return _ResolvedTarget(pid=pid, path=_check_regular_file(target_path, what="stdout"))
 
 
 def _parse_lsof_fd1(stdout: str) -> tuple[str | None, str | None]:

--- a/tests/agents/test_tail.py
+++ b/tests/agents/test_tail.py
@@ -409,6 +409,10 @@ class TestAttachSession:
             assert b"hello" in sess.buffer.snapshot()
         assert not sess._thread.is_alive()  # noqa: SLF001 (test inspecting lifecycle)
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows does not allow renaming an open file handle",
+    )
     def test_reader_follows_inode_through_rename(self, tmp_path: Path) -> None:
         # logrotate-style: the path is renamed away after attach, but the
         # producer keeps writing to the original inode. The reader holds


### PR DESCRIPTION
Fixes #1852

## Summary
- make the Linux fd resolver use `Path.is_absolute()` instead of a POSIX-only string-prefix check, so host-neutral tests can use real Windows temp paths
- keep `/dev/pts`, `/dev/tty`, and `/dev/null` rejection behavior intact
- skip the inode-through-rename tail test on Windows, where renaming an open handle is not supported by the default file sharing mode

## Tests
- `uv run pytest tests\agents\test_tail.py -q`
- `uv run ruff check app\agents\tail.py tests\agents\test_tail.py`
- `uv run ruff format --check app\agents\tail.py tests\agents\test_tail.py`
- `uv run mypy app\agents\tail.py`