### PR TITLE
fix(agents): exclude Codex and Cursor Desktop from scan classifier

### DIFF
--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -56,6 +56,28 @@ _CLAUDE_DESKTOP_PATH_HINTS: tuple[str, ...] = (
     "\\program files\\claude\\",
     "\\appdata\\local\\programs\\claude\\",
 )
+# macOS hints target the main bundle binary at
+# `<App>.app/Contents/MacOS/<App>` only, not the whole bundle. This keeps
+# Electron helper processes living under `<App>.app/Contents/Frameworks/`
+# eligible for the loose matcher — e.g. Cursor's agent runs as a
+# `Cursor Helper (Plugin)` subprocess that callers still expect to see
+# surfaced as `cursor` in `opensre agents scan --all`.
+_CODEX_DESKTOP_PATH_HINTS: tuple[str, ...] = (
+    "codex.app/contents/macos/codex/",
+    "/snap/codex/",
+    "/.mount_codex",
+    "/var/lib/flatpak/app/com.openai.codex/",
+    "\\program files\\codex\\",
+    "\\appdata\\local\\programs\\codex\\",
+)
+_CURSOR_DESKTOP_PATH_HINTS: tuple[str, ...] = (
+    "cursor.app/contents/macos/cursor/",
+    "/snap/cursor/",
+    "/.mount_cursor",
+    "/var/lib/flatpak/app/com.cursor.cursor/",
+    "\\program files\\cursor\\",
+    "\\appdata\\local\\programs\\cursor\\",
+)
 
 
 @dataclass(frozen=True)
@@ -419,7 +441,7 @@ def _agent_name_for_command(command: str) -> str | None:
         return "cursor-agent"
     if not _is_claude_desktop_artifact(cmdline) and _claude_code_cli_matches_cmdline(cmdline):
         return "claude-code"
-    if _is_codex_command(command):
+    if not _is_codex_desktop_artifact(cmdline) and _is_codex_command(command):
         return "codex"
     if _has_command_token(lower, "aider"):
         return "aider"
@@ -476,6 +498,8 @@ def _classify_agent(
     if executable == "aider":
         return "aider"
     if executable == "codex":
+        if _is_codex_desktop_artifact(cmdline):
+            return None
         return "codex"
     if executable == "gemini":
         return "gemini-cli"
@@ -487,7 +511,11 @@ def _classify_agent(
 
 
 def _classify_agent_loose(process_name: str, cmdline: list[str]) -> str | None:
-    if _is_claude_desktop_artifact(cmdline):
+    if (
+        _is_claude_desktop_artifact(cmdline)
+        or _is_codex_desktop_artifact(cmdline)
+        or _is_cursor_desktop_artifact(cmdline)
+    ):
         return None
     haystack = f"{process_name} {' '.join(cmdline)}".lower()
     tokens = {_normalized_token(part) for part in cmdline}
@@ -503,18 +531,31 @@ def _classify_agent_loose(process_name: str, cmdline: list[str]) -> str | None:
     return None
 
 
-def _is_claude_desktop_artifact(cmdline: list[str]) -> bool:
+def _matches_desktop_path_hints(cmdline: list[str], hints: tuple[str, ...]) -> bool:
     # Match desktop-bundle / installer hints against argv[0] only — never against
     # the full command. Prompt-bearing flags (e.g. `claude --print "inspect
     # /Applications/Claude.app/..."`) must not falsely trip the negative filter.
     #
-    # The trailing-slash sentinel lets `/claude-desktop/` match both directories
-    # (`/usr/lib/claude-desktop/...`) and end-of-string binaries
-    # (`/.../bin/claude-desktop`) while rejecting `/.../my-claude-desktop-tools/`.
+    # The trailing-slash sentinel lets directory hints (e.g. `/<agent>-desktop/`)
+    # match both directories (`/usr/lib/<agent>-desktop/...`) and end-of-string
+    # binaries (`/.../bin/<agent>-desktop`) while rejecting substrings like
+    # `/.../my-<agent>-desktop-tools/`.
     if not cmdline:
         return False
     lowered = cmdline[0].lower() + "/"
-    return any(hint in lowered for hint in _CLAUDE_DESKTOP_PATH_HINTS)
+    return any(hint in lowered for hint in hints)
+
+
+def _is_claude_desktop_artifact(cmdline: list[str]) -> bool:
+    return _matches_desktop_path_hints(cmdline, _CLAUDE_DESKTOP_PATH_HINTS)
+
+
+def _is_codex_desktop_artifact(cmdline: list[str]) -> bool:
+    return _matches_desktop_path_hints(cmdline, _CODEX_DESKTOP_PATH_HINTS)
+
+
+def _is_cursor_desktop_artifact(cmdline: list[str]) -> bool:
+    return _matches_desktop_path_hints(cmdline, _CURSOR_DESKTOP_PATH_HINTS)
 
 
 def _is_noise_process(process_name: str, cmdline: list[str]) -> bool:

--- a/app/agents/discovery.py
+++ b/app/agents/discovery.py
@@ -443,6 +443,10 @@ def _agent_name_for_command(command: str) -> str | None:
         return "claude-code"
     if not _is_codex_desktop_artifact(cmdline) and _is_codex_command(command):
         return "codex"
+    # No cursor desktop guard here: this function never returns a bare
+    # `cursor` label (only `cursor-agent` / `cursor-agent-exec` / `cursor-
+    # claude-code`), so Cursor.app cannot reach a labelling path. Add one
+    # if a bare-`cursor` return is ever introduced.
     if _has_command_token(lower, "aider"):
         return "aider"
     if _has_command_token(lower, "gemini"):
@@ -505,6 +509,12 @@ def _classify_agent(
         return "gemini-cli"
     if executable in {"cursor-agent", "cursor-agent-cli"}:
         return "cursor"
+    if executable == "cursor" and _is_cursor_desktop_artifact(cmdline):
+        # Belt-and-suspenders: no current strict branch returns "cursor" for a
+        # bare `cursor` executable (Cursor's CLI is `cursor-agent`), so this is
+        # a no-op today. Kept explicit so a future `if executable == "cursor":
+        # return "cursor"` cannot silently reintroduce the desktop mislabel.
+        return None
     if include_all:
         return _classify_agent_loose(process_name, cmdline)
     return None

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -55,12 +55,25 @@ desktop artifacts and never labeled as `claude-code`. The negative filter
 matches against `argv[0]` only, so a CLI installed under a Claude-flavored
 prefix (for example `/opt/Claude/claude`) is still surfaced.
 
+The same cross-platform desktop filter also rejects **Codex Desktop**
+(`Codex.app/Contents/MacOS/Codex`, `/snap/codex/`, `/.mount_Codex…`,
+Flatpak `com.openai.codex`, Windows `Program Files\Codex\` and
+`AppData\Local\Programs\codex\`) and **Cursor Desktop**
+(`Cursor.app/Contents/MacOS/Cursor`, `/snap/cursor/`, `/.mount_Cursor…`,
+Flatpak `com.cursor.cursor`, Windows `Program Files\Cursor\` and
+`AppData\Local\Programs\cursor\`), so neither GUI is mislabeled as the
+`codex` or `cursor` CLI in strict or `--all` mode. The macOS hints
+deliberately target only the main bundle binary so Electron helper
+subprocesses (e.g. `Cursor Helper (Plugin)` running Cursor's AI agent)
+remain eligible for the loose `--all` matcher.
+
 ### Loose mode (`--all`)
 
 `opensre agents scan --all` relaxes the argv requirements so that helper and
 broker processes whose argv contains agent-shaped tokens are also surfaced.
-The Claude Desktop / Electron negative filter is still applied — `--all`
-never mislabels desktop processes as `claude-code`.
+The Claude / Codex / Cursor Desktop negative filter is still applied —
+`--all` never mislabels desktop processes as `claude-code`, `codex`, or
+`cursor`.
 
 ### Registering discovered sessions
 

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -386,6 +386,156 @@ def test_is_claude_desktop_artifact_passes_through_cli_invocations(
     assert discovery._is_claude_desktop_artifact(cmdline) is False
 
 
+def test_discover_agent_processes_rejects_codex_desktop_main_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=801, command="/Applications/Codex.app/Contents/MacOS/Codex"),
+        ],
+    )
+
+    assert discovery.discover_agent_processes() == []
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "/Applications/Codex.app/Contents/MacOS/Codex",
+        "/snap/codex/current/usr/bin/codex",
+        "/tmp/.mount_Codex_xyz123/usr/bin/codex",
+        "/var/lib/flatpak/app/com.openai.codex/current/active/files/bin/codex",
+        "'C:\\Program Files\\Codex\\Codex.exe'",
+        "'C:\\Users\\me\\AppData\\Local\\Programs\\codex\\Codex.exe'",
+    ],
+)
+def test_discover_agent_processes_rejects_codex_desktop_cross_platform_paths(
+    monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [ProcessRow(pid=802, command=command)],
+    )
+
+    assert discovery.discover_agent_processes() == []
+    assert discovery.discover_agent_processes(include_all=True) == []
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "/Applications/Cursor.app/Contents/MacOS/Cursor",
+        "/snap/cursor/current/usr/bin/cursor",
+        "/tmp/.mount_Cursor_xyz123/usr/bin/cursor",
+        "/var/lib/flatpak/app/com.cursor.cursor/current/active/files/bin/cursor",
+        "'C:\\Program Files\\Cursor\\Cursor.exe'",
+        "'C:\\Users\\me\\AppData\\Local\\Programs\\cursor\\Cursor.exe'",
+    ],
+)
+def test_discover_agent_processes_rejects_cursor_desktop_cross_platform_paths(
+    monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [ProcessRow(pid=803, command=command)],
+    )
+
+    assert discovery.discover_agent_processes() == []
+    assert discovery.discover_agent_processes(include_all=True) == []
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        ["/Applications/Codex.app/Contents/MacOS/Codex"],
+        ["/snap/codex/current/usr/bin/codex"],
+        ["/tmp/.mount_Codex_xyz123/usr/bin/codex"],
+        ["/var/lib/flatpak/app/com.openai.codex/current/active/files/bin/codex"],
+        ["C:\\Program Files\\Codex\\Codex.exe"],
+        ["C:\\Users\\me\\AppData\\Local\\Programs\\codex\\Codex.exe"],
+    ],
+)
+def test_is_codex_desktop_artifact_recognises_known_packaging_paths(
+    cmdline: list[str],
+) -> None:
+    assert discovery._is_codex_desktop_artifact(cmdline) is True
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        ["codex"],
+        ["codex", "--resume", "id"],
+        ["/usr/local/bin/codex"],
+        ["/Users/me/.local/bin/codex"],
+        ["/opt/Codex/codex"],
+        ["/opt/codex-cli/bin/codex"],
+        ["node", "/opt/codex.js"],
+        [
+            "codex",
+            "--print",
+            "inspect /Applications/Codex.app/Contents/MacOS/Codex logs",
+        ],
+        # Electron helper paths inside the bundle stay eligible for the loose
+        # matcher — only the main `<bundle>/Contents/MacOS/<binary>` is blocked.
+        ["/Applications/Codex.app/Contents/Frameworks/Codex Helper"],
+    ],
+)
+def test_is_codex_desktop_artifact_passes_through_cli_invocations(
+    cmdline: list[str],
+) -> None:
+    assert discovery._is_codex_desktop_artifact(cmdline) is False
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        ["/Applications/Cursor.app/Contents/MacOS/Cursor"],
+        ["/snap/cursor/current/usr/bin/cursor"],
+        ["/tmp/.mount_Cursor_xyz123/usr/bin/cursor"],
+        ["/var/lib/flatpak/app/com.cursor.cursor/current/active/files/bin/cursor"],
+        ["C:\\Program Files\\Cursor\\Cursor.exe"],
+        ["C:\\Users\\me\\AppData\\Local\\Programs\\cursor\\Cursor.exe"],
+    ],
+)
+def test_is_cursor_desktop_artifact_recognises_known_packaging_paths(
+    cmdline: list[str],
+) -> None:
+    assert discovery._is_cursor_desktop_artifact(cmdline) is True
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        ["cursor-agent"],
+        ["cursor-agent-cli"],
+        ["/usr/local/bin/cursor-agent"],
+        ["/opt/Cursor/cursor"],
+        [
+            "cursor-agent",
+            "--print",
+            "/Applications/Cursor.app/Contents/MacOS/Cursor",
+        ],
+        # Cursor's AI agent ships as a Helper inside the .app bundle. The
+        # narrow `cursor.app/contents/macos/cursor/` hint must let helper
+        # subprocess paths through so they remain eligible for the loose
+        # matcher (see `test_…_all_mode_still_keeps_non_desktop_loose_matches`).
+        ["/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Plugin)"],
+    ],
+)
+def test_is_cursor_desktop_artifact_passes_through_cli_invocations(
+    cmdline: list[str],
+) -> None:
+    assert discovery._is_cursor_desktop_artifact(cmdline) is False
+
+
 def test_discover_agents_legacy_path_matches_bare_claude_via_cursor_terminal(
     tmp_path: Path,
 ) -> None:
@@ -407,6 +557,17 @@ def test_discover_agents_legacy_path_rejects_claude_desktop_main(tmp_path: Path)
     records = discover_agents(
         process_rows=[
             ProcessRow(pid=901, command="/Applications/Claude.app/Contents/MacOS/Claude"),
+        ],
+        cursor_projects_dir=tmp_path,
+    )
+
+    assert records == []
+
+
+def test_discover_agents_legacy_path_rejects_codex_desktop_main(tmp_path: Path) -> None:
+    records = discover_agents(
+        process_rows=[
+            ProcessRow(pid=902, command="/Applications/Codex.app/Contents/MacOS/Codex"),
         ],
         cursor_projects_dir=tmp_path,
     )

--- a/tests/agents/test_discovery.py
+++ b/tests/agents/test_discovery.py
@@ -401,6 +401,25 @@ def test_discover_agent_processes_rejects_codex_desktop_main_in_strict_mode(
     assert discovery.discover_agent_processes() == []
 
 
+def test_discover_agent_processes_rejects_cursor_desktop_main_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Strict-mode regression guard: no current branch in `_classify_agent`
+    # returns "cursor" for `executable == "cursor"`, but the explicit guard
+    # next to the `cursor-agent` / `cursor-agent-cli` block must keep
+    # Cursor.app from ever being labelled in strict mode.
+    monkeypatch.setattr(discovery.os, "getpid", lambda: 10)
+    monkeypatch.setattr(
+        discovery,
+        "_current_process_rows",
+        lambda: [
+            ProcessRow(pid=804, command="/Applications/Cursor.app/Contents/MacOS/Cursor"),
+        ],
+    )
+
+    assert discovery.discover_agent_processes() == []
+
+
 @pytest.mark.parametrize(
     "command",
     [


### PR DESCRIPTION
Fixes #2480

#### Describe the changes you have made in this PR -

`opensre agents scan` (strict mode) was mislabeling Codex Desktop's main process as `codex`, and `opensre agents scan --all` (loose mode) was additionally mislabeling Cursor Desktop's main process as `cursor`. Both bugs are the same class as the Claude Desktop ↔ Claude Code CLI bug fixed in #2269, where a GUI app's main binary shares a basename with a CLI tool and trips the strict / loose classifier in `app/agents/discovery.py`.

This PR replicates the exact pattern from #2269 for Codex and Cursor — a per-agent desktop path-hint deny-list matched against `argv[0]` only — using the cross-platform shape already established for Claude (macOS app bundle, Linux Snap, AppImage mount, Flatpak, Windows Program Files, Windows AppData). The Claude desktop helper at `_is_claude_desktop_artifact` is refactored to share a small `_matches_desktop_path_hints` private helper with the two new artifact checkers; the public API of `_is_claude_desktop_artifact` is unchanged so the #2269 tests pass untouched.

The negative filter is wired into both reachable classification paths so neither surface mislabels the desktop GUIs:

- `_classify_agent` — the modern strict + loose path used by `discover_agent_processes` (the `opensre agents scan` CLI surface).
- `_agent_name_for_command` — the legacy path used by `discover_agents`, `registered_and_discovered_agents`, and the Cursor terminal-scrollback parser.

The macOS hints are deliberately narrowed to the main bundle binary (`<App>.app/Contents/MacOS/<App>/`) instead of the broader `<App>.app/Contents/` form used for Claude. This is required so that Cursor's AI agent — which ships as an Electron helper subprocess inside the bundle (`Cursor Helper (Plugin)`) — remains eligible for the loose `--all` matcher; the existing regression test `test_discover_agent_processes_all_mode_still_keeps_non_desktop_loose_matches` locks this behavior. The Codex hint is narrowed for symmetry, with a parametrised `test_is_codex_desktop_artifact_passes_through_cli_invocations` case that pins the contract.

Out of scope, by maintainer ruling on #2275: Linux prefixes that collide with legitimate CLI install layouts (`/opt/Codex/`, `/opt/Cursor/`, `/usr/share/codex/`, `/usr/share/cursor/`). The Claude precedent in #2269 explicitly accepts `/opt/Claude/claude` as a valid CLI install path, and this PR keeps the same scope discipline — there are pass-through tests pinning `/opt/Codex/codex` and `/opt/Cursor/cursor` as legitimate CLI prefixes.

Docs: extended the cross-platform desktop filter paragraph in `docs/agents.mdx` to mention Codex Desktop and Cursor Desktop alongside Claude Desktop.

### Demo/Screenshot for feature changes and bug fixes -

Same driver script runs on `main` and on this branch. It spawns two fake desktop processes via `exec -a` (Codex.app/Contents/MacOS/Codex and Cursor.app/Contents/MacOS/Cursor), then runs `opensre agents scan` and `opensre agents scan --all` and prints only the rows that reference the fake PIDs.

**Before — `main`** (bug reproduces in both strict and `--all`):

![issue-2480-before](https://vhs.charm.sh/vhs-4yg9XujnFs1zD5M32eudqQ.gif)

**After — this branch** (both modes correctly filter the desktop GUIs):

![issue-2480-after](https://vhs.charm.sh/vhs-54pXfvK2fK8xDc9suLWOBr.gif)

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

- The bug class is structurally identical to the Claude Desktop variant fixed in #2269: a desktop GUI whose main binary has the same basename as the CLI agent slips through the basename-matched classifier in `app/agents/discovery.py`. Two design directions were on the table:
  1. **Generalize via `app/integrations/llm_cli/binary_resolver.py`** — invert the filter to a positive "argv[0] resolves to a known CLI install path for this agent" check. This was the original direction proposed in #2275; the maintainer closed that issue because the cross-OS install matrix (`npm prefix`, `/opt/homebrew/bin`, Volta, PNPM_HOME, XDG_DATA_HOME, Windows `LOCALAPPDATA/Programs/...`, etc.) was too broad to keep accurate. Rejected here.
  2. **Replicate the per-agent deny-list from #2269** — add cross-platform path hints per agent and a small artifact-check helper. Same maintenance surface as the existing Claude pattern, +12 lines per agent, no new abstractions. **This PR.**
- Key helpers:
  - `_matches_desktop_path_hints(cmdline, hints)` — the three-line lowercased-argv[0] + trailing-slash sentinel match, extracted from the original `_is_claude_desktop_artifact`. Single source of truth for the matching logic.
  - `_is_codex_desktop_artifact(cmdline)` / `_is_cursor_desktop_artifact(cmdline)` — one-line wrappers around `_matches_desktop_path_hints` with each agent's hint tuple. `_is_claude_desktop_artifact` is now also a one-line wrapper, with identical public behavior to #2269.
- Why the macOS hint shape is narrower than Claude's: Cursor's AI agent process is an Electron helper at `Cursor.app/Contents/Frameworks/Cursor Helper (Plugin).app/Contents/MacOS/...`, and an existing test (`test_discover_agent_processes_all_mode_still_keeps_non_desktop_loose_matches`) requires those helpers to remain eligible for the loose matcher. Narrowing the hint to `cursor.app/contents/macos/cursor/` blocks only the main binary at `Cursor.app/Contents/MacOS/Cursor` while letting the helpers through. The Codex hint is narrowed the same way for symmetry — a parametrised pass-through test pins the contract.
- Two reachable classification paths exist in `discovery.py` (`_classify_agent` strict/loose and the legacy `_agent_name_for_command`); both are gated in this PR. #2269 gated both for Claude — same scope here.
- Tests cover: strict-mode rejection for Codex.app, cross-platform `[]` for both agents (6 packaging shapes each), helper-on-true and CLI-on-false parametrised checks of the new artifact helpers (including the `--print "...<bundle path>..."` prompt-content regression and the Electron-helper pass-through), and a legacy-path regression test exercising `discover_agents` with a Codex Desktop `ProcessRow`. All 538 `tests/agents/` tests pass on this branch.
- Pre-merge gates clean: `make lint`, `make format-check`, `make typecheck`, `make test-cov` all green.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.