### PR TITLE
fix(repl): improve /investigate picker UX and restore live stream

### DIFF
--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -156,52 +156,63 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
     if template_name not in ALERT_TEMPLATE_CHOICES:
         template_name = ""
 
-    path = resolve_alert_path(raw_target)
-    if not path.exists():
-        if template_name:
-            task = session.task_registry.create(
-                TaskKind.INVESTIGATION, command=f"/investigate {template_name}"
-            )
-            task.mark_running()
-            try:
-                with apply_reasoning_effort(session.reasoning_effort):
-                    suppress = getattr(console, "suppress_prompt_spinner", None)
-                    if callable(suppress):
-                        suppress()
-                    final_state = run_sample_alert_for_session(
-                        template_name=template_name,
-                        context_overrides=session.accumulated_context or None,
-                        cancel_requested=task.cancel_requested,
-                    )
-            except KeyboardInterrupt:
-                task.mark_cancelled()
-                console.print(f"[{WARNING}]investigation cancelled.[/]")
-                session.record("alert", f"/investigate {template_name}", ok=False)
-                session.mark_latest(ok=False, kind="slash")
-                return True
-            except OpenSREError as exc:
-                task.mark_failed(str(exc))
-                console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-                if exc.suggestion:
-                    console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
-                session.record("alert", f"/investigate {template_name}", ok=False)
-                session.mark_latest(ok=False, kind="slash")
-                return True
-            except Exception as exc:
-                task.mark_failed(str(exc))
-                report_exception(exc, context="interactive_shell.investigate_template")
-                console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
-                session.record("alert", f"/investigate {template_name}", ok=False)
-                session.mark_latest(ok=False, kind="slash")
-                return True
-
-            root = final_state.get("root_cause")
-            task.mark_completed(result=str(root) if root is not None else "")
-            session.last_state = final_state
-            session.accumulate_from_state(final_state)
-            session.record("alert", f"/investigate {template_name}")
+    # Treat canonical template names as templates even if same-named files exist
+    # in the working directory. Users can still force file mode with an explicit
+    # path form (for example: ``/investigate ./generic``).
+    if template_name:
+        task = session.task_registry.create(
+            TaskKind.INVESTIGATION, command=f"/investigate {template_name}"
+        )
+        task.mark_running()
+        try:
+            with (
+                track_investigation(
+                    entrypoint=EntrypointSource.CLI_REPL_FILE,
+                    trigger_mode=TriggerMode.FILE,
+                    input_path=f"template:{template_name}",
+                    interactive=True,
+                ),
+                apply_reasoning_effort(session.reasoning_effort),
+            ):
+                suppress = getattr(console, "suppress_prompt_spinner", None)
+                if callable(suppress):
+                    suppress()
+                final_state = run_sample_alert_for_session(
+                    template_name=template_name,
+                    context_overrides=session.accumulated_context or None,
+                    cancel_requested=task.cancel_requested,
+                )
+        except KeyboardInterrupt:
+            task.mark_cancelled()
+            console.print(f"[{WARNING}]investigation cancelled.[/]")
+            session.record("alert", f"/investigate {template_name}", ok=False)
+            session.mark_latest(ok=False, kind="slash")
+            return True
+        except OpenSREError as exc:
+            task.mark_failed(str(exc))
+            console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+            if exc.suggestion:
+                console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
+            session.record("alert", f"/investigate {template_name}", ok=False)
+            session.mark_latest(ok=False, kind="slash")
+            return True
+        except Exception as exc:
+            task.mark_failed(str(exc))
+            report_exception(exc, context="interactive_shell.investigate_template")
+            console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+            session.record("alert", f"/investigate {template_name}", ok=False)
+            session.mark_latest(ok=False, kind="slash")
             return True
 
+        root = final_state.get("root_cause")
+        task.mark_completed(result=str(root) if root is not None else "")
+        session.last_state = final_state
+        session.accumulate_from_state(final_state)
+        session.record("alert", f"/investigate {template_name}")
+        return True
+
+    path = resolve_alert_path(raw_target)
+    if not path.exists():
         console.print(f"[{ERROR}]file not found:[/] {escape(str(path))}")
         session.mark_latest(ok=False, kind="slash")
         return True

--- a/app/cli/interactive_shell/command_registry/investigation.py
+++ b/app/cli/interactive_shell/command_registry/investigation.py
@@ -44,6 +44,47 @@ def _interactive_template_menu(session: ReplSession, console: Console) -> bool:
         repl_section_break(console)
 
 
+def _interactive_investigate_menu(session: ReplSession, console: Console) -> bool:
+    from app.cli.support.constants import SAMPLE_ALERT_OPTIONS
+
+    root = "/investigate"
+    choices: list[tuple[str, str]] = [
+        ("alert.json", "alert.json (bundled demo alert file)"),
+    ]
+    choices.extend(SAMPLE_ALERT_OPTIONS)
+    choices.append(("__browse__", "custom file path…"))
+    choices.append(("done", "done"))
+
+    while True:
+        target = repl_choose_one(
+            title="investigate",
+            breadcrumb=root,
+            choices=choices,
+        )
+        if target is None or target == "done":
+            return True
+        if target == "__browse__":
+            custom_path = _prompt_investigate_path(console)
+            if custom_path is None:
+                continue
+            target = custom_path
+        _cmd_investigate_file(session, console, [target])
+        repl_section_break(console)
+
+
+def _prompt_investigate_path(console: Console) -> str | None:
+    """Prompt for a user-supplied alert path from the investigate picker."""
+    console.print()
+    console.print(
+        f"[{DIM}]Enter a local alert file path (.json/.md/.txt). Use absolute or relative path.[/]"
+    )
+    try:
+        value = console.input(f"[{HIGHLIGHT}]file path> [/]").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    return value if value else None
+
+
 def _cmd_template(session: ReplSession, console: Console, args: list[str]) -> bool:
     from app.cli.investigation.alert_templates import build_alert_template
     from app.cli.support.constants import ALERT_TEMPLATE_CHOICES
@@ -72,8 +113,13 @@ def _cmd_template(session: ReplSession, console: Console, args: list[str]) -> bo
 
 
 def _validate_investigate_args(args: list[str]) -> str | None:
+    if not args and repl_tty_interactive():
+        return None
     if not args:
-        return f"[{DIM}]usage:[/] /investigate <file>"
+        return (
+            f"[{DIM}]usage:[/] /investigate <file|template>  "
+            f"(e.g. /investigate alert.json or /investigate generic)"
+        )
     return None
 
 
@@ -86,11 +132,76 @@ def _validate_save_args(args: list[str]) -> str | None:
 def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str]) -> bool:
     from app.analytics.cli import track_investigation
     from app.analytics.source import EntrypointSource, TriggerMode
-    from app.cli.investigation import run_investigation_for_session
+    from app.cli.investigation import run_investigation_for_session, run_sample_alert_for_session
     from app.cli.investigation.payload import resolve_alert_path
+    from app.cli.support.constants import ALERT_TEMPLATE_CHOICES
 
-    path = resolve_alert_path(args[0])
+    if not args and repl_tty_interactive():
+        return _interactive_investigate_menu(session, console)
+    if not args:
+        console.print(
+            f"[{DIM}]usage:[/] /investigate <file|template>  "
+            f"(e.g. /investigate alert.json or /investigate generic)"
+        )
+        session.mark_latest(ok=False, kind="slash")
+        return True
+
+    raw_target = args[0]
+    normalized_target = raw_target.strip().lower()
+    template_name = normalized_target
+    for prefix in ("sample:", "template:"):
+        if template_name.startswith(prefix):
+            template_name = template_name[len(prefix) :].strip()
+            break
+    if template_name not in ALERT_TEMPLATE_CHOICES:
+        template_name = ""
+
+    path = resolve_alert_path(raw_target)
     if not path.exists():
+        if template_name:
+            task = session.task_registry.create(
+                TaskKind.INVESTIGATION, command=f"/investigate {template_name}"
+            )
+            task.mark_running()
+            try:
+                with apply_reasoning_effort(session.reasoning_effort):
+                    suppress = getattr(console, "suppress_prompt_spinner", None)
+                    if callable(suppress):
+                        suppress()
+                    final_state = run_sample_alert_for_session(
+                        template_name=template_name,
+                        context_overrides=session.accumulated_context or None,
+                        cancel_requested=task.cancel_requested,
+                    )
+            except KeyboardInterrupt:
+                task.mark_cancelled()
+                console.print(f"[{WARNING}]investigation cancelled.[/]")
+                session.record("alert", f"/investigate {template_name}", ok=False)
+                session.mark_latest(ok=False, kind="slash")
+                return True
+            except OpenSREError as exc:
+                task.mark_failed(str(exc))
+                console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+                if exc.suggestion:
+                    console.print(f"[{WARNING}]suggestion:[/] {escape(exc.suggestion)}")
+                session.record("alert", f"/investigate {template_name}", ok=False)
+                session.mark_latest(ok=False, kind="slash")
+                return True
+            except Exception as exc:
+                task.mark_failed(str(exc))
+                report_exception(exc, context="interactive_shell.investigate_template")
+                console.print(f"[{ERROR}]investigation failed:[/] {escape(str(exc))}")
+                session.record("alert", f"/investigate {template_name}", ok=False)
+                session.mark_latest(ok=False, kind="slash")
+                return True
+
+            root = final_state.get("root_cause")
+            task.mark_completed(result=str(root) if root is not None else "")
+            session.last_state = final_state
+            session.accumulate_from_state(final_state)
+            session.record("alert", f"/investigate {template_name}")
+            return True
+
         console.print(f"[{ERROR}]file not found:[/] {escape(str(path))}")
         session.mark_latest(ok=False, kind="slash")
         return True
@@ -151,7 +262,7 @@ def _cmd_investigate_file(session: ReplSession, console: Console, args: list[str
     # Match `run_new_alert` in runtime/execution.py: inherit service / cluster / region
     # across subsequent investigations in the same REPL session.
     session.accumulate_from_state(final_state)
-    session.record("alert", f"/investigate {args[0]}")
+    session.record("alert", f"/investigate {raw_target}")
     return True
 
 
@@ -216,6 +327,17 @@ _TEMPLATE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
     ("grafana", "Grafana alert template"),
     ("honeycomb", "Honeycomb trigger template"),
     ("coralogix", "Coralogix alert template"),
+    ("splunk", "Splunk alert template"),
+)
+
+_INVESTIGATE_FIRST_ARGS: tuple[tuple[str, str], ...] = (
+    ("alert.json", "run bundled demo alert file"),
+    ("generic", "run generic sample alert"),
+    ("datadog", "run Datadog sample alert"),
+    ("grafana", "run Grafana sample alert"),
+    ("honeycomb", "run Honeycomb sample alert"),
+    ("coralogix", "run Coralogix sample alert"),
+    ("splunk", "run Splunk sample alert"),
 )
 
 COMMANDS: list[SlashCommand] = [
@@ -230,6 +352,7 @@ COMMANDS: list[SlashCommand] = [
             "/template grafana",
             "/template honeycomb",
             "/template coralogix",
+            "/template splunk",
         ),
         notes=("In a TTY, bare /template opens an interactive menu.",),
         first_arg_completions=_TEMPLATE_FIRST_ARGS,
@@ -237,9 +360,15 @@ COMMANDS: list[SlashCommand] = [
     ),
     SlashCommand(
         "/investigate",
-        "Run an RCA investigation from a file.",
+        "Run an RCA investigation from a file or sample template.",
         _cmd_investigate_file,
-        usage=("/investigate <file>",),
+        usage=(
+            "/investigate <file|template>",
+            "/investigate alert.json",
+            "/investigate generic",
+        ),
+        notes=("In a TTY, bare /investigate opens runnable demo/template options.",),
+        first_arg_completions=_INVESTIGATE_FIRST_ARGS,
         execution_tier=ExecutionTier.SAFE,
         validate_args=_validate_investigate_args,
     ),

--- a/app/cli/interactive_shell/command_registry/slash_catalog.py
+++ b/app/cli/interactive_shell/command_registry/slash_catalog.py
@@ -151,8 +151,9 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         ),
     ),
     "/investigate": _mcp(
-        "Run an RCA investigation from a local alert file path. Requires confirmation.",
+        "Run an RCA investigation from a local alert file path or a built-in sample template.",
         "User asks to investigate a file path or run RCA from a saved alert file",
+        "User asks to run one of the built-in sample alerts/templates",
         anti_examples=(
             "User pastes alert text inline (use investigation_start instead)",
             "User asks how investigations work (assistant_handoff)",
@@ -229,7 +230,7 @@ _MCP_BY_COMMAND: dict[str, _SlashMcpFields] = {
         "User asks to list running or recent tasks",
     ),
     "/template": _mcp(
-        "Print a starter alert JSON template (generic, datadog, grafana, honeycomb, coralogix).",
+        "Print a starter alert JSON template (generic, datadog, grafana, honeycomb, coralogix, splunk).",
         "User asks for an alert template or example payload format",
     ),
     "/tests": _mcp(

--- a/app/cli/interactive_shell/prompting/prompt_surface.py
+++ b/app/cli/interactive_shell/prompting/prompt_surface.py
@@ -191,6 +191,18 @@ class ShellCompleter(Completer):
             cmd_name = parts[0].lower()
             raw_arg = "" if trailing_space or len(parts) < 2 else parts[1]
             if cmd_name in ("/investigate", "/save"):
+                if cmd_name == "/investigate":
+                    entry = SLASH_COMMANDS.get(cmd_name)
+                    hints = entry.first_arg_completions if entry is not None else ()
+                    sub_prefix = raw_arg.lower()
+                    for sub, meta in hints:
+                        if sub.startswith(sub_prefix):
+                            yield Completion(
+                                sub,
+                                start_position=-len(raw_arg),
+                                display=sub,
+                                display_meta=meta,
+                            )
                 yield from PathCompleter(expanduser=True).get_completions(
                     Document(raw_arg, len(raw_arg)),
                     complete_event,

--- a/app/cli/interactive_shell/runtime/dispatch.py
+++ b/app/cli/interactive_shell/runtime/dispatch.py
@@ -46,6 +46,7 @@ _EXCLUSIVE_STDIN_MENU_COMMANDS: frozenset[str] = frozenset(
         "/history",
         "/help",
         "/integrations",
+        "/investigate",
         "/list",
         "/mcp",
         "/model",

--- a/app/cli/interactive_shell/runtime/loop.py
+++ b/app/cli/interactive_shell/runtime/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import re
@@ -207,7 +208,18 @@ async def run_interactive(
         if show_spinner:
             spinner.start()
         try:
-            with repl_safe_progress_scope():
+            # Commands that take exclusive stdin ownership (e.g. bare
+            # ``/investigate`` and other inline pickers) can safely use the
+            # full Rich Live investigation stream because prompt_toolkit is not
+            # actively reading input while we await ``state.queue.join()``.
+            # Keep the REPL-safe append-only renderer for non-exclusive turns
+            # to avoid Live redraw contention with the active prompt.
+            progress_scope = (
+                contextlib.nullcontext()
+                if dispatch_needs_exclusive_stdin(text, session)
+                else repl_safe_progress_scope()
+            )
+            with progress_scope:
                 await asyncio.to_thread(
                     dispatch_one_turn,
                     text,

--- a/app/cli/interactive_shell/ui/banner.py
+++ b/app/cli/interactive_shell/ui/banner.py
@@ -259,7 +259,7 @@ _TIPS: tuple[str, ...] = (
     "Paste alert JSON or describe an incident",
     "Type /help to list slash commands",
     "Run /doctor for environment diagnostics",
-    "Use /investigate <file> for file alerts",
+    "Use /investigate for runnable demos/templates",
 )
 
 # Panel geometry. The body switches to a stacked layout on narrow terminals,

--- a/app/cli/support/constants.py
+++ b/app/cli/support/constants.py
@@ -24,6 +24,7 @@ ALERT_TEMPLATE_CHOICES: tuple[str, ...] = (
     "grafana",
     "honeycomb",
     "coralogix",
+    "splunk",
 )
 
 SAMPLE_ALERT_OPTIONS: tuple[tuple[str, str], ...] = (
@@ -32,6 +33,7 @@ SAMPLE_ALERT_OPTIONS: tuple[tuple[str, str], ...] = (
     ("grafana", "Grafana - Pipeline failure rate high"),
     ("honeycomb", "Honeycomb - checkout-api latency regression"),
     ("coralogix", "Coralogix - payments worker errors"),
+    ("splunk", "Splunk - payments service error spike"),
 )
 
 SETUP_SERVICES: tuple[str, ...] = (

--- a/tests/cli/interactive_shell/test_command_registry.py
+++ b/tests/cli/interactive_shell/test_command_registry.py
@@ -12,7 +12,10 @@ from app.cli.interactive_shell.command_registry.integrations import (
     _LIST_FIRST_ARGS,
     _MCP_FIRST_ARGS,
 )
-from app.cli.interactive_shell.command_registry.investigation import _TEMPLATE_FIRST_ARGS
+from app.cli.interactive_shell.command_registry.investigation import (
+    _INVESTIGATE_FIRST_ARGS,
+    _TEMPLATE_FIRST_ARGS,
+)
 from app.cli.interactive_shell.command_registry.model import _MODEL_FIRST_ARGS
 from app.cli.interactive_shell.command_registry.session_cmds import (
     _TRUST_FIRST_ARGS,
@@ -64,6 +67,7 @@ def test_registry_first_arg_completion_hints_co_located_with_handlers() -> None:
         "/list": _LIST_FIRST_ARGS,
         "/integrations": _INTEGRATIONS_FIRST_ARGS,
         "/mcp": _MCP_FIRST_ARGS,
+        "/investigate": _INVESTIGATE_FIRST_ARGS,
         "/template": _TEMPLATE_FIRST_ARGS,
         "/trust": _TRUST_FIRST_ARGS,
         "/verbose": _VERBOSE_FIRST_ARGS,

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1103,6 +1103,62 @@ class TestInvestigateFileCommand:
         assert captured == ["generic"]
         assert session.last_state == {"root_cause": "sample cause"}
 
+    def test_template_arg_tracks_cli_repl_file_source(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        track_calls: list[tuple[str, str, str | None]] = []
+
+        class _TrackContext:
+            def __enter__(self) -> None:
+                return None
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                _ = (exc_type, exc, tb)
+                return False
+
+        def _fake_track(*, entrypoint, trigger_mode, input_path=None, **kwargs):  # type: ignore[no-untyped-def]
+            _ = kwargs
+            track_calls.append((entrypoint.value, trigger_mode.value, input_path))
+            return _TrackContext()
+
+        monkeypatch.setattr("app.analytics.cli.track_investigation", _fake_track)
+        monkeypatch.setattr(
+            "app.cli.investigation.run_sample_alert_for_session",
+            lambda **_kwargs: {"root_cause": "sample cause"},
+        )
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash("/investigate generic", session, console)
+
+        assert track_calls == [("cli_repl_file", "file", "template:generic")]
+
+    def test_template_name_takes_precedence_over_local_same_name_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "generic").write_text('{"alert_name": "local-file"}', encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        calls: list[str] = []
+
+        def _fake_sample(
+            *,
+            template_name: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict[str, str]:
+            _ = (context_overrides, cancel_requested)
+            calls.append(template_name)
+            return {"root_cause": "template-wins"}
+
+        monkeypatch.setattr("app.cli.investigation.run_sample_alert_for_session", _fake_sample)
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash("/investigate generic", session, console)
+
+        assert calls == ["generic"]
+        assert session.last_state == {"root_cause": "template-wins"}
+
     def test_missing_arg_in_tty_opens_interactive_menu(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/interactive_shell/test_commands.py
+++ b/tests/cli/interactive_shell/test_commands.py
@@ -1049,6 +1049,7 @@ class TestInvestigateFileCommand:
         console, buf = _capture()
         dispatch_slash("/investigate", ReplSession(), console)
         assert "usage" in buf.getvalue()
+        assert "/investigate <file|template>" in buf.getvalue()
 
     def test_missing_file_prints_error(self) -> None:
         session = ReplSession()
@@ -1079,6 +1080,94 @@ class TestInvestigateFileCommand:
         dispatch_slash(f"/investigate {alert_file}", session, console)
         assert session.last_state == {"root_cause": "test cause"}
         assert '{"alert_name": "test"}' in captured[0]
+
+    def test_template_arg_runs_sample_alert(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[str] = []
+
+        def _fake_sample(
+            *,
+            template_name: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict[str, str]:
+            _ = (context_overrides, cancel_requested)
+            captured.append(template_name)
+            return {"root_cause": "sample cause"}
+
+        monkeypatch.setattr("app.cli.investigation.run_sample_alert_for_session", _fake_sample)
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash("/investigate generic", session, console)
+
+        assert captured == ["generic"]
+        assert session.last_state == {"root_cause": "sample cause"}
+
+    def test_missing_arg_in_tty_opens_interactive_menu(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import investigation as investigation_cmd
+
+        picks = iter(["generic", "done"])
+        captured: list[str] = []
+
+        def _fake_sample(
+            *,
+            template_name: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict[str, str]:
+            _ = (context_overrides, cancel_requested)
+            captured.append(template_name)
+            return {"root_cause": "sample from menu"}
+
+        monkeypatch.setattr(investigation_cmd, "repl_tty_interactive", lambda: True)
+        monkeypatch.setattr(investigation_cmd, "repl_choose_one", lambda **_: next(picks))
+        monkeypatch.setattr("app.cli.investigation.run_sample_alert_for_session", _fake_sample)
+
+        session = ReplSession()
+        console, buf = _capture()
+        dispatch_slash("/investigate", session, console)
+
+        assert captured == ["generic"]
+        assert session.last_state == {"root_cause": "sample from menu"}
+        assert "usage" not in buf.getvalue().lower()
+
+    def test_tty_investigate_menu_browse_path_runs_custom_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.cli.interactive_shell.command_registry import investigation as investigation_cmd
+
+        alert_file = tmp_path / "custom_alert.json"
+        alert_file.write_text('{"alert_name": "custom"}', encoding="utf-8")
+
+        picks = iter(["__browse__", "done"])
+        captured: list[str] = []
+
+        def _fake(
+            alert_text: str,
+            context_overrides: object = None,
+            cancel_requested: object = None,
+        ) -> dict[str, str]:
+            _ = (context_overrides, cancel_requested)
+            captured.append(alert_text)
+            return {"root_cause": "custom path run"}
+
+        monkeypatch.setattr(investigation_cmd, "repl_tty_interactive", lambda: True)
+        monkeypatch.setattr(investigation_cmd, "repl_choose_one", lambda **_: next(picks))
+        monkeypatch.setattr(
+            investigation_cmd,
+            "_prompt_investigate_path",
+            lambda _console: str(alert_file),
+        )
+        monkeypatch.setattr("app.cli.investigation.run_investigation_for_session", _fake)
+
+        session = ReplSession()
+        console, _ = _capture()
+        dispatch_slash("/investigate", session, console)
+
+        assert session.last_state == {"root_cause": "custom path run"}
+        assert '"alert_name": "custom"' in captured[0]
 
     def test_investigate_file_tracks_cli_repl_file_source(
         self, tmp_path: object, monkeypatch: object
@@ -1387,7 +1476,7 @@ class TestPrePolicyValidation:
     @pytest.mark.parametrize(
         "command,expected_usage_fragment",
         [
-            ("/investigate", "/investigate <file>"),
+            ("/investigate", "/investigate <file|template>"),
             ("/save", "/save <path>"),
             ("/cancel", "/cancel <task_id>"),
         ],
@@ -1424,7 +1513,7 @@ class TestPrePolicyValidation:
         console, buf = _capture()
         dispatch_slash("/investigate", session, console, confirm_fn=_confirm, is_tty=True)
 
-        assert "/investigate <file>" in buf.getvalue()
+        assert "/investigate <file|template>" in buf.getvalue()
         assert confirm_calls == [], "trust mode must not skip arg validation"
 
     def test_investigate_with_valid_arg_skips_policy_prompt(self, tmp_path: Path) -> None:
@@ -1458,7 +1547,7 @@ class TestSlashValidatorFunctions:
     @pytest.mark.parametrize(
         "validator,expected_usage_fragment",
         [
-            (_validate_investigate_args, "/investigate <file>"),
+            (_validate_investigate_args, "/investigate <file|template>"),
             (_validate_save_args, "/save <path>"),
             (_validate_cancel_args, "/cancel <task_id>"),
         ],

--- a/tests/cli/interactive_shell/test_terminal_runtime.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime.py
@@ -318,6 +318,17 @@ def test_shell_completer_path_completion_honors_mixed_case_prefix(tmp_path: Path
     assert "RePoRtS" in joined
 
 
+def test_shell_completer_investigate_includes_template_hints() -> None:
+    completions = list(
+        ShellCompleter().get_completions(
+            Document("/investigate ", len("/investigate ")),
+            CompleteEvent(text_inserted=True),
+        )
+    )
+    assert any(c.text == "generic" for c in completions)
+    assert any(c.text == "splunk" for c in completions)
+
+
 def test_run_new_alert_marks_task_failed_on_opensre_error(monkeypatch: pytest.MonkeyPatch) -> None:
     from rich.console import Console
 

--- a/tests/cli/interactive_shell/test_terminal_runtime_routing.py
+++ b/tests/cli/interactive_shell/test_terminal_runtime_routing.py
@@ -80,6 +80,7 @@ def test_dispatch_needs_exclusive_stdin_for_bare_integration_menu(
 
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/integrations", session) is True
     assert loop_dispatch.dispatch_needs_exclusive_stdin("integrations", session) is True
+    assert loop_dispatch.dispatch_needs_exclusive_stdin("/investigate", session) is True
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/mcp", session) is True
     assert loop_dispatch.dispatch_needs_exclusive_stdin("/model", session) is True
 


### PR DESCRIPTION
## Summary
This PR improves the REPL `/investigate` workflow and fixes several regressions discovered while testing it.

Fixes #2389

### What changed
- Added an interactive `/investigate` picker (TTY) when no args are provided.
  - Built-in runnable options now include:
    - bundled `alert.json`
    - sample templates: `generic`, `datadog`, `grafana`, `honeycomb`, `coralogix`, `splunk`
  - Added `custom file path…` option to run user-provided alert files directly from the picker.
- `/investigate` now accepts template names directly (for example `/investigate generic`) in addition to file paths.
- Updated `/investigate` usage/help text and first-arg completions to reflect file-or-template behavior.
- Added `splunk` to shared template/sample constants and `/template` discoverability.
- Fixed REPL stdin ownership for `/investigate` menu navigation to prevent arrow-key garbage/escape sequence leakage.
- Restored full live investigation progress streaming in REPL for exclusive-stdin investigate flows (matching `opensre investigate` UX) while keeping safe append-only mode for non-exclusive turns.
- Updated slash catalog metadata and banner tip copy.

## Tests
- `make lint`
- `make format-check`
- `make typecheck`
- `GRAFANA_CONFIG_SKIP_ENV_FILE=1 uv run pytest tests/cli/ -v`

All passed locally.
