### PR TITLE
fix(synthetic): normalize topology target groups

### DIFF
--- a/tests/synthetic/rds_postgres/scenario_loader.py
+++ b/tests/synthetic/rds_postgres/scenario_loader.py
@@ -41,6 +41,7 @@ class ScenarioMetadata:
     scenario_difficulty: int = 1
     adversarial_signals: list[str] = ()  # type: ignore[assignment]
     depends_on: str = ""
+    topology: dict[str, Any] | None = None
 
 
 TrajectoryMatching = Literal["strict", "lcs", "set"]
@@ -239,6 +240,7 @@ def _validated_metadata(raw: dict[str, Any]) -> ScenarioMetadata:
         scenario_difficulty=validated.get("scenario_difficulty", 1),  # type: ignore[arg-type]
         adversarial_signals=list(validated.get("adversarial_signals") or []),
         depends_on=validated.get("depends_on", ""),  # type: ignore[arg-type]
+        topology=dict(validated["topology"]) if "topology" in validated else None,
     )
 
 

--- a/tests/synthetic/rds_postgres/test_suite.py
+++ b/tests/synthetic/rds_postgres/test_suite.py
@@ -52,6 +52,51 @@ def test_scenario_evidence_matches_available_evidence() -> None:
         )
 
 
+def test_topology_string_target_group_arn_normalizes_to_list() -> None:
+    fixture = load_scenario(SUITE_DIR / "015-mysql-ec2-load-attribution")
+
+    topology = fixture.metadata.topology or {}
+
+    assert topology["target_group_arn"] == (
+        "arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/orders-web-tg/def456"
+    )
+    assert topology["target_group_arns"] == [topology["target_group_arn"]]
+
+
+def test_topology_list_target_group_arn_normalizes_to_list() -> None:
+    real_dir = SUITE_DIR / "999-test-list-target-groups"
+    real_dir.mkdir(exist_ok=True)
+    try:
+        (real_dir / "scenario.yml").write_text(
+            textwrap.dedent("""\
+            base: 000-healthy
+            scenario_id: 999-test-list-target-groups
+            failure_mode: healthy
+            severity: info
+            topology:
+              target_group_arn:
+                - arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/acme/aaa111
+                - arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/bravo/bbb222
+                - arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/charlie/ccc333
+        """)
+        )
+        _write_minimal_answer_yml(real_dir)
+
+        fixture = load_scenario(real_dir)
+        topology = fixture.metadata.topology or {}
+
+        assert topology["target_group_arns"] == topology["target_group_arn"]
+        assert topology["target_group_arns"] == [
+            "arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/acme/aaa111",
+            "arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/bravo/bbb222",
+            "arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/charlie/ccc333",
+        ]
+    finally:
+        for f in real_dir.iterdir():
+            f.unlink()
+        real_dir.rmdir()
+
+
 def test_score_result_does_not_apply_failover_wording_to_storage_scenario() -> None:
     fixture = load_scenario(SUITE_DIR / "008-storage-full-missing-metric")
 

--- a/tests/synthetic/schemas.py
+++ b/tests/synthetic/schemas.py
@@ -256,7 +256,8 @@ class TopologyMetadata(TypedDict, total=False):
 
     vpc_id: str
     load_balancer_arn: str
-    target_group_arn: str
+    target_group_arn: str | list[str]
+    target_group_arns: list[str]
     tiers: list[TopologyTier]
 
 
@@ -620,6 +621,8 @@ def validate_scenario_metadata(data: dict[str, Any]) -> ScenarioMetadataSchema:
             f"{ctx}: unknown evidence source(s) {unknown}; expected subset of {sorted(VALID_EVIDENCE_SOURCES)}"
         )
 
+    _normalize_topology_target_groups(data, ctx)
+
     return data  # type: ignore[return-value]
 
 
@@ -654,3 +657,30 @@ def _require_non_empty_str_list(
 
     if not all(isinstance(item, str) and item.strip() for item in value):
         raise ValueError(f"{ctx}: all '{key}' entries must be non-empty strings")
+
+
+def _normalize_topology_target_groups(data: dict[str, Any], ctx: str) -> None:
+    topology = data.get("topology")
+    if topology is None:
+        return
+    if not isinstance(topology, dict):
+        raise ValueError(f"{ctx}: 'topology' must be an object when present")
+
+    raw_arn = topology.get("target_group_arn")
+    if raw_arn is None:
+        topology["target_group_arns"] = []
+        return
+    if isinstance(raw_arn, str):
+        topology["target_group_arns"] = [raw_arn]
+        return
+    if isinstance(raw_arn, list):
+        if not all(isinstance(item, str) for item in raw_arn):
+            raise ValueError(
+                f"{ctx}: 'topology.target_group_arn' must contain only strings when it is a list"
+            )
+        topology["target_group_arns"] = list(raw_arn)
+        return
+
+    raise ValueError(
+        f"{ctx}: 'topology.target_group_arn' must be a string or list of strings when present"
+    )


### PR DESCRIPTION
Fixes #2100.

## What changed
- Lets `topology.target_group_arn` be either a single string or a list of strings.
- Normalizes the loaded topology to `target_group_arns` so downstream fixture consumers have one list shape.
- Carries normalized topology through `ScenarioMetadata` and adds coverage for both existing string-form and new list-form fixtures.

## Notes
- Current `main` only has RDS synthetic scenarios through `020`, so there is no `022` fixture to update on this branch. The list-form loader test covers the multi-target-group shape requested for future `022`/multi-tenant scenarios.

## Validation
- `uv run pytest tests/synthetic/rds_postgres/test_suite.py -q -k "topology or scenario_metadata or scenario_evidence or load_all"`
- `uv run ruff check tests/synthetic/schemas.py tests/synthetic/rds_postgres/scenario_loader.py tests/synthetic/rds_postgres/test_suite.py`
- `uv run ruff format --check tests/synthetic/schemas.py tests/synthetic/rds_postgres/scenario_loader.py tests/synthetic/rds_postgres/test_suite.py`
- `uv run mypy tests/synthetic/schemas.py tests/synthetic/rds_postgres/scenario_loader.py`

I also tried the full `tests/synthetic/rds_postgres/test_suite.py`; its live LLM parametrized cases fail locally before this code path because `ANTHROPIC_API_KEY` is not set.

## AI checklist
- [x] I reviewed the relevant issue and verified it is open/unassigned before starting.
- [x] I kept the change scoped to the fixture schema/loader boundary requested in the issue.
- [x] I added regression coverage for both string and list topology target group forms.
- [x] I ran targeted tests, lint, format check, and type checking listed above.