### PR TITLE
fix(integrations): handle expected mongodb validation failures

### DIFF
--- a/app/integrations/mongodb.py
+++ b/app/integrations/mongodb.py
@@ -13,6 +13,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from pydantic import Field, field_validator
+from pymongo.errors import (
+    ConfigurationError,
+    ConnectionFailure,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
 
 from app.integrations._validation_helpers import report_validation_failure
 from app.strict_config import StrictConfigModel
@@ -99,6 +105,27 @@ def _get_client(config: MongoDBConfig) -> Any:
     )
 
 
+def _expected_validation_error_detail(err: Exception) -> str | None:
+    if isinstance(err, OperationFailure):
+        if err.code == 18:
+            return "MongoDB authentication failed. Check the username, password, and authSource."
+        if err.code == 13:
+            return "MongoDB user is not authorized to run the validation ping."
+    if isinstance(err, ConfigurationError):
+        return f"MongoDB configuration is invalid: {err}"
+    if isinstance(err, ServerSelectionTimeoutError):
+        return (
+            "MongoDB server selection timed out. Check the host, TLS setting, "
+            "network/firewall access, and replica set reachability."
+        )
+    if isinstance(err, ConnectionFailure):
+        return (
+            "MongoDB connection failed. Check the host, TLS setting, "
+            "network/firewall access, and replica set reachability."
+        )
+    return None
+
+
 def validate_mongodb_config(config: MongoDBConfig) -> MongoDBValidationResult:
     """Validate MongoDB connectivity with a lightweight ping command."""
     if not config.connection_string:
@@ -123,6 +150,10 @@ def validate_mongodb_config(config: MongoDBConfig) -> MongoDBValidationResult:
         finally:
             client.close()
     except Exception as err:
+        expected_detail = _expected_validation_error_detail(err)
+        if expected_detail is not None:
+            logger.warning("[mongodb] validate_mongodb_config failed: %s", expected_detail)
+            return MongoDBValidationResult(ok=False, detail=expected_detail)
         report_validation_failure(
             err,
             logger=logger,

--- a/tests/test_mongodb_integration.py
+++ b/tests/test_mongodb_integration.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
+
 from app.integrations.catalog import classify_integrations as _classify_integrations
 from app.integrations.mongodb import (
     MongoDBConfig,
@@ -108,6 +110,43 @@ class TestMongoDBValidation:
         result = validate_mongodb_config(config)
         assert result.ok is False
         assert "Conn error" in result.detail
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_validate_auth_failure_returns_actionable_detail_without_sentry(
+        self, mock_report, mock_get_client
+    ):
+        mock_client = MagicMock()
+        mock_client.admin.command.side_effect = OperationFailure(
+            "Authentication failed.",
+            code=18,
+        )
+        mock_get_client.return_value = mock_client
+
+        config = MongoDBConfig(connection_string="mongodb://host")
+        result = validate_mongodb_config(config)
+
+        assert result.ok is False
+        assert "authentication failed" in result.detail.lower()
+        assert "authSource" in result.detail
+        mock_report.assert_not_called()
+        mock_client.close.assert_called_once()
+
+    @patch("app.integrations.mongodb._get_client")
+    @patch("app.integrations.mongodb.report_validation_failure")
+    def test_validate_server_selection_timeout_without_sentry(self, mock_report, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.admin.command.side_effect = ServerSelectionTimeoutError("SSL handshake failed")
+        mock_get_client.return_value = mock_client
+
+        config = MongoDBConfig(connection_string="mongodb://host")
+        result = validate_mongodb_config(config)
+
+        assert result.ok is False
+        assert "server selection timed out" in result.detail
+        assert "TLS setting" in result.detail
+        mock_report.assert_not_called()
+        mock_client.close.assert_called_once()
 
 
 class TestMongoDBAdminUnauthorized:


### PR DESCRIPTION
Fixes #2352.
Fixes #2351.

## What changed
- Classifies expected MongoDB validation failures before the broad Sentry-reporting fallback.
- Returns actionable validation messages for authentication failures, authorization failures, configuration errors, server-selection timeouts, and connection failures.
- Keeps unexpected MongoDB validation errors reporting through `report_validation_failure`.

## Validation
- `uv run pytest tests/test_mongodb_integration.py tests/integrations/test_validator_sentry_capture.py -q`
- `uv run ruff check app/integrations/mongodb.py tests/test_mongodb_integration.py tests/integrations/test_validator_sentry_capture.py`
- `uv run ruff format --check app/integrations/mongodb.py tests/test_mongodb_integration.py tests/integrations/test_validator_sentry_capture.py`
- `uv run mypy app/integrations/mongodb.py`

## AI checklist
- [x] I verified both linked issues are open, unassigned, and have no comments before starting.
- [x] I matched the Sentry stack paths to `validate_mongodb_config`.
- [x] I added regression tests proving auth and server-selection failures return clean validation results without Sentry capture.
- [x] I preserved Sentry reporting for unexpected validation exceptions.