### PR TITLE
fix(cli): exit repl on closed prompt io

### DIFF
--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
 import re
@@ -52,6 +53,11 @@ _CPR_SEQUENCE_RE = re.compile(
     r"|\d{1,4};\d{1,4}R"  # row;colR without ESC or [
     r"|\d{1,4}R(?=[\[\d])"  # trailing rowR before another CPR fragment
 )
+_PROMPT_IO_CLOSED_ERRNOS = frozenset({errno.EBADF, errno.EIO, errno.ENXIO})
+
+
+def _is_prompt_io_closed(exc: OSError) -> bool:
+    return exc.errno in _PROMPT_IO_CLOSED_ERRNOS
 
 
 def _drain_stale_cpr_bytes() -> None:
@@ -316,6 +322,13 @@ async def run_interactive(
                         state.cancel_current_dispatch()
                         continue
                     return
+                except OSError as exc:
+                    if _is_prompt_io_closed(exc):
+                        log.debug("Prompt input closed; exiting interactive shell", exc_info=True)
+                        if state.is_dispatch_running():
+                            state.cancel_current_dispatch()
+                        return
+                    raise
                 except KeyboardInterrupt:
                     if state.is_dispatch_running():
                         state.cancel_current_dispatch()

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import errno
 import io
 import re
 import threading
@@ -69,6 +71,52 @@ def test_strip_cpr_sequences_removes_terminal_cursor_replies(
     expected: str,
 ) -> None:
     assert loop_module._strip_cpr_sequences(text) == expected
+
+
+def test_prompt_io_closed_predicate_only_matches_closed_terminal_errors() -> None:
+    assert loop_module._is_prompt_io_closed(OSError(errno.EIO, "Input/output error")) is True
+    assert loop_module._is_prompt_io_closed(OSError(errno.EBADF, "Bad file descriptor")) is True
+    assert loop_module._is_prompt_io_closed(OSError(errno.EACCES, "Permission denied")) is False
+
+
+@pytest.mark.asyncio
+async def test_run_interactive_exits_when_prompt_io_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _idle_sampler() -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        loop_module,
+        "start_sampler",
+        lambda: asyncio.create_task(_idle_sampler()),
+    )
+    monkeypatch.setattr(loop_module, "patch_stdout", lambda **_kwargs: contextlib.nullcontext())
+
+    class _PromptApp:
+        is_running = False
+
+        def invalidate(self) -> None:
+            return
+
+        def exit(self) -> None:
+            return
+
+    class _PromptSession:
+        app = _PromptApp()
+        history = InMemoryHistory()
+        key_bindings = None
+        calls = 0
+
+        async def prompt_async(self, *_args: object, **_kwargs: object) -> str:
+            self.calls += 1
+            raise OSError(errno.EIO, "Input/output error")
+
+    prompt = _PromptSession()
+
+    await loop_module.run_interactive(ReplSession(), pt_session=prompt)  # type: ignore[arg-type]
+
+    assert prompt.calls == 1
 
 
 def test_repl_input_lexer_highlights_first_slash_token() -> None:


### PR DESCRIPTION
Fixes #2365.

## What changed
- Treats closed terminal/input prompt errors (`EIO`, `EBADF`, `ENXIO`) like EOF in the interactive shell prompt loop.
- Cancels any running dispatch before exiting when the prompt device disappears.
- Leaves unrelated `OSError` failures to propagate so real bugs are not hidden.

## Validation
- `uv run pytest tests/cli/interactive_shell/test_terminal_runtime.py -q -k "prompt_io_closed or run_interactive_exits_when_prompt_io_closes or strip_cpr"`
- `uv run ruff check app/cli/interactive_shell/runtime/loop.py tests/cli/interactive_shell/test_terminal_runtime.py`
- `uv run ruff format --check app/cli/interactive_shell/runtime/loop.py tests/cli/interactive_shell/test_terminal_runtime.py`
- `uv run mypy app/cli/interactive_shell/runtime/loop.py`

## AI checklist
- [x] I verified the issue is open, unassigned, and has no comments before starting.
- [x] I matched the Sentry stack to `run_interactive` around `prompt_async`.
- [x] I added regression coverage for `EIO` prompt teardown and for not swallowing unrelated `OSError` values.
- [x] I ran targeted tests, lint, format check, and type checking listed above.