### PR TITLE
fix(agent): harden agent LLM response handling

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -177,7 +177,10 @@ class AnthropicAgentClient:
             raise RuntimeError(f"{self.provider_name} invocation failed") from last_err
 
         if isinstance(response, str):
-            return AgentLLMResponse(content=response)
+            return AgentLLMResponse(
+                content=response,
+                raw_content=[{"type": "text", "text": response}],
+            )
 
         if not hasattr(response, "content"):
             raise RuntimeError(
@@ -190,7 +193,7 @@ class AnthropicAgentClient:
             return AgentLLMResponse(
                 content=raw_content,
                 stop_reason=str(getattr(response, "stop_reason", "end_turn") or "end_turn"),
-                raw_content=raw_content,
+                raw_content=[{"type": "text", "text": raw_content}],
             )
         if not isinstance(raw_content, list):
             raise RuntimeError(

--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -176,9 +176,34 @@ class AnthropicAgentClient:
         else:
             raise RuntimeError(f"{self.provider_name} invocation failed") from last_err
 
+        if isinstance(response, str):
+            return AgentLLMResponse(content=response)
+
+        if not hasattr(response, "content"):
+            raise RuntimeError(
+                f"{self.provider_name} API returned an unexpected response: "
+                f"{type(response).__name__}"
+            )
+
+        raw_content = response.content
+        if isinstance(raw_content, str):
+            return AgentLLMResponse(
+                content=raw_content,
+                stop_reason=str(getattr(response, "stop_reason", "end_turn") or "end_turn"),
+                raw_content=raw_content,
+            )
+        if not isinstance(raw_content, list):
+            raise RuntimeError(
+                f"{self.provider_name} API returned unexpected content: "
+                f"{type(raw_content).__name__}"
+            )
+
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
-        for block in response.content:
+        for block in raw_content:
+            if isinstance(block, str):
+                text_parts.append(block)
+                continue
             block_type = getattr(block, "type", None)
             if block_type == "text":
                 text_parts.append(block.text)
@@ -188,8 +213,8 @@ class AnthropicAgentClient:
         return AgentLLMResponse(
             content="".join(text_parts),
             tool_calls=tool_calls,
-            stop_reason=str(response.stop_reason),
-            raw_content=response.content,
+            stop_reason=str(getattr(response, "stop_reason", "end_turn") or "end_turn"),
+            raw_content=raw_content,
         )
 
     @staticmethod
@@ -565,7 +590,7 @@ class CLIBackedAgentClient:
     def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
         # Return the same dicts — used only to pass back into invoke() below.
         return [
-            {"name": t.name, "description": t.description, "input_schema": t.input_schema}
+            {"name": t.name, "description": t.description, "input_schema": t.public_input_schema}
             for t in tools
         ]
 

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -210,6 +210,7 @@ def test_anthropic_string_response_is_returned_as_text(
 
     assert response.content == "plain text response"
     assert response.tool_calls == []
+    assert response.raw_content == [{"type": "text", "text": "plain text response"}]
 
 
 def test_anthropic_string_content_is_returned_as_text(
@@ -232,7 +233,7 @@ def test_anthropic_string_content_is_returned_as_text(
     response = client.invoke(messages=[{"role": "user", "content": "hi"}])
 
     assert response.content == "plain content"
-    assert response.raw_content == "plain content"
+    assert response.raw_content == [{"type": "text", "text": "plain content"}]
 
 
 def test_bedrock_rate_limit_error_is_not_retried(

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -194,6 +194,47 @@ def test_anthropic_rate_limit_error_is_not_retried(
     assert call_count == 1, "rate limit should not be retried"
 
 
+def test_anthropic_string_response_is_returned_as_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider shims may return bare text; keep it from surfacing as AttributeError."""
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=lambda **_: "plain text response")
+    )
+
+    response = client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "plain text response"
+    assert response.tool_calls == []
+
+
+def test_anthropic_string_content_is_returned_as_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A string content payload should be accepted as final text."""
+    _install_fake_anthropic(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    client = AnthropicAgentClient(model="claude-sonnet-4-6")
+    client._client = types.SimpleNamespace(
+        messages=types.SimpleNamespace(
+            create=lambda **_: types.SimpleNamespace(
+                content="plain content",
+                stop_reason="end_turn",
+            )
+        )
+    )
+
+    response = client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.content == "plain content"
+    assert response.raw_content == "plain content"
+
+
 def test_bedrock_rate_limit_error_is_not_retried(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -603,6 +644,56 @@ def test_cli_backed_agent_client_tool_call_parsing() -> None:
     assert result.tool_calls[0].name == "my_tool"
     assert result.tool_calls[0].input == {"x": 1}
     assert result.content == ""
+
+
+def test_cli_backed_agent_client_tool_schemas_use_public_schema() -> None:
+    """CLI-backed investigation prompts must not expose injected runtime parameters."""
+    import types as _types
+
+    from app.services.agent_llm_client import CLIBackedAgentClient
+
+    fake_adapter = _types.SimpleNamespace(
+        name="codex",
+        binary_env_key="CODEX_BIN",
+        install_hint="",
+        auth_hint="codex login",
+        default_exec_timeout_sec=30.0,
+        detect=lambda: _types.SimpleNamespace(
+            installed=True, bin_path="/usr/bin/codex", logged_in=True, detail=""
+        ),
+        build=lambda **_kw: _types.SimpleNamespace(
+            argv=("/usr/bin/codex",), stdin="", cwd="/", env=None, timeout_sec=30.0
+        ),
+        parse=lambda **_kw: "",
+        explain_failure=lambda **_kw: "",
+    )
+    tool = _types.SimpleNamespace(
+        name="query_logs",
+        description="Query logs",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "api_key": {"type": "string"},
+            },
+            "required": ["query", "api_key"],
+        },
+        public_input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    )
+
+    client = CLIBackedAgentClient(fake_adapter, model=None)
+
+    assert client.tool_schemas([tool]) == [
+        {
+            "name": "query_logs",
+            "description": "Query logs",
+            "input_schema": tool.public_input_schema,
+        }
+    ]
 
 
 def test_cli_backed_agent_client_build_assistant_message_includes_tool_json() -> None:


### PR DESCRIPTION
Fixes #2414
Fixes #2415
Refs #2382

## Summary
- accept bare/text Anthropic responses as final agent text instead of crashing on `response.content`
- fail with a structured runtime error when Anthropic returns an unsupported response/content shape
- make CLI-backed investigation prompts use each tool's `public_input_schema` so injected runtime parameters are not exposed

## Tests
- `uv run pytest tests/services/test_agent_llm_client.py -q`
- `uv run ruff check app/services/agent_llm_client.py tests/services/test_agent_llm_client.py`
- `uv run ruff format --check app/services/agent_llm_client.py tests/services/test_agent_llm_client.py`