### PR TITLE
Fix/repl guardrails bare help

### DIFF
--- a/app/cli/interactive_shell/command_registry/cli_parity.py
+++ b/app/cli/interactive_shell/command_registry/cli_parity.py
@@ -231,7 +231,11 @@ def _cmd_tests(session: ReplSession, console: Console, args: list[str]) -> bool:
 
 
 def _cmd_guardrails(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001
-    return run_cli_command(console, ["guardrails", *args])
+    # ``opensre guardrails`` and its subcommands are all non-interactive printers
+    # (init/test/audit/rules just ``click.echo``). Capture so the output — and
+    # Click's usage block when no subcommand is given — reaches the REPL buffer
+    # instead of bypassing ``console.print`` via the child's inherited stdout FD.
+    return run_cli_command(console, ["guardrails", *args], capture_output=True)
 
 
 def _cmd_update(session: ReplSession, console: Console, args: list[str]) -> bool:  # noqa: ARG001

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1682,6 +1682,32 @@ class TestCliDelegatedCommands:
 
         assert captured_kwargs == [{"capture_output": True}]
 
+    @pytest.mark.parametrize(
+        "slash_input",
+        ["/guardrails", "/guardrails rules", "/guardrails --help"],
+    )
+    def test_slash_guardrails_opts_into_output_capture(
+        self, monkeypatch: object, slash_input: str
+    ) -> None:
+        """Bare ``/guardrails`` (no subcommand), known subcommands, and flag-style
+        invocations must all call ``run_cli_command`` with
+        ``capture_output=True``. Without this, Click's usage block (printed for
+        the no-subcommand case) and subcommand output bypass ``console.print``
+        and never reach the REPL buffer — see issue #2388.
+        """
+        from app.cli.interactive_shell.command_registry import cli_parity as m
+
+        captured_kwargs: list[dict[str, object]] = []
+
+        def _fake_run_cli_command(_console: Console, _args: list[str], **kwargs: object) -> bool:
+            captured_kwargs.append(kwargs)
+            return True
+
+        monkeypatch.setattr(m, "run_cli_command", _fake_run_cli_command)
+        dispatch_slash(slash_input, ReplSession(), Console())
+
+        assert captured_kwargs == [{"capture_output": True}]
+
     def test_slash_onboard_with_args_forwards_them_to_subprocess(self, monkeypatch: object) -> None:
         """Args passed to ``/onboard`` must be forwarded to the subprocess."""
         from app.cli.interactive_shell.command_registry import cli_parity as m


### PR DESCRIPTION
Fixes #2388

<!-- Add issue number above -->

#### Describe the changes you have made in this PR -

`/guardrails` in the REPL only printed `CLI command exited with non-zero code 2` Click's usage block was lost to the child subprocess's inherited stdout FD instead of reaching the REPL buffer.

This passes `capture_output=True` (introduced in #2430) to `_cmd_guardrails`, so subprocess stdout/stderr are captured and replayed through the Rich console. The full usage block now appears in the REPL (42 chars → 429 chars). All `guardrails` subcommands (`init`, `test`, `audit`, `rules`) are non-interactive `click.echo` printers, so capture is safe across the board.

This branch is based on #2430. It rebases cleanly onto `main` once #2430 lands.

### Demo/Screenshot for feature changes and bug fixes -

https://www.loom.com/share/2d32ae8fb43f40238395bb34b92332ab

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** Inside the REPL, prompt_toolkit's `patch_stdout` wraps `console.print` so output stays above the live prompt. `run_cli_command` was launching the Click subcommand with inherited stdout — so the child wrote directly to the parent process's stdout FD, completely bypassing that redirection. The user saw only the trailing error line that the wrapper itself called `console.print` for.

**Why I picked this fix:** PR #2430 already added a `capture_output` knob on `run_cli_command` for the same class of bug on `/tests`. The cleanest fix here is to opt `_cmd_guardrails` into that same behavior rather than introduce a parallel mechanism. I verified every `guardrails` subcommand in `app/guardrails/cli.py` to confirm none of them prompt for input — they all just `click.echo`, so capture is safe across the whole group (no risk of swallowing an interactive prompt).

**Alternatives I considered and rejected:**
- *Disable `patch_stdout` for the duration of the call.* Heavier, ripples through the REPL loop, and removes the visual separation between subprocess output and the prompt.
- *Add an interactive override per-subcommand.* Unnecessary — none of the four `guardrails` subcommands need a TTY.
- *Special-case the bare-command path only.* Would leave subcommand output broken in the same way; capturing across the group fixes the whole class.

**Key change:** [app/cli/interactive_shell/command_registry/cli_parity.py:233-239](app/cli/interactive_shell/command_registry/cli_parity.py#L233-L239) — `_cmd_guardrails` now passes `capture_output=True`, with a short comment explaining why every guardrails subcommand is capture-safe.

**Tests:** Parametrized `test_slash_guardrails_opts_into_output_capture` covers the three input shapes: bare (`/guardrails` — the reported bug), known subcommand (`/guardrails rules`), and flag form (`/guardrails --help`). All hit `dispatch_slash` end-to-end, so a future refactor that bypasses `_cmd_guardrails` will still trip the test.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.
