### PR TITLE
fix(datadog): keep monitor transport misses local

### DIFF
--- a/app/services/datadog/client.py
+++ b/app/services/datadog/client.py
@@ -230,6 +230,13 @@ class DatadogClient:
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
+        except httpx.TransportError as exc:
+            logger.warning(
+                "[datadog] list_monitors transport error type=%s detail=%s",
+                type(exc).__name__,
+                exc,
+            )
+            return {"success": False, "error": str(exc)}
         except Exception as exc:
             capture_service_error(
                 exc,

--- a/tests/services/test_datadog_client.py
+++ b/tests/services/test_datadog_client.py
@@ -170,6 +170,20 @@ def test_list_monitors_http_error(client, mock_httpx_client):
     assert "HTTP 403" in result["error"]
 
 
+def test_list_monitors_transport_error_is_not_reported(client, mock_httpx_client):
+    mock_instance = MagicMock()
+    mock_httpx_client.return_value = mock_instance
+    mock_instance.get.side_effect = httpx.ConnectError("dns failed")
+
+    with patch("app.services.datadog.client.capture_service_error") as capture:
+        result = client.list_monitors()
+
+    mock_instance.get.assert_called_once()
+    capture.assert_not_called()
+    assert result["success"] is False
+    assert result["error"] == "dns failed"
+
+
 def test_list_monitors_generic_exception(client, mock_httpx_client):
     mock_instance = MagicMock()
     mock_httpx_client.return_value = mock_instance


### PR DESCRIPTION
Fixes #2236

#### Describe the changes you have made in this PR -

- Handles Datadog monitor-list transport failures as expected connectivity/configuration failures.
- Keeps HTTP status failures and unexpected exceptions on the existing service-client telemetry path.
- Adds a regression test proving DNS/connect failures return a tool-safe error without calling `capture_service_error`.

### Demo/Screenshot for feature changes and bug fixes -

Terminal proof:

```text
uv run pytest tests/services/test_datadog_client.py -q
20 passed in 3.18s

uv run ruff check app/services/datadog/client.py tests/services/test_datadog_client.py
All checks passed!

uv run ruff format --check app/services/datadog/client.py tests/services/test_datadog_client.py
2 files already formatted

uv run mypy app/services/datadog/client.py
Success: no issues found in 1 source file
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

`list_monitors()` already returns structured failure payloads for Datadog errors. A DNS/connect failure means the configured Datadog endpoint is unreachable from the user runtime, so it should be visible to the caller and logs but should not create an internal service-client Sentry event. The new branch is intentionally scoped to `httpx.TransportError`; HTTP status errors and unexpected exceptions still use the existing telemetry helper.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions