### PR TITLE
feat(wizard): add Telegram onboarding

### DIFF
--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -26,7 +26,12 @@ from app.cli.interactive_shell.ui.theme import (
     TEXT,
     WARNING,
 )
-from app.cli.wizard.config import PROVIDER_BY_VALUE, SUPPORTED_PROVIDERS, ProviderOption
+from app.cli.wizard.config import (
+    PROJECT_ENV_PATH,
+    PROVIDER_BY_VALUE,
+    SUPPORTED_PROVIDERS,
+    ProviderOption,
+)
 from app.cli.wizard.env_sync import sync_env_secret, sync_env_values, sync_provider_env
 from app.cli.wizard.integration_health import IntegrationHealthResult
 from app.cli.wizard.probes import ProbeResult, probe_local_target, probe_remote_target
@@ -281,6 +286,18 @@ def _local_defaults() -> dict[str, str | bool | None]:
 def _integration_defaults(service: str) -> tuple[Mapping[str, object], Mapping[str, object]]:
     entry = _as_mapping(get_integration(service))
     return entry, _as_mapping(entry.get("credentials"))
+
+
+def _project_env_value(key: str) -> str:
+    try:
+        lines = PROJECT_ENV_PATH.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    for line in lines:
+        name, sep, value = line.partition("=")
+        if sep and name.strip() == key:
+            return value.strip().strip("\"'")
+    return ""
 
 
 def _step(title: str) -> None:
@@ -1636,6 +1653,9 @@ def _configure_discord() -> tuple[str, str]:
 
 def _configure_telegram() -> tuple[str, str]:
     _, credentials = _integration_defaults("telegram")
+    default_chat_id_hint = _string_value(
+        credentials.get("default_chat_id"), _project_env_value("TELEGRAM_DEFAULT_CHAT_ID")
+    )
     _console.print(
         "\n[bold]Telegram Integration[/bold]\n"
         f"[{SECONDARY}]Create a bot with @BotFather, then add it to the target chat.[/]\n"
@@ -1648,7 +1668,7 @@ def _configure_telegram() -> tuple[str, str]:
         )
         default_chat_id = _prompt_value(
             "Default chat ID (optional)",
-            default=_string_value(credentials.get("default_chat_id")),
+            default=default_chat_id_hint,
             allow_empty=True,
         )
         with _console.status("Validating Telegram bot token...", spinner="dots"):
@@ -1665,7 +1685,8 @@ def _configure_telegram() -> tuple[str, str]:
                 },
             )
             sync_env_secret("TELEGRAM_BOT_TOKEN", bot_token)
-            env_path = sync_env_values({"TELEGRAM_DEFAULT_CHAT_ID": default_chat_id})
+            env_values = {"TELEGRAM_DEFAULT_CHAT_ID": default_chat_id} if default_chat_id else {}
+            env_path = sync_env_values(env_values)
             return "Telegram", str(env_path)
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 

--- a/app/cli/wizard/flow.py
+++ b/app/cli/wizard/flow.py
@@ -193,6 +193,12 @@ def validate_discord_bot(**kwargs):
     return _validate(**kwargs)
 
 
+def validate_telegram_bot(**kwargs):
+    from app.cli.wizard.integration_health import validate_telegram_bot as _validate
+
+    return _validate(**kwargs)
+
+
 def validate_openclaw_integration(**kwargs):
     from app.cli.wizard.integration_health import validate_openclaw_integration as _validate
 
@@ -1628,6 +1634,42 @@ def _configure_discord() -> tuple[str, str]:
         _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
 
 
+def _configure_telegram() -> tuple[str, str]:
+    _, credentials = _integration_defaults("telegram")
+    _console.print(
+        "\n[bold]Telegram Integration[/bold]\n"
+        f"[{SECONDARY}]Create a bot with @BotFather, then add it to the target chat.[/]\n"
+    )
+    while True:
+        bot_token = _prompt_value(
+            "Telegram bot token",
+            default=_string_value(credentials.get("bot_token")),
+            secret=True,
+        )
+        default_chat_id = _prompt_value(
+            "Default chat ID (optional)",
+            default=_string_value(credentials.get("default_chat_id")),
+            allow_empty=True,
+        )
+        with _console.status("Validating Telegram bot token...", spinner="dots"):
+            result = validate_telegram_bot(bot_token=bot_token)
+        _render_integration_result("Telegram", result)
+        if result.ok:
+            upsert_integration(
+                "telegram",
+                {
+                    "credentials": {
+                        "bot_token": bot_token,
+                        "default_chat_id": default_chat_id,
+                    }
+                },
+            )
+            sync_env_secret("TELEGRAM_BOT_TOKEN", bot_token)
+            env_path = sync_env_values({"TELEGRAM_DEFAULT_CHAT_ID": default_chat_id})
+            return "Telegram", str(env_path)
+        _console.print(f"[{SECONDARY}]Try again or press Ctrl+C to cancel.[/]")
+
+
 def _configure_splunk() -> tuple[str, str]:
     _, credentials = _integration_defaults("splunk")
     while True:
@@ -1812,6 +1854,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
             label="Discord",
             hint="Trigger investigations via slash commands and post findings to threads",
         ),
+        Choice(value="telegram", label="Telegram", hint="Post findings to a Telegram chat"),
         Choice(value="aws", label="AWS", hint="Inspect CloudWatch, EKS, and account resources"),
         Choice(
             value="github", label="GitHub MCP", hint="Let the agent inspect repos, PRs, and issues"
@@ -1895,6 +1938,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "coralogix": _configure_coralogix,
         "slack": _configure_slack,
         "discord": _configure_discord,
+        "telegram": _configure_telegram,
         "aws": _configure_aws,
         "github": _configure_github_mcp,
         "sentry": _configure_sentry,
@@ -1919,6 +1963,7 @@ def _configure_selected_integrations() -> tuple[list[str], str | None]:
         "coralogix": "coralogix",
         "slack": "slack",
         "discord": "discord",
+        "telegram": "telegram",
         "aws": "aws",
         "github": "github mcp",
         "sentry": "sentry",

--- a/app/cli/wizard/integration_health.py
+++ b/app/cli/wizard/integration_health.py
@@ -24,6 +24,7 @@ from app.cli.wizard.integration_validators.http_probe_validators import (
     validate_jira_integration,
     validate_notion_integration,
     validate_slack_webhook,
+    validate_telegram_bot,
 )
 from app.cli.wizard.integration_validators.mcp_validators import (
     validate_github_mcp_integration,
@@ -53,5 +54,6 @@ __all__ = [
     "validate_sentry_integration",
     "validate_slack_webhook",
     "validate_splunk_integration",
+    "validate_telegram_bot",
     "validate_vercel_integration",
 ]

--- a/app/cli/wizard/integration_validators/http_probe_validators.py
+++ b/app/cli/wizard/integration_validators/http_probe_validators.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import re
+
 import httpx
 
 from app.integrations.models import SlackWebhookConfig
 
 from .shared import IntegrationHealthResult
+
+_TELEGRAM_BOT_TOKEN_RE = re.compile(r"^\d+:[A-Za-z0-9_-]+$")
+
+
+def _redact_secret(text: str, secret: str) -> str:
+    return text.replace(secret, "<redacted>") if secret else text
 
 
 def validate_slack_webhook(*, webhook_url: str) -> IntegrationHealthResult:
@@ -144,11 +152,18 @@ def validate_telegram_bot(*, bot_token: str) -> IntegrationHealthResult:
     token = bot_token.strip()
     if not token:
         return IntegrationHealthResult(ok=False, detail="Telegram bot token is required.")
+    if not _TELEGRAM_BOT_TOKEN_RE.fullmatch(token):
+        return IntegrationHealthResult(
+            ok=False,
+            detail="Telegram bot token format is invalid; expected '<numeric-id>:<token>'.",
+        )
 
     try:
         resp = httpx.get(f"https://api.telegram.org/bot{token}/getMe", timeout=10)
     except httpx.RequestError as err:
-        return IntegrationHealthResult(ok=False, detail=f"Telegram API unreachable: {err}")
+        return IntegrationHealthResult(
+            ok=False, detail=f"Telegram API unreachable: {_redact_secret(str(err), token)}"
+        )
 
     description = ""
     payload: dict[str, object] = {}
@@ -159,6 +174,7 @@ def validate_telegram_bot(*, bot_token: str) -> IntegrationHealthResult:
         description = str(raw_description).strip() if raw_description else ""
     except ValueError:
         payload = {}
+        description = ""
 
     if resp.status_code == 200 and payload.get("ok") is True:
         user = payload.get("result")

--- a/app/cli/wizard/integration_validators/http_probe_validators.py
+++ b/app/cli/wizard/integration_validators/http_probe_validators.py
@@ -137,3 +137,45 @@ def validate_discord_bot(*, bot_token: str) -> IntegrationHealthResult:
     return IntegrationHealthResult(
         ok=False, detail=f"Discord API returned unexpected HTTP {resp.status_code}."
     )
+
+
+def validate_telegram_bot(*, bot_token: str) -> IntegrationHealthResult:
+    """Validate a Telegram bot token by calling Telegram's getMe endpoint."""
+    token = bot_token.strip()
+    if not token:
+        return IntegrationHealthResult(ok=False, detail="Telegram bot token is required.")
+
+    try:
+        resp = httpx.get(f"https://api.telegram.org/bot{token}/getMe", timeout=10)
+    except httpx.RequestError as err:
+        return IntegrationHealthResult(ok=False, detail=f"Telegram API unreachable: {err}")
+
+    description = ""
+    payload: dict[str, object] = {}
+    try:
+        raw_payload = resp.json()
+        payload = raw_payload if isinstance(raw_payload, dict) else {}
+        raw_description = payload.get("description")
+        description = str(raw_description).strip() if raw_description else ""
+    except ValueError:
+        payload = {}
+
+    if resp.status_code == 200 and payload.get("ok") is True:
+        user = payload.get("result")
+        username = ""
+        if isinstance(user, dict):
+            username = str(user.get("username") or "").strip()
+        return IntegrationHealthResult(
+            ok=True,
+            detail=f"Telegram bot authenticated as @{username or 'unknown'}.",
+        )
+    if resp.status_code == 401:
+        return IntegrationHealthResult(ok=False, detail="Telegram bot token is invalid or revoked.")
+    if description:
+        return IntegrationHealthResult(
+            ok=False,
+            detail=f"Telegram API check failed: {description}",
+        )
+    return IntegrationHealthResult(
+        ok=False, detail=f"Telegram API returned unexpected HTTP {resp.status_code}."
+    )

--- a/docs/messaging/index.mdx
+++ b/docs/messaging/index.mdx
@@ -11,7 +11,7 @@ OpenSRE can deliver investigation findings — and accept investigation triggers
 |---|---|---|---|---|
 | [**Slack**](/messaging/slack) | Teams already paged in Slack channels | ❌ delivery only (incoming webhook) | `opensre integrations setup slack` | ~5 min |
 | [**Discord**](/messaging/discord) | Communities and teams using Discord servers | ✅ `/investigate` slash command in any channel the bot is in | `opensre onboard` or `opensre integrations setup discord` | ~10 min |
-| [**Telegram**](/messaging/telegram) | Mobile-first and on-call rotations | ❌ delivery only | Environment variables (no wizard yet) | ~5 min |
+| [**Telegram**](/messaging/telegram) | Mobile-first and on-call rotations | ❌ delivery only | `opensre onboard` or environment variables | ~5 min |
 | [**WhatsApp**](/messaging/whatsapp) | Mobile alerting via Twilio WhatsApp | ❌ delivery only | `opensre integrations setup whatsapp` | ~5 min |
 | [**Twilio SMS**](/messaging/twilio-sms) | SMS paging via Twilio (separate from WhatsApp) | ❌ delivery only | `opensre integrations setup twilio` | ~5 min |
 
@@ -69,10 +69,10 @@ After editing `.env`, run `opensre integrations verify <service>` (e.g. `opensre
 
 ## Re-running the wizard
 
-You can re-run the Discord wizard at any time to update credentials:
+You can re-run the Discord or Telegram wizard at any time to update credentials:
 
 ```bash
 opensre onboard
 ```
 
-Existing values are pre-populated, so you can press Enter to keep what you have. Slack, WhatsApp, and Twilio SMS use `opensre integrations setup slack`, `opensre integrations setup whatsapp`, and `opensre integrations setup twilio`. Telegram does not currently have a wizard step that persists credentials — use `.env` for Telegram (see [#1481](https://github.com/Tracer-Cloud/opensre/issues/1481)).
+Existing values are pre-populated, so you can press Enter to keep what you have. Slack, WhatsApp, and Twilio SMS use `opensre integrations setup slack`, `opensre integrations setup whatsapp`, and `opensre integrations setup twilio`. Telegram can be configured from `opensre onboard`; direct `.env` values remain supported for scripted deployments.

--- a/docs/messaging/telegram.mdx
+++ b/docs/messaging/telegram.mdx
@@ -6,7 +6,7 @@ description: "Deliver investigation findings to a Telegram chat or channel."
 OpenSRE's Telegram integration delivers investigation findings to any chat your bot has been added to — useful for mobile-first on-call rotations and personal alerting.
 
 <Note>
-Unlike Slack and Discord, Telegram is **not** included in the interactive `opensre onboard` wizard today. Configure it via environment variables or by editing `~/.config/opensre/integrations.json` directly. Tracked at [#1481](https://github.com/Tracer-Cloud/opensre/issues/1481).
+Telegram can be configured from the interactive `opensre onboard` wizard. Direct environment variables and `~/.config/opensre/integrations.json` entries remain supported for scripted deployments.
 </Note>
 
 ---
@@ -88,7 +88,19 @@ If `getUpdates` returns an empty array, post a fresh message in the chat and rel
 
 ## Step 4: Configure the integration
 
-Set two environment variables in your `.env` file:
+Run the setup wizard and select **Telegram**:
+
+```bash
+opensre onboard
+```
+
+When prompted, enter:
+- **Telegram bot token** - the HTTP API token from BotFather.
+- **Default chat ID** *(optional)* - the destination from Step 3. Delivery requires a chat ID unless each send call overrides it.
+
+The wizard validates the token with Telegram's `getMe` endpoint, saves the integration, and writes the default chat ID to `.env`.
+
+For scripted deployments, you can set the same values directly in `.env`:
 
 ```bash
 TELEGRAM_BOT_TOKEN=<numeric-id>:<token-secret>
@@ -98,7 +110,7 @@ TELEGRAM_DEFAULT_CHAT_ID=<chat-id>
 | Variable | Description |
 |---|---|
 | `TELEGRAM_BOT_TOKEN` | Bot HTTP API token from BotFather. Required. |
-| `TELEGRAM_DEFAULT_CHAT_ID` | Default delivery destination. Required for delivery to work. |
+| `TELEGRAM_DEFAULT_CHAT_ID` | Default delivery destination. Required for delivery to work unless each send call supplies a chat ID. |
 
 OpenSRE picks these up at startup and registers Telegram as an active integration.
 

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -221,6 +221,76 @@ def test_run_wizard_configures_optional_integrations(monkeypatch, tmp_path, caps
     assert "Grafana" in output
 
 
+def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "telegram"])
+    password_responses = iter(["llm-secret", "123456:bot-token"])
+    text_responses = iter(["987654321"])
+    saved_integrations: list[tuple[str, dict]] = []
+    synced_env_values: list[dict[str, str]] = []
+    synced_env_secrets: list[tuple[str, str]] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(password_responses)
+        return m
+
+    def _mock_text(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(text_responses)
+        return m
+
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow.questionary, "text", _mock_text)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(
+        flow,
+        "validate_telegram_bot",
+        lambda **_kwargs: flow.IntegrationHealthResult(ok=True, detail="Telegram ok"),
+    )
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr(flow, "save_llm_api_key", lambda *_args, **_kwargs: None)
+
+    def _sync_env_values(values: dict[str, str], **_kwargs):
+        synced_env_values.append(values)
+        return tmp_path / ".env"
+
+    def _sync_env_secret(key: str, value: str) -> None:
+        synced_env_secrets.append((key, value))
+
+    monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(flow, "sync_env_secret", _sync_env_secret)
+    monkeypatch.setattr(
+        flow,
+        "upsert_integration",
+        lambda service, payload: saved_integrations.append((service, payload)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert saved_integrations == [
+        (
+            "telegram",
+            {
+                "credentials": {
+                    "bot_token": "123456:bot-token",
+                    "default_chat_id": "987654321",
+                }
+            },
+        )
+    ]
+    assert synced_env_secrets == [("TELEGRAM_BOT_TOKEN", "123456:bot-token")]
+    assert synced_env_values == [{"TELEGRAM_DEFAULT_CHAT_ID": "987654321"}]
+
+
 def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "honeycomb"])
     password_responses = iter(["llm-secret", "hny_test"])

--- a/tests/cli/wizard/test_flow.py
+++ b/tests/cli/wizard/test_flow.py
@@ -291,6 +291,144 @@ def test_run_wizard_configures_telegram(monkeypatch, tmp_path) -> None:
     assert synced_env_values == [{"TELEGRAM_DEFAULT_CHAT_ID": "987654321"}]
 
 
+def test_run_wizard_telegram_reuses_existing_env_chat_id(monkeypatch, tmp_path) -> None:
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "telegram"])
+    password_responses = iter(["llm-secret", "123456:bot-token"])
+    text_responses = iter([""])
+    saved_integrations: list[tuple[str, dict]] = []
+    synced_env_values: list[dict[str, str]] = []
+    synced_env_secrets: list[tuple[str, str]] = []
+    env_path = tmp_path / ".env"
+    env_path.write_text("TELEGRAM_DEFAULT_CHAT_ID=chat-from-env\n", encoding="utf-8")
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(password_responses)
+        return m
+
+    def _mock_text(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(text_responses)
+        return m
+
+    monkeypatch.setattr(flow, "PROJECT_ENV_PATH", env_path)
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow.questionary, "text", _mock_text)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(
+        flow,
+        "validate_telegram_bot",
+        lambda **_kwargs: flow.IntegrationHealthResult(ok=True, detail="Telegram ok"),
+    )
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr(flow, "save_llm_api_key", lambda *_args, **_kwargs: None)
+
+    def _sync_env_values(values: dict[str, str], **_kwargs):
+        synced_env_values.append(values)
+        return tmp_path / ".env"
+
+    def _sync_env_secret(key: str, value: str) -> None:
+        synced_env_secrets.append((key, value))
+
+    monkeypatch.setattr(flow, "sync_env_values", _sync_env_values)
+    monkeypatch.setattr(flow, "sync_env_secret", _sync_env_secret)
+    monkeypatch.setattr(
+        flow,
+        "upsert_integration",
+        lambda service, payload: saved_integrations.append((service, payload)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert saved_integrations == [
+        (
+            "telegram",
+            {
+                "credentials": {
+                    "bot_token": "123456:bot-token",
+                    "default_chat_id": "chat-from-env",
+                }
+            },
+        )
+    ]
+    assert synced_env_secrets == [("TELEGRAM_BOT_TOKEN", "123456:bot-token")]
+    assert synced_env_values == [{"TELEGRAM_DEFAULT_CHAT_ID": "chat-from-env"}]
+
+
+def test_run_wizard_telegram_blank_chat_id_does_not_clear_env(monkeypatch, tmp_path) -> None:
+    select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "telegram"])
+    password_responses = iter(["llm-secret", "123456:bot-token"])
+    text_responses = iter([""])
+    saved_integrations: list[tuple[str, dict]] = []
+    synced_env_values: list[dict[str, str]] = []
+
+    def _mock_select(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(select_responses)
+        return m
+
+    def _mock_password(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(password_responses)
+        return m
+
+    def _mock_text(*_args, **_kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(text_responses)
+        return m
+
+    monkeypatch.setattr(flow, "PROJECT_ENV_PATH", tmp_path / "missing.env")
+    monkeypatch.setattr(flow, "select_prompt", _mock_select)
+    monkeypatch.setattr(flow.questionary, "password", _mock_password)
+    monkeypatch.setattr(flow.questionary, "text", _mock_text)
+    monkeypatch.setattr(flow, "get_store_path", lambda: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "probe_local_target", lambda _path: ProbeResult("local", True, "ok"))
+    monkeypatch.setattr(
+        flow,
+        "validate_telegram_bot",
+        lambda **_kwargs: flow.IntegrationHealthResult(ok=True, detail="Telegram ok"),
+    )
+    monkeypatch.setattr(flow, "save_local_config", lambda **_kwargs: tmp_path / "opensre.json")
+    monkeypatch.setattr(flow, "sync_provider_env", lambda **_kwargs: tmp_path / ".env")
+    monkeypatch.setattr(flow, "save_llm_api_key", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        flow,
+        "sync_env_values",
+        lambda values, **_kwargs: synced_env_values.append(values) or tmp_path / ".env",
+    )
+    monkeypatch.setattr(flow, "sync_env_secret", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        flow,
+        "upsert_integration",
+        lambda service, payload: saved_integrations.append((service, payload)),
+    )
+
+    exit_code = flow.run_wizard()
+
+    assert exit_code == 0
+    assert saved_integrations == [
+        (
+            "telegram",
+            {
+                "credentials": {
+                    "bot_token": "123456:bot-token",
+                    "default_chat_id": "",
+                }
+            },
+        )
+    ]
+    assert synced_env_values == [{}]
+
+
 def test_run_wizard_configures_honeycomb(monkeypatch, tmp_path) -> None:
     select_responses = iter(["quickstart", "anthropic", "claude-opus-4-7", "honeycomb"])
     password_responses = iter(["llm-secret", "hny_test"])

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -529,6 +529,20 @@ def test_validate_telegram_bot_rejects_empty_token() -> None:
     assert "required" in result.detail.lower()
 
 
+def test_validate_telegram_bot_rejects_malformed_token_without_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _unexpected_get(*_a: object, **_kw: object) -> None:
+        raise AssertionError("malformed tokens must not reach Telegram")
+
+    monkeypatch.setattr("httpx.get", _unexpected_get)
+
+    result = validate_telegram_bot(bot_token="123:bad?token")
+
+    assert result.ok is False
+    assert "format is invalid" in result.detail.lower()
+
+
 def test_validate_telegram_bot_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "httpx.get",
@@ -537,7 +551,7 @@ def test_validate_telegram_bot_invalid_token(monkeypatch: pytest.MonkeyPatch) ->
             json=lambda: {"ok": False, "description": "Unauthorized"},
         ),
     )
-    result = validate_telegram_bot(bot_token="bad-token")
+    result = validate_telegram_bot(bot_token="123:badtoken")
     assert result.ok is False
     assert "invalid or revoked" in result.detail.lower()
 
@@ -550,21 +564,27 @@ def test_validate_telegram_bot_api_error_detail(monkeypatch: pytest.MonkeyPatch)
             json=lambda: {"ok": False, "description": "Bad Request: token malformed"},
         ),
     )
-    result = validate_telegram_bot(bot_token="bad-token")
+    result = validate_telegram_bot(bot_token="123:bad_token")
     assert result.ok is False
     assert "token malformed" in result.detail
 
 
-def test_validate_telegram_bot_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_telegram_bot_network_error_redacts_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import httpx as _httpx
 
     def _raise(*_a: object, **_kw: object) -> None:
-        raise _httpx.RequestError("connection refused")
+        raise _httpx.RequestError(
+            "connection refused for https://api.telegram.org/bot123:some_token/getMe"
+        )
 
     monkeypatch.setattr("httpx.get", _raise)
-    result = validate_telegram_bot(bot_token="some-token")
+    result = validate_telegram_bot(bot_token="123:some_token")
     assert result.ok is False
     assert "unreachable" in result.detail.lower()
+    assert "123:some_token" not in result.detail
+    assert "<redacted>" in result.detail
 
 
 def test_validate_betterstack_integration_succeeds(monkeypatch) -> None:

--- a/tests/cli/wizard/test_integration_health.py
+++ b/tests/cli/wizard/test_integration_health.py
@@ -19,6 +19,7 @@ from app.cli.wizard.integration_health import (
     validate_incident_io_integration,
     validate_sentry_integration,
     validate_slack_webhook,
+    validate_telegram_bot,
     validate_vercel_integration,
 )
 from app.integrations.betterstack import BetterStackValidationResult
@@ -50,6 +51,7 @@ def test_legacy_integration_health_import_surface_still_exports_validators() -> 
         "validate_sentry_integration",
         "validate_slack_webhook",
         "validate_splunk_integration",
+        "validate_telegram_bot",
         "validate_vercel_integration",
     }
 
@@ -499,6 +501,68 @@ def test_validate_discord_bot_network_error(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr("httpx.get", _raise)
     result = validate_discord_bot(bot_token="some-token")
+    assert result.ok is False
+    assert "unreachable" in result.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# validate_telegram_bot
+# ---------------------------------------------------------------------------
+
+
+def test_validate_telegram_bot_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "httpx.get",
+        lambda *_a, **_kw: types.SimpleNamespace(
+            status_code=200,
+            json=lambda: {"ok": True, "result": {"username": "opensre_bot"}},
+        ),
+    )
+    result = validate_telegram_bot(bot_token="123:token")
+    assert result.ok is True
+    assert "opensre_bot" in result.detail
+
+
+def test_validate_telegram_bot_rejects_empty_token() -> None:
+    result = validate_telegram_bot(bot_token="  ")
+    assert result.ok is False
+    assert "required" in result.detail.lower()
+
+
+def test_validate_telegram_bot_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "httpx.get",
+        lambda *_a, **_kw: types.SimpleNamespace(
+            status_code=401,
+            json=lambda: {"ok": False, "description": "Unauthorized"},
+        ),
+    )
+    result = validate_telegram_bot(bot_token="bad-token")
+    assert result.ok is False
+    assert "invalid or revoked" in result.detail.lower()
+
+
+def test_validate_telegram_bot_api_error_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "httpx.get",
+        lambda *_a, **_kw: types.SimpleNamespace(
+            status_code=400,
+            json=lambda: {"ok": False, "description": "Bad Request: token malformed"},
+        ),
+    )
+    result = validate_telegram_bot(bot_token="bad-token")
+    assert result.ok is False
+    assert "token malformed" in result.detail
+
+
+def test_validate_telegram_bot_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx as _httpx
+
+    def _raise(*_a: object, **_kw: object) -> None:
+        raise _httpx.RequestError("connection refused")
+
+    monkeypatch.setattr("httpx.get", _raise)
+    result = validate_telegram_bot(bot_token="some-token")
     assert result.ok is False
     assert "unreachable" in result.detail.lower()
 


### PR DESCRIPTION
Fixes #1481

#### Describe the changes you have made in this PR -

- Added Telegram to the `opensre onboard` integration picker.
- Added wizard-side Telegram bot token validation using Telegram's `getMe` endpoint.
- Persisted Telegram bot token/default chat ID through the same integration/env sync path used by the onboarding wizard.
- Updated Telegram messaging docs to document onboarding support while keeping direct `.env` setup as a scripted-deployment path.
- Added regression coverage for the validator import surface, Telegram validator edge cases, and the wizard happy path.

### Demo/Screenshot for feature changes and bug fixes -

Terminal proof:

```text
uv run pytest tests/cli/wizard/test_integration_health.py tests/cli/wizard/test_flow.py -q
72 passed in 4.83s

uv run ruff check app/ tests/
All checks passed!

uv run ruff format --check app/ tests/
1554 files already formatted

uv run mypy app/
Success: no issues found in 687 source files
```

Note: `uv run pytest tests/cli/ -q --maxfail=1` was attempted for the broader CLI scope, but the local Windows process was killed with exit 137 before pytest emitted a failure trace. `uv run pytest tests/cli/ --collect-only -q` successfully collected 1602 tests.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This solves the missing Telegram branch in the onboarding wizard by following the existing Discord/Slack integration pattern: collect saved defaults, prompt for credentials, validate before persistence, then sync the integration record and environment values. The Telegram validator uses `getMe` because it confirms token validity without sending a message; delivery-specific chat routing remains covered by the existing docs and runtime delivery path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions