### PR TITLE
fix(remote): keep IMDS probe misses local

### DIFF
--- a/app/remote/server.py
+++ b/app/remote/server.py
@@ -657,13 +657,7 @@ def _imds_token() -> str | None:
             _mark_remote_recovered("imds_token_fetch_failed")
             return token
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
-        _report_remote_once(
-            exc,
-            component="server",
-            event="imds_token_fetch_failed",
-            message="IMDS token fetch failed",
-            severity="info",
-        )
+        logger.debug("IMDS token fetch unavailable: %s", exc)
         return None
 
 
@@ -677,14 +671,7 @@ def _imds_get(path: str, *, token: str | None) -> str | None:
             _mark_remote_recovered("imds_metadata_fetch_failed", extras)
             return value
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
-        _report_remote_once(
-            exc,
-            component="server",
-            event="imds_metadata_fetch_failed",
-            message=f"IMDS metadata fetch failed for {path}",
-            severity="info",
-            extras=extras,
-        )
+        logger.debug("IMDS metadata fetch unavailable for %s: %s", path, exc)
         return None
 
 

--- a/tests/remote/test_server.py
+++ b/tests/remote/test_server.py
@@ -506,7 +506,9 @@ def test_imds_get_returns_none_on_url_error(monkeypatch: pytest.MonkeyPatch) -> 
     assert _imds_get("latest/meta-data/instance-id", token="test-token") is None
 
 
-def test_imds_token_reports_failure_once(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_imds_token_does_not_report_expected_probe_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def _raise_url_error(*args: object, **kwargs: object) -> None:
         raise urllib.error.URLError("connection refused")
 
@@ -517,13 +519,12 @@ def test_imds_token_reports_failure_once(monkeypatch: pytest.MonkeyPatch) -> Non
         assert _imds_token() is None
         assert _imds_token() is None
 
-    report.assert_called_once()
-    assert report.call_args.kwargs["component"] == "server"
-    assert report.call_args.kwargs["event"] == "imds_token_fetch_failed"
-    assert report.call_args.kwargs["severity"] == "info"
+    report.assert_not_called()
 
 
-def test_imds_token_reports_again_after_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_imds_token_expected_probe_failure_stays_unreported_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     responses: list[object] = [
         urllib.error.URLError("connection refused"),
         urllib.error.URLError("connection refused"),
@@ -546,11 +547,12 @@ def test_imds_token_reports_again_after_success(monkeypatch: pytest.MonkeyPatch)
         assert _imds_token() == "test-token"
         assert _imds_token() is None
 
-    assert report.call_count == 2
-    assert report.call_args.kwargs["event"] == "imds_token_fetch_failed"
+    report.assert_not_called()
 
 
-def test_imds_get_reports_failure_once(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_imds_get_does_not_report_expected_probe_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def _raise_url_error(*args: object, **kwargs: object) -> None:
         raise urllib.error.URLError("connection refused")
 
@@ -561,13 +563,12 @@ def test_imds_get_reports_failure_once(monkeypatch: pytest.MonkeyPatch) -> None:
         assert _imds_get("latest/meta-data/instance-id", token="test-token") is None
         assert _imds_get("latest/meta-data/instance-id", token="test-token") is None
 
-    report.assert_called_once()
-    assert report.call_args.kwargs["component"] == "server"
-    assert report.call_args.kwargs["event"] == "imds_metadata_fetch_failed"
-    assert report.call_args.kwargs["severity"] == "info"
+    report.assert_not_called()
 
 
-def test_imds_get_reports_again_after_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_imds_get_expected_probe_failure_stays_unreported_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     responses: list[object] = [
         urllib.error.URLError("connection refused"),
         urllib.error.URLError("connection refused"),
@@ -590,8 +591,7 @@ def test_imds_get_reports_again_after_success(monkeypatch: pytest.MonkeyPatch) -
         assert _imds_get("latest/meta-data/instance-id", token="test-token") == "i-123"
         assert _imds_get("latest/meta-data/instance-id", token="test-token") is None
 
-    assert report.call_count == 2
-    assert report.call_args.kwargs["event"] == "imds_metadata_fetch_failed"
+    report.assert_not_called()
 
 
 def test_check_llm_connectivity_reports_bedrock_failure(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #2427
Fixes #2277
Fixes #2278

#### Describe the changes you have made in this PR -

- Stops reporting expected EC2 IMDS probe misses to Sentry from the remote server startup path.
- Keeps the remote server behavior unchanged: missing IMDS still returns `None`, and successful probes still populate instance metadata.
- Leaves higher-signal remote health failures, such as Bedrock connectivity failures, on the existing `report_remote_exception` path.
- Updates remote server regression tests to assert IMDS URL/timeout/OS probe misses stay local.

### Demo/Screenshot for feature changes and bug fixes -

Terminal proof:

```text
uv run pytest tests/remote/test_server.py -q
54 passed in 7.41s

uv run ruff check app/remote/server.py tests/remote/test_server.py
All checks passed!

uv run ruff format --check app/remote/server.py tests/remote/test_server.py
2 files already formatted

uv run mypy app/remote/server.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The remote server probes IMDS opportunistically to enrich `/ok` with EC2 metadata. Connection refused and timeout errors are expected on local machines, non-EC2 hosts, and locked-down networks, so those probe misses should not create Sentry issues. The patch keeps the metadata fallback contract intact and converts those expected misses to debug logs, while leaving unrelated remote health reporting untouched.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions