### PR TITLE
fix(integrations): skip Discord/Telegram classify silently when bot_token is empty

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -507,6 +507,8 @@ def _classify_service_instance(
         return None, None
 
     if key == "discord":
+        if not (credentials.get("bot_token") or "").strip():
+            return None, None
         try:
             discord_config = DiscordBotConfig.model_validate(
                 {
@@ -519,11 +521,11 @@ def _classify_service_instance(
         except Exception as exc:
             _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
-        if discord_config.bot_token:
-            return discord_config.model_dump(), "discord"
-        return None, None
+        return discord_config.model_dump(), "discord"
 
     if key == "telegram":
+        if not (credentials.get("bot_token") or "").strip():
+            return None, None
         try:
             tg_config = TelegramBotConfig.model_validate(
                 {
@@ -534,9 +536,7 @@ def _classify_service_instance(
         except Exception as exc:
             _report_classify_failure(exc, integration=key, record_id=record_id)
             return None, None
-        if tg_config.bot_token:
-            return tg_config.model_dump(), "telegram"
-        return None, None
+        return tg_config.model_dump(), "telegram"
 
     if key == "whatsapp":
         try:

--- a/tests/integrations/test_catalog_silent_fallback_elimination.py
+++ b/tests/integrations/test_catalog_silent_fallback_elimination.py
@@ -137,7 +137,7 @@ def test_classify_failure_skips_integration_and_reports(
     with patch("app.integrations._catalog_impl.report_exception") as mock_report:
         result = _classify_service_instance(
             integration,
-            {"endpoint": "https://x", "api_key": "k"},
+            {"endpoint": "https://x", "api_key": "k", "bot_token": "fake-token"},
             record_id=f"rec-{integration}",
         )
 
@@ -153,6 +153,31 @@ def test_classify_failure_skips_integration_and_reports(
     assert tags["surface"] == "integration"
     assert mock_report.call_args.kwargs["severity"] == "warning"
     assert mock_report.call_args.kwargs["extras"]["record_id"] == f"rec-{integration}"
+
+
+@pytest.mark.parametrize("bot_token", ["", " ", None])
+@pytest.mark.parametrize("integration", ["discord", "telegram"])
+def test_classify_empty_bot_token_silently_skips(
+    integration: str,
+    bot_token: str | None,
+) -> None:
+    """Discord/Telegram records with empty bot_token are silently skipped without
+    reporting to Sentry — empty token means 'not configured', not misconfigured."""
+    credentials: dict[str, Any] = {"endpoint": "https://x"}
+    if bot_token is not None:
+        credentials["bot_token"] = bot_token
+
+    with patch("app.integrations._catalog_impl.report_exception") as mock_report:
+        result = _classify_service_instance(
+            integration,
+            credentials,
+            record_id="rec-test",
+        )
+
+    assert result == (None, None)
+    assert mock_report.call_count == 0, (
+        f"{integration} with empty bot_token should not report to Sentry"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Discord and Telegram records with an empty/whitespace `bot_token` are now silently skipped during integration classification instead of raising `ValidationError` → Sentry
- Real validation failures (misformatted token, conflicting fields) are still caught and forwarded to Sentry via `_report_classify_failure`
- Removed unreachable `if discord_config.bot_token: / return None, None` dead-code paths that couldn't fire after a successful validator (the validator already enforces non-empty)
- Updated the classify-failure test to supply a `bot_token` in the generic credentials fixture so the patched-class path is still exercised
- Added 6 new parametrized tests confirming empty/None/whitespace tokens skip silently without calling `report_exception`

## Test plan

- [x] `uv run pytest tests/integrations/test_catalog_silent_fallback_elimination.py` — 57 passed
- [x] `uv run pytest tests/integrations/` — 1148 passed
- [x] `uv run ruff check app/integrations/_catalog_impl.py` — all checks passed

Closes #2437

https://claude.ai/code/session_01JkTYiuvUbFv1dTkYQ4rdmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkTYiuvUbFv1dTkYQ4rdmN)_