### PR TITLE
fix(llm): classify expired bedrock credentials

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -350,6 +350,47 @@ def _is_anthropic_bedrock_model(model_id: str) -> bool:
     return False
 
 
+def _anthropic_error_message(err: Exception) -> str:
+    body = getattr(err, "body", None)
+    if isinstance(body, dict):
+        message = body.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+        error_obj = body.get("error")
+        if isinstance(error_obj, dict):
+            message = error_obj.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+    message = getattr(err, "message", "")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return str(err)
+
+
+def _format_bedrock_permission_denied(model: str, err: PermissionDeniedError) -> str:
+    upstream_message = _anthropic_error_message(err)
+    normalized = upstream_message.lower()
+    if "security token" in normalized and "expired" in normalized:
+        return (
+            f"Bedrock AWS credentials expired for model '{model}'. "
+            "Refresh your AWS session credentials or SSO login, including "
+            "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN, then retry."
+        )
+    if "security token" in normalized and "invalid" in normalized:
+        return (
+            f"Bedrock AWS credentials were rejected for model '{model}'. "
+            "Check AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, and region."
+        )
+
+    detail = upstream_message.strip().rstrip(".")
+    cause = f" Cause: {detail}." if detail else ""
+    return (
+        f"Bedrock model '{model}' is not available for your account.{cause} "
+        "Check your AWS Marketplace subscription and account permissions, "
+        "or update BEDROCK_REASONING_MODEL / BEDROCK_TOOLCALL_MODEL."
+    )
+
+
 class BedrockLLMClient:
     """LLM client for Amazon Bedrock (IAM auth, no API key).
 
@@ -451,11 +492,7 @@ class BedrockLLMClient:
                     "Update BEDROCK_REASONING_MODEL or BEDROCK_TOOLCALL_MODEL to a supported model."
                 ) from err
             except PermissionDeniedError as err:
-                raise RuntimeError(
-                    f"Bedrock model '{self._model}' is not available for your account. "
-                    "Check your AWS Marketplace subscription and account permissions, "
-                    "or update BEDROCK_REASONING_MODEL / BEDROCK_TOOLCALL_MODEL."
-                ) from err
+                raise RuntimeError(_format_bedrock_permission_denied(self._model, err)) from err
             except Exception as err:
                 last_err = err
                 if attempt == max_attempts - 1:

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -1966,6 +1966,39 @@ def test_bedrock_invoke_anthropic_permission_denied_raises_immediately(monkeypat
     assert sleeps == [], "non-transient errors must not be retried"
 
 
+def test_bedrock_invoke_anthropic_expired_security_token_is_credentials_error(
+    monkeypatch,
+) -> None:
+    """Expired AWS STS credentials should not be reported as model unavailability."""
+    monkeypatch.setattr(
+        "app.guardrails.engine.get_guardrail_engine",
+        _InactiveGuardrailEngine,
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm_client.time, "sleep", lambda s: sleeps.append(s))
+
+    upstream_message = "The security token included in the request is expired"
+    resp = _make_anthropic_http_response(403, {"message": upstream_message})
+    err = PermissionDeniedError(
+        message=upstream_message,
+        response=resp,
+        body={"message": upstream_message},
+    )  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        llm_client, "AnthropicBedrock", lambda **_: _make_bedrock_anthropic_client(err)
+    )
+
+    client = llm_client.BedrockLLMClient(model="anthropic.claude-opus-4-7")
+    with pytest.raises(RuntimeError) as excinfo:
+        client.invoke("hello")
+
+    rendered = str(excinfo.value)
+    assert "AWS credentials expired" in rendered
+    assert "AWS_SESSION_TOKEN" in rendered
+    assert "Marketplace" not in rendered
+    assert sleeps == [], "credential errors must not be retried"
+
+
 def test_bedrock_invoke_converse_validation_exception_raises_immediately(monkeypatch) -> None:
     """ValidationException from boto3 converse must raise RuntimeError without retrying."""
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes #2327.

## What changed
- Extracts the upstream Anthropic/Bedrock permission-denied message from SDK error bodies.
- Classifies expired AWS security tokens as credential/session failures instead of model/account unavailability.
- Keeps the existing model-unavailable/Marketplace guidance for genuine Bedrock permission-denied cases, now with upstream cause text when present.

## Validation
- `uv run pytest tests/services/test_llm_client.py -q`
- `uv run ruff check app/services/llm_client.py tests/services/test_llm_client.py`
- `uv run ruff format --check app/services/llm_client.py tests/services/test_llm_client.py`
- `uv run mypy app/services/llm_client.py`

## AI checklist
- [x] I verified the issue is open, unassigned, and has no comments before starting.
- [x] I matched the Sentry stack to `BedrockLLMClient._invoke_anthropic` handling `PermissionDeniedError`.
- [x] I added regression coverage for expired AWS security-token errors not being reported as Marketplace/model access failures.
- [x] I ran the full `tests/services/test_llm_client.py` suite plus lint, format check, and mypy.