### PR TITLE
fix(analytics): handle telemetry client startup errors

### DIFF
--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -10,6 +10,7 @@ import os
 import platform
 import queue
 import re
+import ssl
 import tempfile
 import threading
 import time
@@ -771,13 +772,18 @@ class Analytics:
         self._worker = worker
 
     def _worker_loop(self) -> None:
-        with httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False) as client:
+        client: httpx.Client | None = None
+        try:
             while True:
                 item = self._queue.get()
                 if item is None:
                     self._queue.task_done()
                     break
                 try:
+                    if client is None:
+                        client = self._start_http_client(item)
+                    if client is None:
+                        return
                     self._send(client, item)
                 finally:
                     self._queue.task_done()
@@ -789,10 +795,44 @@ class Analytics:
                     return
                 try:
                     if item is not None:
+                        if client is None:
+                            client = self._start_http_client(item)
+                        if client is None:
+                            return
                         self._send(client, item)
                 finally:
                     self._queue.task_done()
                     self._mark_done()
+        finally:
+            if client is not None:
+                close = getattr(client, "close", None)
+                if callable(close):
+                    close()
+
+    def _start_http_client(self, item: _Envelope) -> httpx.Client | None:
+        try:
+            return httpx.Client(timeout=_SEND_TIMEOUT, trust_env=False)
+        except (httpx.TransportError, OSError, ssl.SSLError) as exc:
+            # Telemetry transport setup failures are environmental. Disable
+            # this in-process analytics worker and drain queued events so CLI
+            # shutdown never hangs behind a dead background thread.
+            self._worker_alive = False
+            self._disabled = True
+            _log_failure("posthog_worker_start", exc, event=item.event)
+            self._discard_pending_worker_items()
+            return None
+
+    def _discard_pending_worker_items(self) -> None:
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                if item is not None:
+                    self._mark_done()
+            finally:
+                self._queue.task_done()
 
     def _send(self, client: httpx.Client, item: _Envelope) -> None:
         properties: Properties = {

--- a/app/analytics/provider.py
+++ b/app/analytics/provider.py
@@ -732,6 +732,8 @@ class Analytics:
         try:
             self._ensure_worker()
             with self._pending_lock:
+                if self._disabled or self._shutdown:
+                    return
                 self._pending += 1
                 pending_registered = True
                 self._drained.clear()
@@ -816,8 +818,9 @@ class Analytics:
             # Telemetry transport setup failures are environmental. Disable
             # this in-process analytics worker and drain queued events so CLI
             # shutdown never hangs behind a dead background thread.
-            self._worker_alive = False
-            self._disabled = True
+            with self._pending_lock:
+                self._worker_alive = False
+                self._disabled = True
             _log_failure("posthog_worker_start", exc, event=item.event)
             self._discard_pending_worker_items()
             return None

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -593,6 +593,29 @@ def test_worker_client_start_ssl_error_drains_without_sentry(
     assert failures == [("posthog_worker_start", "SSLError", {"event": Event.CLI_INVOKED.value})]
 
 
+def test_capture_rechecks_disabled_after_worker_start(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+
+    analytics = provider.Analytics()
+
+    def _disable_during_worker_start() -> None:
+        analytics._disabled = True
+
+    monkeypatch.setattr(analytics, "_ensure_worker", _disable_during_worker_start)
+
+    analytics.capture(Event.CLI_INVOKED)
+
+    assert analytics._pending == 0
+    assert analytics._queue.qsize() == 0
+
+
 def test_get_or_create_anonymous_id_returns_uuid_when_write_fails(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/analytics/test_provider.py
+++ b/tests/analytics/test_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import ssl
 import subprocess
 import sys
 import threading
@@ -555,6 +556,41 @@ def test_analytics_disabled_when_do_not_track_opt_out(monkeypatch, tmp_path: Pat
     assert analytics._pending == 0
     assert analytics._queue.qsize() == 0
     assert client_inits == 0
+
+
+def test_worker_client_start_ssl_error_drains_without_sentry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("OPENSRE_ANALYTICS_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setattr(provider, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(provider, "_ANONYMOUS_ID_PATH", tmp_path / "anonymous_id")
+    monkeypatch.setattr(provider.atexit, "register", lambda _func: None)
+
+    class _FailingClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise ssl.SSLError("unknown error")
+
+    failures: list[tuple[str, str, dict[str, object]]] = []
+    sentry: list[BaseException] = []
+
+    def _record_failure(stage: str, error: BaseException, **extra: object) -> None:
+        failures.append((stage, type(error).__name__, extra))
+
+    monkeypatch.setattr(provider.httpx, "Client", _FailingClient)
+    monkeypatch.setattr(provider, "_log_failure", _record_failure)
+    monkeypatch.setattr(provider, "_capture_sentry_failure", lambda exc: sentry.append(exc))
+
+    analytics = provider.Analytics()
+    analytics.capture(Event.CLI_INVOKED)
+    analytics.shutdown(flush=True, timeout=2.0)
+
+    assert analytics._pending == 0
+    assert analytics._drained.is_set()
+    assert analytics._disabled is True
+    assert sentry == []
+    assert failures == [("posthog_worker_start", "SSLError", {"event": Event.CLI_INVOKED.value})]
 
 
 def test_get_or_create_anonymous_id_returns_uuid_when_write_fails(


### PR DESCRIPTION
Fixes #2403

## Summary
- start the PostHog httpx client only after an analytics event is available, avoiding a startup race where the worker can die before the queue is populated
- treat telemetry client startup TLS/transport errors as environmental, log them locally, disable this in-process worker, and drain queued events without Sentry noise
- close real clients explicitly while keeping lightweight test stubs supported

## Tests
- `uv run pytest tests/analytics/test_provider.py -q`
- `uv run ruff check app/analytics/provider.py tests/analytics/test_provider.py`
- `uv run ruff format --check app/analytics/provider.py tests/analytics/test_provider.py`