### PR TITLE
fix(grafana): support HTTP Basic auth for localhost endpoints

### DIFF
--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -211,6 +211,8 @@ def _classify_service_instance(
                 {
                     "endpoint": credentials.get("endpoint", ""),
                     "api_key": credentials.get("api_key", ""),
+                    "username": credentials.get("username", ""),
+                    "password": credentials.get("password", ""),
                     "integration_id": record_id,
                 }
             )
@@ -223,6 +225,8 @@ def _classify_service_instance(
             return {
                 "endpoint": grafana_config.endpoint,
                 "api_key": "",
+                "username": grafana_config.username or "admin",
+                "password": grafana_config.password or "admin",
                 "integration_id": grafana_config.integration_id,
             }, "grafana_local"
         if grafana_config.api_key and grafana_config.api_key != "local":

--- a/app/integrations/_catalog_impl.py
+++ b/app/integrations/_catalog_impl.py
@@ -225,8 +225,8 @@ def _classify_service_instance(
             return {
                 "endpoint": grafana_config.endpoint,
                 "api_key": "",
-                "username": grafana_config.username or "admin",
-                "password": grafana_config.password or "admin",
+                "username": grafana_config.username,
+                "password": grafana_config.password,
                 "integration_id": grafana_config.integration_id,
             }, "grafana_local"
         if grafana_config.api_key and grafana_config.api_key != "local":

--- a/app/integrations/config_models.py
+++ b/app/integrations/config_models.py
@@ -40,6 +40,8 @@ class GrafanaIntegrationConfig(StrictConfigModel):
     endpoint: str
     api_key: str = ""
     integration_id: str = ""
+    username: str = ""
+    password: str = ""
 
     _normalize_endpoint = field_validator("endpoint", mode="before")(normalize_url())
 

--- a/app/services/grafana/__init__.py
+++ b/app/services/grafana/__init__.py
@@ -41,6 +41,8 @@ def get_grafana_client_from_credentials(
     endpoint: str,
     api_key: str,
     account_id: str = "user_integration",
+    username: str = "",
+    password: str = "",
 ) -> GrafanaClient:
     """Create a Grafana client from integration credentials.
 
@@ -51,6 +53,8 @@ def get_grafana_client_from_credentials(
         endpoint: Grafana instance URL (e.g., https://myorg.grafana.net)
         api_key: Grafana service account token (glsa_...)
         account_id: Identifier for caching (default: "user_integration")
+        username: Username for basic auth (optional, used for localhost)
+        password: Password for basic auth (optional, used for localhost)
 
     Returns:
         GrafanaClient configured with discovered datasource UIDs
@@ -63,6 +67,8 @@ def get_grafana_client_from_credentials(
         account_id=account_id,
         instance_url=endpoint.rstrip("/"),
         read_token=api_key,
+        username=username,
+        password=password,
     )
     client = GrafanaClient(config=config)
 
@@ -73,6 +79,8 @@ def get_grafana_client_from_credentials(
             account_id=account_id,
             instance_url=endpoint.rstrip("/"),
             read_token=api_key,
+            username=username,
+            password=password,
             loki_datasource_uid=discovered.get("loki_uid", ""),
             tempo_datasource_uid=discovered.get("tempo_uid", ""),
             mimir_datasource_uid=discovered.get("mimir_uid", ""),

--- a/app/services/grafana/base.py
+++ b/app/services/grafana/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from typing import Any
@@ -52,6 +53,8 @@ class GrafanaClientBase:
         self.account_id = config.account_id
         self.instance_url = config.instance_url
         self.read_token = config.read_token
+        self.username = config.username
+        self.password = config.password
         self.loki_datasource_uid = config.loki_datasource_uid
         self.tempo_datasource_uid = config.tempo_datasource_uid
         self.mimir_datasource_uid = config.mimir_datasource_uid
@@ -293,6 +296,9 @@ class GrafanaClientBase:
             return []
 
     def _get_auth_headers(self) -> dict[str, str]:
+        if self.username and self.password:
+            credentials = base64.b64encode(f"{self.username}:{self.password}".encode()).decode()
+            return {"Authorization": f"Basic {credentials}"}
         if not self.read_token:
             return {}
         return {"Authorization": f"Bearer {self.read_token}"}

--- a/app/services/grafana/config.py
+++ b/app/services/grafana/config.py
@@ -19,6 +19,8 @@ class GrafanaAccountConfig(StrictConfigModel):
     tempo_datasource_uid: str = ""
     mimir_datasource_uid: str = ""
     description: str = ""
+    username: str = ""
+    password: str = ""
 
     @field_validator("instance_url", mode="before")
     @classmethod

--- a/app/tools/GrafanaLogsTool/__init__.py
+++ b/app/tools/GrafanaLogsTool/__init__.py
@@ -18,12 +18,16 @@ def _map_pipeline_to_service_name(pipeline_name: str) -> str:
 def _resolve_grafana_client(
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
 ):
     if not grafana_endpoint:
         return None
     return get_grafana_client_from_credentials(
         endpoint=grafana_endpoint,
         api_key=grafana_api_key or "",
+        username=grafana_username,
+        password=grafana_password,
     )
 
 
@@ -31,6 +35,8 @@ def _grafana_creds(grafana: dict) -> dict:
     return {
         "grafana_endpoint": grafana.get("grafana_endpoint") or grafana.get("endpoint"),
         "grafana_api_key": grafana.get("grafana_api_key") or grafana.get("api_key"),
+        "grafana_username": grafana.get("username", ""),
+        "grafana_password": grafana.get("password", ""),
     }
 
 
@@ -86,6 +92,8 @@ def _query_grafana_logs_available(sources: dict[str, dict]) -> bool:
             "limit": {"type": "integer", "default": 100},
             "grafana_endpoint": {"type": "string"},
             "grafana_api_key": {"type": "string"},
+            "grafana_username": {"type": "string"},
+            "grafana_password": {"type": "string"},
             "pipeline_name": {"type": "string"},
         },
         "required": ["service_name"],
@@ -100,6 +108,8 @@ def query_grafana_logs(
     limit: int = 100,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
     pipeline_name: str | None = None,
     grafana_backend: Any = None,
     **_kwargs: Any,
@@ -146,7 +156,7 @@ def query_grafana_logs(
             result_data["truncation_note"] = summary
         return result_data
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
+    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key, grafana_username, grafana_password)
     if not client or not client.is_configured:
         return {
             "source": "grafana_loki",

--- a/app/tools/GrafanaLogsTool/__init__.py
+++ b/app/tools/GrafanaLogsTool/__init__.py
@@ -156,7 +156,9 @@ def query_grafana_logs(
             result_data["truncation_note"] = summary
         return result_data
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key, grafana_username, grafana_password)
+    client = _resolve_grafana_client(
+        grafana_endpoint, grafana_api_key, grafana_username, grafana_password
+    )
     if not client or not client.is_configured:
         return {
             "source": "grafana_loki",

--- a/app/tools/GrafanaMetricsTool/__init__.py
+++ b/app/tools/GrafanaMetricsTool/__init__.py
@@ -72,7 +72,13 @@ def _query_grafana_metrics_available(sources: dict[str, dict]) -> bool:
     anti_examples=["Use this tool for pod logs or deployment status."],
     input_model=QueryGrafanaMetricsInput,
     output_model=QueryGrafanaMetricsOutput,
-    injected_params=("grafana_endpoint", "grafana_api_key", "grafana_backend"),
+    injected_params=(
+        "grafana_endpoint",
+        "grafana_api_key",
+        "grafana_username",
+        "grafana_password",
+        "grafana_backend",
+    ),
     is_available=_query_grafana_metrics_available,
     extract_params=_query_grafana_metrics_extract_params,
 )
@@ -99,7 +105,9 @@ def query_grafana_metrics(
             "service_name": service_name,
         }
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key, grafana_username, grafana_password)
+    client = _resolve_grafana_client(
+        grafana_endpoint, grafana_api_key, grafana_username, grafana_password
+    )
     if not client or not client.is_configured:
         return {
             "source": "grafana_mimir",

--- a/app/tools/GrafanaMetricsTool/__init__.py
+++ b/app/tools/GrafanaMetricsTool/__init__.py
@@ -81,6 +81,8 @@ def query_grafana_metrics(
     service_name: str | None = None,
     grafana_endpoint: str | None = None,
     grafana_api_key: str | None = None,
+    grafana_username: str = "",
+    grafana_password: str = "",
     grafana_backend: Any = None,
     **_kwargs: Any,
 ) -> dict:
@@ -97,7 +99,7 @@ def query_grafana_metrics(
             "service_name": service_name,
         }
 
-    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key)
+    client = _resolve_grafana_client(grafana_endpoint, grafana_api_key, grafana_username, grafana_password)
     if not client or not client.is_configured:
         return {
             "source": "grafana_mimir",

--- a/tests/integrations/test_catalog_multi_instance.py
+++ b/tests/integrations/test_catalog_multi_instance.py
@@ -176,6 +176,25 @@ def test_local_and_cloud_grafana_share_all_grafana_instances_bucket() -> None:
     assert set(names) == {"local", "prod"}
 
 
+def test_local_grafana_without_basic_auth_keeps_credentials_empty() -> None:
+    """Regression for Greptile: localhost Grafana without credentials should
+    remain anonymous (no injected admin:admin fallback)."""
+    local_only = {
+        "id": "env-grafana",
+        "service": "grafana",
+        "status": "active",
+        "credentials": {
+            "endpoint": "http://localhost:3000",
+            "api_key": "local",
+        },
+    }
+
+    resolved = classify_integrations([local_only])
+    assert resolved["grafana_local"]["endpoint"] == "http://localhost:3000"
+    assert resolved["grafana_local"]["username"] == ""
+    assert resolved["grafana_local"]["password"] == ""
+
+
 def test_classify_inactive_record_is_skipped() -> None:
     inactive = {
         "id": "g1",

--- a/tests/tools/test_grafana_metrics_tool.py
+++ b/tests/tools/test_grafana_metrics_tool.py
@@ -31,6 +31,20 @@ def test_extract_params_maps_fields() -> None:
     assert params["grafana_endpoint"] == "https://grafana.example.com"
 
 
+def test_extract_params_includes_basic_auth_fields() -> None:
+    rt = query_grafana_metrics.__opensre_registered_tool__
+    sources = mock_agent_state({"grafana": {"username": "local-user", "password": "local-pass"}})
+    params = rt.extract_params(sources)
+    assert params["grafana_username"] == "local-user"
+    assert params["grafana_password"] == "local-pass"
+
+
+def test_injected_params_include_basic_auth_fields() -> None:
+    rt = query_grafana_metrics.__opensre_registered_tool__
+    assert "grafana_username" in rt.injected_params
+    assert "grafana_password" in rt.injected_params
+
+
 def test_run_with_backend() -> None:
     mock_backend = MagicMock()
     mock_backend.query_timeseries.return_value = {


### PR DESCRIPTION
## Summary

Fixes Grafana integration failures on localhost where API key auth was explicitly disabled. Now supports HTTP Basic auth (e.g., admin:admin) credentials.

## Changes

- Add `username` and `password` fields to `GrafanaIntegrationConfig` for Basic auth support
- Extract credentials from `integrations.json` for localhost endpoints  
- Pass credentials through entire stack: config → catalog → client → tools
- Implement `_get_auth_headers()` to prioritize Basic auth over Bearer token
- Encode credentials as base64 per HTTP Basic auth spec
- Maintain backward compatibility with Bearer token auth

## Root Cause

The integration classifier (`_catalog_impl.py`) deliberately set `api_key=""` for localhost/127.0.0.1/0.0.0.0 endpoints, forcing authentication failure even when credentials were configured. This prevented local Grafana instances from working.

## Testing

- Tested against localhost Grafana with admin:admin credentials
- Verified 401 errors no longer occur
- Backward compatible with existing Bearer token configurations

Fixes #2500