### PR TITLE
fix(cli): exit repl cleanly on prompt eio

### DIFF
--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
 import re
@@ -316,6 +317,12 @@ async def run_interactive(
                         state.cancel_current_dispatch()
                         continue
                     return
+                except OSError as exc:
+                    if exc.errno == errno.EIO:
+                        if state.is_dispatch_running():
+                            state.cancel_current_dispatch()
+                        return
+                    raise
                 except KeyboardInterrupt:
                     if state.is_dispatch_running():
                         state.cancel_current_dispatch()

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import errno
 import io
 import re
 import threading
@@ -69,6 +71,40 @@ def test_strip_cpr_sequences_removes_terminal_cursor_replies(
     expected: str,
 ) -> None:
     assert loop_module._strip_cpr_sequences(text) == expected
+
+
+@pytest.mark.asyncio
+async def test_run_interactive_exits_cleanly_on_prompt_eio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A closed stdin/TTY should exit the REPL like EOF, not leak an OSError traceback."""
+
+    class _FakeApp:
+        is_running = False
+
+        def invalidate(self) -> None:
+            return None
+
+        def exit(self) -> None:
+            return None
+
+    class _PromptSession:
+        app = _FakeApp()
+        history = InMemoryHistory()
+
+        async def prompt_async(self, *_args: object, **_kwargs: object) -> str:
+            raise OSError(errno.EIO, "Input/output error")
+
+    async def _sleep_forever() -> None:
+        await asyncio.Event().wait()
+
+    def _patch_stdout(*_args: object, **_kwargs: object) -> contextlib.AbstractContextManager[None]:
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(loop_module, "install_session_key_bindings", lambda *_args: None)
+    monkeypatch.setattr(loop_module, "patch_stdout", _patch_stdout)
+    monkeypatch.setattr(loop_module, "_drain_stale_cpr_bytes", lambda: None)
+    monkeypatch.setattr(loop_module, "start_sampler", lambda: asyncio.create_task(_sleep_forever()))
+
+    await loop_module.run_interactive(ReplSession(), pt_session=_PromptSession())  # type: ignore[arg-type]
 
 
 def test_repl_input_lexer_highlights_first_slash_token() -> None:

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -107,6 +107,66 @@ async def test_run_interactive_exits_cleanly_on_prompt_eio(monkeypatch: pytest.M
     await loop_module.run_interactive(ReplSession(), pt_session=_PromptSession())  # type: ignore[arg-type]
 
 
+@pytest.mark.asyncio
+async def test_run_interactive_cancels_running_dispatch_on_prompt_eio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the TTY closes mid-turn, the active dispatch must receive cancellation."""
+
+    class _FakeApp:
+        is_running = False
+
+        def invalidate(self) -> None:
+            return None
+
+        def exit(self) -> None:
+            return None
+
+    class _PromptSession:
+        app = _FakeApp()
+        history = InMemoryHistory()
+        calls = 0
+
+        async def prompt_async(self, *_args: object, **_kwargs: object) -> str:
+            self.calls += 1
+            if self.calls == 1:
+                return "hello"
+            await asyncio.wait_for(asyncio.to_thread(dispatch_started.wait), timeout=2.0)
+            raise OSError(errno.EIO, "Input/output error")
+
+    dispatch_started = threading.Event()
+    dispatch_cancelled = threading.Event()
+
+    def _dispatch_one_turn(
+        _text: str,
+        _session: ReplSession,
+        console: loop_module.StreamingConsole,
+        **_kwargs: object,
+    ) -> None:
+        dispatch_started.set()
+        while not console.cancel_requested:
+            time.sleep(0.005)
+        dispatch_cancelled.set()
+
+    async def _sleep_forever() -> None:
+        await asyncio.Event().wait()
+
+    def _patch_stdout(*_args: object, **_kwargs: object) -> contextlib.AbstractContextManager[None]:
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(loop_module, "install_session_key_bindings", lambda *_args: None)
+    monkeypatch.setattr(loop_module, "patch_stdout", _patch_stdout)
+    monkeypatch.setattr(loop_module, "_drain_stale_cpr_bytes", lambda: None)
+    monkeypatch.setattr(loop_module, "start_sampler", lambda: asyncio.create_task(_sleep_forever()))
+    monkeypatch.setattr(loop_module, "dispatch_one_turn", _dispatch_one_turn)
+    monkeypatch.setattr(loop_module, "dispatch_needs_exclusive_stdin", lambda *_args: False)
+    monkeypatch.setattr(loop_module._prompt_surface, "render_submitted_prompt", lambda *_args: None)
+
+    await loop_module.run_interactive(ReplSession(), pt_session=_PromptSession())  # type: ignore[arg-type]
+
+    assert dispatch_cancelled.wait(timeout=2.0)
+
+
 def test_repl_input_lexer_highlights_first_slash_token() -> None:
     lexer = ReplInputLexer()
     get_line = lexer.lex_document(Document("/model show", len("/model")))


### PR DESCRIPTION
Fixes #2365

## Summary
- handle `OSError(errno.EIO)` from `prompt_async` the same way as a closed input stream
- cancel any active dispatch before exiting when stdin/TTY is gone
- add a prompt-loop regression test for closed stdin so this does not return as a Sentry traceback

## Tests
- `uv run pytest tests/cli/interactive_shell/test_terminal_runtime.py -q`
- `uv run ruff check app/cli/interactive_shell/runtime/loop.py tests/cli/interactive_shell/test_terminal_runtime.py`
- `uv run ruff format --check app/cli/interactive_shell/runtime/loop.py tests/cli/interactive_shell/test_terminal_runtime.py`