### PR TITLE
fix(agent): classify OpenAI runtime errors

### DIFF
--- a/app/services/agent_llm_client.py
+++ b/app/services/agent_llm_client.py
@@ -411,6 +411,7 @@ class OpenAIAgentClient:
         self._client = OpenAI(api_key=api_key, base_url=base_url, timeout=_CLIENT_TIMEOUT_SEC)
         self._model = model
         self._max_tokens = max_tokens
+        self._api_key_env = api_key_env
 
     def tool_schemas(self, tools: list[Any]) -> list[dict[str, Any]]:
         return [_openai_tool_schema(t) for t in tools]
@@ -423,6 +424,9 @@ class OpenAIAgentClient:
         tools: list[dict[str, Any]] | None = None,
     ) -> AgentLLMResponse:
         from openai import (
+            APIConnectionError,
+            APIStatusError,
+            APITimeoutError,
             AuthenticationError,
             BadRequestError,
             NotFoundError,
@@ -450,15 +454,44 @@ class OpenAIAgentClient:
                 response = self._client.chat.completions.create(**kwargs)
                 break
             except AuthenticationError as err:
-                raise RuntimeError("OpenAI authentication failed.") from err
+                raise RuntimeError(self._authentication_error_message()) from err
             except NotFoundError as err:
                 raise RuntimeError(f"OpenAI model '{self._model}' not found.") from err
             except BadRequestError as err:
-                raise RuntimeError(f"OpenAI request rejected: {err}") from err
+                raise RuntimeError(f"OpenAI request rejected (HTTP 400): {err}") from err
             except RateLimitError as err:
                 raise RuntimeError(f"OpenAI rate limit exceeded: {err}") from err
             except PermissionDeniedError as err:
                 raise RuntimeError(f"OpenAI request forbidden: {err}") from err
+            except APITimeoutError as err:
+                last_err = err
+                if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                    raise RuntimeError(self._timeout_error_message()) from err
+                time.sleep(backoff)
+                backoff *= 2
+            except APIConnectionError as err:
+                last_err = err
+                if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                    raise RuntimeError(self._connection_error_message()) from err
+                time.sleep(backoff)
+                backoff *= 2
+            except APIStatusError as err:
+                status_code = int(getattr(err, "status_code", 0) or 0)
+                if status_code == 402:
+                    raise RuntimeError(self._billing_error_message()) from err
+                if status_code == 429:
+                    raise RuntimeError(f"OpenAI rate limit exceeded: {err}") from err
+                if 400 <= status_code < 500:
+                    raise RuntimeError(
+                        f"OpenAI request rejected (HTTP {status_code}): {err}"
+                    ) from err
+                last_err = err
+                if attempt == _RETRY_MAX_ATTEMPTS - 1:
+                    raise RuntimeError(
+                        f"OpenAI API failed after {_RETRY_MAX_ATTEMPTS} attempts: {err}"
+                    ) from err
+                time.sleep(backoff)
+                backoff *= 2
             except Exception as err:
                 last_err = err
                 if attempt == _RETRY_MAX_ATTEMPTS - 1:
@@ -494,6 +527,31 @@ class OpenAIAgentClient:
             # exclude_none=True strips null fields (refusal, audio, function_call …)
             # that strict OpenAI-compatible endpoints may reject on replay.
             raw_content=msg.model_dump(exclude_none=True),
+        )
+
+    def _authentication_error_message(self) -> str:
+        api_key_env = getattr(self, "_api_key_env", "OPENAI_API_KEY")
+        return (
+            "OpenAI authentication failed. "
+            f"Check {api_key_env} in your environment, .env, or secure local keychain."
+        )
+
+    @staticmethod
+    def _billing_error_message() -> str:
+        return "OpenAI billing quota exceeded. Check your plan and billing details."
+
+    @staticmethod
+    def _timeout_error_message() -> str:
+        return (
+            "OpenAI API request timed out. "
+            "Check that the service is running and responsive at the configured endpoint."
+        )
+
+    @staticmethod
+    def _connection_error_message() -> str:
+        return (
+            "Cannot connect to OpenAI API. "
+            "Check your network connection and that the endpoint URL is reachable."
         )
 
     @staticmethod

--- a/app/utils/sentry_sdk.py
+++ b/app/utils/sentry_sdk.py
@@ -63,7 +63,7 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bmissing\s+[A-Z0-9_]+_API_KEY\b", re.I),
     # Pydantic validation: "LLM provider 'minimax' requires MINIMAX_API_KEY to be set."
     re.compile(r"\brequires\s+[A-Z0-9_]+_API_KEY\s+to\s+be\s+set\b", re.I),
-    re.compile(r"\brate limit exceeded\b.*\b(?:quota|billing)\b", re.I),
+    re.compile(r"\brate limit exceeded\b", re.I),
     re.compile(r"\bcredit balance is too low\b", re.I),
     # llm_client.py uses "was not found"; agent_llm_client.py uses "not found" — cover both.
     re.compile(r"\bmodel\s+['\"][^'\"]+['\"]\s+(?:was )?not found\b", re.I),
@@ -76,6 +76,7 @@ _OPERATOR_ACTIONABLE_LLM_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Provider read timeout after retries — anchored to the suffix produced by
     # _format_openai_connection_error so generic non-LLM timeout messages are unaffected.
     re.compile(r"\bapi request timed out\. check that the service is running\b", re.I),
+    re.compile(r"\bapi failed after\s+\d+\s+attempts\b.*\boverloaded\b", re.I | re.DOTALL),
     # Anthropic / provider account-level usage-limit enforcement (HTTP 400).
     re.compile(r"\byou have reached your specified api usage limits\b", re.I),
     # Billing quota exhausted: catches the OpenAI ``insufficient_quota`` path

--- a/tests/services/test_agent_llm_client.py
+++ b/tests/services/test_agent_llm_client.py
@@ -223,6 +223,18 @@ def _install_fake_openai(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespa
     class AuthenticationError(Exception):
         pass
 
+    class APIConnectionError(Exception):
+        pass
+
+    class APIStatusError(Exception):
+        def __init__(self, message: str, *, status_code: int, body: dict | None = None) -> None:
+            super().__init__(message)
+            self.status_code = status_code
+            self.body = body or {}
+
+    class APITimeoutError(Exception):
+        pass
+
     class BadRequestError(Exception):
         pass
 
@@ -242,6 +254,9 @@ def _install_fake_openai(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespa
             )
 
     fake_module.AuthenticationError = AuthenticationError
+    fake_module.APIConnectionError = APIConnectionError
+    fake_module.APIStatusError = APIStatusError
+    fake_module.APITimeoutError = APITimeoutError
     fake_module.BadRequestError = BadRequestError
     fake_module.NotFoundError = NotFoundError
     fake_module.RateLimitError = RateLimitError
@@ -453,6 +468,134 @@ def test_openai_rate_limit_error_is_not_retried(
         client.invoke(messages=[{"role": "user", "content": "hi"}])
 
     assert call_count == 1, "429 should not retry"
+
+
+def test_openai_authentication_error_includes_config_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_openai = _install_fake_openai(monkeypatch)
+
+    def raise_auth(**_: object) -> object:
+        raise fake_openai.AuthenticationError("bad key")
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=raise_auth))
+    )
+    client._model = "gpt-4o"
+    client._max_tokens = 512
+    client._api_key_env = "OPENROUTER_API_KEY"
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    message = str(exc.value)
+    assert "OpenAI authentication failed" in message
+    assert "OPENROUTER_API_KEY" in message
+
+
+def test_openai_billing_status_error_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_openai = _install_fake_openai(monkeypatch)
+    monkeypatch.setattr("app.services.agent_llm_client.time.sleep", lambda _: None)
+    call_count = 0
+
+    def raise_billing(**_: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        raise fake_openai.APIStatusError("payment required", status_code=402)
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=raise_billing))
+    )
+    client._model = "openrouter/gpt-4o"
+    client._max_tokens = 512
+
+    with pytest.raises(RuntimeError, match="billing quota exceeded"):
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert call_count == 1
+
+
+def test_openai_timeout_error_retries_then_raises_actionable_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_openai = _install_fake_openai(monkeypatch)
+    monkeypatch.setattr("app.services.agent_llm_client.time.sleep", lambda _: None)
+    call_count = 0
+
+    def raise_timeout(**_: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        raise fake_openai.APITimeoutError("request timed out")
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=raise_timeout))
+    )
+    client._model = "gpt-4o"
+    client._max_tokens = 512
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert call_count == 3
+    assert "API request timed out" in str(exc.value)
+    assert "configured endpoint" in str(exc.value)
+
+
+def test_openai_connection_error_retries_then_raises_actionable_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_openai = _install_fake_openai(monkeypatch)
+    monkeypatch.setattr("app.services.agent_llm_client.time.sleep", lambda _: None)
+    call_count = 0
+
+    def raise_connection(**_: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        raise fake_openai.APIConnectionError("connection error")
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=raise_connection))
+    )
+    client._model = "gpt-4o"
+    client._max_tokens = 512
+
+    with pytest.raises(RuntimeError) as exc:
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert call_count == 3
+    assert "Cannot connect to OpenAI API" in str(exc.value)
+    assert "endpoint URL" in str(exc.value)
+
+
+def test_openai_server_status_error_is_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_openai = _install_fake_openai(monkeypatch)
+    monkeypatch.setattr("app.services.agent_llm_client.time.sleep", lambda _: None)
+    call_count = 0
+
+    def raise_server_error(**_: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        raise fake_openai.APIStatusError("bad gateway", status_code=502)
+
+    client = OpenAIAgentClient.__new__(OpenAIAgentClient)
+    client._client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=raise_server_error))
+    )
+    client._model = "gpt-4o"
+    client._max_tokens = 512
+
+    with pytest.raises(RuntimeError, match="API failed after 3 attempts"):
+        client.invoke(messages=[{"role": "user", "content": "hi"}])
+
+    assert call_count == 3
 
 
 def test_openai_permission_denied_error_is_not_retried(

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -785,6 +785,10 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
             "Openai rate limit exceeded (HTTP 429) after multiple retries. Check your quota and billing details.",
         ),
         (
+            "RuntimeError",
+            "OpenAI rate limit exceeded: Error code: 429 - {'error': {'message': 'model busy'}}",
+        ),
+        (
             "BadRequestError",
             "Your credit balance is too low to access the Anthropic API.",
         ),
@@ -815,7 +819,19 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
         ),
         (
             "RuntimeError",
+            "OpenAI API request timed out. Check that the service is running and responsive at the configured endpoint.",
+        ),
+        (
+            "RuntimeError",
             "Minimax API request timed out. Check that the service is running and responsive at the configured endpoint.",
+        ),
+        (
+            "RuntimeError",
+            "OpenAI billing quota exceeded. Check your plan and billing details.",
+        ),
+        (
+            "RuntimeError",
+            "Cannot connect to OpenAI API. Check your network connection and that the endpoint URL is reachable.",
         ),
         # Anthropic account-level usage limit enforcement via HTTP 400 (issues #1883, #1885).
         (
@@ -839,6 +855,10 @@ def test_before_send_filters_nested_lists_of_dicts() -> None:
         (
             "RuntimeError",
             "OpenAI model 'llama3.2' not found.",
+        ),
+        (
+            "RuntimeError",
+            "Anthropic API failed after 3 attempts: Error code: 529 - {'error': {'type': 'overloaded_error', 'message': 'Overloaded'}}",
         ),
     ],
 )


### PR DESCRIPTION
Fixes #2344
Fixes #2332
Fixes #2331
Fixes #2273
Fixes #2272
Fixes #2289
Fixes #2288
Fixes #2226
Refs #2330

#### Describe the changes you have made in this PR -

- Adds explicit OpenAI-compatible agent handling for auth, billing, timeout, connection, 4xx, 429, and 5xx SDK errors.
- Preserves retry behavior for transient timeout/connection/5xx failures while failing fast for deterministic auth/billing/config failures.
- Extends Sentry filtering for operator-actionable or provider-transient LLM failures so external provider noise does not page as internal OpenSRE bugs.
- Adds regression coverage for OpenAI agent error classes and Sentry before-send filtering.

### Demo/Screenshot for feature changes and bug fixes -

Terminal proof:

```text
uv run pytest tests/services/test_agent_llm_client.py tests/test_sentry_init.py -q
124 passed in 4.46s

uv run ruff check app/services/agent_llm_client.py app/utils/sentry_sdk.py tests/services/test_agent_llm_client.py tests/test_sentry_init.py
All checks passed!

uv run ruff format --check app/services/agent_llm_client.py app/utils/sentry_sdk.py tests/services/test_agent_llm_client.py tests/test_sentry_init.py
4 files already formatted

uv run mypy app/services/agent_llm_client.py app/utils/sentry_sdk.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The agent LLM client already separated deterministic provider errors from generic retryable exceptions for several Anthropic paths, but the OpenAI-compatible branch still let important SDK classes fall through to broad `Exception` handling. I added explicit classification at the provider boundary: deterministic auth/billing/config failures raise immediately with actionable messages, transient network/timeouts/5xx keep the bounded retry loop, and final user-facing messages align with the existing Sentry de-noise patterns. The tests construct minimal fake OpenAI SDK errors so each branch is exercised without live provider calls.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions