### PR TITLE
fix(integrations): skip blank discord tokens quietly

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -507,10 +507,13 @@ def _classify_service_instance(
         return None, None
 
     if key == "discord":
+        bot_token = str(credentials.get("bot_token") or "").strip()
+        if not bot_token:
+            return None, None
         try:
             discord_config = DiscordBotConfig.model_validate(
                 {
-                    "bot_token": credentials.get("bot_token", ""),
+                    "bot_token": bot_token,
                     "application_id": credentials.get("application_id", ""),
                     "public_key": credentials.get("public_key", ""),
                     "default_channel_id": credentials.get("default_channel_id"),

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -133,11 +133,14 @@ def test_classify_failure_skips_integration_and_reports(
         raise RuntimeError(f"forced {integration} failure")
 
     monkeypatch.setattr(f"app.integrations._catalog_impl.{patch_symbol}", _boom)
+    credentials = {"endpoint": "https://x", "api_key": "k"}
+    if integration == "discord":
+        credentials["bot_token"] = "t"
 
     with patch("app.integrations._catalog_impl.report_exception") as mock_report:
         result = _classify_service_instance(
             integration,
-            {"endpoint": "https://x", "api_key": "k"},
+            credentials,
             record_id=f"rec-{integration}",
         )
 
@@ -153,6 +156,18 @@ def test_classify_failure_skips_integration_and_reports(
     assert tags["surface"] == "integration"
     assert mock_report.call_args.kwargs["severity"] == "warning"
     assert mock_report.call_args.kwargs["extras"]["record_id"] == f"rec-{integration}"
+
+
+def test_classify_discord_blank_token_skips_without_reporting() -> None:
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = _classify_service_instance(
+            "discord",
+            {"bot_token": "   ", "application_id": "app-id"},
+            record_id="rec-discord-blank",
+        )
+
+    assert result == (None, None)
+    mock_report.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2437

## Summary
- treat a stored Discord integration with a blank `bot_token` as unconfigured instead of raising/reporting a validation exception
- trim the token before validating so accepted configs keep the normalized token
- keep the existing classify-failure reporting path covered for malformed non-empty Discord configs

## Tests
- `uv run pytest tests\integrations\test_catalog_silent_fallback_elimination.py -q`
- `uv run ruff check app\integrations\_catalog_impl.py tests\integrations\test_catalog_silent_fallback_elimination.py`
- `uv run ruff format --check app\integrations\_catalog_impl.py tests\integrations\test_catalog_silent_fallback_elimination.py`
- `uv run mypy app\integrations\_catalog_impl.py`