### PR TITLE
fix(repl): /clear re-renders only the ready-box, not the full splash

### DIFF
--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -16,7 +16,7 @@ from app.cli.interactive_shell.ui import (
     ERROR,
     HIGHLIGHT,
     WARNING,
-    render_banner,
+    render_ready_box,
     repl_table,
     resolve_provider_models,
 )
@@ -36,7 +36,7 @@ from app.llm_reasoning_effort import (
 
 def _cmd_clear(_session: ReplSession, console: Console, _args: list[str]) -> bool:
     console.clear()
-    render_banner(console)
+    render_ready_box(console)
     return True
 
 

--- a/app/cli/interactive_shell/ui/__init__.py
+++ b/app/cli/interactive_shell/ui/__init__.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from app.cli.interactive_shell.ui.agents_view import _build_agents_table, render_agents_table
-from app.cli.interactive_shell.ui.banner import render_banner, resolve_provider_models
+from app.cli.interactive_shell.ui.banner import (
+    render_banner,
+    render_ready_box,
+    resolve_provider_models,
+)
 from app.cli.interactive_shell.ui.choice_menu import (
     print_valid_choice_list,
     repl_choose_one,
@@ -70,6 +74,7 @@ __all__ = [
     "print_repl_table",
     "render_agents_table",
     "render_banner",
+    "render_ready_box",
     "render_integrations_table",
     "render_mcp_table",
     "render_models_table",


### PR DESCRIPTION
## Summary

- `_cmd_clear` was calling `render_banner()` after `console.clear()`, which runs `render_splash()` → `render_ready_box()` in sequence
- `render_splash()` re-emits the full ASCII art logo and, on first-run, blocks on `sys.stdin.readline()` — both wrong in a mid-session clear
- Switch `_cmd_clear` to call `render_ready_box(console)` directly (the same path `/welcome` and greeting aliases already use), so `/clear` produces a clean, non-blocking panel redraw
- Export `render_ready_box` from `app/cli/interactive_shell/ui/__init__.py` to match existing conventions

## Test plan

- [ ] Run `uv run opensre`, type `/clear` — terminal clears and the `OpenSRE · vX.Y.Z` panel re-renders cleanly without the ASCII art splash
- [ ] Confirm no blocking stdin prompt appears on `/clear` (regression from `render_splash` first-run gate)
- [ ] `make lint && make typecheck` — both pass

Fixes #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)