### PR TITLE
fix(repl): forward session to render_ready_box in /clear

### DIFF
--- a/app/cli/interactive_shell/command_registry/session_cmds.py
+++ b/app/cli/interactive_shell/command_registry/session_cmds.py
@@ -34,9 +34,9 @@ from app.llm_reasoning_effort import (
 )
 
 
-def _cmd_clear(_session: ReplSession, console: Console, _args: list[str]) -> bool:
+def _cmd_clear(session: ReplSession, console: Console, _args: list[str]) -> bool:
     console.clear()
-    render_ready_box(console)
+    render_ready_box(console, session=session)
     return True
 
 


### PR DESCRIPTION
## Summary

Follow-up to #2472, addressing review comment [r3292476780](https://github.com/Tracer-Cloud/opensre/pull/2472#discussion_r3292476780).

`_cmd_clear` was calling `render_ready_box(console)` without forwarding the session, so `build_ready_panel` always received `session=None`. This forced `trust_mode=False`, silently hiding the bold "trust mode" warning for any user who had activated trust mode before running `/clear`.

- Rename `_session` → `session` (was unused, now passed through)
- Pass `session=session` to `render_ready_box` so the panel reflects actual session state

## Test plan

- [ ] Activate trust mode (`/trust on`), then run `/clear` — panel should show bold "trust mode" warning, not the provider name
- [ ] Without trust mode, `/clear` panel shows provider name as before
- [ ] `make lint && make typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)