### PR TITLE
fix(integrations): quiet expected mongodb verify failures

### DIFF
--- a/app/integrations/mongodb.py
+++ b/app/integrations/mongodb.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pydantic import Field, field_validator
+from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
 
 from app.integrations._validation_helpers import report_validation_failure
 from app.strict_config import StrictConfigModel
@@ -122,6 +123,29 @@ def validate_mongodb_config(config: MongoDBConfig) -> MongoDBValidationResult:
             )
         finally:
             client.close()
+    except OperationFailure as err:
+        if getattr(err, "code", None) == 18:
+            logger.warning("[mongodb] validate_mongodb_config authentication failed")
+            return MongoDBValidationResult(
+                ok=False,
+                detail=(
+                    "MongoDB authentication failed. Check the username, password, "
+                    "authSource, and connection string."
+                ),
+            )
+        report_validation_failure(
+            err,
+            logger=logger,
+            integration="mongodb",
+            method="validate_mongodb_config",
+        )
+        return MongoDBValidationResult(ok=False, detail=f"MongoDB connection failed: {err}")
+    except ServerSelectionTimeoutError as err:
+        logger.warning("[mongodb] validate_mongodb_config server selection failed: %s", err)
+        return MongoDBValidationResult(
+            ok=False,
+            detail=f"MongoDB server selection failed: {err}",
+        )
     except Exception as err:
         report_validation_failure(
             err,

--- a/tests/test_mongodb_integration.py
+++ b/tests/test_mongodb_integration.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
+
 from app.integrations.catalog import classify_integrations as _classify_integrations
 from app.integrations.mongodb import (
     MongoDBConfig,
@@ -108,6 +110,40 @@ class TestMongoDBValidation:
         result = validate_mongodb_config(config)
         assert result.ok is False
         assert "Conn error" in result.detail
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_validate_auth_failure_no_sentry(self, mock_report, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.admin.command.side_effect = OperationFailure(
+            "Authentication failed.",
+            code=18,
+        )
+        mock_get_client.return_value = mock_client
+
+        config = MongoDBConfig(connection_string="mongodb://host")
+        result = validate_mongodb_config(config)
+
+        assert result.ok is False
+        assert "authentication failed" in result.detail.lower()
+        mock_report.assert_not_called()
+        mock_client.close.assert_called_once()
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_validate_server_selection_timeout_no_sentry(self, mock_report, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.admin.command.side_effect = ServerSelectionTimeoutError("SSL handshake failed")
+        mock_get_client.return_value = mock_client
+
+        config = MongoDBConfig(connection_string="mongodb://host")
+        result = validate_mongodb_config(config)
+
+        assert result.ok is False
+        assert "server selection failed" in result.detail
+        assert "SSL handshake failed" in result.detail
+        mock_report.assert_not_called()
+        mock_client.close.assert_called_once()
 
 
 class TestMongoDBAdminUnauthorized:


### PR DESCRIPTION
Fixes #2351
Fixes #2352

## Summary
- treat MongoDB authentication failures as expected verification failures with a clear operator-facing detail
- treat MongoDB server-selection/SSL handshake failures as verification failures without reporting them to Sentry as OpenSRE bugs
- keep unexpected MongoDB validator exceptions on the existing `report_validation_failure` path

## Tests
- `uv run pytest tests/test_mongodb_integration.py tests/integrations/test_validator_sentry_capture.py -q`
- `uv run ruff check app/integrations/mongodb.py tests/test_mongodb_integration.py tests/integrations/test_validator_sentry_capture.py`
- `uv run ruff format --check app/integrations/mongodb.py tests/test_mongodb_integration.py`