### PR TITLE
fix(integrations): quiet expected env validation failures

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.config import get_tracer_base_url
 from app.integrations.airflow import (
     DEFAULT_AIRFLOW_BASE_URL,
@@ -95,10 +97,17 @@ def _report_env_loader_failure(exc: BaseException, *, integration: str) -> None:
     """Route a per-vendor env-loader failure to Sentry + warning log.
 
     Replaces ``except Exception: pass`` and ``logger.debug(..., exc_info=True)``
-    paths in ``load_env_integrations``: integration is still skipped, but the
-    misconfiguration reaches Sentry rather than being lost to debug output
-    (#1468).
+    paths in ``load_env_integrations``: integration is still skipped. Expected
+    Pydantic validation errors stay local to avoid paging on user config, while
+    unexpected loader exceptions still reach Sentry (#1468).
     """
+    if isinstance(exc, ValidationError):
+        logger.warning(
+            "env_loader_invalid: integration=%s validation_errors=%d",
+            integration,
+            exc.error_count(),
+        )
+        return
     report_exception(
         exc,
         logger=logger,

--- a/tests/integrations/test_argocd_catalog_verify.py
+++ b/tests/integrations/test_argocd_catalog_verify.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from app.integrations.catalog import classify_integrations, resolve_effective_integrations
@@ -134,6 +136,19 @@ def test_resolve_effective_integrations_ignores_invalid_argocd_env(
     monkeypatch.setenv("ARGOCD_PASSWORD", "pw")
 
     assert "argocd" not in resolve_effective_integrations()
+
+
+def test_invalid_argocd_env_validation_is_not_reported_to_sentry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.integrations.catalog.load_integrations", lambda: [])
+    monkeypatch.setenv("ARGOCD_BASE_URL", "http://argocd.example.com")
+    monkeypatch.setenv("ARGOCD_AUTH_TOKEN", "tok_env")
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        assert "argocd" not in resolve_effective_integrations()
+
+    mock_report.assert_not_called()
 
 
 def test_argocd_multi_instance_env_is_propagated(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -10,11 +10,13 @@ or ``logger.debug(..., exc_info=True)`` with no Sentry trace:
      openclaw, mariadb, rabbitmq, rds, betterstack, alertmanager,
      victoria_logs, supabase).
 
-After the fix every site routes through ``_report_classify_failure`` or
-``_report_env_loader_failure``, which call ``report_exception`` with
+After the fix every unexpected site routes through ``_report_classify_failure``
+or ``_report_env_loader_failure``, which call ``report_exception`` with
 ``surface=integration``, ``component=app.integrations._catalog_impl``,
-``event=classify_failed`` / ``event=env_loader_failed``, and the vendor
-tag — preserving the historic "skip the integration" caller contract.
+``event=classify_failed`` / ``event=env_loader_failed``, and the vendor tag.
+Expected pydantic env validation errors are skipped with a local warning,
+preserving the historic "skip the integration" caller contract without
+creating Sentry noise for user config.
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from app.integrations._catalog_impl import (
     _classify_service_instance,
@@ -72,6 +75,23 @@ def test_report_env_loader_failure_forwards_tags() -> None:
         "integration": "rabbitmq",
         "event": "env_loader_failed",
     }
+
+
+def test_report_env_loader_failure_skips_expected_validation_errors() -> None:
+    class _EnvConfig(BaseModel):
+        value: int
+
+    try:
+        _EnvConfig(value="not-an-int")
+    except ValidationError as exc:
+        validation_error = exc
+    else:  # pragma: no cover - pydantic should always reject this fixture
+        raise AssertionError("expected validation error")
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        _report_env_loader_failure(validation_error, integration="argocd")
+
+    mock_report.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2421

#### Describe the changes you have made in this PR -

- Keeps env-derived integration discovery from reporting expected Pydantic validation errors to Sentry.
- Preserves Sentry reporting for unexpected env-loader exceptions so real loader regressions remain visible.
- Adds Argo CD-specific regression coverage for invalid plain-HTTP remote env config.

### Demo/Screenshot for feature changes and bug fixes -

Terminal proof:

```text
uv run pytest tests/integrations/test_argocd_catalog_verify.py tests/integrations/test_catalog_silent_fallback_elimination.py -q
63 passed in 12.12s

uv run ruff check app/integrations/_catalog_impl.py tests/integrations/test_argocd_catalog_verify.py tests/integrations/test_catalog_silent_fallback_elimination.py
All checks passed!

uv run ruff format --check app/integrations/_catalog_impl.py tests/integrations/test_argocd_catalog_verify.py tests/integrations/test_catalog_silent_fallback_elimination.py
3 files already formatted

uv run mypy app/integrations/_catalog_impl.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`load_env_integrations()` should skip invalid user-provided env configuration, but a Pydantic `ValidationError` from an invalid Argo CD URL is not an internal loader defect. The shared env-loader reporting helper now treats Pydantic validation as expected operator config and logs a safe count-only warning, while continuing to send unexpected runtime failures through the existing `report_exception` path.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions