### PR TITLE
fix(remote): keep expected connection failures local

### DIFF
--- a/app/cli/support/exception_reporting.py
+++ b/app/cli/support/exception_reporting.py
@@ -17,7 +17,7 @@ def should_report_exception(exc: BaseException, *, expected: bool = False) -> bo
         return False
     if isinstance(exc, (KeyboardInterrupt, EOFError, OpenSREError, click.Abort)):
         return False
-    return not isinstance(exc, click.UsageError)
+    return not isinstance(exc, (click.ClickException, click.UsageError))
 
 
 def report_exception(

--- a/app/remote/client.py
+++ b/app/remote/client.py
@@ -290,28 +290,10 @@ class RemoteAgentClient:
                 system=system,
             )
         except httpx.TimeoutException as exc:
-            report_remote_exception(
-                exc,
-                logger=logger,
-                component="client",
-                event="preflight_timeout",
-                message="Remote preflight timed out",
-                severity="warning",
-                extras={"base_url": self.base_url},
-                include_traceback=False,
-            )
+            logger.warning("Remote preflight timed out for %s: %s", self.base_url, exc)
             return PreflightResult(ok=False, error="connection timed out")
         except httpx.ConnectError as exc:
-            report_remote_exception(
-                exc,
-                logger=logger,
-                component="client",
-                event="preflight_connection_refused",
-                message="Remote preflight connection failed",
-                severity="warning",
-                extras={"base_url": self.base_url},
-                include_traceback=False,
-            )
+            logger.warning("Remote preflight connection failed for %s: %s", self.base_url, exc)
             return PreflightResult(ok=False, error="connection refused")
         except httpx.HTTPStatusError as exc:
             report_remote_exception(

--- a/tests/cli/test_exception_reporting.py
+++ b/tests/cli/test_exception_reporting.py
@@ -13,6 +13,7 @@ def test_should_not_report_unknown_command_usage_error() -> None:
 
 def test_should_not_report_expected_cli_errors() -> None:
     assert should_report_exception(click.UsageError("No such option: --bogus")) is False
+    assert should_report_exception(click.ClickException("remote is unavailable")) is False
     assert should_report_exception(OpenSREError("missing integration")) is False
     assert should_report_exception(KeyboardInterrupt()) is False
     assert should_report_exception(click.Abort()) is False

--- a/tests/remote/test_client.py
+++ b/tests/remote/test_client.py
@@ -458,7 +458,7 @@ class TestPreflight:
         assert report.call_args.kwargs["event"] == "endpoint_probe_failed"
         assert report.call_args.kwargs["severity"] == "warning"
 
-    def test_preflight_reports_timeout(self) -> None:
+    def test_preflight_keeps_timeout_local(self) -> None:
         client = RemoteAgentClient("http://host:2024")
         with (
             patch.object(client, "health", side_effect=httpx.TimeoutException("timed out")),
@@ -468,12 +468,9 @@ class TestPreflight:
 
         assert result.ok is False
         assert result.error == "connection timed out"
-        report.assert_called_once()
-        assert report.call_args.kwargs["event"] == "preflight_timeout"
-        assert report.call_args.kwargs["severity"] == "warning"
-        assert report.call_args.kwargs["include_traceback"] is False
+        report.assert_not_called()
 
-    def test_preflight_reports_connection_refused_without_traceback(self) -> None:
+    def test_preflight_keeps_connection_refused_local(self) -> None:
         client = RemoteAgentClient("http://host:2024")
         with (
             patch.object(client, "health", side_effect=httpx.ConnectError("refused")),
@@ -483,10 +480,7 @@ class TestPreflight:
 
         assert result.ok is False
         assert "connection refused" in (result.error or "")
-        report.assert_called_once()
-        assert report.call_args.kwargs["event"] == "preflight_connection_refused"
-        assert report.call_args.kwargs["severity"] == "warning"
-        assert report.call_args.kwargs["include_traceback"] is False
+        report.assert_not_called()
 
     def test_preflight_reports_unexpected_failure(self) -> None:
         client = RemoteAgentClient("http://host:2024")


### PR DESCRIPTION
Fixes #2235
Fixes #2276

#### Describe the changes you have made in this PR -

- Keeps remote preflight timeout/connect-refused failures as local warnings with structured `PreflightResult` errors.
- Leaves remote HTTP status failures and unexpected client failures on the existing Sentry path.
- Treats ClickException as expected CLI output rather than an internal crash report.
- Adds regression coverage for remote preflight timeouts/connect failures and CLI exception reporting policy.

### Demo/Screenshot for feature changes and bug fixes -

Terminal proof:

```text
uv run pytest tests/remote/test_client.py tests/cli/test_exception_reporting.py tests/cli/test_remote.py -q
60 passed in 4.96s

uv run ruff check app/remote/client.py app/cli/support/exception_reporting.py tests/remote/test_client.py tests/cli/test_exception_reporting.py tests/cli/test_remote.py
All checks passed!

uv run ruff format --check app/remote/client.py app/cli/support/exception_reporting.py tests/remote/test_client.py tests/cli/test_exception_reporting.py tests/cli/test_remote.py
5 files already formatted

uv run mypy app/remote/client.py app/cli/support/exception_reporting.py
Success: no issues found in 2 source files
```

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Remote preflight is a user-facing connectivity probe. Timeout and connect-refused failures should produce actionable CLI output and logs, not Sentry events for OpenSRE internals. I scoped the no-report path to `httpx.TimeoutException` and `httpx.ConnectError`; HTTP responses and unexpected exceptions still report. The CLI boundary now also treats `click.ClickException` as expected user-facing output, matching how commands intentionally surface actionable failures.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions