### PR TITLE
fix(llm): classify provider model allowlist errors

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -679,6 +679,7 @@ _OPENAI_INVALID_MODEL_IDENTIFIER_PHRASES = (
     "model identifier",  # OpenAI / LiteLLM
     "invalid model id",  # OpenAI
     "invalid model name",  # OpenRouter
+    "supported api model names",  # OpenAI-compatible providers with allowlists
 )
 
 

--- a/tests/services/test_llm_client.py
+++ b/tests/services/test_llm_client.py
@@ -864,6 +864,37 @@ def test_openai_invoke_stream_invalid_model_identifier_raises_not_found(monkeypa
         list(client.invoke_stream("hello"))
 
 
+def test_openai_invoke_stream_provider_model_allowlist_raises_not_found(
+    monkeypatch,
+) -> None:
+    class _Completions:
+        def create(self, **_kwargs):
+            raise _make_fake_openai_bad_request_error(
+                "Error code: 400 - {'error': {'message': "
+                "'The supported API model names are deepseek-v4-pro or deepseek-v4-flash, "
+                "but you passed gpt-5.4.'}}"
+            )
+
+    class _Chat:
+        def __init__(self) -> None:
+            self.completions = _Completions()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.chat = _Chat()
+
+    monkeypatch.setattr(llm_client, "resolve_llm_api_key", lambda _env: "k")
+    monkeypatch.setattr(llm_client, "OpenAI", _OpenAI)
+
+    client = llm_client.OpenAILLMClient(model="gpt-5.4", api_key_env="DEEPSEEK_API_KEY")
+    with pytest.raises(RuntimeError) as excinfo:
+        list(client.invoke_stream("hello"))
+
+    rendered = str(excinfo.value)
+    assert "Deepseek model 'gpt-5.4' was not found" in rendered
+    assert "request rejected" not in rendered
+
+
 def test_openai_invoke_invalid_reasoning_model_falls_back_to_toolcall(monkeypatch) -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
Fixes #2334.

## What changed
- Recognizes OpenAI-compatible provider allowlist errors like `The supported API model names are ... but you passed ...` as invalid model configuration.
- Routes those stream failures through the existing model-not-found guidance instead of a generic HTTP 400 rejection.
- Adds regression coverage for the DeepSeek-style allowlist error shape from the Sentry report.

## Validation
- `uv run pytest tests/services/test_llm_client.py -q`
- `uv run ruff check app/services/llm_client.py tests/services/test_llm_client.py`
- `uv run ruff format --check app/services/llm_client.py tests/services/test_llm_client.py`
- `uv run mypy app/services/llm_client.py`

## AI checklist
- [x] I verified the issue is open, unassigned, and has no comments before starting.
- [x] I matched the stack to `OpenAILLMClient.invoke_stream` BadRequest handling.
- [x] I reused the existing invalid-model classifier rather than adding a new error path.
- [x] I ran the full `tests/services/test_llm_client.py` suite plus lint, format check, and mypy.